### PR TITLE
Fix: Ensure JSON Serialization of Protobuf Objects in GeminiSchemaConverter Test

### DIFF
--- a/tests/schema_converters/GeminiSchemaConverter_test.py
+++ b/tests/schema_converters/GeminiSchemaConverter_test.py
@@ -4,6 +4,7 @@ import json
 from swarmauri.standard.tools.concrete.AdditionTool import AdditionTool
 from swarmauri.standard.toolkits.concrete.Toolkit import Toolkit
 from swarmauri.standard.agents.concrete.ToolAgent import ToolAgent
+from google.protobuf.json_format import MessageToDict
 
 from swarmauri.standard.schema_converters.concrete.GeminiSchemaConverter import (
     GeminiSchemaConverter as Schema,
@@ -32,6 +33,7 @@ def test_convert():
     toolkit = Toolkit()
     tool = AdditionTool()
     toolkit.add_tool(tool)
-    result = [Schema().convert(toolkit.tools[tool]) for tool in toolkit.tools]
+    schema = Schema()
+    result = [MessageToDict(schema.convert(toolkit.tools[tool])) for tool in toolkit.tools]
     logging.info(result)
     assert json.loads(json.dumps(result))


### PR DESCRIPTION
This PR addresses a TypeError encountered during the JSON serialization of FunctionDeclaration objects in the GeminiSchemaConverter_test.py. The test_convert method has been updated to use MessageToDict from google.protobuf.json_format, which converts protobuf messages into JSON-serializable dictionaries.