### PR TITLE
Update conversation test

### DIFF
--- a/tests/conversations/Conversation_test.py
+++ b/tests/conversations/Conversation_test.py
@@ -42,3 +42,14 @@ def test_add_messages():
     ]
     conversation.add_messages(messages)
     assert conversation.history[-len(messages) :] == messages
+
+
+@pytest.mark.unit
+def test_remove_message():
+    conversation = Conversation()
+    message1 = HumanMessage(content="Test message 1")
+    message2 = HumanMessage(content="Test message 2")
+    conversation.add_message(message1)
+    conversation.add_message(message2)
+    conversation.remove_message(message1)
+    assert message1 not in conversation.history

--- a/tests/conversations/Conversation_test.py
+++ b/tests/conversations/Conversation_test.py
@@ -1,18 +1,44 @@
 import pytest
-import os
 from swarmauri.standard.conversations.concrete.Conversation import Conversation
+from swarmauri.standard.messages.concrete.HumanMessage import HumanMessage
+
 
 @pytest.mark.unit
 def test_ubc_resource():
     conversation = Conversation()
-    assert conversation.resource == 'Conversation'
+    assert conversation.resource == "Conversation"
+
 
 @pytest.mark.unit
 def test_ubc_type():
     conversation = Conversation()
-    assert conversation.type == 'Conversation'
+    assert conversation.type == "Conversation"
+
 
 @pytest.mark.unit
 def test_serialization():
     conversation = Conversation()
-    assert conversation.id == Conversation.model_validate_json(conversation.model_dump_json()).id
+    assert (
+        conversation.id
+        == Conversation.model_validate_json(conversation.model_dump_json()).id
+    )
+
+
+@pytest.mark.unit
+def test_add_message():
+    conversation = Conversation()
+    message = HumanMessage(content="Test message")
+    conversation.add_message(message)
+    assert conversation.history[-1] == message
+
+
+@pytest.mark.unit
+def test_add_messages():
+    conversation = Conversation()
+    messages = [
+        HumanMessage(content="Test message 1"),
+        HumanMessage(content="Test message 2"),
+        HumanMessage(content="Test message 3"),
+    ]
+    conversation.add_messages(messages)
+    assert conversation.history[-len(messages) :] == messages


### PR DESCRIPTION
This PR fixes issue #188 

Expected outcomes when running

- [x] add_message : should pass
- [x] add_messages : should pass
- [ ] remove_message: should not pass

The reason why `remove_message` should not pass is because `remove_message` has not yet been impemented in `Conversation`