### PR TITLE
Error correction for ColemanLiauIndex_test.py::test_call

### DIFF
--- a/tests/tools/ColemanLiauIndex_test.py
+++ b/tests/tools/ColemanLiauIndex_test.py
@@ -18,4 +18,17 @@ def test_initialization():
 @pytest.mark.unit
 def test_call():
     tool = Tool()
-    assert tool(10, 10) == str(20)
+    # Example input text for CLI calculation
+    input_data = {"input_text": "This is a simple test text. It contains two sentences."}
+    
+    # Calculating expected CLI score manually
+    num_sentences = 2
+    num_words = 10
+    num_characters = 42
+
+    L = (num_characters / num_words) * 100
+    S = (num_sentences / num_words) * 100
+    expected_cli_score = 0.0588 * L - 0.296 * S - 15.8
+
+    # Assert that the CLI tool calculates the expected value
+    assert tool(input_data) == pytest.approx(expected_cli_score, 0.01)


### PR DESCRIPTION
Error correction for "FAILED tests/tools/ColemanLiauIndex_test.py::test_call - TypeError: ColemanLiauIndexTool.__call__() takes 2 positional arguments but 3 were given"