### PR TITLE
Error correction for tests/tools/LexicalDensity_test.py::test_call

### DIFF
--- a/tests/tools/LexicalDensity_test.py
+++ b/tests/tools/LexicalDensity_test.py
@@ -18,4 +18,16 @@ def test_initialization():
 @pytest.mark.unit
 def test_call():
     tool = Tool()
-    assert tool(10, 10) == str(20)
+    input_text = "This is a test sentence."
+    expected_lexical_density = tool.calculate_lexical_density(input_text)
+    
+    assert tool(input_text) == pytest.approx(expected_lexical_density, 0.01)
+
+@pytest.mark.unit
+def test_call_empty_text():
+    tool = Tool()
+    input_text = ""
+    expected_lexical_density = 0.0
+    
+    # Call the tool with the empty text and check if it returns 0.0
+    assert tool(input_text) == expected_lexical_density


### PR DESCRIPTION
Made a correction for error: "tests/tools/LexicalDensity_test.py::test_call - TypeError: LexicalDensityTool.__call__() takes 2 positional arguments but 3 were given" and if it's an empty string