### PR TITLE
implemented DuckDBVectorStore

### DIFF
--- a/pkgs/swarmauri/swarmauri/vector_stores/concrete/__init__.py
+++ b/pkgs/swarmauri/swarmauri/vector_stores/concrete/__init__.py
@@ -2,6 +2,7 @@
 
 from swarmauri.vector_stores.concrete.Doc2VecVectorStore import Doc2VecVectorStore
 from swarmauri.vector_stores.concrete.MlmVectorStore import MlmVectorStore
-from swarmauri.vector_stores.concrete.SpatialDocVectorStore import SpatialDocVectorStore
+
+# from swarmauri.vector_stores.concrete.SpatialDocVectorStore import SpatialDocVectorStore
 from swarmauri.vector_stores.concrete.SqliteVectorStore import SqliteVectorStore
 from swarmauri.vector_stores.concrete.TfidfVectorStore import TfidfVectorStore


### PR DESCRIPTION
The last implementation of `DuckDBVectorStore` was returning the error below and was also missing some important test cases like `test_retrieve`
```
================================================================================================= short test summary info =================================================================================================
FAILED pkgs/community/tests/unit/vector_stores/DuckDBVectorStore_unit_test.py::test_retrieve[:memory:] - AssertionError: assert 'fox' in 'a lazy dog sleeps all day'
FAILED pkgs/community/tests/unit/vector_stores/DuckDBVectorStore_unit_test.py::test_retrieve[test_db.db] - AssertionError: assert 'fox' in 'a lazy dog sleeps all day'
============================================================================================== 2 failed, 14 passed in 12.43s ==============================================================================================
```
----------
I have solved all and eveything passes now
```
======================================================================================================================== 21 passed in 13.66s =========================================================================================================================
```