### PR TITLE
marked expected to fail tests with xfail

### DIFF
--- a/pkgs/experimental/tests/expected_to_fail/OpenRouter_xfail_test.py
+++ b/pkgs/experimental/tests/expected_to_fail/OpenRouter_xfail_test.py
@@ -1,6 +1,6 @@
 import pytest
 import os
-from swarmauri.llms.concrete.OpenRouterModel import OpenRouterModel as LLM
+from swarmauri_experimental.llms.OpenRouterModel import OpenRouterModel as LLM
 from swarmauri.conversations.concrete.Conversation import Conversation
 from swarmauri.messages.concrete.HumanMessage import HumanMessage
 from swarmauri.messages.concrete.SystemMessage import SystemMessage

--- a/pkgs/swarmauri/tests/expected_to_fail/llms/MistralModel_xfail_test.py
+++ b/pkgs/swarmauri/tests/expected_to_fail/llms/MistralModel_xfail_test.py
@@ -11,6 +11,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
+@pytest.mark.xfail(reason="These models are expected to fail")
 @pytest.fixture(scope="module")
 def mistral_model():
     API_KEY = os.getenv("MISTRAL_API_KEY")
@@ -20,6 +21,7 @@ def mistral_model():
     return llm
 
 
+@pytest.mark.xfail(reason="These models are expected to fail")
 @pytest.mark.acceptance
 def test_nonpreamble_system_context(mistral_model):
     model = mistral_model
@@ -48,6 +50,7 @@ def test_nonpreamble_system_context(mistral_model):
     assert "Jeff" in prediction
 
 
+@pytest.mark.xfail(reason="These models are expected to fail")
 @pytest.mark.acceptance
 def test_multiple_system_contexts(mistral_model):
     model = mistral_model

--- a/pkgs/swarmauri/tests/expected_to_fail/llms/PerplexityModel_xfail_test.py
+++ b/pkgs/swarmauri/tests/expected_to_fail/llms/PerplexityModel_xfail_test.py
@@ -17,6 +17,7 @@ def perplexity_model():
     return llm
 
 
+@pytest.mark.xfail(reason="These models are expected to fail")
 @pytest.mark.acceptance
 def test_nonpreamble_system_context(perplexity_model):
     model = perplexity_model
@@ -45,6 +46,7 @@ def test_nonpreamble_system_context(perplexity_model):
     assert "Jeff" in prediction
 
 
+@pytest.mark.xfail(reason="These models are expected to fail")
 @pytest.mark.acceptance
 def test_multiple_system_contexts(perplexity_model):
     model = perplexity_model


### PR DESCRIPTION
I used `@pytest.mark.xfail(reason="These models are expected to fail")` on the test cases in the `expected_to_fail` folder
I also moved `openrouter_xfail_test` file to experimental.