### PR TITLE
Timeouts

### DIFF
--- a/pkgs/swarmauri/tests/unit/llms/GroqAIAudio_unit_test.py
+++ b/pkgs/swarmauri/tests/unit/llms/GroqAIAudio_unit_test.py
@@ -4,7 +4,19 @@ import os
 from swarmauri.llms.concrete.GroqAIAudio import GroqAIAudio as LLM
 from swarmauri.utils.timeout_wrapper import timeout
 
+# Retrieve API key from environment variable
 API_KEY = os.getenv("GROQ_API_KEY")
+
+# Get the current working directory
+current_dir = os.getcwd()
+
+# Construct file paths dynamically
+file_path = os.path.join(
+    current_dir, "pkgs", "swarmauri", "tests", "static", "test.mp3"
+)
+file_path2 = os.path.join(
+    current_dir, "pkgs", "swarmauri", "tests", "static", "test_fr.mp3"
+)
 
 
 @pytest.fixture(scope="module")
@@ -54,7 +66,7 @@ def test_audio_transcription(groqai_model, model_name):
     model.name = model_name
 
     prediction = model.predict(
-        audio_path="pkgs/swarmauri/tests/static/test.mp3",
+        audio_path=file_path,
     )
 
     logging.info(prediction)
@@ -70,7 +82,7 @@ def test_audio_translation(groqai_model):
     model.name = "whisper-large-v3"
 
     prediction = model.predict(
-        audio_path="pkgs/swarmauri/tests/static/test_fr.mp3",
+        audio_path=file_path2,
         task="translation",
     )
 

--- a/pkgs/swarmauri/tests/unit/llms/OpenAIAudioTTS_unit_test.py
+++ b/pkgs/swarmauri/tests/unit/llms/OpenAIAudioTTS_unit_test.py
@@ -9,9 +9,19 @@ from swarmauri.utils.timeout_wrapper import timeout
 load_dotenv()
 
 API_KEY = os.getenv("OPENAI_API_KEY")
-file_path = "pkgs/swarmauri/tests/static/test_tts.mp3"
-file_path2 = "pkgs/swarmauri/tests/static/test.mp3"
-file_path3 = "pkgs/swarmauri/tests/static/test_fr.mp3"
+# Get the current directory in the CI environment
+current_dir = os.getcwd()
+
+# Dynamically set file paths
+file_path = os.path.join(
+    current_dir, "pkgs", "swarmauri", "tests", "static", "test_tts.mp3"
+)
+file_path2 = os.path.join(
+    current_dir, "pkgs", "swarmauri", "tests", "static", "test.mp3"
+)
+file_path3 = os.path.join(
+    current_dir, "pkgs", "swarmauri", "tests", "static", "test_fr.mp3"
+)
 
 
 @pytest.fixture(scope="module")

--- a/pkgs/swarmauri/tests/unit/llms/OpenAIAudio_unit_test.py
+++ b/pkgs/swarmauri/tests/unit/llms/OpenAIAudio_unit_test.py
@@ -5,12 +5,22 @@ from swarmauri.llms.concrete.OpenAIAudio import OpenAIAudio as LLM
 from dotenv import load_dotenv
 from swarmauri.utils.timeout_wrapper import timeout
 
-file_path = "pkgs/swarmauri/tests/static/test.mp3"
-file_path2 = "pkgs/swarmauri/tests/static/test_fr.mp3"
-
+# Load environment variables
 load_dotenv()
 
+# Retrieve API key from environment variable
 API_KEY = os.getenv("OPENAI_API_KEY")
+
+# Get the current working directory
+current_dir = os.getcwd()
+
+# Construct file paths dynamically
+file_path = os.path.join(
+    current_dir, "pkgs", "swarmauri", "tests", "static", "test.mp3"
+)
+file_path2 = os.path.join(
+    current_dir, "pkgs", "swarmauri", "tests", "static", "test_fr.mp3"
+)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
In the workflow we are having error such as `- FileNotFoundError: [Errno 2] No such file or directory: 'pkgs/***/tests/static/test.mp3'` in `OpenAIAudio`, `OpenAIAudiotts` and `GroqAudio`

But these files are present in the specified path and when we run it locally, it passes without any erros.
To resolve this, I have used `os.getcwd()` and `os.path.join()` to dynamically construct file paths that work consistently across different environments.

Hopefully, this should resolve the file path issue on the workflow

This PR closes the following issues
- #699 
- #695
