### PR TITLE
swarm - fixed cohere warning

### DIFF
--- a/pkgs/swarmauri/tests/unit/llms/CohereModel_unit_test.py
+++ b/pkgs/swarmauri/tests/unit/llms/CohereModel_unit_test.py
@@ -18,13 +18,6 @@ API_KEY = os.getenv("COHERE_API_KEY")
 
 
 @pytest.fixture(scope="module")
-def event_loop():
-    loop = asyncio.new_event_loop()
-    yield loop
-    loop.close()
-
-
-@pytest.fixture(scope="module")
 def cohere_model():
     if not API_KEY:
         pytest.skip("Skipping due to environment variable not set")


### PR DESCRIPTION
This PR fixes the error below
```
t/llms/CohereModel_unit_test.py::test_apredict[command]
  /home/runner/runner7/_work/***-sdk/***-sdk/.venv_11853140589_***/lib/python3.12/site-packages/pytest_asyncio/plugin.py:783: DeprecationWarning: The event_loop fixture provided by pytest-asyncio has been redefined in
  /home/runner/runner7/_work/***-sdk/***-sdk/pkgs/***/tests/unit/llms/CohereModel_unit_test.py:20
  Replacing the event_loop fixture with a custom implementation is deprecated
  and will lead to errors in the future.
  If you want to request an asyncio event loop with a scope other than function
  scope, use the "scope" argument to the asyncio mark when marking the tests.
  If you want to return different types of event loops, use the event_loop_policy
  fixture.
```