### PR TITLE
Fix: Max size comparison with count in MaxSystemContextConversation

### DIFF
--- a/pkgs/swarmauri/swarmauri/conversations/concrete/MaxSystemContextConversation.py
+++ b/pkgs/swarmauri/swarmauri/conversations/concrete/MaxSystemContextConversation.py
@@ -43,7 +43,7 @@ class MaxSystemContextConversation(IMaxSize, ConversationSystemContextMixin, Con
         alternating = True
         count = 0 
         for message in self._history[user_start_index:]:
-            if count >= self.max_size: # max size
+            if count > self.max_size: # max size
                 break
             if alternating and isinstance(message, HumanMessage) or not alternating and isinstance(message, AgentMessage):
                 res.append(message)

--- a/pkgs/swarmauri/tests/unit/conversations/MaxSystemContextConversation_unit_test.py
+++ b/pkgs/swarmauri/tests/unit/conversations/MaxSystemContextConversation_unit_test.py
@@ -41,7 +41,7 @@ def test_enforce_max_size_limit():
     conversation.add_message(AgentMessage(content="agent2"))
     conversation.add_message(HumanMessage(content="human3"))
 
-    assert len(conversation.history) == 3
+    assert len(conversation.history) == 4
     assert conversation.history[0].content == "systest"
     assert conversation.history[1].content == "human2"
     assert conversation.history[2].content == "agent2"


### PR DESCRIPTION
### Description:

The history property of MaxSystemContextConversation incorrectly compares the max_size with the number of messages in res. This usually results in res being: [SystemContext, Human Message, Agent Message, Human Message, Agent Message] i.e ending with Agent Message instead of Human Message resulting in unexpected behaviour.

Steps to replicate issue:
1. Create a RagAgent with MaxSystemContextConversation and max_size set to 4
2. Call exec method for 3 user queries, starting from 3rd query the behaviour will be unexpected.

### Screenshot of unexpected behaviour:
<img width="472" alt="Screenshot 2024-12-27 at 3 29 58 AM" src="https://github.com/user-attachments/assets/0066093d-7782-4c0a-bb53-b25e4623c09e" />

### Screenshot of expected behaviour:
<img width="629" alt="Screenshot 2024-12-27 at 3 32 41 AM" src="https://github.com/user-attachments/assets/bd5366ce-62a9-4fd4-bb66-82dad226ee68" />
