### PR TITLE
Fix: TextBlobNounParser not working in jupyter notebooks

### DIFF
--- a/pkgs/swarmauri/swarmauri/parsers/concrete/TextBlobNounParser.py
+++ b/pkgs/swarmauri/swarmauri/parsers/concrete/TextBlobNounParser.py
@@ -23,6 +23,7 @@ class TextBlobNounParser(ParserBase):
             nltk.download("averaged_perceptron_tagger")
             nltk.download("brown")
             nltk.download("wordnet")
+            nltk.download('punkt_tab')
             super().__init__(**kwargs)
         except Exception as e:
             raise RuntimeError(f"Failed to initialize NLTK resources: {str(e)}")


### PR DESCRIPTION
### Fixes issue: #59 

### Description

TextBlobNounParser cannot be used in jupyter notebooks due to punkt_tab not found.

### Expected behaviour after making changes:
`document = parser.parse("The quick brown fox jumps over the lazy dog.")`
`document`
`[Document(name=None, id='93ed43c5-8b15-45e4-8abe-70f9f58c6d1c', members=[], owner=None, host=None, resource='Document', version='0.1.0', type='Document', content='The quick brown fox jumps over the lazy dog.', metadata={'noun_phrases': ['quick brown fox jumps', 'lazy dog']}, embedding=None)]`

### Unexpected behaviour before changes:

```documents = parser.parse('One more large chapula please.')

ERROR: ---------------------------------------------------------------------------
LookupError                               Traceback (most recent call last)
/usr/local/lib/python3.10/dist-packages/swarmauri/parsers/concrete/TextBlobNounParser.py in parse(self, data)
     49             # Extracts noun phrases to demonstrate one of TextBlob's capabilities.
---> 50             noun_phrases = list(blob.noun_phrases)
     51 

11 frames
LookupError: 
**********************************************************************
  Resource punkt_tab not found.
  Please use the NLTK Downloader to obtain the resource:

  >>> import nltk
  >>> nltk.download('punkt_tab')
  
  For more information see: https://www.nltk.org/data.html

  Attempted to load tokenizers/punkt_tab/english/

  Searched in:
    - '/root/nltk_data'
    - '/usr/nltk_data'
    - '/usr/share/nltk_data'
    - '/usr/lib/nltk_data'
    - '/usr/share/nltk_data'
    - '/usr/local/share/nltk_data'
    - '/usr/lib/nltk_data'
    - '/usr/local/lib/nltk_data'
**********************************************************************


During handling of the above exception, another exception occurred:

RuntimeError                              Traceback (most recent call last)
/usr/local/lib/python3.10/dist-packages/swarmauri/parsers/concrete/TextBlobNounParser.py in parse(self, data)
     55             return [document]
     56         except Exception as e:
---> 57             raise RuntimeError(f"Error during text parsing: {str(e)}")

RuntimeError: Error during text parsing: 
**********************************************************************
  Resource punkt_tab not found.
  Please use the NLTK Downloader to obtain the resource:

  >>> import nltk
  >>> nltk.download('punkt_tab')
  
  For more information see: https://www.nltk.org/data.html

  Attempted to load tokenizers/punkt_tab/english/

  Searched in:
    - '/root/nltk_data'
    - '/usr/nltk_data'
    - '/usr/share/nltk_data'
    - '/usr/lib/nltk_data'
    - '/usr/share/nltk_data'
    - '/usr/local/share/nltk_data'
    - '/usr/lib/nltk_data'
    - '/usr/local/lib/nltk_data'
**********************************************************************```

