### PR TITLE
update model names in Cohere and Groq models

### DIFF
--- a/list_models.py
+++ b/list_models.py
@@ -1,0 +1,17 @@
+import requests
+import os
+import json
+
+api_key = os.environ.get("GROQ_API_KEY")
+url = "https://api.groq.com/openai/v1/models"
+
+headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+
+response = requests.get(url, headers=headers)
+
+for model in response.json().get("data"):
+    print(model.get("id"))
+
+# writing the response to a file of the key "id"
+with open("response.json", "w") as file:
+    json.dump(response.json(), file, indent=4)

--- a/pkgs/standards/swarmauri_standard/swarmauri_standard/llms/CohereModel.py
+++ b/pkgs/standards/swarmauri_standard/swarmauri_standard/llms/CohereModel.py
@@ -1,7 +1,7 @@
 import json
 import asyncio
 import httpx
-from typing import List, Dict, Literal, AsyncIterator, Iterator, Type
+from typing import List, Dict, Literal, AsyncIterator, Iterator
 from pydantic import PrivateAttr
 
 from swarmauri_standard.utils.retry_decorator import retry_on_status_codes
@@ -11,7 +11,8 @@ from swarmauri_base.messages.MessageBase import MessageBase
 from swarmauri_base.llms.LLMBase import LLMBase
 from swarmauri_core.ComponentBase import ComponentBase
 
-@ComponentBase.register_type(LLMBase, 'CohereModel')
+
+@ComponentBase.register_type(LLMBase, "CohereModel")
 class CohereModel(LLMBase):
     """
     This class provides both synchronous and asynchronous methods for interacting with
@@ -33,11 +34,19 @@ class CohereModel(LLMBase):
     api_key: str
     allowed_models: List[str] = [
         "command",
-        "command-r-plus-08-2024",
-        "command-r-plus-04-2024",
-        "command-r-03-2024",
+        "command-r",
+        "command-r-plus",
         "command-r-08-2024",
+        "command-r-plus-08-2024",
+        "command-r7b-12-2024",
         "command-light",
+        "command-nightly",
+        "command-light-nightly",
+        "c4ai-aya-expanse-8b",
+        "c4ai-aya-expanse-32b",
+
+        # "command-r-plus-04-2024", # Deprecated
+        # "command-r-03-2024", # Deprecated
     ]
     name: str = "command"
     type: Literal["CohereModel"] = "CohereModel"

--- a/pkgs/standards/swarmauri_standard/swarmauri_standard/llms/GroqModel.py
+++ b/pkgs/standards/swarmauri_standard/swarmauri_standard/llms/GroqModel.py
@@ -29,23 +29,26 @@ class GroqModel(LLMBase):
 
     api_key: str
     allowed_models: List[str] = [
-        "gemma-7b-it",
+        # "gemma-7b-it", # deprecated
         "gemma2-9b-it",
         "llama-3.1-70b-versatile",
         "llama-3.1-8b-instant",
         "llama-3.2-11b-text-preview",
         "llama-3.2-1b-preview",
         "llama-3.2-3b-preview",
-        "llama-3.2-90b-text-preview",
+        # "llama-3.2-90b-text-preview", # deprecated
         "llama-guard-3-8b",
         "llama3-70b-8192",
         "llama3-8b-8192",
-        "llama3-groq-70b-8192-tool-use-preview",
-        "llama3-groq-8b-8192-tool-use-preview",
-        "llava-v1.5-7b-4096-preview",
+        # "llama3-groq-70b-8192-tool-use-preview", # deprecated
+        # "llama3-groq-8b-8192-tool-use-preview", # deprecated
+        # "llava-v1.5-7b-4096-preview", # deprecated
         "mixtral-8x7b-32768",
+        "llama-3.3-70b-versatile",
+        "llama-3.3-70b-specdec",
+        "llama-3.2-11b-vision-preview"
     ]
-    name: str = "gemma-7b-it"
+    name: str = "gemma2-9b-it"
     type: Literal["GroqModel"] = "GroqModel"
     _client: httpx.Client = PrivateAttr(default=None)
     _async_client: httpx.AsyncClient = PrivateAttr(default=None)

--- a/pkgs/standards/swarmauri_standard/swarmauri_standard/llms/GroqToolModel.py
+++ b/pkgs/standards/swarmauri_standard/swarmauri_standard/llms/GroqToolModel.py
@@ -8,7 +8,7 @@ from pydantic import PrivateAttr
 from swarmauri_standard.conversations.Conversation import Conversation
 from swarmauri_standard.utils.retry_decorator import retry_on_status_codes
 from swarmauri_standard.messages.AgentMessage import AgentMessage, UsageData
-from swarmauri_standard.schema_converters.concrete.GroqSchemaConverter import (
+from swarmauri_standard.schema_converters.GroqSchemaConverter import (
     GroqSchemaConverter,
 )
 from swarmauri_base.messages.MessageBase import MessageBase
@@ -37,16 +37,18 @@ class GroqToolModel(LLMBase):
     allowed_models: List[str] = [
         "llama3-8b-8192",
         "llama3-70b-8192",
-        "llama3-groq-70b-8192-tool-use-preview",
-        "llama3-groq-8b-8192-tool-use-preview",
+        # "llama3-groq-70b-8192-tool-use-preview", # deprecated
+        # "llama3-groq-8b-8192-tool-use-preview", # deprecated
         "llama-3.1-70b-versatile",
         "llama-3.1-8b-instant",
+        "llama-3.3-70b-versatile",
+
         # parallel tool use not supported
         # "mixtral-8x7b-32768",
         # "gemma-7b-it",
         # "gemma2-9b-it",
     ]
-    name: str = "llama3-groq-70b-8192-tool-use-preview"
+    name: str = "llama-3.3-70b-versatile"
     type: Literal["GroqToolModel"] = "GroqToolModel"
     _client: httpx.Client = PrivateAttr(default=None)
     _async_client: httpx.AsyncClient = PrivateAttr(default=None)

--- a/pkgs/standards/swarmauri_standard/swarmauri_standard/llms/MistralModel.py
+++ b/pkgs/standards/swarmauri_standard/swarmauri_standard/llms/MistralModel.py
@@ -39,6 +39,37 @@ class MistralModel(LLMBase):
         "open-mistral-nemo",
         "codestral-latest",
         "open-codestral-mamba",
+
+        "ministral-3b-latest",
+        "ministral-8b-latest",
+        "ministral-8b-2410",
+        "mistral-tiny",
+        "mistral-tiny-2312",
+        "mistral-tiny-2407",
+        "mistral-tiny-latest",
+        "open-mistral-nemo-2407"
+        "mistral-small",
+        "mistral-small-2312",
+        "open-mixtral-8x22b-2404",
+        "mistral-small-2402",
+        "mistral-small-2409",
+        "mistral-medium-2312",
+        "mistral-medium",
+        "mistral-large-2402",
+        "pixtral-12b-latest",
+        "pixtral-12b-2409",
+        "pixtral-12b",
+        "codestral-mamba-latest",
+        "codestral-mamba-2407",
+        "open-codestral-mamba",
+        "codestral-2412",
+        "codestral-2501",
+        "codestral-2411-rc5",
+        "codestral-2405",
+        "pixtral-large-latest",
+        "pixtral-large-2411",
+        "mistral-large-2411",
+        "mistral-large-2407"
     ]
     name: str = "open-mixtral-8x7b"
     type: Literal["MistralModel"] = "MistralModel"

--- a/pkgs/standards/swarmauri_standard/tests/unit/llms/GroqModel_unit_test.py
+++ b/pkgs/standards/swarmauri_standard/tests/unit/llms/GroqModel_unit_test.py
@@ -86,7 +86,7 @@ def test_serialization(groq_model):
 @timeout(5)
 @pytest.mark.unit
 def test_default_name(groq_model):
-    assert groq_model.name == "gemma-7b-it"
+    assert groq_model.name == "gemma2-9b-it"
 
 
 @timeout(5)

--- a/pkgs/standards/swarmauri_standard/tests/unit/llms/GroqToolModel_unit_test.py
+++ b/pkgs/standards/swarmauri_standard/tests/unit/llms/GroqToolModel_unit_test.py
@@ -82,7 +82,7 @@ def test_serialization(groq_tool_model):
 @timeout(5)
 @pytest.mark.unit
 def test_default_name(groq_tool_model):
-    assert groq_tool_model.name == "llama3-groq-70b-8192-tool-use-preview"
+    assert groq_tool_model.name == "llama-3.3-70b-versatile"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Introduce a new feature to list models from the Groq API and update model names in the Cohere and Groq classes, including deprecating outdated model names.