### PR TITLE
Add storage adapter docs

### DIFF
--- a/pkgs/standards/peagen/README.md
+++ b/pkgs/standards/peagen/README.md
@@ -325,6 +325,10 @@ projects = pea.load_projects()
 result, idx = pea.process_single_project(projects[0], start_idx=0)
 ```
 
+### Storage Adapters & Publishers
+
+Peagen's artifact output and event publishing are pluggable. Use the `storage_adapter` argument to control where files are saved and optionally provide a publisher for notifications. Built-in options include `FileStorageAdapter`, `MinioStorageAdapter`, and `RedisPublisher`. See [docs/storage_adapters_and_publishers.md](docs/storage_adapters_and_publishers.md) for details.
+
 ### Contributing & Extending Templates
 
 * **Template Conventions:** Place new Jinja2 files under your `TEMPLATE_BASE_DIR` as `*.j2`, using the same context variables (`projects`, `packages`, `modules`) that core templates rely on.

--- a/pkgs/standards/peagen/docs/storage_adapters_and_publishers.md
+++ b/pkgs/standards/peagen/docs/storage_adapters_and_publishers.md
@@ -1,0 +1,37 @@
+# Storage Adapters and Publisher Plugins
+
+Peagen writes artifacts to a pluggable storage backend and can publish events during processing. Both systems are extensible so you can integrate your own infrastructure.
+
+## Storage Adapters
+
+`Peagen` accepts a `storage_adapter` implementing simple `upload()` and `download()` methods. Two adapters ship with the SDK:
+
+- `FileStorageAdapter` – stores artifacts on the local filesystem.
+- `MinioStorageAdapter` – targets S3 compatible object stores.
+
+To use a different solution, subclass one of these classes or implement the same two-method API and pass the instance when creating `Peagen`:
+
+```python
+from peagen.core import Peagen
+from peagen.storage_adapters.file_storage_adapter import FileStorageAdapter
+
+pea = Peagen(
+    projects_payload_path="projects.yaml",
+    storage_adapter=FileStorageAdapter("./artifacts"),
+)
+```
+
+Any class providing `upload()` and `download()` can serve as the adapter, enabling integrations with cloud services or databases.
+
+## Publisher Plugins
+
+The CLI can emit JSON events such as `process.started` and `process.done`. The repository includes a `RedisPublisher` that sends messages via Redis Pub/Sub:
+
+```python
+from peagen.publishers.redis_publisher import RedisPublisher
+
+bus = RedisPublisher("redis://localhost:6379/0")
+bus.publish("peagen.events", {"type": "process.started"})
+```
+
+To support another message bus, implement the same `publish()` method and use your class when wiring Peagen. See the `.peagen.toml` scaffold for configuration hints.


### PR DESCRIPTION
## Summary
- describe custom storage adapters and publisher plugins
- mention pluggable storage and publisher in README

## Testing
- `pytest pkgs/standards/peagen/tests/unit/test_graph.py -q` *(fails: command not found)*