### PR TITLE
Fix MinkowskiDistance docstring

### DIFF
--- a/pkgs/standards/swarmauri_distance_minkowski/swarmauri_distance_minkowski/MinkowskiDistance.py
+++ b/pkgs/standards/swarmauri_distance_minkowski/swarmauri_distance_minkowski/MinkowskiDistance.py
@@ -16,7 +16,7 @@ class MinkowskiDistance(DistanceBase):
 
     Parameters:
     - p (int): The order of the Minkowski distance. p=2 corresponds to the Euclidean distance,
-               while p=1 corresponds to the Manhattan distance. Default is
+               while p=1 corresponds to the Manhattan distance. Default is 2.
     """
 
     type: Literal["MinkowskiDistance"] = "MinkowskiDistance"


### PR DESCRIPTION
## Summary
- clarify default p parameter docstring for `MinkowskiDistance`

## Testing
- `pytest` *(fails: command not found)*