### PR TITLE
Add plugin mode CLI option

### DIFF
--- a/pkgs/standards/peagen/peagen/cli_common.py
+++ b/pkgs/standards/peagen/peagen/cli_common.py
@@ -95,6 +95,7 @@ def common_peagen_options(fn: Callable[..., Any]) -> Callable[..., Any]:
         template_set: Optional[str]
         additional_package_dirs: Optional[str]
         notify: Optional[str]
+        plugin_mode: Optional[str]
 
     Example:
 
@@ -124,7 +125,9 @@ def common_peagen_options(fn: Callable[..., Any]) -> Callable[..., Any]:
         ctx: typer.Context = click.get_current_context()
         # before first CLI option is copied:
         if ctx.obj is None:
-            ctx.obj = types.SimpleNamespace(**load_peagen_toml())
+            cfg = load_peagen_toml()
+            ctx.obj = types.SimpleNamespace(**cfg)
+            ctx.obj.plugin_mode = cfg.get("plugins", {}).get("mode")
 
         # print(ctx.obj)
         # copy recognised kwargs into ctx.obj
@@ -140,6 +143,7 @@ def common_peagen_options(fn: Callable[..., Any]) -> Callable[..., Any]:
             "template_set",
             "additional_package_dirs",
             "notify",
+            "plugin_mode",
         ):
             if key in kwargs:
                 setattr(ctx.obj, key, kwargs[key])

--- a/pkgs/standards/peagen/peagen/commands/process.py
+++ b/pkgs/standards/peagen/peagen/commands/process.py
@@ -83,6 +83,9 @@ def process_cmd(
     insecure: bool = typer.Option(
         False, "--insecure", help="When using s3://, disable TLS."
     ),
+    plugin_mode: Optional[str] = typer.Option(
+        None, "--plugin-mode", help="Plugin mode to use."
+    ),
 ):
     """
     File: **process.py**
@@ -93,6 +96,10 @@ def process_cmd(
     projects/<project>/runs/<run-id>/, honours publishers.adapters layout.
     """
     toml_cfg = load_peagen_toml()
+    plugins_cfg = toml_cfg.get("plugins", {})
+    plugin_mode = plugin_mode if plugin_mode is not None else plugins_cfg.get("mode")
+    ctx.obj.plugin_mode = plugin_mode
+    _config["plugin_mode"] = plugin_mode
 
     # ── GENERAL & LLM ────────────────────────────────────────────────────
     workspace_cfg = toml_cfg.get("workspace", {})

--- a/pkgs/standards/peagen/peagen/commands/revise.py
+++ b/pkgs/standards/peagen/peagen/commands/revise.py
@@ -13,6 +13,7 @@ from typing import Optional
 
 import typer
 from pydantic import FilePath
+from peagen.cli_common import load_peagen_toml
 
 # ── absolute-import everything ────────────────────────────────────────────────
 from peagen._api_key import _resolve_api_key
@@ -91,6 +92,9 @@ def revise(
         None,
         help="Path to a custom agent prompt template file to be used in the agent environment.",
     ),
+    plugin_mode: Optional[str] = typer.Option(
+        None, "--plugin-mode", help="Plugin mode to use."
+    ),
 ):
     """
     Revise a single project specified by its PROJECT_NAME in the YAML payload.
@@ -158,6 +162,9 @@ def revise(
     _config["truncate"] = trunc
     _config["revise"] = True
     _config["transitive"] = transitive
+    toml_cfg = load_peagen_toml()
+    plugin_mode = plugin_mode if plugin_mode is not None else toml_cfg.get("plugins", {}).get("mode")
+    _config["plugin_mode"] = plugin_mode
 
     # Resolve the appropriate API key
     resolved_key = _resolve_api_key(provider, api_key, env)

--- a/pkgs/standards/peagen/peagen/commands/sort.py
+++ b/pkgs/standards/peagen/peagen/commands/sort.py
@@ -10,6 +10,9 @@ Usage (wired in peagen/cli.py):
 import typer
 from pprint import pformat
 from pydantic import FilePath
+from typing import Optional
+
+from peagen.cli_common import load_peagen_toml
 
 # ── absolute-import everything ────────────────────────────────────────────────
 from peagen.core import Peagen, Fore, Style
@@ -77,6 +80,9 @@ def sort(
         "--show-deps/--no-show-deps",
         help="If set, will show the direct dependenices of each file in the sort (one hop).",
     ),
+    plugin_mode: Optional[str] = typer.Option(
+        None, "--plugin-mode", help="Plugin mode to use."
+    ),
 ):
     """
     Sort and show the list of files that would be processed for a project (Dry run).
@@ -92,6 +98,9 @@ def sort(
         raise typer.Exit(code=1)
 
     _config["transitive"] = transitive
+    toml_cfg = load_peagen_toml()
+    plugin_mode = plugin_mode if plugin_mode is not None else toml_cfg.get("plugins", {}).get("mode")
+    _config["plugin_mode"] = plugin_mode
 
     # Convert additional_package_dirs from comma-delimited string to list[FilePath]
     additional_dirs_list = (


### PR DESCRIPTION
## Summary
- allow plugin mode flag in common CLI options
- store plugin mode from `.peagen.toml` or command line
- add `--plugin-mode` to `process`, `sort` and `revise` commands

## Testing
- `python scripts/run_all_tests.py` *(fails: No route to host)*