### PR TITLE
Add plugins schema

### DIFF
--- a/pkgs/standards/peagen/peagen/schemas/peagen.toml.schema.v1.json
+++ b/pkgs/standards/peagen/peagen/schemas/peagen.toml.schema.v1.json
@@ -71,6 +71,25 @@
       },
       "required": [ "default_publisher", "adapters" ],
       "additionalProperties": false
+    },
+
+    "plugins": {
+      "type": "object",
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["fallback", "switch", "fan-out"]
+        },
+        "switch": {
+          "type": "object",
+          "patternProperties": {
+            "^[A-Za-z0-9_\\-]+$": { "type": "string" }
+          },
+          "additionalProperties": false
+        }
+      },
+      "required": ["mode"],
+      "additionalProperties": false
     }
   },
 

--- a/pkgs/standards/peagen/tests/examples/peagen_tomls/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/peagen_tomls/.peagen.toml
@@ -37,3 +37,11 @@ host     = "localhost"
 port     = 6379
 db       = 0
 password = "..."                   # leave blank if no auth
+
+# ─────────────────────────────── Plugins ───────────────────────────────
+[plugins]
+mode = "switch"
+
+[plugins.switch]
+agents = "default_agent_plugin"
+tools  = "default_tool_plugin"

--- a/pkgs/standards/peagen/tests/examples/peagen_tomls/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/peagen_tomls/.peagen.toml
@@ -41,7 +41,3 @@ password = "..."                   # leave blank if no auth
 # ─────────────────────────────── Plugins ───────────────────────────────
 [plugins]
 mode = "switch"
-
-[plugins.switch]
-agents = "default_agent_plugin"
-tools  = "default_tool_plugin"


### PR DESCRIPTION
## Summary
- extend peagen config schema with `plugins` section and required `mode`
- include optional `[plugins.switch]` mapping in example TOML

## Testing
- `pytest -q` *(fails: command not found)*