### PR TITLE
Implement plugin loading modes for peagen

### DIFF
--- a/pkgs/standards/peagen/peagen/__init__.py
+++ b/pkgs/standards/peagen/peagen/__init__.py
@@ -1,0 +1,29 @@
+"""Initialize the Peagen package and register plugins."""
+
+import sys as _sys
+from .plugin_registry import discover_and_register_plugins
+
+
+def _determine_plugin_mode() -> str:
+    """Resolve plugin loading mode from CLI flags or ``.peagen.toml``."""
+    args = _sys.argv[1:]
+    for i, arg in enumerate(args):
+        if arg.startswith("--plugin-mode="):
+            return arg.split("=", 1)[1]
+        if arg in {"--plugin-mode", "--plugin_mode"} and i + 1 < len(args):
+            return args[i + 1]
+
+    try:
+        from peagen.cli_common import load_peagen_toml
+
+        cfg = load_peagen_toml()
+        mode = cfg.get("peagen", {}).get("plugin_mode")
+        if mode:
+            return mode
+    except Exception:
+        pass
+
+    return "fan-out"
+
+
+discover_and_register_plugins(mode=_determine_plugin_mode())

--- a/pkgs/standards/peagen/peagen/plugin_registry.py
+++ b/pkgs/standards/peagen/peagen/plugin_registry.py
@@ -1,36 +1,16 @@
 # peagen/plugin_registry.py
-"""
-peagen.plugin_registry
-
-Maintain the plugin registry loaded from distribution entry points.
-
-``registry`` maps plugin groups to dictionaries of ``{name: object}``.
-For example::
-
-    registry = {
-        "template_sets":    {"init-ci": <module>, ...},
-        "storage_adapters": {"file": <class FileStorageAdapter>, ...},
-        ...
-    }
-
-``_load()`` discovers entry points for each group defined in ``GROUPS``,
-validates them and populates this mapping at import time. Supported plugin
-groups are: ``template_sets``, ``storage_adapters``, ``publishers``,
-``indexers``, ``result_backends`` and ``evaluators``.
-"""
+"""Plugin registry for the Peagen microkernel."""
 
 from importlib.metadata import entry_points
 from collections import defaultdict
-from typing import Dict
 from types import ModuleType
+from typing import Dict
 
 # ---------------------------------------------------------------------------
 # Config – group key → (entry-point group string, expected base class)
-# We’ll special-case "template_sets" so it can resolve to ModuleType or class,
-# and treat every other group as before (must resolve to a class).
 # ---------------------------------------------------------------------------
 GROUPS = {
-    "template_sets": ("peagen.template_sets", None),  # None = allow modules or classes
+    "template_sets": ("peagen.template_sets", None),
     "storage_adapters": ("peagen.storage_adapters", object),
     "publishers": ("peagen.publishers", object),
     "indexers": ("peagen.indexers", object),
@@ -41,29 +21,53 @@ GROUPS = {
 registry: Dict[str, Dict[str, object]] = defaultdict(dict)
 
 
-def _load() -> None:
+def discover_and_register_plugins(
+    mode: str = "fan-out", switch_map: dict[str, str] | None = None
+) -> None:
+    """Discover entry-point plugins and register them.
+
+    Parameters
+    ----------
+    mode:
+        ``"fan-out"`` loads every discovered plugin. ``"fallback"`` prefers
+        built-ins when names clash. ``"switch"`` only loads the plugin named in
+        ``switch_map`` for each group, falling back to built-ins.
+    switch_map:
+        Optional mapping of ``group_key`` → ``plugin_name`` for ``"switch"`` mode.
     """
-    Discover every plugin exactly once at import time.
-    Populates the `registry` mapping:
-      registry = {
-        "template_sets":    {"init-ci": <module '...'>, ...},
-        "storage_adapters": {"file": <class FileStorageAdapter>, ...},
-        ...
-      }
-    """
+
+    switch_map = switch_map or {}
+
     for group_key, (ep_group, base_cls) in GROUPS.items():
-        for ep in entry_points(group=ep_group):
+        eps = list(entry_points(group=ep_group))
+        builtins = [ep for ep in eps if ep.module.startswith("peagen.")]
+        others = [ep for ep in eps if not ep.module.startswith("peagen.")]
+
+        if mode == "switch":
+            chosen = builtins[:]
+            target = switch_map.get(group_key)
+            if target:
+                chosen.extend(ep for ep in others if ep.name == target)
+            eps_to_process = chosen
+        else:
+            eps_to_process = builtins + others
+
+        for ep in eps_to_process:
+            if ep.name in registry[group_key]:
+                if mode == "fallback":
+                    continue
+                raise RuntimeError(
+                    f"Duplicate plugin name '{ep.name}' detected in group '{group_key}'."
+                )
+
             obj = ep.load()
 
-            # ─── template_sets: allow modules or classes ──────────────────────
             if group_key == "template_sets":
                 if not (isinstance(obj, ModuleType) or isinstance(obj, type)):
                     raise TypeError(
                         f"Entry-point '{ep.name}' in group '{ep_group}' "
                         f"resolved to {type(obj).__name__}; expected a module or class."
                     )
-
-            # ─── other groups: must be a class and subclass of base_cls ────────
             else:
                 if not isinstance(obj, type):
                     raise TypeError(
@@ -72,19 +76,10 @@ def _load() -> None:
                     )
                 if not issubclass(obj, base_cls):
                     raise TypeError(
-                        f"Entry-point '{ep.name}' in group '{ep_group}' "
-                        f"must subclass {base_cls.__name__}."
+                        f"Entry-point '{ep.name}' in group '{ep_group}' must subclass {base_cls.__name__}."
                     )
-
-            # ─── no duplicate names on the same group ─────────────────────────
-            if ep.name in registry[group_key]:
-                raise RuntimeError(
-                    f"Duplicate plugin name '{ep.name}' detected in group "
-                    f"'{group_key}'."
-                )
 
             registry[group_key][ep.name] = obj
 
 
-# run discovery immediately on import
-_load()
+discover_and_register_plugins()


### PR DESCRIPTION
## Summary
- revert previous plugin mode changes to `swarmauri`
- add `discover_and_register_plugins` with mode handling to `peagen.plugin_registry`
- initialize plugin mode from CLI or `.peagen.toml` in new `peagen.__init__`

## Testing
- `ruff format pkgs/standards/peagen/peagen/plugin_registry.py pkgs/standards/peagen/peagen/__init__.py pkgs/swarmauri/swarmauri/plugin_manager.py pkgs/swarmauri/swarmauri/__init__.py`
- `ruff check pkgs/standards/peagen/peagen/plugin_registry.py pkgs/standards/peagen/peagen/__init__.py pkgs/swarmauri/swarmauri/plugin_manager.py pkgs/swarmauri/swarmauri/__init__.py`
- `pytest pkgs/base/tests/unit -q` *(fails: command not found)*