### PR TITLE
Fix alt text in docs index

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,6 +1,6 @@
 # Welcome to Swarmauri
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri/">


### PR DESCRIPTION
## Summary
- fix a typo in the docs index image alt text

## Testing
- `python scripts/run_all_tests.py` *(fails: No route to host)*