### PR TITLE
Fix ParserBase docstring

### DIFF
--- a/pkgs/base/swarmauri_base/parsers/ParserBase.py
+++ b/pkgs/base/swarmauri_base/parsers/ParserBase.py
@@ -9,11 +9,11 @@ from swarmauri_core.parsers.IParser import IParser
 @ComponentBase.register_model()
 class ParserBase(IParser, ComponentBase):
     """
-    Interface for chunking text into smaller pieces.
+    Parse input data into ``Document`` objects.
 
-    This interface defines abstract methods for chunking texts. Implementing classes
-    should provide concrete implementations for these methods tailored to their specific
-    chunking algorithms.
+    This interface defines abstract methods that convert raw input into
+    ``Document`` instances. Implementing classes should override these
+    methods with parsing logic suited to their specific needs.
     """
 
     resource: Optional[str] = Field(default=ResourceTypes.PARSER.value)


### PR DESCRIPTION
## Summary
- clarify ParserBase class docstring that it parses data into Document objects

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*