### PR TITLE
Add slug utilities and mapping

### DIFF
--- a/pkgs/standards/peagen/peagen/commands/process.py
+++ b/pkgs/standards/peagen/peagen/commands/process.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-import re
+from peagen.slug_utils import slugify
 import secrets
 import time
 from datetime import datetime, timezone
@@ -169,7 +169,7 @@ def process_cmd(
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     run_id = f"{timestamp}-{secrets.token_hex(4)}"
 
-    project_slug = re.sub(r"[^0-9A-Za-z_-]+", "-", (project_name or "multi")).lower()
+    project_slug = slugify(project_name or "multi")
     proj_prefix = f"projects/{project_slug}/runs/{run_id}/"  # ← canonical
 
     # ── BUILD STORAGE ADAPTER (prefix-aware) ────────────────────────────

--- a/pkgs/standards/peagen/peagen/slug_utils.py
+++ b/pkgs/standards/peagen/peagen/slug_utils.py
@@ -1,0 +1,9 @@
+"""Utilities for generating project slugs."""
+
+import re
+
+
+def slugify(name: str) -> str:
+    """Return a filesystem-friendly slug version of *name*."""
+    slug = re.sub(r"[^0-9A-Za-z_-]+", "-", name).strip("-")
+    return slug.lower()


### PR DESCRIPTION
## Summary
- add `slug_utils.slugify`
- use `slugify` in process command and core module
- track project slug mapping in `Peagen`

## Testing
- `pytest -q` *(fails: command not found)*