### PR TITLE
Document template set extras keys

### DIFF
--- a/pkgs/standards/peagen/docs/specification/PTGEN_SPECIFICATION_0.0.4.md
+++ b/pkgs/standards/peagen/docs/specification/PTGEN_SPECIFICATION_0.0.4.md
@@ -71,8 +71,9 @@ This specification addresses:
    4.1 [PROJECTS_PAYLOAD.YAML](#41-projects_payloadyaml)  
    4.2 [PTREE.YAML.J2](#42-ptreeyamlj2)  
    4.3 [AGENT_DEFAULT.J2](#43-agent_defaultj2)  
-   4.4 [FILE TEMPLATES](#44-file-templates)  
-   4.5 [Context Production and Consumption Summary](#45-context-production-and-consumption-summary)  
+   4.4 [FILE TEMPLATES](#44-file-templates)
+   4.5 [Template Set Extras Reference](#45-template-set-extras-reference)
+   4.6 [Context Production and Consumption Summary](#46-context-production-and-consumption-summary)
 5. [Conceptual Generation Mechanics](#5-conceptual-generation-mechanics)  
    5.1 [Process Flow](#51-process-flow)  
    5.2 [Rationale for a Conceptual Approach](#52-rationale-for-a-conceptual-approach)  
@@ -201,7 +202,16 @@ This template serves as the default for generating file content. It merges the r
 
 ---
 
-### 4.5. Context Production and Consumption Summary
+### 4.5. Template Set Extras Reference
+
+Each template set can interpret custom keys within the `EXTRAS` container. A small
+`EXTRAS.md` file resides in every template set directory under
+`peagen/templates/<TEMPLATE_SET>/`. These documents list the extra keys that are
+understood by that template set.
+
+---
+
+### 4.6. Context Production and Consumption Summary
 
 - **PROJECTS_PAYLOAD.YAML**  
   – Produces the PROJECT, PKG, and MOD contexts. Only the minimal keys (NAME, ROOT, TEMPLATE_SET for projects; NAME and MODULES for packages; NAME for modules) are defined at the top level. All additional metadata is nested under EXTRAS.

--- a/pkgs/standards/peagen/peagen/templates/component/EXTRAS.md
+++ b/pkgs/standards/peagen/peagen/templates/component/EXTRAS.md
@@ -1,0 +1,3 @@
+# Extras Keys for component
+
+This template set does not use an EXTRAS section.

--- a/pkgs/standards/peagen/peagen/templates/cpp_python_pkg/EXTRAS.md
+++ b/pkgs/standards/peagen/peagen/templates/cpp_python_pkg/EXTRAS.md
@@ -1,0 +1,9 @@
+# Extras Keys for cpp_python_pkg
+
+This template set recognizes the following EXTRAS keys:
+
+- AUTHORS
+- PURPOSE
+- DESCRIPTION
+- REQUIREMENTS
+- DEPENDENCIES

--- a/pkgs/standards/peagen/peagen/templates/no_requirements/EXTRAS.md
+++ b/pkgs/standards/peagen/peagen/templates/no_requirements/EXTRAS.md
@@ -1,0 +1,3 @@
+# Extras Keys for no_requirements
+
+This template set does not use an EXTRAS section.

--- a/pkgs/standards/peagen/peagen/templates/python_api_gw/EXTRAS.md
+++ b/pkgs/standards/peagen/peagen/templates/python_api_gw/EXTRAS.md
@@ -1,0 +1,9 @@
+# Extras Keys for python_api_gw
+
+This template set recognizes the following EXTRAS keys:
+
+- RESOURCE_KIND
+- PURPOSE
+- DESCRIPTION
+- REQUIREMENTS
+- DEPENDENCIES

--- a/pkgs/standards/peagen/peagen/templates/python_api_gw_service/EXTRAS.md
+++ b/pkgs/standards/peagen/peagen/templates/python_api_gw_service/EXTRAS.md
@@ -1,0 +1,9 @@
+# Extras Keys for python_api_gw_service
+
+This template set recognizes the following EXTRAS keys:
+
+- RESOURCE_KIND
+- PURPOSE
+- DESCRIPTION
+- REQUIREMENTS
+- DEPENDENCIES

--- a/pkgs/standards/peagen/peagen/templates/python_orm/EXTRAS.md
+++ b/pkgs/standards/peagen/peagen/templates/python_orm/EXTRAS.md
@@ -1,0 +1,12 @@
+# Extras Keys for python_orm
+
+This template set recognizes the following EXTRAS keys:
+
+- RESOURCE_KIND
+- PURPOSE
+- DESCRIPTION
+- REQUIREMENTS
+- HAS_CHILDREN
+- CHILD_NAME
+- FIELD_DEFINITIONS
+- DEPENDENCIES

--- a/pkgs/standards/peagen/peagen/templates/pythonpkg/EXTRAS.md
+++ b/pkgs/standards/peagen/peagen/templates/pythonpkg/EXTRAS.md
@@ -1,0 +1,16 @@
+# Extras Keys for pythonpkg
+
+This template set recognizes the following EXTRAS keys:
+
+- AUTHORS
+- PURPOSE
+- DESCRIPTION
+- REQUIREMENTS
+- DEPENDENCIES
+- BASE_FILE
+- EXTERNAL_DOC_FILES
+- MIXIN_FILES
+- BASE_CLASS
+- MIXINS
+- RESOURCE_KIND
+- EXAMPLES

--- a/pkgs/standards/peagen/peagen/templates/react_atom/EXTRAS.md
+++ b/pkgs/standards/peagen/peagen/templates/react_atom/EXTRAS.md
@@ -1,0 +1,10 @@
+# Extras Keys for react_atom
+
+This template set recognizes the following EXTRAS keys:
+
+- RESOURCE_KIND
+- PURPOSE
+- DESCRIPTION
+- REQUIREMENTS
+- STATES
+- DEPENDENCIES

--- a/pkgs/standards/peagen/peagen/templates/rust_python_pkg/EXTRAS.md
+++ b/pkgs/standards/peagen/peagen/templates/rust_python_pkg/EXTRAS.md
@@ -1,0 +1,9 @@
+# Extras Keys for rust_python_pkg
+
+This template set recognizes the following EXTRAS keys:
+
+- AUTHORS
+- PURPOSE
+- DESCRIPTION
+- REQUIREMENTS
+- DEPENDENCIES

--- a/pkgs/standards/peagen/peagen/templates/svelte_atom/EXTRAS.md
+++ b/pkgs/standards/peagen/peagen/templates/svelte_atom/EXTRAS.md
@@ -1,0 +1,10 @@
+# Extras Keys for svelte_atom
+
+This template set recognizes the following EXTRAS keys:
+
+- RESOURCE_KIND
+- PURPOSE
+- DESCRIPTION
+- REQUIREMENTS
+- STATES
+- DEPENDENCIES

--- a/pkgs/standards/peagen/peagen/templates/swarmauri_base/EXTRAS.md
+++ b/pkgs/standards/peagen/peagen/templates/swarmauri_base/EXTRAS.md
@@ -1,0 +1,14 @@
+# Extras Keys for swarmauri_base
+
+This template set recognizes the following EXTRAS keys:
+
+- RESOURCE_KIND
+- PURPOSE
+- DESCRIPTION
+- REQUIREMENTS
+- DEPENDENCIES
+- INTERFACE_FILE
+- EXTERNAL_DOC_FILES
+- MIXIN_FILES
+- INTERFACE_NAME
+- EXAMPLES

--- a/pkgs/standards/peagen/peagen/templates/swarmauri_core/EXTRAS.md
+++ b/pkgs/standards/peagen/peagen/templates/swarmauri_core/EXTRAS.md
@@ -1,0 +1,13 @@
+# Extras Keys for swarmauri_core
+
+This template set recognizes the following EXTRAS keys:
+
+- RESOURCE_KIND
+- PURPOSE
+- DESCRIPTION
+- REQUIREMENTS
+- DEPENDENCIES
+- BASE_FILE
+- EXTERNAL_DOC_FILES
+- MIXIN_FILES
+- EXAMPLES

--- a/pkgs/standards/peagen/peagen/templates/swarmauri_standard/EXTRAS.md
+++ b/pkgs/standards/peagen/peagen/templates/swarmauri_standard/EXTRAS.md
@@ -1,0 +1,15 @@
+# Extras Keys for swarmauri_standard
+
+This template set recognizes the following EXTRAS keys:
+
+- RESOURCE_KIND
+- PURPOSE
+- DESCRIPTION
+- REQUIREMENTS
+- DEPENDENCIES
+- BASE_FILE
+- EXTERNAL_DOC_FILES
+- MIXIN_FILES
+- BASE_CLASS
+- MIXINS
+- EXAMPLES

--- a/pkgs/standards/peagen/peagen/templates/swarmauri_standard_standalone/EXTRAS.md
+++ b/pkgs/standards/peagen/peagen/templates/swarmauri_standard_standalone/EXTRAS.md
@@ -1,0 +1,16 @@
+# Extras Keys for swarmauri_standard_standalone
+
+This template set recognizes the following EXTRAS keys:
+
+- RESOURCE_KIND
+- PURPOSE
+- DESCRIPTION
+- REQUIREMENTS
+- DEPENDENCIES
+- AUTHORS
+- BASE_FILE
+- EXTERNAL_DOC_FILES
+- MIXIN_FILES
+- BASE_CLASS
+- MIXINS
+- EXAMPLES

--- a/pkgs/standards/peagen/peagen/templates/test3/EXTRAS.md
+++ b/pkgs/standards/peagen/peagen/templates/test3/EXTRAS.md
@@ -1,0 +1,3 @@
+# Extras Keys for test3
+
+This template set does not use an EXTRAS section.

--- a/pkgs/standards/peagen/peagen/templates/test5/EXTRAS.md
+++ b/pkgs/standards/peagen/peagen/templates/test5/EXTRAS.md
@@ -1,0 +1,3 @@
+# Extras Keys for test5
+
+This template set does not use an EXTRAS section.

--- a/pkgs/standards/peagen/peagen/templates/vue_atom/EXTRAS.md
+++ b/pkgs/standards/peagen/peagen/templates/vue_atom/EXTRAS.md
@@ -1,0 +1,10 @@
+# Extras Keys for vue_atom
+
+This template set recognizes the following EXTRAS keys:
+
+- RESOURCE_KIND
+- PURPOSE
+- DESCRIPTION
+- REQUIREMENTS
+- STATES
+- DEPENDENCIES


### PR DESCRIPTION
## Summary
- add `EXTRAS.md` docs under each template directory
- mention these docs in PTGEN specification

## Testing
- `python scripts/run_all_tests.py` *(fails: No route to host)*