### PR TITLE
Print run-id in peagen process command

### DIFF
--- a/pkgs/standards/peagen/peagen/commands/process.py
+++ b/pkgs/standards/peagen/peagen/commands/process.py
@@ -168,6 +168,7 @@ def process_cmd(
     # ─────────────────────────────────────────────────────────────────────
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     run_id = f"{timestamp}-{secrets.token_hex(4)}"
+    typer.echo(f"run-id: {run_id}")
 
     project_slug = slugify(project_name or "multi")
     proj_prefix = f"projects/{project_slug}/runs/{run_id}/"  # ← canonical


### PR DESCRIPTION
## Summary
- print run-id when running `peagen process`

## Testing
- `pytest -q` *(fails: command not found)*