### PR TITLE
Update peagen .peagen.toml schema

### DIFF
--- a/pkgs/standards/peagen/README.md
+++ b/pkgs/standards/peagen/README.md
@@ -125,6 +125,8 @@ command defaults. A typical configuration might look like:
 
 ```toml
 # .peagen.toml
+schemaVersion = "1.0.3"
+
 [llm]
 default_provider = "openai"
 default_model_name = "gpt-4"
@@ -133,10 +135,19 @@ default_model_name = "gpt-4"
 openai = "sk-..."
 
 [storage]
-default_adapter = "file"
+default_storage_adapter = "file"
 
 [storage.adapters.file]
 output_dir = "./peagen_artifacts"
+
+[publishers]
+default_publisher = "redis"
+
+[publishers.adapters.redis]
+host = "localhost"
+port = 6379
+db = 0
+password = "..."
 ```
 
 With these values in place you can omit `--provider`, `--model-name`, and other

--- a/pkgs/standards/peagen/peagen/scaffold/project/.peagen.toml.j2
+++ b/pkgs/standards/peagen/peagen/scaffold/project/.peagen.toml.j2
@@ -1,4 +1,5 @@
 # .peagen.toml
+schemaVersion = "1.0.3"
 [workspace]
 org          = "your_org"
 template_set = "default"
@@ -32,7 +33,7 @@ secure = false
 [publishers]
 default_publisher = "redis"
 
-[publishers.redis]
+[publishers.adapters.redis]
 host     = "<ip>"
 port     = 6379
 db       = 0

--- a/pkgs/standards/peagen/tests/examples/peagen_tomls/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/peagen_tomls/.peagen.toml
@@ -1,4 +1,5 @@
 # .peagen.toml
+schemaVersion = "1.0.3"
 [workspace]
 org          = "test"
 template_set = "default"
@@ -32,7 +33,7 @@ secure = false
 [publishers]
 default_publisher = "redis"
 
-[publishers.redis]
+[publishers.adapters.redis]
 host     = "localhost"
 port     = 6379
 db       = 0


### PR DESCRIPTION
## Summary
- add `schemaVersion = "1.0.3"` to peagen example config and scaffold template
- nest redis publisher config under `[publishers.adapters.redis]`
- document the new layout in README

## Testing
- `python scripts/run_all_tests.py peagen` *(fails: No route to host)*