### PR TITLE
Update adapter docs

### DIFF
--- a/pkgs/standards/peagen/docs/storage_adapters_and_publishers.md
+++ b/pkgs/standards/peagen/docs/storage_adapters_and_publishers.md
@@ -4,10 +4,38 @@ Peagen writes artifacts to a pluggable storage backend and can publish events du
 
 ## Storage Adapters
 
-`Peagen` accepts a `storage_adapter` implementing simple `upload()` and `download()` methods. Two adapters ship with the SDK:
+`Peagen` accepts a `storage_adapter` implementing simple `upload()` and `download()` methods. Four adapters ship with the SDK:
 
 - `FileStorageAdapter` – stores artifacts on the local filesystem.
 - `MinioStorageAdapter` – targets S3 compatible object stores.
+- `GithubStorageAdapter` – saves files into a GitHub repository.
+- `GithubReleaseStorageAdapter` – uploads artifacts as release assets.
+
+Enable any of these via `.peagen.toml` using the `[storage.adapters.<name>]`
+tables. For example:
+
+```toml
+[storage]
+default_storage_adapter = "file"
+
+[storage.adapters.file]
+output_dir = "./peagen_artifacts"
+
+[storage.adapters.minio]
+endpoint = "localhost:9000"
+bucket = "peagen"
+
+[storage.adapters.github]
+token = "ghp_..."
+org = "my-org"
+repo = "my-repo"
+
+[storage.adapters.gh_release]
+token = "ghp_..."
+org = "my-org"
+repo = "my-repo"
+tag = "v1.0.0"
+```
 
 To use a different solution, subclass one of these classes or implement the same two-method API and pass the instance when creating `Peagen`:
 
@@ -25,7 +53,22 @@ Any class providing `upload()` and `download()` can serve as the adapter, enabli
 
 ## Publisher Plugins
 
-The CLI can emit JSON events such as `process.started` and `process.done`. The repository includes a `RedisPublisher` that sends messages via Redis Pub/Sub:
+The CLI can emit JSON events such as `process.started` and `process.done`. One built-in publisher ships with the SDK:
+
+- `RedisPublisher` – sends messages via Redis Pub/Sub.
+
+Enable it in `.peagen.toml` using the `[publishers.adapters.redis]` table:
+
+```toml
+[publishers]
+default_publisher = "redis"
+
+[publishers.adapters.redis]
+uri = "redis://localhost:6379/0"
+channel = "peagen.events"
+```
+
+You can also instantiate it programmatically:
 
 ```python
 from peagen.publishers.redis_publisher import RedisPublisher


### PR DESCRIPTION
## Summary
- document built-in storage adapters and Redis publisher
- show how to enable adapters in `.peagen.toml`

## Testing
- `python scripts/run_all_tests.py` *(fails: No route to host)*