### PR TITLE
Remove NATS references and document EDA protocol

### DIFF
--- a/pkgs/standards/peagen/README.md
+++ b/pkgs/standards/peagen/README.md
@@ -373,6 +373,12 @@ result, idx = pea.process_single_project(projects[0], start_idx=0)
 
 Peagen's artifact output and event publishing are pluggable. Use the `storage_adapter` argument to control where files are saved and optionally provide a publisher for notifications. Built-in options include `FileStorageAdapter`, `MinioStorageAdapter`, and `RedisPublisher`. See [docs/storage_adapters_and_publishers.md](docs/storage_adapters_and_publishers.md) for details.
 
+For the event schema and routing key conventions, see [docs/eda_protocol.md](docs/eda_protocol.md). Events can also be emitted directly from the CLI using `--notify`:
+
+```bash
+peagen process projects.yaml --notify redis://localhost:6379/0/custom.events
+```
+
 ### Parallel Processing & Artifact Storage Options
 
 Peagen can accelerate generation by spawning multiple workers. Set `--workers <N>`

--- a/pkgs/standards/peagen/docs/eda_protocol.md
+++ b/pkgs/standards/peagen/docs/eda_protocol.md
@@ -1,0 +1,34 @@
+# Peagen Event Protocol
+
+Peagen publishes JSON messages to notify external systems about key events during processing. Messages are sent via a pluggable publisher interface (e.g. `RedisPublisher`).
+
+## Event Structure
+
+Each event is a JSON object with a top-level `type` field. Implementations may include additional fields for context.
+
+```json
+{
+  "type": "process.started",
+  "extra": {"project": "myproj"}
+}
+```
+
+## Core Events
+
+| Event Type               | Description                                     |
+|--------------------------|-------------------------------------------------|
+| `process.started`        | Emitted when `peagen process` begins processing |
+| `process.done`           | Emitted after all projects are processed        |
+| `peagen.experiment.done` | Emitted by the DOE generator on completion      |
+
+## Routing Keys
+
+Events are published on a channel or routing key. The default is `peagen.events` for general messages. `peagen.experiment.done` is a dedicated key for DOE results.
+
+Use the CLI `--notify` flag to select the publisher and optionally override the channel:
+
+```bash
+peagen process projects.yaml --notify redis://localhost:6379/0/custom.events
+```
+
+The path component (`/custom.events`) becomes the channel name. See `storage_adapters_and_publishers.md` for configuring publishers.


### PR DESCRIPTION
## Summary
- define Peagen event protocol
- note CLI `--notify` usage in README
- use publisher registry in `doe` command instead of NATS

## Testing
- `pytest -q` *(fails: command not found)*