### PR TITLE
Add TomlMixin with TOML support

### DIFF
--- a/pkgs/base/pyproject.toml
+++ b/pkgs/base/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
 "pydantic>=2.0",
 "requests>=2.0",
 "pandas>=2.2",
+"catoml",
 "swarmauri_core",
 "swarmauri_typing"
 ]
@@ -28,6 +29,7 @@ dependencies = [
 [tool.uv.sources]
 swarmauri_core = { workspace = true }
 swarmauri_typing = { workspace = true }
+catoml = { workspace = true }
 
 [dependency-groups]
 dev = [

--- a/pkgs/base/swarmauri_base/ComponentBase.py
+++ b/pkgs/base/swarmauri_base/ComponentBase.py
@@ -19,6 +19,7 @@ from swarmauri_base.DynamicBase import SubclassUnion as SubclassUnion
 from swarmauri_base.LoggerMixin import LoggerMixin
 from swarmauri_base.ServiceMixin import ServiceMixin
 from swarmauri_base.YamlMixin import YamlMixin
+from swarmauri_base.TomlMixin import TomlMixin
 
 ###########################################
 # ComponentBase
@@ -28,7 +29,7 @@ T = TypeVar("T", bound="ComponentBase")
 
 
 @DynamicBase.register_type()
-class ComponentBase(LoggerMixin, YamlMixin, ServiceMixin, DynamicBase):
+class ComponentBase(LoggerMixin, YamlMixin, TomlMixin, ServiceMixin, DynamicBase):
     """
     Base class for all components.
     """

--- a/pkgs/base/swarmauri_base/ObserveBase.py
+++ b/pkgs/base/swarmauri_base/ObserveBase.py
@@ -9,6 +9,7 @@ from typing import (
 
 from pydantic import ConfigDict
 from swarmauri_base.YamlMixin import YamlMixin
+from swarmauri_base.TomlMixin import TomlMixin
 from swarmauri_base.ServiceMixin import ServiceMixin
 from swarmauri_base.DynamicBase import DynamicBase
 
@@ -16,7 +17,7 @@ T = TypeVar("T", bound="ObserveBase")
 
 
 @DynamicBase.register_type()
-class ObserveBase(YamlMixin, ServiceMixin, DynamicBase):
+class ObserveBase(YamlMixin, TomlMixin, ServiceMixin, DynamicBase):
     """
     Base class for all components.
     """

--- a/pkgs/base/swarmauri_base/TomlMixin.py
+++ b/pkgs/base/swarmauri_base/TomlMixin.py
@@ -1,0 +1,47 @@
+import json
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - fallback for Python <3.11
+    import tomli as tomllib
+
+import catoml
+from pydantic import BaseModel, ValidationError
+
+
+class TomlMixin(BaseModel):
+    @classmethod
+    def model_validate_toml(cls, toml_data: str):
+        try:
+            toml_content = tomllib.loads(toml_data)
+        except Exception as e:  # pragma: no cover - tomllib provides decode error
+            raise ValueError(f"Invalid TOML data: {e}")
+
+        try:
+            return cls.model_validate_json(json.dumps(toml_content))
+        except ValidationError as e:
+            raise ValueError(f"Validation failed: {e}")
+
+    def model_dump_toml(self, fields_to_exclude=None, api_key_placeholder=None):
+        if fields_to_exclude is None:
+            fields_to_exclude = []
+
+        json_data = json.loads(self.model_dump_json())
+
+        def process_fields(data, fields_to_exclude):
+            if isinstance(data, dict):
+                return {
+                    key: (
+                        api_key_placeholder
+                        if key == "api_key" and api_key_placeholder is not None
+                        else process_fields(value, fields_to_exclude)
+                    )
+                    for key, value in data.items()
+                    if key not in fields_to_exclude
+                }
+            elif isinstance(data, list):
+                return [process_fields(item, fields_to_exclude) for item in data]
+            else:
+                return data
+
+        filtered_data = process_fields(json_data, fields_to_exclude)
+        return catoml.dumps(filtered_data)

--- a/pkgs/base/tests/i9n/YamlMixinUnitTest.py
+++ b/pkgs/base/tests/i9n/YamlMixinUnitTest.py
@@ -2,10 +2,11 @@ import yaml
 import pytest
 
 from swarmauri_base.YamlMixin import YamlMixin
+from swarmauri_base.TomlMixin import TomlMixin
 
 
 # Integration model combining several features
-class IntegrationModel(YamlMixin):
+class IntegrationModel(YamlMixin, TomlMixin):
     name: str
     age: int
     api_key: str = None

--- a/pkgs/base/tests/unit/YamlMixin_unit_test.py
+++ b/pkgs/base/tests/unit/YamlMixin_unit_test.py
@@ -1,10 +1,11 @@
 import pytest
 import yaml
 from swarmauri_base.YamlMixin import YamlMixin
+from swarmauri_base.TomlMixin import TomlMixin
 
 
 # --- Dummy model for testing ---
-class DummyModel(YamlMixin):
+class DummyModel(YamlMixin, TomlMixin):
     name: str
     age: int
     api_key: str = None


### PR DESCRIPTION
## Summary
- implement `TomlMixin` for TOML serialization/deserialization
- include `catoml` dependency and workspace source
- integrate `TomlMixin` in core base classes and tests

## Testing
- `pytest -q` *(fails: command not found)*