### PR TITLE
Add TomlMixin and tests

### DIFF
--- a/pkgs/base/swarmauri_base/TomlMixin.py
+++ b/pkgs/base/swarmauri_base/TomlMixin.py
@@ -1,0 +1,38 @@
+import json
+from pydantic import BaseModel, ValidationError
+import catoml
+
+
+class TomlMixin(BaseModel):
+    @classmethod
+    def model_validate_toml(cls, toml_data: str):
+        try:
+            toml_content = catoml.loads(toml_data)
+            return cls.model_validate_json(json.dumps(toml_content))
+        except ValueError as e:
+            raise ValueError(f"Invalid TOML data: {e}")
+        except ValidationError as e:
+            raise ValueError(f"Validation failed: {e}")
+
+    def model_dump_toml(self, fields_to_exclude=None, api_key_placeholder=None):
+        if fields_to_exclude is None:
+            fields_to_exclude = []
+
+        json_data = json.loads(self.model_dump_json())
+
+        def process_fields(data, fields_to_exclude):
+            if isinstance(data, dict):
+                return {
+                    key: (
+                        api_key_placeholder if key == "api_key" and api_key_placeholder is not None else process_fields(value, fields_to_exclude)
+                    )
+                    for key, value in data.items()
+                    if key not in fields_to_exclude
+                }
+            elif isinstance(data, list):
+                return [process_fields(item, fields_to_exclude) for item in data]
+            else:
+                return data
+
+        filtered_data = process_fields(json_data, fields_to_exclude)
+        return catoml.dumps(filtered_data)

--- a/pkgs/base/tests/i9n/TomlMixinUnitTest.py
+++ b/pkgs/base/tests/i9n/TomlMixinUnitTest.py
@@ -1,0 +1,61 @@
+import catoml
+import pytest
+
+from swarmauri_base.TomlMixin import TomlMixin
+
+
+# Integration model combining several features
+class IntegrationModel(TomlMixin):
+    name: str
+    age: int
+    api_key: str = None
+    details: dict = {}
+
+
+@pytest.mark.i9n
+def test_integration_toml_roundtrip():
+    input_toml = """
+name = "Diana"
+age = 40
+api_key = "original_key"
+
+[details]
+info = "integrated"
+api_key = "inner_key"
+"""
+    model = IntegrationModel.model_validate_toml(input_toml)
+
+    output_toml = model.model_dump_toml(fields_to_exclude=["age"], api_key_placeholder="REDACTED")
+    output_data = catoml.loads(output_toml)
+
+    assert output_data["name"] == "Diana"
+    assert "age" not in output_data
+    assert output_data["api_key"] == "REDACTED"
+    assert output_data["details"]["api_key"] == "REDACTED"
+    assert output_data["details"]["info"] == "integrated"
+
+
+@pytest.mark.i9n
+def test_integration_toml_parsing_and_dumping():
+    complex_toml = """
+name = "Eve"
+age = 28
+api_key = "top_secret"
+
+[details]
+list_of_items = ["item1", "item2"]
+
+[details.nested]
+key = "value"
+api_key = "inner_secret"
+"""
+    model = IntegrationModel.model_validate_toml(complex_toml)
+    output_toml = model.model_dump_toml(api_key_placeholder="HIDDEN", fields_to_exclude=["age"])
+    output_data = catoml.loads(output_toml)
+
+    assert output_data["name"] == "Eve"
+    assert "age" not in output_data
+    assert output_data["api_key"] == "HIDDEN"
+    assert output_data["details"]["nested"]["api_key"] == "HIDDEN"
+    assert output_data["details"]["list_of_items"] == ["item1", "item2"]
+    assert output_data["details"]["nested"]["key"] == "value"

--- a/pkgs/base/tests/unit/TomlMixin_unit_test.py
+++ b/pkgs/base/tests/unit/TomlMixin_unit_test.py
@@ -1,0 +1,101 @@
+import pytest
+import catoml
+
+from swarmauri_base.TomlMixin import TomlMixin
+
+
+# --- Dummy model for testing ---
+class DummyModel(TomlMixin):
+    name: str
+    age: int
+    api_key: str = None
+
+
+# --- Unit Tests ---
+
+
+@pytest.mark.unit
+def test_model_validate_toml_success():
+    toml_data = """
+name = "Alice"
+age = 25
+api_key = "secret_key"
+"""
+    model = DummyModel.model_validate_toml(toml_data)
+    assert model.name == "Alice"
+    assert model.age == 25
+    assert model.api_key == "secret_key"
+
+
+@pytest.mark.unit
+def test_model_validate_toml_invalid_toml():
+    invalid_toml = """
+name = "Alice"
+age = 25
+api_key =
+"""
+    with pytest.raises(ValueError, match="Invalid TOML data"):
+        DummyModel.model_validate_toml(invalid_toml)
+
+
+@pytest.mark.unit
+def test_model_validate_toml_validation_error():
+    toml_data = """
+name = "Bob"
+age = "not_a_number"
+api_key = "secret_key"
+"""
+    with pytest.raises(ValueError, match="Validation failed"):
+        DummyModel.model_validate_toml(toml_data)
+
+
+@pytest.mark.unit
+def test_model_dump_toml_without_exclusions():
+    model = DummyModel(name="Alice", age=25, api_key="secret_key")
+    toml_output = model.model_dump_toml()
+    output_data = catoml.loads(toml_output)
+    assert output_data["name"] == "Alice"
+    assert output_data["age"] == 25
+    assert output_data["api_key"] == "secret_key"
+
+
+@pytest.mark.unit
+def test_model_dump_toml_with_field_exclusion():
+    model = DummyModel(name="Alice", age=25, api_key="secret_key")
+    toml_output = model.model_dump_toml(fields_to_exclude=["age"])
+    output_data = catoml.loads(toml_output)
+    assert "age" not in output_data
+    assert output_data["name"] == "Alice"
+    assert output_data["api_key"] == "secret_key"
+
+
+@pytest.mark.unit
+def test_model_dump_toml_with_api_key_placeholder():
+    model = DummyModel(name="Alice", age=25, api_key="secret_key")
+    placeholder = "REDACTED"
+    toml_output = model.model_dump_toml(api_key_placeholder=placeholder)
+    output_data = catoml.loads(toml_output)
+    assert output_data["api_key"] == placeholder
+    assert output_data["name"] == "Alice"
+    assert output_data["age"] == 25
+
+
+@pytest.mark.unit
+def test_model_dump_toml_with_nested_data():
+    class NestedModel(TomlMixin):
+        name: str
+        details: dict
+
+    nested_toml = """
+name = "Charlie"
+
+[details]
+api_key = "nested_secret"
+info = "some_info"
+"""
+    model = NestedModel.model_validate_toml(nested_toml)
+    toml_output = model.model_dump_toml(api_key_placeholder="REDACTED")
+    output_data = catoml.loads(toml_output)
+    assert output_data["name"] == "Charlie"
+    assert output_data["details"]["api_key"] == "REDACTED"
+    assert output_data["details"]["info"] == "some_info"


### PR DESCRIPTION
## Summary
- implement `TomlMixin` with model_validate_toml and model_dump_toml helpers
- add unit tests for `TomlMixin`
- add integration tests for `TomlMixin`

## Testing
- `pytest pkgs/base/tests/unit/TomlMixin_unit_test.py pkgs/base/tests/i9n/TomlMixinUnitTest.py -q` *(fails: command not found)*