### PR TITLE
Add deprecation warnings for distance classes

### DIFF
--- a/pkgs/experimental/swarmauri_experimental/swarmauri_experimental/vcms/concrete/DeepFaceDistance.py
+++ b/pkgs/experimental/swarmauri_experimental/swarmauri_experimental/vcms/concrete/DeepFaceDistance.py
@@ -5,6 +5,13 @@ import numpy as np
 from deepface import DeepFace
 from swarmauri.vcms.base.DeepFaceBase import DeepFaceBase
 from swarmauri.distances.base.VisionDistanceBase import VisionDistanceBase
+import warnings
+
+warnings.warn(
+    "This distance class will be deprecated in v0.10.0",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 class DeepFaceDistance(DeepFaceBase, VisionDistanceBase):
     

--- a/pkgs/standards/swarmauri_distance_minkowski/swarmauri_distance_minkowski/MinkowskiDistance.py
+++ b/pkgs/standards/swarmauri_distance_minkowski/swarmauri_distance_minkowski/MinkowskiDistance.py
@@ -3,6 +3,13 @@ from scipy.spatial.distance import minkowski
 from swarmauri_standard.vectors.Vector import Vector
 from swarmauri_base.distances.DistanceBase import DistanceBase
 from swarmauri_base.ComponentBase import ComponentBase
+import warnings
+
+warnings.warn(
+    "This distance class will be deprecated in v0.10.0",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 @ComponentBase.register_type(DistanceBase, "MinkowskiDistance")

--- a/pkgs/swarmauri_standard/swarmauri_standard/distances/CanberraDistance.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/distances/CanberraDistance.py
@@ -3,6 +3,13 @@ from typing import List, Literal
 from swarmauri_standard.vectors.Vector import Vector
 from swarmauri_base.distances.DistanceBase import DistanceBase
 from swarmauri_base.ComponentBase import ComponentBase
+import warnings
+
+warnings.warn(
+    "This distance class will be deprecated in v0.10.0",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 @ComponentBase.register_type(DistanceBase, "CanberraDistance")

--- a/pkgs/swarmauri_standard/swarmauri_standard/distances/ChebyshevDistance.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/distances/ChebyshevDistance.py
@@ -2,6 +2,13 @@ from typing import List, Literal
 from swarmauri_standard.vectors.Vector import Vector
 from swarmauri_base.distances.DistanceBase import DistanceBase
 from swarmauri_base.ComponentBase import ComponentBase
+import warnings
+
+warnings.warn(
+    "This distance class will be deprecated in v0.10.0",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 @ComponentBase.register_type(DistanceBase, "ChebyshevDistance")

--- a/pkgs/swarmauri_standard/swarmauri_standard/distances/ChiSquaredDistance.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/distances/ChiSquaredDistance.py
@@ -3,6 +3,13 @@ from typing import List, Literal
 from swarmauri_standard.vectors.Vector import Vector
 from swarmauri_base.distances.DistanceBase import DistanceBase
 from swarmauri_base.ComponentBase import ComponentBase
+import warnings
+
+warnings.warn(
+    "This distance class will be deprecated in v0.10.0",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 @ComponentBase.register_type(DistanceBase, "ChiSquaredDistance")

--- a/pkgs/swarmauri_standard/swarmauri_standard/distances/CosineDistance.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/distances/CosineDistance.py
@@ -4,6 +4,13 @@ from typing import List, Literal
 from swarmauri_standard.vectors.Vector import Vector
 from swarmauri_base.distances.DistanceBase import DistanceBase
 from swarmauri_base.ComponentBase import ComponentBase
+import warnings
+
+warnings.warn(
+    "This distance class will be deprecated in v0.10.0",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 @ComponentBase.register_type(DistanceBase, "CosineDistance")

--- a/pkgs/swarmauri_standard/swarmauri_standard/distances/EuclideanDistance.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/distances/EuclideanDistance.py
@@ -3,6 +3,13 @@ from typing import List, Literal
 from swarmauri_standard.vectors.Vector import Vector
 from swarmauri_base.distances.DistanceBase import DistanceBase
 from swarmauri_base.ComponentBase import ComponentBase
+import warnings
+
+warnings.warn(
+    "This distance class will be deprecated in v0.10.0",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 @ComponentBase.register_type(DistanceBase, "EuclideanDistance")

--- a/pkgs/swarmauri_standard/swarmauri_standard/distances/HaversineDistance.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/distances/HaversineDistance.py
@@ -3,6 +3,13 @@ from math import radians, cos, sin, sqrt, atan2
 from swarmauri_standard.vectors.Vector import Vector
 from swarmauri_base.distances.DistanceBase import DistanceBase
 from swarmauri_base.ComponentBase import ComponentBase
+import warnings
+
+warnings.warn(
+    "This distance class will be deprecated in v0.10.0",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 @ComponentBase.register_type(DistanceBase, "HaversineDistance")

--- a/pkgs/swarmauri_standard/swarmauri_standard/distances/JaccardIndexDistance.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/distances/JaccardIndexDistance.py
@@ -2,6 +2,13 @@ from typing import List, Literal
 from swarmauri_standard.vectors.Vector import Vector
 from swarmauri_base.distances.DistanceBase import DistanceBase
 from swarmauri_base.ComponentBase import ComponentBase
+import warnings
+
+warnings.warn(
+    "This distance class will be deprecated in v0.10.0",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 @ComponentBase.register_type(DistanceBase, "JaccardIndexDistance")

--- a/pkgs/swarmauri_standard/swarmauri_standard/distances/LevenshteinDistance.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/distances/LevenshteinDistance.py
@@ -3,6 +3,13 @@ from typing import List, Literal
 from swarmauri_standard.vectors.Vector import Vector
 from swarmauri_base.distances.DistanceBase import DistanceBase
 from swarmauri_base.ComponentBase import ComponentBase
+import warnings
+
+warnings.warn(
+    "This distance class will be deprecated in v0.10.0",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 @ComponentBase.register_type(DistanceBase, "LevenshteinDistance")

--- a/pkgs/swarmauri_standard/swarmauri_standard/distances/ManhattanDistance.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/distances/ManhattanDistance.py
@@ -2,6 +2,13 @@ from typing import List, Literal
 from swarmauri_standard.vectors.Vector import Vector
 from swarmauri_base.distances.DistanceBase import DistanceBase
 from swarmauri_base.ComponentBase import ComponentBase
+import warnings
+
+warnings.warn(
+    "This distance class will be deprecated in v0.10.0",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 @ComponentBase.register_type(DistanceBase, "ManhattanDistance")

--- a/pkgs/swarmauri_standard/swarmauri_standard/distances/SorensenDiceDistance.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/distances/SorensenDiceDistance.py
@@ -3,6 +3,13 @@ from typing import List, Literal
 from swarmauri_standard.vectors.Vector import Vector
 from swarmauri_base.distances.DistanceBase import DistanceBase
 from swarmauri_base.ComponentBase import ComponentBase
+import warnings
+
+warnings.warn(
+    "This distance class will be deprecated in v0.10.0",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 @ComponentBase.register_type(DistanceBase, "SorensenDiceDistance")

--- a/pkgs/swarmauri_standard/swarmauri_standard/distances/SquaredEuclideanDistance.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/distances/SquaredEuclideanDistance.py
@@ -2,6 +2,13 @@ from typing import List, Literal
 from swarmauri_standard.vectors.Vector import Vector
 from swarmauri_base.distances.DistanceBase import DistanceBase
 from swarmauri_base.ComponentBase import ComponentBase
+import warnings
+
+warnings.warn(
+    "This distance class will be deprecated in v0.10.0",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 @ComponentBase.register_type(DistanceBase, "SquaredEuclideanDistance")


### PR DESCRIPTION
## Summary
- deprecate standard distance classes in v0.10.0
- deprecate MinkowskiDistance
- deprecate DeepFaceDistance

## Testing
- `python -m compileall -q pkgs/swarmauri_standard/swarmauri_standard/distances pkgs/standards/swarmauri_distance_minkowski/swarmauri_distance_minkowski/MinkowskiDistance.py pkgs/experimental/swarmauri_experimental/swarmauri_experimental/vcms/concrete/DeepFaceDistance.py`