### PR TITLE
Add metric distance docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Individual components follow these naming conventions:
 - `swarmauri_parser_`*: Text parsing utilities
 - `swarmauri_distance_`*: Distance calculation methods
 
+For an overview of metric distances and how they differ from similarity measures, see [Metric Distances and Similarity](docs/docs/concept/distances.md).
 
 ## For Contributors
 If you want to contribute to the Swarmauri SDK, please read our [guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/CONTRIBUTING.md) and [style guide](https://github.com/swarmauri/swarmauri-sdk/blob/master/STYLE_GUIDE.md) to get started.

--- a/docs/docs/concept/distances.md
+++ b/docs/docs/concept/distances.md
@@ -1,0 +1,30 @@
+# Metric Distances and Similarity
+
+Metric theory-based distances quantify how far apart two vectors are within a metric space. They satisfy non-negativity, identity of indiscernibles, symmetry, and the triangle inequality. The SDK exposes these metrics through distance classes that also provide convenience methods to convert a distance into a similarity score.
+
+## Available Distance Classes
+
+Common implementations include:
+
+- `CosineDistance`
+- `EuclideanDistance`
+- `SquaredEuclideanDistance`
+- `ManhattanDistance`
+- `MinkowskiDistance`
+- `ChebyshevDistance`
+- `CanberraDistance`
+- `HaversineDistance`
+- `JaccardIndexDistance`
+- `SorensenDiceDistance`
+- `ChiSquaredDistance`
+- `LevenshteinDistance`
+
+These classes live under the `swarmauri.distances` namespace and implement both `distance()` and `similarity()` methods.
+
+## Similarity Measures
+
+Similarity measures compute how alike two vectors are without guaranteeing the properties of a metric. They implement the `ISimilarity` interface and often return a value in the range `[0, 1]`. Examples include the experimental `SSASimilarity` and `SSIVSimilarity` classes.
+
+## Deprecation Notice
+
+The distance classes are **deprecated** and scheduled for removal in `v0.10.0`. Future releases will focus on dedicated similarity implementations that conform to `ISimilarity`. Migrate your code to these similarity classes to remain compatible with upcoming versions.

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -131,6 +131,7 @@ Here are some recommended next steps to continue your journey with Swarmauri SDK
 3. **Join the Community**: Connect with other developers in our [Discord server](https://discord.gg/swarmauri)
 4. **Contribute**: Learn how to [contribute to the project](./home/contribute.md)
 5. **Stay Updated**: Follow our [blog](../blog/index.md) for the latest updates
+6. **Understand Distances vs Similarity**: Read about [metric distances and similarity measures](./concept/distances.md)
 
 For more detailed information, visit our [comprehensive documentation](https://docs.swarmauri.com).
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -134,6 +134,7 @@ nav:
   - Base: concept/base.md
   - Standard: concept/standard.md
   - Swarmauri: concept/swarmauri.md
+  - Distances vs Similarity: concept/distances.md
 
 - API Documentation:
   - api/index.md


### PR DESCRIPTION
## Summary
- document the difference between metric distances and similarity measures
- note upcoming deprecation of distance classes
- link to the new documentation from the docs index and README
- add the page to the mkdocs navigation

## Testing
- `git status --short`