### PR TITLE
Add Peagen EDA protocol docs

### DIFF
--- a/pkgs/standards/peagen/README.md
+++ b/pkgs/standards/peagen/README.md
@@ -371,7 +371,7 @@ result, idx = pea.process_single_project(projects[0], start_idx=0)
 
 ### Storage Adapters & Publishers
 
-Peagen's artifact output and event publishing are pluggable. Use the `storage_adapter` argument to control where files are saved and optionally provide a publisher for notifications. Built-in options include `FileStorageAdapter`, `MinioStorageAdapter`, and `RedisPublisher`. See [docs/storage_adapters_and_publishers.md](docs/storage_adapters_and_publishers.md) for details.
+Peagen's artifact output and event publishing are pluggable. Use the `storage_adapter` argument to control where files are saved and optionally provide a publisher for notifications. Built-in options include `FileStorageAdapter`, `MinioStorageAdapter`, and `RedisPublisher`. See [docs/storage_adapters_and_publishers.md](docs/storage_adapters_and_publishers.md) for setup instructions. Event types and routing keys are documented in [docs/eda_protocol.md](docs/eda_protocol.md).
 
 ### Parallel Processing & Artifact Storage Options
 
@@ -402,6 +402,8 @@ pea = Peagen(
 bus.publish("peagen.events", {"type": "process.started"})
 pea.process_all_projects()
 ```
+
+See [docs/eda_protocol.md](docs/eda_protocol.md) for the payload schema and how to override the default channel.
 
 ### Contributing & Extending Templates
 

--- a/pkgs/standards/peagen/docs/eda_protocol.md
+++ b/pkgs/standards/peagen/docs/eda_protocol.md
@@ -1,0 +1,36 @@
+# Event-Driven Architecture (EDA) Protocol
+
+Peagen can emit JSON events during processing to integrate with external workflows. This document outlines the common event types, payload structure, and routing conventions used by the CLI and library.
+
+## Core Event Types
+
+- `process.started` – emitted when a generation run begins.
+- `process.done` – emitted after all files have been rendered. Includes the total runtime in seconds.
+- `peagen.experiment.done` – sent by `peagen experiment` when a design of experiments expansion completes.
+
+Additional custom events may be published by plugins or downstream tools, but the above form the core API guaranteed by Peagen.
+
+## Payload Schema
+
+Each event payload is a JSON object with a required top-level `type` key. Additional fields provide metadata about the run or experiment. Typical fields include:
+
+- `seconds` – runtime duration for `process.done` events.
+- `output` – path to the generated artifact or experiment bundle.
+- `count` – number of design points produced by `peagen experiment`.
+- `uri` – notification target used when publishing.
+
+Publishers may attach extra keys as needed. Consumers should handle unknown fields gracefully.
+
+## Routing Keys
+
+By default events are published to the `peagen.events` channel. Specific events may use dedicated subjects such as `peagen.experiment.done`. When using the CLI, the channel can be overridden via the notifier URI:
+
+```bash
+peagen process --notify redis://localhost:6379/0/mychannel
+```
+
+Here `mychannel` becomes the routing key instead of `peagen.events`.
+
+## Related Documentation
+
+Examples of publishing events are shown in the [README](../README.md) and in [storage_adapters_and_publishers.md](storage_adapters_and_publishers.md). Use those snippets as a starting point when wiring Peagen into your own message bus.


### PR DESCRIPTION
## Summary
- document Peagen event protocol in `docs/eda_protocol.md`
- link event documentation from README

## Testing
- `pytest -q` *(fails: command not found)*