### PR TITLE
Update kernel shutdown tool to use REST client

### DIFF
--- a/pkgs/community/swarmauri_tool_jupytershutdownkernel/README.md
+++ b/pkgs/community/swarmauri_tool_jupytershutdownkernel/README.md
@@ -18,7 +18,7 @@
 
 # Swarmauri Tool Jupyter Shutdown Kernel
 
-The swarmauri_tool_jupytershutdownkernel package provides a straightforward solution to shut down a running Jupyter kernel programmatically. It uses jupyter_client under the hood and is integrated into the Swarmauri framework ecosystem. This tool can be useful for automated resource management, testing scenarios that require repeated kernel restarts, or any workflow that programmatically terminates Jupyter kernels.
+The swarmauri_tool_jupytershutdownkernel package provides a straightforward solution to shut down a running Jupyter kernel programmatically. It uses **jupyter_rest_client** under the hood and is integrated into the Swarmauri framework ecosystem. This tool can be useful for automated resource management, testing scenarios that require repeated kernel restarts, or any workflow that programmatically terminates Jupyter kernels.
 
 ## Installation
 
@@ -26,7 +26,7 @@ You can install this module directly via PyPI using pip:
 
   pip install swarmauri_tool_jupytershutdownkernel
 
-This will install the package and its dependencies, including jupyter_client and the Swarmauri libraries required by JupyterShutdownKernelTool.
+This will install the package and its dependencies, including **jupyter_rest_client** and the Swarmauri libraries required by JupyterShutdownKernelTool.
 
 Ensure you are running a Python version between 3.10 and 3.13, and that you have the appropriate Swarmauri core/base packages installed. Typically, pip will handle these dependencies automatically.
 
@@ -68,7 +68,7 @@ def shutdown_kernel_example(kernel_identifier: str):
 
 ### Dependencies
 
-• jupyter_client – Underlies the kernel shutdown implementation.  
+• jupyter_rest_client – Provides the HTTP interface used for kernel shutdown.
 • swarmauri_core / swarmauri_base – Provide the foundational classes (ComponentBase and ToolBase).  
 • pydantic – Used internally for type validation in Swarmauri parameters.  
 

--- a/pkgs/community/swarmauri_tool_jupytershutdownkernel/payload.json
+++ b/pkgs/community/swarmauri_tool_jupytershutdownkernel/payload.json
@@ -1,6 +1,6 @@
 {
     "PROJECT_ROOT": "pkgs",
-    "PACKAGE_DESCRIPTION": "A tool designed to shut down a running Jupyter kernel programmatically using jupyter_client, releasing all associated resources.",
+    "PACKAGE_DESCRIPTION": "A tool designed to shut down a running Jupyter kernel programmatically using jupyter_rest_client, releasing all associated resources.",
     "PACKAGE_ROOT": "swarmauri_tool_jupytershutdownkernel",
     "RESOURCE_KIND": "tool",
     "MODULE_NAME": "JupyterShutdownKernelTool",
@@ -19,7 +19,7 @@
     "EXTERNAL_DOC_EXAMPLE_FILE": null,
     "THIRD_PARTY_DEPENDENCIES": [
         {
-            "name": "jupyter_client",
+            "name": "jupyter_rest_client",
             "version": "*"
         }
     ]

--- a/pkgs/community/swarmauri_tool_jupytershutdownkernel/pyproject.bak.toml
+++ b/pkgs/community/swarmauri_tool_jupytershutdownkernel/pyproject.bak.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "swarmauri_tool_jupytershutdownkernel"
 version = "0.6.2.dev3"
-description = "A tool designed to shut down a running Jupyter kernel programmatically using jupyter_client, releasing all associated resources."
+description = "A tool designed to shut down a running Jupyter kernel programmatically using jupyter_rest_client, releasing all associated resources."
 authors = ["Jacob Stewart <jacob@swarmauri.com>"]
 license = "Apache-2.0"
 readme = "README.md"
@@ -23,7 +23,7 @@ swarmauri_base = { git = "https://github.com/swarmauri/swarmauri-sdk.git", branc
 swarmauri_standard = { git = "https://github.com/swarmauri/swarmauri-sdk.git", branch = "mono/dev", subdirectory = "pkgs/swarmauri_standard" }
 
 # Dependencies
-jupyter_client = "^8.6.3"
+jupyter_rest_client = "^0.1.0"
 
 [tool.poetry.group.dev.dependencies]
 flake8 = "^7.0"

--- a/pkgs/community/swarmauri_tool_jupytershutdownkernel/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_jupytershutdownkernel/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "swarmauri_tool_jupytershutdownkernel"
 version = "0.7.4.dev10"
-description = "A tool designed to shut down a running Jupyter kernel programmatically using jupyter_client, releasing all associated resources."
+description = "A tool designed to shut down a running Jupyter kernel programmatically using jupyter_rest_client, releasing all associated resources."
 license = "Apache-2.0"
 readme = "README.md"
 repository = "http://github.com/swarmauri/swarmauri-sdk/pkgs/community/swarmauri_tool_jupytershutdownkernel/"
@@ -15,7 +15,7 @@ classifiers = [
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
-    "jupyter_client>=8.6.3",
+    "jupyter_rest_client>=0.1.0",
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",


### PR DESCRIPTION
## Summary
- swap jupyter_client for jupyter_rest_client
- handle HTTP errors from shutdown
- update docs and metadata to reference jupyter_rest_client

## Testing
- `python scripts/run_all_tests.py swarmauri_tool_jupytershutdownkernel` *(fails: No route to host)*