### PR TITLE
Use websocket for Jupyter IOPub retrieval

### DIFF
--- a/pkgs/community/swarmauri_tool_jupytergetiopubmessage/README.md
+++ b/pkgs/community/swarmauri_tool_jupytergetiopubmessage/README.md
@@ -37,26 +37,21 @@ If you see a valid version number, the package is installed and ready to use.
 
 ## Usage
 
-Below is a brief example of how to use JupyterGetIOPubMessageTool to capture messages from an active Jupyter kernel. In most scenarios, you will have a running Jupyter kernel and a kernel client available.
+Below is a brief example of how to use ``JupyterGetIOPubMessageTool`` to capture
+messages from an active Jupyter kernel. The tool expects the WebSocket URL for
+the kernel's ``/api/kernels/{id}/channels`` endpoint.
 
 --------------------------------------------------------------------------------
 Example usage:
 
-from jupyter_client import KernelManager
 from swarmauri_tool_jupytergetiopubmessage import JupyterGetIOPubMessageTool
 
-# Initialize a new Jupyter kernel
-km = KernelManager()
-km.start_kernel()
-kc = km.client()
-kc.start_channels()
+# URL to the running kernel's channels endpoint
+channels_url = "ws://localhost:8888/api/kernels/12345/channels"
 
-# Execute a sample command in the kernel to produce some output
-kc.execute("print('Hello from the kernel!')")
-
-# Initialize and use the JupyterGetIOPubMessageTool
+# Initialize and use the tool
 tool = JupyterGetIOPubMessageTool()
-result = tool(kernel_client=kc, timeout=3.0)
+result = tool(channels_url, timeout=3.0)
 
 print("Captured stdout:", result["stdout"])
 print("Captured stderr:", result["stderr"])
@@ -64,9 +59,6 @@ print("Captured logs:", result["logs"])
 print("Execution results:", result["execution_results"])
 print("Did timeout occur?:", result["timeout_exceeded"])
 
-# Clean up kernel resources
-kc.stop_channels()
-km.shutdown_kernel()
 
 --------------------------------------------------------------------------------
 
@@ -74,10 +66,11 @@ This usage example demonstrates how to retrieve stdout messages, stderr messages
 
 ## Dependencies
 
-• Python 3.10 to 3.13  
-• jupyter_client  
-• swarmauri_core (for component registration)  
-• swarmauri_base (for the base tool functionality)  
+• Python 3.10 to 3.13
+• websocket-client
+• jupyter_client
+• swarmauri_core (for component registration)
+• swarmauri_base (for the base tool functionality)
 
 Additional development dependencies (e.g., flake8, pytest) are specified in the pyproject.toml file but not required for basic usage.
 

--- a/pkgs/community/swarmauri_tool_jupytergetiopubmessage/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_jupytergetiopubmessage/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
     "jupyter_client>=8.6.3",
+    "websocket-client>=1.8.0",
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",

--- a/pkgs/community/swarmauri_tool_jupytergetiopubmessage/swarmauri_tool_jupytergetiopubmessage/JupyterGetIOPubMessageTool.py
+++ b/pkgs/community/swarmauri_tool_jupytergetiopubmessage/swarmauri_tool_jupytergetiopubmessage/JupyterGetIOPubMessageTool.py
@@ -1,7 +1,9 @@
 from typing import List, Dict, Any, Literal
 from pydantic import Field
 import time
+import json
 import logging
+import importlib
 
 from swarmauri_standard.tools.Parameter import Parameter
 from swarmauri_base.tools.ToolBase import ToolBase
@@ -26,9 +28,11 @@ class JupyterGetIOPubMessageTool(ToolBase):
     parameters: List[Parameter] = Field(
         default_factory=lambda: [
             Parameter(
-                name="kernel_client",
-                input_type="object",
-                description="A Jupyter kernel client instance used to retrieve IOPub messages.",
+                name="channels_url",
+                input_type="string",
+                description=(
+                    "WebSocket URL for the kernel channels endpoint (/api/kernels/{id}/channels)."
+                ),
                 required=True,
             ),
             Parameter(
@@ -46,16 +50,16 @@ class JupyterGetIOPubMessageTool(ToolBase):
     )
     type: Literal["JupyterGetIOPubMessageTool"] = "JupyterGetIOPubMessageTool"
 
-    def __call__(self, kernel_client: Any, timeout: float = 5.0) -> Dict[str, Any]:
+    def __call__(self, channels_url: str, timeout: float = 5.0) -> Dict[str, Any]:
         """
-        Retrieves IOPub messages from the specified Jupyter kernel client within a given timeout.
+        Retrieve IOPub messages from the kernel's WebSocket ``channels`` endpoint.
 
-        This method listens on the kernel client's IOPub channel for output, errors, and logging
-        data. It collects all relevant messages until it either encounters an idle signal, or
-        the timeout is reached. Message parsing errors are logged and handled gracefully.
+        This method connects to ``/api/kernels/{id}/channels`` via WebSocket and
+        listens for messages until the kernel becomes idle or the timeout
+        expires. Message parsing errors are logged and collected.
 
         Args:
-            kernel_client (Any): A Jupyter kernel client instance to retrieve IOPub messages from.
+            channels_url (str): WebSocket URL to ``/api/kernels/{id}/channels``.
             timeout (float, optional): Time in seconds to wait for IOPub messages. Defaults to 5.0.
 
         Returns:
@@ -67,9 +71,11 @@ class JupyterGetIOPubMessageTool(ToolBase):
                 - "timeout_exceeded": Boolean indicating whether a timeout occurred
 
         Example:
-            >>> # Suppose 'kc' is a properly initialized Jupyter kernel client:
             >>> tool = JupyterGetIOPubMessageTool()
-            >>> result = tool(kc, timeout=3.0)
+            >>> result = tool(
+            ...     "ws://localhost:8888/api/kernels/12345/channels",
+            ...     timeout=3.0,
+            ... )
             >>> print(result["stdout"])
             ['Hello world!']
         """
@@ -79,18 +85,24 @@ class JupyterGetIOPubMessageTool(ToolBase):
         )
         start_time = time.time()
 
+        websocket_module = importlib.import_module("websocket")
+        ws = websocket_module.create_connection(channels_url, timeout=timeout)
+        ws.settimeout(0.1)
+
         # Containers for captured data
         stdout_messages = []
         stderr_messages = []
         logs = []
         execution_results = []
 
-        # Continue to retrieve messages until idle or timeout
-        while True:
-            try:
+        try:
+            # Continue to retrieve messages until idle or timeout
+            while True:
                 # Check elapsed time for timeout
                 if (time.time() - start_time) > timeout:
-                    logger.warning("Timeout exceeded while waiting for IOPub messages.")
+                    logger.warning(
+                        "Timeout exceeded while waiting for IOPub messages."
+                    )
                     return {
                         "stdout": stdout_messages,
                         "stderr": stderr_messages,
@@ -99,10 +111,17 @@ class JupyterGetIOPubMessageTool(ToolBase):
                         "timeout_exceeded": True,
                     }
 
-                # Attempt to get a single message from the IOPub channel (with a short block)
-                msg = kernel_client.get_iopub_msg(timeout=0.1)
-                if not msg:
-                    continue  # No message received yet, keep checking
+                try:
+                    raw_msg = ws.recv()
+                except websocket_module.WebSocketTimeoutException:
+                    continue
+
+                try:
+                    msg = json.loads(raw_msg)
+                except Exception as exc:
+                    logger.error("Error parsing IOPub message: %s", str(exc))
+                    logs.append({"error": f"Error parsing IOPub message: {str(exc)}"})
+                    continue
 
                 msg_type = msg["msg_type"]
                 msg_content = msg["content"]
@@ -143,10 +162,8 @@ class JupyterGetIOPubMessageTool(ToolBase):
                     # Other messages (e.g., clear_output, update_display_data) can be logged
                     logs.append({"type": msg_type, "content": msg_content})
 
-            except Exception as e:
-                logger.error("Error parsing IOPub message: %s", str(e))
-                logs.append({"error": f"Error parsing IOPub message: {str(e)}"})
-                # If there's an error, we continue listening unless time is up
+        finally:
+            ws.close()
 
         # Successfully captured messages without timeout
         return {

--- a/pkgs/community/swarmauri_tool_jupytergetiopubmessage/tests/unit/test_JupyterGetIOPubMessageTool.py
+++ b/pkgs/community/swarmauri_tool_jupytergetiopubmessage/tests/unit/test_JupyterGetIOPubMessageTool.py
@@ -2,11 +2,14 @@
 Unit tests for the JupyterGetIOPubMessageTool class.
 
 This module contains pytest-based test cases for verifying the functionality and correctness
-of the JupyterGetIOPubMessageTool class. It uses mock objects to simulate the behavior of a
-Jupyter kernel client.
+of the JupyterGetIOPubMessageTool class. It uses mock WebSocket objects to simulate the
+behavior of a Jupyter kernel connection.
 """
 
+import sys
 import time
+import types
+import json
 import pytest
 from unittest.mock import MagicMock, patch
 from swarmauri_tool_jupytergetiopubmessage.JupyterGetIOPubMessageTool import (
@@ -15,24 +18,34 @@ from swarmauri_tool_jupytergetiopubmessage.JupyterGetIOPubMessageTool import (
 
 
 @pytest.fixture
-def mock_kernel_client():
-    """
-    Pytest fixture that creates a mock Jupyter kernel client with a controllable sequence of messages.
-    """
-    client = MagicMock()
+def mock_websocket(monkeypatch):
+    """Create a mock WebSocket module with controllable messages."""
     messages = []
 
-    def get_iopub_msg(timeout: float = 0.1):
-        """
-        Returns the next message from the predefined messages list if available, otherwise None.
-        """
+    class DummyTimeout(Exception):
+        pass
+
+    ws = MagicMock()
+
+    def recv() -> str:
         if messages:
             return messages.pop(0)
-        return None
+        raise DummyTimeout()
 
-    client.get_iopub_msg.side_effect = get_iopub_msg
-    client._messages = messages  # Expose the list so tests can manipulate it as needed
-    return client
+    ws.recv.side_effect = recv
+    ws.settimeout = MagicMock()
+    ws._messages = messages
+
+    def create_connection(url: str, timeout: float | None = None):
+        return ws
+
+    dummy_module = types.SimpleNamespace(
+        create_connection=create_connection,
+        WebSocketTimeoutException=DummyTimeout,
+    )
+
+    monkeypatch.setitem(sys.modules, "websocket", dummy_module)
+    return ws
 
 
 def test_init():
@@ -51,40 +64,46 @@ def test_init():
 
     # Check parameters
     assert len(tool.parameters) == 2, (
-        "Should have two parameters: kernel_client and timeout"
+        "Should have two parameters: channels_url and timeout"
     )
 
     param_names = {p.name for p in tool.parameters}
-    assert "kernel_client" in param_names, "Missing 'kernel_client' parameter"
+    assert "channels_url" in param_names, "Missing 'channels_url' parameter"
     assert "timeout" in param_names, "Missing 'timeout' parameter"
 
 
-def test_retrieves_messages(mock_kernel_client):
+def test_retrieves_messages(mock_websocket):
     """
     Tests that JupyterGetIOPubMessageTool correctly retrieves various IOPub messages and stops
     on an idle status message without timing out.
     """
     # Prepare mock messages
-    mock_kernel_client._messages.extend(
+    mock_websocket._messages.extend(
         [
-            {
-                "msg_type": "stream",
-                "content": {"name": "stdout", "text": "Hello from stdout\n"},
-            },
-            {
-                "msg_type": "stream",
-                "content": {"name": "stderr", "text": "Warning: something\n"},
-            },
-            {
-                "msg_type": "execute_result",
-                "content": {"data": {"text/plain": "Execution result"}},
-            },
-            {"msg_type": "status", "content": {"execution_state": "idle"}},
+            json.dumps(
+                {
+                    "msg_type": "stream",
+                    "content": {"name": "stdout", "text": "Hello from stdout\n"},
+                }
+            ),
+            json.dumps(
+                {
+                    "msg_type": "stream",
+                    "content": {"name": "stderr", "text": "Warning: something\n"},
+                }
+            ),
+            json.dumps(
+                {
+                    "msg_type": "execute_result",
+                    "content": {"data": {"text/plain": "Execution result"}},
+                }
+            ),
+            json.dumps({"msg_type": "status", "content": {"execution_state": "idle"}}),
         ]
     )
 
     tool = JupyterGetIOPubMessageTool()
-    result = tool(kernel_client=mock_kernel_client, timeout=2.0)
+    result = tool("ws://test/api/kernels/1/channels", timeout=2.0)
 
     assert result["timeout_exceeded"] is False, "Should not have exceeded timeout"
     assert len(result["stdout"]) == 1, "Should have captured one stdout message"
@@ -99,32 +118,29 @@ def test_retrieves_messages(mock_kernel_client):
 
 
 @pytest.mark.parametrize("idle_messages", [[], None])
-def test_timeout(mock_kernel_client, idle_messages):
+def test_timeout(mock_websocket, idle_messages):
     """
     Tests that JupyterGetIOPubMessageTool correctly reports a timeout when no idle status message
     is received within the specified duration.
     """
     # Add messages that never include an idle status.
-    mock_kernel_client._messages.extend(
+    mock_websocket._messages.extend(
         [
-            {
-                "msg_type": "stream",
-                "content": {"name": "stdout", "text": "Still running...\n"},
-            },
-            {
-                "msg_type": "stream",
-                "content": {"name": "stdout", "text": "More output...\n"},
-            },
+            json.dumps(
+                {
+                    "msg_type": "stream",
+                    "content": {"name": "stdout", "text": "Still running...\n"},
+                }
+            ),
+            json.dumps(
+                {
+                    "msg_type": "stream",
+                    "content": {"name": "stdout", "text": "More output...\n"},
+                }
+            ),
         ]
     )
 
-    # Patch get_iopub_msg so that it returns messages from the _messages list.
-    def fake_get_iopub_msg(timeout=0.1):
-        if mock_kernel_client._messages:
-            return mock_kernel_client._messages.pop(0)
-        return None
-
-    mock_kernel_client.get_iopub_msg.side_effect = fake_get_iopub_msg
 
     # Patch time.time to simulate passage of time so we trigger timeout quickly.
     with patch.object(time, "time") as mock_time:
@@ -140,7 +156,7 @@ def test_timeout(mock_kernel_client, idle_messages):
         mock_time.side_effect = fake_time
 
         tool = JupyterGetIOPubMessageTool()
-        result = tool(kernel_client=mock_kernel_client, timeout=2.0)
+        result = tool("ws://test/api/kernels/1/channels", timeout=2.0)
 
     assert result["timeout_exceeded"] is True, "Should have exceeded timeout"
     assert len(result["stdout"]) == 2, (
@@ -148,7 +164,7 @@ def test_timeout(mock_kernel_client, idle_messages):
     )
 
 
-def test_error_handling(mock_kernel_client):
+def test_error_handling(mock_websocket):
     """
     Tests that JupyterGetIOPubMessageTool handles error messages properly and logs the traceback.
     """
@@ -157,15 +173,15 @@ def test_error_handling(mock_kernel_client):
         '  File "<ipython-input-1>"',
         "NameError: name 'x' is not defined",
     ]
-    mock_kernel_client._messages.extend(
+    mock_websocket._messages.extend(
         [
-            {"msg_type": "error", "content": {"traceback": error_traceback}},
-            {"msg_type": "status", "content": {"execution_state": "idle"}},
+            json.dumps({"msg_type": "error", "content": {"traceback": error_traceback}}),
+            json.dumps({"msg_type": "status", "content": {"execution_state": "idle"}}),
         ]
     )
 
     tool = JupyterGetIOPubMessageTool()
-    result = tool(kernel_client=mock_kernel_client, timeout=2.0)
+    result = tool("ws://test/api/kernels/1/channels", timeout=2.0)
 
     assert result["timeout_exceeded"] is False, (
         "Should not exceed timeout with valid idle message"


### PR DESCRIPTION
## Summary
- connect to kernel channels via WebSocket in `JupyterGetIOPubMessageTool`
- update docs for WebSocket usage
- add websocket-client dependency for IOPub retrieval

## Testing
- `pytest -q pkgs/community/swarmauri_tool_jupytergetiopubmessage/tests/unit/test_JupyterGetIOPubMessageTool.py` *(fails: command not found)*