### PR TITLE
Use websocket client for shell messages

### DIFF
--- a/pkgs/community/swarmauri_tool_jupytergetshellmessage/README.md
+++ b/pkgs/community/swarmauri_tool_jupytergetshellmessage/README.md
@@ -18,7 +18,7 @@
 
 # Swarmauri Tool Jupyter Get Shell Message
 
-A dedicated Python package providing a tool to retrieve shell messages from a running Jupyter kernel using jupyter_client. Built on the swarmauri framework, JupyterGetShellMessageTool is suitable for debugging, logging, and diagnostic purposes.
+A dedicated Python package providing a tool to retrieve shell messages from a running Jupyter kernel over a WebSocket connection. Built on the swarmauri framework, JupyterGetShellMessageTool is suitable for debugging, logging, and diagnostic purposes.
 
 ---
 
@@ -34,9 +34,9 @@ If you are using Poetry for dependency management, add it to your project by spe
     swarmauri_tool_jupytergetshellmessage = "^0.1.0.dev1"
 
 Once installed, the package automatically brings in its required dependencies:
-• swarmauri_core  
-• swarmauri_base  
-• jupyter_client  
+• swarmauri_core
+• swarmauri_base
+• websocket-client
 
 No specialized steps beyond a standard Python environment with pip or Poetry are necessary.
 
@@ -70,7 +70,7 @@ The tool attempts to connect to the active Jupyter kernel, retrieve available sh
 ## Dependencies
 
 • swarmauri_core and swarmauri_base provide the core classes (ComponentBase, ToolBase) for building and integrating tools across the swarmauri ecosystem.  
-• jupyter_client is leveraged to interface with the running Jupyter kernel, enabling retrieval of shell-based IPC messages.  
+• websocket-client is used to communicate with the running Jupyter kernel's shell WebSocket channel.
 
 These dependencies are automatically installed when installing this package via pip or Poetry.
 

--- a/pkgs/community/swarmauri_tool_jupytergetshellmessage/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_jupytergetshellmessage/pyproject.toml
@@ -17,6 +17,7 @@ authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
     "jupyter_client>=8.6.3",
     "ipykernel>=6.29.5",
+    "websocket-client>=1.8.0",
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",


### PR DESCRIPTION
## Summary
- replace BlockingKernelClient use with a websocket connection
- load connection info from JSON and capture shell-channel messages
- adjust unit tests for the new websocket client
- add websocket dependency
- document websocket-client usage

## Testing
- `ruff check pkgs/community/swarmauri_tool_jupytergetshellmessage/swarmauri_tool_jupytergetshellmessage/JupyterGetShellMessageTool.py pkgs/community/swarmauri_tool_jupytergetshellmessage/tests/unit/test_JupyterGetShellMessageTool.py`
- `pytest pkgs/community/swarmauri_tool_jupytergetshellmessage/tests/unit/test_JupyterGetShellMessageTool.py -q` *(fails: command not found)*