### PR TITLE
Add swarmauri registry unit tests

### DIFF
--- a/pkgs/swarmauri/tests/unit/determine_plugin_citizenship_unit_test.py
+++ b/pkgs/swarmauri/tests/unit/determine_plugin_citizenship_unit_test.py
@@ -1,0 +1,41 @@
+import pytest
+from importlib.metadata import EntryPoint
+
+from swarmauri.plugin_manager import determine_plugin_citizenship
+from swarmauri.plugin_citizenship_registry import PluginCitizenshipRegistry
+
+
+@pytest.fixture(autouse=True)
+def restore_registry():
+    first = PluginCitizenshipRegistry.FIRST_CLASS_REGISTRY.copy()
+    second = PluginCitizenshipRegistry.SECOND_CLASS_REGISTRY.copy()
+    third = PluginCitizenshipRegistry.THIRD_CLASS_REGISTRY.copy()
+    yield
+    PluginCitizenshipRegistry.FIRST_CLASS_REGISTRY = first
+    PluginCitizenshipRegistry.SECOND_CLASS_REGISTRY = second
+    PluginCitizenshipRegistry.THIRD_CLASS_REGISTRY = third
+
+
+@pytest.mark.unit
+def test_third_class_detection():
+    ep = EntryPoint(name="Dummy", value="pkg.module:Dummy", group="swarmauri.plugins")
+    assert determine_plugin_citizenship(ep) == "third"
+
+
+@pytest.mark.unit
+def test_first_class_detection():
+    ep = EntryPoint(name="DummyAgent", value="pkg.agent:DummyAgent", group="swarmauri.agents")
+    PluginCitizenshipRegistry.FIRST_CLASS_REGISTRY["swarmauri.agents.DummyAgent"] = "pkg.agent:DummyAgent"
+    assert determine_plugin_citizenship(ep) == "first"
+
+
+@pytest.mark.unit
+def test_second_class_detection():
+    ep = EntryPoint(name="CommunityAgent", value="pkg.agent:CommunityAgent", group="swarmauri.agents")
+    assert determine_plugin_citizenship(ep) == "second"
+
+
+@pytest.mark.unit
+def test_unrecognized_plugin():
+    ep = EntryPoint(name="Unknown", value="pkg.unknown:Unknown", group="unknown.group")
+    assert determine_plugin_citizenship(ep) is None

--- a/pkgs/swarmauri/tests/unit/importer_unit_test.py
+++ b/pkgs/swarmauri/tests/unit/importer_unit_test.py
@@ -1,0 +1,20 @@
+import importlib.machinery
+import pytest
+
+from swarmauri.importer import SwarmauriImporter
+from swarmauri.plugin_citizenship_registry import PluginCitizenshipRegistry
+
+
+@pytest.fixture(autouse=True)
+def restore_registry():
+    third = PluginCitizenshipRegistry.THIRD_CLASS_REGISTRY.copy()
+    yield
+    PluginCitizenshipRegistry.THIRD_CLASS_REGISTRY = third
+
+
+@pytest.mark.unit
+def test_find_spec_for_registered_module():
+    PluginCitizenshipRegistry.THIRD_CLASS_REGISTRY["swarmauri.plugins.math"] = "math"
+    importer = SwarmauriImporter()
+    spec = importer.find_spec("swarmauri.plugins.math")
+    assert isinstance(spec, importlib.machinery.ModuleSpec)

--- a/pkgs/swarmauri/tests/unit/interface_registry_unit_test.py
+++ b/pkgs/swarmauri/tests/unit/interface_registry_unit_test.py
@@ -1,0 +1,30 @@
+import pytest
+
+from swarmauri.interface_registry import InterfaceRegistry
+from swarmauri_base.agents.AgentBase import AgentBase
+
+
+@pytest.fixture(autouse=True)
+def restore_interfaces():
+    original = InterfaceRegistry.INTERFACE_REGISTRY.copy()
+    yield
+    InterfaceRegistry.INTERFACE_REGISTRY = original
+
+
+@pytest.mark.unit
+def test_get_registered_interface():
+    assert InterfaceRegistry.get_interface_for_resource("swarmauri.agents") is AgentBase
+
+
+@pytest.mark.unit
+def test_get_interface_invalid_raises():
+    with pytest.raises(KeyError):
+        InterfaceRegistry.get_interface_for_resource("swarmauri.invalid")
+
+
+@pytest.mark.unit
+def test_register_and_unregister_interface():
+    InterfaceRegistry.register_interface("swarmauri.tests", AgentBase)
+    assert InterfaceRegistry.get_interface_for_resource("swarmauri.tests") is AgentBase
+    InterfaceRegistry.unregister_interface("swarmauri.tests")
+    assert InterfaceRegistry.INTERFACE_REGISTRY["swarmauri.tests"] is None

--- a/pkgs/swarmauri/tests/unit/plugin_citizenship_registry_unit_test.py
+++ b/pkgs/swarmauri/tests/unit/plugin_citizenship_registry_unit_test.py
@@ -1,0 +1,62 @@
+import pytest
+from importlib.metadata import EntryPoint
+
+from swarmauri.plugin_citizenship_registry import PluginCitizenshipRegistry
+
+
+@pytest.fixture(autouse=True)
+def restore_registry():
+    """Restore plugin registries after each test."""
+    first = PluginCitizenshipRegistry.FIRST_CLASS_REGISTRY.copy()
+    second = PluginCitizenshipRegistry.SECOND_CLASS_REGISTRY.copy()
+    third = PluginCitizenshipRegistry.THIRD_CLASS_REGISTRY.copy()
+    yield
+    PluginCitizenshipRegistry.FIRST_CLASS_REGISTRY = first
+    PluginCitizenshipRegistry.SECOND_CLASS_REGISTRY = second
+    PluginCitizenshipRegistry.THIRD_CLASS_REGISTRY = third
+
+
+@pytest.mark.unit
+def test_add_and_remove_entry():
+    PluginCitizenshipRegistry.add_to_registry(
+        "first", "swarmauri.agents.TestAgent", "tests.test_module.TestAgent"
+    )
+    assert (
+        PluginCitizenshipRegistry.FIRST_CLASS_REGISTRY["swarmauri.agents.TestAgent"]
+        == "tests.test_module.TestAgent"
+    )
+
+    PluginCitizenshipRegistry.remove_from_registry(
+        "first", "swarmauri.agents.TestAgent"
+    )
+    assert "swarmauri.agents.TestAgent" not in PluginCitizenshipRegistry.FIRST_CLASS_REGISTRY
+
+
+@pytest.mark.unit
+def test_add_duplicate_entry_raises():
+    PluginCitizenshipRegistry.add_to_registry(
+        "third", "swarmauri.plugins.sample", "math"
+    )
+    with pytest.raises(ValueError):
+        PluginCitizenshipRegistry.add_to_registry(
+            "third", "swarmauri.plugins.sample", "math"
+        )
+
+
+@pytest.mark.unit
+def test_update_and_delete_entry():
+    PluginCitizenshipRegistry.add_to_registry(
+        "second", "swarmauri.chains.TestChain", "pkg.Chain"
+    )
+    PluginCitizenshipRegistry.update_entry(
+        "second", "swarmauri.chains.TestChain", "pkg.NewChain"
+    )
+    assert (
+        PluginCitizenshipRegistry.SECOND_CLASS_REGISTRY["swarmauri.chains.TestChain"]
+        == "pkg.NewChain"
+    )
+
+    PluginCitizenshipRegistry.delete_entry(
+        "second", "swarmauri.chains.TestChain"
+    )
+    assert "swarmauri.chains.TestChain" not in PluginCitizenshipRegistry.SECOND_CLASS_REGISTRY


### PR DESCRIPTION
## Summary
- add new unit tests for PluginCitizenshipRegistry operations
- add InterfaceRegistry tests
- test citizenship classification in plugin manager
- ensure importer resolves modules mapped in registries

## Testing
- `uv run --package swarmauri --directory swarmauri pytest` *(fails: No route to host)*