### PR TITLE
Add evaluation after peagen fetch

### DIFF
--- a/pkgs/swarmauri_standard/swarmauri_standard/programs/Program.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/programs/Program.py
@@ -2,6 +2,7 @@ import copy
 import logging
 import uuid
 from datetime import datetime
+from pathlib import Path
 from typing import Any, ClassVar, Dict, Literal, Optional
 
 from swarmauri_base.programs.ProgramBase import ProgramBase
@@ -184,3 +185,27 @@ class Program(ProgramBase):
 
         logger.info(f"Program {self.id} validation successful")
         return True
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_workspace(cls, root: Path) -> "Program":
+        """Create a program from all source files in *root*.
+
+        Args:
+            root (Path): Workspace directory containing source files.
+
+        Returns:
+            Program: Instance populated with file contents.
+        """
+        root = root.resolve()
+        content: Dict[str, str] = {}
+        for path in root.rglob("*"):
+            if path.is_file() and path.suffix in {".py", ".txt", ".md"}:
+                rel = path.relative_to(root)
+                content[str(rel)] = path.read_text(encoding="utf-8")
+
+        return cls(content=content)
+
+    def get_source_files(self) -> Dict[str, str]:
+        """Return program source files keyed by relative path."""
+        return self.content

--- a/pkgs/swarmauri_standard/tests/unit/programs/Program_unit_test.py
+++ b/pkgs/swarmauri_standard/tests/unit/programs/Program_unit_test.py
@@ -183,3 +183,15 @@ def test_validate_invalid_program_version():
         mock_logger.error.assert_called_with(
             "Program version mismatch or missing in metadata"
         )
+
+
+@pytest.mark.unit
+def test_from_workspace_and_get_source_files(tmp_path):
+    """Test creating a Program from a workspace directory."""
+    file_path = tmp_path / "example.py"
+    file_path.write_text("print('hello')")
+
+    program = Program.from_workspace(tmp_path)
+
+    assert "example.py" in program.content
+    assert program.get_source_files()["example.py"] == "print('hello')"


### PR DESCRIPTION
## Summary
- let `peagen program fetch` optionally run an evaluator pool
- expose `Program.from_workspace` and `get_source_files`
- test creating a program from a workspace

## Testing
- `uv run --package swarmauri_standard --directory swarmauri_standard pytest` *(fails: No route to host)*
- `uv run --package peagen --directory standards/peagen pytest` *(fails: No route to host)*