### PR TITLE
Implement pea-ip-0001 features

### DIFF
--- a/pkgs/standards/peagen/peagen/_template_sets.py
+++ b/pkgs/standards/peagen/peagen/_template_sets.py
@@ -1,0 +1,72 @@
+"""Install template-set packages specified in .peagen.toml."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+def _build_pip_cmd(editable: bool = False) -> List[str]:
+    """Return a pip install command, preferring uv if available."""
+    if shutil.which("uv"):
+        cmd = ["uv", "pip", "install", "--no-deps"]
+    else:
+        cmd = [sys.executable, "-m", "pip", "install", "--no-deps"]
+    if editable:
+        cmd.append("-e")
+    return cmd
+
+
+def _pip_install(path: str, editable: bool = False) -> None:
+    cmd = _build_pip_cmd(editable)
+    cmd.append(path)
+    subprocess.check_call(cmd)
+
+
+def install_template_sets(specs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Install each template-set spec and return manifest info."""
+    installed: List[Dict[str, Any]] = []
+    tmp_root = Path(tempfile.mkdtemp(prefix="tmplset_"))
+    for spec in specs:
+        typ = spec.get("type")
+        target = spec.get("target")
+        name = spec.get("name")
+        try:
+            if typ == "pip":
+                _pip_install(target)
+            elif typ == "git":
+                clone_dir = tmp_root / name
+                cmd = ["git", "clone", "--depth", "1"]
+                if spec.get("ref"):
+                    cmd += ["--branch", spec["ref"]]
+                cmd += [target, str(clone_dir)]
+                subprocess.check_call(cmd)
+                _pip_install(str(clone_dir))
+            elif typ == "local":
+                _pip_install(target, editable=True)
+            elif typ == "bundle":
+                _pip_install(target)
+            else:
+                raise ValueError(f"unknown template-set type: {typ}")
+        except Exception as exc:
+            raise RuntimeError(f"failed to install template-set {name}: {exc}") from exc
+        # try to resolve installed version
+        version = "unknown"
+        try:
+            from importlib.metadata import version as _ver
+
+            version = _ver(name)
+        except Exception:
+            pass
+        installed.append({
+            "name": name,
+            "type": typ,
+            "version": version,
+            "source": target,
+        })
+    shutil.rmtree(tmp_root, ignore_errors=True)
+    return installed

--- a/pkgs/standards/peagen/peagen/cli_common.py
+++ b/pkgs/standards/peagen/peagen/cli_common.py
@@ -66,7 +66,18 @@ class PathOrURI(str):
 # ─────────────────────────────────────────────────────────────────────────────
 # 2. load .peagen.toml
 # ─────────────────────────────────────────────────────────────────────────────
-def load_peagen_toml(start_dir: pathlib.Path = pathlib.Path.cwd()) -> dict[str, Any]:
+def load_peagen_toml(
+    start_dir: pathlib.Path = pathlib.Path.cwd(), path: pathlib.Path | None = None
+) -> dict[str, Any]:
+    """Locate and load ``.peagen.toml`` starting from ``start_dir`` or an explicit ``path``."""
+    if path:
+        cfg_path = path.expanduser().resolve()
+        if cfg_path.is_file():
+            import tomllib
+
+            return tomllib.loads(cfg_path.read_text("utf-8"))
+        return {}
+
     for folder in [start_dir, *start_dir.parents]:
         cfg_path = folder / ".peagen.toml"
         if cfg_path.is_file():

--- a/pkgs/standards/peagen/peagen/commands/program.py
+++ b/pkgs/standards/peagen/peagen/commands/program.py
@@ -30,6 +30,7 @@ from peagen._source_packages import (
     materialise_packages,
     _materialise_source_pkg,
 )
+from peagen._template_sets import install_template_sets
 from peagen.storage_adapters import make_adapter_for_uri
 from peagen.schemas import MANIFEST_V3_SCHEMA  # JSON-Schema dict
 from jsonschema import validate as json_validate, ValidationError
@@ -55,6 +56,10 @@ def fetch(
     no_source: bool = typer.Option(
         False, help="Skip cloning/copying `source_packages` (debug only)"
     ),
+    install_template_sets: bool = typer.Option(
+        True, "--install-template-sets/--no-install-template-sets",
+        help="Install template sets before fetching",
+    ),
 ):
     """
     Reconstruct a complete workspace from manifest(s).
@@ -67,6 +72,8 @@ def fetch(
 
     for m_uri in manifests:
         manifest = _download_manifest(m_uri)
+        if install_template_sets and "template_sets" in manifest:
+            install_template_sets(manifest.get("template_sets", []))
         if not no_source:
             for spec in manifest["source_packages"]:
                 _materialise_source_pkg(spec, out_dir, upload=False)

--- a/pkgs/standards/peagen/peagen/commands/templates.py
+++ b/pkgs/standards/peagen/peagen/commands/templates.py
@@ -13,7 +13,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import peagen.templates as _pt  # root namespace that ships built-in sets
 import typer
@@ -141,6 +141,9 @@ def add_template_set(
             "contains a template-set extension."
         ),
     ),
+    from_bundle: Optional[str] = typer.Option(
+        None, "--from-bundle", help="Install from bundled archive"
+    ),
     editable: bool = typer.Option(
         False,
         "--editable",
@@ -166,7 +169,7 @@ def add_template_set(
     * **Wheel / sdist** → `pip install ./dist/…`
     * **Directory** → `pip install (-e) <dir>`  (use *-e/--editable* to develop)
     """
-    src_path = Path(source)
+    src_path = Path(from_bundle) if from_bundle else Path(source)
     is_local = src_path.exists()
 
     # ------------------------------------------------------------------ helpers

--- a/pkgs/standards/peagen/peagen/core.py
+++ b/pkgs/standards/peagen/peagen/core.py
@@ -71,6 +71,12 @@ class Peagen(ComponentBase):
         ),
     )
 
+    # New: template-sets installed for this run
+    template_sets: List[Dict[str, Any]] = Field(
+        default_factory=list,
+        description="Manifest entries for installed template-sets",
+    )
+
     # Internal state
     projects_list: List[Dict[str, Any]] = Field(default_factory=list, exclude=True)
     dependency_graph: Dict[str, List[str]] = Field(default_factory=dict, exclude=True)
@@ -389,10 +395,11 @@ class Peagen(ComponentBase):
 
 
             manifest_meta: Dict[str, Any] = {
-                "schema_version": 3,
+                "schema_version": "3.1.0",
                 "workspace_uri": workspace_uri,
                 "project": project_name,
                 "source_packages": self.source_packages,
+                "template_sets": self.template_sets,
                 "peagen_version": __version__,
             }
 

--- a/pkgs/standards/peagen/peagen/schemas/__init__.py
+++ b/pkgs/standards/peagen/peagen/schemas/__init__.py
@@ -15,9 +15,21 @@ MANIFEST_V3_SCHEMA = json.loads(
        .read_text(encoding="utf-8")
 )
 
+MANIFEST_V3_1_SCHEMA = json.loads(
+    res.files(__package__)
+       .joinpath("manifest.schema.v3.1.json")
+       .read_text(encoding="utf-8")
+)
+
 PEAGEN_TOML_V1_SCHEMA = json.loads(
     res.files(__package__)
        .joinpath("peagen.toml.schema.v1.json")
+       .read_text(encoding="utf-8")
+)
+
+PEAGEN_TOML_V1_1_SCHEMA = json.loads(
+    res.files(__package__)
+       .joinpath("peagen.toml.schema.v1.1.0.json")
        .read_text(encoding="utf-8")
 )
 
@@ -42,8 +54,10 @@ PROJECTS_PAYLOAD_V1_SCHEMA = json.loads(
 
 
 __all__ = [
-    "MANIFEST_V3_SCHEMA", 
-    "PEAGEN_TOML_V1_SCHEMA", 
+    "MANIFEST_V3_SCHEMA",
+    "MANIFEST_V3_1_SCHEMA",
+    "PEAGEN_TOML_V1_SCHEMA",
+    "PEAGEN_TOML_V1_1_SCHEMA",
     "DOE_SPEC_V1_SCHEMA",
     "PTREE_V1_SCHEMA",
     "PROJECTS_PAYLOAD_V1_SCHEMA",

--- a/pkgs/standards/peagen/peagen/schemas/manifest.schema.v3.1.json
+++ b/pkgs/standards/peagen/peagen/schemas/manifest.schema.v3.1.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://peagen.dev/schemas/manifest-v3.1.json",
+  "title": "Peagen Manifest (schema_version 3.1)",
+  "schemaVersion": "3.1.0",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "workspace_uri",
+    "project",
+    "generated",
+    "template_sets",
+    "source_packages",
+    "peagen_version",
+    "generated_at"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "3.1.0",
+      "description": "Hard-coded version tag; bump only on breaking changes."
+    },
+    "workspace_uri": {
+      "type": "string",
+      "description": "Fetchable root location of the rendered workspace. Acceptable schemes: file://<abs-path> (local run), minio://host:port/bucket[/prefix]/, s3://bucket[/prefix]/, gh://owner/repo[/prefix]/ (GitHub Contents API). Evaluators choose an adapter based on the URI scheme."
+    },
+    "project": {
+      "type": "string",
+      "description": "Human-readable project name taken from payload NAME."
+    },
+    "generated": {
+      "type": "array",
+      "description": "Relative paths of all files Peagen created or overwrote during this run. Paths always use Unix-style '/' separators.",
+      "items": { "type": "string" }
+    },
+    "template_sets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "type", "version", "source"],
+        "properties": {
+          "name": { "type": "string" },
+          "type": { "type": "string" },
+          "version": { "type": "string" },
+          "source": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "source_packages": {
+      "type": "array",
+      "description": "External code or material cloned or copied into the workspace before rendering. Evaluators must materialise these the same way to reconstruct the full tree.",
+      "items": {
+        "type": "object",
+        "required": ["type", "dest"],
+        "properties": {
+          "type": {
+            "enum": ["git", "local", "bundle", "uri"],
+            "description": "Source type: 'git' clones from remote; 'local' copies from filesystem; 'bundle' extracts archives; 'uri' downloads generic assets."
+          },
+          "uri": {
+            "type": "string",
+            "description": "HTTPS or SSH URI for git packages."
+          },
+          "ref": {
+            "type": "string",
+            "description": "Tag, branch, or commit SHA for git packages."
+          },
+          "path": {
+            "type": "string",
+            "description": "Absolute or relative path for local packages."
+          },
+          "dest": {
+            "type": "string",
+            "description": "Destination folder inside the workspace (Unix style)."
+          },
+          "expose_to_jinja": { "type": "boolean" },
+          "checksum": {
+            "type": "string",
+            "description": "Optional sha256 (or similar) checksum for byte-level reproducibility."
+          }
+        },
+        "allOf": [
+          {
+            "if": { "properties": { "type": { "const": "git" } } },
+            "then": { "required": ["uri"] }
+          },
+          {
+            "if": { "properties": { "type": { "const": "local" } } },
+            "then": { "required": ["path"] }
+          }
+        ],
+        "additionalProperties": false
+      }
+    },
+    "peagen_version": {
+      "type": "string",
+      "description": "Semantic version of the Peagen CLI that produced the manifest."
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "UTC timestamp (ISO-8601) when rendering finished."
+    }
+  },
+  "additionalProperties": false
+}

--- a/pkgs/standards/peagen/peagen/schemas/peagen.toml.schema.v1.1.0.json
+++ b/pkgs/standards/peagen/peagen/schemas/peagen.toml.schema.v1.1.0.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://example.com/peagen.schema.json",
+  "title": "Peagen Configuration Schema (v1.1.0)",
+  "type": "object",
+
+  "properties": {
+    "schemaVersion": {
+      "const": "1.1.0",
+      "description": "Version of this Peagen configuration schema"
+    },
+
+    "workspace": {
+      "type": "object",
+      "properties": {
+        "org":          { "type": "string" },
+        "workers":      { "type": "integer" }
+      },
+      "required": [ "org" ],
+      "additionalProperties": true
+    },
+
+    "llm": {
+      "type": "object",
+      "properties": {
+        "default_provider":    { "type": "string" },
+        "default_model_name":  { "type": "string" },
+        "default_temperature": { "type": "number" },
+        "default_max_tokens":  { "type": "integer" }
+      },
+      "required": [ "default_provider", "default_model_name" ],
+      "additionalProperties": true
+    },
+
+    "storage": {
+      "type": "object",
+      "properties": {
+        "default_storage_adapter": { "type": "string" },
+        "adapters": {
+          "type": "object",
+          "patternProperties": {
+            "^[A-Za-z0-9_\\-]+$": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "minProperties": 1,
+          "additionalProperties": false
+        }
+      },
+      "required": [ "default_storage_adapter", "adapters" ],
+      "additionalProperties": false
+    },
+
+    "publishers": {
+      "type": "object",
+      "properties": {
+        "default_publisher": { "type": "string" },
+        "adapters": {
+          "type": "object",
+          "patternProperties": {
+            "^[A-Za-z0-9_\\-]+$": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "minProperties": 1,
+          "additionalProperties": false
+        }
+      },
+      "required": [ "default_publisher", "adapters" ],
+      "additionalProperties": false
+    },
+
+    "plugins": {
+      "type": "object",
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["fallback", "switch", "fan-out"]
+        },
+        "switch": {
+          "type": "object",
+          "patternProperties": {
+            "^[A-Za-z0-9_\\-]+$": { "type": "string" }
+          },
+          "additionalProperties": false
+        }
+      },
+      "required": ["mode"],
+      "additionalProperties": false
+    },
+
+    "template_sets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "type", "target"],
+        "properties": {
+          "name": { "type": "string" },
+          "type": { "enum": ["pip", "git", "local", "bundle"] },
+          "target": { "type": "string" },
+          "ref": { "type": "string" },
+          "bundle_file": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+
+    "source_packages": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "type", "dest"],
+        "properties": {
+          "name": { "type": "string" },
+          "type": { "enum": ["git", "local", "bundle", "uri"] },
+          "uri": { "type": "string" },
+          "path": { "type": "string" },
+          "archive": { "type": "string" },
+          "ref": { "type": "string" },
+          "dest": { "type": "string" },
+          "expose_to_jinja": { "type": "boolean" }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+
+  "required": [ "schemaVersion", "workspace", "llm", "storage", "publishers" ],
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- add helper to install template sets
- expose new schemas and update manifest version
- support new CLI flags for `peagen process`
- allow program fetch to install template sets
- add `--from-bundle` option to template-set add

## Testing
- `uv run --package peagen --directory standards/peagen pytest` *(fails: No route to host)*