### PR TITLE
Fix validate workflow skip monorepo pyproject

### DIFF
--- a/.github/workflows/v0.7.0_validate_changed_files.yaml
+++ b/.github/workflows/v0.7.0_validate_changed_files.yaml
@@ -45,7 +45,9 @@ jobs:
         id: detect
         run: |
           echo "Detecting changed packages …"
-          CHANGED_FILES=$(grep '^pkgs/' changed_files.txt || true)
+          # Exclude the monorepo root pyproject.toml as it does not represent
+          # a real package and will always fail validation.
+          CHANGED_FILES=$(grep '^pkgs/' changed_files.txt | grep -v '^pkgs/pyproject.toml$' || true)
           if [ -z "$CHANGED_FILES" ]; then
             echo "No changes in pkgs/. Exiting."
             echo 'matrix=[]' >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- skip the monorepo `pkgs/pyproject.toml` file when generating the matrix in the validate-changed-files workflow

## Testing
- `git status --short`