### PR TITLE
Add unit tests for peagen publishers

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_rabbitmq_publisher.py
+++ b/pkgs/standards/peagen/tests/unit/test_rabbitmq_publisher.py
@@ -1,0 +1,77 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from peagen.publishers.rabbitmq_publisher import RabbitMQPublisher
+
+
+@pytest.mark.unit
+def test_init_with_uri():
+    fake_channel = MagicMock()
+    fake_conn = MagicMock(channel=MagicMock(return_value=fake_channel))
+    with patch("pika.URLParameters") as mock_params, patch(
+        "pika.BlockingConnection", return_value=fake_conn
+    ) as mock_conn:
+        mock_params.return_value = "params"
+        pub = RabbitMQPublisher(
+            uri="amqp://guest:guest@localhost:5672/", exchange="ex", routing_key="rk"
+        )
+        mock_params.assert_called_once_with("amqp://guest:guest@localhost:5672/")
+        mock_conn.assert_called_once_with("params")
+        assert pub._exchange == "ex"
+        assert pub._routing_key == "rk"
+        assert pub._channel is fake_channel
+
+
+@pytest.mark.unit
+def test_init_with_host_and_port():
+    fake_channel = MagicMock()
+    fake_conn = MagicMock(channel=MagicMock(return_value=fake_channel))
+    with patch("pika.URLParameters") as mock_params, patch(
+        "pika.BlockingConnection", return_value=fake_conn
+    ) as mock_conn:
+        mock_params.return_value = "params"
+        RabbitMQPublisher(host="localhost", port=5672)
+        mock_params.assert_called_once_with("amqp://localhost:5672/")
+        mock_conn.assert_called_once_with("params")
+
+
+@pytest.mark.unit
+def test_init_with_credentials():
+    with patch("pika.URLParameters") as mock_params, patch(
+        "pika.BlockingConnection", return_value=MagicMock(channel=MagicMock())
+    ):
+        mock_params.return_value = "params"
+        RabbitMQPublisher(host="localhost", port=5672, username="user", password="pass")
+        mock_params.assert_called_once_with("amqp://user:pass@localhost:5672/")
+
+
+@pytest.mark.unit
+def test_mixed_config_error():
+    with pytest.raises(ValueError):
+        RabbitMQPublisher(uri="amqp://localhost", host="localhost")
+
+
+@pytest.mark.unit
+def test_missing_host_port_error():
+    with pytest.raises(ValueError):
+        RabbitMQPublisher(host="localhost")
+
+
+@pytest.mark.unit
+def test_publish_message():
+    fake_channel = MagicMock()
+    fake_conn = MagicMock(channel=MagicMock(return_value=fake_channel))
+    with patch("pika.URLParameters", return_value="params"), patch(
+        "pika.BlockingConnection", return_value=fake_conn
+    ):
+        pub = RabbitMQPublisher(host="localhost", port=5672, exchange="ex")
+        pub.publish("rk", {"a": 1})
+        fake_channel.basic_publish.assert_called_once_with(
+            exchange="ex",
+            routing_key="rk",
+            body=json.dumps({"a": 1}).encode(),
+        )
+
+

--- a/pkgs/standards/peagen/tests/unit/test_redis_publisher.py
+++ b/pkgs/standards/peagen/tests/unit/test_redis_publisher.py
@@ -1,0 +1,61 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from peagen.publishers.redis_publisher import RedisPublisher
+
+
+@pytest.mark.unit
+def test_init_with_uri():
+    fake = MagicMock()
+    with patch("redis.from_url", return_value=fake) as mock_from_url:
+        pub = RedisPublisher(uri="redis://localhost:6379/0")
+        assert pub._client is fake
+        mock_from_url.assert_called_once_with(
+            "redis://localhost:6379/0", decode_responses=True
+        )
+
+
+@pytest.mark.unit
+def test_init_with_host_port_db():
+    fake = MagicMock()
+    with patch("redis.from_url", return_value=fake) as mock_from_url:
+        RedisPublisher(host="localhost", port=6379, db=1)
+        mock_from_url.assert_called_once_with(
+            "redis://localhost:6379/1", decode_responses=True
+        )
+
+
+@pytest.mark.unit
+def test_init_with_auth():
+    fake = MagicMock()
+    with patch("redis.from_url", return_value=fake) as mock_from_url:
+        RedisPublisher(
+            host="localhost", port=6379, db=0, username="user", password="pass"
+        )
+        mock_from_url.assert_called_once_with(
+            "redis://user:pass@localhost:6379/0", decode_responses=True
+        )
+
+
+@pytest.mark.unit
+def test_mixed_config_error():
+    with pytest.raises(ValueError):
+        RedisPublisher(uri="redis://localhost", host="localhost")
+
+
+@pytest.mark.unit
+def test_missing_opts_error():
+    with pytest.raises(ValueError):
+        RedisPublisher(host="localhost", port=6379)
+
+
+@pytest.mark.unit
+def test_publish_json():
+    client = MagicMock()
+    with patch("redis.from_url", return_value=client):
+        pub = RedisPublisher(uri="redis://localhost:6379/0")
+        pub.publish("chan", {"a": 1})
+        client.publish.assert_called_once_with("chan", json.dumps({"a": 1}))
+

--- a/pkgs/standards/peagen/tests/unit/test_webhook_publisher.py
+++ b/pkgs/standards/peagen/tests/unit/test_webhook_publisher.py
@@ -1,0 +1,35 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+import httpx
+
+from peagen.publishers.webhook_publisher import WebhookPublisher
+
+
+@pytest.mark.unit
+def test_success():
+    resp = MagicMock(status_code=200)
+    with patch("httpx.post", return_value=resp) as mock_post:
+        pub = WebhookPublisher("https://example.com")
+        pub.publish("chan", {"x": 1})
+        mock_post.assert_called_once_with(
+            "https://example.com", json={"channel": "chan", "payload": {"x": 1}}
+        )
+
+
+@pytest.mark.unit
+def test_http_error():
+    with patch("httpx.post", side_effect=httpx.HTTPError("boom")):
+        pub = WebhookPublisher("https://example.com")
+        with pytest.raises(RuntimeError):
+            pub.publish("chan", {})
+
+
+@pytest.mark.unit
+def test_non_200():
+    resp = MagicMock(status_code=500, text="fail")
+    with patch("httpx.post", return_value=resp):
+        pub = WebhookPublisher("https://example.com")
+        with pytest.raises(RuntimeError):
+            pub.publish("chan", {})
+


### PR DESCRIPTION
## Summary
- move publisher tests out of regression suite
- split publisher tests per class under `tests/unit`

## Testing
- `uv run --package peagen --directory standards/peagen pytest -q` *(fails: Failed to fetch typing-extensions)*