### PR TITLE
Generate extras schemas per template set

### DIFF
--- a/pkgs/standards/peagen/peagen/commands/extras.py
+++ b/pkgs/standards/peagen/peagen/commands/extras.py
@@ -1,4 +1,5 @@
 """Generate extras schemas via CLI."""
+
 from __future__ import annotations
 
 import json
@@ -33,10 +34,14 @@ def _build_schema(keys: List[str], set_name: str) -> dict:
 
 
 @extras_app.command("generate")
-def generate() -> None:
+def generate(
+    templates_root: Path = typer.Option(
+        None, help="Root directory containing template sets"
+    ),
+) -> None:
     """Regenerate EXTRAS schema files from templates."""
     base = Path(__file__).resolve().parents[1]
-    templates_root = base / "templates"
+    templates_root = Path(templates_root) if templates_root else base / "templates"
     schemas_dir = base / "schemas" / "extras"
     schemas_dir.mkdir(parents=True, exist_ok=True)
 
@@ -46,5 +51,6 @@ def generate() -> None:
         schema = _build_schema(keys, set_name)
         out_path = schemas_dir / f"{set_name}.schema.v1.json"
         out_path.write_text(json.dumps(schema, indent=2), encoding="utf-8")
-        typer.echo(f"✅ Wrote {out_path}")
-
+        template_out_path = md_file.parent / "extras.schema.v1.json"
+        template_out_path.write_text(json.dumps(schema, indent=2), encoding="utf-8")
+        typer.echo(f"✅ Wrote {out_path} and {template_out_path}")

--- a/pkgs/standards/peagen/peagen/schemas/projects_payload.schema.v1.json
+++ b/pkgs/standards/peagen/peagen/schemas/projects_payload.schema.v1.json
@@ -1,170 +1,185 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://example.com/projects_payload.schema.json",
-  "title": "Projects Payload Schema (v1.0.0)",
-  "schemaVersion": "1.0.0",
-  "type": "object",
-  "properties": {
-    "schemaVersion": {
-      "type": "string",
-      "const": "1.0.0",
-      "description": "Projects payload schema version"
-    },
-    "PROJECTS": {
-      "type": "array",
-      "items": {
-        "oneOf": [
-          { "$ref": "#/definitions/projectEntry" },
-          { "$ref": "#/definitions/projectGroup" }
-        ]
-      },
-      "description": "Either individual project entries with experiments :contentReference[oaicite:0]{index=0}:contentReference[oaicite:1]{index=1} or grouped payloads with META :contentReference[oaicite:2]{index=2}:contentReference[oaicite:3]{index=3}"
-    },
-    "SOURCE": {
-      "$ref": "#/definitions/source",
-      "description": "Optional metadata about spec/template and checksum :contentReference[oaicite:4]{index=4}:contentReference[oaicite:5]{index=5}"
-    }
-  },
-  "required": ["schemaVersion", "PROJECTS"],
-  "additionalProperties": false,
-  "definitions": {
-    "projectEntry": {
-      "type": "object",
-      "properties": {
-        "NAME":    { "type": "string" },
-        "ROOT":    { "type": "string" },
-        "PACKAGES": {
-          "type": "array",
-          "items": { "$ref": "#/definitions/package" }
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://example.com/projects_payload.schema.json",
+    "title": "Projects Payload Schema (v1.0.0)",
+    "schemaVersion": "1.0.0",
+    "type": "object",
+    "properties": {
+        "schemaVersion": {
+            "type": "string",
+            "const": "1.0.0",
+            "description": "Projects payload schema version",
         },
-        "EXPERIMENT": { "$ref": "#/definitions/experiment" }
-      },
-      "required": ["NAME", "ROOT", "PACKAGES", "EXPERIMENT"],
-      "additionalProperties": true
-    },
-    "projectGroup": {
-      "type": "object",
-      "properties": {
         "PROJECTS": {
-          "type": "array",
-          "items": { "$ref": "#/definitions/projectDefinition" }
+            "type": "array",
+            "items": {
+                "oneOf": [
+                    {"$ref": "#/definitions/projectEntry"},
+                    {"$ref": "#/definitions/projectGroup"},
+                ]
+            },
+            "description": "Either individual project entries with experiments :contentReference[oaicite:0]{index=0}:contentReference[oaicite:1]{index=1} or grouped payloads with META :contentReference[oaicite:2]{index=2}:contentReference[oaicite:3]{index=3}",
         },
-        "META": {
-          "type": "object",
-          "properties": {
-            "design_id":      { "type": "string" },
-            "LLM_FACTORS":    { "type": "object", "additionalProperties": true },
-            "factors":        { "type": "object", "additionalProperties": true },
-            "spec_name":      { "type": "string" },
-            "peagen_version": { "type": "string" }
-          },
-          "required": ["design_id", "LLM_FACTORS", "factors", "spec_name", "peagen_version"],
-          "additionalProperties": true
-        }
-      },
-      "required": ["PROJECTS", "META"],
-      "additionalProperties": true
-    },
-    "package": {
-      "type": "object",
-      "properties": {
-        "NAME":                   { "type": "string" },
-        "TEMPLATE_SET_OVERRIDE":  { "type": "string" },
-        "EXTRAS": {
-          "anyOf": [
-            { "$ref": "extras/component.schema.v1.json" },
-            { "$ref": "extras/cpp_python_pkg.schema.v1.json" },
-            { "$ref": "extras/no_requirements.schema.v1.json" },
-            { "$ref": "extras/python_api_gw.schema.v1.json" },
-            { "$ref": "extras/python_api_gw_service.schema.v1.json" },
-            { "$ref": "extras/python_orm.schema.v1.json" },
-            { "$ref": "extras/pythonpkg.schema.v1.json" },
-            { "$ref": "extras/react_atom.schema.v1.json" },
-            { "$ref": "extras/rust_python_pkg.schema.v1.json" },
-            { "$ref": "extras/svelte_atom.schema.v1.json" },
-            { "$ref": "extras/swarmauri_base.schema.v1.json" },
-            { "$ref": "extras/swarmauri_core.schema.v1.json" },
-            { "$ref": "extras/swarmauri_standard.schema.v1.json" },
-            { "$ref": "extras/swarmauri_standard_standalone.schema.v1.json" },
-            { "$ref": "extras/test3.schema.v1.json" },
-            { "$ref": "extras/test5.schema.v1.json" },
-            { "$ref": "extras/vue_atom.schema.v1.json" }
-          ]
+        "SOURCE": {
+            "$ref": "#/definitions/source",
+            "description": "Optional metadata about spec/template and checksum :contentReference[oaicite:4]{index=4}:contentReference[oaicite:5]{index=5}",
         },
-        "MODULES": {
-          "type": "array",
-          "items": { "$ref": "#/definitions/module" }
-        }
-      },
-      "required": ["NAME", "TEMPLATE_SET_OVERRIDE", "MODULES"],
-      "additionalProperties": true
     },
-    "module": {
-      "type": "object",
-      "properties": {
-        "NAME":   { "type": "string" },
-        "EXTRAS": {
-          "anyOf": [
-            { "$ref": "extras/component.schema.v1.json" },
-            { "$ref": "extras/cpp_python_pkg.schema.v1.json" },
-            { "$ref": "extras/no_requirements.schema.v1.json" },
-            { "$ref": "extras/python_api_gw.schema.v1.json" },
-            { "$ref": "extras/python_api_gw_service.schema.v1.json" },
-            { "$ref": "extras/python_orm.schema.v1.json" },
-            { "$ref": "extras/pythonpkg.schema.v1.json" },
-            { "$ref": "extras/react_atom.schema.v1.json" },
-            { "$ref": "extras/rust_python_pkg.schema.v1.json" },
-            { "$ref": "extras/svelte_atom.schema.v1.json" },
-            { "$ref": "extras/swarmauri_base.schema.v1.json" },
-            { "$ref": "extras/swarmauri_core.schema.v1.json" },
-            { "$ref": "extras/swarmauri_standard.schema.v1.json" },
-            { "$ref": "extras/swarmauri_standard_standalone.schema.v1.json" },
-            { "$ref": "extras/test3.schema.v1.json" },
-            { "$ref": "extras/test5.schema.v1.json" },
-            { "$ref": "extras/vue_atom.schema.v1.json" }
-          ]
-        }
-      },
-      "required": ["NAME", "EXTRAS"],
-      "additionalProperties": false
+    "required": ["schemaVersion", "PROJECTS"],
+    "additionalProperties": false,
+    "definitions": {
+        "projectEntry": {
+            "type": "object",
+            "properties": {
+                "NAME": {"type": "string"},
+                "ROOT": {"type": "string"},
+                "PACKAGES": {
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/package"},
+                },
+                "EXPERIMENT": {"$ref": "#/definitions/experiment"},
+            },
+            "required": ["NAME", "ROOT", "PACKAGES", "EXPERIMENT"],
+            "additionalProperties": true,
+        },
+        "projectGroup": {
+            "type": "object",
+            "properties": {
+                "PROJECTS": {
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/projectDefinition"},
+                },
+                "META": {
+                    "type": "object",
+                    "properties": {
+                        "design_id": {"type": "string"},
+                        "LLM_FACTORS": {"type": "object", "additionalProperties": true},
+                        "factors": {"type": "object", "additionalProperties": true},
+                        "spec_name": {"type": "string"},
+                        "peagen_version": {"type": "string"},
+                    },
+                    "required": [
+                        "design_id",
+                        "LLM_FACTORS",
+                        "factors",
+                        "spec_name",
+                        "peagen_version",
+                    ],
+                    "additionalProperties": true,
+                },
+            },
+            "required": ["PROJECTS", "META"],
+            "additionalProperties": true,
+        },
+        "package": {
+            "type": "object",
+            "properties": {
+                "NAME": {"type": "string"},
+                "TEMPLATE_SET_OVERRIDE": {"type": "string"},
+                "EXTRAS": {
+                    "anyOf": [
+                        {"$ref": "../templates/component/extras.schema.v1.json"},
+                        {"$ref": "../templates/cpp_python_pkg/extras.schema.v1.json"},
+                        {"$ref": "../templates/no_requirements/extras.schema.v1.json"},
+                        {"$ref": "../templates/python_api_gw/extras.schema.v1.json"},
+                        {
+                            "$ref": "../templates/python_api_gw_service/extras.schema.v1.json"
+                        },
+                        {"$ref": "../templates/python_orm/extras.schema.v1.json"},
+                        {"$ref": "../templates/pythonpkg/extras.schema.v1.json"},
+                        {"$ref": "../templates/react_atom/extras.schema.v1.json"},
+                        {"$ref": "../templates/rust_python_pkg/extras.schema.v1.json"},
+                        {"$ref": "../templates/svelte_atom/extras.schema.v1.json"},
+                        {"$ref": "../templates/swarmauri_base/extras.schema.v1.json"},
+                        {"$ref": "../templates/swarmauri_core/extras.schema.v1.json"},
+                        {
+                            "$ref": "../templates/swarmauri_standard/extras.schema.v1.json"
+                        },
+                        {
+                            "$ref": "../templates/swarmauri_standard_standalone/extras.schema.v1.json"
+                        },
+                        {"$ref": "../templates/test3/extras.schema.v1.json"},
+                        {"$ref": "../templates/test5/extras.schema.v1.json"},
+                        {"$ref": "../templates/vue_atom/extras.schema.v1.json"},
+                    ]
+                },
+                "MODULES": {"type": "array", "items": {"$ref": "#/definitions/module"}},
+            },
+            "required": ["NAME", "TEMPLATE_SET_OVERRIDE", "MODULES"],
+            "additionalProperties": true,
+        },
+        "module": {
+            "type": "object",
+            "properties": {
+                "NAME": {"type": "string"},
+                "EXTRAS": {
+                    "anyOf": [
+                        {"$ref": "../templates/component/extras.schema.v1.json"},
+                        {"$ref": "../templates/cpp_python_pkg/extras.schema.v1.json"},
+                        {"$ref": "../templates/no_requirements/extras.schema.v1.json"},
+                        {"$ref": "../templates/python_api_gw/extras.schema.v1.json"},
+                        {
+                            "$ref": "../templates/python_api_gw_service/extras.schema.v1.json"
+                        },
+                        {"$ref": "../templates/python_orm/extras.schema.v1.json"},
+                        {"$ref": "../templates/pythonpkg/extras.schema.v1.json"},
+                        {"$ref": "../templates/react_atom/extras.schema.v1.json"},
+                        {"$ref": "../templates/rust_python_pkg/extras.schema.v1.json"},
+                        {"$ref": "../templates/svelte_atom/extras.schema.v1.json"},
+                        {"$ref": "../templates/swarmauri_base/extras.schema.v1.json"},
+                        {"$ref": "../templates/swarmauri_core/extras.schema.v1.json"},
+                        {
+                            "$ref": "../templates/swarmauri_standard/extras.schema.v1.json"
+                        },
+                        {
+                            "$ref": "../templates/swarmauri_standard_standalone/extras.schema.v1.json"
+                        },
+                        {"$ref": "../templates/test3/extras.schema.v1.json"},
+                        {"$ref": "../templates/test5/extras.schema.v1.json"},
+                        {"$ref": "../templates/vue_atom/extras.schema.v1.json"},
+                    ]
+                },
+            },
+            "required": ["NAME", "EXTRAS"],
+            "additionalProperties": false,
+        },
+        "experiment": {
+            "type": "object",
+            "properties": {
+                "FACTORS": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[A-Za-z0-9_]+$": {"type": ["string", "number", "boolean"]}
+                    },
+                    "additionalProperties": false,
+                }
+            },
+            "required": ["FACTORS"],
+            "additionalProperties": true,
+        },
+        "projectDefinition": {
+            "type": "object",
+            "properties": {
+                "NAME": {"type": "string"},
+                "ROOT": {"type": "string"},
+                "PACKAGES": {
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/package"},
+                },
+            },
+            "required": ["NAME", "ROOT", "PACKAGES"],
+            "additionalProperties": true,
+        },
+        "source": {
+            "type": "object",
+            "properties": {
+                "spec": {"type": "string"},
+                "template": {"type": "string"},
+                "context": {"type": ["string", "null"]},
+                "spec_checksum": {"type": "string"},
+            },
+            "required": ["spec", "template", "context", "spec_checksum"],
+            "additionalProperties": true,
+        },
     },
-    "experiment": {
-      "type": "object",
-      "properties": {
-        "FACTORS": {
-          "type": "object",
-          "patternProperties": {
-            "^[A-Za-z0-9_]+$": { "type": ["string", "number", "boolean"] }
-          },
-          "additionalProperties": false
-        }
-      },
-      "required": ["FACTORS"],
-      "additionalProperties": true
-    },
-    "projectDefinition": {
-      "type": "object",
-      "properties": {
-        "NAME":     { "type": "string" },
-        "ROOT":     { "type": "string" },
-        "PACKAGES": {
-          "type": "array",
-          "items": { "$ref": "#/definitions/package" }
-        }
-      },
-      "required": ["NAME", "ROOT", "PACKAGES"],
-      "additionalProperties": true
-    },
-    "source": {
-      "type": "object",
-      "properties": {
-        "spec":           { "type": "string" },
-        "template":       { "type": "string" },
-        "context":        { "type": ["string", "null"] },
-        "spec_checksum":  { "type": "string" }
-      },
-      "required": ["spec", "template", "context", "spec_checksum"],
-      "additionalProperties": true
-    }
-  }
 }

--- a/scripts/generate_extras_schemas.py
+++ b/scripts/generate_extras_schemas.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import List
+import argparse
 
 TEMPLATES_ROOT = Path("pkgs/standards/peagen/peagen/templates")
 SCHEMAS_DIR = Path("pkgs/standards/peagen/peagen/schemas/extras")
@@ -35,17 +36,27 @@ def _build_schema(keys: List[str], set_name: str) -> dict:
     }
 
 
-def generate_schemas() -> None:
+def generate_schemas(templates_root: Path = TEMPLATES_ROOT) -> None:
     """Generate schema files for all template-sets."""
     SCHEMAS_DIR.mkdir(parents=True, exist_ok=True)
-    for md_file in TEMPLATES_ROOT.glob("*/EXTRAS.md"):
+    for md_file in templates_root.glob("*/EXTRAS.md"):
         set_name = md_file.parent.name
         keys = _parse_keys(md_file)
         schema = _build_schema(keys, set_name)
         out_path = SCHEMAS_DIR / f"{set_name}.schema.v1.json"
         out_path.write_text(json.dumps(schema, indent=2), encoding="utf-8")
-        print(f"✅ Wrote {out_path}")
+        template_out_path = md_file.parent / "extras.schema.v1.json"
+        template_out_path.write_text(json.dumps(schema, indent=2), encoding="utf-8")
+        print(f"✅ Wrote {out_path} and {template_out_path}")
 
 
 if __name__ == "__main__":
-    generate_schemas()
+    parser = argparse.ArgumentParser(description="Generate EXTRAS schemas")
+    parser.add_argument(
+        "--templates-root",
+        type=Path,
+        default=TEMPLATES_ROOT,
+        help="Root directory containing template sets",
+    )
+    args = parser.parse_args()
+    generate_schemas(args.templates_root)


### PR DESCRIPTION
## Summary
- add templates_root option for `peagen extras generate`
- write extras schema files into each template set directory
- support `--templates-root` in `scripts/generate_extras_schemas.py`
- reference template-set extras schemas from `projects_payload.schema.v1.json`

## Testing
- `uv run --package peagen --directory standards/peagen pytest` *(fails: No route to host)*