### PR TITLE
Remove code_generation_mode from J2PromptTemplate

### DIFF
--- a/pkgs/standards/swarmauri_prompt_j2prompttemplate/pyproject.toml
+++ b/pkgs/standards/swarmauri_prompt_j2prompttemplate/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
+    "inflect>=7.0.0",
     "jinja2>=3.1.6",
     "pydantic>=1.8.2",
     "swarmauri_core",

--- a/pkgs/standards/swarmauri_prompt_j2prompttemplate/swarmauri_prompt_j2prompttemplate/J2PromptTemplate.py
+++ b/pkgs/standards/swarmauri_prompt_j2prompttemplate/swarmauri_prompt_j2prompttemplate/J2PromptTemplate.py
@@ -137,8 +137,8 @@ class J2PromptTemplate(PromptTemplateBase):
             loader=FileSystemLoader([directory]), autoescape=False
         )
         fallback_env.filters["split"] = self.split_whitespace
-        if self.code_generation_mode:
-            fallback_env.filters["make_singular"] = self.make_singular
+        fallback_env.filters["make_singular"] = self.make_singular
+        fallback_env.filters["make_plural"] = self.make_plural
 
         self.template = fallback_env.get_template(template_name)
 

--- a/pkgs/standards/swarmauri_prompt_j2prompttemplate/swarmauri_prompt_j2prompttemplate/J2PromptTemplate.py
+++ b/pkgs/standards/swarmauri_prompt_j2prompttemplate/swarmauri_prompt_j2prompttemplate/J2PromptTemplate.py
@@ -18,9 +18,8 @@ class J2PromptTemplate(PromptTemplateBase):
 
     Features:
     - Support for multiple template directories with fallback mechanism
-    - Built-in filters: split_whitespace, make_singular (when code_generation_mode is True)
+    - Built-in filters: split_whitespace, make_singular, make_plural
     - Template caching for performance
-    - Configurable for both general-purpose use and code generation
     """
 
     # The template attribute may be a literal string (template content),
@@ -29,7 +28,6 @@ class J2PromptTemplate(PromptTemplateBase):
     variables: Dict[str, Union[str, int, float, Any]] = {}
     # Optional templates_dir attribute (can be a single path or a list of paths)
     templates_dir: Optional[Union[str, List[str]]] = None
-    # Whether to enable code generation specific features like linguistic filters
 
     model_config = ConfigDict(arbitrary_types_allowed=True, extra="allow")
     type: Literal["J2PromptTemplate"] = "J2PromptTemplate"
@@ -55,6 +53,7 @@ class J2PromptTemplate(PromptTemplateBase):
         # Add basic filters
         env.filters["split"] = self.split_whitespace
         env.filters["make_singular"] = self.make_singular
+        env.filters["make_plural"] = self.make_plural
 
         return env
 
@@ -136,8 +135,8 @@ class J2PromptTemplate(PromptTemplateBase):
             loader=FileSystemLoader([directory]), autoescape=False
         )
         fallback_env.filters["split"] = self.split_whitespace
-        if self.code_generation_mode:
-            fallback_env.filters["make_singular"] = self.make_singular
+        fallback_env.filters["make_singular"] = self.make_singular
+        fallback_env.filters["make_plural"] = self.make_plural
 
         self.template = fallback_env.get_template(template_name)
 
@@ -198,11 +197,6 @@ class J2PromptTemplate(PromptTemplateBase):
         except ImportError:
             # Return the original if inflect is not available
             return word
-<<<<<<< HEAD
-            
-=======
-
->>>>>>> upstream/mono/dev
     @staticmethod
     def make_plural(word: str) -> str:
         """
@@ -211,19 +205,10 @@ class J2PromptTemplate(PromptTemplateBase):
         """
         try:
             import inflect
-<<<<<<< HEAD
-=======
-
->>>>>>> upstream/mono/dev
             p = inflect.engine()
             return p.plural(word) or word
         except ImportError:
             return word
-<<<<<<< HEAD
-    
-=======
-
->>>>>>> upstream/mono/dev
     def add_filter(self, name: str, filter_func: Callable) -> None:
         """
         Adds a custom filter to the Jinja2 environment.
@@ -236,5 +221,5 @@ class J2PromptTemplate(PromptTemplateBase):
         env.filters[name] = filter_func
 
 
-# Create a singleton instance for peagen usage with code generation mode enabled
+# Create a singleton instance for peagen usage
 j2pt = J2PromptTemplate()

--- a/pkgs/standards/swarmauri_prompt_j2prompttemplate/tests/unit/test_J2PromptTemplate.py
+++ b/pkgs/standards/swarmauri_prompt_j2prompttemplate/tests/unit/test_J2PromptTemplate.py
@@ -90,14 +90,13 @@ def test_j2pt_singleton_exists():
     from swarmauri_prompt_j2prompttemplate import j2pt
 
     assert j2pt is not None
-    assert j2pt.code_generation_mode is True
 
 
 @pytest.mark.unit
-def test_j2pt_code_generation_filters():
+def test_j2pt_builtin_filters():
     from swarmauri_prompt_j2prompttemplate import j2pt
 
-    # Test the make_singular filter which is only available in code_generation_mode
+    # Test the make_singular filter which is always available
     template_str = "{{ 'users' | make_singular }}"
     j2pt.set_template(template_str)
     result = j2pt.fill({})
@@ -111,7 +110,6 @@ def test_j2pt_copy():
     # Test basic copy functionality
     copy_instance = j2pt.model_copy(deep=False)
     assert copy_instance is not j2pt
-    assert copy_instance.code_generation_mode == j2pt.code_generation_mode
 
     # Test templates_dir handling
     original_dir = j2pt.templates_dir

--- a/pkgs/standards/swarmauri_prompt_j2prompttemplate/tests/unit/test_J2PromptTemplate.py
+++ b/pkgs/standards/swarmauri_prompt_j2prompttemplate/tests/unit/test_J2PromptTemplate.py
@@ -93,7 +93,7 @@ def test_j2pt_singleton_exists():
 
 
 @pytest.mark.unit
-def test_j2pt_builtin_filters():
+def test_j2pt_builtin_singular_filter():
     from swarmauri_prompt_j2prompttemplate import j2pt
 
     # Test the make_singular filter which is always available
@@ -101,6 +101,16 @@ def test_j2pt_builtin_filters():
     j2pt.set_template(template_str)
     result = j2pt.fill({})
     assert result == "user"
+
+@pytest.mark.unit
+def test_j2pt_builtin_plural_filter():
+    from swarmauri_prompt_j2prompttemplate import j2pt
+
+    # Test the make_singular filter which is always available
+    template_str = "{{ 'user' | make_plural }}"
+    j2pt.set_template(template_str)
+    result = j2pt.fill({})
+    assert result == "users"
 
 
 @pytest.mark.unit

--- a/pkgs/uv.lock
+++ b/pkgs/uv.lock
@@ -525,7 +525,7 @@ wheels = [
 
 [[package]]
 name = "catoml"
-version = "0.1.1.dev18"
+version = "0.1.1.dev21"
 source = { editable = "catoml" }
 
 [package.dev-dependencies]
@@ -560,7 +560,7 @@ dev = [
 
 [[package]]
 name = "cayaml"
-version = "0.1.0.dev9"
+version = "0.1.0.dev10"
 source = { editable = "cayaml" }
 
 [package.dev-dependencies]
@@ -3312,10 +3312,12 @@ version = "0.1.2.dev10"
 source = { editable = "standards/peagen" }
 dependencies = [
     { name = "colorama" },
+    { name = "httpx" },
     { name = "inflect" },
     { name = "jinja2" },
     { name = "jsonpatch" },
     { name = "minio" },
+    { name = "pika" },
     { name = "pygithub" },
     { name = "python-dotenv" },
     { name = "redis" },
@@ -3330,6 +3332,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "flake8" },
+    { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-benchmark" },
@@ -3337,17 +3340,18 @@ dev = [
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "python-dotenv" },
-    { name = "requests" },
     { name = "ruff" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "colorama" },
+    { name = "httpx", specifier = ">=0.27.0" },
     { name = "inflect" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "jsonpatch", specifier = ">=1.33" },
     { name = "minio" },
+    { name = "pika" },
     { name = "pygithub" },
     { name = "python-dotenv" },
     { name = "redis" },
@@ -3362,6 +3366,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "flake8", specifier = ">=7.0" },
+    { name = "httpx", specifier = ">=0.27.0" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.24.0" },
     { name = "pytest-benchmark", specifier = ">=4.0.0" },
@@ -3369,7 +3374,6 @@ dev = [
     { name = "pytest-timeout", specifier = ">=2.3.1" },
     { name = "pytest-xdist", specifier = ">=3.6.1" },
     { name = "python-dotenv" },
-    { name = "requests", specifier = ">=2.32.3" },
     { name = "ruff", specifier = ">=0.9.9" },
 ]
 
@@ -3383,6 +3387,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772 },
+]
+
+[[package]]
+name = "pika"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/db/d4102f356af18f316c67f2cead8ece307f731dd63140e2c71f170ddacf9b/pika-1.3.2.tar.gz", hash = "sha256:b2a327ddddf8570b4965b3576ac77091b850262d34ce8c1d8cb4e4146aa4145f", size = 145029 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/f3/f412836ec714d36f0f4ab581b84c491e3f42c6b5b97a6c6ed1817f3c16d0/pika-1.3.2-py3-none-any.whl", hash = "sha256:0779a7c1fafd805672796085560d290213a465e4f6f76a6fb19e378d8041a14f", size = 155415 },
 ]
 
 [[package]]
@@ -4836,7 +4849,7 @@ wheels = [
 
 [[package]]
 name = "swarmauri"
-version = "0.7.4.dev10"
+version = "0.7.4.dev11"
 source = { editable = "swarmauri" }
 dependencies = [
     { name = "httpx" },
@@ -4929,7 +4942,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-base"
-version = "0.7.4.dev9"
+version = "0.7.4.dev12"
 source = { editable = "base" }
 dependencies = [
     { name = "numpy" },
@@ -4984,7 +4997,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-core"
-version = "0.7.4.dev9"
+version = "0.7.4.dev12"
 source = { editable = "core" }
 dependencies = [
     { name = "pydantic" },
@@ -5021,7 +5034,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-distance-minkowski"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "standards/swarmauri_distance_minkowski" }
 dependencies = [
     { name = "scipy" },
@@ -5068,7 +5081,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-embedding-doc2vec"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "standards/swarmauri_embedding_doc2vec" }
 dependencies = [
     { name = "gensim" },
@@ -5115,7 +5128,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-embedding-mlm"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_embedding_mlm" }
 dependencies = [
     { name = "swarmauri-base" },
@@ -5164,7 +5177,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-embedding-nmf"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "standards/swarmauri_embedding_nmf" }
 dependencies = [
     { name = "scikit-learn" },
@@ -5211,7 +5224,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-evaluator-abstractmethods"
-version = "0.1.1.dev2"
+version = "0.1.1.dev5"
 source = { editable = "standards/swarmauri_evaluator_abstractmethods" }
 dependencies = [
     { name = "swarmauri-base" },
@@ -5254,7 +5267,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-evaluator-anyusage"
-version = "0.1.1.dev2"
+version = "0.1.1.dev5"
 source = { editable = "standards/swarmauri_evaluator_anyusage" }
 dependencies = [
     { name = "swarmauri-base" },
@@ -5297,7 +5310,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-evaluator-externalimports"
-version = "0.1.1.dev1"
+version = "0.1.1.dev4"
 source = { editable = "standards/swarmauri_evaluator_externalimports" }
 dependencies = [
     { name = "swarmauri-base" },
@@ -5436,7 +5449,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-llm-leptonai"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_llm_leptonai" }
 dependencies = [
     { name = "openai" },
@@ -5483,7 +5496,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-measurement-mutualinformation"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_measurement_mutualinformation" }
 dependencies = [
     { name = "pandas" },
@@ -5530,7 +5543,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-measurement-tokencountestimator"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_measurement_tokencountestimator" }
 dependencies = [
     { name = "swarmauri-base" },
@@ -5612,7 +5625,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-ocr-pytesseract"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_ocr_pytesseract" }
 dependencies = [
     { name = "pytesseract" },
@@ -5659,7 +5672,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-parser-beautifulsoupelement"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "standards/swarmauri_parser_beautifulsoupelement" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -5706,7 +5719,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-parser-bertembedding"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_parser_bertembedding" }
 dependencies = [
     { name = "swarmauri-base" },
@@ -5804,7 +5817,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-parser-fitzpdf"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_parser_fitzpdf" }
 dependencies = [
     { name = "pymupdf" },
@@ -5851,7 +5864,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-parser-keywordextractor"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "standards/swarmauri_parser_keywordextractor" }
 dependencies = [
     { name = "swarmauri-base" },
@@ -5898,7 +5911,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-parser-pypdf2"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_parser_pypdf2" }
 dependencies = [
     { name = "pypdf2" },
@@ -5945,7 +5958,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-parser-pypdftk"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_parser_pypdftk" }
 dependencies = [
     { name = "pypdftk" },
@@ -5992,7 +6005,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-parser-slate"
-version = "0.1.0.dev10"
+version = "0.1.0.dev13"
 source = { editable = "community/swarmauri_parser_slate" }
 dependencies = [
     { name = "slate3k" },
@@ -6037,7 +6050,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-parser-textblob"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_parser_textblob" }
 dependencies = [
     { name = "nltk" },
@@ -6201,7 +6214,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-state-clipboard"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_state_clipboard" }
 dependencies = [
     { name = "swarmauri-base" },
@@ -6244,7 +6257,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-tool-captchagenerator"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_tool_captchagenerator" }
 dependencies = [
     { name = "captcha" },
@@ -6291,7 +6304,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-tool-dalechallreadability"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_tool_dalechallreadability" }
 dependencies = [
     { name = "swarmauri-base" },
@@ -6338,7 +6351,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-tool-downloadpdf"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_tool_downloadpdf" }
 dependencies = [
     { name = "swarmauri-base" },
@@ -6383,7 +6396,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-tool-entityrecognition"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_tool_entityrecognition" }
 dependencies = [
     { name = "swarmauri-base" },
@@ -6434,7 +6447,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-tool-folium"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_tool_folium" }
 dependencies = [
     { name = "folium" },
@@ -6481,7 +6494,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-tool-gmail"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_tool_gmail" }
 dependencies = [
     { name = "google-api-python-client" },
@@ -6528,7 +6541,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-tool-jupyterclearoutput"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_tool_jupyterclearoutput" }
 dependencies = [
     { name = "nbconvert" },
@@ -6575,7 +6588,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-tool-jupyterdisplay"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_tool_jupyterdisplay" }
 dependencies = [
     { name = "ipython", version = "8.33.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -6623,7 +6636,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-tool-jupyterdisplayhtml"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_tool_jupyterdisplayhtml" }
 dependencies = [
     { name = "ipython", version = "8.33.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -6671,7 +6684,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-tool-jupyterexecuteandconvert"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_tool_jupyterexecuteandconvert" }
 dependencies = [
     { name = "nbconvert" },
@@ -6718,7 +6731,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-tool-jupyterexecutecell"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_tool_jupyterexecutecell" }
 dependencies = [
     { name = "ipykernel" },
@@ -6770,7 +6783,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-tool-jupyterexecutenotebook"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_tool_jupyterexecutenotebook" }
 dependencies = [
     { name = "ipykernel" },
@@ -6821,7 +6834,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-tool-jupyterexecutenotebookwithparameters"
-version = "1.1.4.dev10"
+version = "1.1.4.dev13"
 source = { editable = "community/swarmauri_tool_jupyterexecutenotebookwithparameters" }
 dependencies = [
     { name = "papermill" },
@@ -6868,7 +6881,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-tool-jupyterexporthtml"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_tool_jupyterexporthtml" }
 dependencies = [
     { name = "nbconvert" },
@@ -6915,7 +6928,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-tool-jupyterexportlatex"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_tool_jupyterexportlatex" }
 dependencies = [
     { name = "nbconvert" },
@@ -6962,7 +6975,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-tool-jupyterexportmarkdown"
-version = "1.1.4.dev10"
+version = "1.1.4.dev13"
 source = { editable = "community/swarmauri_tool_jupyterexportmarkdown" }
 dependencies = [
     { name = "papermill" },
@@ -7011,7 +7024,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-tool-jupyterexportpython"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_tool_jupyterexportpython" }
 dependencies = [
     { name = "nbconvert" },
@@ -7058,7 +7071,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-tool-jupyterfromdict"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_tool_jupyterfromdict" }
 dependencies = [
     { name = "nbformat" },
@@ -7105,13 +7118,14 @@ dev = [
 
 [[package]]
 name = "swarmauri-tool-jupytergetiopubmessage"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_tool_jupytergetiopubmessage" }
 dependencies = [
     { name = "jupyter-client" },
     { name = "swarmauri-base" },
     { name = "swarmauri-core" },
     { name = "swarmauri-standard" },
+    { name = "websocket-client" },
 ]
 
 [package.dev-dependencies]
@@ -7134,6 +7148,7 @@ requires-dist = [
     { name = "swarmauri-base", editable = "base" },
     { name = "swarmauri-core", editable = "core" },
     { name = "swarmauri-standard", editable = "swarmauri_standard" },
+    { name = "websocket-client", specifier = ">=1.8.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -7152,7 +7167,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-tool-jupytergetshellmessage"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_tool_jupytergetshellmessage" }
 dependencies = [
     { name = "ipykernel" },
@@ -7201,7 +7216,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-tool-jupyterreadnotebook"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_tool_jupyterreadnotebook" }
 dependencies = [
     { name = "nbformat" },
@@ -7248,7 +7263,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-tool-jupyterruncell"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_tool_jupyterruncell" }
 dependencies = [
     { name = "ipython", version = "8.33.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -7296,7 +7311,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-tool-jupytershutdownkernel"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_tool_jupytershutdownkernel" }
 dependencies = [
     { name = "jupyter-client" },
@@ -7343,7 +7358,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-tool-jupyterstartkernel"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_tool_jupyterstartkernel" }
 dependencies = [
     { name = "ipykernel" },
@@ -7392,7 +7407,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-tool-jupytervalidatenotebook"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_tool_jupytervalidatenotebook" }
 dependencies = [
     { name = "nbformat" },
@@ -7443,7 +7458,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-tool-jupyterwritenotebook"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_tool_jupyterwritenotebook" }
 dependencies = [
     { name = "nbformat" },
@@ -7490,7 +7505,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-tool-lexicaldensity"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_tool_lexicaldensity" }
 dependencies = [
     { name = "nltk" },
@@ -7539,7 +7554,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-tool-matplotlib"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "standards/swarmauri_tool_matplotlib" }
 dependencies = [
     { name = "matplotlib" },
@@ -7586,7 +7601,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-tool-psutil"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_tool_psutil" }
 dependencies = [
     { name = "psutil" },
@@ -7633,7 +7648,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-tool-qrcodegenerator"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_tool_qrcodegenerator" }
 dependencies = [
     { name = "qrcode" },
@@ -7680,7 +7695,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-tool-searchword"
-version = "0.1.0.dev8"
+version = "0.1.0.dev11"
 source = { editable = "community/swarmauri_tool_searchword" }
 dependencies = [
     { name = "pydantic" },
@@ -7727,7 +7742,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-tool-sentencecomplexity"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_tool_sentencecomplexity" }
 dependencies = [
     { name = "nltk" },
@@ -7774,7 +7789,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-tool-sentimentanalysis"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_tool_sentimentanalysis" }
 dependencies = [
     { name = "swarmauri-base" },
@@ -7825,7 +7840,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-tool-smogindex"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_tool_smogindex" }
 dependencies = [
     { name = "nltk" },
@@ -7874,7 +7889,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-tool-textlength"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_tool_textlength" }
 dependencies = [
     { name = "nltk" },
@@ -7921,7 +7936,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-tool-webscraping"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_tool_webscraping" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -7968,7 +7983,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-tool-zapierhook"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_tool_zapierhook" }
 dependencies = [
     { name = "swarmauri-base" },
@@ -8013,7 +8028,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-toolkit-github"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_toolkit_github" }
 dependencies = [
     { name = "pygithub" },
@@ -8060,7 +8075,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-toolkit-jupytertoolkit"
-version = "0.2.4.dev10"
+version = "0.2.4.dev13"
 source = { editable = "community/swarmauri_toolkit_jupytertoolkit" }
 dependencies = [
     { name = "pydantic" },
@@ -8147,7 +8162,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-typing"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "typing" }
 
 [package.dev-dependencies]
@@ -8184,7 +8199,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-vectorstore-annoy"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_vectorstore_annoy" }
 dependencies = [
     { name = "annoy" },
@@ -8233,7 +8248,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-vectorstore-cloudweaviate"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_vectorstore_cloudweaviate" }
 dependencies = [
     { name = "swarmauri-base" },
@@ -8282,7 +8297,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-vectorstore-doc2vec"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "standards/swarmauri_vectorstore_doc2vec" }
 dependencies = [
     { name = "swarmauri-base" },
@@ -8329,7 +8344,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-vectorstore-duckdb"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_vectorstore_duckdb" }
 dependencies = [
     { name = "duckdb" },
@@ -8378,7 +8393,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-vectorstore-mlm"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_vectorstore_mlm" }
 dependencies = [
     { name = "swarmauri-base" },
@@ -8429,7 +8444,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-vectorstore-neo4j"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_vectorstore_neo4j" }
 dependencies = [
     { name = "neo4j" },
@@ -8478,7 +8493,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-vectorstore-persistentchromadb"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_vectorstore_persistentchromadb" }
 dependencies = [
     { name = "chromadb" },
@@ -8527,7 +8542,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-vectorstore-pinecone"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_vectorstore_pinecone" }
 dependencies = [
     { name = "pinecone", extra = ["grpc"] },
@@ -8625,7 +8640,7 @@ dev = [
 
 [[package]]
 name = "swarmauri-vectorstore-redis"
-version = "0.7.4.dev10"
+version = "0.7.4.dev13"
 source = { editable = "community/swarmauri_vectorstore_redis" }
 dependencies = [
     { name = "redis" },


### PR DESCRIPTION
## Summary
- cleanup merge artifacts and code_generation references
- always register `split`, `make_singular` and `make_plural` filters
- update tests for new behaviour

## Testing
- `uv run --package swarmauri_prompt_j2prompttemplate --directory standards/swarmauri_prompt_j2prompttemplate pytest` *(fails: Failed to fetch `yake`)*
- `uv run --package peagen --directory standards/peagen pytest` *(fails: Failed to fetch `transformers`)*