### PR TITLE
Align core.py arg docs with IP-0001

### DIFF
--- a/pkgs/standards/peagen/peagen/core.py
+++ b/pkgs/standards/peagen/peagen/core.py
@@ -50,10 +50,10 @@ class Peagen(ComponentBase):
     # Runtime / env setup
     base_dir: str = Field(exclude=True, default_factory=os.getcwd)
 
-    # Legacy flag – converted to SOURCE_PACKAGES during CLI parsing.
+    # Legacy flag – converted to TEMPLATE_SETS during CLI parsing.
     additional_package_dirs: List[Path] = Field(
         default_factory=list,
-        description="DEPRECATED – converted to SOURCE_PACKAGES at CLI level."
+        description="DEPRECATED – converted to anonymous template-set entries at CLI level."
     )
 
     # New: scratch workspace chosen by process.py
@@ -66,15 +66,19 @@ class Peagen(ComponentBase):
     source_packages: List[Dict[str, Any]] = Field(
         default_factory=list,
         description=(
-            "Each item: {type:'git'|'local', uri/path, ref?, dest, checksum?}. "
-            "'dest' is relative to workspace_root."
+            "Each item: {type:'git'|'local'|'bundle'|'uri', uri/archive, ref?, dest, "
+            "expose_to_jinja?, checksum?}. 'dest' is relative to workspace_root."
         ),
     )
 
     # New: template-sets installed for this run
     template_sets: List[Dict[str, Any]] = Field(
         default_factory=list,
-        description="Manifest entries for installed template-sets",
+        description=(
+            "Manifest entries for installed template-sets. "
+            "Each item: {name, type:'pip'|'git'|'local'|'bundle', "
+            "target, ref?, bundle_file?}."
+        ),
     )
 
     # Internal state
@@ -102,7 +106,7 @@ class Peagen(ComponentBase):
         that exist inside the workspace** plus built-ins & plugin templates.
         """
         # ── Auto-convert any leftover `additional_package_dirs`
-        #    into synthetic 'local' SOURCE_PACKAGE specs, so they get
+        #    into synthetic 'local' TEMPLATE_SET entries, so they get
         #    written to the manifest without CLI help.
         # -----------------------------------------------------------
         ns_dirs: List[str] = list(peagen.templates.__path__)


### PR DESCRIPTION
## Summary
- update `Peagen` arg descriptions in core.py to match IP‑0001
- fix internal comment about `additional_package_dirs`

## Testing
- `uv run --package peagen --directory standards/peagen pytest` *(fails: No route to host)*