### PR TITLE
Fix ruff issues in swarmauri_standard

### DIFF
--- a/pkgs/swarmauri_standard/swarmauri_standard/inner_products/FrobeniusRealInnerProduct.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/inner_products/FrobeniusRealInnerProduct.py
@@ -3,13 +3,14 @@ from typing import Literal, TypeVar, Union
 
 import numpy as np
 from numpy.typing import NDArray
+from swarmauri_core.vectors.IVector import IVector
 from swarmauri_base.ComponentBase import ComponentBase
 from swarmauri_base.inner_products.InnerProductBase import InnerProductBase
 
 # Configure logging
 logger = logging.getLogger(__name__)
 
-Vector = TypeVar("Vector", bound="IVector")
+Vector = TypeVar("Vector", bound=IVector)
 Matrix = TypeVar("Matrix", bound=np.ndarray)
 
 

--- a/pkgs/swarmauri_standard/swarmauri_standard/inner_products/HermitianInnerProduct.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/inner_products/HermitianInnerProduct.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Callable, Literal, TypeVar, Union
+from typing import Callable, Literal, TypeVar, Union
 
 import numpy as np
 from swarmauri_base.ComponentBase import ComponentBase

--- a/pkgs/swarmauri_standard/swarmauri_standard/inner_products/RKHSInnerProduct.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/inner_products/RKHSInnerProduct.py
@@ -2,7 +2,7 @@ import logging
 from typing import Callable, Literal, TypeVar, Union
 
 import numpy as np
-from swarmauri_base.ComponentBase import ComponentBase, ResourceTypes
+from swarmauri_base.ComponentBase import ComponentBase
 from swarmauri_base.inner_products.InnerProductBase import InnerProductBase
 from swarmauri_core.vectors.IVector import IVector
 

--- a/pkgs/swarmauri_standard/swarmauri_standard/inner_products/WeightedL2InnerProduct.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/inner_products/WeightedL2InnerProduct.py
@@ -3,6 +3,7 @@ from numbers import Number
 from typing import Any, Callable, Dict, Literal, TypeVar, Union
 
 import numpy as np
+from swarmauri_core.vectors.IVector import IVector
 from swarmauri_base.ComponentBase import ComponentBase
 from swarmauri_base.inner_products.InnerProductBase import InnerProductBase
 
@@ -10,7 +11,7 @@ from swarmauri_base.inner_products.InnerProductBase import InnerProductBase
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
-Vector = TypeVar("Vector", bound="IVector")
+Vector = TypeVar("Vector", bound=IVector)
 Matrix = TypeVar("Matrix", bound=np.ndarray)
 
 

--- a/pkgs/swarmauri_standard/swarmauri_standard/metrics/EuclideanMetric.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/metrics/EuclideanMetric.py
@@ -2,6 +2,8 @@ import logging
 import math
 from typing import List, Literal, Sequence, Union
 
+import numpy as np
+
 from swarmauri_base.ComponentBase import ComponentBase
 from swarmauri_base.metrics.MetricBase import MetricBase
 from swarmauri_core.matrices.IMatrix import IMatrix

--- a/pkgs/swarmauri_standard/swarmauri_standard/metrics/SupremumMetric.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/metrics/SupremumMetric.py
@@ -96,8 +96,10 @@ class SupremumMetric(MetricBase):
                 # Try to handle other types
                 try:
                     return abs(x - y)
-                except:
-                    raise TypeError(f"Unsupported input types: {type(x)} and {type(y)}")
+                except Exception as exc:
+                    raise TypeError(
+                        f"Unsupported input types: {type(x)} and {type(y)}"
+                    ) from exc
 
         except Exception as e:
             logger.error(f"Error calculating supremum distance: {str(e)}")

--- a/pkgs/swarmauri_standard/swarmauri_standard/norms/L2EuclideanNorm.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/norms/L2EuclideanNorm.py
@@ -196,7 +196,7 @@ class L2EuclideanNorm(NormBase):
         """
         try:
             # Check if inputs are of the same type
-            if type(x) != type(y):
+            if type(x) is not type(y):
                 raise TypeError(
                     f"Inputs must be of the same type, got {type(x)} and {type(y)}"
                 )

--- a/pkgs/swarmauri_standard/swarmauri_standard/norms/SupremumComplexNorm.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/norms/SupremumComplexNorm.py
@@ -1,9 +1,8 @@
 import logging
-from typing import Literal, Optional, Union
+from typing import Literal, Union
 
 import numpy as np
-from pydantic import Field
-from swarmauri_base.ComponentBase import ComponentBase, ResourceTypes
+from swarmauri_base.ComponentBase import ComponentBase
 from swarmauri_base.norms.NormBase import (
     CallableType,
     MatrixType,
@@ -248,8 +247,8 @@ class SupremumComplexNorm(NormBase):
                 # For single values or incompatible types
                 try:
                     x_plus_y = complex(x) + complex(y)
-                except:
-                    raise TypeError("Inputs cannot be added")
+                except Exception as exc:
+                    raise TypeError("Inputs cannot be added") from exc
 
             # Compute norms
             norm_x = abs(self.compute(x))

--- a/pkgs/swarmauri_standard/swarmauri_standard/pseudometrics/EquivalenceRelationPseudometric.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/pseudometrics/EquivalenceRelationPseudometric.py
@@ -1,4 +1,4 @@
-from typing import Callable, List, Literal, Sequence, TypeVar, Union, Any, Callable
+from typing import List, Literal, Sequence, TypeVar, Union, Any, Callable
 import logging
 from pydantic import Field
 

--- a/pkgs/swarmauri_standard/swarmauri_standard/pseudometrics/FunctionDifferencePseudometric.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/pseudometrics/FunctionDifferencePseudometric.py
@@ -1,8 +1,7 @@
-from typing import TypeVar, Union, Callable, Sequence, Literal, Any, Dict, List, Optional, Set
+from typing import TypeVar, Union, Callable, Sequence, Literal, Any, Dict, List, Optional
 import logging
 import numpy as np
 import random
-from functools import partial
 
 from swarmauri_base.pseudometrics.PseudometricBase import PseudometricBase
 from swarmauri_base.ComponentBase import ComponentBase
@@ -139,7 +138,6 @@ class FunctionDifferencePseudometric(PseudometricBase):
         for _ in range(self.num_samples):
             if len(dimensions) == 1:
                 # 1D case - return scalar
-                dim = dimensions[0]
                 lower, upper = bounds[0]
                 point = random.uniform(lower, upper)
                 self._sample_points.append(point)

--- a/pkgs/swarmauri_standard/swarmauri_standard/pseudometrics/LpPseudometric.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/pseudometrics/LpPseudometric.py
@@ -1,8 +1,7 @@
-from typing import TypeVar, Union, Callable, Sequence, Literal, List, Optional, Any, Dict, Tuple
+from typing import TypeVar, Union, Callable, Sequence, Literal, List, Optional, Tuple
 import logging
 import numpy as np
 import math
-from functools import lru_cache
 
 from swarmauri_base.ComponentBase import ComponentBase
 from swarmauri_base.pseudometrics.PseudometricBase import PseudometricBase
@@ -141,8 +140,10 @@ class LpPseudometric(PseudometricBase):
             try:
                 # Try to convert to array as a last resort
                 return np.array(x, dtype=float)
-            except:
-                raise TypeError(f"Unsupported input type for LpPseudometric: {type(x)}")
+            except Exception as exc:
+                raise TypeError(
+                    f"Unsupported input type for LpPseudometric: {type(x)}"
+                ) from exc
     
     def _filter_coordinates(self, arr: np.ndarray) -> np.ndarray:
         """

--- a/pkgs/swarmauri_standard/swarmauri_standard/pseudometrics/ProjectionPseudometricR2.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/pseudometrics/ProjectionPseudometricR2.py
@@ -1,4 +1,4 @@
-from typing import Callable, List, Literal, Optional, Sequence, TypeVar, Union, Tuple
+from typing import Callable, List, Literal, Sequence, TypeVar, Union, Tuple
 import logging
 import numpy as np
 from pydantic import Field

--- a/pkgs/swarmauri_standard/swarmauri_standard/pseudometrics/ZeroPseudometric.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/pseudometrics/ZeroPseudometric.py
@@ -206,4 +206,4 @@ class ZeroPseudometric(PseudometricBase):
         str
             A string representation suitable for debugging
         """
-        return f"ZeroPseudometric()"
+        return "ZeroPseudometric()"

--- a/pkgs/swarmauri_standard/swarmauri_standard/similarities/ExponentialDistanceSimilarity.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/similarities/ExponentialDistanceSimilarity.py
@@ -2,7 +2,6 @@ import logging
 import math
 from typing import Callable, List, Literal, Sequence
 
-from pydantic import Field
 from swarmauri_base.ComponentBase import ComponentBase
 from swarmauri_base.similarities.SimilarityBase import SimilarityBase
 from swarmauri_core.similarities.ISimilarity import ComparableType

--- a/pkgs/swarmauri_standard/tests/unit/inner_products/EuclideanInnerProduct_unit_test.py
+++ b/pkgs/swarmauri_standard/tests/unit/inner_products/EuclideanInnerProduct_unit_test.py
@@ -201,7 +201,6 @@ def test_linearity_first_argument(euclidean_inner_product, a1, a2, b, alpha, bet
     # Direct computation to verify
     a1_array = np.array(a1)
     a2_array = np.array(a2)
-    b_array = np.array(b)
 
     combined = alpha * a1_array + beta * a2_array
     left_side = euclidean_inner_product.compute(combined, b)

--- a/pkgs/swarmauri_standard/tests/unit/inner_products/WeightedL2InnerProduct_unit_test.py
+++ b/pkgs/swarmauri_standard/tests/unit/inner_products/WeightedL2InnerProduct_unit_test.py
@@ -100,7 +100,9 @@ def test_validate_weight_at_points_valid(weighted_l2_constant):
 def test_validate_weight_at_points_invalid():
     """Test validation fails with non-positive weights."""
     # Create a weight function that returns negative values
-    negative_weight_func = lambda x: -1.0
+    def negative_weight_func(x):
+        return -1.0
+
     inner_product = WeightedL2InnerProduct(weight_function=negative_weight_func)
 
     with pytest.raises(ValueError, match="Weight function must be strictly positive"):
@@ -236,7 +238,10 @@ def test_compute_with_complex_arrays(weighted_l2_constant):
 @pytest.mark.unit
 def test_invalid_weight_function():
     """Test inner product with a weight function that returns zero or negative values."""
-    invalid_weight_func = lambda x: np.zeros_like(x) if isinstance(x, np.ndarray) else 0
+
+    def invalid_weight_func(x):
+        return np.zeros_like(x) if isinstance(x, np.ndarray) else 0
+
     inner_product = WeightedL2InnerProduct(weight_function=invalid_weight_func)
 
     a = np.array([1, 2, 3])

--- a/pkgs/swarmauri_standard/tests/unit/pseudometrics/EquivalenceRelationPseudometric_unit_test.py
+++ b/pkgs/swarmauri_standard/tests/unit/pseudometrics/EquivalenceRelationPseudometric_unit_test.py
@@ -1,7 +1,6 @@
 import pytest
 import logging
-from typing import List, Any, Callable
-from unittest.mock import Mock
+from typing import List, Any
 
 from swarmauri_standard.pseudometrics.EquivalenceRelationPseudometric import EquivalenceRelationPseudometric
 

--- a/pkgs/swarmauri_standard/tests/unit/pseudometrics/FunctionDifferencePseudometric_unit_test.py
+++ b/pkgs/swarmauri_standard/tests/unit/pseudometrics/FunctionDifferencePseudometric_unit_test.py
@@ -1,7 +1,7 @@
 import pytest
 import logging
 import numpy as np
-from typing import Dict, List, Callable, Any
+from typing import Dict, Callable
 from swarmauri_standard.pseudometrics.FunctionDifferencePseudometric import FunctionDifferencePseudometric
 
 # Configure logging for tests
@@ -419,7 +419,8 @@ def test_with_constant_functions(fixed_points_pseudometric, simple_functions):
 def test_evaluate_function(fixed_points_pseudometric):
     """Test the internal _evaluate_function method."""
     # Simple function
-    func = lambda x: x**2
+    def func(x):
+        return x**2
     points = [-2, -1, 0, 1, 2]
     
     # Expected values: [4, 1, 0, 1, 4]

--- a/pkgs/swarmauri_standard/tests/unit/pseudometrics/LpPseudometric_unit_test.py
+++ b/pkgs/swarmauri_standard/tests/unit/pseudometrics/LpPseudometric_unit_test.py
@@ -2,7 +2,6 @@ import pytest
 import numpy as np
 import math
 import logging
-from typing import List, Tuple, Any
 
 from swarmauri_standard.pseudometrics.LpPseudometric import LpPseudometric
 from swarmauri_base.pseudometrics.PseudometricBase import PseudometricBase

--- a/pkgs/swarmauri_standard/tests/unit/pseudometrics/ZeroPseudometric_unit_test.py
+++ b/pkgs/swarmauri_standard/tests/unit/pseudometrics/ZeroPseudometric_unit_test.py
@@ -1,7 +1,5 @@
 import pytest
 import logging
-from typing import List, Sequence, Union, Any, Callable
-from unittest.mock import patch
 
 from swarmauri_standard.pseudometrics.ZeroPseudometric import ZeroPseudometric
 from swarmauri_core.vectors.IVector import IVector

--- a/pkgs/swarmauri_standard/tests/unit/similarities/OverlapCoefficientSimilarity_unit_test.py
+++ b/pkgs/swarmauri_standard/tests/unit/similarities/OverlapCoefficientSimilarity_unit_test.py
@@ -1,7 +1,5 @@
 import pytest
 import logging
-from typing import List, Set
-from collections import Counter
 
 from swarmauri_standard.similarities.OverlapCoefficientSimilarity import OverlapCoefficientSimilarity
 


### PR DESCRIPTION
## Summary
- fix several ruff linting failures in `swarmauri_standard`
- remove unused imports and update type hints
- replace bare `except` statements
- convert lambda assignments to functions in tests

## Testing
- `ruff check`
- `uv run --package swarmauri_standard --directory swarmauri_standard pytest` *(fails: network requests)*