### PR TITLE
Add interface abstract method tests

### DIFF
--- a/pkgs/core/tests/unit/iagent_unit_test.py
+++ b/pkgs/core/tests/unit/iagent_unit_test.py
@@ -1,0 +1,10 @@
+import pytest
+from swarmauri_core.agents.IAgent import IAgent
+
+
+@pytest.mark.unit
+def test_iagent_methods_are_abstract():
+    for name in ["exec", "aexec", "batch", "abatch"]:
+        assert hasattr(IAgent, name)
+        method = getattr(IAgent, name)
+        assert getattr(method, "__isabstractmethod__", False)

--- a/pkgs/core/tests/unit/iparser_unit_test.py
+++ b/pkgs/core/tests/unit/iparser_unit_test.py
@@ -1,0 +1,8 @@
+import pytest
+from swarmauri_core.parsers.IParser import IParser
+
+
+@pytest.mark.unit
+def test_iparser_methods_are_abstract():
+    assert hasattr(IParser, "parse")
+    assert getattr(IParser.parse, "__isabstractmethod__", False)

--- a/pkgs/core/tests/unit/ipredict_unit_test.py
+++ b/pkgs/core/tests/unit/ipredict_unit_test.py
@@ -1,0 +1,44 @@
+import inspect
+import pytest
+from swarmauri_core.llms.IPredict import IPredict
+
+
+@pytest.mark.unit
+def test_ipredict_methods_are_abstract():
+    for name in [
+        "predict",
+        "apredict",
+        "stream",
+        "astream",
+        "batch",
+        "abatch",
+    ]:
+        assert hasattr(IPredict, name)
+        method = getattr(IPredict, name)
+        assert getattr(method, "__isabstractmethod__", False)
+
+
+class DummyPredict(IPredict):
+    def predict(self, *args, **kwargs):
+        return None
+
+    async def apredict(self, *args, **kwargs):
+        return None
+
+    def stream(self, *args, **kwargs):
+        return None
+
+    async def astream(self, *args, **kwargs):
+        return None
+
+    def batch(self, *args, **kwargs):
+        return []
+
+    async def abatch(self, *args, **kwargs):
+        return []
+
+
+@pytest.mark.unit
+def test_ipredict_can_be_subclassed():
+    dummy = DummyPredict()
+    assert isinstance(dummy, IPredict)

--- a/pkgs/core/tests/unit/ivectorstore_unit_test.py
+++ b/pkgs/core/tests/unit/ivectorstore_unit_test.py
@@ -1,0 +1,20 @@
+import pytest
+from swarmauri_core.vector_stores.IVectorStore import IVectorStore
+
+
+@pytest.mark.unit
+def test_ivectorstore_methods_are_abstract():
+    method_names = [
+        "add_document",
+        "add_documents",
+        "get_document",
+        "get_all_documents",
+        "delete_document",
+        "clear_documents",
+        "update_document",
+        "document_count",
+    ]
+    for name in method_names:
+        assert hasattr(IVectorStore, name)
+        method = getattr(IVectorStore, name)
+        assert getattr(method, "__isabstractmethod__", False)


### PR DESCRIPTION
## Summary
- add unit tests for IPredict, IAgent, IVectorStore and IParser interfaces

## Testing
- `uv run --package swarmauri_core --directory core pytest` *(fails: No route to host)*