### PR TITLE
Add basic tests for base mixins

### DIFF
--- a/pkgs/base/tests/unit/ComponentBase_unit_test.py
+++ b/pkgs/base/tests/unit/ComponentBase_unit_test.py
@@ -1,0 +1,16 @@
+import pytest
+from swarmauri_base.ComponentBase import ComponentBase, ResourceTypes
+
+class DummyComponent(ComponentBase):
+    pass
+
+@pytest.mark.unit
+def test_component_base_defaults():
+    comp = DummyComponent()
+    assert comp.resource == "ComponentBase"
+    assert comp.type == "DummyComponent"
+    assert comp.version == "0.1.0"
+
+@pytest.mark.unit
+def test_resource_types_contains_tool():
+    assert ResourceTypes.TOOL.value == "Tool"

--- a/pkgs/base/tests/unit/ObserveBase_unit_test.py
+++ b/pkgs/base/tests/unit/ObserveBase_unit_test.py
@@ -1,0 +1,14 @@
+import pytest
+from swarmauri_base.ObserveBase import ObserveBase
+from swarmauri_base.DynamicBase import DynamicBase
+
+@DynamicBase.register_type()
+class CustomObserver(ObserveBase):
+    pass
+
+@pytest.mark.unit
+def test_observe_base_registration_and_defaults():
+    obs = CustomObserver()
+    assert obs.type == "CustomObserver"
+    reg = DynamicBase._registry["ObserveBase"]["subtypes"]
+    assert reg["CustomObserver"] is CustomObserver

--- a/pkgs/base/tests/unit/ServiceMixin_unit_test.py
+++ b/pkgs/base/tests/unit/ServiceMixin_unit_test.py
@@ -1,0 +1,16 @@
+import pytest
+from swarmauri_base.ServiceMixin import ServiceMixin
+
+class DummyService(ServiceMixin):
+    pass
+
+@pytest.mark.unit
+def test_service_mixin_defaults():
+    first = DummyService()
+    second = DummyService()
+    assert isinstance(first.id, str) and first.id
+    assert first.members is None
+    assert first.owners is None
+    assert first.host is None
+    # ids should be unique
+    assert first.id != second.id


### PR DESCRIPTION
## Summary
- add ServiceMixin unit test
- add ComponentBase unit test
- add ObserveBase unit test

## Testing
- `uv run --package swarmauri-base --directory base pytest` *(fails: No route to host)*