### PR TITLE
Add additional peagen unit tests

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_manifest_writer.py
+++ b/pkgs/standards/peagen/tests/unit/test_manifest_writer.py
@@ -1,0 +1,46 @@
+import json
+import threading
+from pathlib import Path
+
+import pytest
+
+from peagen.manifest_writer import ManifestWriter
+
+
+class DummyAdapter:
+    def __init__(self):
+        self.uploaded = []
+        self.root_uri = "s3://unit/"
+
+    def upload(self, key: str, fh):
+        # record only the key
+        self.uploaded.append(key)
+
+
+@pytest.mark.unit
+def test_manifest_writer_add_and_finalise(tmp_path: Path, monkeypatch):
+    adapter = DummyAdapter()
+
+    class FakeThread:
+        def __init__(self, target, name=None, daemon=None):
+            self.target = target
+
+        def start(self):
+            self.target()
+
+    monkeypatch.setattr(threading, "Thread", FakeThread)
+
+    writer = ManifestWriter(slug="proj", adapter=adapter, tmp_root=tmp_path)
+    writer.add({"file": "a.txt"})
+    writer.add({"file": "b.txt"})
+
+    uri = writer.finalise()
+
+    assert uri == "s3://unit/.peagen/proj_manifest.json"
+    manifest_path = tmp_path / "proj_manifest.json"
+    data = json.loads(manifest_path.read_text())
+    assert data["generated"] == ["a.txt", "b.txt"]
+    assert not (tmp_path / "proj_manifest.partial.jsonl").exists()
+
+    assert f".peagen/{writer.path.name}" in adapter.uploaded
+    assert ".peagen/proj_manifest.json" in adapter.uploaded

--- a/pkgs/standards/peagen/tests/unit/test_plugin_registry.py
+++ b/pkgs/standards/peagen/tests/unit/test_plugin_registry.py
@@ -1,0 +1,73 @@
+import sys
+import types
+import importlib.metadata as im
+
+import pytest
+
+from peagen import plugin_registry
+
+
+@pytest.fixture(autouse=True)
+def clear_registry():
+    plugin_registry.registry.clear()
+    yield
+    plugin_registry.registry.clear()
+
+
+def _make_ep(name: str, module_name: str, obj_name: str, group: str):
+    mod = types.ModuleType(module_name)
+    cls = type(obj_name, (), {})
+    setattr(mod, obj_name, cls)
+    sys.modules[module_name] = mod
+    return im.EntryPoint(name, f"{module_name}:{obj_name}", group), cls
+
+
+@pytest.mark.unit
+def test_discover_and_register_plugins(monkeypatch):
+    ep1, cls1 = _make_ep("builtin", "peagen.builtin_mod", "Builtin", "peagen.storage_adapters")
+    ep2, cls2 = _make_ep("external", "ext.mod", "External", "peagen.storage_adapters")
+
+    def fake_entry_points(group: str):
+        if group == "peagen.storage_adapters":
+            return [ep1, ep2]
+        return []
+
+    monkeypatch.setattr(plugin_registry, "entry_points", fake_entry_points)
+
+    plugin_registry.discover_and_register_plugins()
+
+    assert plugin_registry.registry["storage_adapters"]["builtin"] is cls1
+    assert plugin_registry.registry["storage_adapters"]["external"] is cls2
+
+
+@pytest.mark.unit
+def test_duplicate_plugin_raises(monkeypatch):
+    ep1, _ = _make_ep("name", "peagen.mod1", "A", "peagen.storage_adapters")
+    ep2, _ = _make_ep("name", "ext.mod1", "B", "peagen.storage_adapters")
+
+    def fake_entry_points(group: str):
+        if group == "peagen.storage_adapters":
+            return [ep1, ep2]
+        return []
+
+    monkeypatch.setattr(plugin_registry, "entry_points", fake_entry_points)
+
+    with pytest.raises(RuntimeError):
+        plugin_registry.discover_and_register_plugins()
+
+
+@pytest.mark.unit
+def test_fallback_mode_skips_duplicate(monkeypatch):
+    ep1, cls1 = _make_ep("name", "peagen.mod2", "A", "peagen.storage_adapters")
+    ep2, _ = _make_ep("name", "ext.mod2", "B", "peagen.storage_adapters")
+
+    def fake_entry_points(group: str):
+        if group == "peagen.storage_adapters":
+            return [ep1, ep2]
+        return []
+
+    monkeypatch.setattr(plugin_registry, "entry_points", fake_entry_points)
+
+    plugin_registry.discover_and_register_plugins(mode="fallback")
+
+    assert plugin_registry.registry["storage_adapters"]["name"] is cls1

--- a/pkgs/standards/peagen/tests/unit/test_slug_utils.py
+++ b/pkgs/standards/peagen/tests/unit/test_slug_utils.py
@@ -1,0 +1,13 @@
+import pytest
+from peagen.slug_utils import slugify
+
+@pytest.mark.unit
+class TestSlugify:
+    def test_basic(self):
+        assert slugify("Hello World") == "hello-world"
+
+    def test_special_characters(self):
+        assert slugify("C++_Project@2020") == "c-_project-2020"
+
+    def test_trimmed(self):
+        assert slugify("!!Danger!!") == "danger"


### PR DESCRIPTION
## Summary
- add slug utilities tests
- add manifest writer tests
- add plugin registry tests
- move new peagen tests into unit test folder

## Testing
- `uv run --package peagen --directory standards/peagen pytest` *(fails: No route to host)*