### PR TITLE
Fix missing imports in DOEManager

### DIFF
--- a/pkgs/standards/peagen/peagen/doe.py
+++ b/pkgs/standards/peagen/peagen/doe.py
@@ -6,6 +6,10 @@ import itertools
 from pathlib import Path
 from typing import Any, Dict
 
+import yaml
+from jinja2 import Template
+import jsonpatch
+
 
 class DOEManager:
     """


### PR DESCRIPTION
## Summary
- add missing imports for `yaml`, `Template` and `jsonpatch` in DOE helper

## Testing
- `ruff check pkgs/standards/peagen/peagen/doe.py`
- `uv run --package peagen --directory standards/peagen pytest` *(fails: No route to host)*