### PR TITLE
Fix peagen plugin discovery

### DIFF
--- a/pkgs/standards/peagen/peagen/__init__.py
+++ b/pkgs/standards/peagen/peagen/__init__.py
@@ -23,7 +23,7 @@ def _determine_plugin_mode() -> str:
     except Exception:
         pass
 
-    return "fan-out"
+    return "fallback"
 
 
 discover_and_register_plugins(mode=_determine_plugin_mode())

--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -83,7 +83,6 @@ dev = [
 init-project       = "peagen.scaffold.project"
 init-template-set  = "peagen.scaffold.template_set"
 init-doe-spec      = "peagen.scaffold.doe_spec"
-init-eval-pool     = "peagen.scaffold.eval_pool"
 init-ci            = "peagen.scaffold.ci"
 
 [project.entry-points."peagen.storage_adapters"]


### PR DESCRIPTION
## Summary
- set plugin discovery to fallback mode
- remove missing eval-pool entry point

## Testing
- `uv run --package peagen --directory standards/peagen pytest` *(fails: No route to host)*