### PR TITLE
Fix peagen runtime helpers

### DIFF
--- a/pkgs/standards/peagen/peagen/_external.py
+++ b/pkgs/standards/peagen/peagen/_external.py
@@ -149,8 +149,8 @@ def chunk_content(full_content: str, logger: Optional[Any] = None) -> str:
             logger.warning(
                 "MdSnippetChunker not found. Returning full content without chunking."
             )
-        return full_content
+        return cleaned_text
     except Exception as e:
         if logger:
             logger.error(f"[ERROR] Failed to chunk content: {e}")
-        return full_content
+        return cleaned_text

--- a/pkgs/standards/peagen/peagen/_processing.py
+++ b/pkgs/standards/peagen/peagen/_processing.py
@@ -29,8 +29,8 @@ def _save_file(
     *,
     storage_adapter=None,
     org: str | None = None,
-    workspace_root: Path,
-    manifest_writer: Optional[ManifestWriter] = None,   # NEW
+    workspace_root: Path = Path("."),
+    manifest_writer: Optional[ManifestWriter] = None,
 ) -> None:
     """
     1.  Write to <workspace_root>/<filepath>.
@@ -116,9 +116,9 @@ def _process_file(
     global_attrs: Dict[str, Any],
     template_dir: str,
     agent_env: Dict[str, Any],
-    j2_instance: Any,
+    j2_instance: Any = j2pt,
     *,
-    workspace_root: Path,
+    workspace_root: Path = Path("."),
     logger: Optional[Any] = None,
     start_idx: int = 0,
     idx_len: int = 1,
@@ -194,11 +194,11 @@ def _process_project_files(
     agent_env: Dict[str, Any],
     logger: Optional[Any] = None,
     *,
-    workspace_root: Path,
+    workspace_root: Path = Path("."),
     start_idx: int = 0,
     storage_adapter: Optional[Any] = None,
     org: Optional[str] = None,
-    manifest_writer: Optional[ManifestWriter] = None,      # NEW
+    manifest_writer: Optional[ManifestWriter] = None,
 ) -> None:
     """
     Processes all file_records, creating fresh J2PromptTemplate instances

--- a/pkgs/standards/peagen/peagen/_rendering.py
+++ b/pkgs/standards/peagen/peagen/_rendering.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, Optional
 import colorama
 from colorama import Fore, Style
 from pydantic import FilePath
+from swarmauri_prompt_j2prompttemplate import j2pt
 
 # Initialize colorama for auto-resetting colors
 colorama.init(autoreset=True)
@@ -18,7 +19,6 @@ colorama.init(autoreset=True)
 def _render_copy_template(
     file_record: Dict[str, Any],
     context: Dict[str, Any],
-    j2_instance: Any,  # <-- new parameter
     logger: Optional[Any] = None,
 ) -> str:
     """
@@ -29,8 +29,8 @@ def _render_copy_template(
     """
     try:
         template_path = file_record.get("FILE_NAME", "NOT_FILE_FOUND")
-        j2_instance.set_template(FilePath(template_path))
-        return j2_instance.fill(context)
+        j2pt.set_template(FilePath(template_path))
+        return j2pt.fill(context)
     except Exception as e:
         if logger:
             e_split = str(e).split("not found")
@@ -45,7 +45,6 @@ def _render_generate_template(
     file_record: Dict[str, Any],
     context: Dict[str, Any],
     agent_prompt_template: str,
-    j2_instance: Any,  # <-- new parameter
     agent_env: Dict[str, str] = {},
     logger: Optional[Any] = None,
 ) -> str:
@@ -57,8 +56,8 @@ def _render_generate_template(
     then calls out to the external agent.
     """
     try:
-        j2_instance.set_template(FilePath(agent_prompt_template))
-        rendered_prompt = j2_instance.fill(context)
+        j2pt.set_template(FilePath(agent_prompt_template))
+        rendered_prompt = j2pt.fill(context)
         from ._external import call_external_agent
 
         return call_external_agent(rendered_prompt, agent_env, logger)

--- a/pkgs/standards/peagen/peagen/core.py
+++ b/pkgs/standards/peagen/peagen/core.py
@@ -139,7 +139,7 @@ class Peagen(ComponentBase):
 
         # 4) Legacy additional_package_dirs (already copied by CLI helper into workspace)
         for p in self.additional_package_dirs:
-            ns_dirs.append(os.fspath(p))
+            ns_dirs.append(p)
 
         # 5) User-specified template_base_dir and repo root
         if self.template_base_dir:
@@ -182,6 +182,11 @@ class Peagen(ComponentBase):
         raise ValueError(
             f"Template set '{template_set}' not found in: {self.namespace_dirs}"
         )
+
+    # Backwards compatibility
+    def get_template_dir_any(self, template_set: str) -> Path:
+        """Alias for locate_template_set for legacy tests."""
+        return self.locate_template_set(template_set)
 
     # ---------------------
     # Public Methods


### PR DESCRIPTION
## Summary
- fix jinja search path handling
- restore rendering helpers with module level j2pt
- make chunk_content return cleaned text when chunker missing
- make processing helpers backwards compatible
- add `get_template_dir_any` alias

## Testing
- `uv run --package peagen --directory standards/peagen pytest` *(fails: Failed to fetch ... No route to host)*