### PR TITLE
Add CLI integration test for Peagen template sets

### DIFF
--- a/pkgs/standards/peagen/tests/i9n/Peagen_templateset_i9n_test.py
+++ b/pkgs/standards/peagen/tests/i9n/Peagen_templateset_i9n_test.py
@@ -1,0 +1,13 @@
+import pytest
+from typer.testing import CliRunner
+
+from peagen.cli import app
+
+
+@pytest.mark.i9n
+def test_template_set_list_contains_known_set():
+    """Run ``peagen template-set list`` and check a known template-set exists."""
+    runner = CliRunner()
+    result = runner.invoke(app, ["template-set", "list"])
+    assert result.exit_code == 0, result.output
+    assert "swarmauri_base" in result.output


### PR DESCRIPTION
## Summary
- test `peagen template-set list` CLI command

## Testing
- `uv run --package peagen --directory standards/peagen pytest standards/peagen/tests/i9n/Peagen_templateset_i9n_test.py -q` *(fails: No route to host)*