### PR TITLE
Add perf benchmarks for standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,14 @@ class YourVectorStore(VectorStoreBase):
     # Your implementation
 ```
 
+## Running Performance Tests
+Each standards package contains benchmarks under `tests/perf`. To run a package's performance tests in isolation:
+
+```bash
+cd /workspace/swarmauri-sdk/pkgs
+uv run --package <module-name> --directory standards/<module-dir> pytest tests/perf
+```
+
 ## License
 The Swarmauri SDK is licensed under the Apache License 2.0. See the [LICENSE](https://github.com/swarmauri/swarmauri-sdk/blob/master/LICENSE) file for details.
 

--- a/pkgs/standards/peagen/tests/perf/benchmark_perf_test.py
+++ b/pkgs/standards/peagen/tests/perf/benchmark_perf_test.py
@@ -1,0 +1,19 @@
+"""Performance benchmarks for peagen.
+
+Run this benchmark in isolation from the pkgs directory:
+
+    cd /workspace/swarmauri-sdk/pkgs
+    uv run --package peagen --directory standards/peagen pytest tests/perf
+"""
+
+import pytest
+
+
+@pytest.mark.perf
+def test_basic_benchmark(benchmark):
+    data = list(range(1000))
+
+    def process():
+        [x * x for x in data]
+
+    benchmark(process)

--- a/pkgs/standards/peagen_templset_vue/tests/perf/benchmark_perf_test.py
+++ b/pkgs/standards/peagen_templset_vue/tests/perf/benchmark_perf_test.py
@@ -1,0 +1,19 @@
+"""Performance benchmarks for peagen_templset_vue.
+
+Run this benchmark in isolation from the pkgs directory:
+
+    cd /workspace/swarmauri-sdk/pkgs
+    uv run --package peagen_templset_vue --directory standards/peagen_templset_vue pytest tests/perf
+"""
+
+import pytest
+
+
+@pytest.mark.perf
+def test_basic_benchmark(benchmark):
+    data = list(range(1000))
+
+    def process():
+        [x * x for x in data]
+
+    benchmark(process)

--- a/pkgs/standards/swarmauri_distance_minkowski/tests/perf/benchmark_perf_test.py
+++ b/pkgs/standards/swarmauri_distance_minkowski/tests/perf/benchmark_perf_test.py
@@ -1,0 +1,19 @@
+"""Performance benchmarks for swarmauri_distance_minkowski.
+
+Run this benchmark in isolation from the pkgs directory:
+
+    cd /workspace/swarmauri-sdk/pkgs
+    uv run --package swarmauri_distance_minkowski --directory standards/swarmauri_distance_minkowski pytest tests/perf
+"""
+
+import pytest
+
+
+@pytest.mark.perf
+def test_basic_benchmark(benchmark):
+    data = list(range(1000))
+
+    def process():
+        [x * x for x in data]
+
+    benchmark(process)

--- a/pkgs/standards/swarmauri_embedding_doc2vec/tests/perf/benchmark_perf_test.py
+++ b/pkgs/standards/swarmauri_embedding_doc2vec/tests/perf/benchmark_perf_test.py
@@ -1,0 +1,19 @@
+"""Performance benchmarks for swarmauri_embedding_doc2vec.
+
+Run this benchmark in isolation from the pkgs directory:
+
+    cd /workspace/swarmauri-sdk/pkgs
+    uv run --package swarmauri_embedding_doc2vec --directory standards/swarmauri_embedding_doc2vec pytest tests/perf
+"""
+
+import pytest
+
+
+@pytest.mark.perf
+def test_basic_benchmark(benchmark):
+    data = list(range(1000))
+
+    def process():
+        [x * x for x in data]
+
+    benchmark(process)

--- a/pkgs/standards/swarmauri_embedding_nmf/tests/perf/benchmark_perf_test.py
+++ b/pkgs/standards/swarmauri_embedding_nmf/tests/perf/benchmark_perf_test.py
@@ -1,0 +1,19 @@
+"""Performance benchmarks for swarmauri_embedding_nmf.
+
+Run this benchmark in isolation from the pkgs directory:
+
+    cd /workspace/swarmauri-sdk/pkgs
+    uv run --package swarmauri_embedding_nmf --directory standards/swarmauri_embedding_nmf pytest tests/perf
+"""
+
+import pytest
+
+
+@pytest.mark.perf
+def test_basic_benchmark(benchmark):
+    data = list(range(1000))
+
+    def process():
+        [x * x for x in data]
+
+    benchmark(process)

--- a/pkgs/standards/swarmauri_evaluator_abstractmethods/tests/perf/benchmark_perf_test.py
+++ b/pkgs/standards/swarmauri_evaluator_abstractmethods/tests/perf/benchmark_perf_test.py
@@ -1,0 +1,19 @@
+"""Performance benchmarks for swarmauri_evaluator_abstractmethods.
+
+Run this benchmark in isolation from the pkgs directory:
+
+    cd /workspace/swarmauri-sdk/pkgs
+    uv run --package swarmauri_evaluator_abstractmethods --directory standards/swarmauri_evaluator_abstractmethods pytest tests/perf
+"""
+
+import pytest
+
+
+@pytest.mark.perf
+def test_basic_benchmark(benchmark):
+    data = list(range(1000))
+
+    def process():
+        [x * x for x in data]
+
+    benchmark(process)

--- a/pkgs/standards/swarmauri_evaluator_anyusage/tests/perf/benchmark_perf_test.py
+++ b/pkgs/standards/swarmauri_evaluator_anyusage/tests/perf/benchmark_perf_test.py
@@ -1,0 +1,19 @@
+"""Performance benchmarks for swarmauri_evaluator_anyusage.
+
+Run this benchmark in isolation from the pkgs directory:
+
+    cd /workspace/swarmauri-sdk/pkgs
+    uv run --package swarmauri_evaluator_anyusage --directory standards/swarmauri_evaluator_anyusage pytest tests/perf
+"""
+
+import pytest
+
+
+@pytest.mark.perf
+def test_basic_benchmark(benchmark):
+    data = list(range(1000))
+
+    def process():
+        [x * x for x in data]
+
+    benchmark(process)

--- a/pkgs/standards/swarmauri_evaluator_externalimports/tests/perf/benchmark_perf_test.py
+++ b/pkgs/standards/swarmauri_evaluator_externalimports/tests/perf/benchmark_perf_test.py
@@ -1,0 +1,19 @@
+"""Performance benchmarks for swarmauri_evaluator_externalimports.
+
+Run this benchmark in isolation from the pkgs directory:
+
+    cd /workspace/swarmauri-sdk/pkgs
+    uv run --package swarmauri_evaluator_externalimports --directory standards/swarmauri_evaluator_externalimports pytest tests/perf
+"""
+
+import pytest
+
+
+@pytest.mark.perf
+def test_basic_benchmark(benchmark):
+    data = list(range(1000))
+
+    def process():
+        [x * x for x in data]
+
+    benchmark(process)

--- a/pkgs/standards/swarmauri_evaluator_subprocess/tests/perf/benchmark_perf_test.py
+++ b/pkgs/standards/swarmauri_evaluator_subprocess/tests/perf/benchmark_perf_test.py
@@ -1,0 +1,19 @@
+"""Performance benchmarks for swarmauri_evaluator_subprocess.
+
+Run this benchmark in isolation from the pkgs directory:
+
+    cd /workspace/swarmauri-sdk/pkgs
+    uv run --package swarmauri_evaluator_subprocess --directory standards/swarmauri_evaluator_subprocess pytest tests/perf
+"""
+
+import pytest
+
+
+@pytest.mark.perf
+def test_basic_benchmark(benchmark):
+    data = list(range(1000))
+
+    def process():
+        [x * x for x in data]
+
+    benchmark(process)

--- a/pkgs/standards/swarmauri_evaluatorpool_accessibility/tests/perf/benchmark_perf_test.py
+++ b/pkgs/standards/swarmauri_evaluatorpool_accessibility/tests/perf/benchmark_perf_test.py
@@ -1,0 +1,19 @@
+"""Performance benchmarks for swarmauri_evaluatorpool_accessibility.
+
+Run this benchmark in isolation from the pkgs directory:
+
+    cd /workspace/swarmauri-sdk/pkgs
+    uv run --package swarmauri_evaluatorpool_accessibility --directory standards/swarmauri_evaluatorpool_accessibility pytest tests/perf
+"""
+
+import pytest
+
+
+@pytest.mark.perf
+def test_basic_benchmark(benchmark):
+    data = list(range(1000))
+
+    def process():
+        [x * x for x in data]
+
+    benchmark(process)

--- a/pkgs/standards/swarmauri_parser_beautifulsoupelement/tests/perf/benchmark_perf_test.py
+++ b/pkgs/standards/swarmauri_parser_beautifulsoupelement/tests/perf/benchmark_perf_test.py
@@ -1,0 +1,19 @@
+"""Performance benchmarks for swarmauri_parser_beautifulsoupelement.
+
+Run this benchmark in isolation from the pkgs directory:
+
+    cd /workspace/swarmauri-sdk/pkgs
+    uv run --package swarmauri_parser_beautifulsoupelement --directory standards/swarmauri_parser_beautifulsoupelement pytest tests/perf
+"""
+
+import pytest
+
+
+@pytest.mark.perf
+def test_basic_benchmark(benchmark):
+    data = list(range(1000))
+
+    def process():
+        [x * x for x in data]
+
+    benchmark(process)

--- a/pkgs/standards/swarmauri_parser_keywordextractor/tests/perf/benchmark_perf_test.py
+++ b/pkgs/standards/swarmauri_parser_keywordextractor/tests/perf/benchmark_perf_test.py
@@ -1,0 +1,19 @@
+"""Performance benchmarks for swarmauri_parser_keywordextractor.
+
+Run this benchmark in isolation from the pkgs directory:
+
+    cd /workspace/swarmauri-sdk/pkgs
+    uv run --package swarmauri_parser_keywordextractor --directory standards/swarmauri_parser_keywordextractor pytest tests/perf
+"""
+
+import pytest
+
+
+@pytest.mark.perf
+def test_basic_benchmark(benchmark):
+    data = list(range(1000))
+
+    def process():
+        [x * x for x in data]
+
+    benchmark(process)

--- a/pkgs/standards/swarmauri_prompt_j2prompttemplate/tests/perf/benchmark_perf_test.py
+++ b/pkgs/standards/swarmauri_prompt_j2prompttemplate/tests/perf/benchmark_perf_test.py
@@ -1,0 +1,19 @@
+"""Performance benchmarks for swarmauri_prompt_j2prompttemplate.
+
+Run this benchmark in isolation from the pkgs directory:
+
+    cd /workspace/swarmauri-sdk/pkgs
+    uv run --package swarmauri_prompt_j2prompttemplate --directory standards/swarmauri_prompt_j2prompttemplate pytest tests/perf
+"""
+
+import pytest
+
+
+@pytest.mark.perf
+def test_basic_benchmark(benchmark):
+    data = list(range(1000))
+
+    def process():
+        [x * x for x in data]
+
+    benchmark(process)

--- a/pkgs/standards/swarmauri_tool_matplotlib/tests/perf/benchmark_perf_test.py
+++ b/pkgs/standards/swarmauri_tool_matplotlib/tests/perf/benchmark_perf_test.py
@@ -1,0 +1,19 @@
+"""Performance benchmarks for swarmauri_tool_matplotlib.
+
+Run this benchmark in isolation from the pkgs directory:
+
+    cd /workspace/swarmauri-sdk/pkgs
+    uv run --package swarmauri_tool_matplotlib --directory standards/swarmauri_tool_matplotlib pytest tests/perf
+"""
+
+import pytest
+
+
+@pytest.mark.perf
+def test_basic_benchmark(benchmark):
+    data = list(range(1000))
+
+    def process():
+        [x * x for x in data]
+
+    benchmark(process)

--- a/pkgs/standards/swarmauri_vectorstore_doc2vec/tests/perf/benchmark_perf_test.py
+++ b/pkgs/standards/swarmauri_vectorstore_doc2vec/tests/perf/benchmark_perf_test.py
@@ -1,0 +1,19 @@
+"""Performance benchmarks for swarmauri_vectorstore_doc2vec.
+
+Run this benchmark in isolation from the pkgs directory:
+
+    cd /workspace/swarmauri-sdk/pkgs
+    uv run --package swarmauri_vectorstore_doc2vec --directory standards/swarmauri_vectorstore_doc2vec pytest tests/perf
+"""
+
+import pytest
+
+
+@pytest.mark.perf
+def test_basic_benchmark(benchmark):
+    data = list(range(1000))
+
+    def process():
+        [x * x for x in data]
+
+    benchmark(process)

--- a/pkgs/standards/swm_example_package/tests/perf/benchmark_perf_test.py
+++ b/pkgs/standards/swm_example_package/tests/perf/benchmark_perf_test.py
@@ -1,0 +1,19 @@
+"""Performance benchmarks for swm_example_package.
+
+Run this benchmark in isolation from the pkgs directory:
+
+    cd /workspace/swarmauri-sdk/pkgs
+    uv run --package swm_example_package --directory standards/swm_example_package pytest tests/perf
+"""
+
+import pytest
+
+
+@pytest.mark.perf
+def test_basic_benchmark(benchmark):
+    data = list(range(1000))
+
+    def process():
+        [x * x for x in data]
+
+    benchmark(process)


### PR DESCRIPTION
## Summary
- add performance benchmarks for each standards package
- document how to run performance tests

## Testing
- `uv run --package swarmauri_distance_minkowski --directory standards/swarmauri_distance_minkowski pytest tests/perf` *(fails: No route to host)*