### PR TITLE
Fix import path in PromptContextChainBase

### DIFF
--- a/pkgs/base/swarmauri_base/chains/PromptContextChainBase.py
+++ b/pkgs/base/swarmauri_base/chains/PromptContextChainBase.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from swarmauri_base.chains.ChainStepBase import ChainStepBase
 from swarmauri_base.chains.ChainContextBase import ChainContextBase
-from swarmauri_base.prompts.PromptMatrixBaseBase import PromptMatrixBase
+from swarmauri_base.prompts.PromptMatrixBase import PromptMatrixBase
 from swarmauri_base.agents.AgentBase import AgentBase
 
 from swarmauri_core.chains.IChainDependencyResolver import IChainDependencyResolver


### PR DESCRIPTION
## Summary
- correct import for `PromptMatrixBase` in `PromptContextChainBase`

## Testing
- `uv run --package swarmauri-standard --directory swarmauri_standard pytest` *(fails: No route to host)*