### PR TITLE
Remove unused eval pool scaffolding

### DIFF
--- a/pkgs/standards/peagen/peagen/commands/init.py
+++ b/pkgs/standards/peagen/peagen/commands/init.py
@@ -7,7 +7,6 @@ The real templates live in:
         ├── project/
         ├── template-set/
         ├── doe-spec/
-        ├── eval-pool/
         └── ci/
 
 Each folder may contain plain files or Jinja-2 templates
@@ -150,24 +149,6 @@ def init_doe_spec(
     }
     _render_scaffold("doe_spec", path, context, force)
     _summary(path, "peagen experiment --spec ... --template project.yaml")
-
-
-# ── init eval-pool ───────────────────────────────────────────────────────────
-@init_app.command("eval-pool", help="Create an evaluator pool stub.")
-def init_eval_pool(
-    path: Path = typer.Argument(".", dir_okay=True, file_okay=False),
-    name: Optional[str] = typer.Option(None, "--name"),
-    metric: str = typer.Option("BLEU", "--metric"),
-    lang: str = typer.Option("python", "--lang", metavar="[python|node|rust]"),
-    force: bool = typer.Option(False, "--force"),
-):
-    context = {
-        "pool_name": name or path.name,
-        "metric": metric,
-        "lang": lang,
-    }
-    _render_scaffold("eval_pool", path, context, force)
-    _summary(path, "docker build -t eval_<pool>:0.1 .")
 
 
 # ── init ci ─────────────────────────────────────────────────────────────────

--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -83,7 +83,6 @@ dev = [
 init-project       = "peagen.scaffold.project"
 init-template-set  = "peagen.scaffold.template_set"
 init-doe-spec      = "peagen.scaffold.doe_spec"
-init-eval-pool     = "peagen.scaffold.eval_pool"
 init-ci            = "peagen.scaffold.ci"
 
 [project.entry-points."peagen.storage_adapters"]


### PR DESCRIPTION
## Summary
- delete CLI command and docs referencing eval-pool scaffolding
- remove eval-pool entry point from `peagen`

## Testing
- `uv run --package peagen --directory standards/peagen pytest` *(fails: Failed to fetch dependency)*