### PR TITLE
Add schema for event messages

### DIFF
--- a/pkgs/standards/peagen/README.md
+++ b/pkgs/standards/peagen/README.md
@@ -374,7 +374,7 @@ result, idx = pea.process_single_project(projects[0], start_idx=0)
 Peagen's artifact output and event publishing are pluggable. Use the `storage_adapter` argument to control where files are saved and optionally provide a publisher for notifications. Built-in options include `FileStorageAdapter`, `MinioStorageAdapter`, `RedisPublisher`, `RabbitMQPublisher`, and `WebhookPublisher`. See [docs/storage_adapters_and_publishers.md](docs/storage_adapters_and_publishers.md) for details.
 
 
-For the event schema and routing key conventions, see [docs/eda_protocol.md](docs/eda_protocol.md). Events can also be emitted directly from the CLI using `--notify`:
+For the event schema and routing key conventions, see [docs/eda_protocol.md](docs/eda_protocol.md). The full JSON schema is distributed as `peagen/schemas/event.schema.v1.json`. Events can also be emitted directly from the CLI using `--notify`:
 
 ```bash
 peagen process projects.yaml --notify redis://localhost:6379/0/custom.events

--- a/pkgs/standards/peagen/docs/eda_protocol.md
+++ b/pkgs/standards/peagen/docs/eda_protocol.md
@@ -4,7 +4,7 @@ Peagen publishes JSON messages to notify external systems about key events durin
 
 ## Event Structure
 
-Each event is a JSON object with a top-level `type` field. Implementations may include additional fields for context.
+Each event is a JSON object with a top-level `type` field. Implementations may include additional fields for context. A machine readable schema is provided at `peagen/schemas/event.schema.v1.json`.
 
 ```json
 {

--- a/pkgs/standards/peagen/peagen/schemas/__init__.py
+++ b/pkgs/standards/peagen/peagen/schemas/__init__.py
@@ -53,6 +53,12 @@ PROJECTS_PAYLOAD_V1_SCHEMA = json.loads(
        .read_text(encoding="utf-8")
 )
 
+EVENT_V1_SCHEMA = json.loads(
+    res.files(__package__)
+       .joinpath("event.schema.v1.json")
+       .read_text(encoding="utf-8")
+)
+
 # ── EXTRAS schemas ─────────────────────────────────────────────
 _extras_pkg = res.files(__package__).joinpath("extras")
 EXTRAS_SCHEMAS = {
@@ -70,5 +76,6 @@ __all__ = [
     "DOE_SPEC_V1_SCHEMA",
     "PTREE_V1_SCHEMA",
     "PROJECTS_PAYLOAD_V1_SCHEMA",
+    "EVENT_V1_SCHEMA",
     "EXTRAS_SCHEMAS",
 ]

--- a/pkgs/standards/peagen/peagen/schemas/event.schema.v1.json
+++ b/pkgs/standards/peagen/peagen/schemas/event.schema.v1.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://example.com/event.schema.json",
+  "title": "Peagen Event Schema (v1.0.0)",
+  "schemaVersion": "1.0.0",
+  "type": "object",
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": ["process.started", "process.done", "peagen.experiment.done"],
+      "description": "Event type identifier"
+    },
+    "extra": {
+      "type": "object",
+      "description": "Optional contextual data",
+      "additionalProperties": true
+    },
+    "seconds": {
+      "type": "number",
+      "description": "Duration in seconds for process.done events"
+    },
+    "output": {
+      "type": "string",
+      "description": "Output path for peagen.experiment.done"
+    },
+    "count": {
+      "type": "integer",
+      "description": "Project count for peagen.experiment.done"
+    }
+  },
+  "required": ["type"],
+  "additionalProperties": true
+}


### PR DESCRIPTION
## Summary
- add `event.schema.v1.json` under `peagen/schemas`
- export the new schema from `peagen.schemas`
- reference schema in documentation

## Testing
- `uv run --package peagen --directory standards/peagen pytest` *(fails: No route to host)*