### PR TITLE
Add Peagen event schema

### DIFF
--- a/pkgs/standards/peagen/peagen/schemas/__init__.py
+++ b/pkgs/standards/peagen/peagen/schemas/__init__.py
@@ -53,6 +53,12 @@ PROJECTS_PAYLOAD_V1_SCHEMA = json.loads(
        .read_text(encoding="utf-8")
 )
 
+EVENT_V1_SCHEMA = json.loads(
+    res.files(__package__)
+       .joinpath("event.schema.v1.json")
+       .read_text(encoding="utf-8")
+)
+
 # ── EXTRAS schemas ─────────────────────────────────────────────
 _extras_pkg = res.files(__package__).joinpath("extras")
 EXTRAS_SCHEMAS = {
@@ -70,5 +76,6 @@ __all__ = [
     "DOE_SPEC_V1_SCHEMA",
     "PTREE_V1_SCHEMA",
     "PROJECTS_PAYLOAD_V1_SCHEMA",
+    "EVENT_V1_SCHEMA",
     "EXTRAS_SCHEMAS",
 ]

--- a/pkgs/standards/peagen/peagen/schemas/event.schema.v1.json
+++ b/pkgs/standards/peagen/peagen/schemas/event.schema.v1.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://example.com/peagen/event.schema.v1.json",
+  "title": "Peagen Event",
+  "type": "object",
+  "required": ["type"],
+  "properties": {
+    "type": {"type": "string"},
+    "extra": {"type": "object", "additionalProperties": true}
+  }
+}


### PR DESCRIPTION
## Summary
- add event.schema.v1.json describing event messages as defined in IP-0002
- expose EVENT_V1_SCHEMA constant in `peagen.schemas`

## Testing
- `uv run --package peagen --directory standards/peagen pytest` *(fails: No route to host)*