### PR TITLE
Deprecate unused peagen storage options

### DIFF
--- a/pkgs/standards/peagen/peagen/commands/process.py
+++ b/pkgs/standards/peagen/peagen/commands/process.py
@@ -89,13 +89,22 @@ def process_cmd(
     ),
     org: Optional[str] = typer.Option(None, "--org", "-o", help="Organization slug."),
     access_key: Optional[str] = typer.Option(
-        None, "--access-key", help="S3/MinIO access key."
+        None,
+        "--access-key",
+        help="S3/MinIO access key.",
+        deprecated=True,
     ),
     secret_key: Optional[str] = typer.Option(
-        None, "--secret-key", help="S3/MinIO secret key."
+        None,
+        "--secret-key",
+        help="S3/MinIO secret key.",
+        deprecated=True,
     ),
     insecure: bool = typer.Option(
-        False, "--insecure", help="When using s3://, disable TLS."
+        False,
+        "--insecure",
+        help="When using s3://, disable TLS.",
+        deprecated=True,
     ),
     plugin_mode: Optional[str] = typer.Option(
         None, "--plugin-mode", help="Plugin mode to use."


### PR DESCRIPTION
## Summary
- mark `--access-key`, `--secret-key` and `--insecure` as deprecated for `peagen process`

## Testing
- `None`