### PR TITLE
Remove context option from peagen doe gen

### DIFF
--- a/pkgs/standards/peagen/README.md
+++ b/pkgs/standards/peagen/README.md
@@ -227,7 +227,7 @@ Expand a Design-of-Experiments spec into a `project_payloads.yaml` bundle.
 ```bash
 peagen doe gen <DOE_SPEC_YML> <TEMPLATE_PROJECT> \
   [--output project_payloads.yaml] \
-  [--context global_patch.yml] \
+  [-c PATH | --config PATH] \
   [--dry-run] [--force]
 ```
 


### PR DESCRIPTION
## Summary
- remove the `--context` flag from `peagen doe gen`
- add `--config/-c` flag to choose an alternate `.peagen.toml`
- load config path in doe generation and event publishing logic
- document the new CLI usage in peagen README

## Testing
- `uv run --package peagen --directory standards/peagen pytest` *(fails: No route to host)*