### PR TITLE
Fix typer Option call

### DIFF
--- a/pkgs/standards/peagen/peagen/commands/process.py
+++ b/pkgs/standards/peagen/peagen/commands/process.py
@@ -88,24 +88,6 @@ def process_cmd(
         None, "--artifacts", "-a", help="dir://PATH or s3://ENDPOINT"
     ),
     org: Optional[str] = typer.Option(None, "--org", "-o", help="Organization slug."),
-    access_key: Optional[str] = typer.Option(
-        None,
-        "--access-key",
-        help="S3/MinIO access key.",
-        deprecated=True,
-    ),
-    secret_key: Optional[str] = typer.Option(
-        None,
-        "--secret-key",
-        help="S3/MinIO secret key.",
-        deprecated=True,
-    ),
-    insecure: bool = typer.Option(
-        False,
-        "--insecure",
-        help="When using s3://, disable TLS.",
-        deprecated=True,
-    ),
     plugin_mode: Optional[str] = typer.Option(
         None, "--plugin-mode", help="Plugin mode to use."
     ),


### PR DESCRIPTION
## Summary
- remove unsupported `deprecated` kwargs from peagen
- drop deprecated CLI flags `--access-key`, `--secret-key`, `--insecure`

## Testing
- `pre-commit` *(fails: command not found)*