### PR TITLE
Add missing spaCy-style docstrings

### DIFF
--- a/.config/component_generator/scripts/dag.py
+++ b/.config/component_generator/scripts/dag.py
@@ -1,3 +1,10 @@
+"""Generate project files from JSON payloads.
+
+This script loads project payloads describing files to copy or generate and
+processes them using Jinja2 templates. It provides helper functions to resolve
+placeholders, perform topological sorting, and save the resulting files.
+"""
+
 import os
 import json
 import re

--- a/docs/scripts/generate_content.py
+++ b/docs/scripts/generate_content.py
@@ -1,3 +1,10 @@
+"""Generate Markdown documentation for package modules.
+
+This script traverses a Python package, creates Markdown files for each module
+and class, and updates ``mkdocs.yml`` with a navigation structure. It also
+ensures a home page exists in the documentation directory.
+"""
+
 import os
 import pkgutil
 import importlib

--- a/pkgs/base/swarmauri_base/ComponentBase.py
+++ b/pkgs/base/swarmauri_base/ComponentBase.py
@@ -1,4 +1,4 @@
-# swarmauri_base/ComponentBase.py
+"""Base component abstractions for the SwarmAuri SDK."""
 
 from enum import Enum
 from typing import (
@@ -48,6 +48,7 @@ class ComponentBase(LoggerMixin, YamlMixin, ServiceMixin, DynamicBase):
 # Resource Types Enum (This should become ResourceKinds)
 ###########################################
 class ResourceTypes(Enum):
+    """Enumeration of core component resource types."""
     UNIVERSAL_BASE = "ComponentBase"
     AGENT = "Agent"
     AGENT_FACTORY = "AgentFactory"

--- a/pkgs/base/swarmauri_base/DynamicBase.py
+++ b/pkgs/base/swarmauri_base/DynamicBase.py
@@ -513,6 +513,7 @@ class DynamicBase(BaseModel):
 
     @classmethod
     def _recreate_models(cls):
+        """Rebuild registered ``pydantic`` models after registry changes."""
         with cls._lock:
             models_with_fields = cls._generate_models_with_fields()
             glogger.debug(
@@ -567,6 +568,7 @@ class DynamicBase(BaseModel):
         """
 
         def decorator(model_cls: Type[BaseModel]):
+            """Register ``model_cls`` as a base model."""
             model_name = model_cls.__name__
             if model_name in cls._registry:
                 glogger.warning(
@@ -601,6 +603,7 @@ class DynamicBase(BaseModel):
         """
 
         def decorator(subclass: Type["DynamicBase"]):
+            """Register ``subclass`` as a subtype."""
             if resource_type is None:
                 resource_types = [
                     base for base in subclass.__bases__ if base is not cls

--- a/pkgs/base/swarmauri_base/LoggerMixin.py
+++ b/pkgs/base/swarmauri_base/LoggerMixin.py
@@ -1,3 +1,5 @@
+"""Mixin providing configurable loggers for models."""
+
 from pydantic import BaseModel, ConfigDict
 from typing import Optional, ClassVar
 
@@ -8,6 +10,8 @@ from swarmauri_base.DynamicBase import DynamicBase
 
 @DynamicBase.register_model()
 class LoggerMixin(BaseModel):
+    """Provide logger configuration fields to derived models."""
+
     # Class-level default logger is now a FullUnion[LoggerBase] instance.
     default_logger: ClassVar[Optional[FullUnion[LoggerBase]]] = None
 
@@ -17,5 +21,8 @@ class LoggerMixin(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def model_post_init(self, logger: Optional[FullUnion[LoggerBase]] = None) -> None:
-        # Directly assign the provided FullUnion[LoggerBase] or fallback to the class-level default.
+        """Assign a logger instance after model initialization."""
+
+        # Directly assign the provided FullUnion[LoggerBase] or fallback to the
+        # class-level default.
         self.logger = self.logger or logger or self.default_logger

--- a/pkgs/base/swarmauri_base/ObserveBase.py
+++ b/pkgs/base/swarmauri_base/ObserveBase.py
@@ -1,4 +1,4 @@
-# swarmauri_base/ObserveBase.py
+"""Base class for observable SwarmAuri components."""
 
 from typing import (
     ClassVar,

--- a/pkgs/base/swarmauri_base/ServiceMixin.py
+++ b/pkgs/base/swarmauri_base/ServiceMixin.py
@@ -1,3 +1,5 @@
+"""Mixin providing service metadata fields."""
+
 from uuid import uuid4
 
 from pydantic import BaseModel, Field
@@ -6,11 +8,15 @@ from swarmauri_base.DynamicBase import DynamicBase
 
 
 def generate_id() -> str:
+    """Return a new unique identifier."""
+
     return str(uuid4())
 
 
 @DynamicBase.register_model()
 class ServiceMixin(BaseModel):
+    """Attach service-related metadata fields to a model."""
+
     # Class-level default logger is now a FullUnion[LoggerBase] instance.
     id: str = Field(default_factory=generate_id)
     members: Optional[List[str]] = None

--- a/pkgs/base/swarmauri_base/YamlMixin.py
+++ b/pkgs/base/swarmauri_base/YamlMixin.py
@@ -1,11 +1,15 @@
+"""Mixin for YAML serialization and validation utilities."""
+
 import json
 import yaml
 from pydantic import BaseModel, ValidationError
 
 
 class YamlMixin(BaseModel):
+    """Provide YAML-based validation and serialization helpers."""
     @classmethod
     def model_validate_yaml(cls, yaml_data: str):
+        """Validate a model from a YAML string."""
         try:
             # Parse YAML into a Python dictionary
             yaml_content = yaml.safe_load(yaml_data)
@@ -18,6 +22,7 @@ class YamlMixin(BaseModel):
             raise ValueError(f"Validation failed: {e}")
 
     def model_dump_yaml(self, fields_to_exclude=None, api_key_placeholder=None):
+        """Return a YAML representation of the model."""
         if fields_to_exclude is None:
             fields_to_exclude = []
 
@@ -26,6 +31,7 @@ class YamlMixin(BaseModel):
 
         # Function to recursively remove specific keys and handle api_key placeholders
         def process_fields(data, fields_to_exclude):
+            """Recursively filter fields and apply placeholders."""
             if isinstance(data, dict):
                 return {
                     key: (

--- a/pkgs/base/swarmauri_base/__init__.py
+++ b/pkgs/base/swarmauri_base/__init__.py
@@ -1,3 +1,5 @@
+"""Convenience re-exports for the SwarmAuri base package."""
+
 from swarmauri_base.DynamicBase import (
     SubclassUnion,
     FullUnion,

--- a/pkgs/base/swarmauri_base/agents/AgentBase.py
+++ b/pkgs/base/swarmauri_base/agents/AgentBase.py
@@ -1,4 +1,4 @@
-# File: swarmauri_core/agents/AgentBase.py
+"""Abstract agent implementations for the SwarmAuri SDK."""
 
 from typing import Any, Optional, Dict, List, Union, Literal
 import asyncio


### PR DESCRIPTION
## Summary
- add module docs for project generation script
- document script for generating documentation
- document base component, resource enum, and logger mixin
- document dynamic base model helpers
- add docs for ObserveBase, ServiceMixin, YamlMixin, and package exports
- document AgentBase module

## Testing
- `python -m py_compile .config/component_generator/scripts/dag.py docs/scripts/generate_content.py pkgs/base/swarmauri_base/*.py pkgs/base/swarmauri_base/agents/AgentBase.py`