### PR TITLE
Fix syntax errors in rendering tests

### DIFF
--- a/pkgs/standards/peagen/tests/r8n/test_rendering.py
+++ b/pkgs/standards/peagen/tests/r8n/test_rendering.py
@@ -67,7 +67,7 @@ class TestRendering:
         j2_instance.fill.assert_called_once_with(context)
         mock_logger.error.assert_not_called()
 
-    def test_render_copy_template_exception
+    def test_render_copy_template_exception(
         self, file_record, context, j2_instance, mock_logger
     ):
         """Test handling of exceptions during copy template rendering"""
@@ -170,3 +170,4 @@ class TestRendering:
 
         # Assertions
         assert result == ""
+        mock_call_agent.assert_not_called()


### PR DESCRIPTION
## Summary
- correct function definition for `test_render_copy_template_exception`
- ensure `mock_call_agent` isn't triggered in `test_render_generate_template_no_logger`

## Testing
- `N/A`