### PR TITLE
Add SubprocessTool and cross-platform tests

### DIFF
--- a/pkgs/swarmauri_standard/swarmauri_standard/tools/SubprocessTool.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/tools/SubprocessTool.py
@@ -1,0 +1,78 @@
+"""
+SubprocessTool.py
+
+Provides a tool for executing shell commands via Python's ``subprocess`` module.
+It captures the command's output and exit status and returns them in a
+structured dictionary.
+"""
+
+import shlex
+import subprocess
+from typing import List, Literal, Dict, Optional
+from pydantic import Field
+
+from swarmauri_standard.tools.Parameter import Parameter
+from swarmauri_base.tools.ToolBase import ToolBase
+from swarmauri_base.ComponentBase import ComponentBase
+
+
+@ComponentBase.register_type(ToolBase, "SubprocessTool")
+class SubprocessTool(ToolBase):
+    """Execute a shell command and return its output."""
+
+    version: str = "1.0.0"
+    parameters: List[Parameter] = Field(
+        default_factory=lambda: [
+            Parameter(
+                name="command",
+                input_type="string",
+                description="Command to execute",
+                required=True,
+            ),
+            Parameter(
+                name="timeout",
+                input_type="number",
+                description="Optional timeout in seconds",
+                required=False,
+            ),
+            Parameter(
+                name="shell",
+                input_type="boolean",
+                description="Run command through the shell",
+                required=False,
+            ),
+        ]
+    )
+    name: str = "SubprocessTool"
+    description: str = "Executes a command in a subprocess and captures its output."
+    type: Literal["SubprocessTool"] = "SubprocessTool"
+
+    def __call__(
+        self, command: str, timeout: Optional[float] = None, shell: bool = False
+    ) -> Dict[str, str]:
+        """Execute ``command`` and return stdout, stderr, and exit code."""
+        try:
+            result = subprocess.run(
+                command if shell else shlex.split(command),
+                capture_output=True,
+                text=True,
+                shell=shell,
+                timeout=timeout,
+            )
+            return {
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+                "exit_code": str(result.returncode),
+            }
+        except subprocess.TimeoutExpired:
+            return {
+                "stdout": "",
+                "stderr": "Process timed out",
+                "exit_code": "timeout",
+            }
+        except Exception as e:  # pragma: no cover - fallback error handling
+            return {
+                "stdout": "",
+                "stderr": str(e),
+                "exit_code": "error",
+            }

--- a/pkgs/swarmauri_standard/tests/unit/tools/SubprocessTool_unit_test.py
+++ b/pkgs/swarmauri_standard/tests/unit/tools/SubprocessTool_unit_test.py
@@ -1,0 +1,42 @@
+import platform
+import pytest
+from swarmauri_standard.tools.SubprocessTool import SubprocessTool as Tool
+
+
+@pytest.mark.unit
+def test_ubc_resource():
+    tool = Tool()
+    assert tool.resource == "Tool"
+
+
+@pytest.mark.unit
+def test_ubc_type():
+    assert Tool().type == "SubprocessTool"
+
+
+@pytest.mark.unit
+def test_initialization():
+    tool = Tool()
+    assert isinstance(tool.id, str)
+
+
+@pytest.mark.unit
+def test_serialization():
+    tool = Tool()
+    assert tool.id == Tool.model_validate_json(tool.model_dump_json()).id
+
+
+@pytest.mark.unit
+def test_call():
+    system = platform.system().lower()
+    if system.startswith("windows"):
+        command = "cmd /c echo hello"
+    else:
+        command = "echo hello"
+
+    tool = Tool()
+    result = tool(command=command, shell=True)
+
+    assert result["exit_code"] == "0"
+    assert result["stdout"].strip() == "hello"
+    assert isinstance(result["stderr"], str)


### PR DESCRIPTION
## Summary
- add `SubprocessTool` that executes shell commands using `subprocess`
- add unit tests with platform detection for the new tool

## Testing
- `uv run --package swarmauri_standard --directory swarmauri_standard pytest` *(fails: No route to host)*