### PR TITLE
Remove pytest-mock usage

### DIFF
--- a/pkgs/community/swarmauri_tool_jupyterfromdict/tests/unit/test_JupyterFromDictTool.py
+++ b/pkgs/community/swarmauri_tool_jupyterfromdict/tests/unit/test_JupyterFromDictTool.py
@@ -8,6 +8,7 @@ errors appropriately.
 
 from nbformat import NotebookNode
 from swarmauri_tool_jupyterfromdict.JupyterFromDictTool import JupyterFromDictTool
+from unittest.mock import patch
 
 
 def test_class_attributes() -> None:
@@ -72,17 +73,13 @@ def test_call_with_invalid_notebook_dict() -> None:
         "Error message should indicate a validation error for an invalid notebook."
     )
 
-    def test_call_with_exception_handling(mocker) -> None:
-        """
-        Ensures a generic exception is also handled and returned as an error if something unexpected occurs.
-        """
-        tool = JupyterFromDictTool()
 
-        # Mock from_dict to raise a generic exception when called
-        mocker.patch("nbformat.from_dict", side_effect=Exception("Mock failure"))
+def test_call_with_exception_handling() -> None:
+    """Ensure a generic exception is handled gracefully."""
+    tool = JupyterFromDictTool()
 
+    with patch("nbformat.from_dict", side_effect=Exception("Mock failure")):
         result = tool({})
 
-        # Assert that the result contains the error message
-        assert "error" in result
-        assert result["error"] == "An error occurred: Mock failure"
+    assert "error" in result
+    assert result["error"] == "An error occurred: Mock failure"

--- a/pkgs/community/swarmauri_vectorstore_neo4j/tests/unit/Neo4jVectorStore_test.py
+++ b/pkgs/community/swarmauri_vectorstore_neo4j/tests/unit/Neo4jVectorStore_test.py
@@ -1,15 +1,15 @@
 import pytest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from swarmauri_standard.documents.Document import Document
 from swarmauri_vectorstore_neo4j.Neo4jVectorStore import Neo4jVectorStore
 
 
 @pytest.fixture
-def mock_driver(mocker):
+def mock_driver():
     """Mock Neo4j driver"""
-    mock_driver = mocker.MagicMock()
-    mock_session = mocker.MagicMock()
-    mock_transaction = mocker.MagicMock()
+    mock_driver = MagicMock()
+    mock_session = MagicMock()
+    mock_transaction = MagicMock()
 
     # Set up the session context manager behavior
     mock_session.__enter__.return_value = mock_session

--- a/pkgs/swarmauri_standard/tests/unit/pseudometrics/LpPseudometric_unit_test.py
+++ b/pkgs/swarmauri_standard/tests/unit/pseudometrics/LpPseudometric_unit_test.py
@@ -3,6 +3,7 @@ import math
 
 import numpy as np
 import pytest
+from unittest.mock import Mock
 from swarmauri_base.pseudometrics.PseudometricBase import PseudometricBase
 
 from swarmauri_standard.pseudometrics.LpPseudometric import LpPseudometric
@@ -252,10 +253,10 @@ def test_check_weak_identity_different_points_with_coordinates():
 
 
 @pytest.mark.unit
-def test_convert_to_array_ivector(mocker):
+def test_convert_to_array_ivector():
     """Test _convert_to_array method with IVector."""
     pseudometric = LpPseudometric()
-    mock_vector = mocker.Mock()
+    mock_vector = Mock()
     mock_vector.to_array.return_value = [1, 2, 3]
 
     result = pseudometric._convert_to_array(mock_vector)
@@ -264,10 +265,10 @@ def test_convert_to_array_ivector(mocker):
 
 
 @pytest.mark.unit
-def test_convert_to_array_imatrix(mocker):
+def test_convert_to_array_imatrix():
     """Test _convert_to_array method with IMatrix."""
     pseudometric = LpPseudometric()
-    mock_matrix = mocker.Mock()
+    mock_matrix = Mock()
     mock_matrix.to_array.return_value = [[1, 2], [3, 4]]
 
     result = pseudometric._convert_to_array(mock_matrix)

--- a/pkgs/swarmauri_standard/tests/unit/pseudometrics/ZeroPseudometric_unit_test.py
+++ b/pkgs/swarmauri_standard/tests/unit/pseudometrics/ZeroPseudometric_unit_test.py
@@ -1,6 +1,7 @@
 import logging
 
 import pytest
+from unittest.mock import MagicMock
 from swarmauri_core.matrices.IMatrix import IMatrix
 from swarmauri_core.vectors.IVector import IVector
 
@@ -165,17 +166,17 @@ def test_logging(zero_pseudometric, caplog):
 
 
 @pytest.mark.unit
-def test_with_mock_vector_and_matrix(mocker):
+def test_with_mock_vector_and_matrix():
     """
     Test with mocked IVector and IMatrix objects to ensure compatibility.
     """
     zero_pseudometric = ZeroPseudometric()
 
-    # Create proper mock objects using mocker
-    mock_vector1 = mocker.MagicMock(spec=IVector)
-    mock_vector2 = mocker.MagicMock(spec=IVector)
-    mock_matrix1 = mocker.MagicMock(spec=IMatrix)
-    mock_matrix2 = mocker.MagicMock(spec=IMatrix)
+    # Create proper mock objects using unittest.mock
+    mock_vector1 = MagicMock(spec=IVector)
+    mock_vector2 = MagicMock(spec=IVector)
+    mock_matrix1 = MagicMock(spec=IMatrix)
+    mock_matrix2 = MagicMock(spec=IMatrix)
 
     # Test distance with different combinations
     assert zero_pseudometric.distance(mock_vector1, mock_vector2) == 0.0


### PR DESCRIPTION
## Summary
- use `unittest.mock` in pseudometric tests
- swap `pytest-mock` fixture usage for builtin mock objects

## Testing
- `ruff check pkgs/community/swarmauri_tool_jupyterfromdict/tests/unit/test_JupyterFromDictTool.py pkgs/community/swarmauri_vectorstore_neo4j/tests/unit/Neo4jVectorStore_test.py pkgs/swarmauri_standard/tests/unit/pseudometrics/LpPseudometric_unit_test.py pkgs/swarmauri_standard/tests/unit/pseudometrics/ZeroPseudometric_unit_test.py`