### PR TITLE
Refactor container tools to configure driver once

### DIFF
--- a/pkgs/standards/swarmauri_tool_containerfeedchars/swarmauri_tool_containerfeedchars/ContainerFeedCharsTool.py
+++ b/pkgs/standards/swarmauri_tool_containerfeedchars/swarmauri_tool_containerfeedchars/ContainerFeedCharsTool.py
@@ -15,6 +15,8 @@ class ContainerFeedCharsTool(ToolBase):
     description: str = "Run a shell command inside a Docker or Kubernetes container."
     type: Literal["ContainerFeedCharsTool"] = "ContainerFeedCharsTool"
 
+    driver: Literal["docker", "kubernetes"] = "docker"
+
     parameters: List[Parameter] = Field(
         default_factory=lambda: [
             Parameter(
@@ -29,19 +31,11 @@ class ContainerFeedCharsTool(ToolBase):
                 description="Shell command to execute",
                 required=True,
             ),
-            Parameter(
-                name="driver",
-                input_type="string",
-                description="Container driver: docker or kubernetes",
-                required=False,
-                enum=["docker", "kubernetes"],
-                default="docker",
-            ),
         ]
     )
 
-    def __call__(self, container_name: str, command: str, driver: str = "docker") -> dict:
-        if driver == "docker":
+    def __call__(self, container_name: str, command: str) -> dict:
+        if self.driver == "docker":
             cmd = ["docker", "exec", container_name, "sh", "-c", command]
         else:
             cmd = ["kubectl", "exec", container_name, "--", "sh", "-c", command]

--- a/pkgs/standards/swarmauri_tool_containermakepr/swarmauri_tool_containermakepr/ContainerMakePrTool.py
+++ b/pkgs/standards/swarmauri_tool_containermakepr/swarmauri_tool_containermakepr/ContainerMakePrTool.py
@@ -15,6 +15,8 @@ class ContainerMakePrTool(ToolBase):
     description: str = "Create a GitHub pull request from a container."
     type: Literal["ContainerMakePrTool"] = "ContainerMakePrTool"
 
+    driver: Literal["docker", "kubernetes"] = "docker"
+
     parameters: List[Parameter] = Field(
         default_factory=lambda: [
             Parameter(
@@ -35,19 +37,11 @@ class ContainerMakePrTool(ToolBase):
                 description="Pull request body",
                 required=True,
             ),
-            Parameter(
-                name="driver",
-                input_type="string",
-                description="Container driver: docker or kubernetes",
-                required=False,
-                enum=["docker", "kubernetes"],
-                default="docker",
-            ),
         ]
     )
 
-    def __call__(self, container_name: str, title: str, body: str, driver: str = "docker") -> dict:
-        if driver == "docker":
+    def __call__(self, container_name: str, title: str, body: str) -> dict:
+        if self.driver == "docker":
             cmd = [
                 "docker",
                 "exec",

--- a/pkgs/standards/swarmauri_tool_containernewsession/swarmauri_tool_containernewsession/ContainerNewSessionTool.py
+++ b/pkgs/standards/swarmauri_tool_containernewsession/swarmauri_tool_containernewsession/ContainerNewSessionTool.py
@@ -15,6 +15,8 @@ class ContainerNewSessionTool(ToolBase):
     description: str = "Start a new Docker or Kubernetes container running a shell."
     type: Literal["ContainerNewSessionTool"] = "ContainerNewSessionTool"
 
+    driver: Literal["docker", "kubernetes"] = "docker"
+
     parameters: List[Parameter] = Field(
         default_factory=lambda: [
             Parameter(
@@ -29,19 +31,11 @@ class ContainerNewSessionTool(ToolBase):
                 description="Container image to launch",
                 required=True,
             ),
-            Parameter(
-                name="driver",
-                input_type="string",
-                description="Container driver: docker or kubernetes",
-                required=False,
-                enum=["docker", "kubernetes"],
-                default="docker",
-            ),
         ]
     )
 
-    def __call__(self, container_name: str, image: str, driver: str = "docker") -> dict:
-        if driver == "docker":
+    def __call__(self, container_name: str, image: str) -> dict:
+        if self.driver == "docker":
             cmd = [
                 "docker",
                 "run",


### PR DESCRIPTION
## Summary
- persist container driver configuration on each tool
- call container tools without driver parameter
- revert plugin citizenship registry init changes

## Testing
- `git commit -m "Revert registry init changes"`
