### PR TITLE
Add generic EvaluatorPool

### DIFF
--- a/pkgs/swarmauri_standard/swarmauri_standard/evaluator_pools/EvaluatorPool.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/evaluator_pools/EvaluatorPool.py
@@ -1,0 +1,11 @@
+from typing import Literal
+
+from swarmauri_base.ComponentBase import ComponentBase
+from swarmauri_base.evaluator_pools.EvaluatorPoolBase import EvaluatorPoolBase
+
+
+@ComponentBase.register_type(EvaluatorPoolBase, "EvaluatorPool")
+class EvaluatorPool(EvaluatorPoolBase):
+    """Concrete evaluator pool with no additional behavior."""
+
+    type: Literal["EvaluatorPool"] = "EvaluatorPool"

--- a/pkgs/swarmauri_standard/tests/unit/evaluator_pools/EvaluatorPool_unit_test.py
+++ b/pkgs/swarmauri_standard/tests/unit/evaluator_pools/EvaluatorPool_unit_test.py
@@ -1,0 +1,23 @@
+import pytest
+
+from swarmauri_standard.evaluator_pools.EvaluatorPool import EvaluatorPool
+
+
+@pytest.mark.unit
+def test_resource_type():
+    pool = EvaluatorPool()
+    assert pool.resource == "EvaluatorPool"
+
+
+@pytest.mark.unit
+def test_type_literal():
+    pool = EvaluatorPool()
+    assert pool.type == "EvaluatorPool"
+
+
+@pytest.mark.unit
+def test_serialization_roundtrip():
+    pool = EvaluatorPool()
+    dumped = pool.model_dump_json()
+    loaded = EvaluatorPool.model_validate_json(dumped)
+    assert isinstance(loaded, EvaluatorPool)


### PR DESCRIPTION
## Summary
- implement a simple `EvaluatorPool` in `swarmauri_standard`
- remove unused package initializer
- test the new `EvaluatorPool`

## Testing
- *(none specified)*