### PR TITLE
Fix ruff lint in jaml package

### DIFF
--- a/pkgs/jaml/jaml/__init__.py
+++ b/pkgs/jaml/jaml/__init__.py
@@ -5,16 +5,31 @@ This file exposes the public API of the JML library.
 """
 
 from .api import (
-    dump,
-    dumps,
-    load,
-    loads,
-    round_trip_dump,
-    round_trip_dumps,
-    round_trip_load,
-    round_trip_loads,
-    check_extension,
-    resolve,
-    render,
+    dump as dump,
+    dumps as dumps,
+    load as load,
+    loads as loads,
+    round_trip_dump as round_trip_dump,
+    round_trip_dumps as round_trip_dumps,
+    round_trip_load as round_trip_load,
+    round_trip_loads as round_trip_loads,
+    check_extension as check_extension,
+    resolve as resolve,
+    render as render,
 )
-from ._lark_parser import parser
+from ._lark_parser import parser as parser
+
+__all__ = [
+    "dump",
+    "dumps",
+    "load",
+    "loads",
+    "round_trip_dump",
+    "round_trip_dumps",
+    "round_trip_load",
+    "round_trip_loads",
+    "check_extension",
+    "resolve",
+    "render",
+    "parser",
+]

--- a/pkgs/jaml/jaml/_ast_nodes.py
+++ b/pkgs/jaml/jaml/_ast_nodes.py
@@ -1,17 +1,18 @@
 from typing import Any, Dict, List, Optional
 
+import logging
 import re
 from lark import Tree
-import logging
-
-logger = logging.getLogger(__name__)  # put this with your other imports
-logger.setLevel(logging.DEBUG)  # caller can override
 
 from ._make_static import make_static_section
 from ._fstring import _evaluate_f_string, _lookup
 from ._substitute import _substitute_vars
 from ._expression import evaluate_expression_tree
 from ._comprehension import iter_environments, _evaluate_comprehension
+
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)  # caller can override
 
 
 class BaseNode:
@@ -383,13 +384,13 @@ class ComprehensionHeaderNode(BaseNode):
         logger.debug("ComprehensionHeaderNode.render() triggered.")
         self._evaluate(global_env, local_env or {}, context or {})
 
-    def _evaluate(self, g: Dict, l: Dict, ctx: Dict):
+    def _evaluate(self, g: Dict, local_env: Dict, ctx: Dict):
         logger.debug("ComprehensionHeaderNode._evaluate() triggered.")
         self.header_envs: List[tuple[str, dict]] = []
 
-        for env in iter_environments(self.clauses, g, l, ctx):
+        for env in iter_environments(self.clauses, g, local_env, ctx):
             logger.debug(f"ComprehensionHeaderNode._evaluate() env: {env}.")
-            scope = {**l, **env}
+            scope = {**local_env, **env}
             if ctx is None:
                 self.header_expr.resolve(g, scope)
             else:

--- a/pkgs/jaml/jaml/_config.py
+++ b/pkgs/jaml/jaml/_config.py
@@ -1,12 +1,15 @@
 from collections.abc import MutableMapping
 from copy import deepcopy
-from typing import Any, Dict, Optional, Sequence
+from typing import Any, Dict, Optional, Sequence, List, TYPE_CHECKING
 
 from ._fstring import _evaluate_f_string
 import logging
 
-logger = logging.getLogger(__name__)  # put this with your other imports
+logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)  # caller can override
+
+if TYPE_CHECKING:
+    from ._ast_nodes import BaseNode
 
 
 class SectionProxy(MutableMapping):

--- a/pkgs/jaml/jaml/_expression.py
+++ b/pkgs/jaml/jaml/_expression.py
@@ -49,7 +49,7 @@ def _lookup(path: str, *envs: Dict[str, Any]) -> Optional[Any]:
 def _tok_to_py(
     tok: Token,
     g: Dict[str, Any],
-    l: Dict[str, Any],
+    local_env: Dict[str, Any],
     c: Dict[str, Any],
 ) -> str:
     """Convert a Lark token to a Python snippet (or placeholder)."""
@@ -87,7 +87,7 @@ def _tok_to_py(
             return tok.value
 
         # Global (@{…}) or local (%{…})
-        val = _lookup(inner, g) if marker == "@" else _lookup(inner, l, g)
+        val = _lookup(inner, g) if marker == "@" else _lookup(inner, local_env, g)
         if val is None:
             return tok.value
         if hasattr(val, "evaluate"):

--- a/pkgs/jaml/jaml/_fstring.py
+++ b/pkgs/jaml/jaml/_fstring.py
@@ -61,8 +61,6 @@ def _lookup(path: str, *envs: Optional[Dict[str, Any]]) -> Optional[Any]:
 
 
 # utils.py
-from typing import Any, Dict, Optional
-import re
 
 
 # ────────────────────────────────────────────────────────────────────────────────

--- a/pkgs/jaml/jaml/_make_static.py
+++ b/pkgs/jaml/jaml/_make_static.py
@@ -1,6 +1,9 @@
 # jaml/_helpers.py  (new small util module)
 from __future__ import annotations
-from typing import Dict
+from typing import Dict, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ._ast_nodes import TableArraySectionNode, SectionNode
 
 
 def make_static_table_array(header_str: str, scope: Dict) -> "TableArraySectionNode":

--- a/pkgs/jaml/jaml/_transformer.py
+++ b/pkgs/jaml/jaml/_transformer.py
@@ -1,5 +1,5 @@
 from lark import Transformer, Token, Tree, v_args
-from typing import Any, List, Union
+from typing import Any, List, Union, TYPE_CHECKING
 from ._ast_nodes import (
     BaseNode,
     StartNode,
@@ -43,6 +43,9 @@ from ._ast_nodes import (
     ReservedFuncNode,
 )
 from ._config import Config
+
+if TYPE_CHECKING:
+    from ._ast_nodes import MLArrayItemNode, SLArrayItemNode
 
 
 class ConfigTransformer(Transformer):
@@ -119,8 +122,8 @@ class ConfigTransformer(Transformer):
             if not isinstance(line, AssignmentNode):
                 continue
 
-            key = line.identifier.value
-            value = line.value
+            # key = line.identifier.value  # unused for now
+            # value = line.value  # unused for now
 
             # (static scalars, arrays, else-as-AST logic remains unchanged)
             # … [rest of existing priming logic] …

--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -246,7 +246,7 @@ log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 asyncio_default_fixture_loop_scope = "function"
 
 [tool.ruff]
-exclude = ["experimental"]
+exclude = ["experimental", "**/*.bak.py"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
## Summary
- clean up jaml `__init__` exports
- fix type hints and imports for `_make_static`
- add type checking imports for `_transformer`
- reorder imports in `_ast_nodes`
- improve `_config` typing and logger setup
- rename a variable in `_expression`
- comment unused variables in `_transformer`
- exclude `*.bak.py` files from ruff checks

## Testing
- `ruff check pkgs/jaml/jaml`