### PR TITLE
Fix README style for evaluator packages

### DIFF
--- a/pkgs/standards/swarmauri_evaluator_abstractmethods/README.md
+++ b/pkgs/standards/swarmauri_evaluator_abstractmethods/README.md
@@ -1,1 +1,24 @@
+![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_evaluator_abstractmethods/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_evaluator_abstractmethods" alt="PyPI - Downloads"/></a>
+    <a href="https://pypi.org/project/swarmauri_evaluator_abstractmethods/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_evaluator_abstractmethods" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_evaluator_abstractmethods/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_evaluator_abstractmethods" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_evaluator_abstractmethods/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_evaluator_abstractmethods?label=swarmauri_evaluator_abstractmethods&color=green" alt="PyPI - swarmauri_evaluator_abstractmethods"/></a>
+</p>
+
+---
+
+# Swarmauri Evaluator Abstractmethods
+
+An evaluator that verifies all methods in abstract base classes are properly marked as abstract.
+
+## Installation
+
+```bash
 pip install swarmauri_evaluator_abstractmethods
+```

--- a/pkgs/standards/swarmauri_evaluator_anyusage/README.md
+++ b/pkgs/standards/swarmauri_evaluator_anyusage/README.md
@@ -1,1 +1,24 @@
+![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_evaluator_anyusage/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_evaluator_anyusage" alt="PyPI - Downloads"/></a>
+    <a href="https://pypi.org/project/swarmauri_evaluator_anyusage/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_evaluator_anyusage" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_evaluator_anyusage/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_evaluator_anyusage" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_evaluator_anyusage/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_evaluator_anyusage?label=swarmauri_evaluator_anyusage&color=green" alt="PyPI - swarmauri_evaluator_anyusage"/></a>
+</p>
+
+---
+
+# Swarmauri Evaluator Anyusage
+
+An evaluator component that detects and penalizes usage of the `Any` type in Python code.
+
+## Installation
+
+```bash
 pip install swarmauri_evaluator_anyusage
+```

--- a/pkgs/standards/swarmauri_evaluator_externalimports/README.md
+++ b/pkgs/standards/swarmauri_evaluator_externalimports/README.md
@@ -1,1 +1,24 @@
+![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_evaluator_externalimports/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_evaluator_externalimports" alt="PyPI - Downloads"/></a>
+    <a href="https://pypi.org/project/swarmauri_evaluator_externalimports/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_evaluator_externalimports" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_evaluator_externalimports/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_evaluator_externalimports" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_evaluator_externalimports/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_evaluator_externalimports?label=swarmauri_evaluator_externalimports&color=green" alt="PyPI - swarmauri_evaluator_externalimports"/></a>
+</p>
+
+---
+
+# Swarmauri Evaluator Externalimports
+
+Evaluator that detects and penalizes non-built-in Python imports in source files.
+
+## Installation
+
+```bash
 pip install swarmauri_evaluator_externalimports
+```

--- a/pkgs/standards/swarmauri_evaluator_subprocess/README.md
+++ b/pkgs/standards/swarmauri_evaluator_subprocess/README.md
@@ -1,1 +1,24 @@
+![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_evaluator_subprocess/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_evaluator_subprocess" alt="PyPI - Downloads"/></a>
+    <a href="https://pypi.org/project/swarmauri_evaluator_subprocess/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_evaluator_subprocess" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_evaluator_subprocess/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_evaluator_subprocess" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_evaluator_subprocess/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_evaluator_subprocess?label=swarmauri_evaluator_subprocess&color=green" alt="PyPI - swarmauri_evaluator_subprocess"/></a>
+</p>
+
+---
+
+# Swarmauri Evaluator Subprocess
+
+A subprocess-based evaluator for executing and measuring program performance in isolated subprocesses.
+
+## Installation
+
+```bash
 pip install swarmauri_evaluator_subprocess
+```

--- a/pkgs/standards/swarmauri_evaluatorpool_accessibility/README.md
+++ b/pkgs/standards/swarmauri_evaluatorpool_accessibility/README.md
@@ -1,1 +1,24 @@
+![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_evaluatorpool_accessibility/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_evaluatorpool_accessibility" alt="PyPI - Downloads"/></a>
+    <a href="https://pypi.org/project/swarmauri_evaluatorpool_accessibility/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_evaluatorpool_accessibility" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_evaluatorpool_accessibility/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_evaluatorpool_accessibility" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_evaluatorpool_accessibility/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_evaluatorpool_accessibility?label=swarmauri_evaluatorpool_accessibility&color=green" alt="PyPI - swarmauri_evaluatorpool_accessibility"/></a>
+</p>
+
+---
+
+# Swarmauri Evaluatorpool Accessibility
+
+A package providing accessibility and readability evaluators for Swarmauri.
+
+## Installation
+
+```bash
 pip install swarmauri_evaluatorpool_accessibility
+```


### PR DESCRIPTION
## Summary
- standardize README formatting for evaluator-related packages

## Testing
- `git status --short`