### PR TITLE
Update schemas per IP-0003

### DIFF
--- a/pkgs/standards/peagen/peagen/core.py
+++ b/pkgs/standards/peagen/peagen/core.py
@@ -411,7 +411,7 @@ class Peagen(ComponentBase):
                         break
 
             manifest_meta: Dict[str, Any] = {
-                "schema_version": "3.1.0",
+                "schemaVersion": "3.1.0",
                 "workspace_uri": workspace_uri,
                 "project": project_name,
                 "source_packages": self.source_packages,

--- a/pkgs/standards/peagen/peagen/manifest_writer.py
+++ b/pkgs/standards/peagen/peagen/manifest_writer.py
@@ -35,7 +35,7 @@ class ManifestWriter:
         slug         Project slug (e.g. ``"ExampleParserProject"``).
         adapter      Storage adapter implementing ``upload(key, file)``.
         tmp_root     Workspace/.peagen directory (created if absent).
-        meta         Static fields for the final manifest (schema_version,
+        meta         Static fields for the final manifest (schemaVersion,
                      workspace_uri, project, source_packages, peagen_version…)
         """
         tmp_root.mkdir(parents=True, exist_ok=True)

--- a/pkgs/standards/peagen/peagen/schemas/manifest.schema.v3.1.json
+++ b/pkgs/standards/peagen/peagen/schemas/manifest.schema.v3.1.json
@@ -5,7 +5,7 @@
   "schemaVersion": "3.1.0",
   "type": "object",
   "required": [
-    "schema_version",
+    "schemaVersion",
     "workspace_uri",
     "project",
     "generated",
@@ -15,9 +15,10 @@
     "generated_at"
   ],
   "properties": {
-    "schema_version": {
+    "schemaVersion": {
       "const": "3.1.0",
-      "description": "Hard-coded version tag; bump only on breaking changes."
+      "description": "Hard-coded version tag; bump only on breaking changes.",
+      "$comment": "Used to detect format version; camelCase per IP-0003."
     },
     "workspace_uri": {
       "type": "string",
@@ -94,7 +95,9 @@
     },
     "peagen_version": {
       "type": "string",
-      "description": "Semantic version of the Peagen CLI that produced the manifest."
+      "pattern": "^(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)$",
+      "description": "Semantic version of the Peagen CLI that produced the manifest.",
+      "$comment": "Semantic version (MAJOR.MINOR.PATCH) of the Peagen CLI that generated this artefact."
     },
     "generated_at": {
       "type": "string",

--- a/pkgs/standards/peagen/peagen/schemas/manifest.schema.v3.json
+++ b/pkgs/standards/peagen/peagen/schemas/manifest.schema.v3.json
@@ -5,7 +5,7 @@
   "schemaVersion": "3.0.0",
   "type": "object",
   "required": [
-    "schema_version",
+    "schemaVersion",
     "workspace_uri",
     "project",
     "generated",
@@ -14,9 +14,10 @@
     "generated_at"
   ],
   "properties": {
-    "schema_version": {
+    "schemaVersion": {
       "const": "3.0.0",
-      "description": "Hard-coded version tag; bump only on breaking changes."
+      "description": "Hard-coded version tag; bump only on breaking changes.",
+      "$comment": "Used to detect format version; camelCase per IP-0003."
     },
     "workspace_uri": {
       "type": "string",
@@ -78,7 +79,9 @@
     },
     "peagen_version": {
       "type": "string",
-      "description": "Semantic version of the Peagen CLI that produced the manifest."
+      "pattern": "^(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)$",
+      "description": "Semantic version of the Peagen CLI that produced the manifest.",
+      "$comment": "Semantic version (MAJOR.MINOR.PATCH) of the Peagen CLI that generated this artefact."
     },
     "generated_at": {
       "type": "string",

--- a/pkgs/standards/peagen/peagen/schemas/projects_payload.schema.v1.json
+++ b/pkgs/standards/peagen/peagen/schemas/projects_payload.schema.v1.json
@@ -27,6 +27,13 @@
   },
   "required": ["schemaVersion", "PROJECTS"],
   "additionalProperties": false,
+  "allOf": [
+    {
+      "if": { "required": ["PROJECTS"] },
+      "then": { "required": ["SOURCE"] },
+      "$comment": "DOE expansions must record the originating SOURCE for provenance."
+    }
+  ],
   "definitions": {
     "projectEntry": {
       "type": "object",
@@ -56,7 +63,11 @@
             "LLM_FACTORS":    { "type": "object", "additionalProperties": true },
             "factors":        { "type": "object", "additionalProperties": true },
             "spec_name":      { "type": "string" },
-            "peagen_version": { "type": "string" }
+            "peagen_version": {
+              "type": "string",
+              "pattern": "^(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)$",
+              "$comment": "Semantic version (MAJOR.MINOR.PATCH) of the Peagen CLI that generated this artefact."
+            }
           },
           "required": ["design_id", "LLM_FACTORS", "factors", "spec_name", "peagen_version"],
           "additionalProperties": true
@@ -160,10 +171,13 @@
       "properties": {
         "spec":           { "type": "string" },
         "template":       { "type": "string" },
-        "context":        { "type": ["string", "null"] },
+        "context":        {
+          "type": ["string", "null"],
+          "$comment": "Null permitted when the context is implicit"
+        },
         "spec_checksum":  { "type": "string" }
       },
-      "required": ["spec", "template", "context", "spec_checksum"],
+      "required": ["spec", "template", "spec_checksum"],
       "additionalProperties": true
     }
   }

--- a/pkgs/standards/peagen/tests/examples/manifests/ExampleParserProject_manifest.json
+++ b/pkgs/standards/peagen/tests/examples/manifests/ExampleParserProject_manifest.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "3.0.0",
+  "schemaVersion": "3.0.0",
   "workspace_uri": "minio://149.255.38.126:9000/test",
   "project": "ExampleParserProject",
   "generated": [


### PR DESCRIPTION
## Summary
- align manifest schema naming with `schemaVersion`
- enforce semantic version pattern for `peagen_version`
- relax SOURCE rules and add provenance requirement
- document new fields in manifest writer and generation code
- update example manifest

## Testing
- `jq empty pkgs/standards/peagen/peagen/schemas/manifest.schema.v3.json`
- `jq empty pkgs/standards/peagen/peagen/schemas/manifest.schema.v3.1.json`
- `jq empty pkgs/standards/peagen/peagen/schemas/projects_payload.schema.v1.json`
