### PR TITLE
Fix ruff issues in jaml tests

### DIFF
--- a/pkgs/jaml/tests/r8n/test_circular_reference.py
+++ b/pkgs/jaml/tests/r8n/test_circular_reference.py
@@ -13,7 +13,7 @@ b = f"%{a}"
     """.strip()
 
     with pytest.raises(ValueError, match="Circular reference detected: a -> b -> a"):
-        ast = round_trip_loads(jml)
+        round_trip_loads(jml)
 
 
 @pytest.mark.unit
@@ -33,7 +33,7 @@ c = f"%{a}"
         ValueError,
         match="Circular reference detected: config.a -> config.b -> config.nested.c -> config.a",
     ):
-        ast = round_trip_loads(jml)
+        round_trip_loads(jml)
 
 
 @pytest.mark.unit
@@ -50,4 +50,4 @@ z = f"%{x}"
     with pytest.raises(
         ValueError, match="Circular reference detected: x -> y -> z -> x"
     ):
-        ast = round_trip_loads(jml)
+        round_trip_loads(jml)

--- a/pkgs/jaml/tests/spec/(MEP-0002) precedence_test.py
+++ b/pkgs/jaml/tests/spec/(MEP-0002) precedence_test.py
@@ -130,7 +130,6 @@ def test_operator_precedence():
 
     # Expected order: IDENTIFIER, OPERATOR, IDENTIFIER.
     token_types = [t.type for t in tokens]
-    token_values = [t.value for t in tokens]
     assert token_types == ["IDENTIFIER", "HSPACES", "SETTER", "HSPACES", "INTEGER"]
 
 

--- a/pkgs/jaml/tests/spec/(MEP-0011) scopes_comprehensions_expressions_test.py
+++ b/pkgs/jaml/tests/spec/(MEP-0011) scopes_comprehensions_expressions_test.py
@@ -31,7 +31,7 @@ url = f"@{base}/config.toml"
     print(resolved_config)
     assert resolved_config["config"]["url"] == "/home/alt/config.toml"
 
-    out = data.dumps()
+    data.dumps()
     rendered_data = data.render()
     print("[DEBUG]:")
     print(rendered_data)
@@ -95,7 +95,7 @@ greeting = f"Hello, %{name}!"
     print(resolved_config)
     assert resolved_config["user"]["greeting"] == "Hello, Bob!"
 
-    out = data.dumps()
+    data.dumps()
     rendered_data = data.render()
     print("[DEBUG]:")
     print(rendered_data)
@@ -123,7 +123,7 @@ summary = f"User: ${user.name}, Age: ${user.age}"
         resolved_config["logic"]["summary"] == 'f"User: ${user.name}, Age: ${user.age}"'
     )
 
-    out = data.dumps()
+    data.dumps()
     rendered_data = data.render(context={"user": {"name": "Alice", "age": 30}})
     assert rendered_data["logic"]["summary"] == "User: Alice, Age: 30"
 
@@ -193,7 +193,7 @@ endpoint = <( "http://" + @{server.host} + ":" + @{server.port} + "/api?token=" 
     print("[DEBUG SETTER]:")
     print(data)
 
-    out = data.dumps()
+    data.dumps()
     rendered_data = data.render(context={"auth_token": "ABC123"})
     print("[DEBUG]:")
     print(rendered_data)
@@ -223,7 +223,7 @@ list_config = [f"item_{x}" for x in [1, 2, 3]]
     print(resolved_config)
     assert resolved_config["items"]["list_config"] == ["item_5", "item_10", "item_15"]
 
-    out = data.dumps()
+    data.dumps()
     rendered_data = data.render()
     print("[DEBUG]:")
     print(rendered_data)
@@ -260,7 +260,7 @@ dict_config = {f"key_{x}" : x * 2 for x in [1, 2, 3]}
         "item_15": 45,
     }
 
-    out = data.dumps()
+    data.dumps()
     rendered_data = data.render()
     print("[DEBUG]:")
     print(rendered_data)
@@ -298,7 +298,7 @@ dict_config = {f"key_{x}" = x * 2 for x in [1, 2, 3]}
         "item_15": 45,
     }
 
-    out = data.dumps()
+    data.dumps()
     rendered_data = data.render()
     assert rendered_data["items"]["dict_config"] == {
         "item_5": 15,
@@ -329,7 +329,7 @@ result = <( 3 + 4 )>
     print(data)
     assert resolved_config["calc"]["result"] == 11
 
-    out = data.dumps()
+    data.dumps()
     rendered_data = data.render()
     assert rendered_data["calc"]["result"] == 11
 
@@ -379,7 +379,7 @@ result = <( 3 + 4 )>
     )
     assert resolved_config["calc"]["result"] == 11
 
-    out = data.dumps()
+    data.dumps()
     rendered_data = data.render(context={"auth_token": "ABC123"})
     print("[DEBUG]:")
     print(rendered_data)
@@ -410,7 +410,7 @@ status = f"{'Yes' if true else 'No'}"
     print(resolved_config)
     assert resolved_config["cond"]["status"] == "No"
 
-    out = data.dumps()
+    data.dumps()
     rendered_data = data.render()
     print("[DEBUG]:")
     print(rendered_data)
@@ -437,7 +437,7 @@ status = <('Yes' if true else 'No')>"""
     print(resolved_config)
     assert resolved_config["cond"]["status"] == "No"
 
-    out = data.dumps()
+    data.dumps()
     rendered_data = data.render()
     print("[DEBUG]:")
     print(rendered_data)

--- a/pkgs/jaml/tests/spec/(MEP-0011a) scopes_comprehensions_expressions_test.py
+++ b/pkgs/jaml/tests/spec/(MEP-0011a) scopes_comprehensions_expressions_test.py
@@ -93,11 +93,12 @@ def test_context_scoped_var_resolve():
     assert data["rootDir"] == '"src"'
 
     resolved_config = data.resolve()
+    assert resolved_config["rootDir"] == "src"
 
     # out = data.dumps()
     # rendered_data = data.render(out, context=BASE_CONTEXT)
     rendered_data = data.render(context=BASE_CONTEXT)
-    final_out = data.dumps()
+    data.dumps()
 
     print("\n\n\n\n[FINAL_OUT]:")
     print(rendered_data)

--- a/pkgs/jaml/tests/spec/(MEP-0012a) scoped_variables_test.py
+++ b/pkgs/jaml/tests/spec/(MEP-0012a) scoped_variables_test.py
@@ -73,7 +73,8 @@ summary = f"User: ${user.name}, Age: ${user.age}"
     # Provide context at render-time:
     ctx = {"user": {"name": "Azzy", "age": 9}}
 
-    rendered = data.render(context=ctx)
+    data = round_trip_loads(toml_str)
+    data.render(context=ctx)
     reserialized = data.render()
     # Expect "User: Azzy, Age: 9"
     assert "User: Azzy, Age: 9" in reserialized
@@ -139,8 +140,7 @@ config_path = f"${base}" + "/dynamic/config.toml"
 """
     ctx = {"base": "/custom"}
     data = round_trip_loads(toml_str)
-    rendered = data.render(context=ctx)
-    reserialized = rendered.dumps()
+    reserialized = data.render(context=ctx).dumps()
     assert (
         "/opt/dynamic/config.toml" in reserialized
         or "/custom/dynamic/config.toml" in reserialized
@@ -166,7 +166,7 @@ file = f"${path}/config.toml"
 """
     ctx = {"path": "/render-time"}
     data = round_trip_loads(toml_str)
-    rendered = data.render(context=ctx)
+    data.render(context=ctx)
     reserialized = data.dumps()
     assert "/render-time/config.toml" in reserialized
 
@@ -191,6 +191,5 @@ file = f"${path}/config.toml" # This comment may cause a failure
     ctx = {"path": "/render-time"}
 
     data = round_trip_loads(toml_str)
-    rendered = data.render(context=ctx)
-    reserialized = rendered.dumps()
+    reserialized = data.render(context=ctx).dumps()
     assert "/render-time/config.toml" in reserialized

--- a/pkgs/jaml/tests/spec/(MEP-0028a) conditional_table_sections_test.py
+++ b/pkgs/jaml/tests/spec/(MEP-0028a) conditional_table_sections_test.py
@@ -31,7 +31,7 @@ def test_conditional_table_header():
     print(data, "\n\n")
     assert """"prod" if @{env}=="production" else null""" in data
 
-    resolved_config = data.resolve()
+    data.resolve()
     assert "prod" in data
     assert "type" in data["prod"]
 

--- a/pkgs/jaml/tests/spec/(MEP-0028b) conditional_table_sections_test.py
+++ b/pkgs/jaml/tests/spec/(MEP-0028b) conditional_table_sections_test.py
@@ -32,7 +32,7 @@ def test_conditional_table_header_with_context():
     print(data, "\n\n")
     assert """"prod" if ${env}=="production" else null""" in data
 
-    resolved_config = data.resolve()
+    data.resolve()
     assert """"prod" if ${env}=="production" else null""" in data
     assert "type" in data[""""prod" if ${env}=="production" else null"""]
 

--- a/pkgs/jaml/tests/spec/(MEP-0028c) conditional_table_array_sections_test.py
+++ b/pkgs/jaml/tests/spec/(MEP-0028c) conditional_table_array_sections_test.py
@@ -22,12 +22,6 @@ def test_section_headers_with_clauses():
     # The base external context used during rendering.
     BASE_CONTEXT = {"env": "production"}
 
-    expected_result = r"""
-    [[prod]]
-    type = "python"
-
-
-    """
 
     data = round_trip_loads(JML_INPUT)
     print("\n\n[TEST DEBUG]:")

--- a/pkgs/jaml/tests/spec/(MEP-0028f) conditional_table_array_sections_test.py
+++ b/pkgs/jaml/tests/spec/(MEP-0028f) conditional_table_array_sections_test.py
@@ -45,14 +45,6 @@ for module in package.modules if package.active]]"""
         ],
     }
 
-    expected_result = r"""
-    rootDir = "src"
-
-    [[file.auth.login.source]]
-
-    [[file.auth.signup.source]]
-
-    """
 
     data = round_trip_loads(JML_INPUT)
     print("\n\n[TEST DEBUG]:")


### PR DESCRIPTION
## Summary
- fix unused variable warnings in jaml test suite
- ensure circular reference tests call round_trip_loads without unused variables
- drop unused variables across several spec tests

## Testing
- `uv run --package jaml --directory jaml pytest` *(fails: test suite has pre-existing failures)*