### PR TITLE
Add evaluation section to Peagen example

### DIFF
--- a/pkgs/standards/peagen/tests/examples/peagen_tomls/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/peagen_tomls/.peagen.toml
@@ -41,3 +41,19 @@ password = "..."                   # leave blank if no auth
 # ─────────────────────────────── Plugins ───────────────────────────────
 [plugins]
 mode = "switch"
+
+# ────────────────────────────── Evaluation ───────────────────────────────
+[evaluation]
+pool = "swarmauri_evaluatorpool_accessibility:AccessibilityEvaluatorPool"
+max_workers = 4
+async = false
+strict = true
+
+[evaluation.evaluators]
+
+[evaluation.evaluators.automated_readability]
+cls = "swarmauri_evaluatorpool_accessibility:AutomatedReadabilityIndexEvaluator"
+
+[evaluation.evaluators.coleman_liau]
+cls = "swarmauri_evaluatorpool_accessibility:ColemanLiauIndexEvaluator"
+


### PR DESCRIPTION
## Summary
- add example evaluation configuration to Peagen test config

## Testing
- `pre-commit`