### PR TITLE
Fix peagen process CLI provider requirement

### DIFF
--- a/pkgs/standards/peagen/peagen/commands/process.py
+++ b/pkgs/standards/peagen/peagen/commands/process.py
@@ -159,7 +159,7 @@ def process_cmd(
         notify = default_publisher
 
     # ── SANITY CHECKS ───────────────────────────────────────────────────
-    if (start_idx and start_file) or (not provider or not model_name):
+    if start_idx and start_file:
         typer.echo("❌ Invalid combination of flags.")
         raise typer.Exit(1)
 
@@ -234,7 +234,9 @@ def process_cmd(
     _config.update(truncate=trunc, revise=False, transitive=transitive, workers=workers)
 
     installed_sets = install_template_sets(template_sets_cfg)
-    resolved_key = _resolve_api_key(provider, api_key, env)
+    resolved_key = (
+        _resolve_api_key(provider, api_key, env) if provider else None
+    )
     agent_env = {
         "provider": provider,
         "model_name": model_name,

--- a/pkgs/standards/peagen/tests/r8n/test_process_cli.py
+++ b/pkgs/standards/peagen/tests/r8n/test_process_cli.py
@@ -1,0 +1,57 @@
+import pytest
+from typer.testing import CliRunner
+from peagen.commands.process import process_app
+from unittest.mock import patch, MagicMock
+
+
+@pytest.mark.r8n
+def test_process_cli_allows_no_provider(tmp_path):
+    payload = tmp_path / "proj.yaml"
+    payload.write_text("schemaVersion: '1.0'\nPROJECTS: []", encoding="utf-8")
+    runner = CliRunner()
+    dummy_registry = {
+        "storage_adapters": {"file": type("Dummy", (), {"__init__": lambda *a, **k: None})}
+    }
+    with patch(
+        "peagen.commands.process.install_template_sets", return_value=[]
+    ), patch(
+        "peagen.commands.process.materialise_packages", return_value=[]
+    ), patch("peagen.commands.process.registry", dummy_registry), patch(
+        "peagen.commands.process.Peagen"
+    ) as MockPeagen:
+        MockPeagen.return_value.process_all_projects.return_value = []
+        with patch(
+            "peagen.commands.process.load_peagen_toml",
+            return_value={"source_packages": [], "template_sets": []},
+        ):
+            result = runner.invoke(process_app, [str(payload)])
+        assert result.exit_code == 0
+        MockPeagen.return_value.process_all_projects.assert_called_once()
+
+
+@pytest.mark.r8n
+def test_process_cli_start_idx_and_file_error(tmp_path):
+    payload = tmp_path / "proj.yaml"
+    payload.write_text("schemaVersion: '1.0'\nPROJECTS: []", encoding="utf-8")
+    runner = CliRunner()
+    dummy_registry = {
+        "storage_adapters": {"file": type("Dummy", (), {"__init__": lambda *a, **k: None})}
+    }
+    with patch(
+        "peagen.commands.process.install_template_sets", return_value=[]
+    ), patch(
+        "peagen.commands.process.materialise_packages", return_value=[]
+    ), patch("peagen.commands.process.registry", dummy_registry), patch(
+        "peagen.commands.process.Peagen"
+    ):
+        with patch(
+            "peagen.commands.process.load_peagen_toml",
+            return_value={"source_packages": [], "template_sets": []},
+        ):
+            result = runner.invoke(
+                process_app,
+                [str(payload), "--start-idx", "1", "--start-file", "foo"],
+            )
+        assert result.exit_code != 0
+        assert "Invalid combination of flags" in result.output
+


### PR DESCRIPTION
## Summary
- allow `peagen process` to run without specifying `--provider`
- cover CLI behaviour with new tests

## Testing
- `uv run --package peagen --directory standards/peagen pytest`