### PR TITLE
Fix syntax errors in RapidSimilarity packages

### DIFF
--- a/pkgs/experimental/RapidSimilarity/DistanceMetrics/DistanceMetrics/__init__.py
+++ b/pkgs/experimental/RapidSimilarity/DistanceMetrics/DistanceMetrics/__init__.py
@@ -1,4 +1,5 @@
-from .euclidean import euclideanfrom .cosine import cosine
+from .euclidean import euclidean
+from .cosine import cosine
 
 __all__ = [
     "euclidean",

--- a/pkgs/experimental/RapidSimilarity/IndexBuilder/IndexBuilder/__init__.py
+++ b/pkgs/experimental/RapidSimilarity/IndexBuilder/IndexBuilder/__init__.py
@@ -1,4 +1,5 @@
-from .tree_index import tree_indexfrom .hash_index import hash_index
+from .tree_index import tree_index
+from .hash_index import hash_index
 
 __all__ = [
     "tree_index",

--- a/pkgs/experimental/RapidSimilarity/QueryEngine/QueryEngine/__init__.py
+++ b/pkgs/experimental/RapidSimilarity/QueryEngine/QueryEngine/__init__.py
@@ -1,4 +1,5 @@
-from .exact_query import exact_queryfrom .approx_query import approx_query
+from .exact_query import exact_query
+from .approx_query import approx_query
 
 __all__ = [
     "exact_query",

--- a/pkgs/standards/peagen/peagen/_external.py
+++ b/pkgs/standards/peagen/peagen/_external.py
@@ -65,6 +65,7 @@ def call_external_agent(
     truncated_prompt = prompt[:140] + "..." if _config["truncate"] else prompt
     if logger:
         logger.info(f"Sending prompt to external llm: \n\t{truncated_prompt}\n")
+        logger.debug(f"Agent env: {agent_env}")
 
     # Extract configuration from agent_env
     provider = os.getenv("PROVIDER") or agent_env.get("provider", "deepinfra").lower()
@@ -74,6 +75,8 @@ def call_external_agent(
 
     # Initialize the generic LLM manager
     llm_manager = GenericLLM()
+    if logger:
+        logger.debug(f"Requesting provider '{provider}' model '{model_name}'")
 
     # Special case for LlamaCpp which doesn't need an API key
     if provider.lower() == "llamacpp":
@@ -114,6 +117,8 @@ def call_external_agent(
 
     # Process and chunk the content
     content = chunk_content(result, logger)
+    if logger:
+        logger.debug(f"Received content length: {len(content)}")
 
     # Clean up
     del agent
@@ -134,23 +139,31 @@ def chunk_content(full_content: str, logger: Optional[Any] = None) -> str:
 
         chunker = MdSnippetChunker()
         chunks = chunker.chunk_text(cleaned_text)
+        if logger:
+            logger.debug(f"Chunker returned {len(chunks)} chunk(s)")
         if len(chunks) > 1:
             logger.warning(
                 "MdSnippetChunker found more than one snippet, took the first."
             )
+            if logger:
+                logger.debug("Returning first chunk of size %d", len(chunks[0][2]))
             return chunks[0][2]
         try:
             return chunks[0][2]
         except IndexError:
             logger.warning("MdSnippetChunker found no chunks, using cleaned_text.")
+            if logger:
+                logger.debug("Returning cleaned_text of length %d", len(cleaned_text))
             return cleaned_text
     except ImportError:
         if logger:
             logger.warning(
                 "MdSnippetChunker not found. Returning full content without chunking."
             )
+            logger.debug("Returning cleaned_text of length %d", len(cleaned_text))
         return cleaned_text
     except Exception as e:
         if logger:
             logger.error(f"[ERROR] Failed to chunk content: {e}")
+            logger.debug("Returning cleaned_text of length %d", len(cleaned_text))
         return cleaned_text

--- a/pkgs/standards/peagen/peagen/_rendering.py
+++ b/pkgs/standards/peagen/peagen/_rendering.py
@@ -29,6 +29,8 @@ def _render_copy_template(
     """
     try:
         template_path = file_record.get("FILE_NAME", "NOT_FILE_FOUND")
+        if logger:
+            logger.debug(f"Rendering copy template {template_path}")
         j2_instance.set_template(FilePath(template_path))
         return j2_instance.fill(context)
     except Exception as e:
@@ -62,6 +64,8 @@ def _render_generate_template(
     then calls out to the external agent.
     """
     try:
+        if logger:
+            logger.debug(f"Rendering generate template {agent_prompt_template}")
         j2_instance.set_template(FilePath(agent_prompt_template))
         rendered_prompt = j2_instance.fill(context)
         from ._external import call_external_agent

--- a/pkgs/standards/peagen/peagen/core.py
+++ b/pkgs/standards/peagen/peagen/core.py
@@ -193,6 +193,8 @@ class Peagen(ComponentBase):
         Returns:
           list[dict]: A list of project dictionaries.
         """
+        if self.logger:
+            self.logger.debug(f"Loading projects from {self.projects_payload_path}")
         try:
             with open(self.projects_payload_path, "r", encoding="utf-8") as f:
                 data = yaml.safe_load(f)
@@ -226,11 +228,15 @@ class Peagen(ComponentBase):
         and (optionally) handles dependency ordering.
         """
 
+        if self.logger:
+            self.logger.debug("Beginning processing of all projects")
         sorted_records = []
         if not self.projects_list:
             self.load_projects()
         self.logger.debug(f"Projects loaded: '{self.projects_list}'")
         for project in self.projects_list:
+            if self.logger:
+                self.logger.debug(f"Starting project {project.get('NAME')}")
             file_records, start_idx = self.process_single_project(project)
             sorted_records.append(file_records)
         return sorted_records
@@ -254,6 +260,8 @@ class Peagen(ComponentBase):
         *   Each file save triggers writer.add(…).
         *   On successful completion we call writer.finalise().
         """
+        if self.logger:
+            self.logger.debug(f"Processing project {project.get('NAME')}")
         all_file_records = []
         packages = project.get("PACKAGES", [])
         project_name = project.get("NAME", "UnnamedProject")
@@ -441,6 +449,10 @@ class Peagen(ComponentBase):
                 start_idx=start_idx,
                 manifest_writer=manifest_writer,
             )
+            if self.logger:
+                self.logger.debug(
+                    f"Processed {len(sorted_records)} files for project '{project_name}'"
+                )
 
             # --------  finalise manifest
             if manifest_writer.path.exists():
@@ -460,4 +472,8 @@ class Peagen(ComponentBase):
                 f"project='{project_name}'."
             )
 
+        if self.logger:
+            self.logger.debug(
+                f"Returning {len(sorted_records)} sorted records for project '{project_name}'"
+            )
         return (sorted_records, start_idx)


### PR DESCRIPTION
## Summary
- fix truncated import lines in RapidSimilarity packages
- add newline at end of `__init__.py` files

## Testing
- `python -m compileall -q pkgs`