### PR TITLE
Fix Coleman-Liau evaluator return schema

### DIFF
--- a/pkgs/standards/swarmauri_evaluatorpool_accessibility/swarmauri_evaluatorpool_accessibility/ColemanLiauIndexEvaluator.py
+++ b/pkgs/standards/swarmauri_evaluatorpool_accessibility/swarmauri_evaluatorpool_accessibility/ColemanLiauIndexEvaluator.py
@@ -15,7 +15,7 @@ class ColemanLiauIndexEvaluator(EvaluatorBase, ComponentBase):
     """
     Coleman–Liau Index evaluator compliant with the Program/Evaluator contracts.
 
-    • ``evaluate()`` always returns a **dict** containing at least ``score``.
+    • ``evaluate()`` returns ``{"score": float, "metadata": dict}``.
     • ``_compute_score()`` returns ``Tuple[float, Dict[str, Any]]`` for internal use.
     """
 
@@ -29,24 +29,9 @@ class ColemanLiauIndexEvaluator(EvaluatorBase, ComponentBase):
     # Public API – called by the pool / runner
     # ──────────────────────────────────────────────────────────────────────
     def evaluate(self, program: Program, **kwargs) -> Dict[str, Any]:
-        """
-        Wraps ``_compute_score`` so downstream code can safely use ``.get("score")``.
-        """
-        result = self._compute_score(program, **kwargs)
-
-        # Legacy tuple → dict shim
-        if isinstance(result, tuple):
-            score, meta = result
-            meta = meta or {}
-            meta["score"] = score
-            return meta
-
-        # Already a dict
-        if isinstance(result, dict):
-            return result
-
-        # Fallback (should never happen)
-        return {"score": float(result)}
+        """Return ``{"score": float, "metadata": dict}`` for the given program."""
+        score, meta = self._compute_score(program, **kwargs)
+        return {"score": score, "metadata": meta}
 
     # ──────────────────────────────────────────────────────────────────────
     # Core scoring logic

--- a/pkgs/standards/swarmauri_evaluatorpool_accessibility/tests/unit/test_ColemanLiauIndexEvaluator.py
+++ b/pkgs/standards/swarmauri_evaluatorpool_accessibility/tests/unit/test_ColemanLiauIndexEvaluator.py
@@ -259,3 +259,14 @@ def test_edge_case_identical_target_and_max_grade_level():
     # With identical target and max, the score should be 1.0 for target and 0.0 otherwise
     assert evaluator._calculate_score(10) == 1.0
     assert evaluator._calculate_score(9) < 1.0
+
+
+@pytest.mark.unit
+def test_evaluate_returns_score_and_metadata(evaluator, mock_program):
+    """evaluate() should return a dict with 'score' and 'metadata'."""
+    mock_program.output = "Hello world."
+
+    result = evaluator.evaluate(mock_program)
+
+    assert set(result.keys()) == {"score", "metadata"}
+    assert isinstance(result["metadata"], dict)


### PR DESCRIPTION
## Summary
- update `ColemanLiauIndexEvaluator.evaluate` to return `{score, metadata}`
- adjust docstring for clarity
- test that `evaluate()` returns both fields

## Testing
- `uv run --package swarmauri_evaluatorpool_accessibility --directory standards/swarmauri_evaluatorpool_accessibility pytest` *(fails: Request failed after 3 retries)*