### PR TITLE
Support file_path in eval manifest

### DIFF
--- a/pkgs/standards/peagen/docs/pea-ips/ip-0004.md
+++ b/pkgs/standards/peagen/docs/pea-ips/ip-0004.md
@@ -126,9 +126,11 @@ If the same key appears multiple times the **earlier** entry wins, ensuring CLI 
 
 | Field          | Type   | Rules                                                     |
 | -------------- | ------ | --------------------------------------------------------- |
-| `program_path` | string | Relative path from workspace root.                        |
+| `program_path` | string | Relative path from workspace root of the program evaluated.                        |
+| `file_path`    | string | Relative path from workspace root of the file evaluated.                        |
 | `scores`       | object | Keys ⊆ `evaluators`, values 0 ≤ *float* ≤ 1 .\*           |
 | `metadata`     | object | Arbitrary per-evaluator details — nested objects allowed. |
+Exactly one of `program_path` or `file_path` must be present in each result.
 
 \* Evaluators that do not emit a numeric score MUST still create an entry with `null`.
 

--- a/pkgs/standards/peagen/peagen/commands/eval.py
+++ b/pkgs/standards/peagen/peagen/commands/eval.py
@@ -128,7 +128,7 @@ def eval_cmd(
         "evaluators": pool_inst.get_evaluator_names(),
         "results": [
             {
-                "program_path": str(pp),
+                "file_path": str(pp),
                 "score": rr.score,
                 "metadata": rr.metadata,
             }

--- a/pkgs/standards/peagen/peagen/schemas/eval_manifest.schema.v1.json
+++ b/pkgs/standards/peagen/peagen/schemas/eval_manifest.schema.v1.json
@@ -46,11 +46,15 @@
       "minItems": 1,
       "items": {
         "type": "object",
-        "required": ["program_path", "scores"],
+        "required": ["scores"],
         "properties": {
           "program_path": {
             "type": "string",
-            "description": "Relative path from workspace root."
+            "description": "Relative path from workspace root representing the program evaluated."
+          },
+          "file_path": {
+            "type": "string",
+            "description": "Relative path from workspace root for an individual file evaluated."
           },
           "scores": {
             "type": "object",
@@ -68,6 +72,10 @@
             "additionalProperties": true
           }
         },
+        "oneOf": [
+          {"required": ["program_path"]},
+          {"required": ["file_path"]}
+        ],
         "additionalProperties": false
       }
     }


### PR DESCRIPTION
## Summary
- extend eval manifest schema to allow `program_path` or `file_path`
- emit `file_path` from `peagen eval` command
- document new manifest field in IP‑0004

## Testing
- `uv run --package peagen --directory standards/peagen pytest` *(fails: No route to host)*