### PR TITLE
Fix evaluator kwargs handling

### DIFF
--- a/pkgs/standards/peagen/peagen/commands/eval.py
+++ b/pkgs/standards/peagen/peagen/commands/eval.py
@@ -91,7 +91,13 @@ def eval_cmd(
                 else spec["cls"].rsplit(".", 1)
             )
             EvalCls = getattr(import_module(mod), cls)
-            evaluator = EvalCls(**spec.get("args", {}))
+
+            args = {}
+            if isinstance(spec.get("args"), dict):
+                args.update(spec["args"])
+            args.update({k: v for k, v in spec.items() if k not in {"cls", "args"}})
+
+            evaluator = EvalCls(**args)
         else:
             raise ValueError(f"Invalid evaluator spec for '{name}': {spec}")
         pool_inst.add_evaluator(evaluator, name=name)

--- a/pkgs/standards/peagen/tests/examples/peagen_tomls/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/peagen_tomls/.peagen.toml
@@ -56,4 +56,5 @@ cls = "swarmauri_evaluatorpool_accessibility:AutomatedReadabilityIndexEvaluator"
 
 [evaluation.evaluators.coleman_liau]
 cls = "swarmauri_evaluatorpool_accessibility:ColemanLiauIndexEvaluator"
+target_grade_level = 12
 


### PR DESCRIPTION
## Summary
- allow evaluator kwargs in `[evaluation.evaluators.*]` sections
- show target_grade_level usage in example `.peagen.toml`

## Testing
- `pre-commit` *(fails: command not found)*