### PR TITLE
Fix readability evaluators to use Program interface

### DIFF
--- a/pkgs/standards/swarmauri_evaluatorpool_accessibility/swarmauri_evaluatorpool_accessibility/FleschKincaidGradeEvaluator.py
+++ b/pkgs/standards/swarmauri_evaluatorpool_accessibility/swarmauri_evaluatorpool_accessibility/FleschKincaidGradeEvaluator.py
@@ -114,26 +114,13 @@ class FleschKincaidGradeEvaluator(EvaluatorBase, ComponentBase):
         Returns:
             The extracted text as a string
         """
-        # Get the program's output
-        output = program.get_output()
-
-        # If output is already a string, use it directly
-        if isinstance(output, str):
-            return output
-
-        # If output is a dictionary, look for text content
-        if isinstance(output, dict):
-            if "text" in output:
-                return str(output["text"])
-            if "content" in output:
-                return str(output["content"])
-
-        # If output is a list, join elements as strings
-        if isinstance(output, list):
-            return " ".join(str(item) for item in output)
-
-        # Fall back to string representation
-        return str(output)
+        try:
+            source_files = program.get_source_files()
+            if isinstance(source_files, dict):
+                return " \n".join(str(v) for v in source_files.values())
+        except Exception as exc:
+            logger.debug(f"Failed to obtain program text: {exc}")
+        return ""
 
     def _count_sentences(self, text: str) -> int:
         """

--- a/pkgs/standards/swarmauri_evaluatorpool_accessibility/swarmauri_evaluatorpool_accessibility/FleschReadingEaseEvaluator.py
+++ b/pkgs/standards/swarmauri_evaluatorpool_accessibility/swarmauri_evaluatorpool_accessibility/FleschReadingEaseEvaluator.py
@@ -81,7 +81,7 @@ class FleschReadingEaseEvaluator(EvaluatorBase, ComponentBase):
             ValueError: If the text cannot be processed
         """
         # Extract text from the program
-        text = program.get_content()
+        text = self._get_program_text(program)
         if not text or not isinstance(text, str):
             logger.warning("Program content is empty or not a string")
             return 0.0, {"error": "No valid text content found"}
@@ -134,6 +134,16 @@ class FleschReadingEaseEvaluator(EvaluatorBase, ComponentBase):
             f"Flesch Reading Ease score: {fre_score:.2f} ({metadata['readability_interpretation']})"
         )
         return fre_score, metadata
+
+    def _get_program_text(self, program: Program) -> str:
+        """Return program text by joining its source files."""
+        try:
+            source_files = program.get_source_files()
+            if isinstance(source_files, dict):
+                return " \n".join(str(v) for v in source_files.values())
+        except Exception as exc:
+            logger.debug(f"Failed to obtain program text: {exc}")
+        return ""
 
     def _clean_text(self, text: str) -> str:
         """

--- a/pkgs/standards/swarmauri_evaluatorpool_accessibility/swarmauri_evaluatorpool_accessibility/GunningFogEvaluator.py
+++ b/pkgs/standards/swarmauri_evaluatorpool_accessibility/swarmauri_evaluatorpool_accessibility/GunningFogEvaluator.py
@@ -42,7 +42,7 @@ class GunningFogEvaluator(EvaluatorBase, ComponentBase):
                 - float: The Gunning Fog Index score (lower is better for readability)
                 - Dict[str, Any]: Metadata including sentence count, word count, and complex word count
         """
-        text = program.get_text()
+        text = self._get_program_text(program)
         if not text or not isinstance(text, str):
             logger.warning("Program text is empty or not a string")
             return 0.0, {"error": "No valid text to analyze"}
@@ -84,6 +84,16 @@ class GunningFogEvaluator(EvaluatorBase, ComponentBase):
 
         logger.debug(f"Computed Gunning Fog Index: {gunning_fog_index:.2f}")
         return normalized_score, metadata
+
+    def _get_program_text(self, program: Program) -> str:
+        """Return a concatenated text representation of the program."""
+        try:
+            source_files = program.get_source_files()
+            if isinstance(source_files, dict):
+                return " \n".join(str(v) for v in source_files.values())
+        except Exception as exc:
+            logger.debug(f"Failed to obtain program text: {exc}")
+        return ""
 
     def _count_sentences(self, text: str) -> int:
         """

--- a/pkgs/standards/swarmauri_evaluatorpool_accessibility/tests/unit/test_FleschKincaidGradeEvaluator.py
+++ b/pkgs/standards/swarmauri_evaluatorpool_accessibility/tests/unit/test_FleschKincaidGradeEvaluator.py
@@ -31,6 +31,7 @@ def mock_program():
         MagicMock: A mock Program instance
     """
     program = MagicMock()
+    program.get_source_files.return_value = {"main.txt": ""}
     return program
 
 
@@ -183,7 +184,7 @@ def test_get_program_text(evaluator, mock_program, output, expected_text):
         output: The mock output to test
         expected_text: Expected extracted text
     """
-    mock_program.get_output.return_value = output
+    mock_program.get_source_files.return_value = {"main.txt": output}
     result = evaluator._get_program_text(mock_program)
     assert result == expected_text
 
@@ -199,7 +200,7 @@ def test_compute_score_with_valid_text(evaluator, mock_program):
     """
     # Sample text with known characteristics
     test_text = "This is a simple sentence. It has two sentences with simple words."
-    mock_program.get_output.return_value = test_text
+    mock_program.get_source_files.return_value = {"main.txt": test_text}
 
     score, metadata = evaluator._compute_score(mock_program)
 
@@ -227,7 +228,7 @@ def test_compute_score_with_empty_text(evaluator, mock_program):
         evaluator: The FleschKincaidGradeEvaluator instance
         mock_program: Mock Program object
     """
-    mock_program.get_output.return_value = ""
+    mock_program.get_source_files.return_value = {"main.txt": ""}
 
     score, metadata = evaluator._compute_score(mock_program)
 
@@ -246,7 +247,7 @@ def test_compute_score_with_insufficient_content(evaluator, mock_program):
         mock_program: Mock Program object
     """
     # A string without any sentence terminators or proper structure
-    mock_program.get_output.return_value = "a"
+    mock_program.get_source_files.return_value = {"main.txt": "a"}
 
     score, metadata = evaluator._compute_score(mock_program)
 
@@ -269,7 +270,7 @@ def test_formula_calculation(evaluator, mock_program):
     """
     # Create text with known characteristics for predictable formula calculation
     test_text = "This is a test. This is another test. This is a third test."
-    mock_program.get_output.return_value = test_text
+    mock_program.get_source_files.return_value = {"main.txt": test_text}
 
     score, metadata = evaluator._compute_score(mock_program)
 

--- a/pkgs/standards/swarmauri_evaluatorpool_accessibility/tests/unit/test_FleschReadingEaseEvaluator.py
+++ b/pkgs/standards/swarmauri_evaluatorpool_accessibility/tests/unit/test_FleschReadingEaseEvaluator.py
@@ -27,7 +27,7 @@ def mock_program():
         MagicMock: A mock Program object with configurable content
     """
     program = MagicMock()
-    program.get_content.return_value = ""
+    program.get_source_files.return_value = {"main.txt": ""}
     return program
 
 
@@ -99,7 +99,7 @@ def test_compute_score(
         expected_score: The expected Flesch Reading Ease score
         expected_metadata_keys: Expected keys in the metadata dictionary
     """
-    mock_program.get_content.return_value = content
+    mock_program.get_source_files.return_value = {"main.txt": content}
 
     score, metadata = evaluator._compute_score(mock_program)
 
@@ -197,7 +197,7 @@ def test_compute_score_with_non_string_content(evaluator, mock_program):
         evaluator: The evaluator instance
         mock_program: A mock Program object
     """
-    mock_program.get_content.return_value = 12345  # Non-string content
+    mock_program.get_source_files.return_value = {"main.txt": 12345}  # Non-string content
 
     score, metadata = evaluator._compute_score(mock_program)
 

--- a/pkgs/standards/swarmauri_evaluatorpool_accessibility/tests/unit/test_GunningFogEvaluator.py
+++ b/pkgs/standards/swarmauri_evaluatorpool_accessibility/tests/unit/test_GunningFogEvaluator.py
@@ -28,7 +28,7 @@ def mock_program():
         MagicMock: A mock program object
     """
     program = MagicMock(spec=Program)
-    program.get_text = MagicMock(return_value="")
+    program.get_source_files.return_value = {"main.txt": ""}
     return program
 
 
@@ -106,7 +106,7 @@ def test_count_complex_words(evaluator):
 @pytest.mark.unit
 def test_compute_score_empty_text(evaluator, mock_program):
     """Test compute_score with empty text."""
-    mock_program.get_text.return_value = ""
+    mock_program.get_source_files.return_value = {"main.txt": ""}
     score, metadata = evaluator._compute_score(mock_program)
 
     assert score == 0.0
@@ -117,7 +117,7 @@ def test_compute_score_empty_text(evaluator, mock_program):
 @pytest.mark.unit
 def test_compute_score_invalid_text(evaluator, mock_program):
     """Test compute_score with invalid text type."""
-    mock_program.get_text.return_value = None
+    mock_program.get_source_files.return_value = {"main.txt": None}
     score, metadata = evaluator._compute_score(mock_program)
 
     assert score == 0.0
@@ -129,7 +129,9 @@ def test_compute_score_invalid_text(evaluator, mock_program):
 def test_compute_score_no_sentences(evaluator, mock_program):
     """Test compute_score with text that has no sentences."""
     # Text with words but no sentence terminators
-    mock_program.get_text.return_value = "words without proper sentence structure"
+    mock_program.get_source_files.return_value = {
+        "main.txt": "words without proper sentence structure"
+    }
 
     # Mock the _count_sentences method to return 0
     with patch.object(evaluator, "_count_sentences", return_value=0):
@@ -144,9 +146,9 @@ def test_compute_score_no_sentences(evaluator, mock_program):
 def test_compute_score_simple_text(evaluator, mock_program):
     """Test compute_score with simple text."""
     # Simple text with known characteristics
-    mock_program.get_text.return_value = (
-        "This is a simple sentence. It has basic words."
-    )
+    mock_program.get_source_files.return_value = {
+        "main.txt": "This is a simple sentence. It has basic words."
+    }
 
     # Mock the counting methods to return controlled values
     with (
@@ -172,9 +174,9 @@ def test_compute_score_simple_text(evaluator, mock_program):
 def test_compute_score_complex_text(evaluator, mock_program):
     """Test compute_score with more complex text."""
     # More complex text with known characteristics
-    mock_program.get_text.return_value = (
-        "The university professor discussed the utilization of computational resources."
-    )
+    mock_program.get_source_files.return_value = {
+        "main.txt": "The university professor discussed the utilization of computational resources."
+    }
 
     # Mock the counting methods to return controlled values
     with (
@@ -200,9 +202,9 @@ def test_compute_score_complex_text(evaluator, mock_program):
 def test_compute_score_very_complex_text(evaluator, mock_program):
     """Test compute_score with text that exceeds the cap."""
     # Very complex text with characteristics that would exceed the cap
-    mock_program.get_text.return_value = (
-        "Antidisestablishmentarianism. Pneumonoultramicroscopicsilicovolcanoconiosis."
-    )
+    mock_program.get_source_files.return_value = {
+        "main.txt": "Antidisestablishmentarianism. Pneumonoultramicroscopicsilicovolcanoconiosis."
+    }
 
     # Mock the counting methods to return values that would exceed the cap
     with (
@@ -231,7 +233,9 @@ def test_logging(evaluator, mock_program, caplog):
     caplog.set_level(logging.DEBUG)
 
     # Set up a valid text
-    mock_program.get_text.return_value = "This is a test. It has two sentences."
+    mock_program.get_source_files.return_value = {
+        "main.txt": "This is a test. It has two sentences."
+    }
 
     evaluator._compute_score(mock_program)
 
@@ -240,7 +244,7 @@ def test_logging(evaluator, mock_program, caplog):
 
     # Test warning for empty text
     caplog.clear()
-    mock_program.get_text.return_value = ""
+    mock_program.get_source_files.return_value = {"main.txt": ""}
 
     evaluator._compute_score(mock_program)
 


### PR DESCRIPTION
## Summary
- update FleschReadingEaseEvaluator, FleschKincaidGradeEvaluator and GunningFogEvaluator to read text via `Program.get_source_files`
- adjust unit tests to mock the new Program interface

## Testing
- `pre-commit` *(fails: command not found)*