### PR TITLE
Fix logger usage in accessibility evaluators

### DIFF
--- a/pkgs/standards/swarmauri_evaluatorpool_accessibility/swarmauri_evaluatorpool_accessibility/AccessibilityEvaluatorPool.py
+++ b/pkgs/standards/swarmauri_evaluatorpool_accessibility/swarmauri_evaluatorpool_accessibility/AccessibilityEvaluatorPool.py
@@ -1,7 +1,6 @@
 # File: swarmauri_standard/evaluator_pools/AccessibilityEvaluatorPool.py
 from __future__ import annotations
 
-import logging
 from typing import Any, Dict, List, Literal, Sequence
 
 from swarmauri_base.ComponentBase import ComponentBase
@@ -22,7 +21,6 @@ from . import (          # noqa: E402
     GunningFogEvaluator,
 )
 
-logger = logging.getLogger(__name__)
 
 
 @ComponentBase.register_type(EvaluatorPoolBase, "AccessibilityEvaluatorPool")
@@ -67,10 +65,11 @@ class AccessibilityEvaluatorPool(EvaluatorPoolBase):
         # custom aggregation that flips “lower-is-better” metrics
         self.set_aggregation_function(self._accessibility_aggregation)
 
-        logger.info(
-            "AccessibilityEvaluatorPool initialised with %d evaluators",
-            self.get_evaluator_count(),
-        )
+        if self.logger:
+            self.logger.info(
+                "AccessibilityEvaluatorPool initialised with %d evaluators",
+                self.get_evaluator_count(),
+            )
 
     # ------------------------------------------------------------------ #
     # built-in evaluator registration
@@ -91,7 +90,8 @@ class AccessibilityEvaluatorPool(EvaluatorPoolBase):
                 # default weight = 1 unless already provided
                 self.weights.setdefault(cls.__name__, 1.0)
             except Exception as exc:  # pragma: no cover
-                logger.error("Failed to instantiate %s: %s", cls.__name__, exc)
+                if self.logger:
+                    self.logger.error("Failed to instantiate %s: %s", cls.__name__, exc)
 
     # ------------------------------------------------------------------ #
     # evaluation – we just rely on the base-class dispatcher

--- a/pkgs/standards/swarmauri_evaluatorpool_accessibility/swarmauri_evaluatorpool_accessibility/AutomatedReadabilityIndexEvaluator.py
+++ b/pkgs/standards/swarmauri_evaluatorpool_accessibility/swarmauri_evaluatorpool_accessibility/AutomatedReadabilityIndexEvaluator.py
@@ -1,6 +1,5 @@
 # File: peagen/evaluators/AutomatedReadabilityIndexEvaluator.py
 
-import logging
 import re
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Tuple
@@ -11,7 +10,6 @@ from swarmauri_base.ComponentBase import ComponentBase
 from swarmauri_base.evaluators.EvaluatorBase import EvaluatorBase
 from swarmauri_standard.programs.Program import Program
 
-logger = logging.getLogger(__name__)
 
 
 @ComponentBase.register_type(
@@ -101,7 +99,8 @@ class AutomatedReadabilityIndexEvaluator(EvaluatorBase, ComponentBase):
                 else:  # plain text
                     segments.append(data)
             except Exception as exc:
-                logger.error("Error parsing %s: %s", rel_path, exc)
+                if self.logger:
+                    self.logger.error("Error parsing %s: %s", rel_path, exc)
 
         return " ".join(segments)
 

--- a/pkgs/standards/swarmauri_evaluatorpool_accessibility/swarmauri_evaluatorpool_accessibility/ColemanLiauIndexEvaluator.py
+++ b/pkgs/standards/swarmauri_evaluatorpool_accessibility/swarmauri_evaluatorpool_accessibility/ColemanLiauIndexEvaluator.py
@@ -1,4 +1,3 @@
-import logging
 import re
 from typing import Any, Dict, Literal, Tuple
 
@@ -7,7 +6,6 @@ from swarmauri_base.ComponentBase import ComponentBase
 from swarmauri_base.evaluators.EvaluatorBase import EvaluatorBase
 from swarmauri_standard.programs.Program import Program
 
-logger = logging.getLogger(__name__)
 
 
 @ComponentBase.register_type(EvaluatorBase, "ColemanLiauIndexEvaluator")

--- a/pkgs/standards/swarmauri_evaluatorpool_accessibility/swarmauri_evaluatorpool_accessibility/FleschKincaidGradeEvaluator.py
+++ b/pkgs/standards/swarmauri_evaluatorpool_accessibility/swarmauri_evaluatorpool_accessibility/FleschKincaidGradeEvaluator.py
@@ -1,4 +1,3 @@
-import logging
 import re
 import string
 from typing import Any, Dict, Literal, Tuple
@@ -7,7 +6,6 @@ from swarmauri_base.ComponentBase import ComponentBase
 from swarmauri_base.evaluators.EvaluatorBase import EvaluatorBase
 from swarmauri_standard.programs.Program import Program
 
-logger = logging.getLogger(__name__)
 
 
 @ComponentBase.register_type(EvaluatorBase, "FleschKincaidGradeEvaluator")
@@ -62,7 +60,8 @@ class FleschKincaidGradeEvaluator(EvaluatorBase, ComponentBase):
         text = self._get_program_text(program)
 
         if not text:
-            logger.warning("No text found in program output")
+            if self.logger:
+                self.logger.warning("No text found in program output")
             return 0.0, {"error": "No text to evaluate"}
 
         # Count sentences, words, and syllables
@@ -70,13 +69,15 @@ class FleschKincaidGradeEvaluator(EvaluatorBase, ComponentBase):
         words = self._count_words(text)
         syllables = self._count_syllables(text)
 
-        logger.debug(
-            f"Text analysis: {sentences} sentences, {words} words, {syllables} syllables"
-        )
+        if self.logger:
+            self.logger.debug(
+                f"Text analysis: {sentences} sentences, {words} words, {syllables} syllables"
+            )
 
         # Calculate the Flesch-Kincaid Grade Level
         if sentences == 0 or words == 0:
-            logger.warning("Text lacks sufficient content for FKGL calculation")
+            if self.logger:
+                self.logger.warning("Text lacks sufficient content for FKGL calculation")
             return 0.0, {
                 "error": "Text lacks sufficient content for analysis",
                 "sentences": sentences,
@@ -109,7 +110,8 @@ class FleschKincaidGradeEvaluator(EvaluatorBase, ComponentBase):
             },
         }
 
-        logger.info(f"Calculated FKGL score: {fkgl_score:.2f}")
+        if self.logger:
+            self.logger.info(f"Calculated FKGL score: {fkgl_score:.2f}")
         return fkgl_score, metadata
 
     def _get_program_text(self, program: Program) -> str:
@@ -127,7 +129,8 @@ class FleschKincaidGradeEvaluator(EvaluatorBase, ComponentBase):
             if isinstance(source_files, dict):
                 return " \n".join(str(v) for v in source_files.values())
         except Exception as exc:
-            logger.debug(f"Failed to obtain program text: {exc}")
+            if self.logger:
+                self.logger.debug(f"Failed to obtain program text: {exc}")
         return ""
 
     def _count_sentences(self, text: str) -> int:

--- a/pkgs/standards/swarmauri_evaluatorpool_accessibility/swarmauri_evaluatorpool_accessibility/GunningFogEvaluator.py
+++ b/pkgs/standards/swarmauri_evaluatorpool_accessibility/swarmauri_evaluatorpool_accessibility/GunningFogEvaluator.py
@@ -1,4 +1,3 @@
-import logging
 import re
 import string
 from typing import Any, Dict, Literal, Tuple
@@ -7,7 +6,6 @@ from swarmauri_base.ComponentBase import ComponentBase
 from swarmauri_base.evaluators.EvaluatorBase import EvaluatorBase
 from swarmauri_standard.programs.Program import Program
 
-logger = logging.getLogger(__name__)
 
 
 @ComponentBase.register_type(EvaluatorBase, "GunningFogEvaluator")
@@ -52,7 +50,8 @@ class GunningFogEvaluator(EvaluatorBase, ComponentBase):
         """
         text = self._get_program_text(program)
         if not text or not isinstance(text, str):
-            logger.warning("Program text is empty or not a string")
+            if self.logger:
+                self.logger.warning("Program text is empty or not a string")
             return 0.0, {"error": "No valid text to analyze"}
 
         # Count sentences, words, and complex words
@@ -62,7 +61,8 @@ class GunningFogEvaluator(EvaluatorBase, ComponentBase):
 
         # Avoid division by zero
         if sentences == 0 or words == 0:
-            logger.warning("Text has no sentences or words")
+            if self.logger:
+                self.logger.warning("Text has no sentences or words")
             return 0.0, {
                 "sentences": sentences,
                 "words": words,
@@ -90,7 +90,8 @@ class GunningFogEvaluator(EvaluatorBase, ComponentBase):
             "percent_complex_words": percent_complex_words,
         }
 
-        logger.debug(f"Computed Gunning Fog Index: {gunning_fog_index:.2f}")
+        if self.logger:
+            self.logger.debug(f"Computed Gunning Fog Index: {gunning_fog_index:.2f}")
         return normalized_score, metadata
 
     def _get_program_text(self, program: Program) -> str:
@@ -100,7 +101,8 @@ class GunningFogEvaluator(EvaluatorBase, ComponentBase):
             if isinstance(source_files, dict):
                 return " \n".join(str(v) for v in source_files.values())
         except Exception as exc:
-            logger.debug(f"Failed to obtain program text: {exc}")
+            if self.logger:
+                self.logger.debug(f"Failed to obtain program text: {exc}")
         return ""
 
     def _count_sentences(self, text: str) -> int:


### PR DESCRIPTION
## Summary
- use `self.logger` instead of module level loggers in accessibility evaluator pool
- remove unused global logger declarations
- guard logging calls with `if self.logger` checks

## Testing
- `uv run --package swarmauri_evaluatorpool_accessibility --directory standards/swarmauri_evaluatorpool_accessibility pytest` *(fails: No route to host)*