### PR TITLE
Fix ruff errors in peagen

### DIFF
--- a/pkgs/standards/peagen/peagen/commands/eval.py
+++ b/pkgs/standards/peagen/peagen/commands/eval.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 import typer
 

--- a/pkgs/standards/peagen/peagen/commands/program.py
+++ b/pkgs/standards/peagen/peagen/commands/program.py
@@ -22,6 +22,8 @@ import tempfile
 from pathlib import Path
 from typing import List, Optional
 from urllib.parse import urlparse, urlunparse
+import hashlib
+import jsonpatch
 
 import typer
 from jsonschema import ValidationError, validate as json_validate


### PR DESCRIPTION
## Summary
- import `List` in `commands/eval.py`
- add missing `hashlib` and `jsonpatch` imports in `commands/program.py`

## Testing
- `ruff check pkgs/standards/peagen/peagen`