### PR TITLE
Add Peagen contribution guide

### DIFF
--- a/pkgs/standards/peagen/docs/contributing.md
+++ b/pkgs/standards/peagen/docs/contributing.md
@@ -1,0 +1,37 @@
+# Contributing to Peagen
+
+This guide explains how to extend Peagen and how to propose major changes via Peagen Improvement Proposals (PEA-IPs).
+
+## Template-Sets
+
+- Place new template files under `peagen/templates/<set_name>`.
+- Expose the set with an entry point under the **`peagen.template_sets`** group in your `pyproject.toml`:
+  ```toml
+  [project.entry-points."peagen.template_sets"]
+  my_templates = "my_package.templates"
+  ```
+
+## Storage Adapters
+
+- Implement a class exposing `upload()` and `download()`.
+- Register it via the **`peagen.storage_adapters`** entry point group.
+
+## Publishers
+
+- Publishers broadcast events produced by the CLI.
+- Create a class with a `publish()` method and add it under the **`peagen.publishers`** group.
+
+## Evaluation Pools
+
+- Evaluation pools manage collections of `EvaluatorBase` instances.
+- Add your pool to the **`peagen.evaluator_pools`** entry point group so `peagen eval` can discover it.
+
+## Peagen Improvement Proposals (PEA-IPs)
+
+For substantial changes to Peagen, submit a PEA-IP:
+
+1. Copy [docs/pea-ips/ip-template.md](docs/pea-ips/ip-template.md) to a new file `ip-XXXX.md` in the same folder.
+2. Fill out all sections, including the **Status** field at the top.
+3. Open a pull request with your proposal.
+
+

--- a/pkgs/standards/peagen/docs/pea-ips/ip-template.md
+++ b/pkgs/standards/peagen/docs/pea-ips/ip-template.md
@@ -1,0 +1,37 @@
+# Peagen Improvement Proposal — **IP-XXXX**
+
+*Short descriptive tagline*
+
+**Status:** Draft
+
+---
+
+## 1 Overview
+
+Provide a concise explanation of the problem and proposed change.
+
+## 2 Motivation
+
+Explain why this change is necessary and what benefits it brings.
+
+## 3 Specification
+
+Detail the technical design, including any new commands, schemas or behaviours.
+
+## 4 Backwards Compatibility
+
+Describe how this proposal affects existing systems and how to mitigate any breaking changes.
+
+## 5 Acceptance Criteria
+
+List measurable outcomes that must be satisfied for this proposal to be considered complete.
+
+## 6 References
+
+Link to related issues, documents or discussions.
+
+---
+
+*Prepared by:* **Author Name**
+*Date:*  YYYY-MM-DD
+*Status updates:* keep the **Status** field current as the proposal evolves


### PR DESCRIPTION
## Summary
- add Peagen-specific contribution instructions
- include status field in Peagen Improvement Proposal template
- remove Peagen IP section from the main contributing guide

## Testing
- `pre-commit` *(fails: command not found)*