### PR TITLE
Add dynamic external llm/agent helpers

### DIFF
--- a/pkgs/swarmauri/swarmauri/external.py
+++ b/pkgs/swarmauri/swarmauri/external.py
@@ -1,0 +1,148 @@
+# external.py
+"""Utility functions for interacting with external LLMs and agents.
+
+These helpers mirror similar functions in ``peagen`` but leverage the
+Swarmauri plugin system to dynamically load components registered under
+the ``swarmauri`` namespace.
+"""
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import re
+from typing import Any, Dict, Optional
+
+from colorama import init as colorama_init
+
+from .plugin_citizenship_registry import PluginCitizenshipRegistry
+
+colorama_init(autoreset=True)
+
+logger = logging.getLogger(__name__)
+
+
+def _load_registered_class(resource_name: str, namespace: str) -> type:
+    """Resolve and import a class registered in ``PluginCitizenshipRegistry``.
+
+    Parameters
+    ----------
+    resource_name:
+        Either a fully qualified resource path (e.g. ``"swarmauri.llms.OpenAIModel"``)
+        or just the class name within the given namespace.
+    namespace:
+        Namespace within ``swarmauri`` where the class is registered
+        (e.g. ``"llms"`` or ``"agents"``).
+    """
+    if resource_name.startswith("swarmauri."):
+        resource_path = resource_name
+        class_name = resource_name.split(".")[-1]
+    else:
+        class_name = resource_name
+        resource_path = f"swarmauri.{namespace}.{class_name}"
+
+    module_path = PluginCitizenshipRegistry.get_external_module_path(resource_path)
+    if not module_path:
+        raise ImportError(f"No module registered for '{resource_path}'")
+
+    module = importlib.import_module(module_path)
+    try:
+        return getattr(module, class_name)
+    except AttributeError as exc:
+        raise ImportError(
+            f"Class '{class_name}' not found in module '{module_path}'"
+        ) from exc
+
+
+def call_external_llm(
+    provider: str,
+    api_key: Optional[str] = None,
+    model_name: Optional[str] = None,
+    timeout: float = 1200.0,
+    **kwargs: Any,
+):
+    """Instantiate an LLM registered on the ``swarmauri`` namespace."""
+    llm_cls = _load_registered_class(provider, "llms")
+
+    init_args = {"timeout": timeout, **kwargs}
+    if model_name:
+        init_args["name"] = model_name
+    if api_key:
+        init_args["api_key"] = api_key
+
+    return llm_cls(**init_args)
+
+
+def chunk_content(full_content: str, logger: Optional[Any] = None) -> str:
+    """Split content into a single code chunk if possible."""
+    pattern = r"<think>[\s\S]*?</think>"
+    cleaned_text = re.sub(pattern, "", full_content).strip()
+
+    try:
+        from swarmauri.chunkers.MdSnippetChunker import MdSnippetChunker
+
+        chunker = MdSnippetChunker()
+        chunks = chunker.chunk_text(cleaned_text)
+        if len(chunks) > 1:
+            if logger:
+                logger.warning(
+                    "MdSnippetChunker found more than one snippet, took the first."
+                )
+            return chunks[0][2]
+        return chunks[0][2] if chunks else cleaned_text
+    except ImportError:
+        if logger:
+            logger.warning(
+                "MdSnippetChunker not found. Returning full content without chunking."
+            )
+        return cleaned_text
+    except Exception as exc:  # pragma: no cover - defensive
+        if logger:
+            logger.error(f"[ERROR] Failed to chunk content: {exc}")
+        return cleaned_text
+
+
+def call_external_agent(
+    prompt: str,
+    agent_env: Dict[str, Any],
+    logger: Optional[Any] = None,
+) -> str:
+    """Execute a prompt against an agent from the ``swarmauri`` namespace."""
+    provider = os.getenv("PROVIDER") or agent_env.get("provider", "DeepInfraModel")
+    api_key = os.getenv(f"{provider.upper()}_API_KEY") or agent_env.get("api_key")
+    model_name = agent_env.get("model_name")
+    max_tokens = int(agent_env.get("max_tokens", 8192))
+
+    if logger:
+        truncated_prompt = prompt[:140] + "..." if len(prompt) > 140 else prompt
+        logger.info(f"Sending prompt to external llm: \n\t{truncated_prompt}\n")
+        logger.debug(f"Agent env: {agent_env}")
+
+    llm = call_external_llm(provider, api_key=api_key, model_name=model_name)
+
+    agent_class_name = agent_env.get("agent_class", "QAAgent")
+    agent_cls = _load_registered_class(agent_class_name, "agents")
+
+    try:
+        agent = agent_cls(llm=llm)
+    except Exception as exc:
+        raise ImportError(
+            f"Failed to instantiate agent '{agent_class_name}': {exc}"
+        ) from exc
+
+    system_context = agent_env.get("system_context", "You are a software developer.")
+    try:
+        from swarmauri.messages.SystemMessage import SystemMessage
+
+        agent.conversation.system_context = SystemMessage(content=system_context)
+    except Exception:  # pragma: no cover - if conversation not available
+        pass
+
+    try:
+        result = agent.exec(prompt, llm_kwargs={"max_tokens": max_tokens})
+    except KeyboardInterrupt:
+        raise KeyboardInterrupt("'Interrupted...'")
+
+    content = chunk_content(result, logger)
+    del agent
+    return content

--- a/pkgs/swarmauri/tests/unit/dummy_module.py
+++ b/pkgs/swarmauri/tests/unit/dummy_module.py
@@ -1,0 +1,12 @@
+class DummyLLM:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+class DummyAgent:
+    def __init__(self, llm=None):
+        self.llm = llm
+        self.conversation = type('Conv', (), {})()
+
+    def exec(self, prompt, llm_kwargs=None):
+        return f"executed:{prompt}"

--- a/pkgs/swarmauri/tests/unit/external_unit_test.py
+++ b/pkgs/swarmauri/tests/unit/external_unit_test.py
@@ -1,0 +1,55 @@
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from swarmauri.external import call_external_llm, call_external_agent
+
+
+@pytest.fixture(autouse=True)
+def clear_env():
+    old = os.environ.copy()
+    yield
+    os.environ.clear()
+    os.environ.update(old)
+
+
+@pytest.mark.unit
+def test_call_external_llm_basic():
+    with patch(
+        "swarmauri.external.PluginCitizenshipRegistry.get_external_module_path",
+        return_value="swarmauri.tests.unit.dummy_module",
+    ) as mock_get, patch("importlib.import_module") as mock_import:
+        module = MagicMock()
+        module.DummyLLM = MagicMock()
+        mock_import.return_value = module
+
+        call_external_llm("DummyLLM", api_key="k", model_name="m")
+
+        mock_get.assert_called_once_with("swarmauri.llms.DummyLLM")
+        module.DummyLLM.assert_called_once_with(api_key="k", name="m", timeout=1200.0)
+
+
+@pytest.mark.unit
+def test_call_external_agent_basic():
+    dummy_llm = MagicMock()
+    dummy_agent_cls = MagicMock()
+    dummy_agent = MagicMock()
+    dummy_agent_cls.return_value = dummy_agent
+    dummy_agent.conversation = MagicMock()
+    dummy_agent.exec.return_value = "result"
+
+    with (
+        patch("swarmauri.external.call_external_llm", return_value=dummy_llm),
+        patch(
+            "swarmauri.external._load_registered_class",
+            return_value=dummy_agent_cls,
+        ),
+        patch("swarmauri.external.chunk_content", side_effect=lambda x, logger=None: x),
+    ):
+        env = {"provider": "DummyLLM", "agent_class": "DummyAgent", "max_tokens": 10}
+        result = call_external_agent("hi", env)
+
+    assert result == "result"
+    dummy_agent_cls.assert_called_once_with(llm=dummy_llm)
+    dummy_agent.exec.assert_called_once_with("hi", llm_kwargs={"max_tokens": 10})


### PR DESCRIPTION
## Summary
- expose `call_external_llm` and `call_external_agent` in the `swarmauri` namespace
- add unit tests for these helpers

## Testing
- `uv run --package swarmauri --directory swarmauri pytest swarmauri/tests/unit/external_unit_test.py -q` *(fails: No route to host)*