### PR TITLE
Add conditional support for DOE patches

### DIFF
--- a/pkgs/standards/peagen/peagen/doe.py
+++ b/pkgs/standards/peagen/peagen/doe.py
@@ -80,6 +80,16 @@ class DOEManager:
 
         for factor in self.spec.values():
             for pt in factor.get("patches", []):
+                # skip patch if 'when' condition evaluates to False
+                if "when" in pt:
+                    cond_tpl = Template(str(pt["when"]))
+                    cond_rendered = cond_tpl.render(**ctx)
+                    try:
+                        should_apply = bool(yaml.safe_load(cond_rendered))
+                    except Exception:
+                        should_apply = False
+                    if not should_apply:
+                        continue
                 raw_val = pt["value"]
 
                 # SPECIAL CASE: single-key mapping like { "CMP.requirements": null }

--- a/pkgs/standards/peagen/peagen/schemas/doe_spec.schema.v1.json
+++ b/pkgs/standards/peagen/peagen/schemas/doe_spec.schema.v1.json
@@ -50,7 +50,8 @@
                 "properties": {
                   "op":   { "type": "string" },
                   "path": { "type": "string" },
-                  "value": {}
+                  "value": {},
+                  "when": {}
                 },
                 "required": ["op", "path"],
                 "additionalProperties": false

--- a/pkgs/standards/peagen/tests/unit/test_doe_manager_when.py
+++ b/pkgs/standards/peagen/tests/unit/test_doe_manager_when.py
@@ -1,0 +1,58 @@
+import yaml
+from peagen.doe import DOEManager
+
+
+def test_patch_when(tmp_path):
+    spec_yaml = tmp_path / "spec.yml"
+    template_yaml = tmp_path / "template.yaml"
+
+    spec_yaml.write_text(
+        yaml.safe_dump(
+            {
+                "schemaVersion": "1.0.1",
+                "FACTORS": {
+                    "C3": {
+                        "description": "third component",
+                        "code": "C3",
+                        "levels": ["none", "ConcreteC"],
+                        "patches": [
+                            {
+                                "op": "remove",
+                                "path": "/PROJECTS/0/PACKAGES/0/MODULES/2",
+                                "value": None,
+                                "when": "{{ C3 == 'none' }}",
+                            }
+                        ],
+                    }
+                },
+            }
+        )
+    )
+
+    template_yaml.write_text(
+        yaml.safe_dump(
+            {
+                "PROJECTS": [
+                    {
+                        "NAME": "Base",
+                        "PACKAGES": [
+                            {
+                                "NAME": "pkg",
+                                "MODULES": [
+                                    {"NAME": "A"},
+                                    {"NAME": "B"},
+                                    {"NAME": "C"},
+                                ],
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+    )
+
+    mgr = DOEManager(str(spec_yaml), str(template_yaml))
+    payloads = mgr.generate()
+    assert len(payloads) == 2
+    assert len(payloads[0]["PACKAGES"][0]["MODULES"]) == 2
+    assert len(payloads[1]["PACKAGES"][0]["MODULES"]) == 3


### PR DESCRIPTION
## Summary
- extend `DOEManager` to honor optional `when` expressions on patches
- allow `when` field in doe spec schema
- test conditional patch handling

## Testing
- `uv run --package peagen --directory standards/peagen pytest` *(fails: No route to host)*