### PR TITLE
Rename peagen base_dir property

### DIFF
--- a/pkgs/standards/peagen/peagen/core.py
+++ b/pkgs/standards/peagen/peagen/core.py
@@ -48,7 +48,7 @@ class Peagen(ComponentBase):
     j2pt: Any = Field(default_factory=lambda: J2PromptTemplate())
 
     # Runtime / env setup
-    base_dir: str = Field(exclude=True, default_factory=os.getcwd)
+    cwd: str = Field(exclude=True, default_factory=os.getcwd)
 
     # Legacy flag – converted to TEMPLATE_SETS during CLI parsing.
     additional_package_dirs: List[Path] = Field(
@@ -142,7 +142,7 @@ class Peagen(ComponentBase):
         # 5) User-specified template_base_dir and repo root
         if self.template_base_dir:
             ns_dirs.append(self.template_base_dir)
-        ns_dirs.append(self.base_dir)
+        ns_dirs.append(self.cwd)
 
         # Finalise
         self.namespace_dirs = ns_dirs
@@ -161,7 +161,7 @@ class Peagen(ComponentBase):
         """
         dirs = [
             os.fspath(package_specific_template_dir),
-            self.base_dir,
+            self.cwd,
             *[
                 os.fspath(Path(self.workspace_root or ".") / spec["dest"])
                 for spec in self.source_packages
@@ -407,8 +407,8 @@ class Peagen(ComponentBase):
             # Pass workspace_root into every file save/upload call
             # ------------------------------------------------------
 
-            # choose workspace_root or fallback to base_dir
-            root = self.workspace_root or Path(self.base_dir)
+            # choose workspace_root or fallback to cwd
+            root = self.workspace_root or Path(self.cwd)
 
             workspace_uri = ""
             if self.storage_adapter:

--- a/pkgs/standards/peagen/tests/r8n/test_core.py
+++ b/pkgs/standards/peagen/tests/r8n/test_core.py
@@ -31,7 +31,7 @@ class TestPeagen:
         assert peagen.template_base_dir is None
         assert isinstance(peagen.agent_env, dict)
         assert peagen.j2pt is not None
-        assert peagen.base_dir == os.getcwd()
+        assert peagen.cwd == os.getcwd()
         assert peagen.projects_list == []
 
     def test_setup_env(self):
@@ -45,12 +45,12 @@ class TestPeagen:
 
             # Check namespace_dirs
             assert "/installed/templates" in peagen.namespace_dirs
-            assert peagen.base_dir in peagen.namespace_dirs
+            assert peagen.cwd in peagen.namespace_dirs
             assert "/custom/templates" in peagen.namespace_dirs
 
             # Check j2pt templates_dir
             assert str(Path("/additional/templates")) in peagen.j2pt.templates_dir
-            assert peagen.base_dir in peagen.j2pt.templates_dir
+            assert peagen.cwd in peagen.j2pt.templates_dir
             assert "/custom/templates" in peagen.j2pt.templates_dir
 
     def test_update_templates_dir(self, basic_peagen):
@@ -66,7 +66,7 @@ class TestPeagen:
             "/package/templates"
         )
         assert basic_peagen.j2pt.templates_dir[1] == os.path.normpath(
-            basic_peagen.base_dir
+            basic_peagen.cwd
         )
         assert os.path.normpath("/add1") in basic_peagen.j2pt.templates_dir
         assert os.path.normpath("/add2") in basic_peagen.j2pt.templates_dir


### PR DESCRIPTION
## Summary
- clarify naming by renaming `base_dir` field to `cwd`
- update usages in `Peagen` and regression tests

## Testing
- `ruff check pkgs/standards/peagen/peagen/core.py`
- `ruff check pkgs/standards/peagen/tests/r8n/test_core.py`
- `ruff check pkgs/standards/peagen --quiet`