### PR TITLE
Add PromptSampler resource

### DIFF
--- a/pkgs/base/README.md
+++ b/pkgs/base/README.md
@@ -125,6 +125,9 @@ class MyConcreteClass(LLMBase):
 ### prompt_templates
 - [`PromptTemplateBase.py`](./swarmauri_base/prompt_templates/PromptTemplateBase.py): Base class for prompt templates.
 
+### prompt_samplers
+- [`PromptSamplerBase.py`](./swarmauri_base/prompt_samplers/PromptSamplerBase.py): Base class for prompt samplers.
+
 ### schema_converters
 - [`SchemaConverterBase.py`](./swarmauri_base/schema_converters/SchemaConverterBase.py): Base class for schema converters.
 

--- a/pkgs/base/swarmauri_base/ComponentBase.py
+++ b/pkgs/base/swarmauri_base/ComponentBase.py
@@ -104,3 +104,4 @@ class ResourceTypes(Enum):
     SIMILARITY = "Similarity"
     PSEUDOMETRIC = "PseudoMetric"
     SEMINORM = "SemiNorm"
+    PROMPT_SAMPLER = "PromptSampler"

--- a/pkgs/base/swarmauri_base/prompt_samplers/PromptSamplerBase.py
+++ b/pkgs/base/swarmauri_base/prompt_samplers/PromptSamplerBase.py
@@ -1,0 +1,16 @@
+from typing import Optional, Literal
+from pydantic import Field
+
+from swarmauri_core.prompt_samplers.IPromptSampler import IPromptSampler
+from swarmauri_base.ComponentBase import ComponentBase, ResourceTypes
+
+
+@ComponentBase.register_model()
+class PromptSamplerBase(IPromptSampler, ComponentBase):
+    """Abstract base class for prompt samplers."""
+
+    resource: Optional[str] = Field(default=ResourceTypes.PROMPT_SAMPLER.value, frozen=True)
+    type: Literal["PromptSamplerBase"] = "PromptSamplerBase"
+
+    def sample(self, *args, **kwargs) -> str:  # pragma: no cover - base method
+        raise NotImplementedError

--- a/pkgs/base/swarmauri_base/prompt_samplers/__init__.py
+++ b/pkgs/base/swarmauri_base/prompt_samplers/__init__.py
@@ -1,0 +1,3 @@
+from .PromptSamplerBase import PromptSamplerBase
+
+__all__ = ["PromptSamplerBase"]

--- a/pkgs/core/swarmauri_core/prompt_samplers/IPromptSampler.py
+++ b/pkgs/core/swarmauri_core/prompt_samplers/IPromptSampler.py
@@ -1,0 +1,10 @@
+from abc import ABC, abstractmethod
+
+
+class IPromptSampler(ABC):
+    """Interface for sampling prompts from a collection."""
+
+    @abstractmethod
+    def sample(self, *args, **kwargs) -> str:
+        """Return a sampled prompt from the provided arguments."""
+        pass

--- a/pkgs/swarmauri_standard/README.md
+++ b/pkgs/swarmauri_standard/README.md
@@ -178,6 +178,11 @@ agents using predefined configurations.
 ### Prompt Templates
 - [PromptTemplate.py](swarmauri_standard/prompt_templates/PromptTemplate.py): Defines templates for generating prompts.
 
+### Prompt Samplers
+- [PromptSampler.py](swarmauri_standard/prompt_samplers/PromptSampler.py): Samples prompts from a sequence.
+- [WeightedPromptSampler.py](swarmauri_standard/prompt_samplers/WeightedPromptSampler.py): Samples prompts using weights.
+- [SequentialPromptSampler.py](swarmauri_standard/prompt_samplers/SequentialPromptSampler.py): Cycles through prompts in order.
+
 ### Schema Converters
 - [AnthropicSchemaConverter.py](swarmauri_standard/schema_converters/AnthropicSchemaConverter.py): Converts schemas for Anthropic models.
 - [CohereSchemaConverter.py](swarmauri_standard/schema_converters/CohereSchemaConverter.py): Converts schemas for Cohere models.

--- a/pkgs/swarmauri_standard/swarmauri_standard/prompt_samplers/PromptSampler.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/prompt_samplers/PromptSampler.py
@@ -1,0 +1,15 @@
+from typing import Literal, Sequence
+import random
+
+from swarmauri_base.prompt_samplers.PromptSamplerBase import PromptSamplerBase
+from swarmauri_base.ComponentBase import ComponentBase
+
+
+@ComponentBase.register_type(PromptSamplerBase, "PromptSampler")
+class PromptSampler(PromptSamplerBase):
+    """Sample a random prompt from a sequence."""
+
+    type: Literal["PromptSampler"] = "PromptSampler"
+
+    def sample(self, prompts: Sequence[str], *args, **kwargs) -> str:
+        return random.choice(list(prompts)) if prompts else ""

--- a/pkgs/swarmauri_standard/swarmauri_standard/prompt_samplers/SequentialPromptSampler.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/prompt_samplers/SequentialPromptSampler.py
@@ -1,0 +1,19 @@
+from typing import Literal, Sequence
+
+from swarmauri_base.prompt_samplers.PromptSamplerBase import PromptSamplerBase
+from swarmauri_base.ComponentBase import ComponentBase
+
+
+@ComponentBase.register_type(PromptSamplerBase, "SequentialPromptSampler")
+class SequentialPromptSampler(PromptSamplerBase):
+    """Cycle through prompts sequentially."""
+
+    type: Literal["SequentialPromptSampler"] = "SequentialPromptSampler"
+    index: int = 0
+
+    def sample(self, prompts: Sequence[str], *args, **kwargs) -> str:
+        if not prompts:
+            return ""
+        prompt = prompts[self.index % len(prompts)]
+        self.index += 1
+        return prompt

--- a/pkgs/swarmauri_standard/swarmauri_standard/prompt_samplers/WeightedPromptSampler.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/prompt_samplers/WeightedPromptSampler.py
@@ -1,0 +1,23 @@
+import random
+from typing import Literal, Sequence, Optional
+
+from swarmauri_base.prompt_samplers.PromptSamplerBase import PromptSamplerBase
+from swarmauri_base.ComponentBase import ComponentBase
+
+
+@ComponentBase.register_type(PromptSamplerBase, "WeightedPromptSampler")
+class WeightedPromptSampler(PromptSamplerBase):
+    """Sample prompts using optional weights."""
+
+    type: Literal["WeightedPromptSampler"] = "WeightedPromptSampler"
+
+    def sample(
+        self,
+        prompts: Sequence[str],
+        *,
+        weights: Optional[Sequence[float]] = None,
+        **kwargs,
+    ) -> str:
+        if not prompts:
+            return ""
+        return random.choices(list(prompts), weights=weights, k=1)[0]

--- a/pkgs/swarmauri_standard/swarmauri_standard/prompt_samplers/__init__.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/prompt_samplers/__init__.py
@@ -1,0 +1,9 @@
+from .PromptSampler import PromptSampler
+from .WeightedPromptSampler import WeightedPromptSampler
+from .SequentialPromptSampler import SequentialPromptSampler
+
+__all__ = [
+    "PromptSampler",
+    "WeightedPromptSampler",
+    "SequentialPromptSampler",
+]

--- a/pkgs/swarmauri_standard/tests/unit/prompt_samplers/PromptSampler_unit_test.py
+++ b/pkgs/swarmauri_standard/tests/unit/prompt_samplers/PromptSampler_unit_test.py
@@ -1,0 +1,27 @@
+import pytest
+from swarmauri_standard.prompt_samplers.PromptSampler import PromptSampler
+
+
+@pytest.mark.unit
+def test_ubc_resource():
+    sampler = PromptSampler()
+    assert sampler.resource == "PromptSampler"
+
+
+@pytest.mark.unit
+def test_ubc_type():
+    sampler = PromptSampler()
+    assert sampler.type == "PromptSampler"
+
+
+@pytest.mark.unit
+def test_serialization():
+    sampler = PromptSampler()
+    assert sampler.id == PromptSampler.model_validate_json(sampler.model_dump_json()).id
+
+
+@pytest.mark.unit
+def test_sampling():
+    sampler = PromptSampler()
+    prompts = ["a", "b", "c"]
+    assert sampler.sample(prompts) in prompts

--- a/pkgs/swarmauri_standard/tests/unit/prompt_samplers/SequentialPromptSampler_unit_test.py
+++ b/pkgs/swarmauri_standard/tests/unit/prompt_samplers/SequentialPromptSampler_unit_test.py
@@ -1,0 +1,30 @@
+import pytest
+from swarmauri_standard.prompt_samplers.SequentialPromptSampler import SequentialPromptSampler
+
+
+@pytest.mark.unit
+def test_ubc_resource():
+    sampler = SequentialPromptSampler()
+    assert sampler.resource == "PromptSampler"
+
+
+@pytest.mark.unit
+def test_ubc_type():
+    sampler = SequentialPromptSampler()
+    assert sampler.type == "SequentialPromptSampler"
+
+
+@pytest.mark.unit
+def test_serialization():
+    sampler = SequentialPromptSampler()
+    assert sampler.id == SequentialPromptSampler.model_validate_json(sampler.model_dump_json()).id
+
+
+@pytest.mark.unit
+def test_sampling_sequential():
+    sampler = SequentialPromptSampler()
+    prompts = ["a", "b", "c"]
+    assert sampler.sample(prompts) == "a"
+    assert sampler.sample(prompts) == "b"
+    assert sampler.sample(prompts) == "c"
+    assert sampler.sample(prompts) == "a"

--- a/pkgs/swarmauri_standard/tests/unit/prompt_samplers/WeightedPromptSampler_unit_test.py
+++ b/pkgs/swarmauri_standard/tests/unit/prompt_samplers/WeightedPromptSampler_unit_test.py
@@ -1,0 +1,28 @@
+import pytest
+from swarmauri_standard.prompt_samplers.WeightedPromptSampler import WeightedPromptSampler
+
+
+@pytest.mark.unit
+def test_ubc_resource():
+    sampler = WeightedPromptSampler()
+    assert sampler.resource == "PromptSampler"
+
+
+@pytest.mark.unit
+def test_ubc_type():
+    sampler = WeightedPromptSampler()
+    assert sampler.type == "WeightedPromptSampler"
+
+
+@pytest.mark.unit
+def test_serialization():
+    sampler = WeightedPromptSampler()
+    assert sampler.id == WeightedPromptSampler.model_validate_json(sampler.model_dump_json()).id
+
+
+@pytest.mark.unit
+def test_sampling():
+    sampler = WeightedPromptSampler()
+    prompts = ["a", "b", "c"]
+    weights = [0.1, 0.7, 0.2]
+    assert sampler.sample(prompts, weights=weights) in prompts


### PR DESCRIPTION
## Summary
- define `IPromptSampler` core interface
- create `PromptSamplerBase` in base
- implement random `PromptSampler` in swarmauri_standard
- document new base/standard modules
- add unit tests
- extend `ResourceTypes` enum with `PROMPT_SAMPLER`
- add weighted and sequential samplers to show extensibility
- use flexible `sample(*args, **kwargs)` interface

## Testing
- `uv run --package swarmauri_base --directory base pytest` *(fails: No route to host)*
- `uv run --package swarmauri_core --directory core pytest` *(fails: No route to host)*
- `uv run --package swarmauri_standard --directory swarmauri_standard pytest` *(fails: No route to host)*