### PR TITLE
Add ConfigLoader package

### DIFF
--- a/pkgs/config_loader/README.md
+++ b/pkgs/config_loader/README.md
@@ -1,0 +1,3 @@
+# config-loader
+
+Simple loader for `.peagen.toml` files.

--- a/pkgs/config_loader/__init__.py
+++ b/pkgs/config_loader/__init__.py
@@ -1,0 +1,3 @@
+from .config_loader import ConfigLoader, PeagenConfig
+
+__all__ = ["ConfigLoader", "PeagenConfig"]

--- a/pkgs/config_loader/config_loader/__init__.py
+++ b/pkgs/config_loader/config_loader/__init__.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+from pydantic import BaseModel, Field, ConfigDict
+import tomllib
+
+
+class WorkspaceConfig(BaseModel):
+    org: str
+    template_set: str | None = None
+    workers: int | None = None
+
+
+class LLMConfig(BaseModel):
+    default_provider: str
+    default_model_name: str
+    default_temperature: float | None = None
+    default_max_tokens: int | None = None
+    providers: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
+
+    model_config = ConfigDict(extra="allow")
+
+
+class StorageConfig(BaseModel):
+    default_storage_adapter: str
+    adapters: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
+
+
+class PublishersConfig(BaseModel):
+    default_publisher: str
+    adapters: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
+
+
+class PluginsConfig(BaseModel):
+    mode: str
+    switch: Dict[str, str] | None = None
+
+
+class EvaluatorConfig(BaseModel):
+    cls: str
+    model_config = ConfigDict(extra="allow")
+
+
+class EvaluationConfig(BaseModel):
+    pool: str | None = None
+    max_workers: int | None = None
+    async_: bool | None = Field(default=None, alias="async")
+    strict: bool | None = None
+    evaluators: Dict[str, EvaluatorConfig] = Field(default_factory=dict)
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class PeagenConfig(BaseModel):
+    workspace: WorkspaceConfig
+    llm: LLMConfig
+    storage: StorageConfig
+    publishers: PublishersConfig
+    plugins: PluginsConfig | None = None
+    evaluation: EvaluationConfig | None = None
+    model_config = ConfigDict(extra="allow")
+
+
+class ConfigLoader:
+    """Load and provide access to ``.peagen.toml`` configuration."""
+
+    _instance: ConfigLoader | None = None
+
+    def __new__(cls, start_dir: Path | None = None, path: Path | None = None) -> "ConfigLoader":
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            cls._instance._load(start_dir or Path.cwd(), path)
+        return cls._instance
+
+    # ------------------------------------------------------------------ private
+    def _load(self, start_dir: Path, path: Path | None) -> None:
+        cfg_path = self._find_config(start_dir, path)
+        data: Dict[str, Any] = {}
+        if cfg_path is not None:
+            text = Path(cfg_path).read_text("utf-8")
+            data = tomllib.loads(text)
+        self._config = self._parse(data)
+
+    @staticmethod
+    def _find_config(start_dir: Path, path: Path | None) -> Path | None:
+        if path:
+            p = path.expanduser().resolve()
+            return p if p.is_file() else None
+        for folder in [start_dir, *start_dir.parents]:
+            cfg = folder / ".peagen.toml"
+            if cfg.is_file():
+                return cfg
+        return None
+
+    @staticmethod
+    def _parse(data: Dict[str, Any]) -> PeagenConfig:
+        llm = data.get("llm", {})
+        providers = {k: v for k, v in llm.items() if isinstance(v, dict)}
+        llm_cfg = {
+            **{k: v for k, v in llm.items() if not isinstance(v, dict)},
+            "providers": providers,
+        }
+
+        storage = data.get("storage", {})
+        storage_cfg = {
+            "default_storage_adapter": storage.get("default_storage_adapter"),
+            "adapters": storage.get("adapters", {**{k: v for k, v in storage.items() if k != "default_storage_adapter"}}),
+        }
+
+        publishers = data.get("publishers", {})
+        publishers_cfg = {
+            "default_publisher": publishers.get("default_publisher"),
+            "adapters": publishers.get("adapters", {**{k: v for k, v in publishers.items() if k != "default_publisher"}}),
+        }
+
+        parsed = PeagenConfig(
+            workspace=data.get("workspace", {}),
+            llm=llm_cfg,
+            storage=storage_cfg,
+            publishers=publishers_cfg,
+            plugins=data.get("plugins"),
+            evaluation=data.get("evaluation"),
+            **{k: v for k, v in data.items() if k not in {"workspace", "llm", "storage", "publishers", "plugins", "evaluation"}},
+        )
+        return parsed
+
+    # ------------------------------------------------------------------ public
+    @property
+    def config(self) -> PeagenConfig:
+        return self._config
+
+    def reload(self, start_dir: Path | None = None, path: Path | None = None) -> None:
+        self._load(start_dir or Path.cwd(), path)

--- a/pkgs/config_loader/pyproject.toml
+++ b/pkgs/config_loader/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "config-loader"
+version = "0.1.0"
+description = "Loader for .peagen.toml configuration"
+requires-python = ">=3.10,<3.13"
+readme = "README.md"
+license = "Apache-2.0"
+dependencies = [
+    "pydantic>=2.0",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+]
+
+[tool.pytest.ini_options]
+markers = ["unit: Unit tests"]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/pkgs/config_loader/tests/test_config_loader.py
+++ b/pkgs/config_loader/tests/test_config_loader.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from config_loader import ConfigLoader
+
+
+def write_sample(tmpdir: Path) -> Path:
+    content = """
+[workspace]
+org = "demo"
+workers = 2
+
+[llm]
+default_provider = "groq"
+default_model_name = "llama"
+[llm.groq]
+API_KEY = "test"
+
+[storage]
+default_storage_adapter = "file"
+[storage.adapters.file]
+output_dir = "./out"
+
+[publishers]
+default_publisher = "redis"
+[publishers.adapters.redis]
+host = "localhost"
+"""
+    cfg_path = tmpdir / ".peagen.toml"
+    cfg_path.write_text(content)
+    return cfg_path
+
+
+def test_loader_parses_config(tmp_path: Path):
+    cfg = write_sample(tmp_path)
+    loader = ConfigLoader(path=cfg)
+    assert loader.config.workspace.org == "demo"
+    assert loader.config.llm.default_provider == "groq"
+    assert "groq" in loader.config.llm.providers
+
+
+def test_loader_singleton(tmp_path: Path):
+    cfg = write_sample(tmp_path)
+    first = ConfigLoader(path=cfg)
+    second = ConfigLoader()
+    assert first is second
+    assert second.config.workspace.org == "demo"
+


### PR DESCRIPTION
## Summary
- add `config_loader` package with singleton `ConfigLoader`
- parse `.peagen.toml` using `pydantic` models
- expose loader at package root
- provide unit tests for parsing and singleton behaviour

## Testing
- `uv run --package config-loader --directory config_loader pytest`