### PR TITLE
Fix new middleware README branding

### DIFF
--- a/pkgs/community/swarmauri_middleware_circuitbreaker/README.md
+++ b/pkgs/community/swarmauri_middleware_circuitbreaker/README.md
@@ -2,28 +2,34 @@
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_middleware_circuitbreaker/">
-        <img src="https://img.shields.io/pypi/dm/swarmauri_middleware_circuitbreaker" alt="PyPI - Downloads"/></a>
-    <a href="https://github.com/swarmauri/swarmauri-sdk/pkgs/pkgs/swarmauri_middleware_circuitbreaker">
-        <img src="https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https://github.com/swarmauri/swarmauri-sdk/pkgs/pkgs/swarmauri_middleware_circuitbreaker&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=hits&edge_flat=false" alt="GitHub Hits"/></a>
-    <a href="https://pypi.org/project/swarmauri/swarmauri_middleware_circuitbreaker">
-        <img src="https://img.shields.io/pypi/pyversions/swarmauri_middleware_circuitbreaker" alt="PyPI - Python Version"/></a>
-    <a href="https://pypi.org/project/swarmauri/swarmauri_middleware_circuitbreaker">
-        <img src="https://img.shields.io/pypi/l/swarmauri_middleware_circuitbreaker" alt="PyPI - License"/></a>
-    <br />
-    <a href="https://pypi.org/project/swarmauri/swarmauri_middleware_circuitbreaker">
-        <img src="https://img.shields.io/pypi/v/swarmauri_middleware_circuitbreaker?label=swarmauri_middleware_circuitbreaker&color=green" alt="PyPI - swarmauri_middleware_circuitbreaker"/></a>
+        <img src="https://img.shields.io/pypi/dm/swarmauri_middleware_circuitbreaker" alt="PyPI - Downloads"/>
+    </a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/community/swarmauri_middleware_circuitbreaker/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/community/swarmauri_middleware_circuitbreaker.svg"/>
+    </a>
+    <a href="https://pypi.org/project/swarmauri_middleware_circuitbreaker/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_middleware_circuitbreaker" alt="PyPI - Python Version"/>
+    </a>
+    <a href="https://pypi.org/project/swarmauri_middleware_circuitbreaker/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_middleware_circuitbreaker" alt="PyPI - License"/>
+    </a>
+    <a href="https://pypi.org/project/swarmauri_middleware_circuitbreaker/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_middleware_circuitbreaker?label=swarmauri_middleware_circuitbreaker&color=green" alt="PyPI - swarmauri_middleware_circuitbreaker"/>
+    </a>
 </p>
 
 ---
 
-# `swarmauri_middleware_circuitbreaker`
+# Swarmauri Middleware Circuitbreaker
 
-Circuit Breaker Middleware for protecting downstream services using pybreaker.
-
-## Overview
-
-This middleware implements a circuit breaker pattern to prevent cascading failures in distributed systems. It monitors failed requests and opens the circuit when a specified threshold of consecutive failures is reached, preventing further requests until the service becomes healthy again.
+Circuit Breaker Middleware for Swarmauri
 
 ## Installation
 
-To install the package, run:
+```bash
+pip install swarmauri_middleware_circuitbreaker
+```
+
+## Want to help?
+
+If you want to contribute to swarmauri-sdk, read up on our [guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/contributing.md) that will help you get started.

--- a/pkgs/community/swarmauri_middleware_ratepolicy/README.md
+++ b/pkgs/community/swarmauri_middleware_ratepolicy/README.md
@@ -1,1 +1,35 @@
-pip install swarmauri-middleware-ratepolicy
+![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_middleware_ratepolicy/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_middleware_ratepolicy" alt="PyPI - Downloads"/>
+    </a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/community/swarmauri_middleware_ratepolicy/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/community/swarmauri_middleware_ratepolicy.svg"/>
+    </a>
+    <a href="https://pypi.org/project/swarmauri_middleware_ratepolicy/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_middleware_ratepolicy" alt="PyPI - Python Version"/>
+    </a>
+    <a href="https://pypi.org/project/swarmauri_middleware_ratepolicy/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_middleware_ratepolicy" alt="PyPI - License"/>
+    </a>
+    <a href="https://pypi.org/project/swarmauri_middleware_ratepolicy/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_middleware_ratepolicy?label=swarmauri_middleware_ratepolicy&color=green" alt="PyPI - swarmauri_middleware_ratepolicy"/>
+    </a>
+</p>
+
+---
+
+# Swarmauri Middleware Ratepolicy
+
+A middleware implementing rate policy and retry logic for Swarmauri
+
+## Installation
+
+```bash
+pip install swarmauri_middleware_ratepolicy
+```
+
+## Want to help?
+
+If you want to contribute to swarmauri-sdk, read up on our [guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/contributing.md) that will help you get started.

--- a/pkgs/standards/swarmauri_middleware_cachecontrol/README.md
+++ b/pkgs/standards/swarmauri_middleware_cachecontrol/README.md
@@ -1,5 +1,35 @@
-# Using Poetry
-poetry add swarmauri-middleware-cachecontrol
+![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
 
-# Using pip
-pip install swarmauri-middleware-cachecontrol
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_middleware_cachecontrol/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_middleware_cachecontrol" alt="PyPI - Downloads"/>
+    </a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_middleware_cachecontrol/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_middleware_cachecontrol.svg"/>
+    </a>
+    <a href="https://pypi.org/project/swarmauri_middleware_cachecontrol/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_middleware_cachecontrol" alt="PyPI - Python Version"/>
+    </a>
+    <a href="https://pypi.org/project/swarmauri_middleware_cachecontrol/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_middleware_cachecontrol" alt="PyPI - License"/>
+    </a>
+    <a href="https://pypi.org/project/swarmauri_middleware_cachecontrol/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_middleware_cachecontrol?label=swarmauri_middleware_cachecontrol&color=green" alt="PyPI - swarmauri_middleware_cachecontrol"/>
+    </a>
+</p>
+
+---
+
+# Swarmauri Middleware Cachecontrol
+
+Middleware for managing HTTP cache headers and client-side caching behavior.
+
+## Installation
+
+```bash
+pip install swarmauri_middleware_cachecontrol
+```
+
+## Want to help?
+
+If you want to contribute to swarmauri-sdk, read up on our [guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/contributing.md) that will help you get started.

--- a/pkgs/standards/swarmauri_middleware_cors/README.md
+++ b/pkgs/standards/swarmauri_middleware_cors/README.md
@@ -1,1 +1,35 @@
-pip install swarmauri-middleware-cors
+![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_middleware_cors/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_middleware_cors" alt="PyPI - Downloads"/>
+    </a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_middleware_cors/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_middleware_cors.svg"/>
+    </a>
+    <a href="https://pypi.org/project/swarmauri_middleware_cors/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_middleware_cors" alt="PyPI - Python Version"/>
+    </a>
+    <a href="https://pypi.org/project/swarmauri_middleware_cors/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_middleware_cors" alt="PyPI - License"/>
+    </a>
+    <a href="https://pypi.org/project/swarmauri_middleware_cors/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_middleware_cors?label=swarmauri_middleware_cors&color=green" alt="PyPI - swarmauri_middleware_cors"/>
+    </a>
+</p>
+
+---
+
+# Swarmauri Middleware CORS
+
+Custom CORS Middleware for Swarmauri Framework
+
+## Installation
+
+```bash
+pip install swarmauri_middleware_cors
+```
+
+## Want to help?
+
+If you want to contribute to swarmauri-sdk, read up on our [guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/contributing.md) that will help you get started.

--- a/pkgs/standards/swarmauri_middleware_exceptionhadling/README.md
+++ b/pkgs/standards/swarmauri_middleware_exceptionhadling/README.md
@@ -1,1 +1,35 @@
-pip install swarmauri-middleware-exceptionhadling
+![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_middleware_exceptionhadling/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_middleware_exceptionhadling" alt="PyPI - Downloads"/>
+    </a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_middleware_exceptionhadling/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_middleware_exceptionhadling.svg"/>
+    </a>
+    <a href="https://pypi.org/project/swarmauri_middleware_exceptionhadling/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_middleware_exceptionhadling" alt="PyPI - Python Version"/>
+    </a>
+    <a href="https://pypi.org/project/swarmauri_middleware_exceptionhadling/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_middleware_exceptionhadling" alt="PyPI - License"/>
+    </a>
+    <a href="https://pypi.org/project/swarmauri_middleware_exceptionhadling/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_middleware_exceptionhadling?label=swarmauri_middleware_exceptionhadling&color=green" alt="PyPI - swarmauri_middleware_exceptionhadling"/>
+    </a>
+</p>
+
+---
+
+# Swarmauri Middleware Exceptionhadling
+
+Middleware for handling exceptions and errors in Swarmauri applications.
+
+## Installation
+
+```bash
+pip install swarmauri_middleware_exceptionhadling
+```
+
+## Want to help?
+
+If you want to contribute to swarmauri-sdk, read up on our [guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/contributing.md) that will help you get started.

--- a/pkgs/standards/swarmauri_middleware_logging/README.md
+++ b/pkgs/standards/swarmauri_middleware_logging/README.md
@@ -1,1 +1,35 @@
-pip install swarmauri-middleware-logging
+![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_middleware_logging/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_middleware_logging" alt="PyPI - Downloads"/>
+    </a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_middleware_logging/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_middleware_logging.svg"/>
+    </a>
+    <a href="https://pypi.org/project/swarmauri_middleware_logging/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_middleware_logging" alt="PyPI - Python Version"/>
+    </a>
+    <a href="https://pypi.org/project/swarmauri_middleware_logging/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_middleware_logging" alt="PyPI - License"/>
+    </a>
+    <a href="https://pypi.org/project/swarmauri_middleware_logging/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_middleware_logging?label=swarmauri_middleware_logging&color=green" alt="PyPI - swarmauri_middleware_logging"/>
+    </a>
+</p>
+
+---
+
+# Swarmauri Middleware Logging
+
+Middleware for logging requests and responses in Swarmauri applications.
+
+## Installation
+
+```bash
+pip install swarmauri_middleware_logging
+```
+
+## Want to help?
+
+If you want to contribute to swarmauri-sdk, read up on our [guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/contributing.md) that will help you get started.

--- a/pkgs/standards/swarmauri_middleware_ratelimit/README.md
+++ b/pkgs/standards/swarmauri_middleware_ratelimit/README.md
@@ -1,1 +1,35 @@
-pip install swarmauri-middleware-ratelimit
+![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_middleware_ratelimit/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_middleware_ratelimit" alt="PyPI - Downloads"/>
+    </a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_middleware_ratelimit/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_middleware_ratelimit.svg"/>
+    </a>
+    <a href="https://pypi.org/project/swarmauri_middleware_ratelimit/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_middleware_ratelimit" alt="PyPI - Python Version"/>
+    </a>
+    <a href="https://pypi.org/project/swarmauri_middleware_ratelimit/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_middleware_ratelimit" alt="PyPI - License"/>
+    </a>
+    <a href="https://pypi.org/project/swarmauri_middleware_ratelimit/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_middleware_ratelimit?label=swarmauri_middleware_ratelimit&color=green" alt="PyPI - swarmauri_middleware_ratelimit"/>
+    </a>
+</p>
+
+---
+
+# Swarmauri Middleware Ratelimit
+
+Rate limiting middleware for Swarmauri applications
+
+## Installation
+
+```bash
+pip install swarmauri_middleware_ratelimit
+```
+
+## Want to help?
+
+If you want to contribute to swarmauri-sdk, read up on our [guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/contributing.md) that will help you get started.

--- a/pkgs/standards/swarmauri_middleware_session/README.md
+++ b/pkgs/standards/swarmauri_middleware_session/README.md
@@ -1,1 +1,35 @@
-pip install swarmauri-middleware-session
+![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_middleware_session/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_middleware_session" alt="PyPI - Downloads"/>
+    </a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_middleware_session/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_middleware_session.svg"/>
+    </a>
+    <a href="https://pypi.org/project/swarmauri_middleware_session/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_middleware_session" alt="PyPI - Python Version"/>
+    </a>
+    <a href="https://pypi.org/project/swarmauri_middleware_session/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_middleware_session" alt="PyPI - License"/>
+    </a>
+    <a href="https://pypi.org/project/swarmauri_middleware_session/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_middleware_session?label=swarmauri_middleware_session&color=green" alt="PyPI - swarmauri_middleware_session"/>
+    </a>
+</p>
+
+---
+
+# Swarmauri Middleware Session
+
+Session middleware for maintaining session state across requests.
+
+## Installation
+
+```bash
+pip install swarmauri_middleware_session
+```
+
+## Want to help?
+
+If you want to contribute to swarmauri-sdk, read up on our [guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/contributing.md) that will help you get started.

--- a/pkgs/standards/swarmauri_middleware_time/README.md
+++ b/pkgs/standards/swarmauri_middleware_time/README.md
@@ -1,1 +1,35 @@
-pip install swarmauri-middleware-time
+![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_middleware_time/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_middleware_time" alt="PyPI - Downloads"/>
+    </a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_middleware_time/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_middleware_time.svg"/>
+    </a>
+    <a href="https://pypi.org/project/swarmauri_middleware_time/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_middleware_time" alt="PyPI - Python Version"/>
+    </a>
+    <a href="https://pypi.org/project/swarmauri_middleware_time/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_middleware_time" alt="PyPI - License"/>
+    </a>
+    <a href="https://pypi.org/project/swarmauri_middleware_time/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_middleware_time?label=swarmauri_middleware_time&color=green" alt="PyPI - swarmauri_middleware_time"/>
+    </a>
+</p>
+
+---
+
+# Swarmauri Middleware Time
+
+Middleware for tracking request processing time in Swarmauri applications
+
+## Installation
+
+```bash
+pip install swarmauri_middleware_time
+```
+
+## Want to help?
+
+If you want to contribute to swarmauri-sdk, read up on our [guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/contributing.md) that will help you get started.


### PR DESCRIPTION
## Summary
- update README formatting for recent standard middlewares
- update README formatting for community ratepolicy and circuitbreaker packages

## Testing
- `uv run --package swarmauri_middleware_cachecontrol --directory standards/swarmauri_middleware_cachecontrol pytest` *(fails: Failed to parse entry in group `dev`: `python-dotenv`)*
- `uv run --package swarmauri_middleware_cors --directory standards/swarmauri_middleware_cors pytest` *(fails: `swarmauri-core` references a workspace but is not a workspace member)*