### PR TITLE
Register middleware packages

### DIFF
--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -56,8 +56,22 @@ members = [
     "standards/swarmauri_publisher_webhook",
     #"standards/swarmauri_vectorstore_tfidf",
     "standards/swarmauri_distance_minkowski",
+    "standards/swarmauri_middleware_auth",
+    "standards/swarmauri_middleware_bulkhead",
+    "standards/swarmauri_middleware_cachecontrol",
+    "standards/swarmauri_middleware_cors",
+    "standards/swarmauri_middleware_exceptionhadling",
+    "standards/swarmauri_middleware_gzipcompression",
+    "standards/swarmauri_middleware_llamaguard",
+    "standards/swarmauri_middleware_logging",
+    "standards/swarmauri_middleware_ratelimit",
+    "standards/swarmauri_middleware_sercurityheaders",
+    "standards/swarmauri_middleware_session",
+    "standards/swarmauri_middleware_time",
     "standards/swarmauri_prompt_j2prompttemplate",
     "standards/peagen",
+    "community/swarmauri_middleware_circuitbreaker",
+    "community/swarmauri_middleware_ratepolicy",
     "community/swarmauri_vectorstore_redis",
     "community/swarmauri_vectorstore_qdrant",
     "community/swarmauri_vectorstore_pinecone",
@@ -152,6 +166,20 @@ swarmauri_evaluator_subprocess = { workspace = true }
 swarmauri_evaluatorpool_accessibility = { workspace = true }
 #swarmauri_vectorstore_tfidf = { workspace = true } # We have a tfidf with built-in formula now, this can move to community support with minor rename
 swarmauri_distance_minkowski = { workspace = true }
+swarmauri_middleware_auth = { workspace = true }
+swarmauri_middleware_bulkhead = { workspace = true }
+swarmauri_middleware_cachecontrol = { workspace = true }
+swarmauri_middleware_cors = { workspace = true }
+swarmauri_middleware_exceptionhadling = { workspace = true }
+swarmauri_middleware_gzipcompression = { workspace = true }
+swarmauri_middleware_llamaguard = { workspace = true }
+swarmauri_middleware_logging = { workspace = true }
+swarmauri_middleware_ratelimit = { workspace = true }
+swarmauri_middleware_sercurityheaders = { workspace = true }
+swarmauri_middleware_session = { workspace = true }
+swarmauri_middleware_time = { workspace = true }
+swarmauri_middleware_circuitbreaker = { workspace = true }
+swarmauri_middleware_ratepolicy = { workspace = true }
 peagen = { workspace = true }
 
 swarmauri_vectorstore_redis = { workspace = true }

--- a/pkgs/swarmauri/swarmauri/interface_registry.py
+++ b/pkgs/swarmauri/swarmauri/interface_registry.py
@@ -50,6 +50,7 @@ from swarmauri_base.logger_formatters.FormatterBase import FormatterBase
 from swarmauri_base.loggers.LoggerBase import LoggerBase
 from swarmauri_base.logger_handlers.HandlerBase import HandlerBase
 from swarmauri_base.rate_limits.RateLimitBase import RateLimitBase
+from swarmauri_base.middlewares.MiddlewareBase import MiddlewareBase
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -86,6 +87,7 @@ class InterfaceRegistry:
         "swarmauri.vlms": VLMBase,
         "swarmauri.measurements": MeasurementBase,
         "swarmauri.messages": MessageBase,
+        "swarmauri.middlewares": MiddlewareBase,
         "swarmauri.parsers": ParserBase,
         "swarmauri.pipelines": PipelineBase,
         "swarmauri.prompts": PromptBase,

--- a/pkgs/swarmauri/swarmauri/plugin_citizenship_registry.py
+++ b/pkgs/swarmauri/swarmauri/plugin_citizenship_registry.py
@@ -276,6 +276,18 @@ class PluginCitizenshipRegistry:
         "swarmauri.loggers.Logger": "swarmauri_standard.loggers.Logger",
         "swarmauri.logger_handlers.StreamHandler": "swarmauri_standard.logger_handlers.StreamHandler",
         "swarmauri.logger_formatters.LoggerFormatter": "swarmauri_standard.logger_formatters.LoggerFormatter",
+        "swarmauri.middlewares.AuthMiddleware": "swarmauri_middleware_auth.AuthMiddleware",
+        "swarmauri.middlewares.BulkheadMiddleware": "swarmauri_middleware_bulkhead.BulkheadMiddleware",
+        "swarmauri.middlewares.CacheControlMiddleware": "swarmauri_middleware_cachecontrol.CacheControlMiddleware",
+        "swarmauri.middlewares.CustomCORSMiddleware": "swarmauri_middleware_cors.CustomCORSMiddleware",
+        "swarmauri.middlewares.ExceptionHandlingMiddleware": "swarmauri_middleware_exceptionhadling.ExceptionHandlingMiddleware",
+        "swarmauri.middlewares.GzipCompressionMiddleware": "swarmauri_middleware_gzipcompression.GzipCompressionMiddleware",
+        "swarmauri.middlewares.LlamaGuardMiddleware": "swarmauri_middleware_llamaguard.LlamaGuardMiddleware",
+        "swarmauri.middlewares.LoggingMiddleware": "swarmauri_middleware_logging.LoggingMiddleware",
+        "swarmauri.middlewares.RateLimitMiddleware": "swarmauri_middleware_ratelimit.RateLimitMiddleware",
+        "swarmauri.middlewares.SecurityHeadersMiddleware": "swarmauri_middleware_sercurityheaders.SecurityHeadersMiddleware",
+        "swarmauri.middlewares.SessionMiddleware": "swarmauri_middleware_session.SessionMiddleware",
+        "swarmauri.middlewares.TimerMiddleware": "swarmauri_middleware_time.TimerMiddleware",
         "swarmauri.rate_limits.TokenBucketRateLimit": "swarmauri_standard.rate_limits.TokenBucketRateLimit",
     }
     SECOND_CLASS_REGISTRY: Dict[str, str] = {}


### PR DESCRIPTION
## Summary
- expose middleware interface in interface registry
- register standard middlewares in the plugin citizenship registry
- include middleware packages in the workspace pyproject

## Testing
- `ruff check` *(fails: Found 76 errors)*