### PR TITLE
Remove fastapi version pin in middleware packages

### DIFF
--- a/pkgs/community/swarmauri_middleware_circuitbreaker/pyproject.toml
+++ b/pkgs/community/swarmauri_middleware_circuitbreaker/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Application Frameworks"
 ]
 dependencies = [
-    "fastapi>=0.68.0",
+    "fastapi",
     "pybreaker>=1.0.0",
     "swarmauri_core",
     "swarmauri_base",

--- a/pkgs/standards/swarmauri_middleware_auth/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_auth/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
-    "fastapi>=0.68.0, <0.69.0",
+    "fastapi",
     "python-dotenv>=0.19.0",
     "loguru>=0.5.1",
     "uvicorn>=0.15.0"

--- a/pkgs/standards/swarmauri_middleware_cachecontrol/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_cachecontrol/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
-    "fastapi>=0.68.0",
+    "fastapi",
     "python-dotenv>=0.19.0"
 ]
 

--- a/pkgs/standards/swarmauri_middleware_gzipcompression/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_gzipcompression/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 ]
 authors = [{name = "Jacob Stewart", email = "jacob@swarmauri.com"}]
 dependencies = [
-    "fastapi>=0.68.0",
+    "fastapi",
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",

--- a/pkgs/standards/swarmauri_middleware_llamaguard/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_llamaguard/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
-    "fastapi>=0.68.0",
+    "fastapi",
     "llmaguard>=0.3.0",
     "python-dotenv>=1.0.0"
 ]

--- a/pkgs/standards/swarmauri_middleware_logging/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_logging/pyproject.toml
@@ -34,7 +34,7 @@ keywords = [
 swarmauri_core = {workspace = true}
 swarmauri_base = {workspace = true}
 swarmauri_standard = {workspace = true}
-fastapi = {version = ">=0.68.0", extras = ["all"]}
+fastapi = {extras = ["all"]}
 typing-extensions = ">=4.2.0"
 python-dotenv = ">=0.19.0"
 requests = ">=2.32.3"

--- a/pkgs/standards/swarmauri_middleware_ratelimit/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_ratelimit/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
-    "fastapi>=0.68.0,<0.69.0"
+    "fastapi"
 ]
 
 [tool.uv.sources]


### PR DESCRIPTION
## Summary
- drop explicit fastapi version requirement across middleware packages

## Testing
- `ruff format pkgs/community/swarmauri_middleware_circuitbreaker` *(fails: No route to host)*
