### PR TITLE
Refactor ensemble API

### DIFF
--- a/pkgs/base/swarmauri_base/ensembles/EnsembleBase.py
+++ b/pkgs/base/swarmauri_base/ensembles/EnsembleBase.py
@@ -9,37 +9,59 @@ from swarmauri_core.ensembles.IEnsemble import IEnsemble
 
 @ComponentBase.register_model()
 class EnsembleBase(IEnsemble, ComponentBase):
-    """Base implementation for LLM ensembles."""
+    """Base implementation for routing prompts to multiple LLMs."""
 
     resource: Optional[str] = Field(default=ResourceTypes.ENSEMBLE.value)
     type: Literal["EnsembleBase"] = "EnsembleBase"
 
     llms: Dict[str, LLMBase] = Field(default_factory=dict)
-    weights: Dict[str, float] = Field(default_factory=dict)
 
-    def add_model(self, name: str, model: LLMBase, weight: float = 1.0) -> None:
+    def add_model(self, name: str, model: LLMBase) -> None:
         if name in self.llms:
             raise ValueError(f"Model '{name}' already exists")
         self.llms[name] = model
-        self.weights[name] = weight
 
     def remove_model(self, name: str) -> bool:
         removed = name in self.llms
         if removed:
             self.llms.pop(name)
-            self.weights.pop(name, None)
         return removed
 
-    def predict(self, prompt: str, **kwargs: Any) -> Any:
-        predictions = {name: llm.predict(prompt, **kwargs) for name, llm in self.llms.items()}
-        return self.combine_predictions(predictions)
+    def list_models(self) -> Dict[str, LLMBase]:
+        return self.llms
 
-    async def apredict(self, prompt: str, **kwargs: Any) -> Any:
-        predictions: Dict[str, Any] = {}
+    def route_by_provider(self, provider: str, prompt: str, **kwargs: Any) -> Any:
+        llm = self.llms.get(provider)
+        if not llm:
+            raise ValueError(f"Provider '{provider}' not found")
+        return llm.predict(prompt, **kwargs)
+
+    async def aroute_by_provider(self, provider: str, prompt: str, **kwargs: Any) -> Any:
+        llm = self.llms.get(provider)
+        if not llm:
+            raise ValueError(f"Provider '{provider}' not found")
+        return await llm.apredict(prompt, **kwargs)
+
+    def _choose_provider(self) -> Optional[str]:
+        return next(iter(self.llms), None)
+
+    def route(self, prompt: str, **kwargs: Any) -> Any:
+        provider = self._choose_provider()
+        if provider is None:
+            return None
+        return self.route_by_provider(provider, prompt, **kwargs)
+
+    async def aroute(self, prompt: str, **kwargs: Any) -> Any:
+        provider = self._choose_provider()
+        if provider is None:
+            return None
+        return await self.aroute_by_provider(provider, prompt, **kwargs)
+
+    def broadcast(self, prompt: str, **kwargs: Any) -> Dict[str, Any]:
+        return {name: llm.predict(prompt, **kwargs) for name, llm in self.llms.items()}
+
+    async def abroadcast(self, prompt: str, **kwargs: Any) -> Dict[str, Any]:
+        responses: Dict[str, Any] = {}
         for name, llm in self.llms.items():
-            predictions[name] = await llm.apredict(prompt, **kwargs)
-        return self.combine_predictions(predictions)
-
-    def combine_predictions(self, predictions: Dict[str, Any]) -> Any:
-        """Combine model predictions. Subclasses can override."""
-        return next(iter(predictions.values()), None)
+            responses[name] = await llm.apredict(prompt, **kwargs)
+        return responses

--- a/pkgs/core/swarmauri_core/ensembles/IEnsemble.py
+++ b/pkgs/core/swarmauri_core/ensembles/IEnsemble.py
@@ -1,28 +1,53 @@
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, Dict
 
 from swarmauri_core.llms.IPredict import IPredict
 
 
 class IEnsemble(ABC):
-    """Interface for ensembles of prediction models."""
+    """Interface for routing predictions across multiple providers."""
 
     @abstractmethod
-    def add_model(self, name: str, model: IPredict, weight: float = 1.0) -> None:
-        """Add a model to the ensemble."""
+    def add_model(self, name: str, model: IPredict) -> None:
+        """Add a provider to the ensemble."""
         pass
 
     @abstractmethod
     def remove_model(self, name: str) -> bool:
-        """Remove a model from the ensemble."""
+        """Remove a provider from the ensemble."""
         pass
 
     @abstractmethod
-    def predict(self, prompt: str, **kwargs: Any) -> Any:
-        """Generate a prediction using the ensemble."""
+    def list_models(self) -> Dict[str, IPredict]:
+        """Return the registered providers."""
         pass
 
     @abstractmethod
-    async def apredict(self, prompt: str, **kwargs: Any) -> Any:
-        """Asynchronously generate a prediction using the ensemble."""
+    def route_by_provider(self, provider: str, prompt: str, **kwargs: Any) -> Any:
+        """Route a request to a specific provider."""
+        pass
+
+    @abstractmethod
+    async def aroute_by_provider(self, provider: str, prompt: str, **kwargs: Any) -> Any:
+        """Asynchronously route a request to a specific provider."""
+        pass
+
+    @abstractmethod
+    def route(self, prompt: str, **kwargs: Any) -> Any:
+        """Route a request to a chosen provider."""
+        pass
+
+    @abstractmethod
+    async def aroute(self, prompt: str, **kwargs: Any) -> Any:
+        """Asynchronously route a request to a chosen provider."""
+        pass
+
+    @abstractmethod
+    def broadcast(self, prompt: str, **kwargs: Any) -> Dict[str, Any]:
+        """Send a request to all providers and return their responses."""
+        pass
+
+    @abstractmethod
+    async def abroadcast(self, prompt: str, **kwargs: Any) -> Dict[str, Any]:
+        """Asynchronously broadcast a request to all providers."""
         pass

--- a/pkgs/swarmauri_standard/swarmauri_standard/ensembles/Ensemble.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/ensembles/Ensemble.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Literal
+from typing import Literal
 
 from swarmauri_base.ComponentBase import ComponentBase
 from swarmauri_base.ensembles.EnsembleBase import EnsembleBase
@@ -6,15 +6,6 @@ from swarmauri_base.ensembles.EnsembleBase import EnsembleBase
 
 @ComponentBase.register_type(EnsembleBase, "Ensemble")
 class Ensemble(EnsembleBase):
-    """Generic weighted voting ensemble."""
+    """Generic ensemble for routing prompts across providers."""
 
     type: Literal["Ensemble"] = "Ensemble"
-
-    def combine_predictions(self, predictions: Dict[str, Any]) -> Any:
-        scores: Dict[Any, float] = {}
-        for name, prediction in predictions.items():
-            weight = self.weights.get(name, 1.0)
-            scores[prediction] = scores.get(prediction, 0.0) + weight
-        if not scores:
-            return None
-        return max(scores.items(), key=lambda item: item[1])[0]


### PR DESCRIPTION
## Summary
- rework `IEnsemble` interface
- update `EnsembleBase` implementation to use routing and broadcasting
- remove prediction-combining logic from standard `Ensemble`
- drop weight-based routing from interface and base implementation

## Testing
- `No tests run due to developer instructions.`