### PR TITLE
Add TaskQueue and pluggable worker support

### DIFF
--- a/pkgs/standards/peagen/peagen/plugin_registry.py
+++ b/pkgs/standards/peagen/peagen/plugin_registry.py
@@ -17,6 +17,7 @@ GROUPS = {
     "result_backends": ("peagen.result_backends", object),
     "evaluators": ("peagen.evaluators", object),
     "evaluator_pools": ("peagen.evaluator_pools", object),
+    "workers": ("peagen.workers", object),
 }
 
 registry: Dict[str, Dict[str, object]] = defaultdict(dict)

--- a/pkgs/standards/peagen/peagen/taskqueue.py
+++ b/pkgs/standards/peagen/peagen/taskqueue.py
@@ -1,0 +1,42 @@
+"""Generic task queue leveraging pluggable workers."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from queue import Queue, Empty
+from typing import Any, Callable, Optional
+
+from peagen.plugin_registry import registry
+
+from .workers.base import WorkerBase
+
+
+class TaskQueue:
+    """Queue that delegates task execution to a configurable worker."""
+
+    def __init__(self, worker: str = "local", max_workers: int = 1) -> None:
+        self.queue: Queue[tuple[Callable[..., Any], tuple[Any, ...], dict[str, Any]]] = Queue()
+        worker_cls = registry.get("workers", {}).get(worker)
+        if worker_cls is None:
+            raise ValueError(f"No worker registered for '{worker}'")
+        if not issubclass(worker_cls, WorkerBase):
+            raise TypeError(f"Worker '{worker}' must inherit from WorkerBase")
+        self.worker: WorkerBase = worker_cls()
+        self.max_workers = max_workers
+
+    def add_task(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> None:
+        """Enqueue a callable to be executed."""
+        self.queue.put((func, args, kwargs))
+
+    def process(self) -> None:
+        """Process tasks until the queue is empty."""
+        with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
+            futures = []
+            while True:
+                try:
+                    func, args, kwargs = self.queue.get_nowait()
+                except Empty:
+                    break
+                futures.append(executor.submit(self.worker.execute, func, *args, **kwargs))
+            for fut in futures:
+                fut.result()

--- a/pkgs/standards/peagen/peagen/workers/__init__.py
+++ b/pkgs/standards/peagen/peagen/workers/__init__.py
@@ -1,0 +1,5 @@
+"""Built-in worker implementations."""
+
+from .local_worker import LocalWorker
+
+__all__ = ["LocalWorker"]

--- a/pkgs/standards/peagen/peagen/workers/base.py
+++ b/pkgs/standards/peagen/peagen/workers/base.py
@@ -1,0 +1,11 @@
+"""Base class for task execution workers."""
+
+from typing import Any, Callable
+
+
+class WorkerBase:
+    """Execute tasks in a specific environment."""
+
+    def execute(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        """Execute *func* with provided arguments."""
+        raise NotImplementedError("Worker subclasses must implement execute()")

--- a/pkgs/standards/peagen/peagen/workers/local_worker.py
+++ b/pkgs/standards/peagen/peagen/workers/local_worker.py
@@ -1,0 +1,12 @@
+"""Simple worker that executes callables in the local Python process."""
+
+from typing import Any, Callable
+
+from .base import WorkerBase
+
+
+class LocalWorker(WorkerBase):
+    """Execute tasks by calling them directly."""
+
+    def execute(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        return func(*args, **kwargs)

--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -110,5 +110,8 @@ redis   = "peagen.publishers.redis_publisher:RedisPublisher"
 webhook = "peagen.publishers.webhook_publisher:WebhookPublisher"
 rabbitmq = "peagen.publishers.rabbitmq_publisher:RabbitMQPublisher"
 
+[project.entry-points."peagen.workers"]
+local = "peagen.workers.local_worker:LocalWorker"
+
 [tool.setuptools.package-data]
 "peagen.schemas" = ["*.json", "extras/*.json"]


### PR DESCRIPTION
## Summary
- add new `workers` plugin group
- implement `TaskQueue` with pluggable workers
- provide default `LocalWorker`
- expose worker entry point in `pyproject.toml`

## Testing
- `python -m py_compile pkgs/standards/peagen/peagen/taskqueue.py pkgs/standards/peagen/peagen/workers/*.py pkgs/standards/peagen/peagen/plugin_registry.py`