### PR TITLE
Add unit tests for peagen modules

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test___init__.py
+++ b/pkgs/standards/peagen/tests/unit/test___init__.py
@@ -1,0 +1,15 @@
+import random; random.seed(0xA11A)
+import importlib
+import types
+import sys
+import pytest
+
+import peagen.plugin_registry as pr
+
+
+@pytest.mark.unit
+def test_determine_plugin_mode(monkeypatch):
+    monkeypatch.setattr(pr, "discover_and_register_plugins", lambda mode=None: None)
+    monkeypatch.setattr(sys, "argv", ["peagen", "--plugin-mode", "switch"])
+    mod = importlib.reload(importlib.import_module("peagen"))
+    assert mod._determine_plugin_mode() == "switch"

--- a/pkgs/standards/peagen/tests/unit/test__api_key.py
+++ b/pkgs/standards/peagen/tests/unit/test__api_key.py
@@ -1,0 +1,31 @@
+import random; random.seed(0xA11A)
+import os
+import typer
+import pytest
+from peagen._api_key import _resolve_api_key
+
+
+@pytest.mark.unit
+def test_cli_override():
+    assert _resolve_api_key("openai", api_key="k") == "k"
+
+
+@pytest.mark.unit
+def test_env_var(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "envk")
+    assert _resolve_api_key("openai") == "envk"
+
+
+@pytest.mark.unit
+def test_toml(monkeypatch, tmp_path):
+    toml = tmp_path / ".peagen.toml"
+    toml.write_text("[llm.openai]\napi_key='tok'")
+    monkeypatch.chdir(tmp_path)
+    assert _resolve_api_key("openai") == "tok"
+
+
+@pytest.mark.unit
+def test_missing_provider():
+    with pytest.raises(typer.Exit):
+        _resolve_api_key("", env_file=None)
+

--- a/pkgs/standards/peagen/tests/unit/test__banner.py
+++ b/pkgs/standards/peagen/tests/unit/test__banner.py
@@ -1,0 +1,15 @@
+import random; random.seed(0xA11A)
+import typer
+import pytest
+
+from peagen._banner import _print_banner
+
+
+@pytest.mark.unit
+def test_print_banner(monkeypatch):
+    lines = []
+    monkeypatch.setattr(typer, "echo", lambda msg=None: lines.append(msg or ""))
+    _print_banner()
+    text = "\n".join(lines)
+    assert "Package Name" in text
+    assert "Version" in text

--- a/pkgs/standards/peagen/tests/unit/test__config.py
+++ b/pkgs/standards/peagen/tests/unit/test__config.py
@@ -1,0 +1,9 @@
+import random; random.seed(0xA11A)
+import pytest
+from peagen import _config
+
+
+@pytest.mark.unit
+def test_version_present():
+    assert isinstance(_config.__version__, str)
+    assert _config.__version__

--- a/pkgs/standards/peagen/tests/unit/test__external.py
+++ b/pkgs/standards/peagen/tests/unit/test__external.py
@@ -1,0 +1,42 @@
+import random; random.seed(0xA11A)
+import builtins
+import types
+import pytest
+
+from peagen._external import chunk_content
+
+
+@pytest.mark.unit
+def test_chunk_multiple(monkeypatch):
+    class FakeChunker:
+        def chunk_text(self, text):
+            return [(None, None, "c1"), (None, None, "c2")]
+
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "swarmauri.chunkers.MdSnippetChunker":
+            return types.SimpleNamespace(MdSnippetChunker=FakeChunker)
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    try:
+        assert chunk_content("x") == "c1"
+    finally:
+        monkeypatch.setattr(builtins, "__import__", real_import)
+
+
+@pytest.mark.unit
+def test_chunk_no_chunker(monkeypatch):
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "swarmauri.chunkers.MdSnippetChunker":
+            raise ImportError
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    try:
+        assert chunk_content("foo") == "foo"
+    finally:
+        monkeypatch.setattr(builtins, "__import__", real_import)

--- a/pkgs/standards/peagen/tests/unit/test__gitops.py
+++ b/pkgs/standards/peagen/tests/unit/test__gitops.py
@@ -1,0 +1,17 @@
+import random; random.seed(0xA11A)
+import subprocess
+from pathlib import Path
+import pytest
+
+from peagen._gitops import _clone_swarmauri_repo
+
+
+@pytest.mark.unit
+def test_clone(monkeypatch, tmp_path):
+    calls = []
+    monkeypatch.setattr(subprocess, "check_call", lambda cmd: calls.append(cmd))
+    monkeypatch.setattr("tempfile.mkdtemp", lambda prefix: str(tmp_path / "repo"))
+    p = _clone_swarmauri_repo(use_dev_branch=True)
+    assert Path(p).exists()
+    assert "mono/dev" in calls[0]
+

--- a/pkgs/standards/peagen/tests/unit/test__graph.py
+++ b/pkgs/standards/peagen/tests/unit/test__graph.py
@@ -1,0 +1,54 @@
+import random; random.seed(0xA11A)
+import pytest
+from peagen._graph import (
+    _build_forward_graph,
+    _topological_sort,
+    _transitive_dependency_sort,
+    get_immediate_dependencies,
+)
+
+
+def _payload():
+    return [
+        {
+            "RENDERED_FILE_NAME": "A",
+            "EXTRAS": {"DEPENDENCIES": ["B"]},
+        },
+        {
+            "RENDERED_FILE_NAME": "B",
+            "EXTRAS": {"DEPENDENCIES": []},
+        },
+        {"RENDERED_FILE_NAME": "C", "EXTRAS": {}},
+    ]
+
+
+@pytest.mark.unit
+def test_build_graph():
+    g, indeg, nodes = _build_forward_graph(_payload())
+    assert g["B"] == ["A"]
+    assert indeg["A"] == 1
+    assert "C" in nodes
+
+
+@pytest.mark.unit
+def test_topological_sort():
+    res = _topological_sort(_payload())
+    names = [r["RENDERED_FILE_NAME"] for r in res]
+    assert names == ["B", "A", "C"]
+
+
+@pytest.mark.unit
+def test_transitive_sort():
+    res = _transitive_dependency_sort(_payload(), "A")
+    names = [r["RENDERED_FILE_NAME"] for r in res]
+    assert names == ["B", "A"]
+    with pytest.raises(ValueError):
+        _transitive_dependency_sort(_payload(), "Z")
+
+
+@pytest.mark.unit
+def test_get_immediate_dependencies():
+    deps = get_immediate_dependencies(_payload(), "A")
+    assert deps == ["B"]
+    with pytest.raises(ValueError):
+        get_immediate_dependencies(_payload(), "Z")

--- a/pkgs/standards/peagen/tests/unit/test__llm.py
+++ b/pkgs/standards/peagen/tests/unit/test__llm.py
@@ -1,0 +1,23 @@
+import random; random.seed(0xA11A)
+import types
+import importlib
+import pytest
+
+from peagen._llm import GenericLLM
+
+
+@pytest.mark.unit
+def test_invalid_provider():
+    with pytest.raises(ValueError):
+        GenericLLM().get_llm("unknown")
+
+
+@pytest.mark.unit
+def test_valid_provider(monkeypatch):
+    class Dummy:
+        pass
+
+    mod = types.SimpleNamespace(OpenAIModel=Dummy)
+    monkeypatch.setattr(importlib, "import_module", lambda name: mod)
+    llm = GenericLLM().get_llm("openai", api_key="key", model_name="gpt")
+    assert isinstance(llm, Dummy)

--- a/pkgs/standards/peagen/tests/unit/test__processing.py
+++ b/pkgs/standards/peagen/tests/unit/test__processing.py
@@ -1,0 +1,62 @@
+import random; random.seed(0xA11A)
+import os
+import pytest
+
+from peagen._processing import (
+    _save_file,
+    _create_context,
+    _process_file,
+)
+
+
+class DummyJ2:
+    def __init__(self):
+        self.tmpl = None
+
+    def set_template(self, p):
+        self.tmpl = p
+
+    def fill(self, ctx):
+        return "content"
+
+
+@pytest.mark.unit
+def test_save_file(tmp_path):
+    _save_file("data", "a/b.txt", workspace_root=tmp_path)
+    assert (tmp_path / "a" / "b.txt").read_text() == "data"
+
+
+@pytest.mark.unit
+def test_create_context():
+    rec = {"RENDERED_FILE_NAME": "f", "PROJECT_NAME": "P", "PACKAGE_NAME": "pkg", "MODULE_NAME": "m"}
+    proj = {"NAME": "P", "PACKAGES": [{"NAME": "pkg", "MODULES": [{"NAME": "m"}]}]}
+    ctx = _create_context(rec, proj)
+    assert ctx["PROJ"]["NAME"] == "P"
+    assert ctx["PKG"]["NAME"] == "pkg"
+    assert ctx["MOD"]["NAME"] == "m"
+
+
+@pytest.mark.unit
+def test_process_file_copy(monkeypatch, tmp_path):
+    rec = {"RENDERED_FILE_NAME": "x.txt", "PROCESS_TYPE": "COPY", "FILE_NAME": "foo"}
+    monkeypatch.setattr("peagen._rendering._render_copy_template", lambda *a, **k: "ok")
+    _process_file(rec, {}, tmp_path, {}, DummyJ2(), workspace_root=tmp_path)
+    assert (tmp_path / "x.txt").exists()
+
+
+@pytest.mark.unit
+def test_process_file_generate(monkeypatch, tmp_path):
+    rec = {
+        "RENDERED_FILE_NAME": "y.txt",
+        "PROCESS_TYPE": "GENERATE",
+        "AGENT_PROMPT_TEMPLATE": "p.j2",
+    }
+    monkeypatch.setattr("peagen._rendering._render_generate_template", lambda *a, **k: "ok")
+    _process_file(rec, {}, str(tmp_path), {}, DummyJ2(), workspace_root=tmp_path)
+    assert (tmp_path / "y.txt").exists()
+
+
+@pytest.mark.unit
+def test_process_file_unknown(tmp_path):
+    rec = {"RENDERED_FILE_NAME": "z", "PROCESS_TYPE": "WHAT"}
+    assert not _process_file(rec, {}, str(tmp_path), {}, DummyJ2(), workspace_root=tmp_path)

--- a/pkgs/standards/peagen/tests/unit/test__rendering.py
+++ b/pkgs/standards/peagen/tests/unit/test__rendering.py
@@ -1,0 +1,36 @@
+import random; random.seed(0xA11A)
+import types
+import pytest
+
+from peagen._rendering import _render_copy_template, _render_generate_template
+
+
+class DummyJ2:
+    def __init__(self):
+        self.template = None
+
+    def set_template(self, path):
+        self.template = str(path)
+
+    def fill(self, ctx):
+        return f"ok:{ctx['FILE']['NAME']}"
+
+
+def _dummy_record(name="f.txt"):
+    return {"FILE_NAME": name, "RENDERED_FILE_NAME": name}
+
+
+@pytest.mark.unit
+def test_render_copy(monkeypatch):
+    j2 = DummyJ2()
+    res = _render_copy_template(_dummy_record(), {"FILE": {"NAME": "x"}}, j2)
+    assert res == "ok:x"
+    assert "f.txt" in j2.template
+
+
+@pytest.mark.unit
+def test_render_generate(monkeypatch):
+    j2 = DummyJ2()
+    monkeypatch.setattr("peagen._external.call_external_agent", lambda *a, **k: "gen")
+    res = _render_generate_template(_dummy_record(), {"FILE": {"NAME": "x"}}, "t.j2", j2)
+    assert res == "gen"

--- a/pkgs/standards/peagen/tests/unit/test__source_packages.py
+++ b/pkgs/standards/peagen/tests/unit/test__source_packages.py
@@ -1,0 +1,42 @@
+import random; random.seed(0xA11A)
+import subprocess
+from pathlib import Path
+import pytest
+
+from peagen._source_packages import (
+    _dir_checksum,
+    _materialise_source_pkg,
+    materialise_packages,
+)
+
+
+@pytest.mark.unit
+def test_dir_checksum(tmp_path):
+    f = tmp_path / "a.txt"
+    f.write_text("x")
+    h = _dir_checksum(tmp_path)
+    assert len(h) == 64
+
+
+@pytest.mark.unit
+def test_materialise_local(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "f.txt").write_text("hi")
+    ws = tmp_path / "ws"
+    spec = {"type": "local", "path": str(src), "dest": "d"}
+    dest = _materialise_source_pkg(spec, ws)
+    assert (dest / "f.txt").exists()
+
+
+@pytest.mark.unit
+def test_materialise_packages(monkeypatch, tmp_path):
+    pkg = tmp_path / "src"
+    pkg.mkdir()
+    (pkg / "f.txt").write_text("hi")
+    spec = {"type": "local", "path": str(pkg), "dest": "d"}
+    ws = tmp_path / "ws"
+    res = materialise_packages([spec], ws)
+    assert (ws / "d" / "f.txt").exists()
+    lock = ws / "source_packages.lock"
+    assert lock.exists()

--- a/pkgs/standards/peagen/tests/unit/test__template_sets.py
+++ b/pkgs/standards/peagen/tests/unit/test__template_sets.py
@@ -1,0 +1,17 @@
+import random; random.seed(0xA11A)
+import subprocess
+import importlib.metadata as im
+import pytest
+
+from peagen._template_sets import install_template_sets
+
+
+@pytest.mark.unit
+def test_install_local(monkeypatch, tmp_path):
+    calls = []
+    monkeypatch.setattr(subprocess, "check_call", lambda cmd: calls.append(cmd))
+    monkeypatch.setattr(im, "version", lambda name: "1.0")
+    specs = [{"name": "pkg", "type": "local", "target": str(tmp_path)}]
+    res = install_template_sets(specs)
+    assert res[0]["name"] == "pkg"
+    assert calls

--- a/pkgs/standards/peagen/tests/unit/test_cli.py
+++ b/pkgs/standards/peagen/tests/unit/test_cli.py
@@ -1,0 +1,10 @@
+import random; random.seed(0xA11A)
+from typer.testing import CliRunner
+import pytest
+from peagen.cli import app
+
+
+@pytest.mark.unit
+def test_cli_help():
+    result = CliRunner().invoke(app, ["--help"])
+    assert result.exit_code == 0

--- a/pkgs/standards/peagen/tests/unit/test_cli_common.py
+++ b/pkgs/standards/peagen/tests/unit/test_cli_common.py
@@ -1,0 +1,19 @@
+import random; random.seed(0xA11A)
+from pathlib import Path
+import pytest
+from peagen.cli_common import PathOrURI, load_peagen_toml
+
+
+@pytest.mark.unit
+def test_path_or_uri(tmp_path):
+    p = PathOrURI(tmp_path / "a")
+    assert str(p).startswith(str(tmp_path))
+    assert PathOrURI("s3://x") == "s3://x"
+
+
+@pytest.mark.unit
+def test_load_toml(tmp_path):
+    f = tmp_path / ".peagen.toml"
+    f.write_text("[peagen]\nplugin_mode='x'")
+    res = load_peagen_toml(start_dir=tmp_path)
+    assert res["peagen"]["plugin_mode"] == "x"

--- a/pkgs/standards/peagen/tests/unit/test_core.py
+++ b/pkgs/standards/peagen/tests/unit/test_core.py
@@ -1,0 +1,14 @@
+import random; random.seed(0xA11A)
+import yaml
+import pytest
+from peagen.core import Peagen
+
+
+@pytest.mark.unit
+def test_load_projects(tmp_path):
+    f = tmp_path / "p.yml"
+    f.write_text(yaml.safe_dump({"PROJECTS": [{"NAME": "Proj"}]}))
+    pg = Peagen(projects_payload_path=str(f))
+    projects = pg.load_projects()
+    assert projects[0]["NAME"] == "Proj"
+    assert pg.slug_map["proj"] == "Proj"


### PR DESCRIPTION
## Summary
- add unit tests for remaining `peagen` modules covering CLI helpers, rendering, processing and utilities
- follow the unit-test guidelines by seeding randomness
- each module now has a matching `test_<module>.py`

## Testing
- `uv run --package peagen --directory standards/peagen pytest --cov=peagen --cov-branch --cov-report=term-missing` *(fails: No route to host)*