### PR TITLE
Add Redis integration test and nightly workflow

### DIFF
--- a/.github/workflows/integration-redis-nightly.yaml
+++ b/.github/workflows/integration-redis-nightly.yaml
@@ -1,0 +1,26 @@
+name: integration-redis-nightly
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  integration_redis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          pip install uv pytest toml
+
+      - name: Run integration redis tests
+        run: |
+          cd pkgs
+          uv run --package peagen --directory standards/peagen pytest -m integration_redis

--- a/ci/docker-redis.yml
+++ b/ci/docker-redis.yml
@@ -1,0 +1,6 @@
+version: "3.9"
+services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"

--- a/pkgs/standards/peagen/tests/integration_redis/test_evolve_step.py
+++ b/pkgs/standards/peagen/tests/integration_redis/test_evolve_step.py
@@ -1,0 +1,42 @@
+"""Integration tests for `peagen evolve step` using Redis Streams."""
+
+from __future__ import annotations
+
+import subprocess
+import time
+
+import pytest
+
+
+@pytest.fixture(scope="module", autouse=True)
+def redis_compose():
+    """Start and stop the Redis docker-compose service."""
+    subprocess.run(["docker-compose", "-f", "ci/docker-redis.yml", "up", "-d"], check=True)
+    # give redis a moment to start
+    time.sleep(2)
+    yield
+    subprocess.run(["docker-compose", "-f", "ci/docker-redis.yml", "down"], check=True)
+
+
+@pytest.mark.integration_redis
+def test_evolve_step_happy_path(tmp_path):
+    """Run warm-spawner with workers then execute `peagen evolve step`."""
+    spawner = subprocess.Popen([
+        "peagen",
+        "worker",
+        "warm-spawner",
+        "--cpu-workers",
+        "4",
+    ])
+    try:
+        subprocess.run(["peagen", "evolve", "step"], check=True)
+    finally:
+        spawner.terminate()
+        spawner.wait()
+
+    metrics = subprocess.check_output(["curl", "-s", "http://localhost:9090/metrics"]).decode()
+    assert 'worker_exit_reason{reason="success"} 5' in metrics
+
+    length = subprocess.check_output(["redis-cli", "XLEN", "peagen.tasks"]).decode().strip()
+    assert length == "0"
+


### PR DESCRIPTION
## Summary
- implement Redis integration test skeleton for `peagen evolve step`
- spin up redis via docker compose in CI
- provide nightly GitHub Actions workflow
- add docker-compose file for redis

## Testing
- `git status --short`
- `git log -1 --stat`