### PR TITLE
Update crouton template READMEs

### DIFF
--- a/pkgs/standards/peagen/peagen/templates/python_crouton_client_backend/README.md
+++ b/pkgs/standards/peagen/peagen/templates/python_crouton_client_backend/README.md
@@ -1,1 +1,51 @@
-Place holder for crouton-client compatible router/service/repository pattern
+# Python Crouton Client Backend
+
+This template scaffolds a backend service that pairs with a Crouton client. It follows the router/service/repository pattern and uses SQLAlchemy models with Pydantic schemas generated from your `projects_payload.yaml` file.
+
+## Expected Layout
+
+```
+{{ PROJ.ROOT }}/
+    {{ PKG.NAME }}/
+        Dockerfile
+        pyproject.toml
+        {{ MOD.NAME }}.py
+```
+
+Running `peagen process projects_payload.yaml` creates the package above using the modules defined in the YAML configuration.
+
+## Usage Example
+
+Create a minimal `projects_payload.yaml`:
+
+```yaml
+PROJECTS:
+  - NAME: "MyBackend"
+    ROOT: "pkgs"
+    TEMPLATE_SET: "python_crouton_client_backend"
+    PACKAGES:
+      - NAME: "my_backend"
+        MODULES:
+          - NAME: "user"
+```
+
+Then run:
+
+```bash
+peagen process projects_payload.yaml
+```
+
+A generated service might look like this:
+
+```python
+class UserService:
+    """Manage user records."""
+
+    def __init__(self, session):
+        """Initialize with an active database session."""
+        self.session = session
+
+    def get_user(self, user_id: int):
+        """Return a user by ID."""
+        ...
+```

--- a/pkgs/standards/peagen/peagen/templates/python_crouton_server/README.md
+++ b/pkgs/standards/peagen/peagen/templates/python_crouton_server/README.md
@@ -1,4 +1,53 @@
-Project Root contains docker-compose and dockerfile.
-PKG.NAME contains the pyproject.toml and dockerfile for the PKG.NAME
-MOD.NAME contains the src for the python associated with the pyproject.toml
-MOD.NAME contains the main.py, v1/main.py, and v1/utils.py
+# Python Crouton Server
+
+This template produces a lightweight API service that exposes CRUD routes for your models. The generator consumes a `projects_payload.yaml` file and renders a Docker‑ready project.
+
+## Project Structure
+
+```
+{{ PROJ.ROOT }}/
+    docker-compose.yaml
+    {{ PKG.NAME }}/
+        Dockerfile
+        pyproject.toml
+        {{ MOD.NAME }}/
+            __init__.py
+            api/
+                __init__.py
+                v1/
+                    main.py
+                    utils.py
+```
+
+`projects_payload.yaml` must define at least a project name, project root, packages and modules. Peagen fills the template using those values to create the files above.
+
+## Example `projects_payload.yaml`
+
+```yaml
+PROJECTS:
+  - NAME: "ExampleService"
+    ROOT: "example_service"
+    TEMPLATE_SET: "python_crouton_server"
+    PACKAGES:
+      - NAME: "example_pkg"
+        MODULES:
+          - NAME: "items"
+```
+
+Generate the project:
+
+```bash
+peagen process projects_payload.yaml
+```
+
+A generated entry point might resemble:
+
+```python
+"""Entry point for the API service."""
+
+from fastapi import FastAPI
+from .api.v1.main import router as v1_router
+
+app = FastAPI()
+app.include_router(v1_router)
+```


### PR DESCRIPTION
## Summary
- document `python_crouton_client_backend` template
- document `python_crouton_server` template

## Testing
- `uv run --package peagen --directory standards/peagen pytest` *(fails: No route to host)*