### PR TITLE
Fix duplicate router append

### DIFF
--- a/pkgs/standards/peagen/peagen/templates/python_crouton_server/{{ PROJ.ROOT }}/{{ PKG.NAME }}/{{ MOD.NAME }}/api/v1/utils.py.j2
+++ b/pkgs/standards/peagen/peagen/templates/python_crouton_server/{{ PROJ.ROOT }}/{{ PKG.NAME }}/{{ MOD.NAME }}/api/v1/utils.py.j2
@@ -83,8 +83,6 @@ def create_routers(
         elif router_type == RouterType.MEMORY:
             router = MemoryCRUDRouter(**common_params)  # type: ignore
         routers.append(router)
-
-        routers.append(router)
     return routers
 
 


### PR DESCRIPTION
## Summary
- remove duplicate `routers.append(router)` line in utils.py template

## Testing
- `grep -n routers.append pkgs/standards/peagen/peagen/templates/python_crouton_server/{{ PROJ.ROOT }}/{{ PKG.NAME }}/{{ MOD.NAME }}/api/v1/utils.py.j2`