### PR TITLE
Add secret-aware toml loader

### DIFF
--- a/pkgs/standards/peagen/peagen/config_loader.py
+++ b/pkgs/standards/peagen/peagen/config_loader.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+from dotenv import dotenv_values
+from jinja2 import Environment
+
 try:
     import tomllib  # Python 3.11+
 except ModuleNotFoundError:  # pragma: no cover - fallback for <3.11
@@ -14,8 +17,14 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for <3.11
 class TomlConfigLoader:
     """Load ``.peagen.toml`` files and expose their data."""
 
-    def __init__(self, path: Optional[Path] = None, start_dir: Optional[Path] = None) -> None:
+    def __init__(
+        self,
+        path: Optional[Path] = None,
+        start_dir: Optional[Path] = None,
+        env_file: Optional[Path] = None,
+    ) -> None:
         self.path = path or self._discover(start_dir or Path.cwd())
+        self.env_file = env_file
         self.config: Dict[str, Any] = {}
         if self.path:
             self.config = self._load(self.path)
@@ -28,10 +37,29 @@ class TomlConfigLoader:
         return None
 
     def _load(self, path: Path) -> Dict[str, Any]:
-        with path.open("rb") as f:
-            return tomllib.load(f)
+        text = path.read_text(encoding="utf-8")
+
+        env = Environment(autoescape=False)
+
+        env_path = self.env_file or path.with_suffix(".env")
+        values = dotenv_values(env_path) if env_path.is_file() else {}
+        secrets = self._to_nested(values)
+
+        rendered = env.from_string(text).render(secrets=secrets)
+        return tomllib.loads(rendered)
 
     def get(self, key: str, default: Any = None) -> Any:
         return self.config.get(key, default)
+
+    def _to_nested(self, values: Dict[str, str]) -> Dict[str, Any]:
+        data: Dict[str, Any] = {}
+        for k, v in values.items():
+            parts = k.split(".")
+            cur = data
+            for part in parts[:-1]:
+                cur = cur.setdefault(part, {})
+            cur[parts[-1]] = v
+        return data
+
 
 

--- a/pkgs/standards/peagen/tests/unit/test_config_loader.py
+++ b/pkgs/standards/peagen/tests/unit/test_config_loader.py
@@ -23,3 +23,30 @@ def test_discover_from_start_dir(tmp_path: Path):
     assert loader.path == cfg
     assert loader.get("x") == 1
 
+
+@pytest.mark.unit
+def test_jinja_env_secrets(tmp_path: Path):
+    env = tmp_path / ".env"
+    env.write_text("OPENAI_KEY=abc", encoding="utf-8")
+    cfg = tmp_path / ".peagen.toml"
+    cfg.write_text("llm_api_key = \"{{ secrets.OPENAI_KEY }}\"", encoding="utf-8")
+    loader = TomlConfigLoader(path=cfg)
+    assert loader.get("llm_api_key") == "abc"
+
+
+@pytest.mark.unit
+def test_nested_env_keys(tmp_path: Path):
+    env = tmp_path / ".env"
+    env.write_text("llm.api_keys.openai=xyz", encoding="utf-8")
+    cfg = tmp_path / ".peagen.toml"
+    cfg.write_text(
+        """
+        [llm.api_keys]
+        openai = "{{ secrets.llm.api_keys.openai }}"
+        """,
+        encoding="utf-8",
+    )
+    loader = TomlConfigLoader(path=cfg)
+    assert loader.get("llm")["api_keys"]["openai"] == "xyz"
+
+


### PR DESCRIPTION
## Summary
- enhance TomlConfigLoader with jinja2 rendering and dotenv secrets
- test loading of secrets and nested dotted env keys

## Testing
- `uv run --package peagen --directory standards/peagen pytest` *(fails: No route to host)*