### PR TITLE
Fix set-matrix deduplication

### DIFF
--- a/.github/workflows/v0.7.0_mono_prepare_validate.yaml
+++ b/.github/workflows/v0.7.0_mono_prepare_validate.yaml
@@ -37,6 +37,10 @@ jobs:
           members = config.get("tool", {}).get("uv", {}).get("workspace", {}).get("members", [])
           if not isinstance(members, list):
               raise Exception("The 'members' entry is not a list.")
+
+          # Remove duplicates while preserving order
+          members = list(dict.fromkeys(members))
+
           # Build a matrix with one entry per member
           matrix = {"include": [{"member": member} for member in members]}
           print(f"Matrix: {json.dumps(matrix)}")


### PR DESCRIPTION
## Summary
- deduplicate workspace members when generating the matrix in **v0.7.0_mono_prepare_validate.yaml**

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a0b81b5308326a53850adf562f9fa