### PR TITLE
Add Peagen task model dataclasses and schemas

### DIFF
--- a/pkgs/standards/peagen/README.md
+++ b/pkgs/standards/peagen/README.md
@@ -414,3 +414,10 @@ pea.process_all_projects()
 * **Template Conventions:** Place new Jinja2 files under your `TEMPLATE_BASE_DIR` as `*.j2`, using the same context variables (`projects`, `packages`, `modules`) that core templates rely on.
 * **Adding New Commands:** Define a new subcommand in `cli.py`, wire it into the parser, instantiate `Peagen`, and call core methods.
 * **Submitting Pull Requests:** Fork the repo, add/update templates under `peagen/templates/`, update docs/README, and open a PR tagging maintainers.
+
+### Task & Result Dataclasses
+
+Peagen exposes the canonical queue messages via `peagen.task_model.Task` and
+`peagen.task_model.Result` (TaskResult). Draft-07 JSON Schemas for these
+structures live in `peagen/schemas/` for validation and integration with other
+tools.

--- a/pkgs/standards/peagen/peagen/schemas/__init__.py
+++ b/pkgs/standards/peagen/peagen/schemas/__init__.py
@@ -67,6 +67,14 @@ EVAL_MANIFEST_V1_SCHEMA = json.loads(
     .read_text(encoding="utf-8")
 )
 
+TASK_V1_SCHEMA = json.loads(
+    res.files(__package__).joinpath("task.schema.v1.json").read_text(encoding="utf-8")
+)
+
+RESULT_V1_SCHEMA = json.loads(
+    res.files(__package__).joinpath("result.schema.v1.json").read_text(encoding="utf-8")
+)
+
 # ── EXTRAS schemas ─────────────────────────────────────────────
 _extras_pkg = res.files(__package__).joinpath("extras")
 EXTRAS_SCHEMAS = {
@@ -87,5 +95,7 @@ __all__ = [
     "PROJECTS_PAYLOAD_V1_SCHEMA",
     "EVENT_V1_SCHEMA",
     "EVAL_MANIFEST_V1_SCHEMA",
+    "TASK_V1_SCHEMA",
+    "RESULT_V1_SCHEMA",
     "EXTRAS_SCHEMAS",
 ]

--- a/pkgs/standards/peagen/peagen/schemas/result.schema.v1.json
+++ b/pkgs/standards/peagen/peagen/schemas/result.schema.v1.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Peagen Result",
+  "type": "object",
+  "required": ["task_id", "status", "data", "created_at", "attempts"],
+  "properties": {
+    "task_id": {"type": "string"},
+    "status": {"type": "string", "enum": ["ok", "error", "skip"]},
+    "data": {"type": "object"},
+    "created_at": {"type": "string", "format": "date-time"},
+    "attempts": {"type": "integer", "minimum": 1}
+  }
+}

--- a/pkgs/standards/peagen/peagen/schemas/task.schema.v1.json
+++ b/pkgs/standards/peagen/peagen/schemas/task.schema.v1.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Peagen Task",
+  "type": "object",
+  "required": ["kind", "id", "payload", "requires", "attempts", "created_at", "schema_v"],
+  "properties": {
+    "kind": {"type": "string", "enum": ["render", "mutate", "execute", "evaluate"]},
+    "id": {"type": "string", "pattern": "^[0-9a-f]{16,}$"},
+    "payload": {"type": "object"},
+    "requires": {"type": "array", "items": {"type": "string"}},
+    "attempts": {"type": "integer", "minimum": 0},
+    "created_at": {"type": "string", "format": "date-time"},
+    "schema_v": {"type": "integer", "minimum": 1}
+  }
+}

--- a/pkgs/standards/peagen/peagen/task_model.py
+++ b/pkgs/standards/peagen/peagen/task_model.py
@@ -1,0 +1,45 @@
+"""Task and Result dataclasses for the Peagen queue fabric."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Literal, Set
+from datetime import datetime, timezone
+
+import msgspec
+
+
+def ts_utc() -> str:
+    """Return current UTC time in ISO-8601 format."""
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+class TaskKind(str, Enum):
+    """Enumeration of task types."""
+
+    RENDER = "render"
+    MUTATE = "mutate"
+    EXECUTE = "execute"
+    EVALUATE = "evaluate"
+
+
+class Task(msgspec.Struct, frozen=True):
+    """Canonical task message."""
+
+    kind: TaskKind
+    id: str
+    payload: dict[str, Any]
+    requires: Set[str] = msgspec.field(default_factory=set)
+    attempts: int = 0
+    created_at: str = msgspec.field(default_factory=ts_utc)
+    schema_v: int = 1
+
+
+class Result(msgspec.Struct, frozen=True):
+    """Result produced by a task handler."""
+
+    task_id: str
+    status: Literal["ok", "error", "skip"]
+    data: dict[str, Any]
+    created_at: str = msgspec.field(default_factory=ts_utc)
+    attempts: int = 1

--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "h11>=0.16.0",
     "httpx>=0.27.0",
     "jsonschema>=4.18.5",
+    "msgspec>=0.18",
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",

--- a/pkgs/standards/peagen/tests/unit/test_task_model.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_model.py
@@ -1,0 +1,36 @@
+import msgspec
+import jsonschema
+import pytest
+
+from peagen.task_model import Task, Result, TaskKind
+from peagen.schemas import TASK_V1_SCHEMA, RESULT_V1_SCHEMA
+
+
+@pytest.mark.unit
+def test_task_roundtrip_and_schema():
+    task = Task(kind=TaskKind.RENDER, id="a1b2c3d4e5f6a7b8", payload={"x": 1})
+    data_json = msgspec.json.encode(task)
+    task2 = msgspec.json.decode(data_json, type=Task)
+    assert task == task2
+
+    data_mp = msgspec.msgpack.encode(task)
+    task3 = msgspec.msgpack.decode(data_mp, type=Task)
+    assert task == task3
+
+    obj = msgspec.json.decode(data_json)
+    jsonschema.validate(obj, TASK_V1_SCHEMA)
+
+
+@pytest.mark.unit
+def test_result_roundtrip_and_schema():
+    result = Result(task_id="abc", status="ok", data={"score": 5})
+    js = msgspec.json.encode(result)
+    result2 = msgspec.json.decode(js, type=Result)
+    assert result == result2
+
+    mp = msgspec.msgpack.encode(result)
+    result3 = msgspec.msgpack.decode(mp, type=Result)
+    assert result == result3
+
+    obj = msgspec.json.decode(js)
+    jsonschema.validate(obj, RESULT_V1_SCHEMA)


### PR DESCRIPTION
## Summary
- implement `task_model.py` with `Task` & `Result` dataclasses
- create Draft-07 JSON Schemas for Task and Result
- expose new schemas via `peagen.schemas`
- add unit tests covering round-trip serialization and schema validation
- document the new dataclasses and schemas in the README
- include msgspec as dependency
- clarify that `Result` is the TaskResult in docs

## Testing
- `uv run --package peagen --directory standards/peagen pytest` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683a0c88ea1c83269954dba2af6289dd