### PR TITLE
Add HTTPLoadedTool package

### DIFF
--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -44,6 +44,7 @@ members = [
     "standards/swarmauri_tool_containerfeedchars",
     "standards/swarmauri_tool_containernewsession",
     "standards/swarmauri_tool_containermakepr",
+    "standards/swarmauri_tool_httploaded",
     "standards/swarmauri_parser_keywordextractor",
     "standards/swarmauri_parser_beautifulsoupelement",
     "standards/swarmauri_evaluator_abstractmethods",
@@ -217,6 +218,7 @@ swarmauri_tool_searchword = { workspace = true }
 swarmauri_tool_containernewsession = { workspace = true }
 swarmauri_tool_containerfeedchars = { workspace = true }
 swarmauri_tool_containermakepr = { workspace = true }
+swarmauri_tool_httploaded = { workspace = true }
 swarmauri_toolkit_containertoolkit = { workspace = true }
 swarmauri_workflow_statedriven = { workspace = true }
 

--- a/pkgs/standards/swarmauri_tool_httploaded/LICENSE
+++ b/pkgs/standards/swarmauri_tool_httploaded/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/standards/swarmauri_tool_httploaded/README.md
+++ b/pkgs/standards/swarmauri_tool_httploaded/README.md
@@ -1,0 +1,20 @@
+![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_tool_httploaded/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_tool_httploaded" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_tool_httploaded/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_tool_httploaded.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_tool_httploaded/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_tool_httploaded" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_tool_httploaded/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_tool_httploaded" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_tool_httploaded/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_tool_httploaded?label=swarmauri_tool_httploaded&color=green" alt="PyPI - swarmauri_tool_httploaded"/></a>
+</p>
+
+---
+
+# Swarmauri Tool HTTPLoaded
+
+Load components from a remote YAML manifest at instantiation time.

--- a/pkgs/standards/swarmauri_tool_httploaded/pyproject.toml
+++ b/pkgs/standards/swarmauri_tool_httploaded/pyproject.toml
@@ -1,0 +1,68 @@
+[project]
+name = "swarmauri_tool_httploaded"
+version = "0.7.6.dev3"
+description = "Load components from a YAML manifest over HTTP."
+license = "Apache-2.0"
+readme = "README.md"
+repository = "http://github.com/swarmauri/swarmauri-sdk"
+requires-python = ">=3.10,<3.13"
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
+dependencies = [
+    "swarmauri_core",
+    "swarmauri_base",
+    "swarmauri_standard",
+    "httpx>=0.27.0",
+    "pyyaml>=6.0",
+]
+
+[tool.uv.sources]
+swarmauri_core = { workspace = true }
+swarmauri_base = { workspace = true }
+swarmauri_standard = { workspace = true }
+
+[tool.pytest.ini_options]
+norecursedirs = ["combined", "scripts"]
+markers = [
+    "test: standard test",
+    "unit: Unit tests",
+    "i9n: Integration tests",
+    "r8n: Regression tests",
+    "timeout: mark test to timeout after X seconds",
+    "xpass: Expected passes",
+    "xfail: Expected failures",
+    "acceptance: Acceptance tests",
+    "perf: Performance tests that measure execution time and resource usage",
+]
+timeout = 300
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
+
+[project.entry-points.'swarmauri.tools']
+HTTPLoadedTool = "swarmauri_tool_httploaded:HTTPLoadedTool"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "python-dotenv",
+    "requests>=2.32.3",
+    "flake8>=7.0",
+    "pytest-timeout>=2.3.1",
+    "ruff>=0.9.9",
+    "pytest-benchmark>=4.0.0",
+]

--- a/pkgs/standards/swarmauri_tool_httploaded/swarmauri_tool_httploaded/HTTPLoadedTool.py
+++ b/pkgs/standards/swarmauri_tool_httploaded/swarmauri_tool_httploaded/HTTPLoadedTool.py
@@ -1,0 +1,72 @@
+import httpx
+import yaml
+from typing import Dict, List, Optional, Any, Literal
+from pydantic import Field, PrivateAttr
+
+from swarmauri_standard.tools.Parameter import Parameter
+from swarmauri_base.tools.ToolBase import ToolBase
+from swarmauri_base.ComponentBase import ComponentBase
+
+
+@ComponentBase.register_type(ToolBase, "HTTPLoadedTool")
+class HTTPLoadedTool(ToolBase):
+    """Load components from a remote YAML manifest when instantiated."""
+
+    name: str = "HTTPLoadedTool"
+    description: str = "Load components from a remote YAML manifest"
+    type: Literal["HTTPLoadedTool"] = "HTTPLoadedTool"
+    parameters: List[Parameter] = Field(default_factory=list)
+
+    url: str
+    headers: Optional[Dict[str, str]] = None
+    use_cache: bool = True
+
+    _cache: Dict[str, str] = PrivateAttr(default_factory=dict)
+    _manifest: Dict[str, Any] = PrivateAttr(default_factory=dict)
+
+    def __init__(self, url: str, headers: Optional[Dict[str, str]] = None, use_cache: bool = True, **data: Any) -> None:
+        super().__init__(url=url, headers=headers, use_cache=use_cache, **data)
+        self.url = url
+        self.headers = headers
+        self.use_cache = use_cache
+        self._load_manifest()
+
+    def _load_manifest(self) -> None:
+        if self.use_cache and self.url in self._cache:
+            yaml_text = self._cache[self.url]
+        else:
+            response = httpx.get(self.url, headers=self.headers)
+            response.raise_for_status()
+            yaml_text = response.text
+            if self.use_cache:
+                self._cache[self.url] = yaml_text
+
+        try:
+            manifest = yaml.safe_load(yaml_text) or {}
+        except yaml.YAMLError as exc:  # pragma: no cover - invalid YAML
+            raise ValueError(f"Invalid YAML manifest: {exc}") from exc
+
+        self._manifest = manifest if isinstance(manifest, dict) else {}
+        self.name = self._manifest.get("name", self.name)
+        self.description = self._manifest.get("description", self.description)
+
+        params_data = self._manifest.get("parameters") or []
+        if isinstance(params_data, list):
+            self.parameters = [
+                Parameter.model_validate_yaml(yaml.dump(p)) if not isinstance(p, Parameter) else p
+                for p in params_data
+                if isinstance(p, (dict, Parameter))
+            ]
+
+    def __call__(self) -> List[ComponentBase]:
+        components_data = self._manifest.get("components", [])
+        if not isinstance(components_data, list):
+            components_data = [components_data]
+
+        loaded_components: List[ComponentBase] = []
+        for entry in components_data:
+            if not isinstance(entry, dict):
+                raise ValueError("Each component entry must be a mapping")
+            comp_yaml = yaml.dump(entry)
+            loaded_components.append(ComponentBase.model_validate_yaml(comp_yaml))
+        return loaded_components

--- a/pkgs/standards/swarmauri_tool_httploaded/swarmauri_tool_httploaded/__init__.py
+++ b/pkgs/standards/swarmauri_tool_httploaded/swarmauri_tool_httploaded/__init__.py
@@ -1,0 +1,13 @@
+from .HTTPLoadedTool import HTTPLoadedTool
+
+__all__ = ["HTTPLoadedTool"]
+
+try:
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError:  # pragma: no cover
+    from importlib_metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("swarmauri_tool_httploaded")
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "0.0.0"

--- a/pkgs/standards/swarmauri_tool_httploaded/tests/unit/test_HTTPLoadedTool.py
+++ b/pkgs/standards/swarmauri_tool_httploaded/tests/unit/test_HTTPLoadedTool.py
@@ -1,0 +1,75 @@
+from unittest.mock import patch, MagicMock
+import pytest
+
+from swarmauri_tool_httploaded import HTTPLoadedTool as Tool
+
+
+MANIFEST = """
+name: Example HTTP Tool
+description: Example description
+parameters:
+  - name: p1
+    input_type: string
+    description: Param 1
+    required: true
+components:
+  - type: CalculatorTool
+"""
+
+
+@pytest.mark.unit
+def test_ubc_resource():
+    with patch("httpx.get") as mock_get:
+        mock_resp = MagicMock(text=MANIFEST)
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+        tool = Tool(url="http://example.com")
+        assert tool.resource == "Tool"
+
+
+@pytest.mark.unit
+def test_ubc_type():
+    with patch("httpx.get") as mock_get:
+        mock_resp = MagicMock(text=MANIFEST)
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+        assert Tool(url="http://example.com").type == "HTTPLoadedTool"
+
+
+@pytest.mark.unit
+def test_initialization():
+    with patch("httpx.get") as mock_get:
+        mock_resp = MagicMock(text=MANIFEST)
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+        tool = Tool(url="http://example.com")
+        assert tool.name == "Example HTTP Tool"
+        assert tool.description == "Example description"
+        assert len(tool.parameters) == 1
+        assert tool.parameters[0].name == "p1"
+
+
+@pytest.mark.unit
+def test_serialization():
+    with patch("httpx.get") as mock_get:
+        mock_resp = MagicMock(text=MANIFEST)
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+        tool = Tool(url="http://example.com")
+        copy = Tool.model_validate_json(tool.model_dump_json())
+        assert copy.url == tool.url
+        assert copy.name == tool.name
+
+
+@pytest.mark.unit
+def test_call():
+    with patch("httpx.get") as mock_get:
+        mock_resp = MagicMock(text=MANIFEST)
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+        tool = Tool(url="http://example.com")
+        result = tool()
+        assert len(result) == 1
+        assert result[0].type == "CalculatorTool"
+        mock_get.assert_called_with("http://example.com", headers=None)
+


### PR DESCRIPTION
## Summary
- move `HTTPLoadedTool` into its own standards package
- populate metadata from remote YAML during initialization
- add unit tests for the new package
- register `swarmauri_tool_httploaded` in workspace

## Testing
- `uv run --package swarmauri_tool_httploaded --directory standards/swarmauri_tool_httploaded pytest` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_e_6839d1def28483269a5fe7ea8987ef5a