### PR TITLE
Add task queue and result backend framework

### DIFF
--- a/pkgs/standards/peagen/peagen/plugin_registry.py
+++ b/pkgs/standards/peagen/peagen/plugin_registry.py
@@ -13,6 +13,7 @@ GROUPS = {
     "template_sets": ("peagen.template_sets", None),
     "storage_adapters": ("peagen.storage_adapters", object),
     "publishers": ("peagen.publishers", object),
+    "task_queues": ("peagen.task_queues", object),
     "indexers": ("peagen.indexers", object),
     "result_backends": ("peagen.result_backends", object),
     "evaluators": ("peagen.evaluators", object),

--- a/pkgs/standards/peagen/peagen/queue/__init__.py
+++ b/pkgs/standards/peagen/peagen/queue/__init__.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from peagen.plugin_registry import registry
+from .base import TaskQueue
+
+
+def make_queue(provider: str, **kwargs) -> TaskQueue:
+    try:
+        cls = registry["task_queues"][provider]
+    except KeyError:
+        raise ValueError(f"No TaskQueue registered for provider '{provider}'")
+    return cls(**kwargs)
+
+
+def __getattr__(name: str):
+    if name == "TaskQueue":
+        return TaskQueue
+    raise AttributeError(name)

--- a/pkgs/standards/peagen/peagen/queue/base.py
+++ b/pkgs/standards/peagen/peagen/queue/base.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Protocol
+from swarmauri_core.ComponentBase import ComponentBase
+
+from .model import Task, Result
+
+
+class TaskQueue(ComponentBase, Protocol):
+    def enqueue(self, task: Task) -> None:
+        ...
+
+    def pop(self, block: bool = True, timeout: int = 1) -> Task | None:
+        ...
+
+    def ack(self, task_id: str) -> None:
+        ...
+
+    def push_result(self, result: Result) -> None:
+        ...
+
+    def wait_for_result(self, task_id: str, timeout: int) -> Result | None:
+        ...
+
+    def requeue_orphans(self, idle_ms: int, max_batch: int) -> int:
+        ...

--- a/pkgs/standards/peagen/peagen/queue/model.py
+++ b/pkgs/standards/peagen/peagen/queue/model.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from enum import Enum
+from typing import Any, Literal, Set
+import time
+
+
+def ts_utc() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+class TaskKind(str, Enum):
+    RENDER = "render"
+    MUTATE = "mutate"
+    EXECUTE = "execute"
+    EVALUATE = "evaluate"
+
+
+@dataclass(slots=True)
+class Task:
+    kind: TaskKind
+    id: str
+    payload: dict[str, Any]
+    requires: Set[str] = field(default_factory=set)
+    attempts: int = 0
+    created_at: str = field(default_factory=ts_utc)
+    schema_v: int = 1
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class Result:
+    task_id: str
+    status: Literal["ok", "error", "skip"]
+    data: dict[str, Any]
+    created_at: str = field(default_factory=ts_utc)
+    attempts: int = 1
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)

--- a/pkgs/standards/peagen/peagen/queue/redis_stream_queue.py
+++ b/pkgs/standards/peagen/peagen/queue/redis_stream_queue.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+import uuid
+from typing import Dict
+
+import redis
+
+from .base import TaskQueue
+from .model import Task, Result
+
+
+class RedisStreamQueue(TaskQueue):
+    STREAM_TASKS = "peagen.tasks"
+    STREAM_RESULTS = "peagen.results"
+    STREAM_DEAD = "peagen.dead"
+
+    def __init__(self, url: str, *, group: str = "peagen", idle_ms: int = 60000, max_retry: int = 3) -> None:
+        self._r = redis.Redis.from_url(url, decode_responses=True)
+        self.group = group
+        self.consumer = os.environ.get("HOSTNAME", "consumer-" + uuid.uuid4().hex[:6])
+        self.idle_ms = idle_ms
+        self.max_retry = max_retry
+        self._msg_map: Dict[str, str] = {}
+        self._ensure_streams()
+
+    def _ensure_streams(self) -> None:
+        try:
+            self._r.xgroup_create(self.STREAM_TASKS, self.group, id="0-0", mkstream=True)
+        except redis.exceptions.ResponseError as e:
+            if "BUSYGROUP" not in str(e):
+                raise
+        self._r.expire(self.STREAM_TASKS, 14 * 24 * 3600)
+        self._r.expire(self.STREAM_RESULTS, 14 * 24 * 3600)
+        self._r.expire(self.STREAM_DEAD, 30 * 24 * 3600)
+
+    # ------------------------------------------------------------------ producer
+    def enqueue(self, task: Task) -> None:
+        data = json.dumps(task.to_dict())
+        msg_id = self._r.xadd(self.STREAM_TASKS, {"data": data}, maxlen=10_000_000)
+        self._msg_map[task.id] = msg_id
+
+    # ------------------------------------------------------------------ consumer
+    def pop(self, block: bool = True, timeout: int = 1) -> Task | None:
+        res = self._r.xreadgroup(
+            self.group,
+            self.consumer,
+            {self.STREAM_TASKS: ">"},
+            count=1,
+            block=timeout * 1000 if block else 0,
+        )
+        if not res:
+            return None
+        _, messages = res[0]
+        msg_id, fields = messages[0]
+        data = json.loads(fields["data"])
+        task = Task(**data)
+        self._msg_map[task.id] = msg_id
+        return task
+
+    def ack(self, task_id: str) -> None:
+        msg_id = self._msg_map.pop(task_id, None)
+        if msg_id:
+            self._r.xack(self.STREAM_TASKS, self.group, msg_id)
+            self._r.xdel(self.STREAM_TASKS, msg_id)
+
+    # ------------------------------------------------------------------ admin
+    def push_result(self, result: Result) -> None:
+        data = json.dumps(result.to_dict())
+        self._r.xadd(self.STREAM_RESULTS, {"data": data}, maxlen=10_000_000)
+
+    def wait_for_result(self, task_id: str, timeout: int) -> Result | None:
+        end = time.time() + timeout
+        last_id = "0-0"
+        while time.time() < end:
+            res = self._r.xread({self.STREAM_RESULTS: last_id}, block=1000, count=1)
+            if not res:
+                continue
+            _, messages = res[0]
+            msg_id, fields = messages[0]
+            last_id = msg_id
+            data = json.loads(fields["data"])
+            if data["task_id"] == task_id:
+                return Result(**data)
+        return None
+
+    def requeue_orphans(self, idle_ms: int = 60000, max_batch: int = 50) -> int:
+        moved = 0
+        start = "0-0"
+        while moved < max_batch:
+            msg_id, msgs = self._r.xautoclaim(
+                self.STREAM_TASKS,
+                self.group,
+                self.consumer,
+                min_idle_time=idle_ms,
+                start_id=start,
+                count=max_batch - moved,
+            )
+            if not msgs:
+                break
+            for mid, fields in msgs:
+                data = json.loads(fields["data"])
+                task = Task(**data)
+                task.attempts += 1
+                if task.attempts > self.max_retry:
+                    self._r.xadd(self.STREAM_DEAD, {"data": json.dumps(task.to_dict())})
+                    self._r.xack(self.STREAM_TASKS, self.group, mid)
+                    self._r.xdel(self.STREAM_TASKS, mid)
+                else:
+                    self._r.xadd(self.STREAM_TASKS, {"data": json.dumps(task.to_dict())})
+                    self._r.xack(self.STREAM_TASKS, self.group, mid)
+                    self._r.xdel(self.STREAM_TASKS, mid)
+                moved += 1
+            start = msg_id
+            if msg_id == "0-0":
+                break
+        return moved

--- a/pkgs/standards/peagen/peagen/queue/stub_queue.py
+++ b/pkgs/standards/peagen/peagen/queue/stub_queue.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from collections import deque
+from typing import Deque, Dict, Tuple
+import time
+import threading
+
+from .base import TaskQueue
+from .model import Task, Result
+
+
+class StubQueue(TaskQueue):
+    """In-memory queue used for development and CI."""
+
+    def __init__(self) -> None:
+        self._todo: Deque[Task] = deque()
+        self._inflight: Dict[str, Tuple[Task, float]] = {}
+        self._done: Dict[str, Result] = {}
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------ producer
+    def enqueue(self, task: Task) -> None:
+        with self._lock:
+            self._todo.append(task)
+
+    # ------------------------------------------------------------------ consumer
+    def pop(self, block: bool = True, timeout: int = 1) -> Task | None:
+        end = time.time() + timeout if block else 0
+        while True:
+            with self._lock:
+                if self._todo:
+                    task = self._todo.popleft()
+                    self._inflight[task.id] = (task, time.time() * 1000)
+                    return task
+            if not block or time.time() >= end:
+                return None
+            time.sleep(0.01)
+
+    def ack(self, task_id: str) -> None:
+        with self._lock:
+            self._inflight.pop(task_id, None)
+
+    # ------------------------------------------------------------------ admin
+    def push_result(self, result: Result) -> None:
+        with self._lock:
+            self._done[result.task_id] = result
+
+    def wait_for_result(self, task_id: str, timeout: int) -> Result | None:
+        end = time.time() + timeout
+        while True:
+            with self._lock:
+                res = self._done.get(task_id)
+                if res:
+                    return res
+            if time.time() >= end:
+                return None
+            time.sleep(0.05)
+
+    def requeue_orphans(self, idle_ms: int = 60000, max_batch: int = 50) -> int:
+        now = time.time() * 1000
+        moved = 0
+        with self._lock:
+            for tid, (task, ts) in list(self._inflight.items()):
+                if now - ts > idle_ms and moved < max_batch:
+                    self._todo.appendleft(task)
+                    del self._inflight[tid]
+                    moved += 1
+        return moved

--- a/pkgs/standards/peagen/peagen/result_backends/__init__.py
+++ b/pkgs/standards/peagen/peagen/result_backends/__init__.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from peagen.plugin_registry import registry
+from .base import ResultBackend
+
+
+def make_backend(provider: str, **kwargs) -> ResultBackend:
+    try:
+        cls = registry["result_backends"][provider]
+    except KeyError:
+        raise ValueError(
+            f"No ResultBackend registered for provider '{provider}'"
+        )
+    return cls(**kwargs)
+
+
+def __getattr__(name: str):
+    if name == "ResultBackend":
+        return ResultBackend
+    raise AttributeError(name)

--- a/pkgs/standards/peagen/peagen/result_backends/base.py
+++ b/pkgs/standards/peagen/peagen/result_backends/base.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import Protocol, Iterable
+from swarmauri_core.ComponentBase import ComponentBase
+
+from peagen.queue.model import Result, TaskKind
+
+
+class ResultBackend(ComponentBase, Protocol):
+    def save(self, result: Result) -> None:
+        ...
+
+    def get(self, task_id: str) -> Result | None:
+        ...
+
+    def iter(self, kind: TaskKind | None = None) -> Iterable[Result]:
+        ...

--- a/pkgs/standards/peagen/peagen/result_backends/fs_backend.py
+++ b/pkgs/standards/peagen/peagen/result_backends/fs_backend.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict
+from pathlib import Path
+from typing import Iterable
+
+from .base import ResultBackend
+from peagen.queue.model import Result, TaskKind
+
+
+class FSBackend(ResultBackend):
+    """Filesystem-backed result store."""
+
+    def __init__(self, root: str = ".peagen/results", compress: bool = False) -> None:
+        self._root = Path(root).expanduser().resolve()
+        self._root.mkdir(parents=True, exist_ok=True)
+        self.compress = compress
+
+    def _path(self, result: Result) -> Path:
+        date = result.created_at.split("T")[0]
+        folder = self._root / date
+        folder.mkdir(parents=True, exist_ok=True)
+        fname = f"{result.task_id}.msgpack"
+        return folder / fname
+
+    def save(self, result: Result) -> None:
+        path = self._path(result)
+        tmp = path.with_suffix(".tmp")
+        data = json.dumps(asdict(result))
+        tmp.write_text(data, encoding="utf-8")
+        os.replace(tmp, path)
+
+    def get(self, task_id: str) -> Result | None:
+        for day in self._root.iterdir():
+            file = day / f"{task_id}.msgpack"
+            if file.exists():
+                data = json.loads(file.read_text("utf-8"))
+                return Result(**data)
+        return None
+
+    def iter(self, kind: TaskKind | None = None) -> Iterable[Result]:
+        for day in sorted(self._root.iterdir()):
+            for file in day.glob("*.msgpack"):
+                data = json.loads(file.read_text("utf-8"))
+                res = Result(**data)
+                if kind is None or data.get("kind") == kind:
+                    yield res

--- a/pkgs/standards/peagen/peagen/result_backends/postgres_backend.py
+++ b/pkgs/standards/peagen/peagen/result_backends/postgres_backend.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from .base import ResultBackend
+from peagen.queue.model import Result, TaskKind
+
+
+class PostgresBackend(ResultBackend):
+    """Placeholder for a Postgres JSONB backend."""
+
+    def __init__(self, dsn: str) -> None:  # pragma: no cover - sketch
+        self.dsn = dsn
+
+    def save(self, result: Result) -> None:  # pragma: no cover - sketch
+        raise NotImplementedError
+
+    def get(self, task_id: str) -> Result | None:  # pragma: no cover - sketch
+        raise NotImplementedError
+
+    def iter(self, kind: TaskKind | None = None):  # pragma: no cover - sketch
+        raise NotImplementedError

--- a/pkgs/standards/peagen/peagen/result_backends/s3_backend.py
+++ b/pkgs/standards/peagen/peagen/result_backends/s3_backend.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from .base import ResultBackend
+from peagen.queue.model import Result, TaskKind
+
+
+class S3Backend(ResultBackend):
+    """Placeholder for an S3/MinIO backend."""
+
+    def __init__(self, bucket: str) -> None:  # pragma: no cover - sketch
+        self.bucket = bucket
+
+    def save(self, result: Result) -> None:  # pragma: no cover - sketch
+        raise NotImplementedError
+
+    def get(self, task_id: str) -> Result | None:  # pragma: no cover - sketch
+        raise NotImplementedError
+
+    def iter(self, kind: TaskKind | None = None):  # pragma: no cover - sketch
+        raise NotImplementedError

--- a/pkgs/standards/peagen/peagen/scaffold/project/.peagen.toml.j2
+++ b/pkgs/standards/peagen/peagen/scaffold/project/.peagen.toml.j2
@@ -49,3 +49,11 @@ username    = "guest"
 password    = "guest"
 exchange    = ""
 routing_key = "peagen.events"
+
+# ───────────────────────────── Task Queue ─────────────────────────────
+[task_queue]
+provider = "stub"
+
+# ─────────────────────────── Result Backend ───────────────────────────
+[result_backend]
+provider = "fs"

--- a/pkgs/standards/peagen/peagen/schemas/peagen.toml.schema.v1.1.0.json
+++ b/pkgs/standards/peagen/peagen/schemas/peagen.toml.schema.v1.1.0.json
@@ -72,6 +72,29 @@
       "additionalProperties": false
     },
 
+    "task_queue": {
+      "type": "object",
+      "properties": {
+        "provider": { "type": "string" },
+        "url": { "type": "string" },
+        "idle_ms": { "type": "integer" },
+        "max_retry": { "type": "integer" }
+      },
+      "required": [ "provider" ],
+      "additionalProperties": false
+    },
+
+    "result_backend": {
+      "type": "object",
+      "properties": {
+        "provider": { "type": "string" },
+        "root": { "type": "string" },
+        "compress": { "type": "boolean" }
+      },
+      "required": [ "provider" ],
+      "additionalProperties": false
+    },
+
     "plugins": {
       "type": "object",
       "properties": {
@@ -127,6 +150,6 @@
     }
   },
 
-  "required": [ "schemaVersion", "workspace", "llm", "storage", "publishers" ],
+  "required": [ "schemaVersion", "workspace", "llm", "storage", "publishers", "task_queue", "result_backend" ],
   "additionalProperties": false
 }

--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -110,5 +110,14 @@ redis   = "peagen.publishers.redis_publisher:RedisPublisher"
 webhook = "peagen.publishers.webhook_publisher:WebhookPublisher"
 rabbitmq = "peagen.publishers.rabbitmq_publisher:RabbitMQPublisher"
 
+[project.entry-points."peagen.task_queues"]
+stub  = "peagen.queue.stub_queue:StubQueue"
+redis = "peagen.queue.redis_stream_queue:RedisStreamQueue"
+
+[project.entry-points."peagen.result_backends"]
+fs       = "peagen.result_backends.fs_backend:FSBackend"
+postgres = "peagen.result_backends.postgres_backend:PostgresBackend"
+s3       = "peagen.result_backends.s3_backend:S3Backend"
+
 [tool.setuptools.package-data]
 "peagen.schemas" = ["*.json", "extras/*.json"]

--- a/pkgs/standards/peagen/tests/examples/peagen_tomls/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/peagen_tomls/.peagen.toml
@@ -38,6 +38,14 @@ port     = 6379
 db       = 0
 password = "..."                   # leave blank if no auth
 
+# ───────────────────────────── Task Queue ─────────────────────────────
+[task_queue]
+provider = "stub"
+
+# ─────────────────────────── Result Backend ───────────────────────────
+[result_backend]
+provider = "fs"
+
 # ─────────────────────────────── Plugins ───────────────────────────────
 [plugins]
 mode = "switch"

--- a/pkgs/standards/peagen/tests/unit/test_result_backend.py
+++ b/pkgs/standards/peagen/tests/unit/test_result_backend.py
@@ -1,0 +1,11 @@
+from peagen.result_backends.fs_backend import FSBackend
+from peagen.queue.model import Result
+
+
+def test_fsbackend_persist(tmp_path):
+    backend = FSBackend(root=tmp_path)
+    res = Result(task_id="42", status="ok", data={})
+    backend.save(res)
+    got = backend.get("42")
+    assert got is not None
+    assert got.task_id == "42"

--- a/pkgs/standards/peagen/tests/unit/test_task_queue.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_queue.py
@@ -1,0 +1,91 @@
+import time
+from peagen.queue.stub_queue import StubQueue
+from peagen.queue.redis_stream_queue import RedisStreamQueue
+from peagen.queue.model import Task, TaskKind, Result
+
+
+class FakeRedis:
+    def __init__(self):
+        self.streams = {"peagen.tasks": [], "peagen.results": [], "peagen.dead": []}
+        self.groups = {}
+
+    def xgroup_create(self, stream, groupname, id="0-0", mkstream=True):
+        self.groups[groupname] = []
+
+    def expire(self, *a, **k):
+        pass
+
+    def xadd(self, stream, fields, maxlen=None):
+        msg_id = str(len(self.streams[stream]) + 1)
+        self.streams[stream].append((msg_id, fields))
+        return msg_id
+
+    def xreadgroup(self, groupname, consumername, streams, count=1, block=0):
+        items = self.streams["peagen.tasks"]
+        if not items:
+            return None
+        msg = items.pop(0)
+        self.groups[groupname].append(msg)
+        return [("peagen.tasks", [msg])]
+
+    def xack(self, stream, group, msg_id):
+        self.groups[group] = [m for m in self.groups[group] if m[0] != msg_id]
+
+    def xdel(self, stream, msg_id):
+        pass
+
+    def xadd_result(self, stream, fields):
+        self.streams[stream].append((str(len(self.streams[stream])+1), fields))
+
+    def xread(self, streams, block=0, count=1):
+        stream = list(streams.keys())[0]
+        last = streams[stream]
+        data = [m for m in self.streams[stream] if m[0] > last]
+        if data:
+            return [(stream, [data[0]])]
+        time.sleep(0.01)
+        return None
+
+    def xautoclaim(self, stream, group, consumer, min_idle_time, start_id="0-0", count=1):
+        pel = self.groups.get(group, [])
+        if not pel:
+            return ("0-0", [])
+        msg = pel.pop(0)
+        return (msg[0], [msg])
+
+
+def test_stubqueue_flow():
+    q = StubQueue()
+    task = Task(TaskKind.MUTATE, "1", {})
+    q.enqueue(task)
+    got = q.pop(block=False)
+    assert got.id == "1"
+    res = Result(task_id="1", status="ok", data={})
+    q.ack("1")
+    q.push_result(res)
+    assert q.wait_for_result("1", 1) == res
+
+
+def test_stubqueue_requeue():
+    q = StubQueue()
+    task = Task(TaskKind.MUTATE, "1", {})
+    q.enqueue(task)
+    _ = q.pop(block=False)
+    time.sleep(0.01)
+    moved = q.requeue_orphans(idle_ms=0, max_batch=10)
+    assert moved == 1
+    assert q.pop(block=False).id == "1"
+
+
+def test_redisqueue_basic(monkeypatch):
+    fake = FakeRedis()
+    monkeypatch.setattr("redis.Redis.from_url", lambda *a, **k: fake)
+    q = RedisStreamQueue("redis://test")
+    task = Task(TaskKind.RENDER, "t1", {})
+    q.enqueue(task)
+    got = q.pop(block=False)
+    assert got.id == "t1"
+    q.ack("t1")
+    result = Result(task_id="t1", status="ok", data={})
+    q.push_result(result)
+    assert q.wait_for_result("t1", 1).task_id == "t1"


### PR DESCRIPTION
## Summary
- implement TaskQueue protocol and StubQueue/RedisStreamQueue adapters
- implement ResultBackend protocol with FSBackend
- expose queue/backends config and entrypoints
- update sample `.peagen.toml` and schema
- document queues and backends in README
- add unit tests for queues and backend
- revert accidental README changes
- simplify queue & backend initialization to rely on plugin_registry

## Testing
- no tests run per instructions

------
https://chatgpt.com/codex/tasks/task_e_683a0e13a3b48326896391e8e7db17b0