### PR TITLE
Add worker fabric skeleton

### DIFF
--- a/pkgs/standards/peagen/docs/feature_evolve/spawner.toml
+++ b/pkgs/standards/peagen/docs/feature_evolve/spawner.toml
@@ -1,0 +1,7 @@
+[spawner]
+queue_url   = "redis://broker:6379/0"
+caps        = ["cpu", "docker"]
+warm_pool   = 2
+max_parallel = 50
+poll_ms     = 1000
+worker_image= "ghcr.io/swarmauri/peagen-worker:latest"

--- a/pkgs/standards/peagen/peagen/cli.py
+++ b/pkgs/standards/peagen/peagen/cli.py
@@ -14,6 +14,7 @@ from peagen.commands import (
     validate_app,
     extras_app,
     eval_app,
+    worker_app,
 )
 
 _print_banner()
@@ -29,6 +30,7 @@ app.add_typer(template_sets_app, name="template-set")
 app.add_typer(extras_app, name="extras-schemas")
 app.add_typer(validate_app, name="validate")
 app.add_typer(eval_app)
+app.add_typer(worker_app, name="worker")
 
 if __name__ == "__main__":
     app()

--- a/pkgs/standards/peagen/peagen/commands/worker.py
+++ b/pkgs/standards/peagen/peagen/commands/worker.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import typer
+
+from peagen.worker import OneShotWorker, WorkerConfig
+from peagen.spawner import SpawnerConfig, WarmSpawner
+
+worker_app = typer.Typer(help="Manage Peagen workers")
+
+
+@worker_app.command("start")
+def start_worker(
+    warm_pool: int = typer.Option(0, "--warm-pool", help="Maintain N idle workers"),
+    config: str = typer.Option("spawner.toml", "--config", help="Spawner config file"),
+) -> None:
+    """Launch a worker or warm-spawner depending on ``--warm-pool``."""
+    if warm_pool > 0:
+        sp_cfg = SpawnerConfig.from_toml(config)
+        sp_cfg.warm_pool = warm_pool
+        WarmSpawner(sp_cfg).run()
+    else:
+        cfg = WorkerConfig.from_env()
+        OneShotWorker(cfg).run()

--- a/pkgs/standards/peagen/peagen/queue/redis_stream_queue.py
+++ b/pkgs/standards/peagen/peagen/queue/redis_stream_queue.py
@@ -26,6 +26,9 @@ class RedisStreamQueue(TaskQueue):
         self._msg_map: Dict[str, str] = {}
         self._ensure_streams()
 
+    def pending_count(self) -> int:
+        return self._r.xlen(self.STREAM_TASKS)
+
     def _ensure_streams(self) -> None:
         try:
             self._r.xgroup_create(self.STREAM_TASKS, self.group, id="0-0", mkstream=True)

--- a/pkgs/standards/peagen/peagen/queue/stub_queue.py
+++ b/pkgs/standards/peagen/peagen/queue/stub_queue.py
@@ -18,6 +18,10 @@ class StubQueue(TaskQueue):
         self._done: Dict[str, Result] = {}
         self._lock = threading.Lock()
 
+    def pending_count(self) -> int:
+        with self._lock:
+            return len(self._todo) + len(self._inflight)
+
     # ------------------------------------------------------------------ producer
     def enqueue(self, task: Task) -> None:
         with self._lock:

--- a/pkgs/standards/peagen/peagen/spawner.py
+++ b/pkgs/standards/peagen/peagen/spawner.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from typing import List, Set
+
+from peagen.queue import make_queue
+
+
+@dataclass
+class SpawnerConfig:
+    queue_url: str
+    caps: List[str]
+    warm_pool: int = 2
+    max_parallel: int = 10
+    poll_ms: int = 1000
+    worker_image: str = "peagen-worker:latest"
+    idle_ms: int = 60000
+
+    @classmethod
+    def from_toml(cls, path: str) -> "SpawnerConfig":
+        import tomllib
+
+        data = tomllib.loads(open(path, "rb").read())
+        cfg = data.get("spawner", {})
+        return cls(
+            queue_url=cfg.get("queue_url", "stub://"),
+            caps=cfg.get("caps", []),
+            warm_pool=int(cfg.get("warm_pool", 2)),
+            max_parallel=int(cfg.get("max_parallel", 10)),
+            poll_ms=int(cfg.get("poll_ms", 1000)),
+            worker_image=cfg.get("worker_image", "peagen-worker:latest"),
+        )
+
+
+class WarmSpawner:
+    """Very small warm-spawner implementation."""
+
+    def __init__(self, cfg: SpawnerConfig) -> None:
+        self.cfg = cfg
+        provider = "redis" if cfg.queue_url.startswith("redis") else "stub"
+        self.queue = make_queue(provider, url=cfg.queue_url)
+        self.workers: List[subprocess.Popen] = []
+
+    # ------------------------------------------------------------ internals
+    def _launch_worker(self) -> None:
+        env = os.environ.copy()
+        env.update(
+            QUEUE_URL=self.cfg.queue_url,
+            WORKER_CAPS=",".join(self.cfg.caps),
+        )
+        cmd = [sys.executable, "-m", "peagen.cli", "worker", "start"]
+        p = subprocess.Popen(cmd, env=env)
+        self.workers.append(p)
+
+    def _cleanup_workers(self) -> int:
+        live = []
+        idle = 0
+        for p in self.workers:
+            if p.poll() is None:
+                live.append(p)
+            else:
+                idle += 1
+        self.workers = live
+        return idle
+
+    # ------------------------------------------------------------ main loop
+    def run(self) -> None:
+        while True:
+            pending = getattr(self.queue, "pending_count", lambda: 0)()
+            idle = self._cleanup_workers()
+            live = len(self.workers)
+            if pending > max(0, live - self.cfg.warm_pool):
+                to_launch = min(pending - (live - self.cfg.warm_pool), self.cfg.max_parallel)
+                for _ in range(to_launch):
+                    self._launch_worker()
+            self.queue.requeue_orphans(self.cfg.idle_ms)
+            time.sleep(self.cfg.poll_ms / 1000)
+
+
+__all__ = ["WarmSpawner", "SpawnerConfig"]

--- a/pkgs/standards/peagen/peagen/worker/__init__.py
+++ b/pkgs/standards/peagen/peagen/worker/__init__.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import os
+import signal
+import sys
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any, Iterable, Protocol, Set
+
+from peagen.queue import make_queue
+from peagen.queue.model import Result, Task, TaskKind
+from peagen.plugin_registry import registry
+
+
+class TaskHandler(Protocol):
+    """Protocol for pluggable task handlers."""
+
+    KIND: TaskKind
+    PROVIDES: Set[str]
+
+    def dispatch(self, task: Task) -> bool:
+        ...
+
+    def handle(self, task: Task) -> Result:
+        ...
+
+
+@dataclass
+class WorkerConfig:
+    queue_url: str
+    caps: Set[str]
+    plugins: Set[str] | None = None
+    concurrency: int = 1
+    idle_exit: int = 600
+    max_uptime: int = 3600
+
+    @classmethod
+    def from_env(cls) -> "WorkerConfig":
+        return cls(
+            queue_url=os.environ.get("QUEUE_URL", "stub://"),
+            caps=set(filter(None, os.environ.get("WORKER_CAPS", "").split(","))),
+            plugins=set(filter(None, os.environ.get("WORKER_PLUGINS", "").split(","))) or None,
+            concurrency=int(os.environ.get("WORKER_CONCURRENCY", "1")),
+            idle_exit=int(os.environ.get("WORKER_IDLE_EXIT", "600")),
+            max_uptime=int(os.environ.get("WORKER_MAX_UPTIME", "3600")),
+        )
+
+
+class OneShotWorker:
+    """Simplified one-shot worker as described in the technical brief."""
+
+    def __init__(self, cfg: WorkerConfig) -> None:
+        self.cfg = cfg
+        provider = "redis" if cfg.queue_url.startswith("redis") else "stub"
+        self.queue = make_queue(provider, url=cfg.queue_url)
+        self.id = uuid.uuid4().hex
+        self.start_ts = time.time()
+        self.last_task_ts = time.time()
+        self._shutdown = False
+        signal.signal(signal.SIGTERM, self._sigterm)
+
+    # ------------------------------------------------------------ lifecycle
+    def _sigterm(self, *_: Any) -> None:
+        self._shutdown = True
+
+    def _select_handler(self, task: Task) -> TaskHandler | None:
+        handlers: Iterable[type] = registry.get("task_handlers", {}).values()
+        for cls in handlers:
+            if self.cfg.plugins and cls.__name__ not in self.cfg.plugins:
+                continue
+            provides = getattr(cls, "PROVIDES", set())
+            if task.requires <= provides <= self.cfg.caps:
+                inst = cls()  # type: ignore[call-arg]
+                if inst.dispatch(task):
+                    return inst
+        return None
+
+    # ------------------------------------------------------------ main loop
+    def run(self) -> str:
+        """Run until a single task is processed or exit condition met."""
+        exit_reason = "idle"
+        while True:
+            if self._shutdown:
+                exit_reason = "signal"
+                break
+            if time.time() - self.start_ts > self.cfg.max_uptime:
+                exit_reason = "timeout"
+                break
+
+            task = self.queue.pop(timeout=1)
+            if task is None:
+                if time.time() - self.last_task_ts > self.cfg.idle_exit:
+                    exit_reason = "idle"
+                    break
+                continue
+
+            self.last_task_ts = time.time()
+            if not task.requires <= self.cfg.caps:
+                # put it back for someone else
+                self.queue.enqueue(task)
+                self.queue.ack(task.id)
+                continue
+
+            handler = self._select_handler(task)
+            if handler is None:
+                self.queue.enqueue(task)
+                self.queue.ack(task.id)
+                continue
+
+            try:
+                t0 = time.time()
+                result = handler.handle(task)
+                runtime = time.time() - t0
+                self.queue.push_result(result)
+                self.queue.ack(task.id)
+                exit_reason = result.status
+            except Exception as exc:  # pragma: no cover - simple log
+                result = Result(task.id, "error", {"msg": str(exc)})
+                self.queue.push_result(result)
+                self.queue.ack(task.id)
+                exit_reason = "error"
+            break
+
+        return exit_reason
+
+
+__all__ = ["OneShotWorker", "WorkerConfig", "TaskHandler"]

--- a/pkgs/standards/peagen/tests/i9n/test_spawner.py
+++ b/pkgs/standards/peagen/tests/i9n/test_spawner.py
@@ -1,0 +1,37 @@
+import pytest
+
+from peagen.spawner import WarmSpawner, SpawnerConfig
+from peagen.worker import OneShotWorker
+from peagen.queue.stub_queue import StubQueue
+from peagen.queue.model import Task, TaskKind, Result
+from peagen import plugin_registry
+
+
+class EchoHandler:
+    KIND = TaskKind.RENDER
+    PROVIDES = {"cpu"}
+
+    def dispatch(self, task: Task) -> bool:
+        return True
+
+    def handle(self, task: Task) -> Result:
+        return Result(task_id=task.id, status="ok", data=task.payload)
+
+
+def test_spawner_launch(monkeypatch):
+    plugin_registry.registry.setdefault("task_handlers", {})["echo"] = EchoHandler
+    q = StubQueue()
+    q.enqueue(Task(TaskKind.RENDER, "1", {}, requires={"cpu"}))
+
+    monkeypatch.setattr("peagen.spawner.make_queue", lambda *a, **k: q)
+    monkeypatch.setattr("peagen.worker.make_queue", lambda *a, **k: q)
+
+    launched = []
+    monkeypatch.setattr(WarmSpawner, "_launch_worker", lambda self: launched.append(1))
+    monkeypatch.setattr("time.sleep", lambda x: (_ for _ in ()).throw(SystemExit))
+
+    cfg = SpawnerConfig(queue_url="stub://", caps=["cpu"], warm_pool=1, poll_ms=1)
+    sp = WarmSpawner(cfg)
+    with pytest.raises(SystemExit):
+        sp.run()
+    assert launched

--- a/pkgs/standards/peagen/tests/unit/test_requeue_orphan.py
+++ b/pkgs/standards/peagen/tests/unit/test_requeue_orphan.py
@@ -1,0 +1,13 @@
+from peagen.queue.stub_queue import StubQueue
+from peagen.queue.model import Task, TaskKind
+
+
+def test_requeue_orphan():
+    q = StubQueue()
+    task = Task(TaskKind.RENDER, "1", {}, requires=set())
+    q.enqueue(task)
+    claimed = q.pop(block=False)
+    assert claimed is not None
+    moved = q.requeue_orphans(idle_ms=0, max_batch=10)
+    assert moved == 1
+    assert q.pop(block=False).id == "1"

--- a/pkgs/standards/peagen/tests/unit/test_worker.py
+++ b/pkgs/standards/peagen/tests/unit/test_worker.py
@@ -1,0 +1,31 @@
+from peagen.worker import OneShotWorker, WorkerConfig, TaskHandler
+from peagen.queue.stub_queue import StubQueue
+from peagen.queue.model import Task, TaskKind, Result
+from peagen import plugin_registry
+
+
+class EchoHandler:
+    KIND = TaskKind.RENDER
+    PROVIDES = {"cpu"}
+
+    def dispatch(self, task: Task) -> bool:
+        return True
+
+    def handle(self, task: Task) -> Result:
+        return Result(task_id=task.id, status="ok", data=task.payload)
+
+
+def test_worker_runs_single_task(monkeypatch):
+    plugin_registry.registry.setdefault("task_handlers", {})["echo"] = EchoHandler
+    q = StubQueue()
+    task = Task(TaskKind.RENDER, "1", {"x": 1}, requires={"cpu"})
+    q.enqueue(task)
+
+    monkeypatch.setattr("peagen.worker.make_queue", lambda *a, **k: q)
+    cfg = WorkerConfig(queue_url="stub://", caps={"cpu"}, idle_exit=1)
+    worker = OneShotWorker(cfg)
+    reason = worker.run()
+    assert reason == "ok"
+    res = q.wait_for_result("1", 1)
+    assert res is not None
+    assert res.status == "ok"


### PR DESCRIPTION
## Summary
- implement basic OneShotWorker and WarmSpawner
- extend queue adapters with pending_count
- expose `worker start` CLI
- add example `spawner.toml`
- add unit and integration tests

## Testing
- `uv run --package peagen --directory standards/peagen pytest` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683a1262e4b883268220ff4f18bbfeac