### PR TITLE
Implement evolve CLI skeleton

### DIFF
--- a/pkgs/standards/peagen/docs/feature_evolve/9  CLI Surfaces & User Stories.md
+++ b/pkgs/standards/peagen/docs/feature_evolve/9  CLI Surfaces & User Stories.md
@@ -28,6 +28,7 @@ peagen
 | `--project`      | Path to project YAML / TOML   | inferred  |
 | `--out`          | Destination directory         | `./build` |
 | `--queue/--sync` | Enqueue vs blocking local run | `--queue` |
+Values fall back to `.peagen.toml` when omitted.
 
 **Example**
 
@@ -49,6 +50,7 @@ peagen render --project site.yaml --out build/ --sync
 | `--backend`      | Force specific LLM backend | auto                |
 | `--queue/--sync` | Run via queue or inline    | `--queue`           |
 
+Defaults read from `.peagen.toml` when flags omitted.
 **Example**
 
 ```bash
@@ -82,6 +84,7 @@ peagen mutate --target-file bad_sort.py --entry-fn sort --sync
 | `--checkpoint`  | Path to save/load EvoDB     | `.peagen/evo_checkpoint.msgpack` |
 | `--resume`      | Continue from checkpoint    | False                            |
 | `--dashboard`   | Launch live TUI             | False                            |
+Defaults read from `.peagen.toml` `[evolve.*]` sections.
 
 **Example (team CI):**
 

--- a/pkgs/standards/peagen/peagen/cli.py
+++ b/pkgs/standards/peagen/peagen/cli.py
@@ -14,6 +14,10 @@ from peagen.commands import (
     validate_app,
     extras_app,
     eval_app,
+    render_app,
+    mutate_app,
+    evolve_app,
+    queue_app,
     worker_app,
 )
 
@@ -24,6 +28,10 @@ app = typer.Typer(help="CLI tool for processing project files using Peagen.")
 app.add_typer(init_app, name="init")
 app.add_typer(doe_app, name="doe")
 app.add_typer(process_app)
+app.add_typer(render_app, name="render")
+app.add_typer(mutate_app, name="mutate")
+app.add_typer(evolve_app, name="evolve")
+app.add_typer(queue_app, name="queue")
 app.add_typer(program_app, name="program")
 app.add_typer(sort_app)
 app.add_typer(template_sets_app, name="template-set")

--- a/pkgs/standards/peagen/peagen/cli_common.py
+++ b/pkgs/standards/peagen/peagen/cli_common.py
@@ -163,3 +163,26 @@ def common_peagen_options(fn: Callable[..., Any]) -> Callable[..., Any]:
         return fn(*args, **kwargs)
 
     return _wrapper
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. global_cli_options decorator
+# ─────────────────────────────────────────────────────────────────────────────
+def global_cli_options(fn: Callable[..., Any]) -> Callable[..., Any]:
+    """Add global CLI options and stash them in ``ctx.obj``."""
+    import functools
+
+    @typer.option("--config", "-c", help="Path to .peagen.toml", default=".peagen.toml")
+    @typer.option("--verbose", "-v", count=True, help="Increase verbosity")
+    @typer.option("--dry-run", is_flag=True, help="Run without writing files")
+    @functools.wraps(fn)
+    def _wrapper(*args, config: str, verbose: int, dry_run: bool, **kwargs):
+        ctx: typer.Context = click.get_current_context()
+        if ctx.obj is None:
+            ctx.obj = types.SimpleNamespace()
+        ctx.obj.config = config
+        ctx.obj.verbose = verbose
+        ctx.obj.dry_run = dry_run
+        return fn(*args, **kwargs)
+
+    return _wrapper
+

--- a/pkgs/standards/peagen/peagen/commands/__init__.py
+++ b/pkgs/standards/peagen/peagen/commands/__init__.py
@@ -9,6 +9,11 @@ from peagen.commands.program import program_app
 from peagen.commands.validate import validate_app
 from peagen.commands.extras import extras_app
 from peagen.commands.eval import eval_app
+from peagen.commands.render import render_app
+from peagen.commands.mutate import mutate_app
+from peagen.commands.evolve import evolve_app
+from peagen.commands.queue import queue_app
+from peagen.commands.worker import worker_app
 
 __all__ = [
     "init_app",
@@ -20,4 +25,9 @@ __all__ = [
     "validate_app",
     "extras_app",
     "eval_app",
+    "render_app",
+    "mutate_app",
+    "evolve_app",
+    "queue_app",
+    "worker_app",
 ]

--- a/pkgs/standards/peagen/peagen/commands/evolve.py
+++ b/pkgs/standards/peagen/peagen/commands/evolve.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import typer
+
+from peagen.cli_common import global_cli_options
+
+evolve_app = typer.Typer(help="Evolution utilities")
+
+
+def evolve_step(
+    target_file: str | None,
+    entry_fn: str | None,
+    selector: str | None,
+    mutator: str | None,
+    backend: str | None,
+    sync: bool,
+) -> None:
+    """Placeholder step implementation."""
+    typer.echo(
+        f"evolve step target={target_file} entry={entry_fn} selector={selector} mutator={mutator} backend={backend} sync={sync}"
+    )
+
+
+def evolve_run(
+    generations: int | None,
+    target_ms: float | None,
+    checkpoint: str,
+    resume: bool,
+    dashboard: bool,
+) -> None:
+    """Placeholder run implementation."""
+    typer.echo(
+        f"evolve run gens={generations} target_ms={target_ms} checkpoint={checkpoint} resume={resume} dashboard={dashboard}"
+    )
+
+
+@evolve_app.command("step")
+@global_cli_options
+def step_cmd(
+    ctx: typer.Context,
+    target_file: str | None = typer.Option(None, "--target-file"),
+    entry_fn: str | None = typer.Option(None, "--entry-fn"),
+    selector: str | None = typer.Option(None, "--selector"),
+    mutator: str | None = typer.Option(None, "--mutator"),
+    backend: str | None = typer.Option(None, "--backend"),
+    sync: bool = typer.Option(False, "--sync"),
+) -> None:
+    evolve_step(target_file, entry_fn, selector, mutator, backend, sync)
+
+
+@evolve_app.command("run")
+@global_cli_options
+def run_cmd(
+    ctx: typer.Context,
+    generations: int | None = typer.Option(None, "--generations"),
+    target_ms: float | None = typer.Option(None, "--target-ms"),
+    checkpoint: str = typer.Option(
+        ".peagen/evo_checkpoint.msgpack", "--checkpoint", help="Checkpoint file"
+    ),
+    resume: bool = typer.Option(False, "--resume"),
+    dashboard: bool = typer.Option(False, "--dashboard"),
+) -> None:
+    evolve_run(generations, target_ms, checkpoint, resume, dashboard)

--- a/pkgs/standards/peagen/peagen/commands/mutate.py
+++ b/pkgs/standards/peagen/peagen/commands/mutate.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import typer
+
+from peagen.cli_common import global_cli_options
+
+mutate_app = typer.Typer(help="Mutate source with LLM")
+
+
+def run_mutate(
+    target_file: str,
+    entry_fn: str,
+    output: str,
+    backend: str | None,
+    queue: bool,
+) -> None:
+    """Placeholder implementation for mutate workflow."""
+    typer.echo(
+        f"mutate target={target_file} entry={entry_fn} output={output} backend={backend} queue={queue}"
+    )
+
+
+@mutate_app.command("mutate")
+@global_cli_options
+def mutate_cmd(
+    ctx: typer.Context,
+    target_file: str = typer.Option(..., "--target-file", help="Source file"),
+    entry_fn: str = typer.Option(..., "--entry-fn", help="Entry function"),
+    output: str = typer.Option("target_mutated.py", "--output", help="Output file"),
+    backend: str | None = typer.Option(None, "--backend", help="LLM backend"),
+    queue: bool = typer.Option(True, "--queue/--sync", help="Queue tasks"),
+) -> None:
+    run_mutate(target_file, entry_fn, output, backend, queue)

--- a/pkgs/standards/peagen/peagen/commands/queue/__init__.py
+++ b/pkgs/standards/peagen/peagen/commands/queue/__init__.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import typer
+
+from .dlq import dlq_app
+
+queue_app = typer.Typer(help="Queue utilities")
+queue_app.add_typer(dlq_app, name="dlq")
+
+__all__ = ["queue_app"]

--- a/pkgs/standards/peagen/peagen/commands/queue/dlq.py
+++ b/pkgs/standards/peagen/peagen/commands/queue/dlq.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import typer
+
+from peagen.cli_common import global_cli_options
+
+dlq_app = typer.Typer(help="Dead-letter queue tools")
+
+
+def dlq_retry(kind: str) -> None:
+    """Placeholder retry implementation."""
+    typer.echo(f"retry dlq kind={kind}")
+
+
+@dlq_app.command("retry")
+@global_cli_options
+def retry_cmd(ctx: typer.Context, kind: str = typer.Option(..., "--kind")) -> None:
+    dlq_retry(kind)

--- a/pkgs/standards/peagen/peagen/commands/render.py
+++ b/pkgs/standards/peagen/peagen/commands/render.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import pathlib
+import typer
+
+from peagen.cli_common import global_cli_options
+
+render_app = typer.Typer(help="Render deterministic templates")
+
+
+def run_render(project: str | None, out: str, queue: bool) -> None:
+    """Placeholder implementation for render workflow."""
+    # Real implementation would enqueue or run locally
+    typer.echo(f"render project={project} out={out} queue={queue}")
+
+
+@render_app.command("render")
+@global_cli_options
+def render_cmd(
+    ctx: typer.Context,
+    project: str | None = typer.Option(None, "--project", help="Project file"),
+    out: str = typer.Option("./build", "--out", help="Output directory"),
+    queue: bool = typer.Option(True, "--queue/--sync", help="Queue tasks"),
+) -> None:
+    run_render(project, out, queue)

--- a/pkgs/standards/peagen/tests/unit/test_cli_new.py
+++ b/pkgs/standards/peagen/tests/unit/test_cli_new.py
@@ -1,0 +1,51 @@
+import pytest
+from typer.testing import CliRunner
+from peagen.cli import app
+
+
+@pytest.mark.unit
+def test_render_invokes_run(monkeypatch):
+    runner = CliRunner()
+    called = {}
+
+    def fake(project, out, queue):
+        called["args"] = (project, out, queue)
+
+    monkeypatch.setattr("peagen.commands.render.run_render", fake)
+    result = runner.invoke(app, ["render", "--project", "p.yaml", "--out", "dst", "--sync"])
+    assert result.exit_code == 0
+    assert called["args"] == ("p.yaml", "dst", False)
+
+
+@pytest.mark.unit
+def test_mutate_invokes_run(monkeypatch):
+    runner = CliRunner()
+    called = {}
+
+    def fake(tf, ef, out, be, q):
+        called["args"] = (tf, ef, out, be, q)
+
+    monkeypatch.setattr("peagen.commands.mutate.run_mutate", fake)
+    result = runner.invoke(app, [
+        "mutate",
+        "--target-file",
+        "file.py",
+        "--entry-fn",
+        "func",
+        "--backend",
+        "llm",
+        "--sync",
+    ])
+    assert result.exit_code == 0
+    assert called["args"] == ("file.py", "func", "target_mutated.py", "llm", False)
+
+
+@pytest.mark.unit
+def test_help_lists_commands():
+    runner = CliRunner()
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "render" in result.output
+    assert "mutate" in result.output
+    assert "evolve" in result.output
+


### PR DESCRIPTION
## Summary
- add Typer apps for render, mutate, evolve and queue
- wire them into peagen CLI
- share global options via new decorator
- document default behaviour in CLI docs
- unit tests for new commands

## Testing
- `uv run --package peagen --directory standards/peagen pytest` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683a1595529083268851ea22eaf5afd7