### PR TITLE
Add operational docs and security workflow updates

### DIFF
--- a/.github/workflows/0.7.0_mono_prepare_validate_publish.yaml
+++ b/.github/workflows/0.7.0_mono_prepare_validate_publish.yaml
@@ -121,6 +121,13 @@ jobs:
           # Run the test command with uv
           uv run --directory "$MEMBER" --package "$PACKAGE_NAME" --isolated --active pytest -vvv
 
+      - name: Security scan
+        run: |
+          sudo apt-get update -y && sudo apt-get install -y trivy
+          pip install bandit
+          make trivy-scan
+          bandit -r src || bandit -r pkgs
+
       ## Patches 
       - name: Create patch for changes
         if: always()
@@ -237,6 +244,9 @@ jobs:
           # Command
           uv build --directory "$MEMBER" --package "$PACKAGE_NAME" -o distout
 
+      - name: Generate SBOM
+        run: make sbom
+
       ## Publish
       - name: Publish
         run: |
@@ -297,7 +307,7 @@ jobs:
           cd pkgs/${{ matrix.member }}
           mkdir -p release_artifacts
           ZIP_PATH=release_artifacts/${{ steps.prepare_release.outputs.package_name }}-${{ steps.prepare_release.outputs.version }}.zip
-          zip -j $ZIP_PATH distout/*.whl distout/*.tar.gz
+          zip -j $ZIP_PATH distout/*.whl distout/*.tar.gz ../../sbom.xml
           echo "Artifacts zipped to: $ZIP_PATH"
 
       - name: Create GitHub Release

--- a/.github/workflows/v0.7.0_mono_prepare_validate.yaml
+++ b/.github/workflows/v0.7.0_mono_prepare_validate.yaml
@@ -108,6 +108,13 @@ jobs:
           # Run the test command with uv
           uv run --directory "$MEMBER" --package "$PACKAGE_NAME" --isolated --active pytest -vvv
 
+      - name: Security scan
+        run: |
+          sudo apt-get update -y && sudo apt-get install -y trivy
+          pip install bandit
+          make trivy-scan
+          bandit -r src || bandit -r pkgs
+
       - name: Create patch for changes
         if: always()
         run: |

--- a/.github/workflows/v0.7.3_single_prepare_validate.yaml
+++ b/.github/workflows/v0.7.3_single_prepare_validate.yaml
@@ -71,6 +71,13 @@ jobs:
           # We run tests; if they fail, let's output an annotation (but we don't stop the workflow).
           uv run --directory "$MEMBER" --package "$PACKAGE_NAME" --isolated --active pytest -vvv
 
+      - name: Security scan
+        run: |
+          sudo apt-get update -y && sudo apt-get install -y trivy
+          pip install bandit
+          make trivy-scan
+          bandit -r src || bandit -r pkgs
+
       - name: Create patch for changes
         if: always()
         run: |

--- a/.github/workflows/v0.7.3_single_prepare_validate_publish.yaml
+++ b/.github/workflows/v0.7.3_single_prepare_validate_publish.yaml
@@ -77,6 +77,13 @@ jobs:
           PACKAGE_NAME=$(python -c "import toml; print(toml.load('${{ github.workspace }}/pkgs/${MEMBER}/pyproject.toml')['project']['name'])")
           uv run --directory "$MEMBER" --package "$PACKAGE_NAME" --isolated --active pytest -vvv
 
+      - name: Security scan
+        run: |
+          sudo apt-get update -y && sudo apt-get install -y trivy
+          pip install bandit
+          make trivy-scan
+          bandit -r src || bandit -r pkgs
+
       # Patches
       - name: Create patch for changes
         if: always()
@@ -188,6 +195,9 @@ jobs:
           PACKAGE_NAME=$(python -c "import toml; print(toml.load('${{ github.workspace }}/pkgs/${MEMBER}/pyproject.toml')['project']['name'])")
           uv build --directory "$MEMBER" --package "$PACKAGE_NAME" -o distout
 
+      - name: Generate SBOM
+        run: make sbom
+
       # Publish
       - name: Publish
         run: |
@@ -245,7 +255,7 @@ jobs:
           cd pkgs/${{ github.event.inputs.member }}
           mkdir -p release_artifacts
           ZIP_PATH=release_artifacts/${{ steps.prepare_release.outputs.package_name }}-${{ steps.prepare_release.outputs.version }}.zip
-          zip -j $ZIP_PATH distout/*.whl distout/*.tar.gz
+          zip -j $ZIP_PATH distout/*.whl distout/*.tar.gz ../../sbom.xml
           echo "Artifacts zipped to: $ZIP_PATH"
 
       - name: Create GitHub Release

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+trivy-scan:
+trivy fs . --exit-code 1 --severity CRITICAL,HIGH --no-progress
+
+bandit-scan:
+bandit -r src || bandit -r pkgs
+
+sbom:
+trivy sbom --format cyclonedx --output sbom.xml .

--- a/docs/docs/guide/operations.md
+++ b/docs/docs/guide/operations.md
@@ -1,0 +1,79 @@
+# Operational Guide
+
+This page collects day‑2 practices for running Peagen in production. It distills
+Section&nbsp;11 of the internal brief and the relevant appendices.
+
+## Autoscaling Recipes
+
+Peagen workers can run on a laptop farm or a full Kubernetes cluster. Example
+manifests live under `infra/examples/`.
+
+| Environment | Scale Up | Idle Scale-Down | Notes |
+|-------------|---------|-----------------|-------|
+| **Docker Compose** | `watch-queue.py` polls `queue_pending_total` every 30&nbsp;s and runs `docker compose up --scale worker=<n>` | Same script scales to zero after five idle minutes | Simple and works without cloud services |
+| **Kubernetes** | `Deployment/peagen-worker` with an `HorizontalPodAutoscaler` using external metric `redis_queue_pending{stream="peagen.tasks"}` | `minReplicas: 0` with a `scaleDown.stabilizationWindowSeconds: 300` | Keep two idle pods ahead via the spawner warm pool |
+| **AWS Fargate** | CloudWatch alarm on pending count triggers Step&nbsp;Function to start tasks | A second alarm sets desired count to zero | Serverless pay‑per‑second |
+| **systemd** | `systemd-run --unit=peagen-worker@$(uuidgen)` from cron when queue depth is high | `StopWhenUnneeded=yes` in the unit file | Runs even on bare metal |
+
+## Fault‑Tolerance Runbook
+
+Workers acknowledge tasks only when processing succeeds. If a container dies
+mid‑task, the spawner periodically calls `XAUTOCLAIM` to reclaim the orphan. Use
+`peagen queue dlq export` to inspect dead‑letter messages for repeated failures.
+
+1. **Crash Recovery** – check `worker_exit_reason_total{reason="error"}` and
+   `queue_pending_idle_max_seconds` for growing values. The spawner should
+   requeue within 60&nbsp;s by default.
+2. **Dead‑Letter Queue** – export stuck tasks using:
+   ```bash
+   peagen queue dlq export > dlq.json
+   ```
+   Triage and requeue once the underlying issue is fixed.
+
+## Monitoring
+
+Metrics follow the observability matrix in the brief. Key signals include:
+
+- `queue_pending_total` and `worker_exit_reason_total`
+- `handler_fail_total` and `result_backend_fail_total`
+- `llm_tokens_total` per backend
+
+Dashboards typically contain a *Main* view for queue and worker health and a
+*Cost* board tracking token spend. See Appendix&nbsp;B for the full metric list.
+
+## Security Hardening
+
+Container images run with `no-new-privileges`, a read‑only root filesystem and
+seccomp `runtime/default`. Workers mount no secrets except environment variables
+injected by the orchestrator. Limit resources with `--pids-limit` and memory
+quotas. The [pen‑test checklist](../../pkgs/standards/peagen/docs/feature_evolve/18%20%20Appendices.md#appendix-e--security--pen-test-checklist)
+requires:
+
+- `bandit -r src` with zero high findings
+- `make trivy-scan` yielding zero critical vulnerabilities
+- Chaos test: kill a worker mid-task and verify requeue
+
+## Budget & Rate‑Limit Controls
+
+Guardrails rely on `llm_tokens_total` and `worker_runtime_seconds` metrics.
+Configure a shared `TokenBucketRateLimit` in Redis or pass
+`--budget-tokens`/`--run-timeout` flags per workflow. Example:
+
+```toml
+[evolve]
+backend = "gpu"
+[evolve.limits]
+budget_tokens = 50000
+run_timeout = 3600
+```
+
+## Example Commands
+
+```bash
+# Deploy reference Redis on Kubernetes
+kubectl apply -f infra/examples/redis-broker.yaml
+
+# Verify worker UID is non-root
+./infra/examples/verify-nonroot.sh
+```
+

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -121,6 +121,7 @@ nav:
   - guide/index.md
   - Installation: guide/installation.md
   - Usage: guide/usage.md
+  - Operations: guide/operations.md
   - Courses:
     - guide/index.md
     - Entry: guide/course/1.md

--- a/infra/examples/redis-broker.yaml
+++ b/infra/examples/redis-broker.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: redis-broker}
+spec:
+  replicas: 1
+  selector: {matchLabels: {app: redis-broker}}
+  template:
+    metadata: {labels: {app: redis-broker}}
+    spec:
+      containers:
+      - name: redis
+        image: redis:7-alpine
+        args: ["--save","", "--appendonly","no"]
+        resources: {limits: {memory: "512Mi"}}
+---
+apiVersion: v1
+kind: Service
+metadata: {name: redis}
+spec:
+  selector: {app: redis-broker}
+  ports: [{port: 6379, targetPort: 6379}]

--- a/infra/examples/spawner-deployment.yaml
+++ b/infra/examples/spawner-deployment.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: peagen-spawner-cpu}
+spec:
+  replicas: 1
+  selector: {matchLabels:{app: peagen-spawner, caps: cpu}}
+  template:
+    metadata: {labels:{app: peagen-spawner, caps: cpu}}
+    spec:
+      containers:
+      - name: spawner
+        image: ghcr.io/swarmauri/peagen-spawner:latest
+        env:
+          - {name: QUEUE_URL, value: "redis://redis:6379/0"}
+          - {name: WORKER_CAPS, value: "cpu,docker,llm"}
+          - {name: WARM_POOL,  value: "2"}

--- a/infra/examples/verify-nonroot.sh
+++ b/infra/examples/verify-nonroot.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Quick check that worker containers run as non-root
+kubectl exec deploy/peagen-worker-gpu -- id -u

--- a/infra/examples/watch-queue.py
+++ b/infra/examples/watch-queue.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Example autoscaler for Docker Compose deployments."""
+import os
+import subprocess
+import time
+import requests
+
+PROM_URL = os.getenv("PROM_URL", "http://localhost:9090/api/v1/query?query=queue_pending_total")
+MAX_REPLICAS = int(os.getenv("MAX_REPLICAS", "32"))
+MIN_REPLICAS = int(os.getenv("MIN_REPLICAS", "1"))
+SCALE_SERVICE = os.getenv("SCALE_SERVICE", "worker")
+
+idle_since = None
+
+while True:
+    try:
+        resp = requests.get(PROM_URL, timeout=5)
+        data = resp.json()["data"]["result"][0]["value"][1]
+        pending = int(float(data))
+    except Exception:
+        pending = 0
+
+    desired = max(MIN_REPLICAS, min(MAX_REPLICAS, pending // 2 or 1))
+    subprocess.run(["docker", "compose", "up", "--scale", f"{SCALE_SERVICE}={desired}", "-d"], check=False)
+
+    if pending == 0:
+        if idle_since is None:
+            idle_since = time.time()
+        elif time.time() - idle_since > 300:
+            subprocess.run(["docker", "compose", "up", "--scale", f"{SCALE_SERVICE}=0", "-d"], check=False)
+    else:
+        idle_since = None
+
+    time.sleep(30)

--- a/infra/examples/worker-daemonset.yaml
+++ b/infra/examples/worker-daemonset.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata: {name: peagen-worker-gpu}
+spec:
+  selector: {matchLabels:{app: peagen-worker, caps: gpu}}
+  template:
+    metadata: {labels:{app: peagen-worker, caps: gpu}}
+    spec:
+      tolerations: [{key: "nvidia.com/gpu", operator: "Exists"}]
+      containers:
+      - name: worker
+        image: ghcr.io/swarmauri/peagen-worker:latest
+        env:
+          - {name: QUEUE_URL, value: "redis://redis:6379/0"}
+          - {name: WORKER_CAPS, value: "gpu,cuda11,docker"}
+          - {name: WORKER_PLUGINS, value: "ExecuteGPUHandler"}
+        resources: {limits: {"nvidia.com/gpu": 1}}

--- a/pkgs/standards/peagen/tests/i9n/test_fault_recovery.py
+++ b/pkgs/standards/peagen/tests/i9n/test_fault_recovery.py
@@ -1,0 +1,73 @@
+import multiprocessing as mp
+import time
+
+from peagen.worker import OneShotWorker, WorkerConfig
+from peagen.spawner import WarmSpawner, SpawnerConfig
+from peagen.queue.stub_queue import StubQueue
+from peagen.queue.model import Task, TaskKind, Result
+from peagen import plugin_registry
+
+
+class SlowHandler:
+    KIND = TaskKind.RENDER
+    PROVIDES = {"cpu"}
+
+    def __init__(self):
+        pass
+
+    def dispatch(self, task: Task) -> bool:
+        return True
+
+    def handle(self, task: Task) -> Result:
+        time.sleep(5)
+        return Result(task.id, "ok", {})
+
+
+def _run_worker(queue_url: str) -> None:
+    cfg = WorkerConfig(queue_url=queue_url, caps={"cpu"})
+    OneShotWorker(cfg).run()
+
+
+def test_worker_crash_requeued(monkeypatch):
+    plugin_registry.registry.setdefault("task_handlers", {})["slow"] = SlowHandler
+
+    q = StubQueue()
+    q.enqueue(Task(TaskKind.RENDER, "1", {}, requires={"cpu"}))
+
+    monkeypatch.setattr("peagen.spawner.make_queue", lambda *a, **k: q)
+    monkeypatch.setattr("peagen.worker.make_queue", lambda *a, **k: q)
+
+    processes = []
+
+    def launch(self):
+        p = mp.Process(target=_run_worker, args=("stub://",))
+        p.start()
+        processes.append(p)
+
+    monkeypatch.setattr(WarmSpawner, "_launch_worker", launch)
+
+    loops = 0
+    real_sleep = time.sleep
+
+    def sleeper(t):
+        nonlocal loops
+        loops += 1
+        if loops == 3:
+            # kill worker while task running
+            if processes:
+                processes[0].terminate()
+        if loops > 5:
+            raise SystemExit
+        real_sleep(0.1)
+
+    monkeypatch.setattr(time, "sleep", sleeper)
+
+    sp = WarmSpawner(SpawnerConfig(queue_url="stub://", caps=["cpu"], warm_pool=1, poll_ms=100, idle_ms=200))
+    with mp.get_context("spawn"):  # ensure clean start
+        try:
+            sp.run()
+        except SystemExit:
+            pass
+
+    assert q.pending_count() == 1
+


### PR DESCRIPTION
## Summary
- document autoscaling, recovery, monitoring and security guidelines
- add example Kubernetes and Docker assets under `infra/examples`
- include budget guardrails and commands
- integrate trivy and bandit scans in CI with SBOM output
- add smoke test for worker crash recovery

## Testing
- `uv run --package peagen --directory standards/peagen pytest` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683a17e39a808326a9352695755bf998