### PR TITLE
Implement CLI features and tests

### DIFF
--- a/pkgs/standards/peagen/peagen/commands/worker.py
+++ b/pkgs/standards/peagen/peagen/commands/worker.py
@@ -10,14 +10,26 @@ worker_app = typer.Typer(help="Manage Peagen workers")
 
 @worker_app.command("start")
 def start_worker(
+    caps: str = typer.Option("", "--caps", envvar="WORKER_CAPS", help="Capability tags"),
+    plugins: str = typer.Option("", "--plugins", envvar="WORKER_PLUGINS", help="Allowed task handlers"),
+    concurrency: int = typer.Option(1, "--concurrency", envvar="WORKER_CONCURRENCY", help="Parallel tasks"),
     warm_pool: int = typer.Option(0, "--warm-pool", help="Maintain N idle workers"),
+    exit_after_idle: int = typer.Option(600, "--exit-after-idle", envvar="WORKER_IDLE_EXIT", help="Seconds before exit"),
     config: str = typer.Option("spawner.toml", "--config", help="Spawner config file"),
 ) -> None:
     """Launch a worker or warm-spawner depending on ``--warm-pool``."""
     if warm_pool > 0:
         sp_cfg = SpawnerConfig.from_toml(config)
         sp_cfg.warm_pool = warm_pool
+        if caps:
+            sp_cfg.caps = [c.strip() for c in caps.split(",") if c.strip()]
         WarmSpawner(sp_cfg).run()
     else:
         cfg = WorkerConfig.from_env()
+        if caps:
+            cfg.caps = set(c.strip() for c in caps.split(",") if c.strip())
+        if plugins:
+            cfg.plugins = set(p.strip() for p in plugins.split(",") if p.strip())
+        cfg.concurrency = concurrency
+        cfg.idle_exit = exit_after_idle
         OneShotWorker(cfg).run()

--- a/pkgs/standards/peagen/tests/unit/test_cli_new.py
+++ b/pkgs/standards/peagen/tests/unit/test_cli_new.py
@@ -1,6 +1,8 @@
 import pytest
 from typer.testing import CliRunner
 from peagen.cli import app
+from peagen.spawner import SpawnerConfig
+from peagen.worker import WorkerConfig
 
 
 @pytest.mark.unit
@@ -48,4 +50,102 @@ def test_help_lists_commands():
     assert "render" in result.output
     assert "mutate" in result.output
     assert "evolve" in result.output
+    assert "worker" in result.output
+
+
+@pytest.mark.unit
+def test_evolve_step_invokes_run(monkeypatch):
+    runner = CliRunner()
+    called = {}
+
+    def fake(tf, ef, sel, mut, be, sync):
+        called["args"] = (tf, ef, sel, mut, be, sync)
+
+    monkeypatch.setattr("peagen.commands.evolve.evolve_step", fake)
+    result = runner.invoke(
+        app,
+        [
+            "evolve",
+            "step",
+            "--target-file",
+            "foo.py",
+            "--entry-fn",
+            "bar",
+            "--selector",
+            "greedy",
+            "--mutator",
+            "simple",
+            "--backend",
+            "cpu",
+            "--sync",
+        ],
+    )
+    assert result.exit_code == 0
+    assert called["args"] == ("foo.py", "bar", "greedy", "simple", "cpu", True)
+
+
+@pytest.mark.unit
+def test_evolve_run_invokes_run(monkeypatch):
+    runner = CliRunner()
+    called = {}
+
+    def fake(gen, target_ms, checkpoint, resume, dash):
+        called["args"] = (gen, target_ms, checkpoint, resume, dash)
+
+    monkeypatch.setattr("peagen.commands.evolve.evolve_run", fake)
+    result = runner.invoke(
+        app,
+        ["evolve", "run", "--generations", "200", "--dashboard"],
+    )
+    assert result.exit_code == 0
+    assert called["args"] == (
+        200,
+        None,
+        ".peagen/evo_checkpoint.msgpack",
+        False,
+        True,
+    )
+
+
+@pytest.mark.unit
+def test_worker_start_invokes_correct_runner(monkeypatch):
+    runner = CliRunner()
+    called = {}
+
+    class DummySpawner:
+        def __init__(self, cfg):
+            called["spawner_cfg"] = cfg
+
+        def run(self):
+            called["spawner_run"] = True
+
+    class DummyWorker:
+        def __init__(self, cfg):
+            called["worker_cfg"] = cfg
+
+        def run(self):
+            called["worker_run"] = True
+
+    monkeypatch.setattr("peagen.commands.worker.WarmSpawner", DummySpawner)
+    monkeypatch.setattr("peagen.commands.worker.OneShotWorker", DummyWorker)
+    monkeypatch.setattr(
+        "peagen.commands.worker.SpawnerConfig.from_toml",
+        lambda p: SpawnerConfig(queue_url="stub://", caps=[]),
+    )
+    monkeypatch.setattr(
+        "peagen.commands.worker.WorkerConfig.from_env",
+        lambda: WorkerConfig(queue_url="stub://", caps=set()),
+    )
+
+    # spawner path
+    res = runner.invoke(app, ["worker", "start", "--warm-pool", "1", "--caps", "cpu"])
+    assert res.exit_code == 0
+    assert called.get("spawner_run")
+    assert not called.get("worker_run")
+    called.clear()
+
+    # worker path
+    res = runner.invoke(app, ["worker", "start", "--caps", "cpu", "--concurrency", "2"])
+    assert res.exit_code == 0
+    assert called.get("worker_run")
 


### PR DESCRIPTION
## Summary
- flesh out `peagen worker start` with options from docs
- extend CLI tests for new commands and worker start behavior

## Testing
- `uv run --package peagen --directory standards/peagen pytest` *(fails: no network access)*

------
https://chatgpt.com/codex/tasks/task_e_683a1b57557c832693c801d668119ada