### PR TITLE
Implement TaskHandler interface and helper

### DIFF
--- a/pkgs/standards/peagen/peagen/handlers/__init__.py
+++ b/pkgs/standards/peagen/peagen/handlers/__init__.py
@@ -1,12 +1,24 @@
-from .base import TaskHandler
+from .base import (
+    ITaskHandler,
+    TaskHandlerBase,
+    TaskHandler,
+    can_handle,
+)
 from .render_handler import RenderHandler
 from .mutate_patch import PatchMutatorHandler
 from .exec_docker import ExecuteDockerHandler
 from .exec_gpu import ExecuteGPUHandler
 from .eval_handler import EvaluateHandler
+from ..plugin_registry import registry, discover_and_register_plugins
+
+if not registry.get("task_handlers"):
+    discover_and_register_plugins()
 
 __all__ = [
+    "ITaskHandler",
+    "TaskHandlerBase",
     "TaskHandler",
+    "can_handle",
     "RenderHandler",
     "PatchMutatorHandler",
     "ExecuteDockerHandler",

--- a/pkgs/standards/peagen/peagen/handlers/base.py
+++ b/pkgs/standards/peagen/peagen/handlers/base.py
@@ -1,23 +1,52 @@
 from __future__ import annotations
 
-from typing import Protocol, Set
+from abc import ABC, abstractmethod
+from typing import Set, Type
 
 from swarmauri_core.ComponentBase import ComponentBase
 
 from peagen.queue.model import Task, Result, TaskKind
 
 
-class TaskHandler(ComponentBase, Protocol):
-    """Protocol for pluggable task handlers."""
+class ITaskHandler(ABC):
+    """Interface for pluggable task handlers."""
 
     KIND: TaskKind
     PROVIDES: Set[str]
 
-    def dispatch(self, task: Task) -> bool
-        ...
+    @abstractmethod
+    def dispatch(self, task: Task) -> bool:
+        """Quick pre-check for ``task``."""
 
+    @abstractmethod
     def handle(self, task: Task) -> Result:
-        """Return True if this handler should handle ``task``."""
+        """Perform domain work and return a :class:`Result`."""
 
-    def handle(self, task: Task) -> Result:
-        """Perform domain logic and return a ``Result``."""
+
+class TaskHandlerBase(ComponentBase, ITaskHandler):
+    """Convenience base class implementing :class:`ITaskHandler`."""
+
+    KIND: TaskKind
+    PROVIDES: Set[str]
+
+    def dispatch(self, task: Task) -> bool:  # pragma: no cover - trivial
+        return task.kind == self.KIND
+
+
+def can_handle(
+    task: Task, handler_cls: Type[ITaskHandler], worker_caps: Set[str]
+) -> bool:
+    """Return ``True`` if ``handler_cls`` can service ``task`` under ``worker_caps``."""
+    provides = getattr(handler_cls, "PROVIDES", set())
+    if task.kind != getattr(handler_cls, "KIND", None):
+        return False
+    if not task.requires.issubset(provides):
+        return False
+    if not provides.issubset(worker_caps):
+        return False
+    return True
+
+
+TaskHandler = TaskHandlerBase
+
+__all__ = ["ITaskHandler", "TaskHandlerBase", "TaskHandler", "can_handle"]

--- a/pkgs/standards/peagen/peagen/handlers/eval_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/eval_handler.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from peagen.queue.model import Task, Result, TaskKind
-from .base import TaskHandler
+from .base import TaskHandlerBase
 
 
-class EvaluateHandler(TaskHandler):
+class EvaluateHandler(TaskHandlerBase):
     KIND = TaskKind.EVALUATE
     PROVIDES = {"cpu"}
 

--- a/pkgs/standards/peagen/peagen/handlers/exec_docker.py
+++ b/pkgs/standards/peagen/peagen/handlers/exec_docker.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from peagen.queue.model import Task, Result, TaskKind
-from .base import TaskHandler
+from .base import TaskHandlerBase
 
 
-class ExecuteDockerHandler(TaskHandler):
+class ExecuteDockerHandler(TaskHandlerBase):
     KIND = TaskKind.EXECUTE
     PROVIDES = {"docker", "cpu"}
 

--- a/pkgs/standards/peagen/peagen/handlers/exec_gpu.py
+++ b/pkgs/standards/peagen/peagen/handlers/exec_gpu.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from peagen.queue.model import Task, Result, TaskKind
-from .base import TaskHandler
+from .base import TaskHandlerBase
 
 
-class ExecuteGPUHandler(TaskHandler):
+class ExecuteGPUHandler(TaskHandlerBase):
     KIND = TaskKind.EXECUTE
     PROVIDES = {"docker", "gpu", "cuda11"}
 

--- a/pkgs/standards/peagen/peagen/handlers/mutate_patch.py
+++ b/pkgs/standards/peagen/peagen/handlers/mutate_patch.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from peagen.queue.model import Task, Result, TaskKind
-from .base import TaskHandler
+from .base import TaskHandlerBase
 
 
 class PromptSampler:
@@ -18,7 +18,7 @@ class LLMEnsemble:
         return prompt  # stub; tests may monkeypatch
 
 
-class PatchMutatorHandler(TaskHandler):
+class PatchMutatorHandler(TaskHandlerBase):
     KIND = TaskKind.MUTATE
     PROVIDES = {"llm", "cpu"}
 

--- a/pkgs/standards/peagen/peagen/handlers/render_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/render_handler.py
@@ -6,10 +6,10 @@ from typing import Any
 from jinja2 import Template
 
 from peagen.queue.model import Task, Result, TaskKind
-from .base import TaskHandler
+from .base import TaskHandlerBase
 
 
-class RenderHandler(TaskHandler):
+class RenderHandler(TaskHandlerBase):
     """Render Jinja template payload."""
 
     KIND = TaskKind.RENDER

--- a/pkgs/standards/peagen/tests/unit/test_handlers.py
+++ b/pkgs/standards/peagen/tests/unit/test_handlers.py
@@ -10,6 +10,7 @@ from peagen.handlers import (
     ExecuteDockerHandler,
     ExecuteGPUHandler,
     EvaluateHandler,
+    can_handle,
 )
 from peagen.task_model import Task, Result, TaskKind
 from peagen.plugin_registry import registry, discover_and_register_plugins
@@ -71,3 +72,10 @@ def test_plugin_discovery_and_allowlist(monkeypatch):
     worker = InlineWorker(q, caps={"cpu"})
     names = [h.__class__.__name__ for h in worker.handlers]
     assert names == ["RenderHandler"]
+
+
+@pytest.mark.unit
+def test_can_handle_helper():
+    task = Task(TaskKind.RENDER, "t", {}, requires={"cpu"})
+    assert can_handle(task, RenderHandler, {"cpu"})
+    assert not can_handle(task, ExecuteGPUHandler, {"cpu"})

--- a/pkgs/standards/peagen/tests/unit/test_worker.py
+++ b/pkgs/standards/peagen/tests/unit/test_worker.py
@@ -1,4 +1,4 @@
-from peagen.worker import OneShotWorker, WorkerConfig, TaskHandler
+from peagen.worker import OneShotWorker, WorkerConfig, ITaskHandler
 from peagen.queue.stub_queue import StubQueue
 from peagen.queue.model import Task, TaskKind, Result
 from peagen import plugin_registry


### PR DESCRIPTION
## Summary
- add `ITaskHandler` and `TaskHandlerBase` abstractions
- expose `TaskHandler` alias and update plugin imports
- enhance `can_handle` with kind and capability checks
- refactor workers and tests to use new interface

## Testing
- `python -m py_compile pkgs/standards/peagen/peagen/handlers/*.py pkgs/standards/peagen/peagen/worker.py pkgs/standards/peagen/peagen/worker/__init__.py pkgs/standards/peagen/tests/unit/*.py`


------
https://chatgpt.com/codex/tasks/task_e_683a1b52ad3c83268dfc4ef557e49185