### PR TITLE
Add operational metrics and scaling utilities

### DIFF
--- a/pkgs/standards/peagen/peagen/commands/queue/__init__.py
+++ b/pkgs/standards/peagen/peagen/commands/queue/__init__.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import typer
 
 from .dlq import dlq_app
+from .recover import recover_app
 
 queue_app = typer.Typer(help="Queue utilities")
 queue_app.add_typer(dlq_app, name="dlq")
+queue_app.add_typer(recover_app, name="recover")
 
 __all__ = ["queue_app"]

--- a/pkgs/standards/peagen/peagen/commands/queue/recover.py
+++ b/pkgs/standards/peagen/peagen/commands/queue/recover.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import typer
+
+from peagen.queue import make_queue
+
+recover_app = typer.Typer(help="Crash recovery utilities")
+
+
+@recover_app.command("orphans")
+def requeue_orphans(
+    queue_url: str = typer.Option(..., "--queue-url"),
+    idle_ms: int = typer.Option(60000, "--idle-ms"),
+    max_batch: int = typer.Option(50, "--max-batch"),
+) -> None:
+    """Requeue orphaned tasks from the message broker."""
+    provider = "redis" if queue_url.startswith("redis") else "stub"
+    queue = make_queue(provider, url=queue_url)
+    moved = queue.requeue_orphans(idle_ms, max_batch)
+    typer.echo(f"moved {moved} orphan tasks")
+

--- a/pkgs/standards/peagen/peagen/handlers/exec_docker.py
+++ b/pkgs/standards/peagen/peagen/handlers/exec_docker.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 from peagen.queue.model import Task, Result, TaskKind
 from .base import TaskHandler
 
@@ -13,6 +14,28 @@ class ExecuteDockerHandler(TaskHandler):
 
     def handle(self, task: Task) -> Result:
         try:
+            src = task.payload.get("src")
+            if not src:
+                raise ValueError("missing src")
+            cmd = [
+                "docker",
+                "run",
+                "--rm",
+                "--network",
+                "none",
+                "--pids-limit",
+                "128",
+                "--memory",
+                "1g",
+                "--security-opt",
+                "no-new-privileges",
+                "-v",
+                f"{src}:/app/script.py:ro",
+                "python:3.11",
+                "python",
+                "/app/script.py",
+            ]
+            subprocess.run(cmd, check=True)
             metrics = {"speed_ms": 1.0, "peak_kb": 1.0}
             return Result(task.id, "ok", metrics)
         except Exception as e:

--- a/pkgs/standards/peagen/peagen/metrics.py
+++ b/pkgs/standards/peagen/peagen/metrics.py
@@ -1,0 +1,43 @@
+"""Prometheus metrics for Peagen workers and spawners."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from prometheus_client import Counter, Gauge, Histogram, start_http_server
+
+__all__ = [
+    "start_metrics_server",
+    "worker_task_total",
+    "worker_runtime_seconds",
+    "worker_exit_reason",
+    "warm_spawner_live_workers",
+    "queue_pending_total",
+]
+
+worker_task_total = Counter(
+    "worker_task_total", "Count of tasks processed", ["status"]
+)
+worker_runtime_seconds = Histogram(
+    "worker_runtime_seconds", "Task runtime in seconds"
+)
+worker_exit_reason = Counter(
+    "worker_exit_reason", "Reason worker exited", ["reason"]
+)
+warm_spawner_live_workers = Gauge(
+    "warm_spawner_live_workers", "Number of active worker processes"
+)
+queue_pending_total = Gauge(
+    "queue_pending_total", "Tasks waiting in queue", ["kind"]
+)
+
+
+_metrics_started = False
+
+def start_metrics_server(port: int = 8000) -> None:
+    """Start the Prometheus metrics HTTP exporter."""
+    global _metrics_started
+    if not _metrics_started:
+        start_http_server(port)
+        _metrics_started = True
+

--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "swarmauri",
     "swarmauri_prompt_j2prompttemplate",
     "pika",
+    "prometheus-client>=0.19",
 ]
 
 


### PR DESCRIPTION
## Summary
- export Prometheus metrics for Peagen workers and spawners
- add rate limiting and metrics to workers
- update warm spawner with metrics gauges
- sandbox Docker execution and add crash recovery CLI
- remove docs and watch script per review

## Testing
- No tests run

------
https://chatgpt.com/codex/tasks/task_e_683a1b5abdf48326b956d1d13de0e265