### PR TITLE
Add integration and chaos tests

### DIFF
--- a/pkgs/standards/peagen/tests/chaos/test_worker_recovery.py
+++ b/pkgs/standards/peagen/tests/chaos/test_worker_recovery.py
@@ -1,0 +1,42 @@
+import threading
+import time
+import pytest
+from peagen.queue.stub_queue import StubQueue
+from peagen.queue.model import Task, TaskKind
+from peagen.worker import OneShotWorker, WorkerConfig
+from peagen.handlers.render_handler import RenderHandler
+from peagen import plugin_registry
+
+
+class SlowHandler(RenderHandler):
+    def handle(self, task: Task):
+        time.sleep(0.2)
+        return super().handle(task)
+
+
+@pytest.mark.chaos
+def test_worker_sigterm_recovery(monkeypatch, tmp_path):
+    plugin_registry.registry.setdefault("task_handlers", {})["slow"] = SlowHandler
+    q = StubQueue()
+    dest = tmp_path / "out.txt"
+    q.enqueue(Task(TaskKind.RENDER, "c1", {"template": "hi", "vars": {}, "dest": str(dest)}, requires={"cpu"}))
+    cfg = WorkerConfig(queue_url="stub://", caps={"cpu"}, idle_exit=1)
+    worker = OneShotWorker(cfg)
+    monkeypatch.setattr(worker, "_select_handler", lambda t: SlowHandler())
+
+    def run_worker():
+        worker.run()
+
+    t = threading.Thread(target=run_worker)
+    t.start()
+    time.sleep(0.05)
+    worker._sigterm()
+    t.join()
+
+    q.requeue_orphans(idle_ms=0)
+    worker2 = OneShotWorker(cfg)
+    worker2.run()
+
+    res = q.wait_for_result("c1", 1)
+    assert res is not None and res.status == "ok"
+    assert dest.exists()

--- a/pkgs/standards/peagen/tests/i9n/test_redis_worker_flow.py
+++ b/pkgs/standards/peagen/tests/i9n/test_redis_worker_flow.py
@@ -1,0 +1,77 @@
+import time
+import pytest
+from peagen.queue.redis_stream_queue import RedisStreamQueue
+from peagen.queue.model import Task, TaskKind, Result
+from peagen.worker import OneShotWorker, WorkerConfig
+from peagen.handlers.render_handler import RenderHandler
+from peagen import plugin_registry
+
+
+class FakeRedis:
+    def __init__(self):
+        self.streams = {"peagen.tasks": [], "peagen.results": [], "peagen.dead": []}
+        self.groups = {}
+
+    def xgroup_create(self, stream, groupname, id="0-0", mkstream=True):
+        self.groups[groupname] = []
+
+    def expire(self, *a, **k):
+        pass
+
+    def xadd(self, stream, fields, maxlen=None):
+        msg_id = str(len(self.streams[stream]) + 1)
+        self.streams[stream].append((msg_id, fields))
+        return msg_id
+
+    def xreadgroup(self, groupname, consumername, streams, count=1, block=0):
+        items = self.streams["peagen.tasks"]
+        if not items:
+            return None
+        msg = items.pop(0)
+        self.groups[groupname].append(msg)
+        return [("peagen.tasks", [msg])]
+
+    def xack(self, stream, group, msg_id):
+        self.groups[group] = [m for m in self.groups[group] if m[0] != msg_id]
+
+    def xdel(self, stream, msg_id):
+        pass
+
+    def xadd_result(self, stream, fields):
+        self.streams[stream].append((str(len(self.streams[stream])+1), fields))
+
+    def xread(self, streams, block=0, count=1):
+        stream = list(streams.keys())[0]
+        last = streams[stream]
+        data = [m for m in self.streams[stream] if m[0] > last]
+        if data:
+            return [(stream, [data[0]])]
+        time.sleep(0.01)
+        return None
+
+    def xautoclaim(self, stream, group, consumer, min_idle_time, start_id="0-0", count=1):
+        pel = self.groups.get(group, [])
+        if not pel:
+            return ("0-0", [])
+        msg = pel.pop(0)
+        return (msg[0], [msg])
+
+
+@pytest.mark.integration_redis
+def test_worker_flow_with_fake_redis(monkeypatch, tmp_path):
+    fake = FakeRedis()
+    monkeypatch.setattr("redis.Redis.from_url", lambda *a, **k: fake)
+    plugin_registry.registry.setdefault("task_handlers", {})["render"] = RenderHandler
+
+    q = RedisStreamQueue("redis://test")
+    dest = tmp_path / "out.txt"
+    q.enqueue(Task(TaskKind.RENDER, "r1", {"template": "hi", "vars": {}, "dest": str(dest)}, requires={"cpu"}))
+
+    cfg = WorkerConfig(queue_url="redis://test", caps={"cpu"})
+    worker = OneShotWorker(cfg)
+    reason = worker.run()
+    assert reason == "ok"
+    res = q.wait_for_result("r1", 1)
+    assert res is not None and res.status == "ok"
+    assert dest.read_text() == "hi"
+    assert not fake.streams["peagen.tasks"]

--- a/pkgs/standards/peagen/tests/i9n/test_stub_worker_flow.py
+++ b/pkgs/standards/peagen/tests/i9n/test_stub_worker_flow.py
@@ -1,0 +1,19 @@
+import pytest
+from peagen.queue.stub_queue import StubQueue
+from peagen.queue.model import Task, TaskKind
+from peagen.worker import InlineWorker
+from peagen.handlers.render_handler import RenderHandler
+from peagen import plugin_registry
+
+
+@pytest.mark.integration_stub
+def test_render_task_via_inline_worker(tmp_path):
+    plugin_registry.registry.setdefault("task_handlers", {})["render"] = RenderHandler
+    q = StubQueue()
+    dest = tmp_path / "out.txt"
+    task = Task(TaskKind.RENDER, "1", {"template": "hi", "vars": {}, "dest": str(dest)}, requires={"cpu"})
+    q.enqueue(task)
+    worker = InlineWorker(q, caps={"cpu"})
+    worker.run_once()
+    assert dest.read_text() == "hi"
+    assert q.pending_count() == 0

--- a/pkgs/standards/peagen/tests/perf/test_benchmark_stub.py
+++ b/pkgs/standards/peagen/tests/perf/test_benchmark_stub.py
@@ -1,0 +1,21 @@
+import pytest
+from peagen.queue.stub_queue import StubQueue
+from peagen.queue.model import Task, TaskKind
+from peagen.worker import InlineWorker
+from peagen.handlers.render_handler import RenderHandler
+from peagen import plugin_registry
+
+
+@pytest.mark.perf
+def test_run_once_benchmark(tmp_path, benchmark):
+    plugin_registry.registry.setdefault("task_handlers", {})["render"] = RenderHandler
+    q = StubQueue()
+    dest = tmp_path / "out.txt"
+    q.enqueue(Task(TaskKind.RENDER, "b1", {"template": "hi", "vars": {}, "dest": str(dest)}, requires={"cpu"}))
+    worker = InlineWorker(q, caps={"cpu"})
+
+    def run():
+        worker.run_once()
+
+    benchmark(run)
+    assert dest.exists()


### PR DESCRIPTION
## Summary
- implement stub queue integration test
- implement redis queue integration test using FakeRedis
- add performance benchmark test
- add chaos test simulating worker recovery
- remove benchmark harness (benchmarks/*)

## Testing
- No tests run due to instruction

------
https://chatgpt.com/codex/tasks/task_e_683a1b6261c88326809e3959fa2ad83f