### PR TITLE
Remove backend_weights docs

### DIFF
--- a/docs/docs/guide/evolve.md
+++ b/docs/docs/guide/evolve.md
@@ -4,17 +4,12 @@ The evolution workflow relies on several plug-in layers:
 
 - **Parent selectors** choose a champion from `EvoDB`.
 - **Mutators** build prompts and apply patches via the LLM ensemble.
-- **LLM back‑ends** are weighted in `.peagen.toml` under `[llm.backend_weights]`.
 
 Example configuration:
 
 ```toml
 [evolve]
 selector = "epsilon"
-
-[llm.backend_weights]
-openai = 3
-local  = 1
 ```
 
 Run `peagen evolve step` to generate a new candidate. After evaluation the

--- a/pkgs/standards/peagen/docs/feature_evolve/18  Appendices.md
+++ b/pkgs/standards/peagen/docs/feature_evolve/18  Appendices.md
@@ -40,10 +40,6 @@ root       = "/var/peagen/results"
 caps        = "cpu,docker,llm"
 warm_pool   = 2
 concurrency = 1
-
-[llm.backend_weights]
-openai = 2
-groq   = 1
 ```
 
 #### A-3  *Hybrid GPU + CPU Cluster*

--- a/pkgs/standards/peagen/docs/feature_evolve/8  Evolution-Specific Components.md
+++ b/pkgs/standards/peagen/docs/feature_evolve/8  Evolution-Specific Components.md
@@ -83,13 +83,7 @@ child = LLMEnsemble.generate(prompt,
 | `groq`   | GroqCloud  | `mixtral-8x22b`, `llama-70b` |
 | `local`  | llama.cpp  | GGUF on local GPU/CPU        |
 
-Routing probability configured in TOML:
-
-```toml
-[llm.backend_weights]
-openai = 3
-groq   = 1
-```
+The ensemble selects an available back-end automatically.
 
 *Metrics:* `llm_tokens_total{backend}`, `llm_latency_seconds`.
 


### PR DESCRIPTION
## Summary
- remove llm.backend_weights bullet from evolve guide
- drop backend_weights explanation from Evolution-Specific Components and Appendices docs

## Testing
- `grep -R "backend_weights" -n | grep -v .venv`

------
https://chatgpt.com/codex/tasks/task_e_683a63e0c41c83268ff9fa100df9a5ea