### PR TITLE
Add detach option to peagen worker start

### DIFF
--- a/pkgs/standards/peagen/docs/feature_evolve/13  Roll-Out & Migration Plan.md
+++ b/pkgs/standards/peagen/docs/feature_evolve/13  Roll-Out & Migration Plan.md
@@ -43,7 +43,7 @@ teams a clear fallback at each checkpoint.
 
    ```bash
    redis-server --daemonize yes
-   peagen worker start &
+   peagen worker start
    peagen evolve step   # should enqueue + drain
    ```
 4. **CI Update** – add Redis service to pipeline; replace `peagen process` job with `peagen render`.

--- a/pkgs/standards/peagen/docs/feature_evolve/6  Worker Fabric.md
+++ b/pkgs/standards/peagen/docs/feature_evolve/6  Worker Fabric.md
@@ -126,7 +126,7 @@ wrap handler execution to record trace IDs alongside metrics and logs.
 
 ```bash
 export QUEUE_URL=stub://
-peagen worker start  # spins inline worker thread
+peagen worker start --no-detach  # spins inline worker thread
 ```
 
 **CPU cluster node**

--- a/pkgs/standards/peagen/peagen/commands/worker.py
+++ b/pkgs/standards/peagen/peagen/commands/worker.py
@@ -2,18 +2,18 @@ from __future__ import annotations
 
 import typer
 
+import os
+import subprocess
+import sys
+
 from peagen.worker import OneShotWorker, WorkerConfig
 from peagen.spawner import SpawnerConfig, WarmSpawner
 
 worker_app = typer.Typer(help="Manage Peagen workers")
 
 
-@worker_app.command("start")
-def start_worker(
-    warm_pool: int = typer.Option(0, "--warm-pool", help="Maintain N idle workers"),
-    config: str = typer.Option("spawner.toml", "--config", help="Spawner config file"),
-) -> None:
-    """Launch a worker or warm-spawner depending on ``--warm-pool``."""
+def _run_worker(warm_pool: int, config: str) -> None:
+    """Run the worker or warm-spawner in the current process."""
     if warm_pool > 0:
         sp_cfg = SpawnerConfig.from_toml(config)
         sp_cfg.warm_pool = warm_pool
@@ -21,3 +21,33 @@ def start_worker(
     else:
         cfg = WorkerConfig.from_env()
         OneShotWorker(cfg).run()
+
+
+@worker_app.command("start")
+def start_worker(
+    warm_pool: int = typer.Option(0, "--warm-pool", help="Maintain N idle workers"),
+    config: str = typer.Option("spawner.toml", "--config", help="Spawner config file"),
+    detach: bool = typer.Option(True, "--detach/--no-detach", help="Run in background"),
+) -> None:
+    """Launch a worker or warm-spawner depending on ``--warm-pool``."""
+    if detach:
+        cmd = [
+            sys.executable,
+            "-m",
+            "peagen.cli",
+            "worker",
+            "start",
+            f"--warm-pool={warm_pool}",
+            f"--config={config}",
+            "--no-detach",
+        ]
+        subprocess.Popen(
+            cmd,
+            env=os.environ.copy(),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        typer.echo("Worker detached")
+    else:
+        _run_worker(warm_pool, config)


### PR DESCRIPTION
## Summary
- add background option to `peagen worker start`
- show how to keep the process attached in docs
- remove manual backgrounding from rollout docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683a76741a988326830e48d17cc75780