### PR TITLE
Fix ruff issues in peagen

### DIFF
--- a/pkgs/standards/peagen/peagen/commands/init.py
+++ b/pkgs/standards/peagen/peagen/commands/init.py
@@ -25,7 +25,6 @@ from swarmauri_standard.loggers.Logger import Logger
 import typer
 from jinja2 import Environment, FileSystemLoader, select_autoescape, Template
 from peagen.plugin_registry import registry
-import inspect
 
 # ── Typer root ───────────────────────────────────────────────────────────────
 init_app = typer.Typer(help="Bootstrap Peagen artefacts (project, template-set …)")
@@ -130,7 +129,7 @@ def init_template_set(
     self.logger.info(name)
     tmpl_mod = registry["template_sets"].get("init-template-set")
     if tmpl_mod is None:
-        typer.echo(f"❌  Template-set 'init-template-set' not found.")
+        typer.echo("❌  Template-set 'init-template-set' not found.")
         raise typer.Exit(code=1)
 
     src_root = Path(list(tmpl_mod.__path__)[0])

--- a/pkgs/standards/peagen/peagen/commands/process.py
+++ b/pkgs/standards/peagen/peagen/commands/process.py
@@ -7,8 +7,7 @@ import pathlib
 import secrets
 import time
 from datetime import datetime, timezone
-from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 from urllib.parse import urlparse
 
 import typer
@@ -25,7 +24,6 @@ from peagen.cli_common import (
 )
 from peagen.core import Fore, Peagen
 from peagen.plugin_registry import registry  # central plugin registry
-from peagen._utils.slug_utils import slugify
 
 process_app = typer.Typer(
     help="Render / generate one or all projects in a YAML payload."
@@ -182,8 +180,6 @@ def process_cmd(
     run_id = f"{timestamp}-{secrets.token_hex(4)}"
     typer.echo(f"run-id: {run_id}")
 
-    project_slug = slugify(project_name or "multi")
-    proj_prefix = f"projects/{project_slug}/runs/{run_id}/"  # ← canonical
 
     # ── BUILD STORAGE ADAPTER (prefix-aware) ────────────────────────────
     art = urlparse(artifacts or "")
@@ -223,7 +219,7 @@ def process_cmd(
         agent_env["agent_prompt_template_file"] = agent_prompt_template_file
 
     with temp_workspace() as ws:
-        fetched_dirs = materialise_packages(source_pkgs, ws, storage_adapter)
+        materialise_packages(source_pkgs, ws, storage_adapter)
         pea = Peagen(
             projects_payload_path=str(projects_payload),
             template_base_dir=None,
@@ -236,7 +232,7 @@ def process_cmd(
             workspace_root=ws,
         )
         pea.logger.debug("")
-        pea.logger.debug(f"pea.j2pt.templates_dir:")
+        pea.logger.debug("pea.j2pt.templates_dir:")
         for d in pea.j2pt.templates_dir:
             pea.logger.debug(f"* {d}")
 
@@ -252,12 +248,12 @@ def process_cmd(
         pea.logger.debug(f"pea.workspace_root: {pea.workspace_root}")
 
         pea.logger.debug("")
-        pea.logger.debug(f"pea.source_packages:")
+        pea.logger.debug("pea.source_packages:")
         for d in pea.source_packages:
             pea.logger.debug(f"* {d}")
 
         pea.logger.debug("")
-        pea.logger.debug(f"pea.namespace_dirs: ")
+        pea.logger.debug("pea.namespace_dirs: ")
         for d in pea.namespace_dirs:
             pea.logger.debug(f"* {d}")
 

--- a/pkgs/standards/peagen/peagen/commands/render.py
+++ b/pkgs/standards/peagen/peagen/commands/render.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import pathlib
 import typer
 
 from peagen.cli_common import global_cli_options

--- a/pkgs/standards/peagen/peagen/commands/worker.py
+++ b/pkgs/standards/peagen/peagen/commands/worker.py
@@ -5,6 +5,7 @@ import typer
 import os
 import subprocess
 import sys
+import psutil
 
 from peagen.worker import OneShotWorker, WorkerConfig
 from peagen.spawner import SpawnerConfig, WarmSpawner

--- a/pkgs/standards/peagen/peagen/core.py
+++ b/pkgs/standards/peagen/peagen/core.py
@@ -13,8 +13,6 @@ from importlib import import_module
 from types import ModuleType
 from typing import Any, Dict, List, Optional, Tuple
 
-import peagen.plugin_registry
-import peagen.templates
 import yaml
 from colorama import Fore, Style
 from colorama import init as colorama_init

--- a/pkgs/standards/peagen/peagen/handlers/base.py
+++ b/pkgs/standards/peagen/peagen/handlers/base.py
@@ -18,8 +18,8 @@ class TaskHandlerBase(ComponentBase):
     def dispatch(self, task: Task) -> bool:
         raise NotImplementedError
 
-    def handle(self, task: Task) -> Result:
-        """Return True if this handler should handle ``task``."""
+    def should_handle(self, task: Task) -> bool:
+        """Return ``True`` if this handler should process ``task``."""
         raise NotImplementedError
 
     def handle(self, task: Task) -> Result:

--- a/pkgs/standards/peagen/peagen/handlers/eval_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/eval_handler.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Set
+
 from peagen.queue.model import Task, Result, TaskKind
 from .base import TaskHandlerBase
 

--- a/pkgs/standards/peagen/peagen/handlers/exec_docker.py
+++ b/pkgs/standards/peagen/peagen/handlers/exec_docker.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Set
+
 from peagen.queue.model import Task, Result, TaskKind
 from .base import TaskHandlerBase
 

--- a/pkgs/standards/peagen/peagen/handlers/exec_gpu.py
+++ b/pkgs/standards/peagen/peagen/handlers/exec_gpu.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Set
+
 from peagen.queue.model import Task, Result, TaskKind
 from .base import TaskHandlerBase
 

--- a/pkgs/standards/peagen/peagen/handlers/mutate_patch.py
+++ b/pkgs/standards/peagen/peagen/handlers/mutate_patch.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from typing import Set
+
 from peagen.queue.model import Task, Result, TaskKind
 from .base import TaskHandlerBase
 

--- a/pkgs/standards/peagen/peagen/handlers/render_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/render_handler.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
 from jinja2 import Template
+
+from typing import Set
 
 from peagen.queue.model import Task, Result, TaskKind
 from .base import TaskHandlerBase

--- a/pkgs/standards/peagen/peagen/llm/ensemble.py
+++ b/pkgs/standards/peagen/peagen/llm/ensemble.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import random
 import time
 from importlib.metadata import entry_points
-from typing import Dict, Any
+from typing import Dict
 
 from peagen.cli_common import load_peagen_toml
 

--- a/pkgs/standards/peagen/peagen/mutators/mutate_patch.py
+++ b/pkgs/standards/peagen/peagen/mutators/mutate_patch.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
 import random
-import time
 from dataclasses import asdict
-from pathlib import Path
 
 from peagen.queue.model import Task, TaskKind, Result
-from peagen.handlers.base import TaskHandler
 from peagen.llm.ensemble import LLMEnsemble
 from peagen.prompt_sampler import PromptSampler
 from peagen.mutators.base import Mutator
@@ -61,12 +58,12 @@ def apply_patch(src: str, diff: str) -> str:
         out.extend(src_lines[i:old_start])
         i = old_start
         while idx < len(lines) and not lines[idx].startswith("@@"):
-            l = lines[idx]
-            if l.startswith("-"):
+            line = lines[idx]
+            if line.startswith("-"):
                 i += 1
-            elif l.startswith("+"):
-                out.append(l[1:] + "\n")
-            elif l.startswith(" ") or l == "":
+            elif line.startswith("+"):
+                out.append(line[1:] + "\n")
+            elif line.startswith(" ") or line == "":
                 out.append(src_lines[i])
                 i += 1
             idx += 1

--- a/pkgs/standards/peagen/peagen/queue/base.py
+++ b/pkgs/standards/peagen/peagen/queue/base.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from typing import Protocol
 from swarmauri_base.ComponentBase import ComponentBase
 
 from .model import Task, Result

--- a/pkgs/standards/peagen/peagen/queue/stub_queue.py
+++ b/pkgs/standards/peagen/peagen/queue/stub_queue.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import deque
-from typing import Deque, Dict, Tuple, ClassVar
+from typing import Deque, Dict, Tuple
 from pydantic import PrivateAttr, ConfigDict
 import time
 import threading

--- a/pkgs/standards/peagen/peagen/spawner.py
+++ b/pkgs/standards/peagen/peagen/spawner.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 import time
 from dataclasses import dataclass
-from typing import List, Set
+from typing import List
 
 from peagen.queue import make_queue
 
@@ -71,7 +71,7 @@ class WarmSpawner:
     def run(self) -> None:
         while True:
             pending = getattr(self.queue, "pending_count", lambda: 0)()
-            idle = self._cleanup_workers()
+            self._cleanup_workers()
             live = len(self.workers)
             if pending > max(0, live - self.cfg.warm_pool):
                 to_launch = min(pending - (live - self.cfg.warm_pool), self.cfg.max_parallel)

--- a/pkgs/standards/peagen/peagen/worker/__init__.py
+++ b/pkgs/standards/peagen/peagen/worker/__init__.py
@@ -2,20 +2,20 @@ from __future__ import annotations
 
 import os
 import signal
-import sys
 import time
 import uuid
 from dataclasses import dataclass
-from typing import Any, Iterable, Protocol, Set, List
+from typing import Any, Iterable, Set, List
 
 from peagen.queue import make_queue
-from peagen.queue.model import Result, Task, TaskKind
+from peagen.queue.base import TaskQueueBase
+from peagen.queue.model import Result, Task
 from peagen.plugin_registry import registry
 from peagen.handlers.base import TaskHandlerBase
+from swarmauri_base.ComponentBase import ComponentBase
 
 # Backwards compatibility alias
 TaskHandler = TaskHandlerBase
-from swarmauri_base.ComponentBase import ComponentBase
 
 
 @dataclass
@@ -102,9 +102,7 @@ class OneShotWorker:
                 continue
 
             try:
-                t0 = time.time()
                 result = handler.handle(task)
-                runtime = time.time() - t0
                 self.queue.push_result(result)
                 self.queue.ack(task.id)
                 exit_reason = result.status
@@ -122,7 +120,7 @@ class InlineWorker(ComponentBase):
     """Simple in-process worker for tests and local runs."""
 
     def __init__(
-        self, queue: make_queue.__annotations__["return"], caps: Set[str] | None = None
+        self, queue: TaskQueueBase, caps: Set[str] | None = None
     ) -> None:
         super().__init__()
         self.queue = queue


### PR DESCRIPTION
## Summary
- remove unused imports and variables
- clean up f-strings
- fix ambiguous variable names
- add missing typing imports
- adjust worker types and imports
- tidy spawner cleanup logic

## Testing
- `ruff check pkgs/standards/peagen/peagen`
- `uv run --package peagen --directory standards/peagen pytest` *(fails: ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_683a7b324d6c83268d51bae6aeda6af5