### PR TITLE
Add S3fs memory program

### DIFF
--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -57,6 +57,8 @@ members = [
     #"standards/swarmauri_vectorstore_tfidf",
     "standards/swarmauri_distance_minkowski",
     "standards/swarmauri_prompt_j2prompttemplate",
+    "standards/swarmauri_program_s3fs",
+    "standards/swarmauri_program_memorys3fs",
     "standards/peagen",
     "community/swarmauri_vectorstore_redis",
     "community/swarmauri_vectorstore_qdrant",
@@ -152,6 +154,8 @@ swarmauri_evaluator_subprocess = { workspace = true }
 swarmauri_evaluatorpool_accessibility = { workspace = true }
 #swarmauri_vectorstore_tfidf = { workspace = true } # We have a tfidf with built-in formula now, this can move to community support with minor rename
 swarmauri_distance_minkowski = { workspace = true }
+swarmauri_program_s3fs = { workspace = true }
+swarmauri_program_memorys3fs = { workspace = true }
 peagen = { workspace = true }
 
 swarmauri_vectorstore_redis = { workspace = true }

--- a/pkgs/standards/swarmauri_program_memorys3fs/LICENSE
+++ b/pkgs/standards/swarmauri_program_memorys3fs/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/standards/swarmauri_program_memorys3fs/README.md
+++ b/pkgs/standards/swarmauri_program_memorys3fs/README.md
@@ -1,0 +1,36 @@
+![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_program_memorys3fs/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_program_memorys3fs" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_program_memorys3fs/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_program_memorys3fs.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_program_memorys3fs/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_program_memorys3fs" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_program_memorys3fs/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_program_memorys3fs" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_program_memorys3fs/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_program_memorys3fs?label=swarmauri_program_memorys3fs&color=green" alt="PyPI - swarmauri_program_memorys3fs"/></a>
+</p>
+
+---
+
+# Swarmauri Program MemoryS3FS
+
+In-memory S3 filesystem based program implementation using `s3fs` and `fsspec`.
+
+## Installation
+
+```bash
+pip install swarmauri_program_memorys3fs
+```
+
+## Usage
+
+```python
+from swarmauri_program_memorys3fs import MemoryS3FSProgram
+
+program = MemoryS3FSProgram()
+program.content["hello.py"] = "print('hi')"
+program.save_to_s3(bucket="my-bucket", prefix="my-prefix")
+```

--- a/pkgs/standards/swarmauri_program_memorys3fs/pyproject.toml
+++ b/pkgs/standards/swarmauri_program_memorys3fs/pyproject.toml
@@ -1,0 +1,65 @@
+[project]
+name = "swarmauri_program_memorys3fs"
+version = "0.1.0"
+description = "In-memory S3 filesystem backed Program implementation"
+license = "Apache-2.0"
+readme = "README.md"
+repository = "http://github.com/swarmauri/swarmauri-sdk"
+requires-python = ">=3.10,<3.13"
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+authors = [{ name = "SwarmAuri Team", email = "info@swarmauri.com" }]
+keywords = ["s3", "memory", "program", "swarmauri"]
+dependencies = [
+    "s3fs>=2024.3.0",
+    "fsspec>=2024.3.0",
+    "swarmauri_base",
+]
+
+[tool.uv.sources]
+swarmauri_base = { workspace = true }
+
+[tool.pytest.ini_options]
+norecursedirs = ["combined", "scripts"]
+markers = [
+    "test: standard test",
+    "unit: Unit tests",
+    "i9n: Integration tests",
+    "r8n: Regression tests",
+    "timeout: mark test to timeout after X seconds",
+    "xpass: Expected passes",
+    "xfail: Expected failures",
+    "acceptance: Acceptance tests",
+    "perf: Performance tests that measure execution time and resource usage",
+]
+timeout = 300
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
+
+[project.entry-points.'swarmauri.programs']
+MemoryS3FSProgram = "swarmauri_program_memorys3fs:MemoryS3FSProgram"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "python-dotenv",
+    "requests>=2.32.3",
+    "flake8>=7.0",
+    "pytest-timeout>=2.3.1",
+    "ruff>=0.9.9",
+    "pytest-benchmark>=4.0.0",
+]

--- a/pkgs/standards/swarmauri_program_memorys3fs/swarmauri_program_memorys3fs/MemoryS3FSProgram.py
+++ b/pkgs/standards/swarmauri_program_memorys3fs/swarmauri_program_memorys3fs/MemoryS3FSProgram.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any, Dict, Optional, ClassVar
+
+import fsspec
+import s3fs
+from pydantic import PrivateAttr
+
+from swarmauri_base.programs.ProgramBase import ProgramBase
+
+
+class MemoryS3FSProgram(ProgramBase):
+    """Program backed by an in-memory S3 filesystem."""
+
+    _program_type: ClassVar[str] = "memory-s3fs"
+    type: str = "MemoryS3FSProgram"
+    id: str
+    version: str
+    metadata: Dict[str, Any]
+    content: Dict[str, str]
+    bucket: Optional[str] = None
+    prefix: str = ""
+
+    _fs: s3fs.S3FileSystem = PrivateAttr()
+
+    def __init__(
+        self,
+        id: Optional[str] = None,
+        version: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        content: Optional[Dict[str, str]] = None,
+        bucket: Optional[str] = None,
+        prefix: str = "",
+        fs: Optional[s3fs.S3FileSystem] = None,
+    ) -> None:
+        super().__init__()
+        self.id = id if id else str(uuid.uuid4())
+        self.version = version if version else "1.0.0"
+        self.metadata = metadata if metadata else {}
+        self.content = content if content else {}
+
+        if "program_id" not in self.metadata:
+            self.metadata["program_id"] = self.id
+        if "program_version" not in self.metadata:
+            self.metadata["program_version"] = self.version
+        if "created_at" not in self.metadata:
+            self.metadata["created_at"] = datetime.utcnow().isoformat()
+
+        self.bucket = bucket
+        self.prefix = prefix
+        self._fs = fs or self._create_memory_fs()
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _create_memory_fs() -> s3fs.S3FileSystem:
+        store = fsspec.filesystem("memory")
+
+        class _FS(s3fs.S3FileSystem):
+            def __init__(self) -> None:
+                super().__init__(anon=True)
+                self.store = store
+
+            def open(self, path: str, mode: str = "r", **kwargs):  # type: ignore[override]
+                return store.open(path, mode, **kwargs)
+
+            def glob(self, path: str, **kwargs):
+                return store.glob(path, **kwargs)
+
+            def isdir(self, path: str):  # type: ignore[override]
+                return store.isdir(path)
+
+            def exists(self, path: str):  # type: ignore[override]
+                return store.exists(path)
+
+            def makedirs(self, path: str, exist_ok: bool = False):
+                store.mkdirs(path, exist_ok=exist_ok)
+
+        return _FS()
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_s3(
+        cls,
+        bucket: str,
+        prefix: str = "",
+        fs: Optional[s3fs.S3FileSystem] = None,
+    ) -> "MemoryS3FSProgram":
+        fs = fs or cls._create_memory_fs()
+        root_path = f"{bucket}/{prefix}".rstrip("/")
+        content: Dict[str, str] = {}
+        for path in fs.glob(f"{root_path}/**"):
+            if fs.isdir(path):
+                continue
+            if path.endswith((".py", ".txt", ".md")):
+                with fs.open(path, "r") as fh:
+                    rel = path[len(root_path) + 1 :]
+                    content[rel] = fh.read()
+        return cls(bucket=bucket, prefix=prefix, fs=fs, content=content)
+
+    def save_to_s3(
+        self, bucket: Optional[str] = None, prefix: Optional[str] = None
+    ) -> None:
+        bucket = bucket or self.bucket
+        prefix = prefix or self.prefix
+        if not bucket:
+            raise ValueError("Bucket must be specified")
+        root_path = f"{bucket}/{prefix}".rstrip("/")
+        for rel, text in self.content.items():
+            dest = f"{root_path}/{rel}".rstrip("/")
+            folder = dest.rsplit("/", 1)[0]
+            if not self._fs.exists(folder):
+                self._fs.makedirs(folder, exist_ok=True)
+            with self._fs.open(dest, "w") as fh:
+                fh.write(text)
+

--- a/pkgs/standards/swarmauri_program_memorys3fs/swarmauri_program_memorys3fs/__init__.py
+++ b/pkgs/standards/swarmauri_program_memorys3fs/swarmauri_program_memorys3fs/__init__.py
@@ -1,0 +1,13 @@
+from .MemoryS3FSProgram import MemoryS3FSProgram
+
+__all__ = ["MemoryS3FSProgram"]
+
+try:
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError:  # pragma: no cover
+    from importlib_metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("swarmauri_program_memorys3fs")
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "0.0.0"

--- a/pkgs/standards/swarmauri_program_memorys3fs/tests/unit/test_MemoryS3FSProgram.py
+++ b/pkgs/standards/swarmauri_program_memorys3fs/tests/unit/test_MemoryS3FSProgram.py
@@ -1,0 +1,37 @@
+import pytest
+
+from swarmauri_program_memorys3fs import MemoryS3FSProgram
+
+
+@pytest.mark.unit
+def test_ubc_resource():
+    assert MemoryS3FSProgram().resource == "Program"
+
+
+@pytest.mark.unit
+def test_ubc_type():
+    assert MemoryS3FSProgram().type == "MemoryS3FSProgram"
+
+
+@pytest.mark.unit
+def test_serialization():
+    prog = MemoryS3FSProgram()
+    assert prog.id == MemoryS3FSProgram.model_validate_json(prog.model_dump_json()).id
+
+
+@pytest.mark.unit
+def test_from_and_save_s3():
+    # create initial files in memory fs via program instance
+    prog = MemoryS3FSProgram()
+    prog._fs.makedirs("bucket/prefix", exist_ok=True)
+    with prog._fs.open("bucket/prefix/hello.py", "w") as f:
+        f.write("print('hi')")
+
+    loaded = MemoryS3FSProgram.from_s3(bucket="bucket", prefix="prefix", fs=prog._fs)
+    assert loaded.content["hello.py"] == "print('hi')"
+
+    loaded.content["readme.md"] = "info"
+    loaded.save_to_s3(bucket="bucket2", prefix="prog")
+    with prog._fs.open("bucket2/prog/readme.md") as f:
+        assert f.read() == "info"
+

--- a/pkgs/standards/swarmauri_program_s3fs/LICENSE
+++ b/pkgs/standards/swarmauri_program_s3fs/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/standards/swarmauri_program_s3fs/README.md
+++ b/pkgs/standards/swarmauri_program_s3fs/README.md
@@ -1,0 +1,35 @@
+![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_program_s3fs/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_program_s3fs" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_program_s3fs/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_program_s3fs.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_program_s3fs/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_program_s3fs" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_program_s3fs/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_program_s3fs" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_program_s3fs/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_program_s3fs?label=swarmauri_program_s3fs&color=green" alt="PyPI - swarmauri_program_s3fs"/></a>
+</p>
+
+---
+
+# Swarmauri Program S3fs
+
+Program representation that stores and retrieves source files from S3 using `s3fs`.
+
+## Installation
+
+```bash
+pip install swarmauri_program_s3fs
+```
+
+## Usage
+
+```python
+from swarmauri_program_s3fs import S3fsProgram
+
+program = S3fsProgram.from_s3(bucket="my-bucket", prefix="my-program")
+program.save_to_s3(bucket="backup-bucket", prefix="backup")
+```

--- a/pkgs/standards/swarmauri_program_s3fs/pyproject.toml
+++ b/pkgs/standards/swarmauri_program_s3fs/pyproject.toml
@@ -1,0 +1,65 @@
+[project]
+name = "swarmauri_program_s3fs"
+version = "0.1.0"
+description = "Program representation that loads and saves content from S3 using s3fs"
+license = "Apache-2.0"
+readme = "README.md"
+repository = "http://github.com/swarmauri/swarmauri-sdk"
+requires-python = ">=3.10,<3.13"
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+authors = [{ name = "SwarmAuri Team", email = "info@swarmauri.com" }]
+keywords = ["s3", "s3fs", "program", "swarmauri"]
+dependencies = [
+    "s3fs>=2024.3.0",
+    "swarmauri_base",
+]
+
+[tool.uv.sources]
+swarmauri_base = { workspace = true }
+
+[tool.pytest.ini_options]
+norecursedirs = ["combined", "scripts"]
+markers = [
+    "test: standard test",
+    "unit: Unit tests",
+    "i9n: Integration tests",
+    "r8n: Regression tests",
+    "timeout: mark test to timeout after X seconds",
+    "xpass: Expected passes",
+    "xfail: Expected failures",
+    "acceptance: Acceptance tests",
+    "perf: Performance tests that measure execution time and resource usage",
+]
+timeout = 300
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
+
+[project.entry-points.'swarmauri.programs']
+S3fsProgram = "swarmauri_program_s3fs:S3fsProgram"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "python-dotenv",
+    "requests>=2.32.3",
+    "flake8>=7.0",
+    "pytest-timeout>=2.3.1",
+    "ruff>=0.9.9",
+    "pytest-benchmark>=4.0.0",
+]
+

--- a/pkgs/standards/swarmauri_program_s3fs/swarmauri_program_s3fs/S3fsProgram.py
+++ b/pkgs/standards/swarmauri_program_s3fs/swarmauri_program_s3fs/S3fsProgram.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime
+from typing import Any, ClassVar, Dict, Optional
+
+import s3fs
+from pydantic import PrivateAttr
+from swarmauri_base.programs.ProgramBase import ProgramBase
+
+logger = logging.getLogger(__name__)
+
+
+class S3fsProgram(ProgramBase):
+    """Program backed by S3 using ``s3fs``."""
+
+    _program_type: ClassVar[str] = "s3fs"
+    type: str = "S3fsProgram"
+    id: str
+    version: str
+    metadata: Dict[str, Any]
+    content: Dict[str, str]
+    bucket: Optional[str] = None
+    prefix: str = ""
+
+    _fs: s3fs.S3FileSystem = PrivateAttr()
+
+    def __init__(
+        self,
+        id: Optional[str] = None,
+        version: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        content: Optional[Dict[str, str]] = None,
+        bucket: Optional[str] = None,
+        prefix: str = "",
+        fs: Optional[s3fs.S3FileSystem] = None,
+    ) -> None:
+        super().__init__()
+        self.id = id if id else str(uuid.uuid4())
+        self.version = version if version else "1.0.0"
+        self.metadata = metadata if metadata else {}
+        self.content = content if content else {}
+
+        if "program_id" not in self.metadata:
+            self.metadata["program_id"] = self.id
+        if "program_version" not in self.metadata:
+            self.metadata["program_version"] = self.version
+        if "created_at" not in self.metadata:
+            self.metadata["created_at"] = datetime.utcnow().isoformat()
+
+        self.bucket = bucket
+        self.prefix = prefix
+        self._fs = fs or s3fs.S3FileSystem()
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_s3(
+        cls,
+        bucket: str,
+        prefix: str = "",
+        fs: Optional[s3fs.S3FileSystem] = None,
+    ) -> "S3fsProgram":
+        """Load program files from an S3 location."""
+        fs = fs or s3fs.S3FileSystem()
+        root_path = f"{bucket}/{prefix}".rstrip("/")
+        content: Dict[str, str] = {}
+        for path in fs.glob(f"{root_path}/**"):
+            if fs.isdir(path):
+                continue
+            if path.endswith((".py", ".txt", ".md")):
+                with fs.open(path, "r") as fh:
+                    rel = path[len(root_path) + 1 :]
+                    content[rel] = fh.read()
+        return cls(bucket=bucket, prefix=prefix, fs=fs, content=content)
+
+    def save_to_s3(
+        self, bucket: Optional[str] = None, prefix: Optional[str] = None
+    ) -> None:
+        """Save program content to S3."""
+        bucket = bucket or self.bucket
+        prefix = prefix or self.prefix
+        if not bucket:
+            raise ValueError("Bucket must be specified")
+        root_path = f"{bucket}/{prefix}".rstrip("/")
+        for rel, text in self.content.items():
+            dest = f"{root_path}/{rel}".rstrip("/")
+            folder = dest.rsplit("/", 1)[0]
+            if not self._fs.exists(folder):
+                self._fs.makedirs(folder, exist_ok=True)
+            with self._fs.open(dest, "w") as fh:
+                fh.write(text)

--- a/pkgs/standards/swarmauri_program_s3fs/swarmauri_program_s3fs/__init__.py
+++ b/pkgs/standards/swarmauri_program_s3fs/swarmauri_program_s3fs/__init__.py
@@ -1,0 +1,13 @@
+from .S3fsProgram import S3fsProgram
+
+__all__ = ["S3fsProgram"]
+
+try:
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError:  # pragma: no cover
+    from importlib_metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("swarmauri_program_s3fs")
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "0.0.0"

--- a/pkgs/standards/swarmauri_program_s3fs/tests/unit/test_S3fsProgram.py
+++ b/pkgs/standards/swarmauri_program_s3fs/tests/unit/test_S3fsProgram.py
@@ -1,0 +1,65 @@
+import pytest
+import fsspec
+import s3fs
+from swarmauri_program_s3fs import S3fsProgram
+
+
+class MemoryS3FS(s3fs.S3FileSystem):
+    """s3fs filesystem backed by in-memory fsspec store for testing."""
+
+    def __init__(self):
+        super().__init__(anon=True)
+        self.store = fsspec.filesystem("memory")
+
+    # Delegate required methods to memory fs
+    def open(self, path, mode="r", **kwargs):  # type: ignore[override]
+        return self.store.open(path, mode, **kwargs)
+
+    def glob(self, path, **kwargs):
+        return self.store.glob(path, **kwargs)
+
+    def isdir(self, path):  # type: ignore[override]
+        return self.store.isdir(path)
+
+    def exists(self, path):  # type: ignore[override]
+        return self.store.exists(path)
+
+    def makedirs(self, path, exist_ok=False):
+        self.store.mkdirs(path, exist_ok=exist_ok)
+
+
+@pytest.fixture
+def mem_fs():
+    return MemoryS3FS()
+
+
+@pytest.mark.unit
+def test_ubc_resource():
+    assert S3fsProgram().resource == "Program"
+
+
+@pytest.mark.unit
+def test_ubc_type():
+    assert S3fsProgram().type == "S3fsProgram"
+
+
+@pytest.mark.unit
+def test_serialization():
+    prog = S3fsProgram()
+    assert prog.id == S3fsProgram.model_validate_json(prog.model_dump_json()).id
+
+
+@pytest.mark.unit
+def test_from_and_save_s3(mem_fs):
+    # prepare files in memory fs
+    mem_fs.makedirs("bucket/prefix", exist_ok=True)
+    with mem_fs.open("bucket/prefix/hello.py", "w") as f:
+        f.write("print('hi')")
+
+    prog = S3fsProgram.from_s3(bucket="bucket", prefix="prefix", fs=mem_fs)
+    assert prog.content["hello.py"] == "print('hi')"
+
+    prog.content["readme.md"] = "info"
+    prog.save_to_s3(bucket="bucket2", prefix="prog",)
+    with mem_fs.open("bucket2/prog/readme.md") as f:
+        assert f.read() == "info"


### PR DESCRIPTION
## Summary
- create `swarmauri_program_memorys3fs` package
- implement `MemoryS3FSProgram` using in-memory s3fs store
- fix `S3fsProgram` to inherit from `ProgramBase`
- document and configure both program packages
- register packages in workspace configuration

## Testing
- `uv run --package swarmauri_program_s3fs --directory pkgs/standards/swarmauri_program_s3fs pytest` *(fails: No route to host)*
- `uv run --package swarmauri_program_memorys3fs --directory pkgs/standards/swarmauri_program_memorys3fs pytest` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683a81bdb6cc83268fa90c74e3c7790b