### PR TITLE
Remove global j2pt references

### DIFF
--- a/pkgs/standards/peagen/peagen/_utils/_processing.py
+++ b/pkgs/standards/peagen/peagen/_utils/_processing.py
@@ -159,8 +159,8 @@ def _process_file(
         )
     # if j2_instance is None:
     #     j2_instance = J2PromptTemplate()
-    #     if j2pt.templates_dir:
-    #         j2_instance.templates_dir = [template_dir] + list(j2pt.templates_dir)
+    #     if template_obj.templates_dir:
+    #         j2_instance.templates_dir = [template_dir] + list(template_obj.templates_dir)
     #     else:
     #         j2_instance.templates_dir = [template_dir]
 
@@ -236,7 +236,7 @@ def _process_project_files(
     file_records: List[Dict[str, Any]],
     template_dir: str,
     agent_env: Dict[str, Any],
-    j2pt:  Any,
+    template_obj:  Any,
     logger: Optional[Any] = None,
     *,
     workspace_root: Path = Path("."),
@@ -272,7 +272,7 @@ def _process_project_files(
         Search order:
         1. this file’s template-set directory
         2. workspace_root      (freshly generated files live here)
-        3. inherited dirs from the project-level j2pt.templates_dir
+        3. inherited dirs from the project-level template_obj.templates_dir
            – already includes CWD and any exposed source-package dirs
         """
         try:
@@ -289,7 +289,7 @@ def _process_project_files(
 
             # ── 3. inherited dirs (CWD, exposed pkgs, etc.) ───────────────
             inherited: list[str] = [
-                os.path.normpath(d) for d in j2pt.templates_dir
+                os.path.normpath(d) for d in template_obj.templates_dir
             ]
 
             # Build ordered, de-duplicated search path

--- a/pkgs/standards/peagen/peagen/commands/process.py
+++ b/pkgs/standards/peagen/peagen/commands/process.py
@@ -232,8 +232,8 @@ def process_cmd(
             workspace_root=ws,
         )
         pea.logger.debug("")
-        pea.logger.debug("pea.j2pt.templates_dir:")
-        for d in pea.j2pt.templates_dir:
+        pea.logger.debug("pea.prompt_template.templates_dir:")
+        for d in pea.prompt_template.templates_dir:
             pea.logger.debug(f"* {d}")
 
         pea.logger.debug("")

--- a/pkgs/standards/peagen/peagen/core.py
+++ b/pkgs/standards/peagen/peagen/core.py
@@ -43,7 +43,7 @@ class Peagen(ComponentBase):
 
     storage_adapter: Optional[Any] = Field(default=None, exclude=True)
     agent_env: Dict[str, Any] = Field(default_factory=dict)
-    j2pt: Any = Field(default_factory=lambda: J2PromptTemplate())
+    prompt_template: Any = Field(default_factory=lambda: J2PromptTemplate())
 
     # Runtime / env setup
     cwd: str = Field(exclude=True, default_factory=os.getcwd)
@@ -145,8 +145,8 @@ class Peagen(ComponentBase):
 
         # Finalise
         self.namespace_dirs = ns_dirs
-        # j2pt expects *template search dirs* in templates_dir attr
-        self.j2pt.templates_dir = []
+        # prompt_template expects *template search dirs* in templates_dir attr
+        self.prompt_template.templates_dir = []
 
         return self
 
@@ -168,8 +168,10 @@ class Peagen(ComponentBase):
             ],
         ]
 
-        self.logger.debug(f"Updated from {self.j2pt.templates_dir} to {[os.path.normpath(d) for d in dirs]}")
-        self.j2pt.templates_dir = [os.path.normpath(d) for d in dirs]
+        self.logger.debug(
+            f"Updated from {self.prompt_template.templates_dir} to {[os.path.normpath(d) for d in dirs]}"
+        )
+        self.prompt_template.templates_dir = [os.path.normpath(d) for d in dirs]
 
     def locate_template_set(self, template_set: str) -> Path:
         """Search `namespace_dirs` for the given template-set folder."""
@@ -298,8 +300,8 @@ class Peagen(ComponentBase):
                 continue
 
             try:
-                self.j2pt.set_template(FilePath(ptree_template_path))
-                rendered_yaml_str = self.j2pt.fill(project_only_context)
+                self.prompt_template.set_template(FilePath(ptree_template_path))
+                rendered_yaml_str = self.prompt_template.fill(project_only_context)
             except Exception as e:
                 self.logger.error(
                     f"[{project_name}] Ptree render failure for package "
@@ -442,7 +444,7 @@ class Peagen(ComponentBase):
                 global_attrs=project,
                 file_records=sorted_records,
                 template_dir=template_dir,
-                j2pt = self.j2pt,
+                template_obj=self.prompt_template,
                 agent_env=self.agent_env,
                 logger=self.logger,
                 storage_adapter=self.storage_adapter,

--- a/pkgs/standards/peagen/tests/r8n/test_core.py
+++ b/pkgs/standards/peagen/tests/r8n/test_core.py
@@ -21,7 +21,7 @@ class TestPeagen:
             template_base_dir="/test/templates",
         )
         instance.logger = mock_logger
-        instance.j2pt = MagicMock()
+        instance.prompt_template = MagicMock()
         return instance
 
     def test_initialization(self):
@@ -30,7 +30,7 @@ class TestPeagen:
         assert peagen.projects_payload_path == "test_payload.yaml"
         assert peagen.template_base_dir is None
         assert isinstance(peagen.agent_env, dict)
-        assert peagen.j2pt is not None
+        assert peagen.prompt_template is not None
         assert peagen.cwd == os.getcwd()
         assert peagen.projects_list == []
 
@@ -48,10 +48,10 @@ class TestPeagen:
             assert peagen.cwd in peagen.namespace_dirs
             assert "/custom/templates" in peagen.namespace_dirs
 
-            # Check j2pt templates_dir
-            assert str(Path("/additional/templates")) in peagen.j2pt.templates_dir
-            assert peagen.cwd in peagen.j2pt.templates_dir
-            assert "/custom/templates" in peagen.j2pt.templates_dir
+            # Check prompt_template templates_dir
+            assert str(Path("/additional/templates")) in peagen.prompt_template.templates_dir
+            assert peagen.cwd in peagen.prompt_template.templates_dir
+            assert "/custom/templates" in peagen.prompt_template.templates_dir
 
     def test_update_templates_dir(self, basic_peagen):
         """Test update_templates_dir method."""
@@ -62,14 +62,14 @@ class TestPeagen:
         basic_peagen.update_templates_dir("/package/templates")
 
         # Check updated templates_dir
-        assert basic_peagen.j2pt.templates_dir[0] == os.path.normpath(
+        assert basic_peagen.prompt_template.templates_dir[0] == os.path.normpath(
             "/package/templates"
         )
-        assert basic_peagen.j2pt.templates_dir[1] == os.path.normpath(
+        assert basic_peagen.prompt_template.templates_dir[1] == os.path.normpath(
             basic_peagen.cwd
         )
-        assert os.path.normpath("/add1") in basic_peagen.j2pt.templates_dir
-        assert os.path.normpath("/add2") in basic_peagen.j2pt.templates_dir
+        assert os.path.normpath("/add1") in basic_peagen.prompt_template.templates_dir
+        assert os.path.normpath("/add2") in basic_peagen.prompt_template.templates_dir
 
     def test_load_projects_dict(self, basic_peagen):
         """Test load_projects when YAML contains a dict with PROJECTS key."""
@@ -187,9 +187,9 @@ class TestPeagen:
             "peagen.core.Peagen.locate_template_set",
             return_value=Path("/test/templates/default"),
         ):
-            with patch.object(basic_peagen.j2pt, "set_template"):
+            with patch.object(basic_peagen.prompt_template, "set_template"):
                 with patch.object(
-                    basic_peagen.j2pt,
+                    basic_peagen.prompt_template,
                     "fill",
                     return_value=rendered_yaml,
                 ):
@@ -240,9 +240,9 @@ class TestPeagen:
             "peagen.core.Peagen.locate_template_set",
             return_value=Path("/test/templates/default"),
         ):
-            with patch.object(basic_peagen.j2pt, "set_template"):
+            with patch.object(basic_peagen.prompt_template, "set_template"):
                 with patch.object(
-                    basic_peagen.j2pt,
+                    basic_peagen.prompt_template,
                     "fill",
                     return_value="rendered content",
                 ):
@@ -292,9 +292,9 @@ class TestPeagen:
             "peagen.core.Peagen.locate_template_set",
             return_value=Path("/test/templates/default"),
         ):
-            with patch.object(basic_peagen.j2pt, "set_template"):
+            with patch.object(basic_peagen.prompt_template, "set_template"):
                 with patch.object(
-                    basic_peagen.j2pt,
+                    basic_peagen.prompt_template,
                     "fill",
                     return_value="rendered content",
                 ):
@@ -347,9 +347,9 @@ class TestPeagen:
             "peagen.core.Peagen.locate_template_set",
             return_value=Path("/test/templates/default"),
         ):
-            with patch.object(basic_peagen.j2pt, "set_template"):
+            with patch.object(basic_peagen.prompt_template, "set_template"):
                 with patch.object(
-                    basic_peagen.j2pt,
+                    basic_peagen.prompt_template,
                     "fill",
                     return_value="rendered content",
                 ):

--- a/pkgs/standards/peagen/tests/r8n/test_jinja2prompttemplate.py
+++ b/pkgs/standards/peagen/tests/r8n/test_jinja2prompttemplate.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from jinja2 import Environment, Template
-from swarmauri_prompt_j2prompttemplate import J2PromptTemplate, j2pt
+from swarmauri_prompt_j2prompttemplate import J2PromptTemplate
 from pydantic import FilePath
 
 
@@ -116,10 +116,6 @@ class TestJinja2PromptTemplate:
         result = template_instance.make_singular("dog")
         assert result == "dog"
 
-    def test_global_j2pt_instance(self):
-        """Test that the global j2pt instance is properly initialized"""
-        assert isinstance(j2pt, J2PromptTemplate)
-        assert j2pt.type == "J2PromptTemplate"
 
     def test_template_with_complex_variables(self, template_instance):
         """Test template rendering with complex variables"""

--- a/pkgs/standards/peagen/tests/r8n/test_processing.py
+++ b/pkgs/standards/peagen/tests/r8n/test_processing.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 from unittest.mock import ANY, MagicMock, mock_open, patch
 
-from swarmauri_prompt_j2prompttemplate import j2pt
+from swarmauri_prompt_j2prompttemplate import J2PromptTemplate
 from peagen._utils._processing import (
     _create_context,
     _process_file,
@@ -197,7 +197,8 @@ class TestProcessProjectFiles:
     @patch("peagen._utils._processing._process_file")
     def test_process_project_files(self, mock_process_file):
         """Test processing multiple file records."""
-        j2pt.templates_dir = ["default_templates"]
+        j2 = J2PromptTemplate()
+        j2.templates_dir = ["default_templates"]
 
         global_attrs = {"TEMPLATE_SET": "default_templates"}
         file_records = [
@@ -211,6 +212,7 @@ class TestProcessProjectFiles:
             file_records=file_records,
             template_dir="templates",
             agent_env={},
+            template_obj=j2,
             logger=MagicMock(),
         )
 
@@ -228,24 +230,27 @@ class TestProcessProjectFiles:
         mock_process_file.return_value = True
 
         # Set initial templates_dir
-        j2pt.templates_dir = ["original_templates"]
+        j2 = J2PromptTemplate()
+        j2.templates_dir = ["original_templates"]
 
         _process_project_files(
             global_attrs=global_attrs,
             file_records=file_records,
             template_dir="templates",
             agent_env={},
+            template_obj=j2,
             logger=mock_logger,
         )
 
-        # Check that j2pt.templates_dir was updated
-        assert j2pt.templates_dir[0] == "custom_templates"
+        # Check that template_obj.templates_dir was updated
+        assert j2.templates_dir[0] == "custom_templates"
         assert mock_logger.debug.call_count >= 1
 
     @patch("peagen._utils._processing._process_file")
     def test_process_project_files_stops_on_false(self, mock_process_file):
         """Test that processing stops if _process_file returns False."""
         global_attrs = {}
+        j2 = J2PromptTemplate()
         file_records = [
             {"RENDERED_FILE_NAME": "file1.txt"},
             {"RENDERED_FILE_NAME": "file2.txt"},
@@ -259,6 +264,7 @@ class TestProcessProjectFiles:
             file_records=file_records,
             template_dir="templates",
             agent_env={},
+            template_obj=j2,
             logger=MagicMock(),
         )
 

--- a/pkgs/standards/swarmauri_prompt_j2prompttemplate/swarmauri_prompt_j2prompttemplate/J2PromptTemplate.py
+++ b/pkgs/standards/swarmauri_prompt_j2prompttemplate/swarmauri_prompt_j2prompttemplate/J2PromptTemplate.py
@@ -225,5 +225,3 @@ class J2PromptTemplate(PromptTemplateBase):
         env.filters[name] = filter_func
 
 
-# Create a singleton instance for peagen usage with code generation mode enabled
-j2pt = J2PromptTemplate()

--- a/pkgs/standards/swarmauri_prompt_j2prompttemplate/swarmauri_prompt_j2prompttemplate/__init__.py
+++ b/pkgs/standards/swarmauri_prompt_j2prompttemplate/swarmauri_prompt_j2prompttemplate/__init__.py
@@ -1,7 +1,7 @@
-from .J2PromptTemplate import J2PromptTemplate, j2pt
+from .J2PromptTemplate import J2PromptTemplate
 
 
-__all__ = ["J2PromptTemplate", "j2pt"]
+__all__ = ["J2PromptTemplate"]
 
 try:
     # For Python 3.8 and newer

--- a/pkgs/standards/swarmauri_prompt_j2prompttemplate/tests/unit/test_J2PromptTemplate.py
+++ b/pkgs/standards/swarmauri_prompt_j2prompttemplate/tests/unit/test_J2PromptTemplate.py
@@ -86,47 +86,32 @@ def test_split_whitespace():
 
 
 @pytest.mark.unit
-def test_j2pt_singleton_exists():
-    from swarmauri_prompt_j2prompttemplate import j2pt
-
-    assert j2pt is not None
-
-
-@pytest.mark.unit
-def test_j2pt_builtin_singular_filter():
-    from swarmauri_prompt_j2prompttemplate import j2pt
-
-    # Test the make_singular filter which is always available
+def test_builtin_singular_filter():
+    j2 = J2PromptTemplate()
     template_str = "{{ 'users' | make_singular }}"
-    j2pt.set_template(template_str)
-    result = j2pt.fill({})
+    j2.set_template(template_str)
+    result = j2.fill({})
     assert result == "user"
 
 
 @pytest.mark.unit
-def test_j2pt_builtin_plural_filter():
-    from swarmauri_prompt_j2prompttemplate import j2pt
-
-    # Test the make_singular filter which is always available
+def test_builtin_plural_filter():
+    j2 = J2PromptTemplate()
     template_str = "{{ 'user' | make_plural }}"
-    j2pt.set_template(template_str)
-    result = j2pt.fill({})
+    j2.set_template(template_str)
+    result = j2.fill({})
     assert result == "users"
 
 
 @pytest.mark.unit
-def test_j2pt_copy():
-    from swarmauri_prompt_j2prompttemplate import j2pt
+def test_copy_instance():
+    j2 = J2PromptTemplate()
+    copy_instance = j2.model_copy(deep=False)
+    assert copy_instance is not j2
 
-    # Test basic copy functionality
-    copy_instance = j2pt.model_copy(deep=False)
-    assert copy_instance is not j2pt
-
-    # Test templates_dir handling
-    original_dir = j2pt.templates_dir
-    j2pt.templates_dir = ["test_dir"]
-    copy_with_dir = j2pt.model_copy(deep=False)
+    original_dir = j2.templates_dir
+    j2.templates_dir = ["test_dir"]
+    copy_with_dir = j2.model_copy(deep=False)
     assert copy_with_dir.templates_dir == ["test_dir"]
 
-    # Restore original
-    j2pt.templates_dir = original_dir
+    j2.templates_dir = original_dir


### PR DESCRIPTION
## Summary
- drop global `j2pt` instance
- rename Peagen attribute to `prompt_template`
- update internal API to use new name
- adjust tests for new API

## Testing
- `uv run --package swarmauri_prompt_j2prompttemplate --directory standards/swarmauri_prompt_j2prompttemplate pytest -q`
- `uv run --package peagen --directory standards/peagen pytest -q` *(fails: ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_683a898793188326ad9e4b97d3ec0843