### PR TITLE
Fix bytes read for spawner config

### DIFF
--- a/pkgs/standards/peagen/peagen/spawner.py
+++ b/pkgs/standards/peagen/peagen/spawner.py
@@ -24,7 +24,8 @@ class SpawnerConfig:
     def from_toml(cls, path: str) -> "SpawnerConfig":
         import tomllib
 
-        data = tomllib.loads(open(path, "rb").read())
+        with open(path, "r", encoding="utf-8") as f:
+            data = tomllib.loads(f.read())
         cfg = data.get("spawner", {})
         return cls(
             queue_url=cfg.get("queue_url", "stub://"),


### PR DESCRIPTION
## Summary
- fix TypeError in `SpawnerConfig.from_toml` by reading config files as text

## Testing
- `ruff format pkgs/standards/peagen/peagen/spawner.py --diff`

------
https://chatgpt.com/codex/tasks/task_e_683a8b32e7dc832696d4c9026aef1769