### PR TITLE
Fix WarmSpawner warm pool logic

### DIFF
--- a/pkgs/standards/peagen/peagen/spawner.py
+++ b/pkgs/standards/peagen/peagen/spawner.py
@@ -74,10 +74,15 @@ class WarmSpawner:
             pending = getattr(self.queue, "pending_count", lambda: 0)()
             self._cleanup_workers()
             live = len(self.workers)
-            if pending > max(0, live - self.cfg.warm_pool):
-                to_launch = min(pending - (live - self.cfg.warm_pool), self.cfg.max_parallel)
-                for _ in range(to_launch):
-                    self._launch_worker()
+
+            desired = min(
+                self.cfg.max_parallel,
+                max(self.cfg.warm_pool, pending + self.cfg.warm_pool),
+            )
+            to_launch = max(0, desired - live)
+            for _ in range(to_launch):
+                self._launch_worker()
+
             self.queue.requeue_orphans(self.cfg.idle_ms)
             time.sleep(self.cfg.poll_ms / 1000)
 


### PR DESCRIPTION
## Summary
- ensure `WarmSpawner` maintains the configured warm pool
- add regression test for warm pool behaviour

## Testing
- `uv run --package peagen --directory standards/peagen pytest tests/i9n/test_spawner.py::test_spawner_maintains_warm_pool -q`

------
https://chatgpt.com/codex/tasks/task_e_683a8d1b0e488326bab3ecedb13fe1ff