### PR TITLE
Fix pydantic attribute errors in peagen

### DIFF
--- a/pkgs/standards/peagen/peagen/handlers/mutate_patch.py
+++ b/pkgs/standards/peagen/peagen/handlers/mutate_patch.py
@@ -7,6 +7,7 @@ from typing import Set
 from peagen.queue.model import Task, Result, TaskKind
 from .base import TaskHandlerBase
 
+from typing import ClassVar
 
 class PromptSampler:
     @staticmethod
@@ -18,9 +19,6 @@ class LLMEnsemble:
     @staticmethod
     def generate(prompt: str) -> str:
         return prompt  # stub; tests may monkeypatch
-
-
-from typing import ClassVar
 
 
 class PatchMutatorHandler(TaskHandlerBase):

--- a/pkgs/standards/peagen/peagen/handlers/mutate_patch.py
+++ b/pkgs/standards/peagen/peagen/handlers/mutate_patch.py
@@ -20,9 +20,12 @@ class LLMEnsemble:
         return prompt  # stub; tests may monkeypatch
 
 
+from typing import ClassVar
+
+
 class PatchMutatorHandler(TaskHandlerBase):
-    KIND: TaskKind = TaskKind.MUTATE
-    PROVIDES: Set[str] = {"llm", "cpu"}
+    KIND: ClassVar[TaskKind] = TaskKind.MUTATE
+    PROVIDES: ClassVar[Set[str]] = {"llm", "cpu"}
 
     def dispatch(self, task: Task) -> bool:
         return task.kind == self.KIND

--- a/pkgs/standards/peagen/peagen/queue/redis_stream_queue.py
+++ b/pkgs/standards/peagen/peagen/queue/redis_stream_queue.py
@@ -18,6 +18,7 @@ class RedisStreamQueue(TaskQueueBase):
     STREAM_DEAD: ClassVar[str] = "peagen.dead"
 
     def __init__(self, url: str, *, group: str = "peagen", idle_ms: int = 60000, max_retry: int = 3) -> None:
+        super().__init__()
         self._r = redis.Redis.from_url(url, decode_responses=True)
         self.group = group
         self.consumer = os.environ.get("HOSTNAME", "consumer-" + uuid.uuid4().hex[:6])
@@ -41,7 +42,7 @@ class RedisStreamQueue(TaskQueueBase):
 
     # ------------------------------------------------------------------ producer
     def enqueue(self, task: Task) -> None:
-        data = json.dumps(task.to_dict())
+        data = json.dumps(task.to_dict(), default=list)
         msg_id = self._r.xadd(self.STREAM_TASKS, {"data": data}, maxlen=10_000_000)
         self._msg_map[task.id] = msg_id
 

--- a/pkgs/standards/peagen/peagen/result_backends/fs_backend.py
+++ b/pkgs/standards/peagen/peagen/result_backends/fs_backend.py
@@ -14,6 +14,7 @@ class FSBackend(ResultBackendBase):
     """Filesystem-backed result store."""
 
     def __init__(self, root: str = ".peagen/results", compress: bool = False) -> None:
+        super().__init__()
         self._root = Path(root).expanduser().resolve()
         self._root.mkdir(parents=True, exist_ok=True)
         self.compress = compress

--- a/pkgs/standards/peagen/peagen/selectors/base.py
+++ b/pkgs/standards/peagen/peagen/selectors/base.py
@@ -42,6 +42,7 @@ class AdaptiveEpsilonSelector(SelectorBase):
     """Adaptive ε-greedy selector used by default."""
 
     def __init__(self, eps_init: float = 0.15, decay: float = 0.96, floor: float = 0.02) -> None:
+        super().__init__()
         self.eps = eps_init
         self.decay = decay
         self.floor = floor


### PR DESCRIPTION
## Summary
- ensure PatchMutatorHandler constants remain as class variables
- initialize ComponentBase properly in FSBackend, RedisStreamQueue and AdaptiveEpsilonSelector
- make RedisStreamQueue JSON-serializable when enqueuing

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a8eb9b7f48326b8014edc81e99601