### PR TITLE
Avoid json.dumps on ComponentBase models

### DIFF
--- a/pkgs/standards/peagen/peagen/queue/redis_stream_queue.py
+++ b/pkgs/standards/peagen/peagen/queue/redis_stream_queue.py
@@ -42,7 +42,10 @@ class RedisStreamQueue(TaskQueueBase):
 
     # ------------------------------------------------------------------ producer
     def enqueue(self, task: Task) -> None:
-        data = json.dumps(task.to_dict(), default=list)
+        if hasattr(task, "model_dump_json"):
+            data = task.model_dump_json()
+        else:
+            data = json.dumps(task.to_dict(), default=list)
         msg_id = self._r.xadd(self.STREAM_TASKS, {"data": data}, maxlen=10_000_000)
         self._msg_map[task.id] = msg_id
 
@@ -72,7 +75,10 @@ class RedisStreamQueue(TaskQueueBase):
 
     # ------------------------------------------------------------------ admin
     def push_result(self, result: Result) -> None:
-        data = json.dumps(result.to_dict())
+        if hasattr(result, "model_dump_json"):
+            data = result.model_dump_json()
+        else:
+            data = json.dumps(result.to_dict())
         self._r.xadd(self.STREAM_RESULTS, {"data": data}, maxlen=10_000_000)
 
     def wait_for_result(self, task_id: str, timeout: int) -> Result | None:
@@ -109,11 +115,21 @@ class RedisStreamQueue(TaskQueueBase):
                 task = Task(**data)
                 task.attempts += 1
                 if task.attempts > self.max_retry:
-                    self._r.xadd(self.STREAM_DEAD, {"data": json.dumps(task.to_dict())})
+                    dead_payload = (
+                        task.model_dump_json()
+                        if hasattr(task, "model_dump_json")
+                        else json.dumps(task.to_dict())
+                    )
+                    self._r.xadd(self.STREAM_DEAD, {"data": dead_payload})
                     self._r.xack(self.STREAM_TASKS, self.group, mid)
                     self._r.xdel(self.STREAM_TASKS, mid)
                 else:
-                    self._r.xadd(self.STREAM_TASKS, {"data": json.dumps(task.to_dict())})
+                    retry_payload = (
+                        task.model_dump_json()
+                        if hasattr(task, "model_dump_json")
+                        else json.dumps(task.to_dict())
+                    )
+                    self._r.xadd(self.STREAM_TASKS, {"data": retry_payload})
                     self._r.xack(self.STREAM_TASKS, self.group, mid)
                     self._r.xdel(self.STREAM_TASKS, mid)
                 moved += 1

--- a/pkgs/standards/peagen/peagen/result_backends/fs_backend.py
+++ b/pkgs/standards/peagen/peagen/result_backends/fs_backend.py
@@ -29,7 +29,10 @@ class FSBackend(ResultBackendBase):
     def save(self, result: Result) -> None:
         path = self._path(result)
         tmp = path.with_suffix(".tmp")
-        data = json.dumps(asdict(result))
+        if hasattr(result, "model_dump_json"):
+            data = result.model_dump_json()
+        else:
+            data = json.dumps(asdict(result))
         tmp.write_text(data, encoding="utf-8")
         os.replace(tmp, path)
 


### PR DESCRIPTION
## Summary
- use `model_dump_json` when available for Redis queue
- use `model_dump_json` when available for FS result backend

## Testing
- `pre-commit` *(fails: This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.)*

------
https://chatgpt.com/codex/tasks/task_e_683a91fbab30832681f7c34e77bc0842