### PR TITLE
Fix spawner worker launch args

### DIFF
--- a/pkgs/standards/peagen/peagen/spawner.py
+++ b/pkgs/standards/peagen/peagen/spawner.py
@@ -53,7 +53,7 @@ class WarmSpawner:
             QUEUE_URL=self.cfg.queue_url,
             WORKER_CAPS=",".join(self.cfg.caps),
         )
-        cmd = [sys.executable, "-m", "peagen.cli", "worker", "start"]
+        cmd = [sys.executable, "-m", "peagen.cli", "worker", "start", "--no-detach"]
         p = subprocess.Popen(cmd, env=env)
         self.workers.append(p)
 

--- a/pkgs/standards/peagen/tests/unit/test_spawner_launch.py
+++ b/pkgs/standards/peagen/tests/unit/test_spawner_launch.py
@@ -1,0 +1,29 @@
+import pytest
+
+from peagen.spawner import WarmSpawner, SpawnerConfig
+
+
+class DummyProc:
+    def __init__(self, cmd, env=None):
+        self.cmd = cmd
+        self.env = env
+
+    def poll(self):
+        return None
+
+
+@pytest.mark.unit
+def test_launch_worker_adds_no_detach(monkeypatch):
+    launched = {}
+    def fake_popen(cmd, env=None):
+        p = DummyProc(cmd, env)
+        launched['proc'] = p
+        return p
+    monkeypatch.setattr('peagen.spawner.subprocess.Popen', fake_popen)
+
+    cfg = SpawnerConfig(queue_url='stub://', caps=['cpu'])
+    sp = WarmSpawner(cfg)
+    sp._launch_worker()
+
+    assert '--no-detach' in launched['proc'].cmd
+    assert sp.workers == [launched['proc']]


### PR DESCRIPTION
## Summary
- ensure warm spawner uses `--no-detach` when launching worker processes
- track launched processes in a new unit test

## Testing
- `No tests run due to instructions`

------
https://chatgpt.com/codex/tasks/task_e_683a968dde6c832681c08b88d5958926