### PR TITLE
Add plugin management CLI for peagen

### DIFF
--- a/pkgs/standards/peagen/docs/cli/plugin.md
+++ b/pkgs/standards/peagen/docs/cli/plugin.md
@@ -1,0 +1,38 @@
+# `peagen plugin`
+
+Manage Peagen plugin distributions.
+
+## list
+
+```console
+peagen plugin list [-v]
+```
+
+Lists discovered plugins grouped by entry-point type. Use `-v` to also show the owning distribution.
+
+## install
+
+```console
+peagen plugin install PKG|WHEEL|DIR [OPTIONS]
+```
+
+Install a plugin package from PyPI, a wheel/sdist file or a local directory. When installing from a directory you can use `--editable` to install in editable mode.
+
+### Options
+
+* `-e`, `--editable` – Install a local directory in editable mode.
+* `--force` – Re-install even if the package is already installed.
+* `-v`, `--verbose` – Show pip/uv output.
+
+## remove
+
+```console
+peagen plugin remove PACKAGE [OPTIONS]
+```
+
+Uninstall a plugin distribution by its package name.
+
+### Options
+
+* `-y`, `--yes` – Skip confirmation prompt.
+* `-v`, `--verbose` – Show pip/uv output.

--- a/pkgs/standards/peagen/peagen/cli.py
+++ b/pkgs/standards/peagen/peagen/cli.py
@@ -19,6 +19,7 @@ from peagen.commands import (
     evolve_app,
     queue_app,
     worker_app,
+    plugins_app,
 )
 
 _print_banner()
@@ -39,6 +40,7 @@ app.add_typer(extras_app, name="extras-schemas")
 app.add_typer(validate_app, name="validate")
 app.add_typer(eval_app)
 app.add_typer(worker_app, name="worker")
+app.add_typer(plugins_app, name="plugin")
 
 if __name__ == "__main__":
     app()

--- a/pkgs/standards/peagen/peagen/commands/__init__.py
+++ b/pkgs/standards/peagen/peagen/commands/__init__.py
@@ -14,6 +14,7 @@ from peagen.commands.mutate import mutate_app
 from peagen.commands.evolve import evolve_app
 from peagen.commands.queue import queue_app
 from peagen.commands.worker import worker_app
+from peagen.commands.plugins import plugins_app
 
 __all__ = [
     "init_app",
@@ -30,4 +31,5 @@ __all__ = [
     "evolve_app",
     "queue_app",
     "worker_app",
+    "plugins_app",
 ]

--- a/pkgs/standards/peagen/peagen/commands/plugins.py
+++ b/pkgs/standards/peagen/peagen/commands/plugins.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import importlib.metadata as im
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional, Dict, Set
+
+import typer
+
+from peagen.plugin_registry import GROUPS, registry, discover_and_register_plugins
+
+plugins_app = typer.Typer(help="Manage Peagen plugins.", add_completion=False)
+
+
+def _installed_plugins() -> Dict[str, Set[str]]:
+    return {k: set(v.keys()) for k, v in registry.items()}
+
+
+def _build_installer(editable: bool, force: bool) -> list[str]:
+    if shutil.which("uv"):
+        cmd = ["uv", "pip", "install"]
+    else:
+        cmd = [sys.executable, "-m", "pip", "install"]
+    cmd += ["--no-deps"]
+    if force:
+        cmd += ["--upgrade", "--force-reinstall"]
+    if editable:
+        cmd += ["-e"]
+    return cmd
+
+
+@plugins_app.command("list", help="List discovered plugins.")
+def list_plugins(verbose: bool = typer.Option(False, "-v", "--verbose")) -> None:
+    for group_key, (ep_group, _) in GROUPS.items():
+        eps = im.entry_points(group=ep_group)
+        if not eps:
+            continue
+        typer.echo(f"\n{group_key}:")
+        for ep in sorted(eps, key=lambda e: e.name):
+            line = f" • {ep.name}"
+            if verbose:
+                dist = getattr(ep, "dist", None)
+                if dist is not None:
+                    line += f" ({dist.metadata.get('Name')})"
+            typer.echo(line)
+
+
+@plugins_app.command("install", help="Install a plugin distribution.")
+def install_plugin(
+    source: str = typer.Argument(..., metavar="PKG|WHEEL|DIR"),
+    editable: bool = typer.Option(False, "--editable", "-e", help="Editable mode for directories."),
+    force: bool = typer.Option(False, "--force", help="Re-install even if already present."),
+    verbose: bool = typer.Option(False, "-v", "--verbose", help="Show pip output."),
+) -> None:
+    src_path = Path(source)
+    is_local = src_path.exists()
+
+    if is_local:
+        if src_path.is_dir():
+            cmd = _build_installer(editable, force)
+            cmd.append(str(src_path.resolve()))
+        else:
+            cmd = _build_installer(False, force)
+            cmd.append(str(src_path.resolve()))
+    else:
+        cmd = _build_installer(False, force)
+        cmd.append(source)
+
+    before = _installed_plugins()
+    typer.echo("⏳  Installing via pip …")
+    try:
+        subprocess.run(
+            cmd,
+            check=True,
+            text=True,
+            stdout=None if verbose else subprocess.PIPE,
+            stderr=None if verbose else subprocess.STDOUT,
+        )
+    except subprocess.CalledProcessError as exc:
+        typer.echo("❌  Installation failed.")
+        if not verbose and exc.stdout:
+            typer.echo(exc.stdout)
+        raise typer.Exit(code=exc.returncode)
+
+    discover_and_register_plugins()
+    after = _installed_plugins()
+    added = {g: after[g] - before.get(g, set()) for g in after}
+    new_items = [f"{g}:{','.join(sorted(v))}" for g, v in added.items() if v]
+    if new_items:
+        typer.echo("✅  Installed plugin(s): " + ", ".join(new_items))
+    else:
+        typer.echo("✅  Installation succeeded.")
+
+
+@plugins_app.command("remove", help="Uninstall a plugin distribution by package name.")
+def remove_plugin(
+    package: str = typer.Argument(..., metavar="PACKAGE"),
+    yes: bool = typer.Option(False, "-y", "--yes", help="Skip confirmation."),
+    verbose: bool = typer.Option(False, "-v", "--verbose", help="Show pip output."),
+) -> None:
+    if not yes:
+        if not typer.confirm(f"Uninstall distribution {package} ?"):
+            typer.echo("Aborted.")
+            raise typer.Exit()
+
+    if shutil.which("uv"):
+        cmd = ["uv", "pip", "uninstall", package]
+    else:
+        cmd = [sys.executable, "-m", "pip", "uninstall", "-y", package]
+
+    typer.echo("⏳  Uninstalling via pip …")
+    try:
+        subprocess.run(
+            cmd,
+            check=True,
+            text=True,
+            stdout=None if verbose else subprocess.PIPE,
+            stderr=None if verbose else subprocess.STDOUT,
+        )
+    except subprocess.CalledProcessError as exc:
+        typer.echo("❌  Uninstall failed.")
+        if not verbose and exc.stdout:
+            typer.echo(exc.stdout)
+        raise typer.Exit(code=exc.returncode)
+
+    discover_and_register_plugins()
+    typer.echo(f"✅  Removed distribution '{package}'.")

--- a/pkgs/standards/peagen/tests/unit/test_plugins_cli.py
+++ b/pkgs/standards/peagen/tests/unit/test_plugins_cli.py
@@ -1,0 +1,37 @@
+import types
+import pytest
+from typer.testing import CliRunner
+
+from peagen.cli import app
+from peagen.commands.plugins import plugins_app
+
+
+@pytest.mark.unit
+def test_help_lists_plugin_command():
+    runner = CliRunner()
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "plugin" in result.output
+
+
+@pytest.mark.unit
+def test_plugin_list(monkeypatch):
+    runner = CliRunner()
+
+    class DummyEP:
+        def __init__(self, name, value, group):
+            self.name = name
+            self.value = value
+            self.group = group
+            self.dist = types.SimpleNamespace(metadata={"Name": "dummy"})
+
+    def fake_eps(group=None):
+        if group == "peagen.storage_adapters":
+            return [DummyEP("example", "pkg:Cls", group)]
+        return []
+
+    monkeypatch.setattr("importlib.metadata.entry_points", fake_eps)
+
+    result = runner.invoke(plugins_app, ["list"])
+    assert result.exit_code == 0
+    assert "example" in result.output


### PR DESCRIPTION
## Summary
- implement `plugins` Typer app with list/install/remove subcommands
- integrate plugin commands into CLI
- document `peagen plugin` usage
- test new CLI behaviour

## Testing
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_plugins_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_683aab2a1ee083269270bb8a8eee3d18