### PR TITLE
Implement mutate CLI workflow

### DIFF
--- a/pkgs/standards/peagen/peagen/handlers/base.py
+++ b/pkgs/standards/peagen/peagen/handlers/base.py
@@ -25,3 +25,7 @@ class TaskHandlerBase(ComponentBase):
     def handle(self, task: Task) -> Result:
         """Perform domain logic and return a ``Result``."""
         raise NotImplementedError
+
+
+# Backwards compatibility alias for older imports
+TaskHandler = TaskHandlerBase

--- a/pkgs/standards/peagen/peagen/mutators/base.py
+++ b/pkgs/standards/peagen/peagen/mutators/base.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
-from typing import Protocol
-
-from peagen.handlers.base import TaskHandler
+from peagen.handlers.base import TaskHandlerBase
 
 
-class Mutator(TaskHandler, Protocol):
-    """Protocol for handlers that mutate source code."""
+class Mutator(TaskHandlerBase):
+    """Base class for handlers that mutate source code."""
 
     def mutate(self) -> None:
         """Optional helper used by subclasses."""

--- a/pkgs/standards/peagen/peagen/mutators/mutate_patch.py
+++ b/pkgs/standards/peagen/peagen/mutators/mutate_patch.py
@@ -10,8 +10,8 @@ from peagen.mutators.base import Mutator
 
 
 class PatchMutator(Mutator):
-    KIND = TaskKind.MUTATE
-    PROVIDES = {"llm", "cpu"}
+    KIND: TaskKind = TaskKind.MUTATE
+    PROVIDES: set[str] = {"llm", "cpu"}
 
     def dispatch(self, task: Task) -> bool:  # type: ignore[override]
         return task.kind == self.KIND

--- a/pkgs/standards/peagen/tests/unit/test_mutate_cmd.py
+++ b/pkgs/standards/peagen/tests/unit/test_mutate_cmd.py
@@ -1,0 +1,42 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from peagen.commands import mutate as mutate_cmd
+
+
+@pytest.mark.unit
+def test_run_mutate_sync(monkeypatch, tmp_path):
+    parent = tmp_path / "src.py"
+    parent.write_text("def f(x):\n    return x\n")
+    out = tmp_path / "child.py"
+    diff = "@@ -1,2 +1,2 @@\n def f(x):\n-    return x\n+    return x+1\n"
+
+    monkeypatch.setattr(
+        mutate_cmd.PromptSampler,
+        "build_mutate_prompt",
+        lambda parent_src, insp, entry: "prompt",
+    )
+    monkeypatch.setattr(
+        mutate_cmd.LLMEnsemble,
+        "generate",
+        lambda prompt, backend=None: diff,
+    )
+
+    mutate_cmd.run_mutate(str(parent), "f", str(out), None, False)
+    assert out.read_text() == "def f(x):\n    return x+1\n"
+
+
+@pytest.mark.unit
+def test_run_mutate_queue(monkeypatch, tmp_path):
+    parent = tmp_path / "src.py"
+    parent.write_text("print('hi')\n")
+    q = mutate_cmd.make_queue("stub")
+    monkeypatch.setattr(mutate_cmd, "make_queue", lambda *a, **k: q)
+
+    mutate_cmd.run_mutate(str(parent), "f", str(tmp_path/"out.py"), None, True)
+    task = q.pop(block=False)
+    assert task is not None
+    assert task.kind == mutate_cmd.TaskKind.MUTATE
+    assert task.payload["parent_src"].startswith("print")


### PR DESCRIPTION
## Summary
- implement functional `peagen mutate` command
- add backward compatible alias for `TaskHandler`
- update mutator base classes
- type `PatchMutator` fields
- test mutate command

## Testing
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_mutate_cmd.py -q`


------
https://chatgpt.com/codex/tasks/task_e_683b6a61af7c83269d086ac2f79598dd