### PR TITLE
Fix circular import in peagen

### DIFF
--- a/pkgs/standards/peagen/peagen/_utils/_validation.py
+++ b/pkgs/standards/peagen/peagen/_utils/_validation.py
@@ -1,0 +1,30 @@
+"""Utility helpers for jsonschema validation."""
+
+from __future__ import annotations
+
+from jsonschema import Draft7Validator
+import typer
+
+
+def _path(err) -> str:
+    """Return dotted-path to a failing node."""
+    return ".".join(str(p) for p in err.absolute_path) or "(root)"
+
+
+def _print_errors(errors) -> None:
+    """Emit formatted jsonschema error messages."""
+    for err in errors:
+        typer.echo(f"   • {_path(err)} – {err.message}", err=True)
+        for sub in err.context:
+            typer.echo(f"     ↳ {_path(sub)} – {sub.message}", err=True)
+
+
+def _validate(data: dict, schema: dict, label: str) -> None:
+    """Run Draft7 validation and pretty-print errors."""
+    validator = Draft7Validator(schema)
+    errors = sorted(validator.iter_errors(data), key=lambda e: e.path)
+    if errors:
+        typer.echo(f"❌  Invalid {label}:", err=True)
+        _print_errors(errors)
+        raise typer.Exit(1)
+    typer.echo(f"✅  {label.capitalize()} is valid.")

--- a/pkgs/standards/peagen/peagen/cli/commands/validate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/validate.py
@@ -7,8 +7,8 @@ import json
 from pathlib import Path
 import typer
 import yaml
-from jsonschema import Draft7Validator
 from swarmauri_standard.loggers.Logger import Logger
+from peagen._utils._validation import _validate
 
 # ── central schema registry ─────────────────────────────────────────────
 from peagen.schemas import (
@@ -23,35 +23,6 @@ from peagen._utils.config_loader import load_peagen_toml
 
 validate_app = typer.Typer(help="Validation utilities for Peagen artefacts.")
 
-
-# ─────────────────────────────────────────────────────────────────────────────
-#  Shared helpers
-# ─────────────────────────────────────────────────────────────────────────────
-def _path(err) -> str:
-    """Return dotted-path to failing node.
-    File: **validate.py** • Method: **_path**"""
-    return ".".join(str(p) for p in err.absolute_path) or "(root)"
-
-
-def _print_errors(errors) -> None:
-    """Emit every jsonschema error.
-    File: **validate.py** • Method: **_print_errors**"""
-    for err in errors:
-        typer.echo(f"   • {_path(err)} – {err.message}", err=True)
-        for sub in err.context:
-            typer.echo(f"     ↳ {_path(sub)} – {sub.message}", err=True)
-
-
-def _validate(data: dict, schema: dict, label: str) -> None:
-    """Run Draft7 validation and pretty-print errors.
-    File: **validate.py** • Method: **_validate**"""
-    validator = Draft7Validator(schema)
-    errors = sorted(validator.iter_errors(data), key=lambda e: e.path)
-    if errors:
-        typer.echo(f"❌  Invalid {label}:", err=True)
-        _print_errors(errors)
-        raise typer.Exit(1)
-    typer.echo(f"✅  {label.capitalize()} is valid.")
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/pkgs/standards/peagen/peagen/core/doe_core.py
+++ b/pkgs/standards/peagen/peagen/core/doe_core.py
@@ -24,7 +24,7 @@ from urllib.parse import urlparse
 from peagen._utils.config_loader import load_peagen_toml
 from peagen.plugins import registry
 from peagen.schemas import DOE_SPEC_V1_1_SCHEMA          # already vendored
-from peagen.cli.commands.validate import _validate           # re-use existing helper
+from peagen._utils._validation import _validate
 
 # ─────────────────────────────── util ──────────────────────────────────────
 _LLM_FALLBACK_KEYS = {


### PR DESCRIPTION
## Summary
- break circular import between core and CLI
- move validation helpers to `_utils`
- update CLI and core imports

## Testing
- `No tests run`

------
https://chatgpt.com/codex/tasks/task_e_683f49a3135c83268382921099a17f0d