### PR TITLE
Fix peagen circular import during worker startup

### DIFF
--- a/pkgs/standards/peagen/docs/pea-ips/ip-0004.md
+++ b/pkgs/standards/peagen/docs/pea-ips/ip-0004.md
@@ -45,7 +45,7 @@ Options
 
 ### Behaviour Notes
 
-* If `WORKSPACE_URI` is a remote adapter URI, artefacts are first fetched to a temp directory (re-using `peagen.cli_common.temp_workspace` helpers).
+* If `WORKSPACE_URI` is a remote adapter URI, artefacts are first fetched to a temp directory (re-using `peagen.common.temp_workspace` helpers).
 * All options **override** values that may be present in `.peagen.toml`.
 * The exit code matrix is:
 
@@ -144,7 +144,7 @@ If the same key appears multiple times the **earlier** entry wins, ensuring CLI 
 | Step             | File / Component                                                      | Description                                       |
 | ---------------- | --------------------------------------------------------------------- | ------------------------------------------------- |
 | CLI command      | `peagen/cli/eval.py`                                                  | Parse args, merge config, pass to core helper.    |
-| Workspace loader | `program.py` / `cli_common.temp_workspace`                            | Re-use fetch logic when URI is remote.            |
+| Workspace loader | `program.py` / `common.temp_workspace`                            | Re-use fetch logic when URI is remote.            |
 | Default Pool     | `peagen/eval/pools/default.py`                                        | Threaded pool honouring `max_workers` & `async`.  |
 | Manifest writer  | `manifest_writer.py`                                                  | Add `mode="eval"` + JSONL roll-up.                |
 | Schema files     | `schemas/eval_manifest.schema.v1.json`, update `peagen.toml.schema.*` | Author & unit-test with `ajv`.                    |

--- a/pkgs/standards/peagen/peagen/common.py
+++ b/pkgs/standards/peagen/peagen/common.py
@@ -1,0 +1,43 @@
+"""Common utilities for non-CLI components."""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import tempfile
+import shutil
+import logging
+from contextlib import contextmanager
+from typing import Any, Callable
+
+__all__ = ["temp_workspace", "PathOrURI"]
+
+
+@contextmanager
+def temp_workspace(prefix: str = "peagen_"):
+    """Yield a temporary directory that is removed on exit."""
+    dirpath = pathlib.Path(tempfile.mkdtemp(prefix=prefix))
+    try:
+        yield dirpath
+    finally:
+        try:
+            shutil.rmtree(dirpath)
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            logging.warning(f"Workspace cleanup failed: {exc}")
+
+
+class PathOrURI(str):
+    """Normalise a filesystem path or return URIs unchanged."""
+
+    def __new__(cls, value: str | os.PathLike) -> "PathOrURI":
+        return super().__new__(cls, cls._normalise(value))
+
+    @staticmethod
+    def _normalise(value: str | os.PathLike) -> str:
+        value = str(value)
+        if "://" in value:
+            return value
+        p = pathlib.Path(value).expanduser().resolve()
+        return str(p)

--- a/pkgs/standards/peagen/peagen/core/eval_core.py
+++ b/pkgs/standards/peagen/peagen/core/eval_core.py
@@ -15,7 +15,7 @@ from importlib import import_module
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
-from peagen.cli.common import PathOrURI, temp_workspace
+from peagen.common import PathOrURI, temp_workspace
 from peagen._utils.config_loader import load_peagen_toml
 from peagen.plugins import registry
 from peagen.eval import DefaultEvaluatorPool


### PR DESCRIPTION
## Summary
- break import cycle by moving `PathOrURI` and `temp_workspace` utilities to a new module `peagen.common`
- adjust evaluation core to use these utilities
- update docs to reference the new location for `temp_workspace`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f4f5e953083269b89220849e1d911