### PR TITLE
Add Task.get method and use tasks directly

### DIFF
--- a/pkgs/standards/peagen/gateway/src/dqueue/models.py
+++ b/pkgs/standards/peagen/gateway/src/dqueue/models.py
@@ -26,6 +26,10 @@ class Task(BaseModel):
     status: Status = Status.pending
     result: Optional[dict] = None
 
+    def get(self, key: str, default=None):
+        """Dictionary-style access helper used by some handlers."""
+        return getattr(self, key, default)
+
 
 class Pool(BaseModel):
     name: str

--- a/pkgs/standards/peagen/peagen/cli/commands/doe.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/doe.py
@@ -51,8 +51,8 @@ def run(  # noqa: PLR0913
         "skip_validate": skip_validate,
     }
 
-    task_dict = json.loads(_make_task(args).model_dump_json())
-    result = asyncio.run(doe_handler(task_dict))
+    task = _make_task(args)
+    result = asyncio.run(doe_handler(task))
 
     typer.echo(json.dumps(result, indent=2) if json_out else f"✅  {result['output']}")
 

--- a/pkgs/standards/peagen/peagen/cli/commands/eval.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/eval.py
@@ -62,7 +62,7 @@ def run(  # noqa: PLR0913 – CLI needs many options
     }
     task = _build_task(args)
 
-    result = asyncio.run(eval_handler(json.loads(task.model_dump_json())))
+    result = asyncio.run(eval_handler(task))
     manifest = result["manifest"]
 
     # ----- output ----------------------------------------------------------

--- a/pkgs/standards/peagen/peagen/cli/commands/fetch.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/fetch.py
@@ -71,8 +71,7 @@ def run(
     args = _collect_args(manifests, out_dir, no_source, install_template_sets_flag)
     task = _build_task(args)
 
-    # ⚠️  requirement: pass model_dump_json into handler
-    result = asyncio.run(fetch_handler(json.loads(task.model_dump_json())))
+    result = asyncio.run(fetch_handler(task))
     typer.echo(json.dumps(result, indent=2))
 
 

--- a/pkgs/standards/peagen/peagen/cli/commands/sort.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/sort.py
@@ -44,9 +44,9 @@ def run_sort(
         # status and result left as defaults (Status.pending, None)
     )
 
-    # 2) Call sort_handler(task.dict()) via asyncio.run
+    # 2) Call sort_handler with the Task instance via asyncio.run
     try:
-        result: Dict[str, Any] = asyncio.run(sort_handler(task.model_dump_json()))
+        result: Dict[str, Any] = asyncio.run(sort_handler(task))
     except Exception as exc:
         typer.echo(f"[ERROR] Exception inside sort_handler: {exc}")
         raise typer.Exit(1)

--- a/pkgs/standards/peagen/peagen/models/schemas.py
+++ b/pkgs/standards/peagen/peagen/models/schemas.py
@@ -26,6 +26,10 @@ class Task(BaseModel):
     status: Status = Status.pending
     result: Optional[dict] = None
 
+    def get(self, key: str, default=None):
+        """Dictionary-style access helper used by some handlers."""
+        return getattr(self, key, default)
+
 
 class Pool(BaseModel):
     name: str


### PR DESCRIPTION
## Summary
- allow `Task` to mimic a mapping by providing `get`
- pass `Task` objects directly to CLI handlers

## Testing
- `python -m py_compile pkgs/standards/peagen/peagen/models/schemas.py pkgs/standards/peagen/gateway/src/dqueue/models.py pkgs/standards/peagen/peagen/cli/commands/fetch.py pkgs/standards/peagen/peagen/cli/commands/doe.py pkgs/standards/peagen/peagen/cli/commands/eval.py pkgs/standards/peagen/peagen/cli/commands/sort.py`

------
https://chatgpt.com/codex/tasks/task_e_6840165b1114832698317bd0caadcae4