### PR TITLE
Fix Task handling in CLI handlers

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/doe.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/doe.py
@@ -51,8 +51,8 @@ def run(  # noqa: PLR0913
         "skip_validate": skip_validate,
     }
 
-    task_dict = json.loads(_make_task(args).model_dump_json())
-    result = asyncio.run(doe_handler(task_dict))
+    task = _make_task(args)
+    result = asyncio.run(doe_handler(task))
 
     typer.echo(json.dumps(result, indent=2) if json_out else f"✅  {result['output']}")
 

--- a/pkgs/standards/peagen/peagen/cli/commands/eval.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/eval.py
@@ -61,8 +61,7 @@ def run(  # noqa: PLR0913 – CLI needs many options
         "skip_failed": skip_failed,
     }
     task = _build_task(args)
-
-    result = asyncio.run(eval_handler(json.loads(task.model_dump_json())))
+    result = asyncio.run(eval_handler(task))
     manifest = result["manifest"]
 
     # ----- output ----------------------------------------------------------

--- a/pkgs/standards/peagen/peagen/cli/commands/fetch.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/fetch.py
@@ -71,8 +71,7 @@ def run(
     args = _collect_args(manifests, out_dir, no_source, install_template_sets_flag)
     task = _build_task(args)
 
-    # ⚠️  requirement: pass model_dump_json into handler
-    result = asyncio.run(fetch_handler(json.loads(task.model_dump_json())))
+    result = asyncio.run(fetch_handler(task))
     typer.echo(json.dumps(result, indent=2))
 
 

--- a/pkgs/standards/peagen/peagen/cli/commands/process.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/process.py
@@ -110,9 +110,9 @@ def run(  # noqa: PLR0913 – CLI signature needs many options
         agent_env,
         output_base,
     )
-    task_dict = _build_task(args).model_dump()
+    task = _build_task(args)
 
-    result = asyncio.run(process_handler(task_dict))
+    result = asyncio.run(process_handler(task))
     typer.echo(json.dumps(result, indent=2))
 
 

--- a/pkgs/standards/peagen/peagen/cli/commands/sort.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/sort.py
@@ -7,7 +7,6 @@ from typing import Any, Dict
 
 from peagen.handlers.sort_handler import sort_handler
 from peagen.models import Task  # pydantic model
-from peagen.models import Status  # ensure Status is available if needed
 
 sort_app = typer.Typer()
 
@@ -44,7 +43,7 @@ def run_sort(
         # status and result left as defaults (Status.pending, None)
     )
 
-    # 2) Call sort_handler(task.dict()) via asyncio.run
+    # 2) Call sort_handler(task) via asyncio.run
     try:
         result: Dict[str, Any] = asyncio.run(sort_handler(task))
     except Exception as exc:

--- a/pkgs/standards/peagen/peagen/handlers/doe_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/doe_handler.py
@@ -1,29 +1,24 @@
 # peagen/handlers/doe_handler.py
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Any, Dict
 
-from peagen.core.doe_core import generate_payload      #  ←── renamed import
+from peagen.core.doe_core import generate_payload  #  ←── renamed import
 from peagen.models import Task
 
 
 async def doe_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, Any]:
-    if not isinstance(task_or_dict, dict):
-        payload = json.loads(task_or_dict.model_dump_json())  # type: ignore[arg-type]
-    else:
-        payload = task_or_dict
-
-    args: Dict[str, Any] = payload["payload"]["args"]
+    payload = task_or_dict.get("payload", {})
+    args: Dict[str, Any] = payload.get("args", {})
 
     return generate_payload(
-        spec_path   = Path(args["spec"]).expanduser(),
-        template_path = Path(args["template"]).expanduser(),
-        output_path = Path(args["output"]).expanduser(),
-        cfg_path    = Path(args["config"]).expanduser() if args.get("config") else None,
-        notify_uri  = args.get("notify"),
-        dry_run     = args.get("dry_run", False),
-        force       = args.get("force", False),
-        skip_validate = args.get("skip_validate", False),
+        spec_path=Path(args["spec"]).expanduser(),
+        template_path=Path(args["template"]).expanduser(),
+        output_path=Path(args["output"]).expanduser(),
+        cfg_path=Path(args["config"]).expanduser() if args.get("config") else None,
+        notify_uri=args.get("notify"),
+        dry_run=args.get("dry_run", False),
+        force=args.get("force", False),
+        skip_validate=args.get("skip_validate", False),
     )

--- a/pkgs/standards/peagen/peagen/handlers/eval_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/eval_handler.py
@@ -11,7 +11,6 @@ Returns a JSON-serialisable mapping:
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Any, Dict
 
@@ -20,12 +19,8 @@ from peagen.models import Task  # for typing only
 
 
 async def eval_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, Any]:
-    if not isinstance(task_or_dict, dict):
-        task_dict: Dict[str, Any] = json.loads(task_or_dict.model_dump_json())  # type: ignore[arg-type]
-    else:
-        task_dict = task_or_dict
-
-    args: Dict[str, Any] = task_dict["payload"]["args"]
+    payload = task_or_dict.get("payload", {})
+    args: Dict[str, Any] = payload.get("args", {})
 
     manifest = evaluate_workspace(
         workspace_uri=args["workspace_uri"],

--- a/pkgs/standards/peagen/peagen/handlers/fetch_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/fetch_handler.py
@@ -9,7 +9,6 @@ Async entry-point for the *fetch* pipeline.
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -27,12 +26,8 @@ async def fetch_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, Any]:
     install_template_sets: bool – install template sets (default True)
     """
     # normalise ---------------------------------------------
-    if not isinstance(task_or_dict, dict):
-        task_dict: Dict[str, Any] = json.loads(task_or_dict.model_dump_json())  # type: ignore[arg-type]
-    else:
-        task_dict = task_or_dict
-
-    args: Dict[str, Any] = task_dict["payload"]["args"]
+    payload = task_or_dict.get("payload", {})
+    args: Dict[str, Any] = payload.get("args", {})
     manifests: List[str] = args["manifests"]
 
     summary = fetch_many(

--- a/pkgs/standards/peagen/peagen/handlers/process_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/process_handler.py
@@ -32,9 +32,6 @@ async def process_handler(task: Dict[str, Any] | Task) -> Dict[str, Any]:
     # ------------------------------------------------------------------ #
     # 0) Normalise input – accept Task *or* plain dict
     # ------------------------------------------------------------------ #
-    if not isinstance(task, dict):
-        task = task.model_dump()  # type: ignore[attr-defined]
-
     payload: Dict[str, Any] = task.get("payload", {})
     args: Dict[str, Any] = payload.get("args", {})
 
@@ -62,9 +59,7 @@ async def process_handler(task: Dict[str, Any] | Task) -> Dict[str, Any]:
     project_name: str | None = args.get("project_name")
     if project_name:
         projects = load_projects_payload(projects_payload)
-        project = next(
-            (p for p in projects if p.get("NAME") == project_name), None
-        )
+        project = next((p for p in projects if p.get("NAME") == project_name), None)
         if project is None:  # defensive
             raise ValueError(f"Project '{project_name}' not found in payload!")
         processed, _ = process_single_project(

--- a/pkgs/standards/peagen/peagen/handlers/sort_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/sort_handler.py
@@ -1,9 +1,15 @@
 # peagen/handlers/sort_handler.py
 
 from typing import Any, Dict
-from peagen.core.sort_core import sort_single_project, sort_all_projects, _merge_cli_into_toml
+from peagen.core.sort_core import (
+    sort_single_project,
+    sort_all_projects,
+    _merge_cli_into_toml,
+)
+from peagen.models import Task
 
-async def sort_handler(task: Dict[str, Any]) -> Dict[str, Any]:
+
+async def sort_handler(task: Dict[str, Any] | Task) -> Dict[str, Any]:
     """
     Handler invoked when payload.action == "sort".
     Expects task["payload"]["args"] to include exactly:

--- a/pkgs/standards/peagen/peagen/models/schemas.py
+++ b/pkgs/standards/peagen/peagen/models/schemas.py
@@ -26,6 +26,10 @@ class Task(BaseModel):
     status: Status = Status.pending
     result: Optional[dict] = None
 
+    def get(self, key: str, default=None):
+        """Dictionary-style access to Task fields."""
+        return self.__dict__.get(key, default)
+
 
 class Pool(BaseModel):
     name: str


### PR DESCRIPTION
## Summary
- support dict-like access for Task
- pass Task objects directly to CLI handlers
- let handlers access Task fields via `.get`

## Testing
- `ruff format` and `ruff check`

------
https://chatgpt.com/codex/tasks/task_e_684017ae4ca08326bbf37e5afdb04ea2