### PR TITLE
Add unit tests for peagen sorting utilities

### DIFF
--- a/pkgs/standards/peagen/tests/unit/CliSort_unit_test.py
+++ b/pkgs/standards/peagen/tests/unit/CliSort_unit_test.py
@@ -1,0 +1,14 @@
+import pytest
+
+from peagen.cli.commands import sort as sort_cmd
+
+
+@pytest.mark.unit
+def test_run_sort_prints(monkeypatch, capsys):
+    async def fake_handler(task):
+        return {"sorted": ["0) a"]}
+
+    monkeypatch.setattr(sort_cmd, "sort_handler", fake_handler)
+    sort_cmd.run_sort("payload.yaml")
+    captured = capsys.readouterr()
+    assert "0) a" in captured.out

--- a/pkgs/standards/peagen/tests/unit/Graph_unit_test.py
+++ b/pkgs/standards/peagen/tests/unit/Graph_unit_test.py
@@ -1,0 +1,41 @@
+import pytest
+
+from peagen._utils._graph import (
+    _topological_sort,
+    _transitive_dependency_sort,
+    get_immediate_dependencies,
+)
+
+
+@pytest.mark.unit
+def test_topological_sort_basic():
+    payload = [
+        {"RENDERED_FILE_NAME": "a", "EXTRAS": {"DEPENDENCIES": []}},
+        {"RENDERED_FILE_NAME": "b", "EXTRAS": {"DEPENDENCIES": ["a"]}},
+        {"RENDERED_FILE_NAME": "c", "EXTRAS": {"DEPENDENCIES": ["b"]}},
+    ]
+    sorted_records = _topological_sort(payload)
+    assert [r["RENDERED_FILE_NAME"] for r in sorted_records] == ["a", "b", "c"]
+
+
+@pytest.mark.unit
+def test_transitive_dependency_sort():
+    payload = [
+        {"RENDERED_FILE_NAME": "a", "EXTRAS": {"DEPENDENCIES": []}},
+        {"RENDERED_FILE_NAME": "b", "EXTRAS": {"DEPENDENCIES": ["a"]}},
+        {"RENDERED_FILE_NAME": "c", "EXTRAS": {"DEPENDENCIES": ["b"]}},
+        {"RENDERED_FILE_NAME": "d", "EXTRAS": {"DEPENDENCIES": []}},
+    ]
+    sorted_records = _transitive_dependency_sort(payload, "c")
+    assert [r["RENDERED_FILE_NAME"] for r in sorted_records] == ["a", "b", "c"]
+
+
+@pytest.mark.unit
+def test_get_immediate_dependencies():
+    payload = [
+        {"RENDERED_FILE_NAME": "a", "EXTRAS": {"DEPENDENCIES": []}},
+        {"RENDERED_FILE_NAME": "b", "EXTRAS": {"DEPENDENCIES": ["a"]}},
+        {"RENDERED_FILE_NAME": "c", "EXTRAS": {"DEPENDENCIES": ["b"]}},
+    ]
+    deps = get_immediate_dependencies(payload, "c")
+    assert deps == ["b"]

--- a/pkgs/standards/peagen/tests/unit/SortCore_unit_test.py
+++ b/pkgs/standards/peagen/tests/unit/SortCore_unit_test.py
@@ -1,0 +1,69 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from peagen.core.sort_core import _merge_cli_into_toml, sort_file_records
+
+
+@pytest.mark.unit
+def test_merge_cli_into_toml(tmp_path):
+    toml_path = tmp_path / ".peagen.toml"
+    toml_path.write_text("template_paths = []\n")
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        params = _merge_cli_into_toml(
+            projects_payload="payload.yaml",
+            project_name="proj",
+            start_idx=None,
+            start_file=None,
+            verbose=1,
+            transitive=True,
+            show_dependencies=False,
+        )
+    finally:
+        os.chdir(cwd)
+    assert params["cfg"]["transitive"] is True
+    assert params["start_idx"] == 0
+    assert params["project_name"] == "proj"
+    assert params["projects_payload_path"] == "payload.yaml"
+
+
+@pytest.mark.unit
+def test_sort_file_records_basic():
+    records = [
+        {"RENDERED_FILE_NAME": "a", "EXTRAS": {"DEPENDENCIES": []}, "PROCESS_TYPE": "COPY"},
+        {"RENDERED_FILE_NAME": "b", "EXTRAS": {"DEPENDENCIES": ["a"]}, "PROCESS_TYPE": "COPY"},
+        {"RENDERED_FILE_NAME": "c", "EXTRAS": {"DEPENDENCIES": ["b"]}, "PROCESS_TYPE": "COPY"},
+    ]
+    sorted_records, next_idx = sort_file_records(records)
+    names = [r["RENDERED_FILE_NAME"] for r in sorted_records]
+    assert names == ["a", "b", "c"]
+    assert next_idx == 3
+
+
+@pytest.mark.unit
+def test_sort_file_records_start_file_and_idx():
+    records = [
+        {"RENDERED_FILE_NAME": "a", "EXTRAS": {"DEPENDENCIES": []}, "PROCESS_TYPE": "COPY"},
+        {"RENDERED_FILE_NAME": "b", "EXTRAS": {"DEPENDENCIES": ["a"]}, "PROCESS_TYPE": "COPY"},
+        {"RENDERED_FILE_NAME": "c", "EXTRAS": {"DEPENDENCIES": ["b"]}, "PROCESS_TYPE": "COPY"},
+    ]
+    sorted_records, next_idx = sort_file_records(records, start_idx=1, start_file="b")
+    names = [r["RENDERED_FILE_NAME"] for r in sorted_records]
+    assert names == ["c"]
+    assert next_idx == 2
+
+
+@pytest.mark.unit
+def test_sort_file_records_transitive():
+    records = [
+        {"RENDERED_FILE_NAME": "a", "EXTRAS": {"DEPENDENCIES": []}, "PROCESS_TYPE": "COPY"},
+        {"RENDERED_FILE_NAME": "b", "EXTRAS": {"DEPENDENCIES": ["a"]}, "PROCESS_TYPE": "COPY"},
+        {"RENDERED_FILE_NAME": "c", "EXTRAS": {"DEPENDENCIES": ["b"]}, "PROCESS_TYPE": "COPY"},
+    ]
+    sorted_records, next_idx = sort_file_records(records, start_file="c", transitive=True)
+    names = [r["RENDERED_FILE_NAME"] for r in sorted_records]
+    assert names == ["a", "b", "c"]
+    assert next_idx == 3

--- a/pkgs/standards/peagen/tests/unit/SortHandler_unit_test.py
+++ b/pkgs/standards/peagen/tests/unit/SortHandler_unit_test.py
@@ -1,0 +1,49 @@
+import pytest
+
+from peagen.handlers import sort_handler as handler_module
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_sort_handler_single_project(monkeypatch):
+    called = {}
+
+    def fake_single(params):
+        called["single"] = True
+        return {"sorted": []}
+
+    def fake_all(params):
+        called["all"] = True
+        return {"sorted_all_projects": {}}
+
+    monkeypatch.setattr(handler_module, "sort_single_project", fake_single)
+    monkeypatch.setattr(handler_module, "sort_all_projects", fake_all)
+    monkeypatch.setattr(handler_module, "_merge_cli_into_toml", lambda **k: {"project_name": "demo"})
+
+    task = {"payload": {"args": {"projects_payload": "p.yaml"}}}
+    await handler_module.sort_handler(task)
+    assert called.get("single") is True
+    assert called.get("all") is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_sort_handler_all_projects(monkeypatch):
+    called = {}
+
+    def fake_single(params):
+        called.setdefault("single", 0)
+        called["single"] += 1
+        return {"sorted": []}
+
+    def fake_all(params):
+        called["all"] = True
+        return {"sorted_all_projects": {}}
+
+    monkeypatch.setattr(handler_module, "sort_single_project", fake_single)
+    monkeypatch.setattr(handler_module, "sort_all_projects", fake_all)
+    monkeypatch.setattr(handler_module, "_merge_cli_into_toml", lambda **k: {"project_name": None})
+
+    task = {"payload": {"args": {"projects_payload": "p.yaml"}}}
+    await handler_module.sort_handler(task)
+    assert called.get("all") is True


### PR DESCRIPTION
## Summary
- add Graph unit tests for topological and transitive sorting
- cover sort_core helper functions and sorting logic
- test behavior of sort_handler dispatcher
- verify CLI run_sort prints handler output

## Testing
- `uv run --package peagen --directory standards/peagen pytest tests/unit -q`

------
https://chatgpt.com/codex/tasks/task_e_684032efdee483269d22b201a6bc5636