### PR TITLE
Remove deprecated template options and verbosity

### DIFF
--- a/pkgs/standards/peagen/README.md
+++ b/pkgs/standards/peagen/README.md
@@ -320,7 +320,6 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           peagen process projects.yaml \
-            --template-base-dir ./templates \
             --provider openai \
             --model-name gpt-4 \
             --transitive \
@@ -349,7 +348,6 @@ agent_env = {
 }
 pea = Peagen(
     projects_payload_path="projects.yaml",
-    additional_package_dirs=[],
     agent_env=agent_env,
 )
 

--- a/pkgs/standards/peagen/peagen/_utils/_jinja.py
+++ b/pkgs/standards/peagen/peagen/_utils/_jinja.py
@@ -32,9 +32,7 @@ def _build_jinja_env(cfg: dict, *, workspace_root: str | Path | None = None) -> 
     # Should support local, git, pypi, or https based retrievals
     ns_dirs.extend(str(Path(p)) for p in cfg.get("template_paths", []))
 
-    # 4) template_base_dir + repo root, if present
-    if cfg.get("template_base_dir"):
-        ns_dirs.append(str(Path(cfg["template_base_dir"])))
+    # 4) base_dir (repo root), if present
     if cfg.get("base_dir"):
         ns_dirs.append(str(Path(cfg["base_dir"])))
 

--- a/pkgs/standards/peagen/peagen/cli/commands/process.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/process.py
@@ -31,7 +31,6 @@ def _collect_args(  # noqa: C901 – straight-through mapper
     project_name: Optional[str],
     start_idx: int,
     start_file: Optional[str],
-    verbose: int,
     transitive: bool,
     agent_env: Optional[str],
     output_base: Optional[Path],
@@ -41,7 +40,6 @@ def _collect_args(  # noqa: C901 – straight-through mapper
         "project_name": project_name,
         "start_idx": start_idx,
         "start_file": start_file,
-        "verbose": verbose,
         "transitive": transitive,
         "output_base": str(output_base) if output_base else None,
     }
@@ -77,9 +75,6 @@ def run(  # noqa: PLR0913 – CLI signature needs many options
     start_file: Optional[str] = typer.Option(
         None, help="Skip files until this RENDERED_FILE_NAME is reached."
     ),
-    verbose: int = typer.Option(
-        0, "--verbose", "-v", count=True, help="Increase log verbosity."
-    ),
     transitive: bool = typer.Option(
         False, "--transitive/--no-transitive", help="Include transitive deps."
     ),
@@ -102,7 +97,6 @@ def run(  # noqa: PLR0913 – CLI signature needs many options
         project_name,
         start_idx,
         start_file,
-        verbose,
         transitive,
         agent_env,
         output_base,
@@ -121,7 +115,6 @@ def submit(  # noqa: PLR0913 – CLI signature needs many options
     project_name: Optional[str] = typer.Option(None),
     start_idx: int = typer.Option(0),
     start_file: Optional[str] = typer.Option(None),
-    verbose: int = typer.Option(0, "--verbose", "-v", count=True),
     transitive: bool = typer.Option(False, "--transitive/--no-transitive"),
     agent_env: Optional[str] = typer.Option(None),
     output_base: Optional[Path] = typer.Option(None, "--output-base"),
@@ -132,7 +125,6 @@ def submit(  # noqa: PLR0913 – CLI signature needs many options
         project_name,
         start_idx,
         start_file,
-        verbose,
         transitive,
         agent_env,
         output_base,

--- a/pkgs/standards/peagen/peagen/cli/commands/sort.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/sort.py
@@ -23,7 +23,6 @@ def run_sort(  # ← now receives the Typer context
     project_name: str = typer.Option(None, help="Name of the project to process."),
     start_idx: int = typer.Option(0, help="Index to start sorting from."),
     start_file: str = typer.Option(None, help="File to start sorting from."),
-    verbose: int = typer.Option(0, help="Verbosity level."),
     transitive: bool = typer.Option(False, help="Include transitive dependencies."),
     show_dependencies: bool = typer.Option(False, help="Show dependency info."),
 ):
@@ -45,7 +44,6 @@ def run_sort(  # ← now receives the Typer context
         "project_name": project_name,
         "start_idx": start_idx,
         "start_file": start_file,
-        "verbose": verbose,
         "transitive": transitive,
         "show_dependencies": show_dependencies,
     }
@@ -87,7 +85,6 @@ def submit_sort(
     project_name: str = typer.Option(None, help="Name of the project to process."),
     start_idx: int = typer.Option(0, help="Index to start sorting from."),
     start_file: str = typer.Option(None, help="File to start sorting from."),
-    verbose: int = typer.Option(0, help="Verbosity level."),
     transitive: bool = typer.Option(False, help="Include transitive dependencies."),
     show_dependencies: bool = typer.Option(False, help="Show dependency info."),
 ):
@@ -117,7 +114,6 @@ def submit_sort(
         "project_name": project_name,
         "start_idx": start_idx,
         "start_file": start_file,
-        "verbose": verbose,
         "transitive": transitive,
         "show_dependencies": show_dependencies,
         "cfg_override": cfg_override,

--- a/pkgs/standards/peagen/peagen/handlers/sort_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/sort_handler.py
@@ -11,7 +11,6 @@ Expected task payload
       "project_name": null,
       "start_idx": 0,
       "start_file": null,
-      "verbose": 0,
       "transitive": false,
       "show_dependencies": false
   },
@@ -50,7 +49,6 @@ async def sort_handler(task: Dict[str, Any]) -> Dict[str, Any]:
         "project_name":     args.get("project_name"),
         "start_idx":        args.get("start_idx", 0),
         "start_file":       args.get("start_file"),
-        "verbose":          args.get("verbose", 0),
         "transitive":       args.get("transitive", False),
         "show_dependencies": args.get("show_dependencies", False),
         "cfg": cfg,                 # ← merged config handed down to the core

--- a/pkgs/standards/peagen/peagen/handlers/templates_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/templates_handler.py
@@ -24,21 +24,19 @@ async def templates_handler(task: Dict[str, Any] | Task) -> Dict[str, Any]:
     op = args.get("operation")
 
     if op == "list":
-        return list_template_sets(verbose=int(args.get("verbose", 0)))
+        return list_template_sets()
     if op == "show":
-        return show_template_set(args["name"], verbose=int(args.get("verbose", 0)))
+        return show_template_set(args["name"])
     if op == "add":
         return add_template_set(
             args["source"],
             from_bundle=args.get("from_bundle"),
             editable=args.get("editable", False),
             force=args.get("force", False),
-            verbose=args.get("verbose", False),
-        )
+    )
     if op == "remove":
         return remove_template_set(
             args["name"],
-            verbose=args.get("verbose", False),
         )
 
     raise ValueError(f"Unknown operation: {op}")


### PR DESCRIPTION
## Summary
- drop `template_base_dir` and `additional_package_dirs` usage
- remove `--verbose` flags from subcommands and related handlers/cores
- adjust peagen tests for new behaviours

## Testing
- `uv run --package peagen --directory peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_6844459f0a0c83268e737733c3972223