### PR TITLE
Fix peagen local command errors

### DIFF
--- a/pkgs/standards/peagen/peagen/_utils/config_loader.py
+++ b/pkgs/standards/peagen/peagen/_utils/config_loader.py
@@ -26,7 +26,9 @@ import peagen.defaults as builtins
 # 1. Low-level loader
 # ────────────────────────────────────────────────────────────────────────────
 def load_peagen_toml(
-    path: str | Path = ".peagen.toml"
+    path: str | Path = ".peagen.toml",
+    *,
+    required: bool = False,
 ) -> Dict[str, Any]:
     """
     Read *path* as TOML and return a dict.  If the file is missing and
@@ -44,7 +46,7 @@ def load_peagen_toml(
 
 
 # ─────────────────────────────── .peagen override ────────────────────────────
-def _effective_cfg(cfg_path: Optional[Path]) -> Dict[str, Any]:
+def _effective_cfg(cfg_path: Optional[Path], *, required: bool = False) -> Dict[str, Any]:
     """
     Load the TOML file *only if* the caller supplied an explicit
     `--config/-c` path.  

--- a/pkgs/standards/peagen/peagen/core/templates_core.py
+++ b/pkgs/standards/peagen/peagen/core/templates_core.py
@@ -135,10 +135,7 @@ def add_template_set(
 # Remove
 # ---------------------------------------------------------------------------
 
-def remove_template_set(
-    name: str,
-    *,
-) -> Dict[str, Any]:
+def remove_template_set(name: str) -> Dict[str, Any]:
     """Uninstall the package that exposes *name* as a template-set."""
     dists: List[str] = []
     for dist in im.distributions():


### PR DESCRIPTION
## Summary
- fix `remove_template_set` signature
- add `required` parameter for config loader

## Testing
- `peagen local process pkgs/standards/peagen/peagen/template_sets/python_orm/example.payload.yaml`

------
https://chatgpt.com/codex/tasks/task_e_68444f8164d48326be722fea3f17069f