### PR TITLE
Fix Jinja rendering for peagen prompts

### DIFF
--- a/pkgs/standards/peagen/peagen/core/render_core.py
+++ b/pkgs/standards/peagen/peagen/core/render_core.py
@@ -65,10 +65,10 @@ def _render_generate_template(
     - agent_env is passed through to call_external_agent.  
     """
     try:
-        template_name = Path(agent_prompt_template).name
+        template_path = Path(agent_prompt_template)
         if logger:
             logger.debug(f"Rendering generate template {agent_prompt_template}")
-        j2_instance.set_template(template_name)
+        j2_instance.set_template(template_path)
 
         print('\n\n\nagent_prompt_template', agent_prompt_template)
         print('\n\ncontext', context)

--- a/pkgs/standards/peagen/tests/unit/test_render_core.py
+++ b/pkgs/standards/peagen/tests/unit/test_render_core.py
@@ -1,0 +1,40 @@
+import pytest
+from pathlib import Path
+from swarmauri_prompt_j2prompttemplate import J2PromptTemplate
+from peagen.core.render_core import _render_generate_template
+
+
+@pytest.mark.unit
+def test_render_generate_template_renders_jinja(tmp_path, monkeypatch):
+    template_file = tmp_path / "prompt.j2"
+    template_file.write_text("Hello {{ name }}")
+
+    j2 = J2PromptTemplate()
+    j2.templates_dir = [tmp_path]
+
+    captured = {}
+
+    def fake_agent(prompt, agent_env, cfg=None, logger=None):
+        captured["prompt"] = prompt
+        return "response"
+
+    monkeypatch.setattr(
+        "peagen.core.render_core.call_external_agent",
+        fake_agent,
+    )
+
+    file_record = {"FILE_NAME": "irrelevant", "RENDERED_FILE_NAME": "out.txt"}
+    context = {"name": "World"}
+
+    result = _render_generate_template(
+        file_record,
+        context,
+        str(template_file),
+        j2,
+        {},
+        None,
+    )
+
+    assert result == "response"
+    assert captured["prompt"] == "Hello World"
+


### PR DESCRIPTION
## Summary
- ensure peagen loads agent prompt templates from file paths
- add regression test confirming rendered prompt is sent to LLM

## Testing
- `uv run --package peagen --directory standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_6844b2873e548326a8685b66e5946c1f