### PR TITLE
Fix unused imports in peagen tests

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_cfg_fsm_invariants.py
+++ b/pkgs/standards/peagen/tests/unit/test_cfg_fsm_invariants.py
@@ -1,11 +1,9 @@
 import pytest
 import toml
-import os
-from pathlib import Path
 from itertools import product
 
 # Replace these imports with the actual locations in your project
-from peagen._utils.config_loader import resolve_cfg, load_peagen_toml
+from peagen._utils.config_loader import resolve_cfg
 import peagen.defaults as defaults
 
 def generate_test_parameters():

--- a/pkgs/standards/peagen/tests/unit/test_process_core.py
+++ b/pkgs/standards/peagen/tests/unit/test_process_core.py
@@ -1,8 +1,6 @@
-import os
 import yaml
 import pytest
 from pathlib import Path
-from swarmauri_prompt_j2prompttemplate import J2PromptTemplate
 
 from peagen.core.process_core import _render_package_ptree, process_single_project
 

--- a/pkgs/standards/peagen/tests/unit/test_render_core.py
+++ b/pkgs/standards/peagen/tests/unit/test_render_core.py
@@ -1,5 +1,4 @@
 import pytest
-from pathlib import Path
 from swarmauri_prompt_j2prompttemplate import J2PromptTemplate
 from peagen.core.render_core import _render_generate_template
 


### PR DESCRIPTION
## Summary
- clean up unused imports flagged by ruff in peagen test suite

## Testing
- `uv run ruff check pkgs/standards/peagen`


------
https://chatgpt.com/codex/tasks/task_e_684515f582848326bc897ebef332092b