### PR TITLE
Fix env var expansion in peagen remote overrides

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/process.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/process.py
@@ -18,9 +18,7 @@ from typing import Any, Dict, Optional
 import httpx
 import typer
 import yaml
-import toml
-
-from peagen._utils.config_loader import _effective_cfg
+from peagen._utils.config_loader import _effective_cfg, load_peagen_toml
 from peagen.handlers.process_handler import process_handler
 from peagen.models import Status, Task  # noqa: F401 – only for type hints
 
@@ -162,7 +160,7 @@ def submit(  # noqa: PLR0913 – CLI signature needs many options
     if inline:
         cfg_override = json.loads(inline)
     if file_:
-        cfg_override.update(toml.loads(Path(file_).read_text()))
+        cfg_override.update(load_peagen_toml(Path(file_), required=True))
     task.payload["cfg_override"] = cfg_override
 
     rpc_req = {

--- a/pkgs/standards/peagen/peagen/cli/commands/sort.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/sort.py
@@ -5,10 +5,9 @@ import json
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-import toml
 import typer
 
-from peagen._utils.config_loader import _effective_cfg
+from peagen._utils.config_loader import _effective_cfg, load_peagen_toml
 from peagen.handlers.sort_handler import sort_handler
 from peagen.models import Task
 
@@ -105,7 +104,7 @@ def submit_sort(
         cfg_override = json.loads(inline)
     if file_:
         cfg_override.update(  # file beats inline
-            toml.loads(Path(file_).read_text())
+            load_peagen_toml(Path(file_), required=True)
         )
 
     # ─────────────────────── 2) build Task model ────────────────────────


### PR DESCRIPTION
## Summary
- ensure remote process and sort commands expand environment variables in override files
- update tests and linting

## Testing
- `ruff check pkgs/standards/peagen/peagen/cli/commands/process.py pkgs/standards/peagen/peagen/cli/commands/sort.py`
- `uv run --package peagen --directory pkgs/standards/peagen pytest -q`
- `peagen remote -q --gateway-url https://gw.peagen.com/rpc --override-file .peagen.toml process projects_payload.yaml`
- `peagen remote -q --gateway-url https://gw.peagen.com/rpc --override-file .peagen.toml task get da44613a-b504-49cc-a6db-c54371ffa98e`


------
https://chatgpt.com/codex/tasks/task_e_68451dc13f5483268d48e509a56bd818