### PR TITLE
Handle template errors without exiting worker

### DIFF
--- a/pkgs/standards/peagen/peagen/core/render_core.py
+++ b/pkgs/standards/peagen/peagen/core/render_core.py
@@ -47,7 +47,8 @@ def _render_copy_template(
                 logger.error(
                     f"{Fore.RED}Failed{Style.RESET_ALL} to render copy template '{template_path}': {e}"
                 )
-        sys.exit(1)
+        # Propagate the exception so callers can handle failure gracefully
+        raise
 
 
 def _render_generate_template(
@@ -93,4 +94,5 @@ def _render_generate_template(
                 logger.error(
                     f"{Fore.RED}Failed{Style.RESET_ALL} to render generate template '{agent_prompt_template}': {e}"
                 )
-        sys.exit(1)
+        # Propagate the exception so callers can handle failure gracefully
+        raise


### PR DESCRIPTION
## Summary
- fix copy and generate helpers to raise exceptions instead of exiting
- this ensures workers send failed status back to the gateway

## Testing
- `uv run --package peagen --directory standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_68452249f6bc8326a57e0ba4857d3549