### PR TITLE
Use unified logger across additional modules

### DIFF
--- a/pkgs/standards/peagen/peagen/_utils/_jinja.py
+++ b/pkgs/standards/peagen/peagen/_utils/_jinja.py
@@ -4,12 +4,15 @@ from types import ModuleType
 
 from jinja2 import Environment, FileSystemLoader
 import peagen.plugins
+from swarmauri_standard.loggers.Logger import Logger
+
+logger = Logger(name=__name__)
 
 def _build_jinja_env(cfg: dict, *, workspace_root: str | Path | None = None) -> Environment:
     """Return a Jinja2 Environment whose loader.searchpath reproduces the
     rules in the original Peagen._setup_env().
     """
-    print('deprecate this - use _search_template_sets')
+    logger.warning("deprecate this - use _search_template_sets")
     ns_dirs: list[str] = []
 
     # 1) Template-set plugins discovered via registry

--- a/pkgs/standards/peagen/peagen/common.py
+++ b/pkgs/standards/peagen/peagen/common.py
@@ -8,7 +8,9 @@ import tempfile
 from contextlib import contextmanager
 import shutil
 
-import logging
+from swarmauri_standard.loggers.Logger import Logger
+
+logger = Logger(name=__name__)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -27,7 +29,7 @@ def temp_workspace(prefix: str = "peagen_"):
             # Already removed – fine.
             pass
         except OSError as exc:
-            logging.warning(f"Workspace cleanup failed: {exc}")
+            logger.warning(f"Workspace cleanup failed: {exc}")
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/pkgs/standards/peagen/peagen/core/_external.py
+++ b/pkgs/standards/peagen/peagen/core/_external.py
@@ -12,6 +12,7 @@ import traceback
 from typing import Any, Dict, Optional
 
 import logging
+from swarmauri_standard.loggers.Logger import Logger
 import colorama
 from colorama import Fore, Style
 from dotenv import load_dotenv
@@ -23,8 +24,8 @@ colorama.init(autoreset=True)
 
 # ANSI escape sequence for underlining (colorama doesn't support underline directly)
 UNDERLINE = "\033[4m"
-logger = logging.getLogger(__name__)
-logging.basicConfig(encoding='utf-8', level=logging.INFO)
+logger = Logger(name=__name__)
+logger.set_level(logging.INFO)
 
 load_dotenv()
 

--- a/pkgs/standards/peagen/peagen/core/process_core.py
+++ b/pkgs/standards/peagen/peagen/core/process_core.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 from datetime import datetime, timezone
 
+from swarmauri_standard.loggers.Logger import Logger
+
 from swarmauri_prompt_j2prompttemplate import J2PromptTemplate
 
 from peagen._utils._context import _create_context
@@ -19,6 +21,8 @@ from peagen._utils._search_template_sets import (
     build_ptree_template_search_paths,
     build_file_template_search_paths,
 )
+
+logger = Logger(name=__name__)
 
 
 def load_projects_payload(
@@ -56,14 +60,17 @@ def locate_template_set(
     Given a template_set name and a list of base directories, return the first
     Path(base_dir)/template_set that exists as a directory. Otherwise raise.
     """
-    print(f"Locating template set '{template_set}' in search paths:")
-    for idx, p in enumerate(search_paths):
-        print(f"  [{idx}] {p}")
+    log = logger or globals().get("logger")
+    if log:
+        log.info(f"Locating template set '{template_set}' in search paths:")
+        for idx, p in enumerate(search_paths):
+            log.debug(f"  [{idx}] {p}")
 
     for base in search_paths:
         candidate = Path(base) / template_set
         if candidate.is_dir():
-            print(f"Found template set '{template_set}' at: {candidate}")
+            if log:
+                log.info(f"Found template set '{template_set}' at: {candidate}")
             return candidate.resolve()
 
     raise ValueError(
@@ -86,8 +93,10 @@ def _render_package_ptree(
     5) Attach "TEMPLATE_SET": template_dir and "PTREE_SEARCH_PATHS": ptree_paths to each record.
     6) Return the list of records (possibly empty).
     """
+    log = logger or globals().get("logger")
     pkg_name = pkg.get("NAME", "<no-package-name>")
-    print(f"--- Rendering ptree for package '{pkg_name}' ---")
+    if log:
+        log.info(f"--- Rendering ptree for package '{pkg_name}' ---")
 
     tmpl_name = (
         pkg.get("TEMPLATE_SET_OVERRIDE")
@@ -95,7 +104,8 @@ def _render_package_ptree(
         or project.get("TEMPLATE_SET")
         or "default"
     )
-    print(f"Using template set name: '{tmpl_name}' for package '{pkg_name}'")
+    if log:
+        log.info(f"Using template set name: '{tmpl_name}' for package '{pkg_name}'")
 
     # 1) Locate the package’s template directory using the global search paths
     template_dir = locate_template_set(tmpl_name, global_search_paths, logger)
@@ -108,9 +118,10 @@ def _render_package_ptree(
         workspace_root=workspace_root,
         source_packages=project.get("SOURCE_PACKAGES", []),
     )
-    print(f"Built ptree search paths for '{pkg_name}':")
-    for idx, p in enumerate(ptree_paths):
-        print(f"  [{idx}] {p}")
+    if log:
+        log.debug(f"Built ptree search paths for '{pkg_name}':")
+        for idx, p in enumerate(ptree_paths):
+            log.debug(f"  [{idx}] {p}")
 
     # 3) Render ptree.yaml.j2 with correct context
     project_copy = dict(project)  # shallow copy of the project dict
@@ -129,9 +140,10 @@ def _render_package_ptree(
 
     j2.set_template(ptree_path)
     rendered = j2.fill({"PROJ": project_copy})
-    print(
-        f"Rendered ptree.yaml.j2 for package '{pkg_name}' (length: {len(rendered)} chars)"
-    )
+    if log:
+        log.debug(
+            f"Rendered ptree.yaml.j2 for package '{pkg_name}' (length: {len(rendered)} chars)"
+        )
 
     # 4) Parse YAML
     try:
@@ -155,7 +167,8 @@ def _render_package_ptree(
         rec["TEMPLATE_SET"] = str(template_dir)
         rec["PTREE_SEARCH_PATHS"] = [str(p) for p in ptree_paths]
 
-    print(f" - Found {len(pkg_file_records)} file-record(s) for package '{pkg_name}'")
+    if log:
+        log.info(f" - Found {len(pkg_file_records)} file-record(s) for package '{pkg_name}'")
 
     return pkg_file_records
 
@@ -173,21 +186,25 @@ def _handle_copy(
     """
     Render a COPY record and save/upload it, then add to the manifest.
     """
+    log = logger or globals().get("logger")
     rendered_name = rec.get("RENDERED_FILE_NAME")
-    print(f"Processing COPY file '{rendered_name}'")
+    if log:
+        log.info(f"Processing COPY file '{rendered_name}'")
 
     content = _render_copy_template(rec, context, j2, logger)
     out_path = workspace_root / rendered_name
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(content or "", encoding="utf-8")
 
-    print(f" - Saved COPY to {out_path}")
+    if log:
+        log.info(f" - Saved COPY to {out_path}")
 
     if storage_adapter:
         key = f"{project_name}/{rendered_name}"
         with open(out_path, "rb") as fsrc:
             storage_adapter.upload(key, fsrc)
-        print(f" - Uploaded COPY to storage key: {key}")
+        if log:
+            log.info(f" - Uploaded COPY to storage key: {key}")
 
     manifest_writer.add(
         {
@@ -195,7 +212,8 @@ def _handle_copy(
             "saved_at": datetime.now(timezone.utc).isoformat(),
         }
     )
-    print(f" - Manifest entry added for '{rendered_name}'")
+    if log:
+        log.debug(f" - Manifest entry added for '{rendered_name}'")
 
 
 def _handle_generate(
@@ -213,11 +231,14 @@ def _handle_generate(
     """
     Render a GENERATE record by calling the external agent, save/upload it, then add to the manifest.
     """
+    log = logger or globals().get("logger")
     rendered_name = rec.get("RENDERED_FILE_NAME")
-    print(f"Processing GENERATE file '{rendered_name}'")
+    if log:
+        log.info(f"Processing GENERATE file '{rendered_name}'")
 
     prompt_tpl = rec.get("AGENT_PROMPT_TEMPLATE")
-    print(prompt_tpl)
+    if log:
+        log.debug(prompt_tpl)
     if not prompt_tpl:
         if logger:
             logger.error(
@@ -233,18 +254,21 @@ def _handle_generate(
         agent_env,
         cfg,
     )
-    print(content)
+    if log:
+        log.debug(content)
     out_path = workspace_root / rendered_name
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(content or "", encoding="utf-8")
 
-    print(f" - Saved GENERATE to {out_path}")
+    if log:
+        log.info(f" - Saved GENERATE to {out_path}")
 
     if storage_adapter:
         key = f"{project_name}/{rendered_name}"
         with open(out_path, "rb") as fsrc:
             storage_adapter.upload(key, fsrc)
-        print(f" - Uploaded GENERATE to storage key: {key}")
+        if log:
+            log.info(f" - Uploaded GENERATE to storage key: {key}")
 
     manifest_writer.add(
         {
@@ -252,7 +276,8 @@ def _handle_generate(
             "saved_at": datetime.now(timezone.utc).isoformat(),
         }
     )
-    print(f" - Manifest entry added for '{rendered_name}'")
+    if log:
+        log.debug(f" - Manifest entry added for '{rendered_name}'")
 
 
 def process_single_project(
@@ -274,10 +299,11 @@ def process_single_project(
        d) Populate cfg["manifest_path"] with the manifest's final path.
     Returns (sorted_records, next_idx).
     """
-    logger = cfg.get("logger")
+    logger = cfg.get("logger") or globals().get("logger")
     project_name = project.get("NAME", "<no-project-name>")
 
-    print(f"========== Starting process for project '{project_name}' ==========")
+    if logger:
+        logger.info(f"========== Starting process for project '{project_name}' ==========")
 
     # ─── STEP 1: Build global search paths ─────────────────────────────────
     base_dir = Path(os.getcwd())
@@ -292,9 +318,10 @@ def process_single_project(
         source_packages=source_pkgs,
         base_dir=base_dir,
     )
-    print("Global Jinja search paths:")
-    for idx, p in enumerate(global_search_paths):
-        print(f"  [{idx}] {p}")
+    if logger:
+        logger.debug("Global Jinja search paths:")
+        for idx, p in enumerate(global_search_paths):
+            logger.debug(f"  [{idx}] {p}")
 
     # ─── STEP 2: Render each package’s ptree.yaml.j2 → file records ─────
     all_file_records: List[Dict[str, Any]] = []
@@ -307,7 +334,8 @@ def process_single_project(
             logger=logger,
         )
         all_file_records.extend(pkg_records)
-    print(f"Total file-records collected: {len(all_file_records)}")
+    if logger:
+        logger.info(f"Total file-records collected: {len(all_file_records)}")
 
     # ─── STEP 3: Topological sort ─────────────────────────────────────────
     sorted_records, next_idx = sort_file_records(
@@ -316,7 +344,8 @@ def process_single_project(
         start_file=start_file,
         transitive=transitive,
     )
-    print(f"Topologically sorted, {len(sorted_records)} files to process.")
+    if logger:
+        logger.info(f"Topologically sorted, {len(sorted_records)} files to process.")
 
     if not sorted_records:
         if logger:
@@ -350,8 +379,9 @@ def process_single_project(
         tmp_root=manifest_dir,
         meta=manifest_meta,
     )
-    print(f"Processing files under: {workspace_root}")
-    print("Beginning file-by-file rendering:")
+    if logger:
+        logger.info(f"Processing files under: {workspace_root}")
+        logger.info("Beginning file-by-file rendering:")
 
     # ─── STEP 5: Render & save each sorted file ───────────────────────────
     for idx, rec in enumerate(sorted_records, start=start_idx):
@@ -363,9 +393,10 @@ def process_single_project(
 
         record_dir = Path(rec.get("TEMPLATE_SET", "")).resolve()
         ptree_paths = [Path(p) for p in rec.get("PTREE_SEARCH_PATHS", [])]
-        print("Pt ree search paths for this file:")
-        for i, p in enumerate(ptree_paths):
-            print(f"  [{i}] {p}")
+        if logger:
+            logger.debug("Pt ree search paths for this file:")
+            for i, p in enumerate(ptree_paths):
+                logger.debug(f"  [{i}] {p}")
 
         file_paths = build_file_template_search_paths(
             record_template_dir=record_dir,
@@ -374,16 +405,19 @@ def process_single_project(
         )
         j2.templates_dir = file_paths
 
-        print("Final Jinja search paths for file:")
-        for i, p in enumerate(file_paths):
-            print(f"  [{i}] {p}")
+        if logger:
+            logger.debug("Final Jinja search paths for file:")
+            for i, p in enumerate(file_paths):
+                logger.debug(f"  [{i}] {p}")
 
         context = _create_context(rec, project, logger)
 
         process_type = rec.get("PROCESS_TYPE", "COPY").upper()
-        print(process_type)
+        if logger:
+            logger.debug(process_type)
         if process_type == "COPY":
-            print("\n\n\n\ncfg:", cfg)
+            if logger:
+                logger.debug("cfg: %s", cfg)
             _handle_copy(
                 rec,
                 context,
@@ -395,7 +429,8 @@ def process_single_project(
                 manifest_writer,
             )
         elif process_type == "GENERATE":
-            print("\n\n\n\ncfg:", cfg)
+            if logger:
+                logger.debug("cfg: %s", cfg)
             _handle_generate(
                 rec,
                 context,
@@ -418,7 +453,8 @@ def process_single_project(
     # final_manifest_path = manifest_writer.finalise()
     # cfg["manifest_path"] = str(final_manifest_path)
     # print(f"Manifest written to: {final_manifest_path}")
-    print(f"========== Completed project '{project_name}' ==========\n")
+    if logger:
+        logger.info(f"========== Completed project '{project_name}' ==========\n")
 
     return sorted_records, next_idx
 

--- a/pkgs/standards/peagen/peagen/core/render_core.py
+++ b/pkgs/standards/peagen/peagen/core/render_core.py
@@ -10,11 +10,12 @@ from colorama import Fore, Style
 from peagen.core._external import call_external_agent
 
 import logging
+from swarmauri_standard.loggers.Logger import Logger
 
 # Initialize colorama for auto-resetting colors
 colorama.init(autoreset=True)
-logger = logging.getLogger(__name__)
-logging.basicConfig(encoding='utf-8', level=logging.INFO)
+logger = Logger(name=__name__)
+logger.set_level(logging.INFO)
 
 def _render_copy_template(
     file_record: Dict[str, Any],
@@ -79,7 +80,8 @@ def _render_generate_template(
             resp = call_external_agent(rendered_prompt, agent_env, cfg, logger)
         else:
             resp = call_external_agent(rendered_prompt, agent_env, logger=logger)
-        print('\n\nresp', resp)
+        if logger:
+            logger.debug("resp %s", resp)
         return resp
     except Exception as e:
         if logger:

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from swarmauri_standard.loggers.Logger import Logger
 import os
 import uuid
 import json
@@ -34,11 +35,10 @@ from peagen.gateway.db_helpers import upsert_task
 from peagen.core.task_core import get_task_result
 # ─────────────────────────── logging ────────────────────────────
 LOG_LEVEL = os.getenv("DQ_LOG_LEVEL", "INFO").upper()
-logging.basicConfig(
-    level=LOG_LEVEL,
-    format="%(asctime)s [%(levelname)5s] %(name)s: %(message)s",
+log = Logger(
+    name="uvicorn",
+    default_level=getattr(logging, LOG_LEVEL, logging.INFO),
 )
-log = logging.getLogger("uvicorn")
 
 # silence noisy deps but keep warnings
 logging.getLogger("httpx").setLevel("WARNING")

--- a/pkgs/standards/peagen/peagen/gateway/db_helpers.py
+++ b/pkgs/standards/peagen/peagen/gateway/db_helpers.py
@@ -1,6 +1,6 @@
 # dqueue/db_helpers.py
 import uuid
-import logging
+from swarmauri_standard.loggers.Logger import Logger
 import datetime as dt
 from typing import Dict, Any
 
@@ -8,7 +8,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from peagen.models import Status, TaskRun
 
-log = logging.getLogger("upsert")
+log = Logger(name="upsert")
 
 def _coerce(row_dict: Dict[str, Any]) -> Dict[str, Any]:
     """

--- a/pkgs/standards/peagen/peagen/handlers/process_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/process_handler.py
@@ -13,7 +13,7 @@ returns a JSON-serialisable result mapping.
 
 from __future__ import annotations
 
-import logging
+from swarmauri_standard.loggers.Logger import Logger
 from typing import Any, Dict, List
 from peagen._utils.config_loader import resolve_cfg
 
@@ -24,7 +24,7 @@ from peagen.core.process_core import (
 )
 from peagen.models import Task, Status  # noqa: F401 – used by type hints
 
-logger = logging.getLogger(__name__)
+logger = Logger(name=__name__)
 
 
 async def process_handler(task: Dict[str, Any] | Task) -> Dict[str, Any]:

--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from swarmauri_standard.loggers.Logger import Logger
 import os
 import socket
 import uuid
@@ -74,11 +75,9 @@ class WorkerBase:
 
         # ─── LOGGING ─────────────────────────────────────────────────
         lvl = (log_level or os.getenv("DQ_LOG_LEVEL", "INFO")).upper()
-        logging.basicConfig(
-            level=lvl,
-            format="%(asctime)s [%(levelname)5s] %(name)s: %(message)s",
-        )
-        self.log = logging.getLogger("uvicorn")
+        log_level_int = getattr(logging, lvl, logging.INFO)
+        self.log = Logger(name="uvicorn", default_level=log_level_int)
+
         # Silence overly‐verbose libraries but keep warnings:
         logging.getLogger("httpx").setLevel("WARNING")
         logging.getLogger("uvicorn.error").setLevel("INFO")


### PR DESCRIPTION
## Summary
- replace print calls with unified logger in `process_core`
- swap deprecated print statement in `_utils/_jinja` for logger warning
- log return value in `render_core` instead of printing

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_68452ab227808326a4627ae509c5dad1