### PR TITLE
Expose resolve_plugin_spec & use in core logic

### DIFF
--- a/pkgs/standards/peagen/peagen/__init__.py
+++ b/pkgs/standards/peagen/peagen/__init__.py
@@ -13,6 +13,6 @@ except PackageNotFoundError:
     __version__ = "0.0.0"
 
 
-from .plugin_manager import PluginManager
+from .plugin_manager import PluginManager, resolve_plugin_spec
 
-__all__ = ["__package_name__", "__version__", "PluginManager"]
+__all__ = ["__package_name__", "__version__", "PluginManager", "resolve_plugin_spec"]

--- a/pkgs/standards/peagen/peagen/_utils/_template_sets.py
+++ b/pkgs/standards/peagen/peagen/_utils/_template_sets.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from importlib import import_module
 from types import ModuleType
 from typing import Any, Dict, List
+
+from peagen.plugin_manager import resolve_plugin_spec
 from jinja2 import FileSystemLoader
 from peagen.plugins import registry 
 
@@ -117,13 +119,12 @@ def _locate_template_set(template_set: str, loader: FileSystemLoader) -> Path:
     # ------------------------------------------------------------------ #
     plugin = registry.get("template_sets", {}).get(template_set)
     if plugin is not None:
-        # The registry guarantees either a module or a class.           #
-        # For a class we jump to its defining module.                   #
+        target = resolve_plugin_spec("template_sets", template_set)
         target_mod: ModuleType
-        if isinstance(plugin, ModuleType):
-            target_mod = plugin
+        if isinstance(target, ModuleType):
+            target_mod = target
         else:  # class
-            target_mod = import_module(plugin.__module__)
+            target_mod = import_module(target.__module__)
 
         # Prefer module.__path__[0] (packages) then module.__file__.
         if hasattr(target_mod, "__path__"):        # namespace / pkg

--- a/pkgs/standards/peagen/peagen/core/doe_core.py
+++ b/pkgs/standards/peagen/peagen/core/doe_core.py
@@ -22,6 +22,7 @@ from urllib.parse import urlparse
 
 from peagen._utils.config_loader import load_peagen_toml
 from peagen.plugins import registry
+from peagen.plugin_manager import resolve_plugin_spec
 
 # ─────────────────────────────── util ──────────────────────────────────────
 _LLM_FALLBACK_KEYS = {
@@ -183,7 +184,7 @@ def _publish_event(notify_uri: str, output_path: Path, count: int, cfg_path: Opt
     bus_cfg = toml_cfg.get("publishers", {}).get("adapters", {}).get(pub_name, {})
 
     channel = nt.path.lstrip("/") or bus_cfg.get("channel", "peagen.events")
-    PubCls = registry["publishers"][pub_name]  # may raise KeyError
+    PubCls = resolve_plugin_spec("publishers", pub_name)  # may raise KeyError
     bus = PubCls(**bus_cfg)
     bus.publish(
         channel,

--- a/pkgs/standards/peagen/peagen/core/doe_core.py
+++ b/pkgs/standards/peagen/peagen/core/doe_core.py
@@ -21,7 +21,6 @@ from jinja2 import Template
 from urllib.parse import urlparse
 
 from peagen._utils.config_loader import load_peagen_toml
-from peagen.plugins import registry
 from peagen.plugin_manager import resolve_plugin_spec
 
 # ─────────────────────────────── util ──────────────────────────────────────

--- a/pkgs/standards/peagen/peagen/core/eval_core.py
+++ b/pkgs/standards/peagen/peagen/core/eval_core.py
@@ -13,9 +13,10 @@ import asyncio
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+from importlib import import_module
+
 from peagen.common import PathOrURI, temp_workspace
 from peagen._utils.config_loader import load_peagen_toml
-from peagen.plugins import registry
 from peagen.plugin_manager import resolve_plugin_spec
 from peagen.plugins.evaluator_pools.default import DefaultEvaluatorPool
 from swarmauri_standard.programs.Program import Program

--- a/pkgs/standards/peagen/peagen/core/eval_core.py
+++ b/pkgs/standards/peagen/peagen/core/eval_core.py
@@ -10,13 +10,13 @@ evaluate_workspace()  – orchestrates one evaluation run and returns a manifest
 from __future__ import annotations
 
 import asyncio
-from importlib import import_module
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from peagen.common import PathOrURI, temp_workspace
 from peagen._utils.config_loader import load_peagen_toml
 from peagen.plugins import registry
+from peagen.plugin_manager import resolve_plugin_spec
 from peagen.plugins.evaluator_pools.default import DefaultEvaluatorPool
 from swarmauri_standard.programs.Program import Program
 
@@ -27,13 +27,7 @@ def _build_pool(pool_ref: Optional[str], eval_cfg: Dict[str, Any]):
     """
     choice = pool_ref or eval_cfg.get("pool")
     if choice:
-        if choice in registry.get("evaluator_pools", {}):
-            PoolCls = registry["evaluator_pools"][choice]
-        else:  # dotted-path “package.module:Class” or “package.module.Class”
-            mod, cls = (
-                choice.split(":", 1) if ":" in choice else choice.rsplit(".", 1)
-            )
-            PoolCls = getattr(import_module(mod), cls)
+        PoolCls = resolve_plugin_spec("evaluator_pools", choice)
     else:
         PoolCls = DefaultEvaluatorPool
 

--- a/pkgs/standards/peagen/peagen/core/render_core.py
+++ b/pkgs/standards/peagen/peagen/core/render_core.py
@@ -1,6 +1,5 @@
 # peagen/core/render_core.py
 
-import sys
 from pathlib import Path
 from typing import Any, Dict, Optional
 

--- a/pkgs/standards/peagen/peagen/core/templates_core.py
+++ b/pkgs/standards/peagen/peagen/core/templates_core.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, List, Optional
 
 import peagen.template_sets as _pt
 from peagen.plugins import registry
+from peagen.plugin_manager import resolve_plugin_spec
 
 
 def _namespace_dirs() -> List[Path]:
@@ -30,12 +31,13 @@ def discover_template_sets() -> Dict[str, List[Path]]:
         except PermissionError:
             continue
     for name, plugin in registry.get("template_sets", {}).items():
-        mod = plugin if isinstance(plugin, ModuleType) else import_module(plugin.__module__)
-        if hasattr(mod, "__path__"):
-            for root in mod.__path__:
+        mod = resolve_plugin_spec("template_sets", name)
+        module = mod if isinstance(mod, ModuleType) else import_module(mod.__module__)
+        if hasattr(module, "__path__"):
+            for root in module.__path__:
                 sets.setdefault(name, []).append(Path(root))
-        elif hasattr(mod, "__file__"):
-            sets.setdefault(name, []).append(Path(mod.__file__).parent)
+        elif hasattr(module, "__file__"):
+            sets.setdefault(name, []).append(Path(module.__file__).parent)
     return sets
 
 

--- a/pkgs/standards/peagen/peagen/plugin_manager.py
+++ b/pkgs/standards/peagen/peagen/plugin_manager.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from importlib import import_module
 from typing import Any, Dict, Optional
 
+from .plugins import discover_and_register_plugins, registry
+
 
 def resolve_plugin_spec(group: str, ref: str) -> Any:
     """Return the object referenced by ``ref`` within ``group``."""
@@ -16,9 +18,6 @@ def resolve_plugin_spec(group: str, ref: str) -> Any:
     mod, cls = ref.split(":", 1) if ":" in ref else ref.rsplit(".", 1)
     module = import_module(mod)
     return getattr(module, cls)
-
-from .plugins import discover_and_register_plugins, registry
-
 
 class PluginManager:
     """Centralised plugin loader.

--- a/pkgs/standards/peagen/tests/unit/test_plugin_manager.py
+++ b/pkgs/standards/peagen/tests/unit/test_plugin_manager.py
@@ -1,0 +1,20 @@
+import types
+from peagen.plugin_manager import resolve_plugin_spec
+from peagen.plugins import registry
+
+class DummyPool:
+    pass
+
+
+def test_resolve_plugin_spec_from_registry(monkeypatch):
+    monkeypatch.setitem(registry.setdefault("evaluator_pools", {}), "dummy", DummyPool)
+    assert resolve_plugin_spec("evaluator_pools", "dummy") is DummyPool
+
+
+def test_resolve_plugin_spec_dotted_path():
+    cls = resolve_plugin_spec(
+        "evaluator_pools",
+        "peagen.plugins.evaluator_pools.default:DefaultEvaluatorPool",
+    )
+    assert cls.__name__.endswith("EvaluatorPool")
+

--- a/pkgs/standards/peagen/tests/unit/test_plugin_manager.py
+++ b/pkgs/standards/peagen/tests/unit/test_plugin_manager.py
@@ -1,4 +1,3 @@
-import types
 from peagen.plugin_manager import resolve_plugin_spec
 from peagen.plugins import registry
 


### PR DESCRIPTION
## Summary
- expose `resolve_plugin_spec` in peagen.plugin_manager
- use `resolve_plugin_spec` to resolve plugins across peagen
- add regression tests for plugin spec resolution

## Testing
- `uv run --package peagen --directory standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_684534c4cdf083268c95d7905ff97a11