### PR TITLE
Implement env-based logging control

### DIFF
--- a/pkgs/swarmauri/swarmauri/__init__.py
+++ b/pkgs/swarmauri/swarmauri/__init__.py
@@ -1,16 +1,16 @@
 import sys as _sys
-import logging
+from .logging_utils import get_logger
 from .importer import SwarmauriImporter
 from .plugin_manager import discover_and_register_plugins
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 try:
     if not any(isinstance(importer, SwarmauriImporter) for importer in _sys.meta_path):
-        logger.info("Registering SwarmauriImporter in _sys.meta_path.")
+        logger.swarmauri("Registering SwarmauriImporter in _sys.meta_path.")
         _sys.meta_path.insert(0, SwarmauriImporter())
     else:
-        logger.info("SwarmauriImporter is already registered.")
+        logger.swarmauri("SwarmauriImporter is already registered.")
 except Exception as e:
     logger.error(f"Failed to register SwarmauriImporter: {e}")
     raise

--- a/pkgs/swarmauri/swarmauri/cli.py
+++ b/pkgs/swarmauri/swarmauri/cli.py
@@ -1,11 +1,21 @@
 import argparse
+import os
 import logging
+from .logging_utils import get_logger, SWARMAURI_LOG_LEVEL
 import subprocess
 from swarmauri.registry import list_registry
 from swarmauri.plugin_manager import get_entry_points, determine_plugin_manager
 
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+env_level = os.getenv("SWARMAURI_LOG_LEVEL")
+if env_level:
+    try:
+        level = int(env_level)
+    except ValueError:
+        level = SWARMAURI_LOG_LEVEL
+    logging.basicConfig(level=level)
+else:
+    logging.basicConfig(level=SWARMAURI_LOG_LEVEL)
+logger = get_logger(__name__)
 
 
 def run_command(command):
@@ -14,7 +24,7 @@ def run_command(command):
     """
     try:
         result = subprocess.run(command, check=True, text=True, capture_output=True)
-        logger.info(result.stdout)
+        logger.swarmauri(result.stdout)
     except subprocess.CalledProcessError as e:
         logger.error(f"Command failed: {e.stderr}")
         raise
@@ -25,10 +35,10 @@ def install_plugin(plugin_name, use_pip=False, use_poetry=False):
     Install a plugin using pip or poetry.
     """
     if use_pip:
-        logger.info(f"Installing plugin '{plugin_name}' using pip...")
+        logger.swarmauri(f"Installing plugin '{plugin_name}' using pip...")
         run_command(["pip", "install", plugin_name])
     elif use_poetry:
-        logger.info(f"Adding plugin '{plugin_name}' using poetry...")
+        logger.swarmauri(f"Adding plugin '{plugin_name}' using poetry...")
         run_command(["poetry", "add", plugin_name])
     else:
         logger.warning("Specify --use-pip or --use-poetry to install the plugin.")
@@ -39,10 +49,10 @@ def remove_plugin(plugin_name, use_pip=False, use_poetry=False):
     Remove a plugin using pip or poetry.
     """
     if use_pip:
-        logger.info(f"Removing plugin '{plugin_name}' using pip...")
+        logger.swarmauri(f"Removing plugin '{plugin_name}' using pip...")
         run_command(["pip", "uninstall", "-y", plugin_name])
     elif use_poetry:
-        logger.info(f"Removing plugin '{plugin_name}' using poetry...")
+        logger.swarmauri(f"Removing plugin '{plugin_name}' using poetry...")
         run_command(["poetry", "remove", plugin_name])
     else:
         logger.warning("Specify --use-pip or --use-poetry to remove the plugin.")
@@ -52,7 +62,7 @@ def validate_plugin(plugin_name):
     """
     Validate a plugin without registering it.
     """
-    logger.info(f"Validating plugin: {plugin_name}")
+    logger.swarmauri(f"Validating plugin: {plugin_name}")
     try:
         for entry_point in get_entry_points():
             if entry_point.name == plugin_name:
@@ -66,7 +76,7 @@ def validate_plugin(plugin_name):
                 plugin_manager.validate(
                     entry_point.name, plugin_class, resource_kind, None
                 )
-                logger.info(f"Plugin '{plugin_name}' validated successfully.")
+                logger.swarmauri(f"Plugin '{plugin_name}' validated successfully.")
                 return
         logger.warning(f"Plugin '{plugin_name}' not found among entry points.")
     except Exception as e:
@@ -78,7 +88,7 @@ def register_plugin(plugin_name):
     """
     Register a plugin in the registry.
     """
-    logger.info(f"Registering plugin: {plugin_name}")
+    logger.swarmauri(f"Registering plugin: {plugin_name}")
     try:
         for entry_point in get_entry_points():
             if entry_point.name == plugin_name:
@@ -90,7 +100,7 @@ def register_plugin(plugin_name):
                     else None
                 )
                 plugin_manager.register(entry_point.name, plugin_class, resource_kind)
-                logger.info(f"Plugin '{plugin_name}' registered successfully.")
+                logger.swarmauri(f"Plugin '{plugin_name}' registered successfully.")
                 return
         logger.warning(f"Plugin '{plugin_name}' not found among entry points.")
     except Exception as e:
@@ -102,7 +112,7 @@ def list_plugins():
     """
     List all registered plugins.
     """
-    logger.info("Listing all registered plugins...")
+    logger.swarmauri("Listing all registered plugins...")
     plugins = list_registry()
     if not plugins:
         print("No plugins registered.")

--- a/pkgs/swarmauri/swarmauri/importer.py
+++ b/pkgs/swarmauri/swarmauri/importer.py
@@ -2,14 +2,14 @@
 
 import sys
 import importlib
-import logging
+from .logging_utils import get_logger
 from importlib.machinery import ModuleSpec
 from types import ModuleType
 
 from .plugin_citizenship_registry import PluginCitizenshipRegistry
 from .interface_registry import InterfaceRegistry
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class SwarmauriImporter:
@@ -104,7 +104,7 @@ class SwarmauriImporter:
 
 # Register the custom importer
 if not any(isinstance(imp, SwarmauriImporter) for imp in sys.meta_path):
-    logger.info("Registering SwarmauriImporter in sys.meta_path.")
+    logger.swarmauri("Registering SwarmauriImporter in sys.meta_path.")
     sys.meta_path.insert(0, SwarmauriImporter())
 else:
-    logger.info("SwarmauriImporter is already registered.")
+    logger.swarmauri("SwarmauriImporter is already registered.")

--- a/pkgs/swarmauri/swarmauri/interface_registry.py
+++ b/pkgs/swarmauri/swarmauri/interface_registry.py
@@ -8,7 +8,7 @@ Provides mechanisms to retrieve and manage interface classes based on resource n
 """
 
 from typing import Optional, Type, Dict, Any, List
-import logging
+from .logging_utils import get_logger
 
 # Example imports for interface definitions
 from swarmauri_base.agents.AgentBase import AgentBase
@@ -53,7 +53,7 @@ from swarmauri_base.rate_limits.RateLimitBase import RateLimitBase
 from swarmauri_base.middlewares.MiddlewareBase import MiddlewareBase
 
 # Configure logging
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class InterfaceRegistry:
@@ -155,11 +155,11 @@ class InterfaceRegistry:
 
         cls.INTERFACE_REGISTRY[resource_kind] = interface_class
         if interface_class:
-            logger.info(
+            logger.swarmauri(
                 f"Registered interface '{interface_class.__name__}' for resource kind '{resource_kind}'."
             )
         else:
-            logger.info(
+            logger.swarmauri(
                 f"Removed interface association for resource kind '{resource_kind}'."
             )
 

--- a/pkgs/swarmauri/swarmauri/logging_utils.py
+++ b/pkgs/swarmauri/swarmauri/logging_utils.py
@@ -1,0 +1,28 @@
+import logging
+import os
+
+SWARMAURI_LOG_LEVEL = 99
+logging.addLevelName(SWARMAURI_LOG_LEVEL, "SWARMAURI")
+
+
+def swarmauri(self, message, *args, **kwargs):
+    if self.isEnabledFor(SWARMAURI_LOG_LEVEL):
+        self._log(SWARMAURI_LOG_LEVEL, message, args, **kwargs)
+
+
+logging.Logger.swarmauri = swarmauri
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a logger configured for Swarmauri logging."""
+    logger = logging.getLogger(name)
+
+    env_level = os.getenv("SWARMAURI_LOG_LEVEL")
+    if env_level:
+        try:
+            level = int(env_level)
+        except ValueError:
+            level = SWARMAURI_LOG_LEVEL
+        logger.setLevel(level)
+
+    return logger

--- a/pkgs/swarmauri/swarmauri/plugin_citizenship_registry.py
+++ b/pkgs/swarmauri/swarmauri/plugin_citizenship_registry.py
@@ -7,12 +7,12 @@ Defines the PluginCitizenshipRegistry class responsible for managing plugin regi
 first, second, and third-class citizens within the swarmauri framework.
 """
 
-import logging
+from .logging_utils import get_logger
 from importlib.metadata import EntryPoint
 from typing import Dict, Optional
 
 # Configure logger
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class PluginCitizenshipRegistry:
@@ -349,7 +349,7 @@ class PluginCitizenshipRegistry:
 
         # Add to the specific registry
         registry[resource_path] = module_path
-        logger.info(
+        logger.swarmauri(
             f"Added to {class_type}-class registry: {resource_path} -> {module_path}"
         )
 
@@ -389,7 +389,9 @@ class PluginCitizenshipRegistry:
 
         # Remove from the specific registry
         del registry[resource_path]
-        logger.info(f"Removed from {class_type}-class registry: {resource_path}")
+        logger.swarmauri(
+            f"Removed from {class_type}-class registry: {resource_path}"
+        )
 
     @classmethod
     def list_registry(cls, class_type: Optional[str] = None) -> Dict[str, str]:
@@ -480,7 +482,7 @@ class PluginCitizenshipRegistry:
 
         old_module_path = registry[resource_path]
         registry[resource_path] = new_module_path
-        logger.info(
+        logger.swarmauri(
             f"Updated {class_type}-class registry entry: {resource_path} -> {new_module_path} (was: {old_module_path})"
         )
 
@@ -551,7 +553,9 @@ class PluginCitizenshipRegistry:
         """
         resource_path = f"{entry_point.group}.{entry_point.name}"
         cls.FIRST_CLASS_REGISTRY[resource_path] = module_path
-        logger.info(f"Registered first-class plugin: {resource_path} -> {module_path}")
+        logger.swarmauri(
+            f"Registered first-class plugin: {resource_path} -> {module_path}"
+        )
 
     @classmethod
     def register_second_class_plugin(cls, entry_point: EntryPoint, module_path: str):
@@ -563,7 +567,9 @@ class PluginCitizenshipRegistry:
         """
         resource_path = f"{entry_point.group}.{entry_point.name}"
         cls.SECOND_CLASS_REGISTRY[resource_path] = module_path
-        logger.info(f"Registered second-class plugin: {resource_path} -> {module_path}")
+        logger.swarmauri(
+            f"Registered second-class plugin: {resource_path} -> {module_path}"
+        )
 
     @classmethod
     def register_third_class_plugin(cls, entry_point: EntryPoint, module_path: str):
@@ -575,4 +581,6 @@ class PluginCitizenshipRegistry:
         """
         resource_path = f"{entry_point.group}.{entry_point.name}"
         cls.THIRD_CLASS_REGISTRY[resource_path] = module_path
-        logger.info(f"Registered third-class plugin: {resource_path} -> {module_path}")
+        logger.swarmauri(
+            f"Registered third-class plugin: {resource_path} -> {module_path}"
+        )

--- a/pkgs/swarmauri/swarmauri/plugin_manager.py
+++ b/pkgs/swarmauri/swarmauri/plugin_manager.py
@@ -4,7 +4,7 @@ import importlib.metadata
 import importlib.util
 import inspect
 import json
-import logging
+from .logging_utils import get_logger
 import sys
 from importlib.metadata import EntryPoint, entry_points
 from typing import Any, Dict, Optional
@@ -14,7 +14,7 @@ from typing import Any, Dict, Optional
 from .interface_registry import InterfaceRegistry
 from .plugin_citizenship_registry import PluginCitizenshipRegistry
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 # --------------------------------------------------------------------------------------
 # 1. GLOBAL CACHE FOR ENTRY POINTS
@@ -116,7 +116,9 @@ def process_plugin(entry_point: EntryPoint) -> bool:
         if loading_strategy == "lazy":
             # Register plugin based on classification (first, second)
             _register_lazy_plugin_from_metadata(entry_point, metadata)
-            logger.info(f"Plugin '{entry_point.name}' registered for lazy loading.")
+            logger.swarmauri(
+                f"Plugin '{entry_point.name}' registered for lazy loading."
+            )
             return True
         else:
             # Eager loading: load the plugin module
@@ -266,7 +268,7 @@ def _register_lazy_plugin_from_metadata(
         PluginCitizenshipRegistry.add_to_registry(
             citizenship, resource_path, module_path
         )
-        logger.info(
+        logger.swarmauri(
             f"Registered {citizenship}-class plugin '{type_name}' at '{resource_path}' [lazy]"
         )
 
@@ -368,7 +370,7 @@ def _process_class_plugin(
         # Step 2: Determine citizenship classification
         citizenship = determine_plugin_citizenship(entry_point)
         if citizenship:
-            logger.info(
+            logger.swarmauri(
                 f"Plugin '{entry_point.name}' is classified as {citizenship}-class."
             )
         else:
@@ -390,7 +392,7 @@ def _process_class_plugin(
                 logger.error(msg)
                 raise PluginValidationError(msg)
 
-            logger.info(
+            logger.swarmauri(
                 f"Validated class-based plugin '{plugin_class.__name__}' against interface '{interface_class.__name__}'"
             )
 
@@ -404,7 +406,7 @@ def _process_class_plugin(
         PluginCitizenshipRegistry.add_to_registry(
             citizenship, resource_path, module_path
         )
-        logger.info(
+        logger.swarmauri(
             f"Registered {citizenship}-class plugin '{plugin_class.__name__}' at '{resource_path}' in PluginCitizenshipRegistry"
         )
 
@@ -497,7 +499,7 @@ def _process_module_plugin(
                         PluginCitizenshipRegistry.add_to_registry(
                             citizenship, class_resource_path, plugin_module.__name__
                         )
-                        logger.info(
+                        logger.swarmauri(
                             f"Registered {citizenship}-class plugin '{attr_name}' at '{class_resource_path}'"
                         )
 
@@ -540,7 +542,7 @@ def _process_module_plugin(
                         PluginCitizenshipRegistry.add_to_registry(
                             "third", generic_resource_path, plugin_module.__name__
                         )
-                        logger.info(
+                        logger.swarmauri(
                             f"Registered third-class generic plugin '{attr_name}' at '{generic_resource_path}'"
                         )
                     else:
@@ -596,13 +598,10 @@ def _process_generic_plugin(
         PluginCitizenshipRegistry.add_to_registry(
             "third", resource_path, entry_point.value.split(":")[0]
         )
-        logger.info(
+        logger.swarmauri(
             f"Registered generic plugin '{entry_point.name}' under '{resource_path}' for lazy loading."
         )
 
-        # Register in TYPE_REGISTRY
-        # 🚧ComponentBase.TYPE_REGISTRY.setdefault("plugins", {})[entry_point.name] = entry_point.load()
-        # 🚧logger.info(f"Registered generic plugin '{entry_point.name}' in TYPE_REGISTRY under 'plugins'")
 
         return True
 


### PR DESCRIPTION
## Summary
- make Swarmauri log level configurable via `SWARMAURI_LOG_LEVEL` env var
- respect the env var in the CLI when configuring logging
- remove outdated TYPE_REGISTRY code references

## Testing
- `uv run --package swarmauri --directory swarmauri pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68452f5d122c8326993cb9b4b08f4c7c