### PR TITLE
Fix ruff lints on peagen

### DIFF
--- a/pkgs/standards/peagen/peagen/core/doe_core.py
+++ b/pkgs/standards/peagen/peagen/core/doe_core.py
@@ -21,7 +21,6 @@ from jinja2 import Template
 from urllib.parse import urlparse
 
 from peagen._utils.config_loader import load_peagen_toml
-from peagen.plugins import registry
 from peagen.plugin_manager import resolve_plugin_spec
 
 # ─────────────────────────────── util ──────────────────────────────────────

--- a/pkgs/standards/peagen/peagen/core/eval_core.py
+++ b/pkgs/standards/peagen/peagen/core/eval_core.py
@@ -13,9 +13,10 @@ import asyncio
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+from importlib import import_module
+
 from peagen.common import PathOrURI, temp_workspace
 from peagen._utils.config_loader import load_peagen_toml
-from peagen.plugins import registry
 from peagen.plugin_manager import resolve_plugin_spec
 from peagen.plugins.evaluator_pools.default import DefaultEvaluatorPool
 from swarmauri_standard.programs.Program import Program

--- a/pkgs/standards/peagen/peagen/core/render_core.py
+++ b/pkgs/standards/peagen/peagen/core/render_core.py
@@ -1,6 +1,5 @@
 # peagen/core/render_core.py
 
-import sys
 from pathlib import Path
 from typing import Any, Dict, Optional
 

--- a/pkgs/standards/peagen/peagen/plugin_manager.py
+++ b/pkgs/standards/peagen/peagen/plugin_manager.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from importlib import import_module
 from typing import Any, Dict, Optional
 
+from .plugins import discover_and_register_plugins, registry
+
 
 def resolve_plugin_spec(group: str, ref: str) -> Any:
     """Return the object referenced by ``ref`` within ``group``."""
@@ -16,9 +18,6 @@ def resolve_plugin_spec(group: str, ref: str) -> Any:
     mod, cls = ref.split(":", 1) if ":" in ref else ref.rsplit(".", 1)
     module = import_module(mod)
     return getattr(module, cls)
-
-from .plugins import discover_and_register_plugins, registry
-
 
 class PluginManager:
     """Centralised plugin loader.

--- a/pkgs/standards/peagen/tests/unit/test_plugin_manager.py
+++ b/pkgs/standards/peagen/tests/unit/test_plugin_manager.py
@@ -1,4 +1,3 @@
-import types
 from peagen.plugin_manager import resolve_plugin_spec
 from peagen.plugins import registry
 


### PR DESCRIPTION
## Summary
- clean up unused imports in `doe_core`, `eval_core`, and `render_core`
- fix import order in `plugin_manager`
- remove unused import in `test_plugin_manager`

## Testing
- `ruff check pkgs/standards/peagen`

------
https://chatgpt.com/codex/tasks/task_e_684539db64808326b34bf404107d7c91