### PR TITLE
Set default worker host

### DIFF
--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -59,7 +59,7 @@ class WorkerBase:
           • DQ_POOL          (default: "default")
           • DQ_GATEWAY       (default: "http://localhost:8000/rpc")
           • DQ_WORKER_ID     (default: random 8‐char prefix)
-          • DQ_HOST          (default: local IP)
+          • DQ_HOST          (default: "127.0.0.1")
           • PORT             (default: 8000)
           • DQ_LOG_LEVEL     (default: "INFO")
         """
@@ -70,7 +70,7 @@ class WorkerBase:
         self.PORT = port or int(os.getenv("PORT", "8000"))
         env_host = host or os.getenv("DQ_HOST", "")
         if not env_host:
-            env_host = get_local_ip()
+            env_host = "127.0.0.1"
         self.HOST = env_host
 
         # ─── LOGGING ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- set `DQ_HOST` default to `127.0.0.1`
- update documentation in `WorkerBase` docstring

## Testing
- `uv run --package peagen --directory standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_68454128f44c83268e041994cb728d2c