### PR TITLE
Fix template set references in docs and tests

### DIFF
--- a/pkgs/standards/peagen/docs/examples/example_projects_payload.yaml
+++ b/pkgs/standards/peagen/docs/examples/example_projects_payload.yaml
@@ -1,7 +1,7 @@
 PROJECTS:
   - NAME: "AdvancedConversationalMemory"
     ROOT: "pkgs"
-    TEMPLATE_SET: "componentv1"
+  TEMPLATE_SET: "swarmauri_standard_standalone"
     EXTRAS:
       REQUIREMENTS:
         - "Aggregate advanced methods for conversational memory management in LLM systems."
@@ -13,7 +13,7 @@ PROJECTS:
       # 1) SessionContextController
       #-----------------------------------------------------
       - NAME: "SessionContextController"
-        TEMPLATE_SET_OVERRIDE: "componentv1"
+        TEMPLATE_SET_OVERRIDE: "swarmauri_standard_standalone"
         EXTRAS:
           AUTHORS:
             - "Jacob Stewart"

--- a/pkgs/standards/peagen/docs/examples/searchword_projects_payload.yaml
+++ b/pkgs/standards/peagen/docs/examples/searchword_projects_payload.yaml
@@ -1,7 +1,7 @@
 PROJECTS:
   - NAME: "SearchWordTool"
     ROOT: "pkgs/community"
-    TEMPLATE_SET: "componentv1"
+  TEMPLATE_SET: "swarmauri_standard_standalone"
     EXTRAS:
       REQUIREMENTS:
         - "Implement a tool to search for a phrase or a word within a file and return its occurances."
@@ -12,7 +12,7 @@ PROJECTS:
       # 1) swarmauri_tool_searchword
       #-----------------------------------------------------
       - NAME: "swarmauri_tool_searchword"
-        TEMPLATE_SET_OVERRIDE: "componentv1"
+        TEMPLATE_SET_OVERRIDE: "swarmauri_standard_standalone"
         EXTRAS:
           AUTHORS:
             - "Vijay Vignesh Prasad Rao"

--- a/pkgs/standards/peagen/tests/examples/doe_specs/doe_spec(evpools).yaml
+++ b/pkgs/standards/peagen/tests/examples/doe_specs/doe_spec(evpools).yaml
@@ -1,5 +1,5 @@
 # doe_spec.yaml
-templateSet: componentv1
+templateSet: swarmauri_standard_standalone
 
 FACTORS:
   COMPONENT:

--- a/pkgs/standards/peagen/tests/examples/projects_payloads/project_payloads.yaml
+++ b/pkgs/standards/peagen/tests/examples/projects_payloads/project_payloads.yaml
@@ -5,7 +5,7 @@ PROJECTS:
     ROOT: pkgs/community
     PACKAGES:
     - NAME: component_base
-      TEMPLATE_SET_OVERRIDE: componentv1
+      TEMPLATE_SET_OVERRIDE: swarmauri_standard_standalone
       EXTRAS: {}
       MODULES:
       - NAME: BaseComponent

--- a/pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml
+++ b/pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml
@@ -5,7 +5,7 @@ PROJECTS:
     ROOT: pkgs/community
     PACKAGES:
       - NAME: component_searchword
-        TEMPLATE_SET_OVERRIDE: componentv1
+        TEMPLATE_SET_OVERRIDE: swarmauri_standard_standalone
         MODULES:
           - NAME: SearchWordTool
             EXTRAS:
@@ -21,7 +21,7 @@ PROJECTS:
     ROOT: pkgs/community
     PACKAGES:
       - NAME: component_searchword
-        TEMPLATE_SET_OVERRIDE: componentv1
+        TEMPLATE_SET_OVERRIDE: swarmauri_standard_standalone
         MODULES:
           - NAME: SearchWordTool
             EXTRAS:
@@ -37,7 +37,7 @@ PROJECTS:
     ROOT: pkgs/community
     PACKAGES:
       - NAME: component_searchword
-        TEMPLATE_SET_OVERRIDE: componentv1
+        TEMPLATE_SET_OVERRIDE: swarmauri_standard_standalone
         MODULES:
           - NAME: SearchWordTool
             EXTRAS:
@@ -53,7 +53,7 @@ PROJECTS:
     ROOT: pkgs/community
     PACKAGES:
       - NAME: component_searchword
-        TEMPLATE_SET_OVERRIDE: componentv1
+        TEMPLATE_SET_OVERRIDE: swarmauri_standard_standalone
         MODULES:
           - NAME: SearchWordTool
             EXTRAS:
@@ -69,7 +69,7 @@ PROJECTS:
     ROOT: pkgs/community
     PACKAGES:
       - NAME: component_regexsearch
-        TEMPLATE_SET_OVERRIDE: componentv1
+        TEMPLATE_SET_OVERRIDE: swarmauri_standard_standalone
         MODULES:
           - NAME: RegexSearchTool
             EXTRAS:
@@ -85,7 +85,7 @@ PROJECTS:
     ROOT: pkgs/community
     PACKAGES:
       - NAME: component_regexsearch
-        TEMPLATE_SET_OVERRIDE: componentv1
+        TEMPLATE_SET_OVERRIDE: swarmauri_standard_standalone
         MODULES:
           - NAME: RegexSearchTool
             EXTRAS:
@@ -101,7 +101,7 @@ PROJECTS:
     ROOT: pkgs/community
     PACKAGES:
       - NAME: component_regexsearch
-        TEMPLATE_SET_OVERRIDE: componentv1
+        TEMPLATE_SET_OVERRIDE: swarmauri_standard_standalone
         MODULES:
           - NAME: RegexSearchTool
             EXTRAS:
@@ -117,7 +117,7 @@ PROJECTS:
     ROOT: pkgs/community
     PACKAGES:
       - NAME: component_regexsearch
-        TEMPLATE_SET_OVERRIDE: componentv1
+        TEMPLATE_SET_OVERRIDE: swarmauri_standard_standalone
         MODULES:
           - NAME: RegexSearchTool
             EXTRAS:


### PR DESCRIPTION
## Summary
- update example and test payloads to reference the `swarmauri_standard_standalone` template set

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68454ab6ab28832697585d49c4f6ad48