### PR TITLE
Fix peagen tests

### DIFF
--- a/pkgs/standards/peagen/peagen/plugin_manager.py
+++ b/pkgs/standards/peagen/peagen/plugin_manager.py
@@ -1,0 +1,22 @@
+from .plugins import (
+    registry,
+    discover_and_register_plugins,
+    PluginManager,
+)
+
+
+def resolve_plugin_spec(group: str, ref: str):
+    """Resolve a plugin reference from *group*.
+
+    This compatibility wrapper instantiates a temporary PluginManager and uses
+    its internal resolution logic.
+    """
+    pm = PluginManager({})
+    return pm._resolve_spec(group, ref)
+
+__all__ = [
+    "registry",
+    "discover_and_register_plugins",
+    "PluginManager",
+    "resolve_plugin_spec",
+]


### PR DESCRIPTION
## Summary
- add `plugin_manager` compatibility module to expose `PluginManager` and `resolve_plugin_spec`

## Testing
- `uv run --package peagen --directory standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_6845557dd74c83269d64d0b928ead123