### PR TITLE
Fix import path for GenericLLM

### DIFF
--- a/pkgs/standards/peagen/peagen/plugins/__init__.py
+++ b/pkgs/standards/peagen/peagen/plugins/__init__.py
@@ -207,7 +207,7 @@ class PluginManager:
             model_name = cfg.get("default_model_name")
             temperature = cfg.get("default_temperature")
             max_tokens = cfg.get("default_max_tokens")
-            from .core._llm import GenericLLM
+            from ..core._llm import GenericLLM
 
             llm_mgr = GenericLLM()
             kwargs: Dict[str, Any] = {}


### PR DESCRIPTION
## Summary
- fix import path in plugin manager so GenericLLM loads correctly

## Testing
- `python -m py_compile pkgs/standards/peagen/peagen/plugins/__init__.py`
- `peagen remote -q --override-file pkgs/standards/peagen/tests/examples/override/.override.toml process pkgs/standards/peagen/tests/examples/projects_payloads/orm_projects_payload.yaml --watch > /tmp/peagen_output.log 2>&1 && tail -n 20 /tmp/peagen_output.log`


------
https://chatgpt.com/codex/tasks/task_e_68455896fdc883269011f10e805ea826