### PR TITLE
Fix peagen pytest failures

### DIFF
--- a/pkgs/standards/peagen/peagen/storage_adapters/minio_storage_adapter.py
+++ b/pkgs/standards/peagen/peagen/storage_adapters/minio_storage_adapter.py
@@ -15,7 +15,7 @@ from minio import Minio
 from minio.error import S3Error
 from pydantic import SecretStr
 
-from peagen.cli_common import load_peagen_toml
+from peagen._utils.config_loader import load_peagen_toml
 
 
 class MinioStorageAdapter:


### PR DESCRIPTION
## Summary
- fix import path in MinioStorageAdapter

## Testing
- `uv run --package peagen --directory standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_684566111318832692dc96d9a6048992