### PR TITLE
Add RedisPublisher plugin implementation

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -199,7 +199,7 @@ Plugins are exposed through `[project.entry-points]` groups. Example:
 
 ```toml
 [project.entry-points."peagen.publishers"]
-rabbitmq = "peagen.publishers.rabbitmq_publisher:RabbitMQPublisher"
+rabbitmq = "peagen.plugins.publishers.rabbitmq_publisher:RabbitMQPublisher"
 ```
 
 ### Monorepo Workspace

--- a/pkgs/standards/peagen/README.md
+++ b/pkgs/standards/peagen/README.md
@@ -381,7 +381,7 @@ adapters and publishers can be supplied programmatically:
 ```python
 from peagen.core import Peagen
 from peagen.storage_adapters.minio_storage_adapter import MinioStorageAdapter
-from peagen.publishers.webhook_publisher import WebhookPublisher
+from peagen.plugins.publishers.webhook_publisher import WebhookPublisher
 
 store = MinioStorageAdapter.from_uri("s3://localhost:9000", bucket="peagen")
 bus = WebhookPublisher("https://example.com/peagen")
@@ -390,8 +390,8 @@ bus = WebhookPublisher("https://example.com/peagen")
 Another Example:
 
 ```
-from peagen.publishers.redis_publisher import RedisPublisher
-from peagen.publishers.rabbitmq_publisher import RabbitMQPublisher
+from peagen.plugins.publishers.redis_publisher import RedisPublisher
+from peagen.plugins.publishers.rabbitmq_publisher import RabbitMQPublisher
 
 store = MinioStorageAdapter.from_uri("s3://localhost:9000", bucket="peagen")
 bus = RedisPublisher("redis://localhost:6379/0")

--- a/pkgs/standards/peagen/docs/storage_adapters_and_publishers.md
+++ b/pkgs/standards/peagen/docs/storage_adapters_and_publishers.md
@@ -57,14 +57,14 @@ The CLI can emit JSON events such as `process.started` and `process.done`. The r
 
 
 ```python
-from peagen.publishers.redis_publisher import RedisPublisher
+from peagen.plugins.publishers.redis_publisher import RedisPublisher
 
 bus = RedisPublisher("redis://localhost:6379/0")
 bus.publish("peagen.events", {"type": "process.started"})
 ```
 
 ```python
-from peagen.publishers.webhook_publisher import WebhookPublisher
+from peagen.plugins.publishers.webhook_publisher import WebhookPublisher
 
 bus = WebhookPublisher("https://example.com/peagen")
 bus.publish("peagen.events", {"type": "process.started"})
@@ -73,7 +73,7 @@ bus.publish("peagen.events", {"type": "process.started"})
 You can also publish events to RabbitMQ using `RabbitMQPublisher`:
 
 ```python
-from peagen.publishers.rabbitmq_publisher import RabbitMQPublisher
+from peagen.plugins.publishers.rabbitmq_publisher import RabbitMQPublisher
 
 bus = RabbitMQPublisher(host="localhost", port=5672, exchange="", routing_key="peagen.events")
 bus.publish("peagen.events", {"type": "process.started"})

--- a/pkgs/standards/peagen/peagen/plugins/publishers/redis_publisher.py
+++ b/pkgs/standards/peagen/peagen/plugins/publishers/redis_publisher.py
@@ -1,3 +1,52 @@
+"""Redis Pub/Sub publisher implementation."""
+
+from __future__ import annotations
+
+import json
+from typing import Dict, Any, Optional
+from urllib.parse import quote_plus
+
+import redis
+
+
 class RedisPublisher:
-    def __init__(self, **kwargs):
-        self.kwargs = kwargs
+    """Sync publisher for Redis Pub/Sub."""
+
+    def __init__(
+        self,
+        *,
+        uri: Optional[str] = None,
+        host: Optional[str] = None,
+        port: Optional[int] = None,
+        db: Optional[int] = None,
+        password: Optional[str] = None,
+        username: Optional[str] = None,
+    ) -> None:
+        individual_opts = any(v is not None for v in (host, port, db, password, username))
+        if uri and individual_opts:
+            raise ValueError(
+                "Cannot specify both `uri` and individual host/port/db/password/username."
+            )
+
+        if uri:
+            redis_uri = uri
+        else:
+            if not (host and port is not None and db is not None):
+                raise ValueError(
+                    "When no `uri` is given, `host`, `port`, and `db` are required."
+                )
+
+            if username and password:
+                auth = f"{quote_plus(username)}:{quote_plus(password)}@"
+            elif password:
+                auth = f":{quote_plus(password)}@"
+            else:
+                auth = ""
+
+            redis_uri = f"redis://{auth}{host}:{port}/{db}"
+
+        self._client: redis.Redis = redis.from_url(redis_uri, decode_responses=True)
+
+    def publish(self, channel: str, payload: Dict[str, Any]) -> None:
+        """Send ``payload`` to ``channel`` as a JSON message."""
+        self._client.publish(channel, json.dumps(payload))

--- a/pkgs/standards/peagen/peagen/publishers/__init__.py
+++ b/pkgs/standards/peagen/peagen/publishers/__init__.py
@@ -1,6 +1,6 @@
-from .redis_publisher import RedisPublisher
-from .webhook_publisher import WebhookPublisher
-from .rabbitmq_publisher import RabbitMQPublisher
+from peagen.plugins.publishers.redis_publisher import RedisPublisher
+from peagen.plugins.publishers.webhook_publisher import WebhookPublisher
+from peagen.plugins.publishers.rabbitmq_publisher import RabbitMQPublisher
 
 __all__ = [
     "RedisPublisher",

--- a/pkgs/standards/peagen/peagen/publishers/redis_publisher.py
+++ b/pkgs/standards/peagen/peagen/publishers/redis_publisher.py
@@ -1,3 +1,0 @@
-class RedisPublisher:
-    def __init__(self, **kwargs):
-        self.kwargs = kwargs

--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -138,9 +138,9 @@ github    = "peagen.storage_adapters.github_storage_adapter:GithubStorageAdapter
 gh_release    = "peagen.storage_adapters.gh_release_storage_adapter:GithubReleaseStorageAdapter"
 
 [project.entry-points."peagen.publishers"]
-redis   = "peagen.publishers.redis_publisher:RedisPublisher"
-webhook = "peagen.publishers.webhook_publisher:WebhookPublisher"
-rabbitmq = "peagen.publishers.rabbitmq_publisher:RabbitMQPublisher"
+redis   = "peagen.plugins.publishers.redis_publisher:RedisPublisher"
+webhook = "peagen.plugins.publishers.webhook_publisher:WebhookPublisher"
+rabbitmq = "peagen.plugins.publishers.rabbitmq_publisher:RabbitMQPublisher"
 
 [project.entry-points."peagen.result_backends"]
 local_fs = "peagen.plugins.result_backends.localfs_backend:LocalFsResultBackend"


### PR DESCRIPTION
## Summary
- implement RedisPublisher under peagen publishers
- mirror implementation in peagen plugins
- remove duplicate redis_publisher and import from plugin path
- adjust docs and entry points to use plugins path

## Testing
- _No tests run due to instructions_

------
https://chatgpt.com/codex/tasks/task_e_684565612044832692446612d9aa4b35