### PR TITLE
fix provider check

### DIFF
--- a/pkgs/standards/peagen/README.md
+++ b/pkgs/standards/peagen/README.md
@@ -141,6 +141,8 @@ output_dir = "./peagen_artifacts"
 
 With these values in place you can omit `--provider`, `--model-name`, and other
 flags when running the CLI.
+If `--provider` is omitted and no `default_provider` is configured (or the
+`PROVIDER` environment variable is unset), Peagen will raise an error.
 
 ### Project YAML Schema Overview
 

--- a/pkgs/standards/peagen/peagen/core/_external.py
+++ b/pkgs/standards/peagen/peagen/core/_external.py
@@ -82,8 +82,14 @@ def call_external_agent(
     provider = (
         agent_env.get("provider")
         or os.getenv("PROVIDER")
-        or llm_section.get("default_provider", "deepinfra")
+        or llm_section.get("default_provider")
     )
+    if not provider:
+        raise ValueError(
+            "No LLM provider specified. Set agent_env['provider'], "
+            "the PROVIDER environment variable, or llm.default_provider "
+            "in .peagen.toml"
+        )
 
     max_tokens = int(
         agent_env.get("max_tokens")


### PR DESCRIPTION
## Summary
- require explicit LLM provider in `call_external_agent`
- document provider requirement in README

## Testing
- `git diff --cached --stat`

------
https://chatgpt.com/codex/tasks/task_e_6845681d39d48326b2b3d8f1b532cac2