### PR TITLE
Update storage adapters to return artifact URIs

### DIFF
--- a/pkgs/standards/peagen/docs/contributing.md
+++ b/pkgs/standards/peagen/docs/contributing.md
@@ -14,6 +14,8 @@ This guide explains how to extend Peagen and how to propose major changes via Pe
 ## Storage Adapters
 
 - Implement a class exposing `upload()` and `download()`.
+  The `upload()` method must return the artifact URI so Peagen can store
+  references in manifests and task payloads.
 - Register it via the **`peagen.storage_adapters`** entry point group.
 
 ## Publishers

--- a/pkgs/standards/peagen/docs/storage_adapters_and_publishers.md
+++ b/pkgs/standards/peagen/docs/storage_adapters_and_publishers.md
@@ -50,7 +50,7 @@ pea = Peagen(
 )
 ```
 
-Any class providing `upload()` and `download()` can serve as the adapter, enabling integrations with cloud services or databases.
+Any class providing `upload()` and `download()` can serve as the adapter, enabling integrations with cloud services or databases. The `upload()` method should return the artifact URI so Peagen can reference it in manifests and task payloads.
 
 ## Publisher Plugins
 

--- a/pkgs/standards/peagen/peagen/storage_adapters/file_storage_adapter.py
+++ b/pkgs/standards/peagen/peagen/storage_adapters/file_storage_adapter.py
@@ -34,8 +34,8 @@ class FileStorageAdapter:
         return f"{base}/{self._prefix}" if self._prefix else f"{base}/"
 
     # ---------------------------------------------------------------- upload
-    def upload(self, key: str, data: BinaryIO) -> None:
-        """Copy *data* to ``${root_dir}/${key}`` atomically."""
+    def upload(self, key: str, data: BinaryIO) -> str:
+        """Copy *data* to ``${root_dir}/${key}`` atomically and return the artifact URI."""
         dest = self._full_key(key)
         dest.parent.mkdir(parents=True, exist_ok=True)
 
@@ -44,6 +44,8 @@ class FileStorageAdapter:
             shutil.copyfileobj(data, fh)
 
         tmp.replace(dest)
+
+        return f"{self.root_uri}{key.lstrip('/')}"
 
     # ---------------------------------------------------------------- download
     def download(self, key: str) -> BinaryIO:

--- a/pkgs/standards/peagen/peagen/storage_adapters/gh_release_storage_adapter.py
+++ b/pkgs/standards/peagen/peagen/storage_adapters/gh_release_storage_adapter.py
@@ -79,8 +79,8 @@ class GithubReleaseStorageAdapter:
             )
 
     # ------------------------------------------------------------------- public
-    def upload(self, key: str, data: BinaryIO) -> None:
-        """Upload ``data`` under ``key`` as a release asset."""
+    def upload(self, key: str, data: BinaryIO) -> str:
+        """Upload ``data`` under ``key`` as a release asset and return the artifact URI."""
         key = self._full_key(key)
 
         data.seek(0)
@@ -96,6 +96,8 @@ class GithubReleaseStorageAdapter:
             tmp.write(content)
             tmp.flush()
             self._release.upload_asset(path=tmp.name, name=key, label=key)
+
+        return f"{self.root_uri}{key.lstrip('/')}"
 
     def download(self, key: str) -> BinaryIO:
         """Return the bytes of asset ``key`` as a BytesIO object."""

--- a/pkgs/standards/peagen/peagen/storage_adapters/minio_storage_adapter.py
+++ b/pkgs/standards/peagen/peagen/storage_adapters/minio_storage_adapter.py
@@ -63,8 +63,8 @@ class MinioStorageAdapter:
         return uri.rstrip("/") + "/"
 
     # ------------------------------------------------------------------
-    def upload(self, key: str, data: BinaryIO) -> None:
-        """Upload *data* to ``bucket/prefix/key``."""
+    def upload(self, key: str, data: BinaryIO) -> str:
+        """Upload *data* to ``bucket/prefix/key`` and return the artifact URI."""
         size: Optional[int] = None
         try:
             size = os.fstat(data.fileno()).st_size  # type: ignore[attr-defined]
@@ -80,6 +80,8 @@ class MinioStorageAdapter:
             length=size if size and size > 0 else -1,
             part_size=10 * 1024 * 1024,
         )
+
+        return f"{self.root_uri}{key.lstrip('/')}"
 
     # ------------------------------------------------------------------
     def download(self, key: str) -> BinaryIO:


### PR DESCRIPTION
## Summary
- return artifact URIs from FileStorageAdapter, MinioStorageAdapter and GithubReleaseStorageAdapter
- document that `upload()` returns the artifact URI

## Testing
- `uv run --package peagen --directory standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_68456a794be08326b63a61b1a1ada109