### PR TITLE
Fix redis publisher module import path

### DIFF
--- a/pkgs/standards/peagen/peagen/publishers/redis_publisher.py
+++ b/pkgs/standards/peagen/peagen/publishers/redis_publisher.py
@@ -1,0 +1,3 @@
+from peagen.plugins.publishers.redis_publisher import RedisPublisher
+
+__all__ = ["RedisPublisher"]


### PR DESCRIPTION
## Summary
- add compatibility stub for `peagen.publishers.redis_publisher`

## Testing
- `uv run --package peagen --directory standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_684572e606788326800cef019d55927d