### PR TITLE
Add unit tests for peagen core modules

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_extras_core.py
+++ b/pkgs/standards/peagen/tests/unit/test_extras_core.py
@@ -1,0 +1,41 @@
+import json
+from pathlib import Path
+import pytest
+
+from peagen.core.extras_core import parse_keys, build_schema, generate_schemas
+
+
+@pytest.mark.unit
+def test_parse_keys_reads_bullets(tmp_path: Path):
+    md = tmp_path / "EXTRAS.md"
+    md.write_text("""
+Intro
+- foo
+- bar
+-notabullet
+- baz
+""")
+    assert parse_keys(md) == ["foo", "bar", "baz"]
+
+
+@pytest.mark.unit
+def test_build_schema_produces_json_schema():
+    schema = build_schema(["one", "two"], "myset")
+    assert schema["$id"].endswith("myset.schema.json")
+    assert set(schema["properties"]) == {"one", "two"}
+
+
+@pytest.mark.unit
+def test_generate_schemas_creates_files(tmp_path: Path):
+    tmpl_root = tmp_path / "tmpl"
+    tmpl_root.mkdir()
+    (tmpl_root / "set1").mkdir()
+    (tmpl_root / "set1" / "EXTRAS.md").write_text("- a\n- b")
+    (tmpl_root / "set2").mkdir()
+    (tmpl_root / "set2" / "EXTRAS.md").write_text("- c")
+
+    out_dir = tmp_path / "schemas"
+    written = generate_schemas(tmpl_root, out_dir)
+    assert len(written) == 2
+    contents = [json.loads(p.read_text()) for p in written]
+    assert all("properties" in c for c in contents)

--- a/pkgs/standards/peagen/tests/unit/test_fetch_core.py
+++ b/pkgs/standards/peagen/tests/unit/test_fetch_core.py
@@ -1,0 +1,46 @@
+import json
+from pathlib import Path
+import pytest
+
+import peagen.core.fetch_core as fetch_core
+
+
+@pytest.mark.unit
+def test_download_manifest_reads_file(tmp_path: Path):
+    manifest = {"workspace_uri": "file:///ws"}
+    f = tmp_path / "m.json"
+    f.write_text(json.dumps(manifest))
+
+    out = fetch_core._download_manifest(str(f))
+    assert out == manifest
+
+
+@pytest.mark.unit
+def test_fetch_single_uses_storage_adapter(tmp_path: Path, monkeypatch):
+    manifest = {
+        "workspace_uri": "file:///ws",
+        "template_sets": ["set"],
+        "source_packages": ["pkg"],
+    }
+    man_file = tmp_path / "manifest.json"
+    man_file.write_text(json.dumps(manifest))
+
+    calls = {}
+
+    class DummyAdapter:
+        def __init__(self, uri: str):
+            calls["uri"] = uri
+
+        def download_prefix(self, prefix: str, dest: Path):
+            calls["download"] = dest
+
+    monkeypatch.setattr(fetch_core, "make_adapter_for_uri", lambda uri: DummyAdapter(uri))
+    monkeypatch.setattr(fetch_core, "install_template_sets", lambda sets: calls.setdefault("install", sets))
+    monkeypatch.setattr(fetch_core, "materialise_packages", lambda pkgs, workspace, upload=False: calls.setdefault("packages", pkgs))
+
+    res = fetch_core.fetch_single(str(man_file), dest_root=tmp_path)
+    assert res["manifest"] == str(man_file)
+    assert calls["uri"] == "file:///ws"
+    assert calls["download"] == tmp_path
+    assert calls["install"] == ["set"]
+    assert calls["packages"] == ["pkg"]

--- a/pkgs/standards/peagen/tests/unit/test_sort_core_file_records.py
+++ b/pkgs/standards/peagen/tests/unit/test_sort_core_file_records.py
@@ -1,0 +1,32 @@
+import pytest
+from peagen.core.sort_core import sort_file_records
+
+
+@pytest.mark.unit
+def test_sort_file_records_basic_order():
+    records = [
+        {"RENDERED_FILE_NAME": "a.txt", "EXTRAS": {}},
+        {"RENDERED_FILE_NAME": "b.txt", "EXTRAS": {"DEPENDENCIES": ["a.txt"]}},
+    ]
+    sorted_recs, next_idx = sort_file_records(file_records=records)
+    assert [r["RENDERED_FILE_NAME"] for r in sorted_recs] == ["a.txt", "b.txt"]
+    assert next_idx == 2
+
+
+@pytest.mark.unit
+def test_sort_file_records_transitive():
+    records = [
+        {"RENDERED_FILE_NAME": "a.txt", "EXTRAS": {}},
+        {"RENDERED_FILE_NAME": "b.txt", "EXTRAS": {"DEPENDENCIES": ["a.txt"]}},
+        {"RENDERED_FILE_NAME": "c.txt", "EXTRAS": {"DEPENDENCIES": ["b.txt"]}},
+    ]
+    sorted_recs, _ = sort_file_records(
+        file_records=records,
+        start_file="c.txt",
+        transitive=True,
+    )
+    assert [r["RENDERED_FILE_NAME"] for r in sorted_recs] == [
+        "a.txt",
+        "b.txt",
+        "c.txt",
+    ]

--- a/pkgs/standards/peagen/tests/unit/test_validate_core.py
+++ b/pkgs/standards/peagen/tests/unit/test_validate_core.py
@@ -1,0 +1,22 @@
+import pytest
+from pathlib import Path
+from peagen.core.validate_core import _collect_errors, validate_artifact
+
+
+@pytest.mark.unit
+def test_collect_errors_reports_schema_mismatches():
+    schema = {
+        "type": "object",
+        "properties": {"a": {"type": "integer"}},
+        "required": ["a"],
+    }
+    data = {"a": "str"}
+    errs = _collect_errors(data, schema)
+    assert errs and "a" in errs[0]
+
+
+@pytest.mark.unit
+def test_validate_artifact_unknown_kind(tmp_path: Path):
+    result = validate_artifact("unknown", tmp_path)
+    assert result["ok"] is False
+    assert "unknown kind" in result["errors"][0]


### PR DESCRIPTION
## Summary
- add tests for `extras_core`, `fetch_core`, `sort_core`, and `validate_core`
- ensure these utilities behave as expected

## Testing
- `uv run --package peagen --directory standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_684575212a848326a1a617929b4330c4