### PR TITLE
Add utility module tests

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_utils_config_loader.py
+++ b/pkgs/standards/peagen/tests/unit/test_utils_config_loader.py
@@ -1,0 +1,34 @@
+import os
+import pytest
+from peagen._utils.config_loader import _expand_env_in_text, _expand_env_vars, _merge, load_peagen_toml
+
+
+@pytest.mark.unit
+def test_expand_env_in_text(monkeypatch):
+    monkeypatch.setenv("FOO", "bar")
+    assert _expand_env_in_text('name="${FOO}"') == 'name="bar"'
+
+
+@pytest.mark.unit
+def test_expand_env_vars(monkeypatch):
+    monkeypatch.setenv("FOO", "bar")
+    data = {"val": "${FOO}"}
+    assert _expand_env_vars(data) == {"val": "bar"}
+
+
+@pytest.mark.unit
+def test_merge_nested_dicts():
+    a = {"a": {"b": 1}, "x": 2}
+    b = {"a": {"c": 3}, "y": 4}
+    result = _merge(a, b)
+    assert result == {"a": {"b": 1, "c": 3}, "x": 2, "y": 4}
+    assert a == {"a": {"b": 1}, "x": 2}
+
+
+@pytest.mark.unit
+def test_load_peagen_toml(tmp_path, monkeypatch):
+    monkeypatch.setenv("FOO", "bar")
+    cfg_file = tmp_path / "cfg.toml"
+    cfg_file.write_text('name = "${FOO}"\n', encoding="utf-8")
+    cfg = load_peagen_toml(cfg_file)
+    assert cfg["name"] == "bar"

--- a/pkgs/standards/peagen/tests/unit/test_utils_context.py
+++ b/pkgs/standards/peagen/tests/unit/test_utils_context.py
@@ -1,0 +1,31 @@
+import pytest
+from peagen._utils._context import _create_context
+
+
+class DummyLogger:
+    def __init__(self):
+        self.debug_messages = []
+
+    def debug(self, msg: str) -> None:
+        self.debug_messages.append(msg)
+
+
+@pytest.mark.unit
+def test_create_context_builds_nested_structures():
+    file_record = {
+        "PROJECT_NAME": "Demo",
+        "PACKAGE_NAME": "pkg1",
+        "MODULE_NAME": "modA",
+    }
+    project_attrs = {
+        "PACKAGES": [
+            {"NAME": "pkg1", "MODULES": [{"NAME": "modA"}]}
+        ]
+    }
+    logger = DummyLogger()
+    ctx = _create_context(file_record, project_attrs, logger)
+    assert ctx["PROJ"] == project_attrs
+    assert ctx["PKG"]["NAME"] == "pkg1"
+    assert ctx["MOD"]["NAME"] == "modA"
+    assert ctx["FILE"] == file_record
+    assert any("context" in m for m in logger.debug_messages)

--- a/pkgs/standards/peagen/tests/unit/test_utils_graph.py
+++ b/pkgs/standards/peagen/tests/unit/test_utils_graph.py
@@ -1,0 +1,32 @@
+import pytest
+from peagen._utils._graph import (
+    get_immediate_dependencies,
+    _topological_sort,
+    _transitive_dependency_sort,
+)
+
+PAYLOAD = [
+    {"RENDERED_FILE_NAME": "a", "EXTRAS": {}},
+    {"RENDERED_FILE_NAME": "b", "EXTRAS": {"DEPENDENCIES": ["a"]}},
+    {"RENDERED_FILE_NAME": "c", "EXTRAS": {"DEPENDENCIES": ["b"]}},
+    {"RENDERED_FILE_NAME": "d", "EXTRAS": {"DEPENDENCIES": ["a", "c"]}},
+]
+
+
+@pytest.mark.unit
+def test_immediate_dependencies():
+    assert get_immediate_dependencies(PAYLOAD, "c") == ["b"]
+    with pytest.raises(ValueError):
+        get_immediate_dependencies(PAYLOAD, "missing")
+
+
+@pytest.mark.unit
+def test_topological_sort():
+    order = [e["RENDERED_FILE_NAME"] for e in _topological_sort(PAYLOAD)]
+    assert order == ["a", "b", "c", "d"]
+
+
+@pytest.mark.unit
+def test_transitive_dependency_sort():
+    order = [e["RENDERED_FILE_NAME"] for e in _transitive_dependency_sort(PAYLOAD, "d")]
+    assert order == ["a", "b", "c", "d"]

--- a/pkgs/standards/peagen/tests/unit/test_utils_init.py
+++ b/pkgs/standards/peagen/tests/unit/test_utils_init.py
@@ -1,0 +1,28 @@
+import pytest
+
+from peagen._utils._init import _call_handler, _summary
+
+
+@pytest.mark.unit
+def test_summary_writes_output(capsys, tmp_path):
+    _summary(tmp_path, "peagen process")
+    out = capsys.readouterr().out
+    assert "Scaffold created" in out
+    assert str(tmp_path) in out
+    assert "peagen process" in out
+
+
+@pytest.mark.unit
+def test_call_handler_invokes_handler(monkeypatch):
+    called = {}
+
+    async def fake_handler(task):
+        called["payload"] = task.payload
+        return {"ok": True}
+
+    monkeypatch.setattr("peagen._utils._init.init_handler", fake_handler)
+    monkeypatch.setattr("peagen._utils._init.uuid.uuid4", lambda: "uuid")
+
+    result = _call_handler({"x": 1})
+    assert result == {"ok": True}
+    assert called["payload"]["args"] == {"x": 1}

--- a/pkgs/standards/peagen/tests/unit/test_utils_slug.py
+++ b/pkgs/standards/peagen/tests/unit/test_utils_slug.py
@@ -1,0 +1,9 @@
+import pytest
+from peagen._utils.slug_utils import slugify
+
+
+@pytest.mark.unit
+def test_slugify_simple():
+    assert slugify("My Project") == "my-project"
+    assert slugify("Hello_World") == "hello_world"
+    assert slugify("Some@Project!") == "some-project"

--- a/pkgs/standards/peagen/tests/unit/test_utils_source_packages.py
+++ b/pkgs/standards/peagen/tests/unit/test_utils_source_packages.py
@@ -1,0 +1,47 @@
+import pytest
+
+from peagen._utils._source_packages import _copy_tree, _dir_checksum, _sync_dir
+
+
+@pytest.mark.unit
+def test_copy_tree_no_overwrite(tmp_path):
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    src.mkdir()
+    dst.mkdir()
+    (src / "a.txt").write_text("A", encoding="utf-8")
+    (src / "b.txt").write_text("B", encoding="utf-8")
+    (dst / "b.txt").write_text("existing", encoding="utf-8")
+
+    _copy_tree(src, dst)
+    assert (dst / "a.txt").read_text(encoding="utf-8") == "A"
+    # existing file should remain untouched
+    assert (dst / "b.txt").read_text(encoding="utf-8") == "existing"
+
+
+@pytest.mark.unit
+def test_dir_checksum_changes(tmp_path):
+    root = tmp_path / "data"
+    root.mkdir()
+    (root / "x.txt").write_text("x")
+    first = _dir_checksum(root)
+    (root / "x.txt").write_text("y")
+    assert _dir_checksum(root) != first
+
+
+@pytest.mark.unit
+def test_sync_dir_uploads(tmp_path):
+    root = tmp_path / "up"
+    root.mkdir()
+    file_path = root / "f.txt"
+    file_path.write_text("data")
+
+    class Dummy:
+        def __init__(self):
+            self.keys = []
+        def upload(self, key, fh):
+            self.keys.append(key)
+
+    adapter = Dummy()
+    _sync_dir(root, adapter, prefix="pre")
+    assert adapter.keys == ["pre/f.txt"]


### PR DESCRIPTION
## Summary
- add test coverage for slugify utility
- add unit tests for context builder helper
- exercise graph utilities
- add config loader unit tests
- test init helper functions
- cover source package utilities

## Testing
- `uv run --package peagen --directory standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_6845752e81b883268a46a8b602f0a3a1