### PR TITLE
Add handler unit tests

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_doe_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_doe_handler.py
@@ -1,0 +1,33 @@
+import pytest
+from pathlib import Path
+
+from peagen.handlers import doe_handler as handler
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_doe_handler_calls_generate_payload(monkeypatch):
+    captured = {}
+
+    def fake_generate_payload(**kwargs):
+        captured.update(kwargs)
+        return {"done": True}
+
+    monkeypatch.setattr(handler, "generate_payload", fake_generate_payload)
+
+    args = {
+        "spec": "spec.yml",
+        "template": "templ.j2",
+        "output": "out.json",
+        "config": "cfg.toml",
+        "notify": "http://x",
+        "dry_run": True,
+        "force": True,
+        "skip_validate": True,
+    }
+
+    result = await handler.doe_handler({"payload": {"args": args}})
+
+    assert result == {"done": True}
+    assert captured["spec_path"] == Path("spec.yml")
+    assert captured["dry_run"] is True

--- a/pkgs/standards/peagen/tests/unit/test_eval_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_eval_handler.py
@@ -1,0 +1,19 @@
+import pytest
+
+from peagen.handlers import eval_handler as handler
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("strict", [False, True])
+async def test_eval_handler(monkeypatch, strict):
+    def fake_evaluate_workspace(**kwargs):
+        return {"results": [{"score": 0}, {"score": 1}]}
+
+    monkeypatch.setattr(handler, "evaluate_workspace", fake_evaluate_workspace)
+
+    args = {"workspace_uri": "ws", "strict": strict}
+    result = await handler.eval_handler({"payload": {"args": args}})
+
+    assert result["manifest"]["results"][0]["score"] == 0
+    assert result["strict_failed"] == (strict and True)

--- a/pkgs/standards/peagen/tests/unit/test_extras_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_extras_handler.py
@@ -1,0 +1,37 @@
+import pytest
+from pathlib import Path
+
+from peagen.handlers import extras_handler as handler
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "templates_root, schemas_dir",
+    [(None, None), ("/tmp/tmpl", "/tmp/schema")],
+)
+async def test_extras_handler_calls_generate_schemas(monkeypatch, templates_root, schemas_dir):
+    called = {}
+
+    def fake_generate_schemas(t_root: Path, s_dir: Path):
+        called["templates_root"] = t_root
+        called["schemas_dir"] = s_dir
+        return [Path("a"), Path("b")]
+
+    monkeypatch.setattr(handler, "generate_schemas", fake_generate_schemas)
+
+    args = {}
+    if templates_root:
+        args["templates_root"] = templates_root
+    if schemas_dir:
+        args["schemas_dir"] = schemas_dir
+
+    result = await handler.extras_handler({"payload": {"args": args}})
+
+    base = Path(handler.__file__).resolve().parents[1]
+    expected_templates = Path(templates_root).expanduser() if templates_root else base / "template_sets"
+    expected_schemas = Path(schemas_dir).expanduser() if schemas_dir else base / "schemas" / "extras"
+
+    assert called["templates_root"] == expected_templates
+    assert called["schemas_dir"] == expected_schemas
+    assert result["generated"] == ["a", "b"]

--- a/pkgs/standards/peagen/tests/unit/test_fetch_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_fetch_handler.py
@@ -1,0 +1,31 @@
+import pytest
+from pathlib import Path
+
+from peagen.handlers import fetch_handler as handler
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetch_handler_passes_args(monkeypatch):
+    captured = {}
+
+    def fake_fetch_many(**kwargs):
+        captured.update(kwargs)
+        return {"count": len(kwargs.get("manifest_uris", []))}
+
+    monkeypatch.setattr(handler, "fetch_many", fake_fetch_many)
+
+    args = {
+        "manifests": ["m1", "m2"],
+        "out_dir": "~/out",
+        "no_source": True,
+        "install_template_sets": False,
+    }
+
+    result = await handler.fetch_handler({"payload": {"args": args}})
+
+    assert result == {"count": 2}
+    assert captured["manifest_uris"] == ["m1", "m2"]
+    assert captured["out_dir"] == Path("~/out").expanduser()
+    assert captured["no_source"] is True
+    assert captured["install_template_sets_flag"] is False

--- a/pkgs/standards/peagen/tests/unit/test_get_task_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_get_task_handler.py
@@ -1,0 +1,16 @@
+import pytest
+
+from peagen.handlers import get_task_handler as handler
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_task_get_handler(monkeypatch):
+    async def fake_get_task_result(task_id):
+        return {"id": task_id}
+
+    monkeypatch.setattr(handler, "get_task_result", fake_get_task_result)
+
+    result = await handler.task_get_handler({"taskId": "123"})
+
+    assert result == {"id": "123"}

--- a/pkgs/standards/peagen/tests/unit/test_init_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_init_handler.py
@@ -1,0 +1,41 @@
+import pytest
+from pathlib import Path
+
+from peagen.handlers import init_handler as handler
+from peagen.core import init_core
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "kind, func",
+    [
+        ("project", "init_project"),
+        ("template-set", "init_template_set"),
+        ("doe-spec", "init_doe_spec"),
+        ("ci", "init_ci"),
+    ],
+)
+async def test_init_handler_dispatch(monkeypatch, kind, func):
+    called = {}
+
+    def fake(**kwargs):
+        called.update(kwargs)
+        return {"kind": kind}
+
+    monkeypatch.setattr(init_core, func, fake)
+    args = {"kind": kind, "path": "~/p"}
+    result = await handler.init_handler({"payload": {"args": args}})
+
+    assert result == {"kind": kind}
+    assert called.get("path") == Path("~/p").expanduser()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_init_handler_errors(monkeypatch):
+    with pytest.raises(ValueError):
+        await handler.init_handler({"payload": {"args": {}}})
+
+    with pytest.raises(ValueError):
+        await handler.init_handler({"payload": {"args": {"kind": "unknown"}}})

--- a/pkgs/standards/peagen/tests/unit/test_mutate_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_mutate_handler.py
@@ -1,0 +1,10 @@
+import pytest
+from pathlib import Path
+
+from peagen.handlers import mutate
+
+
+@pytest.mark.unit
+def test_mutate_module_is_empty():
+    source = Path(mutate.__file__).read_text()
+    assert source.strip() == ""

--- a/pkgs/standards/peagen/tests/unit/test_process_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_process_handler.py
@@ -1,0 +1,56 @@
+import pytest
+
+from peagen.handlers import process_handler as handler
+
+
+class DummyPM:
+    def __init__(self, cfg):
+        self.cfg = cfg
+
+    def get(self, name):
+        return "adapter"
+
+
+class DummyAdapter:
+    def __init__(self, **kw):
+        pass
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("project_name", ["proj", None])
+async def test_process_handler_dispatch(monkeypatch, project_name):
+    monkeypatch.setattr(handler, "resolve_cfg", lambda toml_text=None: {})
+    monkeypatch.setattr(handler, "PluginManager", DummyPM)
+    monkeypatch.setattr(handler, "FileStorageAdapter", DummyAdapter)
+
+    calls = {}
+
+    def fake_load(payload):
+        calls["load"] = payload
+        return [{"NAME": project_name}] if project_name else []
+
+    def fake_single(project, cfg, start_idx, start_file, transitive):
+        calls["single"] = project
+        return ["done"], 0
+
+    def fake_all(payload, cfg, transitive):
+        calls["all"] = payload
+        return {"all": True}
+
+    monkeypatch.setattr(handler, "load_projects_payload", fake_load)
+    monkeypatch.setattr(handler, "process_single_project", fake_single)
+    monkeypatch.setattr(handler, "process_all_projects", fake_all)
+
+    args = {"projects_payload": "pp"}
+    if project_name:
+        args["project_name"] = project_name
+
+    result = await handler.process_handler({"payload": {"args": args}})
+
+    if project_name:
+        assert calls["single"] == {"NAME": project_name}
+        assert result["processed"] == {project_name: ["done"]}
+    else:
+        assert calls["all"] == "pp"
+        assert result["processed"] == {"all": True}

--- a/pkgs/standards/peagen/tests/unit/test_sort_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_sort_handler.py
@@ -1,0 +1,38 @@
+import pytest
+
+from peagen.handlers import sort_handler as handler
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("project_name", ["proj", None])
+async def test_sort_handler_delegates(monkeypatch, project_name):
+    calls = {}
+
+    def fake_resolve_cfg(toml_text=None):
+        return {"cfg": True}
+
+    def fake_single(params):
+        calls["single"] = params
+        return {"single": True}
+
+    def fake_all(params):
+        calls["all"] = params
+        return {"all": True}
+
+    monkeypatch.setattr(handler, "resolve_cfg", fake_resolve_cfg)
+    monkeypatch.setattr(handler, "sort_single_project", fake_single)
+    monkeypatch.setattr(handler, "sort_all_projects", fake_all)
+
+    args = {"projects_payload": "payload"}
+    if project_name:
+        args["project_name"] = project_name
+
+    result = await handler.sort_handler({"payload": {"args": args}})
+
+    if project_name:
+        assert "single" in calls
+        assert result == {"single": True}
+    else:
+        assert "all" in calls
+        assert result == {"all": True}

--- a/pkgs/standards/peagen/tests/unit/test_templates_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_templates_handler.py
@@ -1,0 +1,30 @@
+import pytest
+
+from peagen.handlers import templates_handler as handler
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "op, func, args",
+    [
+        ("list", "list_template_sets", {}),
+        ("show", "show_template_set", {"name": "n"}),
+        ("add", "add_template_set", {"source": "src", "from_bundle": None, "editable": False, "force": False}),
+        ("remove", "remove_template_set", {"name": "n"}),
+    ],
+)
+async def test_templates_handler_dispatch(monkeypatch, op, func, args):
+    called = {}
+
+    def fake(*a, **kw):
+        called["args"] = a
+        called["kwargs"] = kw
+        return {"op": op}
+
+    monkeypatch.setattr(handler, func, fake)
+
+    result = await handler.templates_handler({"payload": {"args": {"operation": op, **args}}})
+
+    assert result == {"op": op}
+    assert called

--- a/pkgs/standards/peagen/tests/unit/test_validate_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_validate_handler.py
@@ -1,0 +1,30 @@
+import pytest
+from pathlib import Path
+
+from peagen.handlers import validate_handler as handler
+from peagen.models import Task
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("as_dict", [True, False])
+async def test_validate_handler(monkeypatch, as_dict):
+    captured = {}
+
+    def fake_validate_artifact(kind, path):
+        captured["kind"] = kind
+        captured["path"] = path
+        return {"ok": True}
+
+    monkeypatch.setattr(handler, "validate_artifact", fake_validate_artifact)
+
+    args = {"kind": "schema", "path": "~/p"}
+    task = {"payload": {"args": args}}
+    if not as_dict:
+        task = Task(pool="p", payload=task["payload"])
+
+    result = await handler.validate_handler(task)
+
+    assert result == {"ok": True}
+    assert captured["kind"] == "schema"
+    assert captured["path"] == Path("~/p").expanduser()


### PR DESCRIPTION
## Summary
- add unit tests for peagen handlers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845776ddf3c8326b7c96ac3b6923a09