### PR TITLE
Enable local and remote mutate flow

### DIFF
--- a/example_ws/.peagen.toml
+++ b/example_ws/.peagen.toml
@@ -1,0 +1,26 @@
+schemaVersion = "1.0.0"
+
+[mutators]
+default_mutator = "peagen.plugins.mutators.echo_mutator:EchoMutator"
+
+[evaluation]
+pool = "peagen.plugins.evaluator_pools.default:DefaultEvaluatorPool"
+max_workers = 1
+strict = true
+async = false
+
+[evaluation.evaluators."peagen.plugins.evaluators.performance_evaluator:PerformanceEvaluator"]
+import_path = "func"
+entry_fn = "square"
+
+[queues]
+default_queue = "in_memory"
+
+[queues.adapters.in_memory]
+maxsize = 10
+
+[result_backends]
+default_backend = "local_fs"
+
+[result_backends.adapters.local_fs]
+root_dir = "./task_runs"

--- a/example_ws/func.py
+++ b/example_ws/func.py
@@ -1,0 +1,2 @@
+def square(x):
+    return x * x

--- a/pkgs/standards/peagen/peagen/cli/commands/mutate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/mutate.py
@@ -24,9 +24,8 @@ def _build_task(args: dict) -> Task:
     return Task(
         id=str(uuid.uuid4()),
         pool="default",
-        action="mutate",
         status=Status.pending,
-        payload={"args": args},
+        payload={"action": "mutate", "args": args},
     )
 
 
@@ -85,7 +84,11 @@ def submit(
         "jsonrpc": "2.0",
         "id": task.id,
         "method": "Task.submit",
-        "params": {"task": task.model_dump()},
+        "params": {
+            "pool": task.pool,
+            "payload": task.payload,
+            "taskId": task.id,
+        },
     }
 
     with httpx.Client(timeout=30.0) as client:

--- a/pkgs/standards/peagen/peagen/core/mutate_core.py
+++ b/pkgs/standards/peagen/peagen/core/mutate_core.py
@@ -33,7 +33,8 @@ def mutate_workspace(
     pm = PluginManager(cfg)
     mutator = pm.get("mutators")
     pool = pm.get("evaluator_pools")
-    evaluator = pm.get("evaluators", "performance")
+    evaluator_ref = "peagen.plugins.evaluators.performance_evaluator:PerformanceEvaluator"
+    evaluator = pm.get("evaluators", evaluator_ref)
     pool.add_evaluator(evaluator, name="performance")
 
     path = Path(workspace_uri) / target_file

--- a/pkgs/standards/peagen/peagen/gateway/db.py
+++ b/pkgs/standards/peagen/peagen/gateway/db.py
@@ -2,8 +2,14 @@ from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
 from sqlalchemy.orm import sessionmaker
 from .runtime_cfg import settings
 
+if settings.pg_host and settings.pg_db and settings.pg_user:
+    dsn = settings.apg_dsn
+else:
+    # Fallback to a local SQLite database when Postgres settings are missing
+    dsn = "sqlite+aiosqlite:///./gateway.db"
+
 engine = create_async_engine(
-    settings.apg_dsn,
+    dsn,
     pool_size=10,
     max_overflow=20,
     echo=False,

--- a/pkgs/standards/peagen/peagen/plugins/mutators/echo_mutator.py
+++ b/pkgs/standards/peagen/peagen/plugins/mutators/echo_mutator.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+class EchoMutator:
+    """Trivial mutator used for testing."""
+
+    def __init__(self, *_, **__):
+        pass
+
+    def mutate(self, prompt: str) -> str:
+        """Return the original code extracted from *prompt* with a comment."""
+        import re
+
+        match = re.search(r"```python\n(.+?)```", prompt, re.DOTALL)
+        src = match.group(1) if match else prompt
+        return src + "\n# mutated\n"

--- a/pkgs/standards/peagen/peagen/worker/__init__.py
+++ b/pkgs/standards/peagen/peagen/worker/__init__.py
@@ -6,6 +6,7 @@ from peagen.handlers.fetch_handler import fetch_handler
 from peagen.handlers.eval_handler import eval_handler
 from peagen.handlers.process_handler import process_handler
 from peagen.handlers.sort_handler import sort_handler
+from peagen.handlers.mutate_handler import mutate_handler
 
 # ----------------------------------------------------------------------------
 # Subclass WorkerBase (optional) so you can override or extend methods if needed.
@@ -22,6 +23,7 @@ class PeagenWorker(WorkerBase):
         self.register_handler("fetch", fetch_handler)
         self.register_handler("process", process_handler)
         self.register_handler("sort", sort_handler)
+        self.register_handler("mutate", mutate_handler)
         # In the future, you might also do:
         #   from peagen.handlers.render_handler import render_handler
         #   self.register_handler("render", render_handler)


### PR DESCRIPTION
## Summary
- implement simple `EchoMutator` and register new handler
- fall back to SQLite when Postgres settings are missing
- ensure evaluator loads by explicit reference
- include action in payload and correct remote RPC params
- add example workspace with config

## Testing
- `peagen local mutate . --target-file func.py --import-path func --entry-fn square --gens 1 --json`
- `peagen remote --gateway-url http://localhost:8000/rpc mutate . --target-file func.py --import-path func --entry-fn square --gens 1`


------
https://chatgpt.com/codex/tasks/task_e_6845906bf9108326aa275be53fe06ff0