### PR TITLE
Fix evaluator instantiation in mutate workflow

### DIFF
--- a/pkgs/standards/peagen/peagen/core/mutate_core.py
+++ b/pkgs/standards/peagen/peagen/core/mutate_core.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Dict, Optional
 
 from peagen._utils.config_loader import load_peagen_toml
-from peagen.plugin_manager import PluginManager
+from peagen.plugin_manager import PluginManager, resolve_plugin_spec
 from swarmauri_standard.programs.Program import Program
 
 PROMPT = """\
@@ -34,7 +34,8 @@ def mutate_workspace(
     mutator = pm.get("mutators")
     pool = pm.get("evaluator_pools")
     evaluator_ref = "peagen.plugins.evaluators.performance_evaluator:PerformanceEvaluator"
-    evaluator = pm.get("evaluators", evaluator_ref)
+    eval_cls = resolve_plugin_spec("evaluators", evaluator_ref)
+    evaluator = eval_cls(import_path=import_path, entry_fn=entry_fn, profile_mod=profile_mod)
     pool.add_evaluator(evaluator, name="performance")
 
     path = Path(workspace_uri) / target_file


### PR DESCRIPTION
## Summary
- import `resolve_plugin_spec` and use it to instantiate the performance evaluator

## Testing
- `peagen local mutate example_ws --target-file func.py --import-path func --entry-fn square --gens 1 --json`
- `peagen remote --gateway-url http://localhost:8000/rpc mutate /workspace/swarmauri-sdk/example_ws --target-file func.py --import-path func --entry-fn square --gens 1`


------
https://chatgpt.com/codex/tasks/task_e_6845959e88d88326a22a5b3721bc2934