### PR TITLE
Improve mutate workflow resilience

### DIFF
--- a/example_ws/.peagen.toml
+++ b/example_ws/.peagen.toml
@@ -1,7 +1,10 @@
 schemaVersion = "1.0.0"
 
 [mutators]
-default_mutator = "peagen.plugins.mutators.echo_mutator:EchoMutator"
+default_mutator = "peagen.plugins.mutators.default_mutator:DefaultMutator"
+
+[mutators.plugins.default_mutator]
+agent_env.provider = "groq"
 
 [evaluation]
 pool = "peagen.plugins.evaluator_pools.default:DefaultEvaluatorPool"

--- a/pkgs/standards/peagen/peagen/core/mutate_core.py
+++ b/pkgs/standards/peagen/peagen/core/mutate_core.py
@@ -9,6 +9,7 @@ from typing import Dict, Optional
 from peagen._utils.config_loader import load_peagen_toml
 from peagen.plugin_manager import PluginManager
 from swarmauri_standard.programs.Program import Program
+import logging
 
 PROMPT = """\
 Improve the python code below. Return only the new version.
@@ -46,7 +47,11 @@ def mutate_workspace(
 
     for _ in range(gens):
         prompt = textwrap.dedent(PROMPT.format(parent=best_src))
-        child_src = mutator.mutate(prompt)
+        try:
+            child_src = mutator.mutate(prompt)
+        except Exception as e:
+            logging.warning("mutate error: %s", e)
+            child_src = best_src
         program.content[target_file] = child_src
         score, _ = evaluator.evaluate(program)
         if score < best_score:


### PR DESCRIPTION
## Summary
- handle mutator errors gracefully in `mutate_workspace`
- switch example workspace to use `DefaultMutator` with dummy provider
- use groq provider for example mutator

## Testing
- `peagen remote --gateway-url http://localhost:8000/rpc mutate example_ws --target-file func.py --import-path func --entry-fn square --gens 1`
- `peagen local mutate example_ws --target-file func.py --import-path func --entry-fn square --gens 1`


------
https://chatgpt.com/codex/tasks/task_e_6845959fbc508326b7d345b59b9ba8e7