### PR TITLE
Update mutate task defaults

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/mutate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/mutate.py
@@ -24,7 +24,6 @@ def _build_task(args: dict) -> Task:
     return Task(
         id=str(uuid.uuid4()),
         pool="default",
-        status=Status.pending,
         payload={"action": "mutate", "args": args},
     )
 


### PR DESCRIPTION
## Summary
- remove explicit `Status.pending` in mutate CLI `_build_task`

## Testing
- `uv run --package peagen --directory standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_68459ae6d8d88326981943f8ec898a96