### PR TITLE
Fix mutate CLI rpc request

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/mutate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/mutate.py
@@ -82,7 +82,6 @@ def submit(
 
     rpc_req = {
         "jsonrpc": "2.0",
-        "id": task.id,
         "method": "Task.submit",
         "params": {
             "pool": task.pool,


### PR DESCRIPTION
## Summary
- remove unused `id` field from mutate CLI's rpc request

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684599ccba4c83268d96aa24d51be683