### PR TITLE
Fix worker default port

### DIFF
--- a/infra/Dockerfile.worker
+++ b/infra/Dockerfile.worker
@@ -20,16 +20,16 @@ COPY ./infra/.worker.peagen.toml ./.peagen.toml
 RUN uv pip install --directory pkgs/standards/peagen --system .
 
 # ────────────────── runtime configuration  ─────────────────────────
-EXPOSE 8000
+EXPOSE 8001
 
 ENV \
     DQ_POOL=""\
     DQ_GATEWAY=""\
-    PORT="8000"
+    PORT="8001"
 
 CMD ["python", "-c", "\
 import uvicorn; \
 uvicorn.run('peagen.worker:app', \
             host='0.0.0.0', \
-            port=8000, \
+            port=8001, \
             log_level='info')"]

--- a/pkgs/standards/peagen/AGENTS.md
+++ b/pkgs/standards/peagen/AGENTS.md
@@ -58,7 +58,7 @@ Workers connect to the gateway via JSON‑RPC and advertise task handlers. Set t
 * `DQ_GATEWAY` – URL of the gateway RPC endpoint (e.g. `http://localhost:8000/rpc`)
 * `DQ_POOL` – name of the worker pool (defaults to `default`)
 * `DQ_HOST` – IP address the worker should advertise (set to `127.0.0.1` if no network)
-* `PORT` – port the worker will listen on (default `8000`)
+* `PORT` – port the worker will listen on (default `8001`)
 
 Launch with Uvicorn:
 

--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -60,14 +60,14 @@ class WorkerBase:
           • DQ_GATEWAY       (default: "http://localhost:8000/rpc")
           • DQ_WORKER_ID     (default: random 8‐char prefix)
           • DQ_HOST          (default: local IP)
-          • PORT             (default: 8000)
+          • PORT             (default: 8001)
           • DQ_LOG_LEVEL     (default: "INFO")
         """
         # ─── CONFIGURE from ENV or parameters ────────────────────────
         self.POOL = pool or os.getenv("DQ_POOL", "default")
         self.DQ_GATEWAY = gateway or os.getenv("DQ_GATEWAY", "http://localhost:8000/rpc")
         self.WORKER_ID = worker_id or os.getenv("DQ_WORKER_ID", str(uuid.uuid4())[:8])
-        self.PORT = port or int(os.getenv("PORT", "8000"))
+        self.PORT = port or int(os.getenv("PORT", "8001"))
         env_host = host or os.getenv("DQ_HOST", "")
         if not env_host:
             env_host = get_local_ip()


### PR DESCRIPTION
## Summary
- update worker default PORT to 8001
- update Peagen deployment docs
- expose port 8001 in worker Dockerfile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684598a3805c8326bc29da8756d2cbb1