### PR TITLE
Update peagen docs

### DIFF
--- a/pkgs/standards/peagen/AGENTS.md
+++ b/pkgs/standards/peagen/AGENTS.md
@@ -11,7 +11,21 @@ This document explains how to launch the Peagen gateway and worker services and 
 * `uvicorn` available on the PATH
 * Docker (optional) for containerized deployments
 
-Environment variables control the runtime configuration. A minimal `.peagen.toml` is required in the working directory for both services. Example contents:
+Environment variables control the runtime configuration. A minimal `.peagen.toml` is required in the working directory for both services.
+
+For quick local testing you can rely on the in-memory queue and filesystem result backend:
+
+```toml
+[queues]
+default_queue = "in_memory"
+
+[result_backends]
+default_backend = "local_fs"
+[result_backends.adapters.local_fs]
+root_dir = "./task_runs"
+```
+
+Production deployments typically use Redis and Postgres instead:
 
 ```toml
 [queues]

--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -55,6 +55,7 @@ dependencies = [
     "sqlalchemy>=2.0",
     "asyncpg>=0.30.0", # need to push out to a standalone with extra
     "psycopg2-binary", # need to push out to a standalone with extra
+    "aiosqlite>=0.19.0", # needed for the SQLite fallback result backend
     
     # brokers (publishers/consumer dependencies)
     "redis", # this publisher needs to be pushed to its own standalone


### PR DESCRIPTION
## Summary
- document local queue and filesystem backend for gateway
- note SQLite fallback works without manual `aiosqlite` install
- include `aiosqlite` in dependencies

## Testing
- No tests run per instructions

------
https://chatgpt.com/codex/tasks/task_e_6845aa7948d48326b8664aa661bf8ab8