### PR TITLE
Add orchestration metadata to peagen tasks

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/mutate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/mutate.py
@@ -13,7 +13,7 @@ import httpx
 import typer
 
 from peagen.handlers.mutate_handler import mutate_handler
-from peagen.models import Task, Status
+from peagen.models import Task
 
 DEFAULT_GATEWAY = "http://localhost:8000/rpc"
 local_mutate_app = typer.Typer(help="Run the mutate workflow")

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -201,13 +201,36 @@ async def pool_join(name: str):
 
 # ─────────────────────────── Task RPCs ──────────────────────────
 @rpc.method("Task.submit")
-async def task_submit(pool: str, payload: dict, taskId: Optional[str]):
+async def task_submit(
+    pool: str,
+    payload: dict,
+    taskId: Optional[str],
+    deps: list[str] | None = None,
+    edge_pred: str | None = None,
+    labels: list[str] | None = None,
+    config_toml: str | None = None,
+):
     await queue.sadd("pools", pool)  # track pool even if not created
 
     if taskId:
-        task = Task(id=taskId, pool=pool, payload=payload)
+        task = Task(
+            id=taskId,
+            pool=pool,
+            payload=payload,
+            deps=deps or [],
+            edge_pred=edge_pred,
+            labels=labels or [],
+            config_toml=config_toml,
+        )
     else:
-        task = Task(pool=pool, payload=payload)
+        task = Task(
+            pool=pool,
+            payload=payload,
+            deps=deps or [],
+            edge_pred=edge_pred,
+            labels=labels or [],
+            config_toml=config_toml,
+        )
 
     # 1) put on the queue for the scheduler
     await queue.rpush(f"queue:{pool}", task.model_dump_json())

--- a/pkgs/standards/peagen/peagen/models/schemas.py
+++ b/pkgs/standards/peagen/peagen/models/schemas.py
@@ -26,6 +26,10 @@ class Task(BaseModel):
     payload: dict
     status: Status = Status.pending
     result: Optional[dict] = None
+    deps: List[str] = Field(default_factory=list)
+    edge_pred: str | None = None
+    labels: List[str] = Field(default_factory=list)
+    config_toml: str | None = None
 
     def get(self, key: str, default=None):
         """Dictionary-style access to Task fields."""

--- a/pkgs/standards/peagen/peagen/models/task_run.py
+++ b/pkgs/standards/peagen/peagen/models/task_run.py
@@ -19,6 +19,10 @@ class TaskRun(Base):
     status       = Column(Enum(Status))
     payload      = Column(JSON)
     result       = Column(JSON, nullable=True)
+    deps         = Column(JSON, nullable=False, default=list)
+    edge_pred    = Column(String, nullable=True)
+    labels       = Column(JSON, nullable=False, default=list)
+    config_toml  = Column(String, nullable=True)
     artifact_uri = Column(String, nullable=True)
     started_at   = Column(TIMESTAMP(timezone=True), default=dt.datetime.utcnow)
     finished_at  = Column(TIMESTAMP(timezone=True), nullable=True)
@@ -34,6 +38,10 @@ class TaskRun(Base):
             status=task.status,
             payload=task.payload,
             result=task.result,
+            deps=task.deps,
+            edge_pred=task.edge_pred,
+            labels=task.labels,
+            config_toml=task.config_toml,
             artifact_uri=(
                 task.result.get("artifact_uri")
                 if task.result and isinstance(task.result, dict)
@@ -67,6 +75,10 @@ class TaskRun(Base):
             "status": self.status,
             "payload": self.payload,
             "result": self.result,
+            "deps": self.deps,
+            "edge_pred": self.edge_pred,
+            "labels": self.labels,
+            "config_toml": self.config_toml,
             "artifact_uri": self.artifact_uri,
             "started_at": self.started_at,
             "finished_at": self.finished_at,

--- a/pkgs/standards/peagen/peagen/plugins/mutators/default_mutator.py
+++ b/pkgs/standards/peagen/peagen/plugins/mutators/default_mutator.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Dict
 
 from peagen.core._external import call_external_agent
 

--- a/pkgs/standards/peagen/tests/unit/test_get_task_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_get_task_handler.py
@@ -12,7 +12,8 @@ async def test_task_get_handler(monkeypatch):
     # task_get_handler lazily imports get_task_result from peagen.core.task_core
     # Insert a stub module into sys.modules so that import resolves without
     # loading the real module (which has heavy deps and circular imports).
-    import sys, types
+    import sys
+    import types
     stub = types.ModuleType("peagen.core.task_core")
     stub.get_task_result = fake_get_task_result
     monkeypatch.setitem(sys.modules, "peagen.core.task_core", stub)

--- a/pkgs/standards/peagen/tests/unit/test_mutate_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_mutate_handler.py
@@ -1,5 +1,4 @@
 import pytest
-from pathlib import Path
 
 from peagen.handlers import mutate_handler as handler
 

--- a/pkgs/standards/peagen/tests/unit/test_task_metadata.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_metadata.py
@@ -1,0 +1,88 @@
+import pytest
+
+from peagen.models import Task, TaskRun
+from peagen.plugins.queues.in_memory_queue import InMemoryQueue
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_task_model_roundtrip():
+    t = Task(
+        pool="p",
+        payload={},
+        deps=["a"],
+        edge_pred="e",
+        labels=["l"],
+        config_toml="cfg",
+    )
+    dumped = t.model_dump_json()
+    t2 = Task.model_validate_json(dumped)
+    assert t2.deps == ["a"]
+    assert t2.edge_pred == "e"
+    assert t2.labels == ["l"]
+    assert t2.config_toml == "cfg"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_taskrun_from_task():
+    t = Task(pool="p", payload={}, deps=["a"], edge_pred="e", labels=["l"], config_toml="c")
+    tr = TaskRun.from_task(t)
+    assert tr.deps == ["a"]
+    assert tr.edge_pred == "e"
+    assert tr.labels == ["l"]
+    assert tr.config_toml == "c"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_task_submit_roundtrip(monkeypatch):
+    q = InMemoryQueue()
+
+    class DummyBackend:
+        async def store(self, task_run):
+            pass
+
+    class StubPM:
+        def __init__(self, cfg):
+            pass
+
+        def get(self, group):
+            if group == "queues":
+                return q
+            if group == "result_backends":
+                return DummyBackend()
+            return None
+
+    import importlib
+    import peagen.plugins
+
+    monkeypatch.setattr(peagen.plugins, "PluginManager", StubPM)
+    import peagen.gateway as gw
+    importlib.reload(gw)
+
+    monkeypatch.setattr(gw, "queue", q)
+    monkeypatch.setattr(gw, "result_backend", DummyBackend())
+    async def noop(task):
+        return None
+
+    monkeypatch.setattr(gw, "_persist", noop)
+    monkeypatch.setattr(gw, "_publish_event", noop)
+
+    task_submit = gw.task_submit
+    task_get = gw.task_get
+
+    result = await task_submit(
+        pool="p",
+        payload={},
+        taskId=None,
+        deps=["d"],
+        edge_pred="ep",
+        labels=["lab"],
+        config_toml="cfg",
+    )
+    tid = result["taskId"]
+    stored = await task_get(tid)
+    assert stored["deps"] == ["d"]
+    assert stored["edge_pred"] == "ep"
+    assert stored["labels"] == ["lab"]
+    assert stored["config_toml"] == "cfg"

--- a/pkgs/standards/peagen/tests/unit/test_utils_config_loader.py
+++ b/pkgs/standards/peagen/tests/unit/test_utils_config_loader.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 from peagen._utils.config_loader import _expand_env_in_text, _expand_env_vars, _merge, load_peagen_toml
 


### PR DESCRIPTION
## Summary
- extend `Task` model with scheduling metadata
- persist new metadata columns in `TaskRun`
- allow RPC submit to accept metadata
- ensure metadata round-trips via queue and database
- cover new behaviour with unit tests
- fix various lint warnings

## Testing
- `ruff check pkgs/standards/peagen`
- `uv run --package peagen --directory standards/peagen pytest -q`
- `peagen local -q sort standards/peagen/tests/examples/projects_payloads/projects_payload_example1.yaml`
- `peagen remote -q --gateway-url http://127.0.0.1:8000/rpc sort /workspace/swarmauri-sdk/pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload_example1.yaml`
- `peagen remote -q --gateway-url http://127.0.0.1:8000/rpc task get 80f5c647-6c92-425b-9a19-3ab37ff5cfa3`


------
https://chatgpt.com/codex/tasks/task_e_6845b653addc832695ee08a4ed2f8cff