### PR TITLE
Fix lint in Peagen package

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/mutate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/mutate.py
@@ -13,7 +13,7 @@ import httpx
 import typer
 
 from peagen.handlers.mutate_handler import mutate_handler
-from peagen.models import Task, Status
+from peagen.models import Task
 
 DEFAULT_GATEWAY = "http://localhost:8000/rpc"
 local_mutate_app = typer.Typer(help="Run the mutate workflow")

--- a/pkgs/standards/peagen/peagen/plugins/mutators/default_mutator.py
+++ b/pkgs/standards/peagen/peagen/plugins/mutators/default_mutator.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Dict
 
 from peagen.core._external import call_external_agent
 

--- a/pkgs/standards/peagen/tests/unit/test_get_task_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_get_task_handler.py
@@ -12,7 +12,9 @@ async def test_task_get_handler(monkeypatch):
     # task_get_handler lazily imports get_task_result from peagen.core.task_core
     # Insert a stub module into sys.modules so that import resolves without
     # loading the real module (which has heavy deps and circular imports).
-    import sys, types
+    import sys
+    import types
+
     stub = types.ModuleType("peagen.core.task_core")
     stub.get_task_result = fake_get_task_result
     monkeypatch.setitem(sys.modules, "peagen.core.task_core", stub)

--- a/pkgs/standards/peagen/tests/unit/test_mutate_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_mutate_handler.py
@@ -1,5 +1,4 @@
 import pytest
-from pathlib import Path
 
 from peagen.handlers import mutate_handler as handler
 

--- a/pkgs/standards/peagen/tests/unit/test_utils_config_loader.py
+++ b/pkgs/standards/peagen/tests/unit/test_utils_config_loader.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 from peagen._utils.config_loader import _expand_env_in_text, _expand_env_vars, _merge, load_peagen_toml
 


### PR DESCRIPTION
## Summary
- clean up unused imports in Peagen CLI and plugin
- tidy up unit tests for linting

## Testing
- `ruff check pkgs`
- `uv run --package peagen --directory standards/peagen pytest`
- `peagen local -q -d runtime sort "$abs_yaml"`
- `peagen remote -q --gateway-url http://localhost:8000/rpc sort "$abs_yaml"`
- `peagen remote -q --gateway-url http://localhost:8000/rpc task get 957ee953-2fbf-4bb3-919d-09526bf45e92`


------
https://chatgpt.com/codex/tasks/task_e_6845b66f74088326b16ecc781f4b4ee1