### PR TITLE
Add orchestration metadata support in Peagen tasks

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/doe.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/doe.py
@@ -88,9 +88,12 @@ def submit(  # noqa: PLR0913
 
     rpc_req = {
         "jsonrpc": "2.0",
-        "id": task.id,
         "method": "Task.submit",
-        "params": {"task": task.model_dump()},
+        "params": {
+            "taskId": task.id,
+            "pool": task.pool,
+            "payload": task.payload,
+        },
     }
 
     with httpx.Client(timeout=30.0) as client:

--- a/pkgs/standards/peagen/peagen/cli/commands/eval.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/eval.py
@@ -102,9 +102,12 @@ def submit(  # noqa: PLR0913
 
     rpc_req = {
         "jsonrpc": "2.0",
-        "id": task.id,
         "method": "Task.submit",
-        "params": {"task": task.model_dump()},
+        "params": {
+            "taskId": task.id,
+            "pool": task.pool,
+            "payload": task.payload,
+        },
     }
 
     with httpx.Client(timeout=30.0) as client:

--- a/pkgs/standards/peagen/peagen/cli/commands/fetch.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/fetch.py
@@ -91,9 +91,12 @@ def submit(
 
     rpc_req = {
         "jsonrpc": "2.0",
-        "id": task.id,
         "method": "Task.submit",
-        "params": {"task": task.model_dump()},
+        "params": {
+            "taskId": task.id,
+            "pool": task.pool,
+            "payload": task.payload,
+        },
     }
 
     with httpx.Client(timeout=30.0) as client:

--- a/pkgs/standards/peagen/peagen/cli/commands/mutate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/mutate.py
@@ -13,7 +13,7 @@ import httpx
 import typer
 
 from peagen.handlers.mutate_handler import mutate_handler
-from peagen.models import Task, Status
+from peagen.models import Task
 
 DEFAULT_GATEWAY = "http://localhost:8000/rpc"
 local_mutate_app = typer.Typer(help="Run the mutate workflow")

--- a/pkgs/standards/peagen/peagen/cli/commands/templates.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/templates.py
@@ -36,7 +36,11 @@ def _submit_task(args: Dict[str, Any], gateway_url: str) -> str:
     envelope = {
         "jsonrpc": "2.0",
         "method": "Task.submit",
-        "params": {"pool": task.pool, "payload": task.payload},
+        "params": {
+            "taskId": task.id,
+            "pool": task.pool,
+            "payload": task.payload,
+        },
     }
     resp = httpx.post(gateway_url, json=envelope, timeout=10.0)
     resp.raise_for_status()

--- a/pkgs/standards/peagen/peagen/models/schemas.py
+++ b/pkgs/standards/peagen/peagen/models/schemas.py
@@ -24,6 +24,10 @@ class Task(BaseModel):
     id: str = Field(default=str(uuid.uuid4()))
     pool: str
     payload: dict
+    deps: List[str] = Field(default_factory=list)
+    edge_pred: str | None = None
+    labels: List[str] = Field(default_factory=list)
+    config_toml: str | None = None
     status: Status = Status.pending
     result: Optional[dict] = None
 

--- a/pkgs/standards/peagen/peagen/models/task_run.py
+++ b/pkgs/standards/peagen/peagen/models/task_run.py
@@ -18,6 +18,10 @@ class TaskRun(Base):
     task_type    = Column(String)
     status       = Column(Enum(Status))
     payload      = Column(JSON)
+    deps         = Column(JSON, default=list)
+    edge_pred    = Column(String, nullable=True)
+    labels       = Column(JSON, default=list)
+    config_toml  = Column(String, nullable=True)
     result       = Column(JSON, nullable=True)
     artifact_uri = Column(String, nullable=True)
     started_at   = Column(TIMESTAMP(timezone=True), default=dt.datetime.utcnow)
@@ -33,6 +37,10 @@ class TaskRun(Base):
             task_type=task.payload.get("kind", "unknown"),
             status=task.status,
             payload=task.payload,
+            deps=task.deps,
+            edge_pred=task.edge_pred,
+            labels=task.labels,
+            config_toml=task.config_toml,
             result=task.result,
             artifact_uri=(
                 task.result.get("artifact_uri")
@@ -66,6 +74,10 @@ class TaskRun(Base):
             "task_type": self.task_type,
             "status": self.status,
             "payload": self.payload,
+            "deps": self.deps,
+            "edge_pred": self.edge_pred,
+            "labels": self.labels,
+            "config_toml": self.config_toml,
             "result": self.result,
             "artifact_uri": self.artifact_uri,
             "started_at": self.started_at,

--- a/pkgs/standards/peagen/peagen/plugins/mutators/default_mutator.py
+++ b/pkgs/standards/peagen/peagen/plugins/mutators/default_mutator.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Dict
 
 from peagen.core._external import call_external_agent
 

--- a/pkgs/standards/peagen/tests/unit/test_get_task_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_get_task_handler.py
@@ -12,7 +12,8 @@ async def test_task_get_handler(monkeypatch):
     # task_get_handler lazily imports get_task_result from peagen.core.task_core
     # Insert a stub module into sys.modules so that import resolves without
     # loading the real module (which has heavy deps and circular imports).
-    import sys, types
+    import sys
+    import types
     stub = types.ModuleType("peagen.core.task_core")
     stub.get_task_result = fake_get_task_result
     monkeypatch.setitem(sys.modules, "peagen.core.task_core", stub)

--- a/pkgs/standards/peagen/tests/unit/test_mutate_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_mutate_handler.py
@@ -1,5 +1,4 @@
 import pytest
-from pathlib import Path
 
 from peagen.handlers import mutate_handler as handler
 

--- a/pkgs/standards/peagen/tests/unit/test_task_metadata.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_metadata.py
@@ -1,0 +1,80 @@
+import pytest
+from peagen.models import Task, TaskRun
+
+
+@pytest.mark.unit
+def test_task_dump_roundtrip():
+    task = Task(
+        pool="p",
+        payload={},
+        deps=["a"],
+        edge_pred="pred",
+        labels=["x"],
+        config_toml="[tool]"
+    )
+    blob = task.model_dump_json()
+    restored = Task.model_validate_json(blob)
+    assert restored.deps == ["a"]
+    assert restored.edge_pred == "pred"
+    assert restored.labels == ["x"]
+    assert restored.config_toml == "[tool]"
+
+
+@pytest.mark.unit
+def test_taskrun_from_task_populates_fields():
+    task = Task(
+        pool="p",
+        payload={},
+        deps=["d1", "d2"],
+        edge_pred="edge",
+        labels=["l"],
+        config_toml="cfg"
+    )
+    tr = TaskRun.from_task(task)
+    assert tr.deps == ["d1", "d2"]
+    assert tr.edge_pred == "edge"
+    assert tr.labels == ["l"]
+    assert tr.config_toml == "cfg"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_save_load_preserves_metadata(monkeypatch):
+    import importlib
+    from peagen.plugins import PluginManager
+    from peagen.plugins.queues import InMemoryQueue
+
+    class DummyBackend:
+        async def store(self, *args, **kwargs):
+            pass
+
+    orig_get = PluginManager.get
+
+    def fake_get(self, group: str, name=None):
+        if group == "queues":
+            return InMemoryQueue()
+        if group == "result_backends":
+            return DummyBackend()
+        return orig_get(self, group, name)
+
+    monkeypatch.setattr(PluginManager, "get", fake_get)
+
+    gateway = importlib.import_module("peagen.gateway.__init__")
+    monkeypatch.setattr(gateway, "queue", InMemoryQueue())
+
+    task = Task(
+        pool="p",
+        payload={},
+        deps=["d"],
+        edge_pred="edge",
+        labels=["lab"],
+        config_toml="cfg",
+    )
+
+    await gateway._save_task(task)
+    loaded = await gateway._load_task(task.id)
+
+    assert loaded.deps == ["d"]
+    assert loaded.edge_pred == "edge"
+    assert loaded.labels == ["lab"]
+    assert loaded.config_toml == "cfg"

--- a/pkgs/standards/peagen/tests/unit/test_utils_config_loader.py
+++ b/pkgs/standards/peagen/tests/unit/test_utils_config_loader.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 from peagen._utils.config_loader import _expand_env_in_text, _expand_env_vars, _merge, load_peagen_toml
 


### PR DESCRIPTION
## Summary
- extend Task schema with orchestration fields
- persist additional metadata in TaskRun rows
- allow RPC submit to accept the new fields
- add regression tests for Task metadata round-tripping
- new unit test covers gateway helpers
- clean up CLI RPC envelopes

## Testing
- `ruff check pkgs/standards/peagen`
- `uv run --package peagen --directory pkgs/standards/peagen pytest -q`
- started gateway and worker with in-memory queue
- `peagen local extras-schemas extras`
- `peagen remote --gateway-url http://localhost:8000/rpc sort /workspace/swarmauri-sdk/pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml --project-name BaseComponent-SearchWord-001`

------
https://chatgpt.com/codex/tasks/task_e_6845b47432e483268c8d680a7da9d4c1