### PR TITLE
Extend task metadata fields

### DIFF
--- a/pkgs/standards/peagen/peagen/models/schemas.py
+++ b/pkgs/standards/peagen/peagen/models/schemas.py
@@ -24,6 +24,10 @@ class Task(BaseModel):
     id: str = Field(default=str(uuid.uuid4()))
     pool: str
     payload: dict
+    deps: list[str] = Field(default_factory=list)
+    edge_pred: Optional[str] = None
+    labels: list[str] = Field(default_factory=list)
+    config_toml: Optional[str] = None
     status: Status = Status.pending
     result: Optional[dict] = None
 

--- a/pkgs/standards/peagen/peagen/models/task_run.py
+++ b/pkgs/standards/peagen/peagen/models/task_run.py
@@ -13,15 +13,19 @@ Base = declarative_base()
 class TaskRun(Base):
     __tablename__ = "task_runs"
 
-    id           = Column(UUID(as_uuid=True), primary_key=True)
-    pool         = Column(String)
-    task_type    = Column(String)
-    status       = Column(Enum(Status))
-    payload      = Column(JSON)
-    result       = Column(JSON, nullable=True)
+    id = Column(UUID(as_uuid=True), primary_key=True)
+    pool = Column(String)
+    task_type = Column(String)
+    status = Column(Enum(Status))
+    payload = Column(JSON)
+    deps = Column(JSON, nullable=True)
+    edge_pred = Column(String, nullable=True)
+    labels = Column(JSON, nullable=True)
+    config_toml = Column(String, nullable=True)
+    result = Column(JSON, nullable=True)
     artifact_uri = Column(String, nullable=True)
-    started_at   = Column(TIMESTAMP(timezone=True), default=dt.datetime.utcnow)
-    finished_at  = Column(TIMESTAMP(timezone=True), nullable=True)
+    started_at = Column(TIMESTAMP(timezone=True), default=dt.datetime.utcnow)
+    finished_at = Column(TIMESTAMP(timezone=True), nullable=True)
 
     # ──────────────────────────────────────────────────────────────
     @classmethod
@@ -33,6 +37,10 @@ class TaskRun(Base):
             task_type=task.payload.get("kind", "unknown"),
             status=task.status,
             payload=task.payload,
+            deps=task.deps,
+            edge_pred=task.edge_pred,
+            labels=task.labels,
+            config_toml=task.config_toml,
             result=task.result,
             artifact_uri=(
                 task.result.get("artifact_uri")
@@ -66,6 +74,10 @@ class TaskRun(Base):
             "task_type": self.task_type,
             "status": self.status,
             "payload": self.payload,
+            "deps": self.deps,
+            "edge_pred": self.edge_pred,
+            "labels": self.labels,
+            "config_toml": self.config_toml,
             "result": self.result,
             "artifact_uri": self.artifact_uri,
             "started_at": self.started_at,


### PR DESCRIPTION
## Summary
- add orchestration metadata fields to Task model
- persist deps, edge predicates, labels, and config path in TaskRun
- keep serialization helpers aware of new columns

## Testing
- `ruff format pkgs/standards/peagen/peagen/models/schemas.py pkgs/standards/peagen/peagen/models/task_run.py`
- `ruff check pkgs/standards/peagen/peagen/models/schemas.py pkgs/standards/peagen/peagen/models/task_run.py`
- `uv run --package peagen --directory standards/peagen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845b6f7992483268583a3cb57e5d974