### PR TITLE
Add circuit breaker to peagen worker

### DIFF
--- a/pkgs/standards/peagen/AGENTS.md
+++ b/pkgs/standards/peagen/AGENTS.md
@@ -73,6 +73,8 @@ Workers connect to the gateway via JSON‑RPC and advertise task handlers. Set t
 * `DQ_POOL` – name of the worker pool (defaults to `default`)
 * `DQ_HOST` – IP address the worker should advertise (set to `127.0.0.1` if no network)
 * `PORT` – port the worker will listen on (default `8001`)
+* `DQ_FAIL_MAX` – number of consecutive failures before opening the circuit (default `5`)
+* `DQ_RESET_TIMEOUT` – seconds to wait before closing the circuit again (default `30`)
 
 Launch with Uvicorn:
 

--- a/pkgs/standards/peagen/tests/unit/test_worker_circuit_breaker.py
+++ b/pkgs/standards/peagen/tests/unit/test_worker_circuit_breaker.py
@@ -1,0 +1,46 @@
+import time
+import pytest
+
+from peagen.worker.base import WorkerBase
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_worker_circuit_breaker(monkeypatch):
+    worker = WorkerBase(
+        gateway="http://example.com",
+        host="127.0.0.1",
+        port=8001,
+        fail_max=1,
+        reset_timeout=10,
+    )
+
+    async def failing(task):
+        raise RuntimeError("boom")
+
+    async def success(task):
+        return {"ok": True}
+
+    worker.register_handler("fail", failing)
+    worker.register_handler("ok", success)
+
+    sent = []
+
+    async def fake_notify(state, task_id, result=None):
+        sent.append((state, result))
+
+    worker._notify = fake_notify
+
+    await worker._run_task({"id": "t1", "payload": {"action": "fail"}})
+    assert sent[-1][0] == "failed"
+    assert worker._failure_count == 1
+    assert worker._circuit_open_until > time.time()
+
+    await worker._run_task({"id": "t2", "payload": {"action": "fail"}})
+    assert sent[-1][1]["error"] == "Circuit open"
+
+    worker._circuit_open_until = time.time() - 1
+    await worker._run_task({"id": "t3", "payload": {"action": "ok"}})
+    assert sent[-1][0] == "success"
+    assert worker._failure_count == 0
+    assert worker._circuit_open_until == 0.0


### PR DESCRIPTION
## Summary
- add fail-fast circuit breaker to WorkerBase
- document new worker env vars in the deployment guide
- test circuit breaker behaviour

## Testing
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_worker_circuit_breaker.py`

------
https://chatgpt.com/codex/tasks/task_e_6845ea79bd708326b87c9fadd7aca055