### PR TITLE
Fix CLI RPC method

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/sort.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/sort.py
@@ -123,7 +123,7 @@ def submit_sort(
         # status and result left as defaults
     )
 
-    # 2) Build Work.start envelope using Task fields
+    # 2) Build Task.submit envelope using Task fields
     envelope = {
         "jsonrpc": "2.0",
         "method": "Task.submit",

--- a/pkgs/standards/peagen/peagen/cli/commands/validate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/validate.py
@@ -84,13 +84,12 @@ def submit_validate(
         payload={"action": "validate", "args": args},
     )
 
-    # 2) Build Work.start envelope using Task fields
+    # 2) Build Task.submit envelope using Task fields
     envelope = {
         "jsonrpc": "2.0",
-        "id": str(uuid.uuid4()),
-        "method": "Work.start",
+        "method": "Task.submit",
         "params": {
-            "id": task.id,
+            "taskId": task.id,
             "pool": task.pool,
             "payload": task.payload,
         },


### PR DESCRIPTION
## Summary
- fix `validate` CLI to call the gateway via `Task.submit`
- clean up comment in `sort` command

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846e379ee6c832698b6063d178827ab