### PR TITLE
Fix gateway queue config and support null queues

### DIFF
--- a/infra/.gw.peagen.toml
+++ b/infra/.gw.peagen.toml
@@ -51,6 +51,13 @@ password = ""                   # leave blank if no auth
 [publishers.adapters.webhook]
 url = ""
 
+# ─────────────────────────────── Queues ───────────────────────────────
+[queues]
+default_queue = "redis"
+
+[queues.adapters.redis]
+uri = "${REDIS_URL}"
+
 
 # ────────────────────────────── Evaluation ───────────────────────────────
 [evaluation]

--- a/infra/.worker.peagen.toml
+++ b/infra/.worker.peagen.toml
@@ -51,6 +51,13 @@ password = ""                   # leave blank if no auth
 [publishers.adapters.webhook]
 url = ""
 
+# ─────────────────────────────── Queues ───────────────────────────────
+[queues]
+default_queue = null
+
+[queues.adapters.redis]
+uri = "${REDIS_URL}"
+
 
 # ────────────────────────────── Evaluation ───────────────────────────────
 [evaluation]

--- a/pkgs/standards/peagen/peagen/plugins/__init__.py
+++ b/pkgs/standards/peagen/peagen/plugins/__init__.py
@@ -232,7 +232,12 @@ class PluginManager:
         items = cfg.get(layout.get("items", "plugins"), {})
         if name is None:
             default_key = layout.get("default")
-            name = cfg.get(default_key) if default_key else None
+            if default_key and default_key in cfg:
+                name = cfg.get(default_key)
+                if name is None:
+                    return None
+            else:
+                name = cfg.get(default_key) if default_key else None
         if not name:
             raise KeyError(f"No plugin name provided for group '{group}'")
         params = items.get(name, {})

--- a/pkgs/standards/peagen/tests/unit/test_plugin_manager.py
+++ b/pkgs/standards/peagen/tests/unit/test_plugin_manager.py
@@ -26,3 +26,10 @@ def test_plugin_manager_instantiates_defaults(tmp_path):
     backend = pm.get("result_backends")
     assert isinstance(queue, DummyQueue)
     assert isinstance(backend, DummyBackend)
+
+
+@pytest.mark.unit
+def test_plugin_manager_allows_null_default():
+    cfg = {"queues": {"default_queue": None}}
+    pm = PluginManager(cfg)
+    assert pm.get("queues") is None


### PR DESCRIPTION
## Summary
- define a Redis queue for the gateway config
- allow worker config to leave queue unset
- return `None` when a plugin default is explicitly null
- test the new behavior

## Testing
- `uv run --project pkgs --package peagen pytest pkgs/standards/peagen/tests/unit/test_plugin_manager.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6846fbcc09ec8326bed7701ef86150d7