### PR TITLE
Configure gw/worker for result backend

### DIFF
--- a/infra/.gw.peagen.toml
+++ b/infra/.gw.peagen.toml
@@ -58,6 +58,13 @@ default_queue = "redis"
 [queues.adapters.redis]
 uri = "${REDIS_URL}"
 
+# ─────────────────────────── Result Backends ──────────────────────────
+[result_backends]
+default_backend = "postgres"
+
+[result_backends.adapters.postgres]
+dsn = "${PG_DSN}"
+
 
 # ────────────────────────────── Evaluation ───────────────────────────────
 [evaluation]

--- a/infra/.worker.peagen.toml
+++ b/infra/.worker.peagen.toml
@@ -58,6 +58,10 @@ default_queue = null
 [queues.adapters.redis]
 uri = "${REDIS_URL}"
 
+# ─────────────────────────── Result Backends ──────────────────────────
+[result_backends]
+default_backend = null
+
 
 # ────────────────────────────── Evaluation ───────────────────────────────
 [evaluation]

--- a/infra/peagen_docker-compose.yml
+++ b/infra/peagen_docker-compose.yml
@@ -143,6 +143,7 @@ services:
       PG_DB:                ${POSTGRES_DB}
       PG_USER:              ${POSTGRES_USER}
       PG_PASS:              ${POSTGRES_PASSWORD}
+      PG_DSN:               postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5342/${POSTGRES_DB}
       REDIS_HOST:           redis
       REDIS_PASSWORD:       ${REDIS_PASSWORD}
       REDIS_URL:            redis://:${REDIS_PASSWORD}@redis:6379/0

--- a/pkgs/standards/peagen/AGENTS.md
+++ b/pkgs/standards/peagen/AGENTS.md
@@ -46,6 +46,7 @@ dsn = "${PG_DSN}"
 1. Ensure Redis and PostgreSQL are reachable and the environment variables below are set:
    * `REDIS_HOST`, `REDIS_PORT`, `REDIS_DB`, `REDIS_PASSWORD`
    * `PG_HOST`, `PG_PORT`, `PG_DB`, `PG_USER`, `PG_PASS`
+   * `PG_DSN` – typically formatted as `postgresql://${PG_USER}:${PG_PASS}@${PG_HOST}:${PG_PORT}/${PG_DB}`
 2. Place a `.peagen.toml` in the current directory (see example above).
 3. Start the gateway with Uvicorn:
 

--- a/pkgs/standards/peagen/tests/unit/test_plugin_manager.py
+++ b/pkgs/standards/peagen/tests/unit/test_plugin_manager.py
@@ -33,3 +33,10 @@ def test_plugin_manager_allows_null_default():
     cfg = {"queues": {"default_queue": None}}
     pm = PluginManager(cfg)
     assert pm.get("queues") is None
+
+
+@pytest.mark.unit
+def test_plugin_manager_allows_null_result_backend():
+    cfg = {"result_backends": {"default_backend": None}}
+    pm = PluginManager(cfg)
+    assert pm.get("result_backends") is None


### PR DESCRIPTION
## Summary
- enable postgres result backend in `.gw.peagen.toml`
- disable the worker result backend by setting `default_backend` to null
- add `PG_DSN` to gateway's docker-compose environment
- document DSN environment variable format
- test that `PluginManager` accepts a null result backend

## Testing
- No tests run due to instructions

------
https://chatgpt.com/codex/tasks/task_e_684712cd818c8326a6a9db223bcb5ce9