### PR TITLE
Add worker IP fallback and unit test

### DIFF
--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -25,6 +25,10 @@ def get_local_ip() -> str:
     try:
         s.connect(("8.8.8.8", 80))
         return s.getsockname()[0]
+    except OSError:
+        # Fall back to localhost if we cannot open a UDP socket (e.g. in
+        # restricted CI environments without network access).
+        return "127.0.0.1"
     finally:
         s.close()
 

--- a/pkgs/standards/peagen/tests/unit/test_worker_utils.py
+++ b/pkgs/standards/peagen/tests/unit/test_worker_utils.py
@@ -1,0 +1,11 @@
+import socket
+import pytest
+from peagen.worker.base import get_local_ip
+
+@pytest.mark.unit
+def test_get_local_ip_handles_error(monkeypatch):
+    def fake_connect(self, addr):
+        raise OSError()
+
+    monkeypatch.setattr(socket.socket, "connect", fake_connect)
+    assert get_local_ip() == "127.0.0.1"


### PR DESCRIPTION
## Summary
- improve network resilience by falling back to `127.0.0.1` if `get_local_ip()` fails
- add unit test for IP fallback logic

## Testing
- `ruff check .`
- `uv run --package peagen --directory standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_684735bd5ac8832698a7138dc88d1db7