### PR TITLE
Fix peagen alembic tests

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_alembic_integration.py
+++ b/pkgs/standards/peagen/tests/unit/test_alembic_integration.py
@@ -1,4 +1,5 @@
 import os
+import sqlite3
 import subprocess
 from pathlib import Path
 
@@ -8,9 +9,15 @@ import pytest
 @pytest.mark.unit
 def test_alembic_upgrade_and_current(tmp_path):
     ALEMBIC_CFG = Path(__file__).resolve().parents[2] / "alembic.ini"
+    repo_root = Path(__file__).resolve().parents[5]
 
     env = os.environ.copy()
     env.setdefault("REDIS_URL", "redis://localhost:6379/0")
+    env.pop("PG_HOST", None)
+    env.pop("PG_PORT", None)
+    env.pop("PG_DB", None)
+    env.pop("PG_USER", None)
+    env.pop("PG_PASS", None)
 
     subprocess.run(
         [
@@ -22,6 +29,7 @@ def test_alembic_upgrade_and_current(tmp_path):
         ],
         check=True,
         env=env,
+        cwd=repo_root,
     )
 
     result = subprocess.run(
@@ -30,6 +38,16 @@ def test_alembic_upgrade_and_current(tmp_path):
         env=env,
         capture_output=True,
         text=True,
+        cwd=repo_root,
     )
 
     assert result.stdout.strip()
+
+    db_path = repo_root / "gateway.db"
+    assert db_path.exists()
+
+    with sqlite3.connect(db_path) as conn:
+        cur = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='task_runs'"
+        )
+        assert cur.fetchone() is not None


### PR DESCRIPTION
## Summary
- ensure alembic integration tests run from repo root
- check that migrations create the gateway database

## Testing
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_alembic_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_684826b4c6b48326b292684f16eba34a