### PR TITLE
Fix ruff violations and clean alembic test

### DIFF
--- a/pkgs/standards/peagen/migrations/env.py
+++ b/pkgs/standards/peagen/migrations/env.py
@@ -2,7 +2,6 @@ import asyncio
 from logging.config import fileConfig
 
 from alembic import context
-from sqlalchemy import pool
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from peagen.gateway.db import engine

--- a/pkgs/standards/peagen/tests/unit/test_alembic_integration.py
+++ b/pkgs/standards/peagen/tests/unit/test_alembic_integration.py
@@ -8,7 +8,7 @@ import pytest
 
 @pytest.mark.unit
 def test_alembic_upgrade_and_current(tmp_path):
-    ALEMBIC_CFG = Path(__file__).resolve().parents[2] / "alembic.ini"
+    alembic_ini = Path(__file__).resolve().parents[2] / "alembic.ini"
     repo_root = Path(__file__).resolve().parents[5]
 
 
@@ -31,7 +31,6 @@ def test_alembic_upgrade_and_current(tmp_path):
         check=True,
         cwd=repo_root,
         env=env,
-        cwd=repo_root,
     )
 
     result = subprocess.run(
@@ -41,7 +40,6 @@ def test_alembic_upgrade_and_current(tmp_path):
         env=env,
         capture_output=True,
         text=True,
-        cwd=repo_root,
     )
 
     assert result.stdout.strip()


### PR DESCRIPTION
## Summary
- fix unused import in alembic migration script
- clean up duplicate kwargs in alembic integration test and ensure config path

## Testing
- `uv run --package peagen --directory standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_6848d4e0cd50832690e502f6ebc4eb1a