### PR TITLE
Fix gateway startup for sqlite and update ruff config

### DIFF
--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -284,7 +284,7 @@ log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 asyncio_default_fixture_loop_scope = "function"
 
 [tool.ruff]
-exclude = ["experimental", ".config", "**/*.bak.py"]
+exclude = ["experimental", ".config", "**/*.bak.py", "standards/peagen/test_project"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -404,9 +404,9 @@ async def health() -> dict:
 # ───────────────────────────────    Startup  ───────────────────────────────
 @app.on_event("startup")
 async def _on_start():
-    await ensure_status_enum(engine)
-
-    if engine.url.get_backend_name() == "sqlite":      # ← guard
+    if engine.url.get_backend_name() != "sqlite":
+        await ensure_status_enum(engine)
+    else:
         async with engine.begin() as conn:
             # run once – creates task_runs if it doesn't exist
             await conn.run_sync(Base.metadata.create_all)

--- a/pkgs/standards/peagen/peagen/models/task_run.py
+++ b/pkgs/standards/peagen/peagen/models/task_run.py
@@ -1,7 +1,7 @@
 import datetime as dt
 from typing import Any, Dict, Iterable, Optional
 
-from sqlalchemy import Column, String, JSON, TIMESTAMP, Enum
+from sqlalchemy import Column, String, JSON, TIMESTAMP
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.dialects import postgresql as psql
 from sqlalchemy.orm import declarative_base


### PR DESCRIPTION
## Summary
- avoid Postgres enum setup when using sqlite gateway
- drop unused Enum import
- exclude test_project from ruff checks

## Testing
- `ruff check .`
- `uv run --package peagen --directory standards/peagen pytest`
- `peagen local -q mutate . --target-file func.py --import-path func --entry-fn square --gens 1`
- `peagen remote -q --gateway-url http://localhost:8000/rpc mutate . --target-file func.py --import-path func --entry-fn square --gens 1`
- `peagen remote -q --gateway-url http://localhost:8000/rpc task get 4c530c6c-29d2-4a79-8df7-3307e1bd83af`


------
https://chatgpt.com/codex/tasks/task_e_684929880020832695b9593bc5143f48