### PR TITLE
Add Task.patch tests

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/task.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/task.py
@@ -42,3 +42,22 @@ def get(  # noqa: D401
         if not watch or reply["status"] in {"finished", "failed"}:
             break
         time.sleep(interval)
+
+
+@remote_task_app.command("patch")
+def patch_task(
+    ctx: typer.Context,
+    task_id: str = typer.Argument(..., help="UUID of the task to update"),
+    changes: str = typer.Argument(..., help="JSON string of fields to modify"),
+):
+    """Send a Task.patch RPC call."""
+
+    payload = json.loads(changes)
+    req = {
+        "jsonrpc": "2.0",
+        "id": str(uuid.uuid4()),
+        "method": "Task.patch",
+        "params": {"taskId": task_id, "changes": payload},
+    }
+    res = httpx.post(ctx.obj.get("gateway_url"), json=req, timeout=30.0).json()
+    typer.echo(json.dumps(res["result"], indent=2))

--- a/pkgs/standards/peagen/tests/unit/test_task_patch_labels.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_patch_labels.py
@@ -1,0 +1,52 @@
+import pytest
+
+from peagen.plugins.queues.in_memory_queue import InMemoryQueue
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_task_patch_updates_labels(monkeypatch):
+    """Ensure Task.patch updates a task's labels in storage."""
+    q = InMemoryQueue()
+
+    class DummyBackend:
+        async def store(self, task_run):
+            pass
+
+    class StubPM:
+        def __init__(self, cfg):
+            pass
+
+        def get(self, group):
+            if group == "queues":
+                return q
+            if group == "result_backends":
+                return DummyBackend()
+            return None
+
+    import importlib
+    import peagen.plugins
+
+    monkeypatch.setattr(peagen.plugins, "PluginManager", StubPM)
+    import peagen.gateway as gw
+    importlib.reload(gw)
+
+    monkeypatch.setattr(gw, "queue", q)
+    monkeypatch.setattr(gw, "result_backend", DummyBackend())
+
+    async def noop(task):
+        return None
+
+    monkeypatch.setattr(gw, "_persist", noop)
+    monkeypatch.setattr(gw, "_publish_event", noop)
+
+    task_submit = gw.task_submit
+    task_patch = gw.task_patch
+    task_get = gw.task_get
+
+    result = await task_submit(pool="p", payload={}, taskId=None)
+    tid = result["taskId"]
+
+    await task_patch(taskId=tid, changes={"labels": ["patched"]})
+    patched = await task_get(tid)
+    assert patched["labels"] == ["patched"]

--- a/pkgs/standards/peagen/tests/unit/test_task_patch_not_found.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_patch_not_found.py
@@ -1,0 +1,46 @@
+import pytest
+
+from peagen.plugins.queues.in_memory_queue import InMemoryQueue
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_task_patch_missing(monkeypatch):
+    """Verify ValueError raised when patching a nonexistent task."""
+    q = InMemoryQueue()
+
+    class DummyBackend:
+        async def store(self, task_run):
+            pass
+
+    class StubPM:
+        def __init__(self, cfg):
+            pass
+
+        def get(self, group):
+            if group == "queues":
+                return q
+            if group == "result_backends":
+                return DummyBackend()
+            return None
+
+    import importlib
+    import peagen.plugins
+
+    monkeypatch.setattr(peagen.plugins, "PluginManager", StubPM)
+    import peagen.gateway as gw
+    importlib.reload(gw)
+
+    monkeypatch.setattr(gw, "queue", q)
+    monkeypatch.setattr(gw, "result_backend", DummyBackend())
+
+    async def noop(task):
+        return None
+
+    monkeypatch.setattr(gw, "_persist", noop)
+    monkeypatch.setattr(gw, "_publish_event", noop)
+
+    task_patch = gw.task_patch
+
+    with pytest.raises(ValueError):
+        await task_patch(taskId="missing", changes={"status": "success"})

--- a/pkgs/standards/peagen/tests/unit/test_task_patch_status.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_patch_status.py
@@ -1,0 +1,52 @@
+import pytest
+
+from peagen.plugins.queues.in_memory_queue import InMemoryQueue
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_task_patch_updates_status(monkeypatch):
+    """Ensure Task.patch modifies the task status."""
+    q = InMemoryQueue()
+
+    class DummyBackend:
+        async def store(self, task_run):
+            pass
+
+    class StubPM:
+        def __init__(self, cfg):
+            pass
+
+        def get(self, group):
+            if group == "queues":
+                return q
+            if group == "result_backends":
+                return DummyBackend()
+            return None
+
+    import importlib
+    import peagen.plugins
+
+    monkeypatch.setattr(peagen.plugins, "PluginManager", StubPM)
+    import peagen.gateway as gw
+    importlib.reload(gw)
+
+    monkeypatch.setattr(gw, "queue", q)
+    monkeypatch.setattr(gw, "result_backend", DummyBackend())
+
+    async def noop(task):
+        return None
+
+    monkeypatch.setattr(gw, "_persist", noop)
+    monkeypatch.setattr(gw, "_publish_event", noop)
+
+    task_submit = gw.task_submit
+    task_patch = gw.task_patch
+    task_get = gw.task_get
+
+    result = await task_submit(pool="p", payload={}, taskId=None)
+    tid = result["taskId"]
+
+    await task_patch(taskId=tid, changes={"status": "success"})
+    patched = await task_get(tid)
+    assert patched["status"] == "success"


### PR DESCRIPTION
## Summary
- expand Peagen unit tests with coverage for the new `Task.patch` RPC
- verify labels and status can be updated and that missing tasks raise errors
- document test intent with docstrings

## Testing
- `ruff check pkgs/standards/peagen/tests/unit/test_task_patch_labels.py pkgs/standards/peagen/tests/unit/test_task_patch_status.py pkgs/standards/peagen/tests/unit/test_task_patch_not_found.py --quiet`
- `uv run --package peagen --directory standards/peagen pytest -q tests/unit/test_task_patch_labels.py tests/unit/test_task_patch_status.py tests/unit/test_task_patch_not_found.py`
- `peagen remote --gateway-url http://127.0.0.1:8000/rpc -q process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml`
- `peagen remote --gateway-url http://127.0.0.1:8000/rpc -q task patch b886159e-d34b-40e1-b564-fc3b722e2412 '{"labels": ["patched"], "status": "success"}'`
- `peagen remote --gateway-url http://127.0.0.1:8000/rpc -q task get b886159e-d34b-40e1-b564-fc3b722e2412`


------
https://chatgpt.com/codex/tasks/task_e_684958363d2c8326a1b1e8872ca443bc