### PR TITLE
Implement batched RPC features and add tests

### DIFF
--- a/pkgs/standards/peagen/migrations/versions/ae1de73e4143_init.py
+++ b/pkgs/standards/peagen/migrations/versions/ae1de73e4143_init.py
@@ -29,6 +29,7 @@ def upgrade() -> None:
             sa.Column("deps", sa.JSON(), nullable=False),
             sa.Column("edge_pred", sa.String()),
             sa.Column("labels", sa.JSON(), nullable=False),
+            sa.Column("in_degree", sa.Integer(), nullable=False, server_default="0"),
             sa.Column("config_toml", sa.String()),
             sa.Column("artifact_uri", sa.String()),
             sa.Column("started_at", sa.TIMESTAMP(timezone=True)),

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -20,10 +20,10 @@ import time
 from json.decoder import JSONDecodeError
 from typing import Optional
 
-from fastapi import FastAPI, Request, Response, Body
+from fastapi import FastAPI, Request, Response
 from peagen.plugins.queues import QueueBase
 
-from peagen.transport import RPCDispatcher, RPCRequest, RPCResponse, RPCError
+from peagen.transport import RPCDispatcher, RPCRequest, RPCError
 from peagen.models import Task, Status, Base, TaskRun
 
 from peagen.gateway.ws_server import router as ws_router
@@ -158,23 +158,10 @@ async def _publish_event(task: Task) -> None:
 
 
 # ─────────────────────────── RPC endpoint ───────────────────────
-@app.post(
-    "/rpc",
-    response_model=RPCResponse,
-    response_model_exclude_none=True,
-    summary="JSON-RPC 2.0 endpoint",
-)
-async def rpc_endpoint(
-    request: Request,
-    body: RPCRequest = Body(..., description="JSON-RPC 2.0 envelope"),
-):
+@app.post("/rpc", summary="JSON-RPC 2.0 endpoint")
+async def rpc_endpoint(request: Request):
     try:
-        # give the call an id if the client omitted one
-        if body.id is None:
-            body.id = str(uuid.uuid4())
-
-        payload = body.model_dump()
-        log.debug("RPC in  <- %s", payload)
+        raw = await request.json()
     except JSONDecodeError:
         log.warning("parse error from %s", request.client.host)
         return Response(
@@ -183,10 +170,21 @@ async def rpc_endpoint(
             media_type="application/json",
         )
 
+    def _ensure_id(obj: dict) -> dict:
+        if obj.get("id") is None:
+            obj["id"] = str(uuid.uuid4())
+        return RPCRequest.model_validate(obj).model_dump()
+
+    if isinstance(raw, list):
+        payload = [_ensure_id(item) for item in raw]
+    else:
+        payload = _ensure_id(raw)
+
+    log.debug("RPC in  <- %s", payload)
     resp = await rpc.dispatch(payload)
-    if "error" in resp:
-        log.warning(f"{body.method} '{body}'")
-        log.warning(f"{body.method} '{resp['error']}'")
+    if isinstance(resp, dict) and "error" in resp:
+        method = payload.get("method") if isinstance(payload, dict) else "batch"
+        log.warning(f"{method} '{resp['error']}'")
     log.debug("RPC out -> %s", resp)
     return resp
 
@@ -216,29 +214,26 @@ async def task_submit(
     deps: list[str] | None = None,
     edge_pred: str | None = None,
     labels: list[str] | None = None,
+    in_degree: int | None = None,
     config_toml: str | None = None,
 ):
     await queue.sadd("pools", pool)  # track pool even if not created
 
-    if taskId:
-        task = Task(
-            id=taskId,
-            pool=pool,
-            payload=payload,
-            deps=deps or [],
-            edge_pred=edge_pred,
-            labels=labels or [],
-            config_toml=config_toml,
-        )
-    else:
-        task = Task(
-            pool=pool,
-            payload=payload,
-            deps=deps or [],
-            edge_pred=edge_pred,
-            labels=labels or [],
-            config_toml=config_toml,
-        )
+    if taskId and await _load_task(taskId):
+        new_id = str(uuid.uuid4())
+        log.warning("task id collision: %s → %s", taskId, new_id)
+        taskId = new_id
+
+    task = Task(
+        id=taskId or str(uuid.uuid4()),
+        pool=pool,
+        payload=payload,
+        deps=deps or [],
+        edge_pred=edge_pred,
+        labels=labels or [],
+        in_degree=in_degree or 0,
+        config_toml=config_toml,
+    )
 
     # 1) put on the queue for the scheduler
     await queue.rpush(f"queue:{pool}", task.model_dump_json())

--- a/pkgs/standards/peagen/peagen/models/schemas.py
+++ b/pkgs/standards/peagen/peagen/models/schemas.py
@@ -31,6 +31,7 @@ class Task(BaseModel):
     deps: List[str] = Field(default_factory=list)
     edge_pred: str | None = None
     labels: List[str] = Field(default_factory=list)
+    in_degree: int = 0
     config_toml: str | None = None
 
     def get(self, key: str, default=None):

--- a/pkgs/standards/peagen/peagen/models/task_run.py
+++ b/pkgs/standards/peagen/peagen/models/task_run.py
@@ -32,6 +32,7 @@ class TaskRun(Base):
     deps         = Column(JSON, nullable=False, default=list)
     edge_pred    = Column(String, nullable=True)
     labels       = Column(JSON, nullable=False, default=list)
+    in_degree    = Column(psql.INTEGER, nullable=False, default=0)
     config_toml  = Column(String, nullable=True)
     artifact_uri = Column(String, nullable=True)
     started_at   = Column(TIMESTAMP(timezone=True), default=dt.datetime.utcnow)
@@ -51,6 +52,7 @@ class TaskRun(Base):
             deps=task.deps,
             edge_pred=task.edge_pred,
             labels=task.labels,
+            in_degree=task.in_degree,
             config_toml=task.config_toml,
             artifact_uri=(
                 task.result.get("artifact_uri")
@@ -88,6 +90,7 @@ class TaskRun(Base):
             "deps": self.deps,
             "edge_pred": self.edge_pred,
             "labels": self.labels,
+            "in_degree": self.in_degree,
             "config_toml": self.config_toml,
             "artifact_uri": self.artifact_uri,
             "started_at": self.started_at,

--- a/pkgs/standards/peagen/peagen/transport/jsonrpc.py
+++ b/pkgs/standards/peagen/peagen/transport/jsonrpc.py
@@ -17,7 +17,11 @@ class RPCDispatcher:
             return fn
         return decorator
 
-    async def dispatch(self, req: dict) -> dict:
+    async def dispatch(self, req: dict | list) -> dict | list:
+        """Dispatch a single request or a batch of requests."""
+        if isinstance(req, list):
+            return [await self.dispatch(r) for r in req]
+
         if req.get("jsonrpc") != "2.0" or "method" not in req:
             return self._error(-32600, "Invalid Request", req.get("id"))
 
@@ -31,7 +35,7 @@ class RPCDispatcher:
             if inspect.isawaitable(result):
                 result = await result
             return {"jsonrpc": "2.0", "result": result, "id": req["id"]}
-        except Exception as exc:                        # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             return self._error(-32000, str(exc), req["id"])
 
     @staticmethod

--- a/pkgs/standards/peagen/tests/unit/test_rpc_batch.py
+++ b/pkgs/standards/peagen/tests/unit/test_rpc_batch.py
@@ -1,0 +1,19 @@
+import pytest
+from peagen.transport import RPCDispatcher
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_rpc_batch_dispatch():
+    rpc = RPCDispatcher()
+
+    @rpc.method("echo")
+    async def echo(value):
+        return value
+
+    req = [
+        {"jsonrpc": "2.0", "id": 1, "method": "echo", "params": {"value": "a"}},
+        {"jsonrpc": "2.0", "id": 2, "method": "echo", "params": {"value": "b"}},
+    ]
+    resp = await rpc.dispatch(req)
+    assert [r["result"] for r in resp] == ["a", "b"]
+

--- a/pkgs/standards/peagen/tests/unit/test_task_id_collision.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_id_collision.py
@@ -1,0 +1,46 @@
+import pytest
+
+from peagen.plugins.queues.in_memory_queue import InMemoryQueue
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_task_submit_id_collision(monkeypatch):
+    q = InMemoryQueue()
+
+    class DummyBackend:
+        async def store(self, task_run):
+            pass
+
+    class StubPM:
+        def __init__(self, cfg):
+            pass
+
+        def get(self, group):
+            if group == "queues":
+                return q
+            if group == "result_backends":
+                return DummyBackend()
+            return None
+
+    import importlib
+    import peagen.plugins
+
+    monkeypatch.setattr(peagen.plugins, "PluginManager", StubPM)
+    import peagen.gateway as gw
+    importlib.reload(gw)
+
+    monkeypatch.setattr(gw, "queue", q)
+    monkeypatch.setattr(gw, "result_backend", DummyBackend())
+    async def noop(task):
+        return None
+
+    monkeypatch.setattr(gw, "_persist", noop)
+    monkeypatch.setattr(gw, "_publish_event", noop)
+
+    task_submit = gw.task_submit
+
+    r1 = await task_submit(pool="p", payload={}, taskId="dup")
+    r2 = await task_submit(pool="p", payload={}, taskId="dup")
+    assert r1["taskId"] == "dup"
+    assert r2["taskId"] != "dup"
+

--- a/pkgs/standards/peagen/tests/unit/test_task_metadata.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_metadata.py
@@ -12,6 +12,7 @@ async def test_task_model_roundtrip():
         deps=["a"],
         edge_pred="e",
         labels=["l"],
+        in_degree=2,
         config_toml="cfg",
     )
     dumped = t.model_dump_json()
@@ -19,17 +20,19 @@ async def test_task_model_roundtrip():
     assert t2.deps == ["a"]
     assert t2.edge_pred == "e"
     assert t2.labels == ["l"]
+    assert t2.in_degree == 2
     assert t2.config_toml == "cfg"
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_taskrun_from_task():
-    t = Task(pool="p", payload={}, deps=["a"], edge_pred="e", labels=["l"], config_toml="c")
+    t = Task(pool="p", payload={}, deps=["a"], edge_pred="e", labels=["l"], in_degree=1, config_toml="c")
     tr = TaskRun.from_task(t)
     assert tr.deps == ["a"]
     assert tr.edge_pred == "e"
     assert tr.labels == ["l"]
+    assert tr.in_degree == 1
     assert tr.config_toml == "c"
 
 
@@ -78,6 +81,7 @@ async def test_task_submit_roundtrip(monkeypatch):
         deps=["d"],
         edge_pred="ep",
         labels=["lab"],
+        in_degree=0,
         config_toml="cfg",
     )
     tid = result["taskId"]
@@ -85,4 +89,5 @@ async def test_task_submit_roundtrip(monkeypatch):
     assert stored["deps"] == ["d"]
     assert stored["edge_pred"] == "ep"
     assert stored["labels"] == ["lab"]
+    assert stored["in_degree"] == 0
     assert stored["config_toml"] == "cfg"


### PR DESCRIPTION
## Summary
- extend Task model with `in_degree`
- support batched JSON‑RPC requests in the gateway and dispatcher
- detect ID collisions in `Task.submit`
- add unit tests for batch dispatch and collision handling

## Testing
- `ruff check .`
- `uv run --package peagen --directory standards/peagen pytest`


------
https://chatgpt.com/codex/tasks/task_e_684962fd365c8326b7f99dcc56651f75