### PR TITLE
Add label-aware task control

### DIFF
--- a/pkgs/standards/peagen/migrations/versions/ae1de73e4143_init.py
+++ b/pkgs/standards/peagen/migrations/versions/ae1de73e4143_init.py
@@ -29,6 +29,7 @@ def upgrade() -> None:
             sa.Column("deps", sa.JSON(), nullable=False),
             sa.Column("edge_pred", sa.String()),
             sa.Column("labels", sa.JSON(), nullable=False),
+            sa.Column("groups", sa.JSON(), nullable=False),
             sa.Column("config_toml", sa.String()),
             sa.Column("artifact_uri", sa.String()),
             sa.Column("started_at", sa.TIMESTAMP(timezone=True)),

--- a/pkgs/standards/peagen/peagen/cli/commands/task.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/task.py
@@ -61,3 +61,53 @@ def patch_task(
     }
     res = httpx.post(ctx.obj.get("gateway_url"), json=req, timeout=30.0).json()
     typer.echo(json.dumps(res["result"], indent=2))
+
+
+def _simple_rpc(ctx: typer.Context, method: str, params: dict) -> None:
+    req = {"jsonrpc": "2.0", "id": str(uuid.uuid4()), "method": method, "params": params}
+    res = httpx.post(ctx.obj.get("gateway_url"), json=req, timeout=30.0).json()
+    typer.echo(json.dumps(res.get("result", res), indent=2))
+
+
+def _id_or_label(identifier: str) -> tuple[str, str]:
+    """Return parameter key/value for task or label identifier."""
+    try:
+        uuid.UUID(identifier)
+        return "taskId", identifier
+    except ValueError:
+        return "label", identifier
+
+
+@remote_task_app.command("pause")
+def pause(ctx: typer.Context, identifier: str = typer.Argument(...)):
+    """Pause a running task."""
+    key, value = _id_or_label(identifier)
+    _simple_rpc(ctx, "Task.pause", {key: value})
+
+
+@remote_task_app.command("resume")
+def resume(ctx: typer.Context, identifier: str = typer.Argument(...)):
+    """Resume a paused task."""
+    key, value = _id_or_label(identifier)
+    _simple_rpc(ctx, "Task.resume", {key: value})
+
+
+@remote_task_app.command("cancel")
+def cancel(ctx: typer.Context, identifier: str = typer.Argument(...)):
+    """Cancel a task."""
+    key, value = _id_or_label(identifier)
+    _simple_rpc(ctx, "Task.cancel", {key: value})
+
+
+@remote_task_app.command("retry")
+def retry(ctx: typer.Context, identifier: str = typer.Argument(...)):
+    """Retry a task from the beginning."""
+    key, value = _id_or_label(identifier)
+    _simple_rpc(ctx, "Task.retry", {key: value})
+
+
+@remote_task_app.command("retry-from")
+def retry_from(ctx: typer.Context, identifier: str = typer.Argument(...), start_idx: int = typer.Argument(...)):
+    """Retry a task from a specific index."""
+    key, value = _id_or_label(identifier)
+    _simple_rpc(ctx, "Task.retryFrom", {key: value, "start_idx": start_idx})

--- a/pkgs/standards/peagen/peagen/models/schemas.py
+++ b/pkgs/standards/peagen/peagen/models/schemas.py
@@ -20,6 +20,7 @@ class Status(str, Enum):
     success = "success"
     failed = "failed"
     cancelled = "cancelled"
+    paused = "paused"
 
 
 class Task(BaseModel):
@@ -31,6 +32,7 @@ class Task(BaseModel):
     deps: List[str] = Field(default_factory=list)
     edge_pred: str | None = None
     labels: List[str] = Field(default_factory=list)
+    groups: List[str] = Field(default_factory=list)
     config_toml: str | None = None
 
     def get(self, key: str, default=None):

--- a/pkgs/standards/peagen/peagen/models/task_run.py
+++ b/pkgs/standards/peagen/peagen/models/task_run.py
@@ -32,6 +32,7 @@ class TaskRun(Base):
     deps         = Column(JSON, nullable=False, default=list)
     edge_pred    = Column(String, nullable=True)
     labels       = Column(JSON, nullable=False, default=list)
+    groups       = Column(JSON, nullable=False, default=list)
     config_toml  = Column(String, nullable=True)
     artifact_uri = Column(String, nullable=True)
     started_at   = Column(TIMESTAMP(timezone=True), default=dt.datetime.utcnow)
@@ -51,6 +52,7 @@ class TaskRun(Base):
             deps=task.deps,
             edge_pred=task.edge_pred,
             labels=task.labels,
+            groups=task.groups,
             config_toml=task.config_toml,
             artifact_uri=(
                 task.result.get("artifact_uri")
@@ -88,6 +90,7 @@ class TaskRun(Base):
             "deps": self.deps,
             "edge_pred": self.edge_pred,
             "labels": self.labels,
+            "groups": self.groups,
             "config_toml": self.config_toml,
             "artifact_uri": self.artifact_uri,
             "started_at": self.started_at,

--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -72,6 +72,8 @@ class WorkerBase:
         self.DQ_GATEWAY = gateway or os.getenv("DQ_GATEWAY", "http://localhost:8000/rpc")
         self.WORKER_ID = worker_id or os.getenv("DQ_WORKER_ID", str(uuid.uuid4())[:8])
         self.PORT = port or int(os.getenv("PORT", "8001"))
+        self.LABELS = os.getenv("DQ_LABELS", "").split(",") if os.getenv("DQ_LABELS") else []
+        self.GROUPS = os.getenv("DQ_GROUPS", "").split(",") if os.getenv("DQ_GROUPS") else []
         env_host = host or os.getenv("DQ_HOST", "")
         if not env_host:
             env_host = get_local_ip()
@@ -256,7 +258,11 @@ class WorkerBase:
                 "workerId": self.WORKER_ID,
                 "pool": self.POOL,
                 "url": self.url_self,
-                "advertises": {"cpu": True},
+                "advertises": {
+                    "cpu": True,
+                    "labels": self.LABELS,
+                    "groups": self.GROUPS,
+                },
             },
         )
         self.log.info("registered  id=%s pool=%s url=%s", self.WORKER_ID, self.POOL, self.url_self)


### PR DESCRIPTION
## Summary
- allow task CLI commands to target task id or label
- expand gateway RPC methods to accept either identifier
- fix label lookup using in-memory filtering

## Testing
- `ruff check .`
- `python -m py_compile pkgs/standards/peagen/peagen/cli/commands/task.py pkgs/standards/peagen/peagen/gateway/__init__.py pkgs/standards/peagen/peagen/models/schemas.py pkgs/standards/peagen/peagen/models/task_run.py pkgs/standards/peagen/peagen/worker/base.py`
- `uv run --package peagen --directory standards/peagen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68496387370c8326acd24bf8170367ee