### PR TITLE
Implement simple dependency handling in peagen

### DIFF
--- a/pkgs/standards/peagen/peagen/defaults.py
+++ b/pkgs/standards/peagen/peagen/defaults.py
@@ -32,3 +32,14 @@ CONFIG = {
     "ready_queue": "queue",          # prefix for per-pool ready queues
     "pubsub": "task:update",         # channel for task event broadcasts
 }
+
+# Built-in Redis key patterns
+WORKER_KEY = "worker:{}"        # format with workerId
+DEP_SET = "task:deps:{}"        # deps for task X
+CHILD_SET = "task:children:{}"  # children dependent on X
+LABEL_SET = "label:{}"          # tasks under a label
+
+# Default TTL values (seconds)
+WORKER_TTL = 15
+TASK_TTL = 24 * 3600
+

--- a/pkgs/standards/peagen/tests/unit/test_scheduler_deps.py
+++ b/pkgs/standards/peagen/tests/unit/test_scheduler_deps.py
@@ -1,0 +1,62 @@
+import importlib
+import pytest
+
+from peagen.models import Task
+from peagen.plugins.queues.in_memory_queue import InMemoryQueue
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dependency_resolution(monkeypatch):
+    q = InMemoryQueue()
+
+    class DummyBackend:
+        async def store(self, task_run):
+            pass
+
+    class StubPM:
+        def __init__(self, cfg):
+            pass
+        def get(self, group):
+            if group == "queues":
+                return q
+            if group == "result_backends":
+                return DummyBackend()
+            return None
+
+    import peagen.plugins
+    monkeypatch.setattr(peagen.plugins, "PluginManager", StubPM)
+    import peagen.gateway as gw
+    importlib.reload(gw)
+
+    monkeypatch.setattr(gw, "queue", q)
+    monkeypatch.setattr(gw, "result_backend", DummyBackend())
+
+    async def _noop(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(gw, "_persist", _noop)
+    monkeypatch.setattr(gw, "_publish_event", _noop)
+
+    submit = gw.task_submit
+    finish = gw.work_finished
+    get = gw.task_get
+
+    res = await submit(pool="p", payload={}, taskId="A", deps=None, labels=None, edge_pred=None)
+    aid = res["taskId"]
+    res2 = await submit(pool="p", payload={}, taskId="B", deps=[aid], edge_pred="results['A']['v']==1", labels=None)
+    bid = res2["taskId"]
+
+    # only A should be queued initially
+    queued = await q.lrange(f"{gw.READY_QUEUE}:p", 0, -1)
+    assert len(queued) == 1
+    assert Task.model_validate_json(queued[0]).id == aid
+
+    await finish(taskId=aid, status="success", result={"v": 1})
+
+    # B should now be queued
+    queued = await q.lrange(f"{gw.READY_QUEUE}:p", 0, -1)
+    ids = [Task.model_validate_json(x).id for x in queued]
+    assert bid in ids
+
+    btask = await get(bid)
+    assert btask["in_degree"] == 0


### PR DESCRIPTION
## Summary
- add label/dependency indexing helpers in gateway
- queue tasks only when all deps are resolved
- evaluate `edge_pred` predicates at dispatch time
- handle a minimal control queue for cancellations
- update scheduler loop to process control ops and check deps
- add unit test covering dependency-driven scheduling
- move gateway constants to defaults module

## Testing
- `ruff check standards/peagen`


------
https://chatgpt.com/codex/tasks/task_e_684963766d3083269c5a71aed9f1bbd1