### PR TITLE
Extend Status enum

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/doe.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/doe.py
@@ -25,7 +25,7 @@ def _make_task(args: dict) -> Task:
         id=str(uuid.uuid4()),
         pool="default",
         action="doe",
-        status=Status.pending,
+        status=Status.waiting,
         payload={"args": args},
     )
 

--- a/pkgs/standards/peagen/peagen/cli/commands/eval.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/eval.py
@@ -32,7 +32,7 @@ def _build_task(args: dict) -> Task:
         id=str(uuid.uuid4()),
         pool="default",
         action="eval",
-        status=Status.pending,
+        status=Status.waiting,
         payload={"args": args},
     )
 

--- a/pkgs/standards/peagen/peagen/cli/commands/fetch.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/fetch.py
@@ -32,7 +32,7 @@ def _build_task(args: dict) -> Task:
         id=str(uuid.uuid4()),
         pool="default",
         action="fetch",
-        status=Status.pending,
+        status=Status.waiting,
         payload={"args": args},
     )
 

--- a/pkgs/standards/peagen/peagen/models/schemas.py
+++ b/pkgs/standards/peagen/peagen/models/schemas.py
@@ -14,9 +14,15 @@ class Role(str, Enum):
 
 
 class Status(str, Enum):
-    pending = "pending"
+    queued = "queued"
+    waiting = "waiting"
+    input_required = "input_required"
+    auth_required = "auth_required"
+    approved = "approved"
+    rejected = "rejected"
     dispatched = "dispatched"
     running = "running"
+    paused = "paused"
     success = "success"
     failed = "failed"
     cancelled = "cancelled"
@@ -26,7 +32,7 @@ class Task(BaseModel):
     id: str = Field(default=str(uuid.uuid4()))
     pool: str
     payload: dict
-    status: Status = Status.pending
+    status: Status = Status.waiting
     result: Optional[dict] = None
     deps: List[str] = Field(default_factory=list)
     edge_pred: str | None = None

--- a/pkgs/standards/peagen/peagen/models/task_run.py
+++ b/pkgs/standards/peagen/peagen/models/task_run.py
@@ -14,7 +14,7 @@ Base = declarative_base()
 # POSTGRES ENUM  (single source of truth for every table + migration)
 # ────────────────────────────────────────────────────────────────────────
 status_enum = psql.ENUM(
-    *(s.value for s in Status),            # "pending", "running", ...
+    *(s.value for s in Status),            # "waiting", "running", ...
     name="status",
     create_type=False,                     # ← **critical**: never emit CREATE TYPE
 )
@@ -26,7 +26,7 @@ class TaskRun(Base):
     id           = Column(UUID(as_uuid=True), primary_key=True)
     pool         = Column(String)
     task_type    = Column(String)
-    status       = Column(status_enum, nullable=False, default=Status.pending.value)
+    status       = Column(status_enum, nullable=False, default=Status.waiting.value)
     payload      = Column(JSON)
     result       = Column(JSON, nullable=True)
     deps         = Column(JSON, nullable=False, default=list)


### PR DESCRIPTION
## Summary
- add new statuses and default to `waiting`
- update TaskRun defaults
- adjust CLI commands to use new default

## Testing
- `ruff check .`
- `uv run --package peagen --directory standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_684971fd9a9c8326bc52c31987e2008b