### PR TITLE
Add control-plane modules

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/doe.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/doe.py
@@ -25,7 +25,7 @@ def _make_task(args: dict) -> Task:
         id=str(uuid.uuid4()),
         pool="default",
         action="doe",
-        status=Status.pending,
+        status=Status.queued,
         payload={"args": args},
     )
 

--- a/pkgs/standards/peagen/peagen/cli/commands/eval.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/eval.py
@@ -32,7 +32,7 @@ def _build_task(args: dict) -> Task:
         id=str(uuid.uuid4()),
         pool="default",
         action="eval",
-        status=Status.pending,
+        status=Status.queued,
         payload={"args": args},
     )
 

--- a/pkgs/standards/peagen/peagen/cli/commands/fetch.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/fetch.py
@@ -32,7 +32,7 @@ def _build_task(args: dict) -> Task:
         id=str(uuid.uuid4()),
         pool="default",
         action="fetch",
-        status=Status.pending,
+        status=Status.queued,
         payload={"args": args},
     )
 

--- a/pkgs/standards/peagen/peagen/cli/commands/task.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/task.py
@@ -61,3 +61,44 @@ def patch_task(
     }
     res = httpx.post(ctx.obj.get("gateway_url"), json=req, timeout=30.0).json()
     typer.echo(json.dumps(res["result"], indent=2))
+
+
+def _simple_call(ctx: typer.Context, method: str, selector: str) -> None:
+    req = {
+        "jsonrpc": "2.0",
+        "id": str(uuid.uuid4()),
+        "method": method,
+        "params": {"selector": selector},
+    }
+    res = httpx.post(ctx.obj.get("gateway_url"), json=req, timeout=30.0).json()
+    typer.echo(json.dumps(res["result"], indent=2))
+
+
+@remote_task_app.command("pause")
+def pause(ctx: typer.Context, selector: str = typer.Argument(...)) -> None:
+    """Pause one task or all tasks matching a label."""
+    _simple_call(ctx, "Task.pause", selector)
+
+
+@remote_task_app.command("resume")
+def resume(ctx: typer.Context, selector: str = typer.Argument(...)) -> None:
+    """Resume a paused task or label set."""
+    _simple_call(ctx, "Task.resume", selector)
+
+
+@remote_task_app.command("cancel")
+def cancel(ctx: typer.Context, selector: str = typer.Argument(...)) -> None:
+    """Cancel a task or label set."""
+    _simple_call(ctx, "Task.cancel", selector)
+
+
+@remote_task_app.command("retry")
+def retry(ctx: typer.Context, selector: str = typer.Argument(...)) -> None:
+    """Retry a task or label set."""
+    _simple_call(ctx, "Task.retry", selector)
+
+
+@remote_task_app.command("retry-from")
+def retry_from(ctx: typer.Context, selector: str = typer.Argument(...)) -> None:
+    """Retry a task and its descendants."""
+    _simple_call(ctx, "Task.retry_from", selector)

--- a/pkgs/standards/peagen/peagen/core/control_core.py
+++ b/pkgs/standards/peagen/peagen/core/control_core.py
@@ -1,0 +1,38 @@
+"""Core helpers for task control-plane operations."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from peagen.models import Task, Status
+
+
+def pause(tasks: Iterable[Task]) -> int:
+    selected = list(tasks)
+    for t in selected:
+        t.status = Status.paused
+    return len(selected)
+
+
+def resume(tasks: Iterable[Task]) -> int:
+    selected = list(tasks)
+    for t in selected:
+        t.status = Status.waiting
+    return len(selected)
+
+
+def cancel(tasks: Iterable[Task]) -> int:
+    selected = list(tasks)
+    for t in selected:
+        t.status = Status.cancelled
+    return len(selected)
+
+
+def retry(tasks: Iterable[Task]) -> int:
+    selected = list(tasks)
+    for t in selected:
+        t.status = Status.queued
+    return len(selected)
+
+# retry_from behaves like retry for now
+retry_from = retry

--- a/pkgs/standards/peagen/peagen/defaults.py
+++ b/pkgs/standards/peagen/peagen/defaults.py
@@ -31,4 +31,5 @@ CONFIG = {
     "control_queue": "control",      # worker ↔ gateway control messages
     "ready_queue": "queue",          # prefix for per-pool ready queues
     "pubsub": "task:update",         # channel for task event broadcasts
+    "task_key": "task:{}",           # Redis hash per task
 }

--- a/pkgs/standards/peagen/peagen/handlers/control_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/control_handler.py
@@ -1,0 +1,48 @@
+"""Gateway helper for pause/resume/cancel/retry commands."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from peagen.plugins.queues import QueueBase
+from peagen.models import Task
+from peagen.core import control_core
+from peagen import defaults
+
+
+TASK_KEY = defaults.CONFIG["task_key"]
+
+
+async def save_task(queue: QueueBase, task: Task, ttl: int) -> None:
+    await queue.hset(
+        TASK_KEY.format(task.id),
+        mapping={"blob": task.model_dump_json(), "status": task.status.value},
+    )
+    await queue.expire(TASK_KEY.format(task.id), ttl)
+
+
+async def apply(
+    op: str,
+    queue: QueueBase,
+    tasks: Iterable[Task],
+    ready_prefix: str,
+    ttl: int,
+) -> int:
+    if op == "pause":
+        count = control_core.pause(tasks)
+    elif op == "resume":
+        count = control_core.resume(tasks)
+    elif op == "cancel":
+        count = control_core.cancel(tasks)
+    elif op == "retry_from":
+        count = control_core.retry_from(tasks)
+    elif op == "retry":
+        count = control_core.retry(tasks)
+    else:
+        return 0
+
+    for t in tasks:
+        await save_task(queue, t, ttl)
+        if op in {"retry", "retry_from"}:
+            await queue.rpush(f"{ready_prefix}:{t.pool}", t.model_dump_json())
+    return count

--- a/pkgs/standards/peagen/peagen/models/schemas.py
+++ b/pkgs/standards/peagen/peagen/models/schemas.py
@@ -14,9 +14,17 @@ class Role(str, Enum):
 
 
 class Status(str, Enum):
-    pending = "pending"
+    """Enumeration of task states."""
+
+    queued = "queued"
+    waiting = "waiting"
+    input_required = "input_required"
+    auth_required = "auth_required"
+    approved = "approved"
+    rejected = "rejected"
     dispatched = "dispatched"
     running = "running"
+    paused = "paused"
     success = "success"
     failed = "failed"
     cancelled = "cancelled"
@@ -26,7 +34,7 @@ class Task(BaseModel):
     id: str = Field(default=str(uuid.uuid4()))
     pool: str
     payload: dict
-    status: Status = Status.pending
+    status: Status = Status.queued
     result: Optional[dict] = None
     deps: List[str] = Field(default_factory=list)
     edge_pred: str | None = None

--- a/pkgs/standards/peagen/peagen/models/task_run.py
+++ b/pkgs/standards/peagen/peagen/models/task_run.py
@@ -14,7 +14,7 @@ Base = declarative_base()
 # POSTGRES ENUM  (single source of truth for every table + migration)
 # ────────────────────────────────────────────────────────────────────────
 status_enum = psql.ENUM(
-    *(s.value for s in Status),            # "pending", "running", ...
+    *(s.value for s in Status),            # "queued", "running", ...
     name="status",
     create_type=False,                     # ← **critical**: never emit CREATE TYPE
 )
@@ -26,7 +26,7 @@ class TaskRun(Base):
     id           = Column(UUID(as_uuid=True), primary_key=True)
     pool         = Column(String)
     task_type    = Column(String)
-    status       = Column(status_enum, nullable=False, default=Status.pending.value)
+    status       = Column(status_enum, nullable=False, default=Status.queued.value)
     payload      = Column(JSON)
     result       = Column(JSON, nullable=True)
     deps         = Column(JSON, nullable=False, default=list)


### PR DESCRIPTION
## Summary
- add `control_core` module for basic status mutations
- implement `control_handler` to persist state and push retries
- delegate gateway RPCs to the new handler
- remove obsolete `pending` status and default new tasks to `queued`
- move Redis key prefixes to peagen.defaults

## Testing
- `ruff check pkgs/standards/peagen/peagen/cli/commands/task.py pkgs/standards/peagen/peagen/gateway/__init__.py pkgs/standards/peagen/peagen/models/schemas.py pkgs/standards/peagen/peagen/core/control_core.py pkgs/standards/peagen/peagen/handlers/control_handler.py pkgs/standards/peagen/peagen/cli/commands/doe.py pkgs/standards/peagen/peagen/cli/commands/fetch.py pkgs/standards/peagen/peagen/cli/commands/eval.py pkgs/standards/peagen/peagen/models/task_run.py pkgs/standards/peagen/peagen/defaults.py`

------
https://chatgpt.com/codex/tasks/task_e_68497201b9f48326ae0a126860e2ecf7