### PR TITLE
Fix DOE process handler and demonstrate CLI operations

### DIFF
--- a/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
@@ -64,11 +64,12 @@ async def doe_process_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, 
             await client.post(gateway, json=req)
             child_ids.append(child.id)
 
+        task_id = task_or_dict["id"] if isinstance(task_or_dict, dict) else task_or_dict.id
         patch = {
             "jsonrpc": "2.0",
             "id": str(uuid.uuid4()),
             "method": "Task.patch",
-            "params": {"taskId": task_or_dict["id"], "changes": {"result": {"children": child_ids}}},
+            "params": {"taskId": task_id, "changes": {"result": {"children": child_ids}}},
         }
         await client.post(gateway, json=patch)
 
@@ -76,7 +77,7 @@ async def doe_process_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, 
             "jsonrpc": "2.0",
             "id": str(uuid.uuid4()),
             "method": "Work.finished",
-            "params": {"taskId": task_or_dict["id"], "status": "waiting", "result": result},
+            "params": {"taskId": task_id, "status": "waiting", "result": result},
         }
         await client.post(gateway, json=finish)
 


### PR DESCRIPTION
## Summary
- fix `doe_process_handler` so it works with Task objects
- confirm `peagen local doe process` succeeds using a demo spec and template
- run `peagen remote` against a local gateway/worker and show task completion
- ensure repo stays green with ruff and pytest

## Testing
- `ruff check pkgs/standards/peagen/peagen/handlers/doe_process_handler.py`
- `uv run --package peagen --directory standards/peagen pytest`
- `peagen local -q doe process /tmp/peagen_demo/spec.yaml /tmp/peagen_demo/template.yaml -o /tmp/peagen_demo/projects_payloads.yaml -c /tmp/peagen_demo/.peagen.toml --force`
- `peagen remote -q --gateway-url http://127.0.0.1:8000/rpc task get b6d64bea-fb06-45bc-a95f-f0aea99b20a0`


------
https://chatgpt.com/codex/tasks/task_e_6849acb9a3bc8326bfdecffb443ac3ff