### PR TITLE
Add help text for peagen CLI args

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/__init__.py
+++ b/pkgs/standards/peagen/peagen/cli/__init__.py
@@ -39,8 +39,12 @@ from .commands import (
 )
 
 app = typer.Typer(help="CLI tool for processing project files using Peagen.")
-local_app = typer.Typer()  # will host all *run* commands
-remote_app = typer.Typer()  # will host all *submit* commands
+local_app = typer.Typer(
+    help="Commands executed locally on this machine."
+)
+remote_app = typer.Typer(
+    help="Commands that submit tasks to a JSON-RPC gateway."
+)
 
 
 # ───────────────────── LOCAL GLOBAL CALLBACK ───────────────────────────────
@@ -123,6 +127,7 @@ def _global_remote_ctx(  # noqa: D401
     verbose: int = typer.Option(0, "-v", "--verbose", count=True),
     quiet: bool = typer.Option(False, "-q", "--quiet"),
 ) -> None:
+    """Set remote command defaults and stash them in ``ctx.obj``."""
     if not quiet:
         _print_banner()
     ctx.ensure_object(dict)

--- a/pkgs/standards/peagen/peagen/cli/commands/doe.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/doe.py
@@ -35,16 +35,38 @@ def _make_task(args: dict, action: str = "doe") -> Task:
 @local_doe_app.command("gen")
 def run_gen(  # noqa: PLR0913
     ctx: typer.Context,
-    spec: Path = typer.Argument(..., exists=True),
-    template: Path = typer.Argument(..., exists=True),
-    output: Path = typer.Option("project_payloads.yaml", "--output", "-o"),
-    config: Optional[Path] = typer.Option(None, "-c", "--config"),
-    notify: Optional[str] = typer.Option(None, "--notify"),
-    dry_run: bool = typer.Option(False, "--dry-run"),
-    force: bool = typer.Option(False, "--force"),
-    skip_validate: bool = typer.Option(False, "--skip-validate"),
-    json_out: bool = typer.Option(False, "--json"),
-):
+    spec: Path = typer.Argument(
+        ..., exists=True, help="Path to the DOE specification YAML"
+    ),
+    template: Path = typer.Argument(
+        ..., exists=True, help="Path to the project-payload template"
+    ),
+    output: Path = typer.Option(
+        "project_payloads.yaml",
+        "--output",
+        "-o",
+        help="Destination YAML file for generated payloads",
+    ),
+    config: Optional[Path] = typer.Option(
+        None, "-c", "--config", help="Override configuration for this run"
+    ),
+    notify: Optional[str] = typer.Option(
+        None, "--notify", help="Webhook URL for completion notification"
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Simulate the run without writing files"
+    ),
+    force: bool = typer.Option(
+        False, "--force", help="Overwrite output even if it exists"
+    ),
+    skip_validate: bool = typer.Option(
+        False, "--skip-validate", help="Skip validating the DOE spec"
+    ),
+    json_out: bool = typer.Option(
+        False, "--json", help="Print the result dictionary as JSON"
+    ),
+) -> None:
+    """Generate a project‑payload bundle from a DOE spec locally."""
     args = {
         "spec": str(spec),
         "template": str(template),
@@ -66,15 +88,35 @@ def run_gen(  # noqa: PLR0913
 @remote_doe_app.command("gen")
 def submit_gen(  # noqa: PLR0913
     ctx: typer.Context,
-    spec: Path = typer.Argument(..., exists=True),
-    template: Path = typer.Argument(..., exists=True),
-    output: Path = typer.Option("project_payloads.yaml", "--output", "-o"),
-    config: Optional[Path] = typer.Option(None, "-c", "--config"),
-    notify: Optional[str] = typer.Option(None, "--notify"),
-    dry_run: bool = typer.Option(False, "--dry-run"),
-    force: bool = typer.Option(False, "--force"),
-    skip_validate: bool = typer.Option(False, "--skip-validate"),
-):
+    spec: Path = typer.Argument(
+        ..., exists=True, help="Path to the DOE specification YAML"
+    ),
+    template: Path = typer.Argument(
+        ..., exists=True, help="Path to the project-payload template"
+    ),
+    output: Path = typer.Option(
+        "project_payloads.yaml",
+        "--output",
+        "-o",
+        help="Destination YAML file for generated payloads",
+    ),
+    config: Optional[Path] = typer.Option(
+        None, "-c", "--config", help="Override configuration for this run"
+    ),
+    notify: Optional[str] = typer.Option(
+        None, "--notify", help="Webhook URL for completion notification"
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Simulate the run without writing files"
+    ),
+    force: bool = typer.Option(
+        False, "--force", help="Overwrite output even if it exists"
+    ),
+    skip_validate: bool = typer.Option(
+        False, "--skip-validate", help="Skip validating the DOE spec"
+    ),
+) -> None:
+    """Submit a DOE generation task to a remote worker."""
     args = {
         "spec": str(spec),
         "template": str(template),
@@ -111,16 +153,38 @@ def submit_gen(  # noqa: PLR0913
 @local_doe_app.command("process")
 def run_process(  # noqa: PLR0913
     ctx: typer.Context,
-    spec: Path = typer.Argument(..., exists=True),
-    template: Path = typer.Argument(..., exists=True),
-    output: Path = typer.Option("project_payloads.yaml", "--output", "-o"),
-    config: Optional[Path] = typer.Option(None, "-c", "--config"),
-    notify: Optional[str] = typer.Option(None, "--notify"),
-    dry_run: bool = typer.Option(False, "--dry-run"),
-    force: bool = typer.Option(False, "--force"),
-    skip_validate: bool = typer.Option(False, "--skip-validate"),
-    json_out: bool = typer.Option(False, "--json"),
-):
+    spec: Path = typer.Argument(
+        ..., exists=True, help="Path to the DOE specification YAML"
+    ),
+    template: Path = typer.Argument(
+        ..., exists=True, help="Path to the project-payload template"
+    ),
+    output: Path = typer.Option(
+        "project_payloads.yaml",
+        "--output",
+        "-o",
+        help="Destination YAML file for generated payloads",
+    ),
+    config: Optional[Path] = typer.Option(
+        None, "-c", "--config", help="Override configuration for this run"
+    ),
+    notify: Optional[str] = typer.Option(
+        None, "--notify", help="Webhook URL for completion notification"
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Simulate the run without writing files"
+    ),
+    force: bool = typer.Option(
+        False, "--force", help="Overwrite output even if it exists"
+    ),
+    skip_validate: bool = typer.Option(
+        False, "--skip-validate", help="Skip validating the DOE spec"
+    ),
+    json_out: bool = typer.Option(
+        False, "--json", help="Print the result dictionary as JSON"
+    ),
+) -> None:
+    """Process a DOE specification locally."""
     args = {
         "spec": str(spec),
         "template": str(template),
@@ -142,15 +206,35 @@ def run_process(  # noqa: PLR0913
 @remote_doe_app.command("process")
 def submit_process(  # noqa: PLR0913
     ctx: typer.Context,
-    spec: Path = typer.Argument(..., exists=True),
-    template: Path = typer.Argument(..., exists=True),
-    output: Path = typer.Option("project_payloads.yaml", "--output", "-o"),
-    config: Optional[Path] = typer.Option(None, "-c", "--config"),
-    notify: Optional[str] = typer.Option(None, "--notify"),
-    dry_run: bool = typer.Option(False, "--dry-run"),
-    force: bool = typer.Option(False, "--force"),
-    skip_validate: bool = typer.Option(False, "--skip-validate"),
-):
+    spec: Path = typer.Argument(
+        ..., exists=True, help="Path to the DOE specification YAML"
+    ),
+    template: Path = typer.Argument(
+        ..., exists=True, help="Path to the project-payload template"
+    ),
+    output: Path = typer.Option(
+        "project_payloads.yaml",
+        "--output",
+        "-o",
+        help="Destination YAML file for generated payloads",
+    ),
+    config: Optional[Path] = typer.Option(
+        None, "-c", "--config", help="Override configuration for this run"
+    ),
+    notify: Optional[str] = typer.Option(
+        None, "--notify", help="Webhook URL for completion notification"
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Simulate the run without writing files"
+    ),
+    force: bool = typer.Option(
+        False, "--force", help="Overwrite output even if it exists"
+    ),
+    skip_validate: bool = typer.Option(
+        False, "--skip-validate", help="Skip validating the DOE spec"
+    ),
+) -> None:
+    """Enqueue DOE processing on a remote worker."""
     args = {
         "spec": str(spec),
         "template": str(template),

--- a/pkgs/standards/peagen/peagen/cli/commands/eval.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/eval.py
@@ -82,12 +82,24 @@ def run(  # noqa: PLR0913 – CLI needs many options
 @remote_eval_app.command("eval")
 def submit(  # noqa: PLR0913
     ctx: typer.Context,
-    workspace_uri: str = typer.Argument(...),
-    program_glob: str = typer.Argument("**/*.*"),
-    pool: Optional[str] = typer.Option(None, "--pool", "-p"),
-    async_eval: bool = typer.Option(False, "--async/--no-async"),
-    strict: bool = typer.Option(False, "--strict"),
-    skip_failed: bool = typer.Option(False, "--skip-failed/--include-failed"),
+    workspace_uri: str = typer.Argument(
+        ..., help="Workspace path or URI"
+    ),
+    program_glob: str = typer.Argument(
+        "**/*.*", help="Glob pattern for program files"
+    ),
+    pool: Optional[str] = typer.Option(
+        None, "--pool", "-p", help="EvaluatorPool reference"
+    ),
+    async_eval: bool = typer.Option(
+        False, "--async/--no-async", help="Run evaluations asynchronously"
+    ),
+    strict: bool = typer.Option(
+        False, "--strict", help="Fail if any program exit code is non-zero"
+    ),
+    skip_failed: bool = typer.Option(
+        False, "--skip-failed/--include-failed", help="Ignore failed programs"
+    ),
 ):
     """Enqueue evaluation on a remote worker."""
     args = {

--- a/pkgs/standards/peagen/peagen/cli/commands/fetch.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/fetch.py
@@ -80,10 +80,20 @@ def run(
 @remote_fetch_app.command("fetch")
 def submit(
     ctx: typer.Context,
-    manifests: List[str] = typer.Argument(...),
-    out_dir: Optional[Path] = typer.Option(None, "--out", "-o"),
-    no_source: bool = typer.Option(False, "--no-source/--with-source"),
-    install_template_sets_flag: bool = typer.Option(True)
+    manifests: List[str] = typer.Argument(
+        ..., help="Manifest JSON URI(s)"
+    ),
+    out_dir: Optional[Path] = typer.Option(
+        None, "--out", "-o", help="Destination folder on the worker"
+    ),
+    no_source: bool = typer.Option(
+        False, "--no-source/--with-source", help="Skip cloning source packages"
+    ),
+    install_template_sets_flag: bool = typer.Option(
+        True,
+        "--install-template-sets/--no-install-template-sets",
+        help="Install template sets referenced by the manifest(s)",
+    )
 ):
     """Enqueue the fetch task on a worker farm and return immediately."""
     args = _collect_args(manifests, out_dir, no_source, install_template_sets_flag)

--- a/pkgs/standards/peagen/peagen/cli/commands/init.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/init.py
@@ -31,11 +31,21 @@ remote_init_app = typer.Typer(
 @local_init_app.command("project")
 def local_init_project(
     ctx: typer.Context,
-    path: Path = typer.Argument(".", exists=False, dir_okay=True, file_okay=False),
-    template_set: str = typer.Option("default", "--template-set"),
-    provider: Optional[str] = typer.Option(None, "--provider"),
-    with_doe: bool = typer.Option(False, "--with-doe"),
-    with_eval_stub: bool = typer.Option(False, "--with-eval-stub"),
+    path: Path = typer.Argument(
+        ".", exists=False, dir_okay=True, file_okay=False, help="Target directory"
+    ),
+    template_set: str = typer.Option(
+        "default", "--template-set", help="Template-set to initialise with"
+    ),
+    provider: Optional[str] = typer.Option(
+        None, "--provider", help="LLM provider slug for the project"
+    ),
+    with_doe: bool = typer.Option(
+        False, "--with-doe", help="Also create a DOE specification stub"
+    ),
+    with_eval_stub: bool = typer.Option(
+        False, "--with-eval-stub", help="Add an evaluation harness"
+    ),
     force: bool = typer.Option(False, "--force", help="Overwrite if dir not empty."),
 ):
     """Create a new Peagen project skeleton locally."""
@@ -59,11 +69,21 @@ def local_init_project(
 @remote_init_app.command("project")
 def remote_init_project(
     ctx: typer.Context,
-    path: Path = typer.Argument(".", exists=False, dir_okay=True, file_okay=False),
-    template_set: str = typer.Option("default", "--template-set"),
-    provider: Optional[str] = typer.Option(None, "--provider"),
-    with_doe: bool = typer.Option(False, "--with-doe"),
-    with_eval_stub: bool = typer.Option(False, "--with-eval-stub"),
+    path: Path = typer.Argument(
+        ".", exists=False, dir_okay=True, file_okay=False, help="Target directory"
+    ),
+    template_set: str = typer.Option(
+        "default", "--template-set", help="Template-set to initialise with"
+    ),
+    provider: Optional[str] = typer.Option(
+        None, "--provider", help="LLM provider slug for the project"
+    ),
+    with_doe: bool = typer.Option(
+        False, "--with-doe", help="Also create a DOE specification stub"
+    ),
+    with_eval_stub: bool = typer.Option(
+        False, "--with-eval-stub", help="Add an evaluation harness"
+    ),
     force: bool = typer.Option(False, "--force", help="Overwrite if dir not empty."),
     gateway_url: str = typer.Option(
         DEFAULT_GATEWAY, "--gateway-url", help="JSON-RPC gateway endpoint"
@@ -86,11 +106,21 @@ def remote_init_project(
 @local_init_app.command("template-set")
 def local_init_template_set(
     ctx: typer.Context,
-    path: Path = typer.Argument(".", dir_okay=True, file_okay=False),
-    name: Optional[str] = typer.Option(None, "--name", help="Template-set ID."),
-    org: Optional[str] = typer.Option(None, "--org"),
-    use_uv: bool = typer.Option(True, "--uv/--no-uv"),
-    force: bool = typer.Option(False, "--force"),
+    path: Path = typer.Argument(
+        ".", dir_okay=True, file_okay=False, help="Location for the new package"
+    ),
+    name: Optional[str] = typer.Option(
+        None, "--name", help="Template-set identifier"
+    ),
+    org: Optional[str] = typer.Option(
+        None, "--org", help="Organisation or namespace"
+    ),
+    use_uv: bool = typer.Option(
+        True, "--uv/--no-uv", help="Use uv for installing dependencies"
+    ),
+    force: bool = typer.Option(
+        False, "--force", help="Overwrite destination if not empty"
+    ),
 ):
     """Create a template-set wheel skeleton locally."""
     self = Logger(name="init_template_set")
@@ -112,11 +142,21 @@ def local_init_template_set(
 @remote_init_app.command("template-set")
 def remote_init_template_set(
     ctx: typer.Context,
-    path: Path = typer.Argument(".", dir_okay=True, file_okay=False),
-    name: Optional[str] = typer.Option(None, "--name", help="Template-set ID."),
-    org: Optional[str] = typer.Option(None, "--org"),
-    use_uv: bool = typer.Option(True, "--uv/--no-uv"),
-    force: bool = typer.Option(False, "--force"),
+    path: Path = typer.Argument(
+        ".", dir_okay=True, file_okay=False, help="Location for the new package"
+    ),
+    name: Optional[str] = typer.Option(
+        None, "--name", help="Template-set identifier"
+    ),
+    org: Optional[str] = typer.Option(
+        None, "--org", help="Organisation or namespace"
+    ),
+    use_uv: bool = typer.Option(
+        True, "--uv/--no-uv", help="Use uv for installing dependencies"
+    ),
+    force: bool = typer.Option(
+        False, "--force", help="Overwrite destination if not empty"
+    ),
     gateway_url: str = typer.Option(
         DEFAULT_GATEWAY, "--gateway-url", help="JSON-RPC gateway endpoint"
     ),
@@ -137,10 +177,18 @@ def remote_init_template_set(
 @local_init_app.command("doe-spec")
 def local_init_doe_spec(
     ctx: typer.Context,
-    path: Path = typer.Argument(".", dir_okay=True, file_okay=False),
-    name: Optional[str] = typer.Option(None, "--name"),
-    org: Optional[str] = typer.Option(None, "--org"),
-    force: bool = typer.Option(False, "--force"),
+    path: Path = typer.Argument(
+        ".", dir_okay=True, file_okay=False, help="Directory for the spec"
+    ),
+    name: Optional[str] = typer.Option(
+        None, "--name", help="DOE spec identifier"
+    ),
+    org: Optional[str] = typer.Option(
+        None, "--org", help="Organisation or namespace"
+    ),
+    force: bool = typer.Option(
+        False, "--force", help="Overwrite destination if not empty"
+    ),
 ):
     """Create a DOE-spec stub locally."""
     self = Logger(name="init_doe_spec")
@@ -160,10 +208,18 @@ def local_init_doe_spec(
 @remote_init_app.command("doe-spec")
 def remote_init_doe_spec(
     ctx: typer.Context,
-    path: Path = typer.Argument(".", dir_okay=True, file_okay=False),
-    name: Optional[str] = typer.Option(None, "--name"),
-    org: Optional[str] = typer.Option(None, "--org"),
-    force: bool = typer.Option(False, "--force"),
+    path: Path = typer.Argument(
+        ".", dir_okay=True, file_okay=False, help="Directory for the spec"
+    ),
+    name: Optional[str] = typer.Option(
+        None, "--name", help="DOE spec identifier"
+    ),
+    org: Optional[str] = typer.Option(
+        None, "--org", help="Organisation or namespace"
+    ),
+    force: bool = typer.Option(
+        False, "--force", help="Overwrite destination if not empty"
+    ),
     gateway_url: str = typer.Option(
         DEFAULT_GATEWAY, "--gateway-url", help="JSON-RPC gateway endpoint"
     ),
@@ -183,9 +239,15 @@ def remote_init_doe_spec(
 @local_init_app.command("ci")
 def local_init_ci(
     ctx: typer.Context,
-    path: Path = typer.Argument(".", dir_okay=True, file_okay=False),
-    github: bool = typer.Option(True, "--github/--gitlab"),
-    force: bool = typer.Option(False, "--force"),
+    path: Path = typer.Argument(
+        ".", dir_okay=True, file_okay=False, help="Directory for the CI file"
+    ),
+    github: bool = typer.Option(
+        True, "--github/--gitlab", help="Generate config for GitHub or GitLab"
+    ),
+    force: bool = typer.Option(
+        False, "--force", help="Overwrite destination if not empty"
+    ),
 ):
     """Drop a CI pipeline file for GitHub or GitLab locally."""
     self = Logger(name="init_ci")
@@ -204,9 +266,15 @@ def local_init_ci(
 @remote_init_app.command("ci")
 def remote_init_ci(
     ctx: typer.Context,
-    path: Path = typer.Argument(".", dir_okay=True, file_okay=False),
-    github: bool = typer.Option(True, "--github/--gitlab"),
-    force: bool = typer.Option(False, "--force"),
+    path: Path = typer.Argument(
+        ".", dir_okay=True, file_okay=False, help="Directory for the CI file"
+    ),
+    github: bool = typer.Option(
+        True, "--github/--gitlab", help="Generate config for GitHub or GitLab"
+    ),
+    force: bool = typer.Option(
+        False, "--force", help="Overwrite destination if not empty"
+    ),
     gateway_url: str = typer.Option(
         DEFAULT_GATEWAY, "--gateway-url", help="JSON-RPC gateway endpoint"
     ),

--- a/pkgs/standards/peagen/peagen/cli/commands/mutate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/mutate.py
@@ -37,9 +37,14 @@ def run(
     entry_fn: str = typer.Option(..., help="Benchmark function"),
     profile_mod: Optional[str] = typer.Option(None, help="Profile helper module"),
     gens: int = typer.Option(1, help="Number of generations"),
-    json_out: bool = typer.Option(False, "--json"),
-    out: Optional[Path] = typer.Option(None, "--out"),
-):
+    json_out: bool = typer.Option(
+        False, "--json", help="Print results to stdout instead of a file"
+    ),
+    out: Optional[Path] = typer.Option(
+        None, "--out", help="Write JSON results to this path"
+    ),
+) -> None:
+    """Run the mutate workflow locally."""
     args = {
         "workspace_uri": workspace_uri,
         "target_file": target_file,
@@ -68,7 +73,8 @@ def submit(
     entry_fn: str = typer.Option(..., help="Benchmark function"),
     profile_mod: Optional[str] = typer.Option(None, help="Profile helper module"),
     gens: int = typer.Option(1, help="Number of generations"),
-):
+) -> None:
+    """Submit a mutate task to the gateway."""
     args = {
         "workspace_uri": workspace_uri,
         "target_file": target_file,

--- a/pkgs/standards/peagen/peagen/cli/commands/process.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/process.py
@@ -124,13 +124,27 @@ def run(  # noqa: PLR0913 – CLI signature needs many options
 @remote_process_app.command("process")
 def submit(  # noqa: PLR0913 – CLI signature needs many options
     ctx: typer.Context,
-    projects_payload: str = typer.Argument(...),
-    project_name: Optional[str] = typer.Option(None),
-    start_idx: int = typer.Option(0),
-    start_file: Optional[str] = typer.Option(None),
-    transitive: bool = typer.Option(False, "--transitive/--no-transitive"),
-    agent_env: Optional[str] = typer.Option(None),
-    output_base: Optional[Path] = typer.Option(None, "--output-base"),
+    projects_payload: str = typer.Argument(
+        ..., help="Path to YAML file or inline text for PROJECTS"
+    ),
+    project_name: Optional[str] = typer.Option(
+        None, help="Process only a single project by its NAME"
+    ),
+    start_idx: int = typer.Option(
+        0, help="Index offset for rendered filenames"
+    ),
+    start_file: Optional[str] = typer.Option(
+        None, help="Skip files until this RENDERED_FILE_NAME is reached"
+    ),
+    transitive: bool = typer.Option(
+        False, "--transitive/--no-transitive", help="Include transitive deps"
+    ),
+    agent_env: Optional[str] = typer.Option(
+        None, help="JSON settings for the LLM agent environment"
+    ),
+    output_base: Optional[Path] = typer.Option(
+        None, "--output-base", help="Root dir for materialised artifacts"
+    ),
     watch: bool = typer.Option(False, "--watch", "-w", help="Poll until finished"),
     interval: float = typer.Option(
         2.0, "--interval", "-i", help="Seconds between polls"

--- a/pkgs/standards/peagen/peagen/cli/commands/sort.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/sort.py
@@ -11,8 +11,8 @@ from peagen._utils.config_loader import _effective_cfg, load_peagen_toml
 from peagen.handlers.sort_handler import sort_handler
 from peagen.models import Task
 
-local_sort_app = typer.Typer()
-remote_sort_app = typer.Typer()
+local_sort_app = typer.Typer(help="Sort generated project files.")
+remote_sort_app = typer.Typer(help="Sort generated project files via JSON-RPC.")
 
 
 @local_sort_app.command("sort")

--- a/pkgs/standards/peagen/peagen/cli/commands/task.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/task.py
@@ -75,30 +75,45 @@ def _simple_call(ctx: typer.Context, method: str, selector: str) -> None:
 
 
 @remote_task_app.command("pause")
-def pause(ctx: typer.Context, selector: str = typer.Argument(...)) -> None:
+def pause(
+    ctx: typer.Context,
+    selector: str = typer.Argument(..., help="Task ID or label selector"),
+) -> None:
     """Pause one task or all tasks matching a label."""
     _simple_call(ctx, "Task.pause", selector)
 
 
 @remote_task_app.command("resume")
-def resume(ctx: typer.Context, selector: str = typer.Argument(...)) -> None:
+def resume(
+    ctx: typer.Context,
+    selector: str = typer.Argument(..., help="Task ID or label selector"),
+) -> None:
     """Resume a paused task or label set."""
     _simple_call(ctx, "Task.resume", selector)
 
 
 @remote_task_app.command("cancel")
-def cancel(ctx: typer.Context, selector: str = typer.Argument(...)) -> None:
+def cancel(
+    ctx: typer.Context,
+    selector: str = typer.Argument(..., help="Task ID or label selector"),
+) -> None:
     """Cancel a task or label set."""
     _simple_call(ctx, "Task.cancel", selector)
 
 
 @remote_task_app.command("retry")
-def retry(ctx: typer.Context, selector: str = typer.Argument(...)) -> None:
+def retry(
+    ctx: typer.Context,
+    selector: str = typer.Argument(..., help="Task ID or label selector"),
+) -> None:
     """Retry a task or label set."""
     _simple_call(ctx, "Task.retry", selector)
 
 
 @remote_task_app.command("retry-from")
-def retry_from(ctx: typer.Context, selector: str = typer.Argument(...)) -> None:
+def retry_from(
+    ctx: typer.Context,
+    selector: str = typer.Argument(..., help="Task ID or label selector"),
+) -> None:
     """Retry a task and its descendants."""
     _simple_call(ctx, "Task.retry_from", selector)

--- a/pkgs/standards/peagen/peagen/cli/commands/templates.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/templates.py
@@ -49,6 +49,7 @@ def _submit_task(args: Dict[str, Any], gateway_url: str) -> str:
 # ─── list ──────────────────────────────
 @local_template_sets_app.command("list", help="List all discovered template-sets.")
 def run_list():
+    """List template-set packages found on the search path."""
     result = _run_handler({"operation": "list"})
     discovered = {e["name"]: e.get("paths", []) for e in result.get("sets", [])}
     if not discovered:
@@ -67,6 +68,7 @@ def submit_list(
         DEFAULT_GATEWAY, "--gateway-url", help="JSON-RPC gateway endpoint"
     ),
 ):
+    """Enqueue a template-set listing task on the gateway."""
     args = {"operation": "list"}
     try:
         task_id = _submit_task(args, gateway_url)
@@ -81,6 +83,7 @@ def submit_list(
 def run_show(
     name: str = typer.Argument(..., metavar="SET_NAME"),
 ):
+    """Show metadata and files for a template-set."""
     try:
         info = _run_handler({"operation": "show", "name": name})
     except Exception as exc:  # noqa: BLE001
@@ -108,6 +111,7 @@ def submit_show(
         DEFAULT_GATEWAY, "--gateway-url", help="JSON-RPC gateway endpoint"
     ),
 ):
+    """Request detailed information about a template-set."""
     args = {"operation": "show", "name": name}
     try:
         task_id = _submit_task(args, gateway_url)
@@ -149,6 +153,7 @@ def run_add(
         help="Re-install even if the distribution is already present.",
     ),
 ):
+    """Install a template-set from PyPI, wheel, or directory."""
     typer.echo("⏳  Installing via pip …")
     try:
         result = _run_handler(
@@ -183,12 +188,17 @@ def submit_add(
     from_bundle: Optional[str] = typer.Option(
         None, "--from-bundle", help="Install from bundled archive"
     ),
-    editable: bool = typer.Option(False, "--editable", "-e"),
-    force: bool = typer.Option(False, "--force"),
+    editable: bool = typer.Option(
+        False, "--editable", "-e", help="Install the source in editable mode"
+    ),
+    force: bool = typer.Option(
+        False, "--force", help="Re-install even if already present"
+    ),
     gateway_url: str = typer.Option(
         DEFAULT_GATEWAY, "--gateway-url", help="JSON-RPC gateway endpoint"
     ),
 ):
+    """Submit a template-set installation job via JSON-RPC."""
     args = {
         "operation": "add",
         "source": source,
@@ -211,6 +221,7 @@ def run_remove(
     name: str = typer.Argument(..., metavar="SET_NAME"),
     yes: bool = typer.Option(False, "-y", "--yes", help="Skip confirmation prompt."),
 ):
+    """Remove the package that provides a template-set."""
     if not yes:
         if not typer.confirm(f"Uninstall template-set '{name}' ?"):
             typer.echo("Aborted.")
@@ -239,6 +250,7 @@ def submit_remove(
         DEFAULT_GATEWAY, "--gateway-url", help="JSON-RPC gateway endpoint"
     ),
 ):
+    """Submit a template-set removal job via JSON-RPC."""
     if not yes:
         if not typer.confirm(f"Uninstall template-set '{name}' ?"):
             typer.echo("Aborted.")

--- a/pkgs/standards/peagen/peagen/cli/commands/validate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/validate.py
@@ -9,8 +9,8 @@ import typer
 from peagen.handlers.validate_handler import validate_handler
 from peagen.models import Task
 
-local_validate_app = typer.Typer()
-remote_validate_app = typer.Typer()
+local_validate_app = typer.Typer(help="Validate Peagen artifacts.")
+remote_validate_app = typer.Typer(help="Validate Peagen artifacts via JSON-RPC.")
 
 # ────────────────────────────── local validate ────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- improve description on global `local` and `remote` command groups
- supply help text for all DOE, mutate, process, fetch, init and task arguments
- document remote template-set options

## Testing
- `uv run --package peagen --directory standards/peagen pytest` *(fails: Request failed after 3 retries)*

------
https://chatgpt.com/codex/tasks/task_e_684a36a9dc4c8326a25cf4d6fa8159d1