### PR TITLE
Add LLM task breakout

### DIFF
--- a/pkgs/standards/peagen/peagen/core/process_core.py
+++ b/pkgs/standards/peagen/peagen/core/process_core.py
@@ -246,6 +246,7 @@ def _handle_generate(
     project_name: str,
     logger: Optional[Any],
     manifest_writer: ManifestWriter,
+    parent_task_id: Optional[str] = None,
 ) -> None:
     """
     Render a GENERATE record by calling the external agent, save/upload it, then add to the manifest.
@@ -272,6 +273,7 @@ def _handle_generate(
         j2,
         agent_env,
         cfg,
+        parent_task_id,
     )
     if log:
         log.debug(content)
@@ -307,6 +309,7 @@ def process_single_project(
     start_idx: int = 0,
     start_file: Optional[str] = None,
     transitive: bool = False,
+    parent_task_id: Optional[str] = None,
 ) -> Tuple[List[Dict[str, Any]], int]:
     """
     1) Build a global Jinja search path that includes built-ins, plugins, and workspace.
@@ -465,6 +468,7 @@ def process_single_project(
                 project_name,
                 logger,
                 manifest_writer,
+                parent_task_id,
             )
         else:
             if logger:
@@ -488,6 +492,7 @@ def process_all_projects(
     projects_payload: Union[str, List[Dict[str, Any]], Dict[str, Any]],
     cfg: Dict[str, Any],
     transitive: bool = False,
+    parent_task_id: Optional[str] = None,
 ) -> Dict[str, List[Dict[str, Any]]]:
     """Process every project described in ``projects_payload``.
 
@@ -507,6 +512,7 @@ def process_all_projects(
             start_idx=next_idx,
             start_file=None,
             transitive=transitive,
+            parent_task_id=parent_task_id,
         )
         results[name] = recs
 

--- a/pkgs/standards/peagen/peagen/core/render_core.py
+++ b/pkgs/standards/peagen/peagen/core/render_core.py
@@ -58,6 +58,7 @@ def _render_generate_template(
     j2_instance: Any,
     agent_env: Dict[str, str] = {},
     cfg: Optional[Dict[str, Any]] = None,
+    parent_task_id: Optional[str] = None,
 ) -> str:
     """
     Render a GENERATE‐style template.  
@@ -75,8 +76,14 @@ def _render_generate_template(
         rendered_prompt = j2_instance.fill(context)
         import inspect
         sig = inspect.signature(call_external_agent)
-        if len(sig.parameters) >= 4:
-            resp = call_external_agent(rendered_prompt, agent_env, cfg, logger)
+        if len(sig.parameters) >= 6:
+            resp = call_external_agent(
+                rendered_prompt,
+                agent_env,
+                cfg,
+                logger=logger,
+                parent_task_id=parent_task_id,
+            )
         else:
             resp = call_external_agent(rendered_prompt, agent_env, logger=logger)
         if logger:

--- a/pkgs/standards/peagen/peagen/handlers/llm_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/llm_handler.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from peagen.core._external import _direct_call_external_agent
+from peagen.models import Task
+
+
+async def llm_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, Any]:
+    """Run an LLM call and return its content."""
+    payload = task_or_dict.get("payload", {})
+    args: Dict[str, Any] = payload.get("args", {})
+    prompt: str = args.get("prompt", "")
+    agent_env: Dict[str, Any] = args.get("agent_env", {})
+    cfg = args.get("cfg")
+    content = _direct_call_external_agent(prompt, agent_env, cfg)
+    return {"content": content}

--- a/pkgs/standards/peagen/peagen/handlers/process_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/process_handler.py
@@ -79,6 +79,7 @@ async def process_handler(task: Dict[str, Any] | Task) -> Dict[str, Any]:
             start_idx=args.get("start_idx", 0),
             start_file=args.get("start_file"),
             transitive=args.get("transitive", False),
+            parent_task_id=task.get("id"),
         )
         result_map: Dict[str, List[Dict[str, Any]]] = {project_name: processed}
     else:
@@ -86,6 +87,7 @@ async def process_handler(task: Dict[str, Any] | Task) -> Dict[str, Any]:
             projects_payload,
             cfg=cfg,
             transitive=args.get("transitive", False),
+            parent_task_id=task.get("id"),
         )
 
     # ------------------------------------------------------------------ #

--- a/pkgs/standards/peagen/tests/unit/test_process_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_process_handler.py
@@ -30,11 +30,11 @@ async def test_process_handler_dispatch(monkeypatch, project_name):
         calls["load"] = payload
         return [{"NAME": project_name}] if project_name else []
 
-    def fake_single(project, cfg, start_idx, start_file, transitive):
+    def fake_single(project, cfg, start_idx, start_file, transitive, *a, **kw):
         calls["single"] = project
         return ["done"], 0
 
-    def fake_all(payload, cfg, transitive):
+    def fake_all(payload, cfg, transitive, *a, **kw):
         calls["all"] = payload
         return {"all": True}
 


### PR DESCRIPTION
## Summary
- spawn a child task for each LLM invocation
- support optional parent task tracking when calling external agents
- expose `llm_handler` for standalone LLM tasks
- propagate parent task IDs through process handler
- update unit tests for new signatures

## Testing
- `ruff check pkgs/standards/peagen/peagen/handlers/llm_handler.py pkgs/standards/peagen/peagen/core/_external.py pkgs/standards/peagen/peagen/core/render_core.py pkgs/standards/peagen/peagen/core/process_core.py pkgs/standards/peagen/peagen/handlers/process_handler.py`
- `uv run --package peagen --directory standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_684a399b17c8832681c429da9952f485