### PR TITLE
Add evolve fanout workflow

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/__init__.py
+++ b/pkgs/standards/peagen/peagen/cli/__init__.py
@@ -23,6 +23,7 @@ from .commands import (
     local_init_app,
     local_process_app,
     local_mutate_app,
+    local_evolve_app,
     local_sort_app,
     local_template_sets_app,
     local_validate_app,
@@ -32,6 +33,7 @@ from .commands import (
     remote_fetch_app,
     remote_process_app,
     remote_mutate_app,
+    remote_evolve_app,
     remote_sort_app,
     remote_task_app,
     remote_template_sets_app,
@@ -149,6 +151,7 @@ local_app.add_typer(local_db_app, name="db")
 local_app.add_typer(local_init_app,          name="init")
 local_app.add_typer(local_process_app)
 local_app.add_typer(local_mutate_app)
+local_app.add_typer(local_evolve_app)
 local_app.add_typer(local_sort_app)
 local_app.add_typer(local_template_sets_app, name="template-set")
 local_app.add_typer(local_validate_app)
@@ -159,6 +162,7 @@ remote_app.add_typer(remote_eval_app)
 remote_app.add_typer(remote_fetch_app)
 remote_app.add_typer(remote_process_app)
 remote_app.add_typer(remote_mutate_app)
+remote_app.add_typer(remote_evolve_app)
 remote_app.add_typer(remote_sort_app)
 remote_app.add_typer(remote_task_app, name="task")
 remote_app.add_typer(remote_template_sets_app, name="template-set")

--- a/pkgs/standards/peagen/peagen/cli/commands/__init__.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/__init__.py
@@ -8,6 +8,7 @@ from .db import local_db_app
 from .init import local_init_app, remote_init_app
 from .process import local_process_app, remote_process_app
 from .mutate import local_mutate_app, remote_mutate_app
+from .evolve import local_evolve_app, remote_evolve_app
 from .sort import local_sort_app, remote_sort_app
 from .task import remote_task_app
 from .templates import local_template_sets_app, remote_template_sets_app
@@ -20,6 +21,8 @@ __all__ = [
     "remote_eval_app",
     "local_mutate_app",
     "remote_mutate_app",
+    "local_evolve_app",
+    "remote_evolve_app",
     "local_extras_app",
     "remote_extras_app",
     "local_fetch_app",

--- a/pkgs/standards/peagen/peagen/cli/commands/evolve.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/evolve.py
@@ -1,0 +1,43 @@
+"""CLI for the evolve workflow."""
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from pathlib import Path
+
+import httpx
+import typer
+
+from peagen.handlers.evolve_handler import evolve_handler
+from peagen.models import Status, Task
+
+local_evolve_app = typer.Typer(help="Expand evolve specs locally")
+remote_evolve_app = typer.Typer(help="Submit evolve specs to a gateway")
+
+
+def _build_task(args: dict) -> Task:
+    return Task(id=str(uuid.uuid4()), pool="default", action="evolve", status=Status.waiting, payload={"action": "evolve", "args": args})
+
+
+@local_evolve_app.command("evolve")
+def run(ctx: typer.Context, evolve_spec: Path = typer.Argument(..., exists=True), json_out: bool = typer.Option(False, "--json")):
+    args = {"evolve_spec": str(evolve_spec)}
+    task = _build_task(args)
+    result = asyncio.run(evolve_handler(task))
+    typer.echo(json.dumps(result, indent=2) if json_out else json.dumps(result, indent=2))
+
+
+@remote_evolve_app.command("evolve")
+def submit(ctx: typer.Context, evolve_spec: Path = typer.Argument(..., exists=True)):
+    args = {"evolve_spec": str(evolve_spec)}
+    task = _build_task(args)
+    rpc_req = {"jsonrpc": "2.0", "method": "Task.submit", "params": {"taskId": task.id, "pool": task.pool, "payload": task.payload}}
+    with httpx.Client(timeout=30.0) as client:
+        reply = client.post(ctx.obj.get("gateway_url"), json=rpc_req).json()
+    if "error" in reply:
+        typer.secho(f"Remote error {reply['error']['code']}: {reply['error']['message']}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(1)
+    typer.secho(f"Submitted task {task.id}", fg=typer.colors.GREEN)
+    if reply.get("result"):
+        typer.echo(json.dumps(reply["result"], indent=2))

--- a/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
@@ -1,0 +1,22 @@
+"""Fan-out evolve spec into multiple mutate tasks."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List
+
+import yaml
+
+from peagen.models import Task
+from peagen.handlers.fanout import fanout
+
+
+async def evolve_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, Any]:
+    """Expand EVOLVE spec and spawn mutate tasks."""
+    payload = task_or_dict.get("payload", {})
+    args: Dict[str, Any] = payload.get("args", {})
+
+    spec_path = Path(args["evolve_spec"]).expanduser()
+    doc = yaml.safe_load(spec_path.read_text())
+    mutations: List[Dict[str, Any]] = doc.get("MUTATIONS", [])
+
+    return await fanout(task_or_dict, "mutate", mutations, {"evolve_spec": str(spec_path)})

--- a/pkgs/standards/peagen/peagen/handlers/fanout.py
+++ b/pkgs/standards/peagen/peagen/handlers/fanout.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Any, Dict, Iterable, List
+
+import httpx
+
+from peagen.models import Task, Status
+
+
+async def fanout(
+    parent: Dict[str, Any] | Task,
+    action: str,
+    args_list: Iterable[Dict[str, Any]],
+    result: Dict[str, Any] | None = None,
+    status: Status = Status.waiting,
+) -> Dict[str, Any]:
+    """Spawn child tasks and patch the parent with their IDs."""
+    gateway = os.getenv("DQ_GATEWAY", "http://localhost:8000/rpc")
+    pool = parent.get("pool", "default")
+    parent_id = parent["id"] if isinstance(parent, dict) else parent.id
+
+    child_ids: List[str] = []
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        for args in args_list:
+            child = Task(
+                id=str(uuid.uuid4()),
+                pool=pool,
+                action=action,
+                status=Status.waiting,
+                payload={"action": action, "args": args},
+            )
+            req = {
+                "jsonrpc": "2.0",
+                "method": "Task.submit",
+                "params": {
+                    "taskId": child.id,
+                    "pool": child.pool,
+                    "payload": child.payload,
+                },
+            }
+            await client.post(gateway, json=req)
+            child_ids.append(child.id)
+
+        patch = {
+            "jsonrpc": "2.0",
+            "id": str(uuid.uuid4()),
+            "method": "Task.patch",
+            "params": {"taskId": parent_id, "changes": {"result": {"children": child_ids}}},
+        }
+        await client.post(gateway, json=patch)
+
+        finish = {
+            "jsonrpc": "2.0",
+            "id": str(uuid.uuid4()),
+            "method": "Work.finished",
+            "params": {"taskId": parent_id, "status": status.value, "result": result},
+        }
+        await client.post(gateway, json=finish)
+
+    return {"children": child_ids, **(result or {})}

--- a/pkgs/standards/peagen/peagen/worker/__init__.py
+++ b/pkgs/standards/peagen/peagen/worker/__init__.py
@@ -8,6 +8,7 @@ from peagen.handlers.eval_handler import eval_handler
 from peagen.handlers.process_handler import process_handler
 from peagen.handlers.sort_handler import sort_handler
 from peagen.handlers.mutate_handler import mutate_handler
+from peagen.handlers.evolve_handler import evolve_handler
 
 # ----------------------------------------------------------------------------
 # Subclass WorkerBase (optional) so you can override or extend methods if needed.
@@ -26,6 +27,7 @@ class PeagenWorker(WorkerBase):
         self.register_handler("process", process_handler)
         self.register_handler("sort", sort_handler)
         self.register_handler("mutate", mutate_handler)
+        self.register_handler("evolve", evolve_handler)
         # In the future, you might also do:
         #   from peagen.handlers.render_handler import render_handler
         #   self.register_handler("render", render_handler)

--- a/pkgs/standards/peagen/tests/unit/test_evolve_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_evolve_handler.py
@@ -1,21 +1,24 @@
 import pytest
 
-from peagen.handlers import doe_process_handler as handler
+from peagen.handlers import evolve_handler as handler
 from peagen.handlers import fanout as fanout_mod
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_doe_process_handler_dispatches(monkeypatch, tmp_path):
+async def test_evolve_handler_dispatches(monkeypatch, tmp_path):
     sent = []
 
     class DummyClient:
         def __init__(self, *a, **kw):
             pass
+
         async def __aenter__(self):
             return self
+
         async def __aexit__(self, exc_type, exc, tb):
             pass
+
         async def post(self, url, json):
             sent.append(json)
             class R:
@@ -25,17 +28,12 @@ async def test_doe_process_handler_dispatches(monkeypatch, tmp_path):
 
     monkeypatch.setattr(fanout_mod, "httpx", type("X", (), {"AsyncClient": DummyClient}))
 
-    def fake_generate_payload(**kwargs):
-        p = tmp_path / "out.yaml"
-        p.write_text("PROJECTS:\n- NAME: A\n- NAME: B\n")
-        return {"output": str(p)}
+    spec = tmp_path / "evolve.yaml"
+    spec.write_text("""MUTATIONS:\n- workspace_uri: ws1\n  target_file: t1\n  import_path: m1\n  entry_fn: f1\n- workspace_uri: ws2\n  target_file: t2\n  import_path: m2\n  entry_fn: f2\n""")
 
-    monkeypatch.setattr(handler, "generate_payload", fake_generate_payload)
-
-    task = {"id": "T0", "pool": "default", "payload": {"args": {"spec": "s", "template": "t", "output": str(tmp_path / "out.yaml")}}}
-    result = await handler.doe_process_handler(task)
+    task = {"id": "T0", "pool": "default", "payload": {"args": {"evolve_spec": str(spec)}}}
+    result = await handler.evolve_handler(task)
 
     assert len(sent) == 4
     assert sent[-1]["method"] == "Work.finished"
-    assert sent[-1]["params"]["status"] == "waiting"
     assert result["children"] and len(result["children"]) == 2


### PR DESCRIPTION
## Summary
- introduce `fanout` helper for spawning child tasks and patching the parent
- refactor DOE process handler to use `fanout`
- add `evolve` handler and CLI commands for local/remote usage
- register `evolve` with the worker and CLI
- cover new logic with tests

## Testing
- `ruff check pkgs/standards/peagen/peagen/handlers/fanout.py pkgs/standards/peagen/peagen/handlers/doe_process_handler.py pkgs/standards/peagen/peagen/handlers/evolve_handler.py pkgs/standards/peagen/peagen/cli/commands/evolve.py pkgs/standards/peagen/tests/unit/test_doe_process_handler.py pkgs/standards/peagen/tests/unit/test_evolve_handler.py pkgs/standards/peagen/peagen/worker/__init__.py pkgs/standards/peagen/peagen/cli/commands/__init__.py pkgs/standards/peagen/peagen/cli/__init__.py`
- `uv run --package peagen --directory standards/peagen pytest -q`
- `peagen remote -q --gateway-url http://127.0.0.1:8000/rpc process empty_payload.yaml --watch` *(success)*
- `peagen remote -q --gateway-url http://127.0.0.1:8000/rpc task get e78a0c48-8215-4852-881f-2a3c5318040a`
- `peagen local -q process empty_payload.yaml`
- `peagen remote -q --gateway-url http://127.0.0.1:8000/rpc evolve evolve_spec.yaml`
- `peagen remote -q --gateway-url http://127.0.0.1:8000/rpc task get 1da44dbd-3139-4e3d-95db-6d5b959fbc97`
- `peagen local -q evolve evolve_spec.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684a3b39b1148326a787a3dba268d662