### PR TITLE
Add fanout pattern and evolve workflow

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/__init__.py
+++ b/pkgs/standards/peagen/peagen/cli/__init__.py
@@ -23,6 +23,7 @@ from .commands import (
     local_init_app,
     local_process_app,
     local_mutate_app,
+    local_evolve_app,
     local_sort_app,
     local_template_sets_app,
     local_validate_app,
@@ -32,6 +33,7 @@ from .commands import (
     remote_fetch_app,
     remote_process_app,
     remote_mutate_app,
+    remote_evolve_app,
     remote_sort_app,
     remote_task_app,
     remote_template_sets_app,
@@ -149,6 +151,7 @@ local_app.add_typer(local_db_app, name="db")
 local_app.add_typer(local_init_app,          name="init")
 local_app.add_typer(local_process_app)
 local_app.add_typer(local_mutate_app)
+local_app.add_typer(local_evolve_app)
 local_app.add_typer(local_sort_app)
 local_app.add_typer(local_template_sets_app, name="template-set")
 local_app.add_typer(local_validate_app)
@@ -159,6 +162,7 @@ remote_app.add_typer(remote_eval_app)
 remote_app.add_typer(remote_fetch_app)
 remote_app.add_typer(remote_process_app)
 remote_app.add_typer(remote_mutate_app)
+remote_app.add_typer(remote_evolve_app)
 remote_app.add_typer(remote_sort_app)
 remote_app.add_typer(remote_task_app, name="task")
 remote_app.add_typer(remote_template_sets_app, name="template-set")

--- a/pkgs/standards/peagen/peagen/cli/commands/__init__.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/__init__.py
@@ -8,6 +8,7 @@ from .db import local_db_app
 from .init import local_init_app, remote_init_app
 from .process import local_process_app, remote_process_app
 from .mutate import local_mutate_app, remote_mutate_app
+from .evolve import local_evolve_app, remote_evolve_app
 from .sort import local_sort_app, remote_sort_app
 from .task import remote_task_app
 from .templates import local_template_sets_app, remote_template_sets_app
@@ -20,6 +21,8 @@ __all__ = [
     "remote_eval_app",
     "local_mutate_app",
     "remote_mutate_app",
+    "local_evolve_app",
+    "remote_evolve_app",
     "local_extras_app",
     "remote_extras_app",
     "local_fetch_app",

--- a/pkgs/standards/peagen/peagen/cli/commands/evolve.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/evolve.py
@@ -1,0 +1,55 @@
+"""CLI for the evolve workflow."""
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from pathlib import Path
+
+import httpx
+import typer
+
+from peagen.handlers.evolve_handler import evolve_handler
+from peagen.models import Status, Task
+
+local_evolve_app = typer.Typer(help="Expand evolve spec and run mutate tasks")
+remote_evolve_app = typer.Typer(help="Expand evolve spec and run mutate tasks")
+
+
+def _build_task(args: dict) -> Task:
+    return Task(
+        id=str(uuid.uuid4()),
+        pool="default",
+        action="evolve",
+        status=Status.waiting,
+        payload={"action": "evolve", "args": args},
+    )
+
+
+@local_evolve_app.command("evolve")
+def run(ctx: typer.Context, spec: Path = typer.Argument(..., exists=True), json_out: bool = typer.Option(False, "--json")):
+    args = {"evolve_spec": str(spec)}
+    task = _build_task(args)
+    result = asyncio.run(evolve_handler(task))
+    typer.echo(json.dumps(result, indent=2) if json_out else json.dumps(result, indent=2))
+
+
+@remote_evolve_app.command("evolve")
+def submit(ctx: typer.Context, spec: Path = typer.Argument(..., exists=True)):
+    args = {"evolve_spec": str(spec)}
+    task = _build_task(args)
+    rpc_req = {
+        "jsonrpc": "2.0",
+        "method": "Task.submit",
+        "params": {"taskId": task.id, "pool": task.pool, "payload": task.payload},
+    }
+    with httpx.Client(timeout=30.0) as client:
+        reply = client.post(ctx.obj.get("gateway_url"), json=rpc_req).json()
+    if "error" in reply:
+        typer.secho(
+            f"Remote error {reply['error']['code']}: {reply['error']['message']}",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(1)
+    typer.secho(f"Submitted task {task.id}", fg=typer.colors.GREEN)

--- a/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
@@ -1,0 +1,36 @@
+"""Expand an evolve spec into multiple mutate tasks."""
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List
+
+import yaml
+
+from peagen.models import Task, Status
+from .fanout import fan_out
+
+
+async def evolve_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, Any]:
+    payload = task_or_dict.get("payload", {})
+    args: Dict[str, Any] = payload.get("args", {})
+
+    spec_path = Path(args["evolve_spec"]).expanduser()
+    doc = yaml.safe_load(spec_path.read_text())
+    jobs: List[Dict[str, Any]] = doc.get("JOBS", [])
+
+    pool = task_or_dict.get("pool", "default")
+    children: List[Task] = []
+    for job in jobs:
+        children.append(
+            Task(
+                id=str(uuid.uuid4()),
+                pool=pool,
+                action="mutate",
+                status=Status.waiting,
+                payload={"action": "mutate", "args": job},
+            )
+        )
+
+    child_ids = await fan_out(task_or_dict, children, result={"evolve_spec": str(spec_path)}, final_status=Status.waiting)
+    return {"children": child_ids, "jobs": len(jobs)}

--- a/pkgs/standards/peagen/peagen/handlers/fanout.py
+++ b/pkgs/standards/peagen/peagen/handlers/fanout.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Iterable, List, Dict, Any
+
+import httpx
+
+from peagen.models import Task, Status
+
+
+async def fan_out(
+    parent: Task | Dict[str, Any],
+    children: Iterable[Task],
+    *,
+    result: Dict[str, Any] | None = None,
+    final_status: Status = Status.waiting,
+) -> List[str]:
+    """Submit *children* and update *parent* with their IDs."""
+    gateway = os.getenv("DQ_GATEWAY", "http://localhost:8000/rpc")
+    parent_id = parent.get("id") if isinstance(parent, dict) else parent.id
+
+    child_ids: List[str] = []
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        for child in children:
+            req = {
+                "jsonrpc": "2.0",
+                "method": "Task.submit",
+                "params": {
+                    "taskId": child.id,
+                    "pool": child.pool,
+                    "payload": child.payload,
+                },
+            }
+            await client.post(gateway, json=req)
+            child_ids.append(child.id)
+
+        patch = {
+            "jsonrpc": "2.0",
+            "id": str(uuid.uuid4()),
+            "method": "Task.patch",
+            "params": {"taskId": parent_id, "changes": {"result": {"children": child_ids}}},
+        }
+        await client.post(gateway, json=patch)
+
+        finish = {
+            "jsonrpc": "2.0",
+            "id": str(uuid.uuid4()),
+            "method": "Work.finished",
+            "params": {"taskId": parent_id, "status": final_status.value, "result": result},
+        }
+        await client.post(gateway, json=finish)
+
+    return child_ids

--- a/pkgs/standards/peagen/peagen/worker/__init__.py
+++ b/pkgs/standards/peagen/peagen/worker/__init__.py
@@ -8,6 +8,7 @@ from peagen.handlers.eval_handler import eval_handler
 from peagen.handlers.process_handler import process_handler
 from peagen.handlers.sort_handler import sort_handler
 from peagen.handlers.mutate_handler import mutate_handler
+from peagen.handlers.evolve_handler import evolve_handler
 
 # ----------------------------------------------------------------------------
 # Subclass WorkerBase (optional) so you can override or extend methods if needed.
@@ -26,6 +27,7 @@ class PeagenWorker(WorkerBase):
         self.register_handler("process", process_handler)
         self.register_handler("sort", sort_handler)
         self.register_handler("mutate", mutate_handler)
+        self.register_handler("evolve", evolve_handler)
         # In the future, you might also do:
         #   from peagen.handlers.render_handler import render_handler
         #   self.register_handler("render", render_handler)

--- a/pkgs/standards/peagen/tests/unit/test_doe_process_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_doe_process_handler.py
@@ -22,7 +22,8 @@ async def test_doe_process_handler_dispatches(monkeypatch, tmp_path):
                     pass
             return R()
 
-    monkeypatch.setattr(handler, "httpx", type("X", (), {"AsyncClient": DummyClient}))
+    import peagen.handlers.fanout as fanout
+    monkeypatch.setattr(fanout, "httpx", type("X", (), {"AsyncClient": DummyClient}))
 
     def fake_generate_payload(**kwargs):
         p = tmp_path / "out.yaml"

--- a/pkgs/standards/peagen/tests/unit/test_evolve_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_evolve_handler.py
@@ -1,0 +1,35 @@
+import pytest
+
+from peagen.handlers import evolve_handler as handler
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_evolve_handler_fanout(monkeypatch, tmp_path):
+    sent = []
+
+    class DummyClient:
+        def __init__(self, *a, **kw):
+            pass
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+        async def post(self, url, json):
+            sent.append(json)
+            class R:
+                def raise_for_status(self):
+                    pass
+            return R()
+
+    import peagen.handlers.fanout as fanout
+    monkeypatch.setattr(fanout, "httpx", type("X", (), {"AsyncClient": DummyClient}))
+
+    spec = tmp_path / "spec.yaml"
+    spec.write_text("JOBS:\n- workspace_uri: ws\n  target_file: t.py\n  import_path: mod\n  entry_fn: f\n")
+
+    task = {"id": "P1", "pool": "default", "payload": {"args": {"evolve_spec": str(spec)}}}
+    result = await handler.evolve_handler(task)
+
+    assert result["jobs"] == 1
+    assert sent and sent[-1]["method"] == "Work.finished"


### PR DESCRIPTION
## Summary
- introduce `fan_out` helper for spawning child tasks and patching parents
- refactor DOE process handler to use `fan_out`
- implement new `evolve` handler and CLI commands
- register evolve handler with worker and CLI
- test fanout behaviour via new unit tests

## Testing
- `ruff check .`
- `uv run --package peagen --directory standards/peagen pytest`
- `peagen remote -q evolve evolve_spec.yaml`
- `peagen remote -q task get 52a6acd0-db41-48ff-9e74-7113385736d7`
- `peagen local -q evolve evolve_spec.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684a3b48b1f88326bc91d785c8a35bc3