### PR TITLE
Add websocket-driven TUI to peagen

### DIFF
--- a/pkgs/standards/peagen/README.md
+++ b/pkgs/standards/peagen/README.md
@@ -422,3 +422,11 @@ pea.process_all_projects()
 * **Template Conventions:** Place new Jinja2 files under your `TEMPLATE_BASE_DIR` as `*.j2`, using the same context variables (`projects`, `packages`, `modules`) that core templates rely on.
 * **Adding New Commands:** Define a new subcommand in `cli.py`, wire it into the parser, instantiate `Peagen`, and call core methods.
 * **Submitting Pull Requests:** Fork the repo, add/update templates under `peagen/templates/`, update docs/README, and open a PR tagging maintainers.
+
+### Textual TUI
+
+Run `python -m peagen.tui.app` to launch an experimental dashboard that
+subscribes to the gateway's `/ws/tasks` WebSocket. Use the tab keys to switch
+between task lists, logs and opened files. The footer shows system metrics and
+current time. Remote artifact paths are downloaded via their storage adapter and
+re-uploaded when saving.

--- a/pkgs/standards/peagen/peagen/tui/__init__.py
+++ b/pkgs/standards/peagen/peagen/tui/__init__.py
@@ -1,0 +1,12 @@
+"""Textual user interface helpers for Peagen."""
+
+from .app import QueueDashboardApp
+from .ws_client import TaskStreamClient
+from .fileops import download_remote, upload_remote
+
+__all__ = [
+    "QueueDashboardApp",
+    "TaskStreamClient",
+    "download_remote",
+    "upload_remote",
+]

--- a/pkgs/standards/peagen/peagen/tui/fileops.py
+++ b/pkgs/standards/peagen/peagen/tui/fileops.py
@@ -1,0 +1,28 @@
+"""Remote file helpers for the Peagen TUI."""
+
+from __future__ import annotations
+import tempfile
+from pathlib import Path
+from urllib.parse import urlparse
+
+from peagen.plugins.storage_adapters import make_adapter_for_uri
+
+
+def download_remote(uri: str) -> tuple[Path, object, str]:
+    """Download *uri* to a temporary file and return (path, adapter, key)."""
+
+    root = uri.rsplit("/", 1)[0] + "/"
+    key = uri.rsplit("/", 1)[1]
+    adapter = make_adapter_for_uri(root)
+    data = adapter.download(key)
+    tmp = Path(tempfile.mkdtemp()) / Path(urlparse(uri).path).name
+    with open(tmp, "wb") as fh:
+        fh.write(data.read())
+    return tmp, adapter, key
+
+
+def upload_remote(adapter: object, key: str, path: Path) -> str:
+    """Upload *path* using *adapter* under *key* and return the artifact URI."""
+
+    with path.open("rb") as fh:
+        return adapter.upload(key, fh)

--- a/pkgs/standards/peagen/peagen/tui/ws_client.py
+++ b/pkgs/standards/peagen/peagen/tui/ws_client.py
@@ -1,0 +1,38 @@
+"""WebSocket client utilities for the Peagen TUI."""
+
+from __future__ import annotations
+
+import json
+from typing import Awaitable, Callable, Dict, List
+
+import websockets
+
+
+class TaskStreamClient:
+    """Consume task events from ``/ws/tasks`` and maintain a tasks mapping."""
+
+    def __init__(self, ws_url: str) -> None:
+        self.ws_url = ws_url
+        self.tasks: Dict[str, dict] = {}
+        self._callbacks: List[Callable[[dict], Awaitable[None]]] = []
+
+    def on_event(self, cb: Callable[[dict], Awaitable[None]]) -> None:
+        """Register *cb* to be awaited for every task update."""
+
+        self._callbacks.append(cb)
+
+    async def listen(self) -> None:
+        async with websockets.connect(self.ws_url) as ws:
+            async for message in ws:
+                try:
+                    event = json.loads(message)
+                except json.JSONDecodeError:
+                    continue
+                data = event.get("data")
+                if not isinstance(data, dict):
+                    continue
+                task_id = data.get("id")
+                if task_id:
+                    self.tasks[task_id] = data
+                for cb in self._callbacks:
+                    await cb(data)

--- a/pkgs/standards/peagen/tests/unit/test_fileops.py
+++ b/pkgs/standards/peagen/tests/unit/test_fileops.py
@@ -1,0 +1,16 @@
+import io
+import pytest
+
+from peagen.plugins.storage_adapters.file_storage_adapter import FileStorageAdapter
+from peagen.tui.fileops import download_remote, upload_remote
+
+
+@pytest.mark.unit
+def test_remote_file_roundtrip(tmp_path):
+    adapter = FileStorageAdapter(tmp_path)
+    uri = adapter.upload("foo.txt", io.BytesIO(b"hi"))
+    path, adp, key = download_remote(uri)
+    assert path.read_text() == "hi"
+    path.write_text("bye")
+    upload_remote(adp, key, path)
+    assert adapter.download(key).read().decode() == "bye"

--- a/pkgs/standards/peagen/tests/unit/test_ws_client.py
+++ b/pkgs/standards/peagen/tests/unit/test_ws_client.py
@@ -1,0 +1,24 @@
+import asyncio
+import json
+
+import pytest
+import websockets
+
+from peagen.tui.ws_client import TaskStreamClient
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ws_client_updates_tasks(tmp_path):
+    async def handler(websocket):
+        await websocket.send(json.dumps({"data": {"id": "42", "status": "running", "done": 0, "total": 1}}))
+        await asyncio.sleep(0.05)
+
+    server = await websockets.serve(handler, "localhost", 8765)
+    client = TaskStreamClient("ws://localhost:8765")
+    task = asyncio.create_task(client.listen())
+    await asyncio.sleep(0.1)
+    task.cancel()
+    server.close()
+    await server.wait_closed()
+    assert "42" in client.tasks


### PR DESCRIPTION
## Summary
- implement `TaskStreamClient` for `/ws/tasks`
- add remote artifact helpers in `tui.fileops`
- update dashboard to use websocket updates and remote editing
- document TUI launch instructions
- include construction emoji placeholder for template-set editing
- test websocket client and remote file helpers

## Checklist
- [x] `ruff check`
- [x] `pytest`
- [ ] Deploy gateway and worker for **remote** with Redis queue, Redis pubsub, MinIO storage and Postgres backend
- [ ] Deploy gateway and worker for **local** with in-memory queue, no pubsub, local FS storage and results backend
- [ ] Submit a task in each mode using `peagen -q` and wait for completion
- [ ] Show `task get` output for each mode proving success

------
https://chatgpt.com/codex/tasks/task_e_684a3b691aa8832685484534d89c90ab