### PR TITLE
Add production-ready websocket TUI

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_worker_list.py
+++ b/pkgs/standards/peagen/tests/unit/test_worker_list.py
@@ -1,0 +1,45 @@
+import pytest
+
+from peagen.plugins.queues.in_memory_queue import InMemoryQueue
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_worker_list(monkeypatch):
+    q = InMemoryQueue()
+
+    class DummyBackend:
+        async def store(self, task_run):
+            pass
+
+    class StubPM:
+        def __init__(self, cfg):
+            pass
+
+        def get(self, group):
+            if group == "queues":
+                return q
+            if group == "result_backends":
+                return DummyBackend()
+            return None
+
+    import importlib
+    import peagen.plugins
+
+    monkeypatch.setattr(peagen.plugins, "PluginManager", StubPM)
+    import peagen.gateway as gw
+    importlib.reload(gw)
+
+    monkeypatch.setattr(gw, "queue", q)
+    monkeypatch.setattr(gw, "result_backend", DummyBackend())
+
+    async def noop(*_args, **_kw):
+        return None
+
+    monkeypatch.setattr(gw, "_persist", noop)
+    monkeypatch.setattr(gw, "_publish_event", noop)
+
+    await gw.worker_register(workerId="w1", pool="p", url="http://w1", advertises={})
+    workers = await gw.worker_list()
+    assert workers[0]["id"] == "w1"
+    assert workers[0]["pool"] == "p"


### PR DESCRIPTION
## Summary
- implement `RemoteBackend` in the Textual TUI and remove FakeBackend
- poll workers via new `Worker.list` RPC
- wire remote backend into dashboard
- test `Worker.list` RPC

## Checklist
- [x] `ruff check`
- [x] `pytest`
- [ ] Deploy gateway and worker for **remote** with Redis queue, Redis pubsub, MinIO storage and Postgres backend
- [ ] Deploy gateway and worker for **local** with in-memory queue, no pubsub, local FS storage and results backend
- [ ] Submit a task in each mode using `peagen -q` and wait for completion
- [ ] Show `task get` output for each mode proving success


------
https://chatgpt.com/codex/tasks/task_e_684a6cfa3b8c8326838a6ab771014eab