### PR TITLE
feat(peagen): emit pool and worker events for TUI

### DIFF
--- a/pkgs/standards/peagen/README.md
+++ b/pkgs/standards/peagen/README.md
@@ -426,7 +426,8 @@ pea.process_all_projects()
 ### Textual TUI
 
 Run `python -m peagen.tui.app` to launch an experimental dashboard that
-subscribes to the gateway's `/ws/tasks` WebSocket. Use the tab keys to switch
-between task lists, logs and opened files. The footer shows system metrics and
-current time. Remote artifact paths are downloaded via their storage adapter and
-re-uploaded when saving.
+subscribes to the gateway's `/ws/tasks` WebSocket. The gateway now emits
+`task.update`, `worker.update` and `queue.update` events. Use the tab keys to
+switch between task lists, logs and opened files. The footer shows system
+metrics and current time. Remote artifact paths are downloaded via their storage
+adapter and re-uploaded when saving.

--- a/pkgs/standards/peagen/peagen/tui/app.py
+++ b/pkgs/standards/peagen/peagen/tui/app.py
@@ -220,10 +220,21 @@ class QueueDashboardApp(App):
     # ── periodic refresh logic ─────────────────────────────────────────────
     def refresh_data(self) -> None:
         tasks = list(self.client.tasks.values()) or self.backend.tasks
-        workers = self.backend.workers
+        if self.client.workers:
+            workers = {
+                wid: datetime.utcfromtimestamp(data.get("last_seen", datetime.utcnow().timestamp()))
+                for wid, data in self.client.workers.items()
+            }
+        else:
+            workers = self.backend.workers
 
         # 1 – workers and counts
-        self.queue_len = sum(1 for t in tasks if getattr(t, "status", t.get("status")) == "running")
+        if self.client.queues:
+            self.queue_len = sum(self.client.queues.values())
+        else:
+            self.queue_len = sum(
+                1 for t in tasks if getattr(t, "status", t.get("status")) == "running"
+            )
         self.done_len = sum(1 for t in tasks if getattr(t, "status", t.get("status")) == "done")
         self.fail_len = sum(1 for t in tasks if getattr(t, "status", t.get("status")) == "failed")
         self.worker_len = len(workers)

--- a/pkgs/standards/peagen/tests/unit/test_ws_client.py
+++ b/pkgs/standards/peagen/tests/unit/test_ws_client.py
@@ -11,7 +11,15 @@ from peagen.tui.ws_client import TaskStreamClient
 @pytest.mark.asyncio
 async def test_ws_client_updates_tasks(tmp_path):
     async def handler(websocket):
-        await websocket.send(json.dumps({"data": {"id": "42", "status": "running", "done": 0, "total": 1}}))
+        await websocket.send(
+            json.dumps({"type": "task.update", "data": {"id": "42", "status": "running", "done": 0, "total": 1}})
+        )
+        await websocket.send(
+            json.dumps({"type": "worker.update", "data": {"id": "w1", "pool": "default"}})
+        )
+        await websocket.send(
+            json.dumps({"type": "queue.update", "data": {"pool": "default", "length": 1}})
+        )
         await asyncio.sleep(0.05)
 
     server = await websockets.serve(handler, "localhost", 8765)
@@ -22,3 +30,5 @@ async def test_ws_client_updates_tasks(tmp_path):
     server.close()
     await server.wait_closed()
     assert "42" in client.tasks
+    assert "w1" in client.workers
+    assert client.queues.get("default") == 1


### PR DESCRIPTION
## Summary
- emit simplified websocket events including queue length and worker updates
- track worker and queue state in `TaskStreamClient`
- display real worker info in TUI dashboard
- mention new gateway events in docs

## Checklist
- [x] `ruff check`
- [ ] `pytest`
- [ ] Deploy gateway and worker for **remote** with Redis queue, Redis pubsub, MinIO storage and Postgres backend
- [ ] Deploy gateway and worker for **local** with in-memory queue, no pubsub, local FS storage and results backend
- [ ] Submit a task in each mode using `peagen -q` and wait for completion
- [ ] Show `task get` output for each mode proving success

------
https://chatgpt.com/codex/tasks/task_e_684a6e7ab28083268421cc37717162e6