### PR TITLE
Stabilize gateway patches in unit tests

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_task_id_collision.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_id_collision.py
@@ -31,7 +31,7 @@ async def test_task_submit_id_collision(monkeypatch):
 
     monkeypatch.setattr(gw, "queue", q)
     monkeypatch.setattr(gw, "result_backend", DummyBackend())
-    async def noop(task):
+    async def noop(*_):
         return None
 
     monkeypatch.setattr(gw, "_persist", noop)

--- a/pkgs/standards/peagen/tests/unit/test_task_metadata.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_metadata.py
@@ -65,7 +65,7 @@ async def test_task_submit_roundtrip(monkeypatch):
 
     monkeypatch.setattr(gw, "queue", q)
     monkeypatch.setattr(gw, "result_backend", DummyBackend())
-    async def noop(task):
+    async def noop(*_):
         return None
 
     monkeypatch.setattr(gw, "_persist", noop)

--- a/pkgs/standards/peagen/tests/unit/test_task_patch_labels.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_patch_labels.py
@@ -34,7 +34,7 @@ async def test_task_patch_updates_labels(monkeypatch):
     monkeypatch.setattr(gw, "queue", q)
     monkeypatch.setattr(gw, "result_backend", DummyBackend())
 
-    async def noop(task):
+    async def noop(*_):
         return None
 
     monkeypatch.setattr(gw, "_persist", noop)

--- a/pkgs/standards/peagen/tests/unit/test_task_patch_status.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_patch_status.py
@@ -34,7 +34,7 @@ async def test_task_patch_updates_status(monkeypatch):
     monkeypatch.setattr(gw, "queue", q)
     monkeypatch.setattr(gw, "result_backend", DummyBackend())
 
-    async def noop(task):
+    async def noop(*_):
         return None
 
     monkeypatch.setattr(gw, "_persist", noop)


### PR DESCRIPTION
## Summary
- ensure patched gateway functions accept arbitrary args in tests

## Testing
- `ruff check .`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_task_id_collision.py::test_task_submit_id_collision -q`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_task_metadata.py::test_task_submit_roundtrip -q`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_task_patch_labels.py::test_task_patch_updates_labels -q`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_task_patch_status.py::test_task_patch_updates_status -q`


------
https://chatgpt.com/codex/tasks/task_e_684a71429fac8326a785fd96670ccf69