### PR TITLE
Implement websocket initial state snapshot

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/ws_server.py
+++ b/pkgs/standards/peagen/peagen/gateway/ws_server.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, WebSocket
 from redis.asyncio import Redis
 from peagen.gateway.runtime_cfg import settings
 from peagen.defaults import CONFIG as defaults
+import json
 
 redis: Redis = Redis.from_url(settings.redis_url, decode_responses=True)
 router = APIRouter()
@@ -13,6 +14,30 @@ router = APIRouter()
 async def ws_tasks(ws: WebSocket):
     """Bridge Redis → WebSocket so any GUI/TUI can stream task events."""
     await ws.accept()
+    # ─────────────────── initial state snapshot ────────────────────
+    # pools & queue lengths
+    pools = await redis.smembers("pools")
+    for pool in pools:
+        qlen = len(await redis.lrange(f"{defaults['ready_queue']}:{pool}", 0, -1))
+        await ws.send_text(
+            json.dumps({"type": "queue.update", "data": {"pool": pool, "length": qlen}})
+        )
+
+    # active workers
+    for key in await redis.keys("worker:*"):
+        worker = await redis.hgetall(key)
+        wid = key.split(":", 1)[1]
+        await ws.send_text(
+            json.dumps({"type": "worker.update", "data": {"id": wid, **worker}})
+        )
+
+    # persisted tasks
+    for key in await redis.keys("task:*"):
+        blob = await redis.hget(key, "blob")
+        if blob:
+            await ws.send_text(
+                json.dumps({"type": "task.update", "data": json.loads(blob)})
+            )
     pubsub = redis.pubsub()
     await pubsub.subscribe(defaults["pubsub"])
     try:


### PR DESCRIPTION
## Summary
- update ws_server to emit initial pools, workers, and tasks when a client connects

## Testing
- `ruff check .`
- `uv run --package peagen --directory standards/peagen pytest`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684a76510b2c8326a9c69216148a72f1