### PR TITLE
Fix worker timestamp handling in Peagen TUI

### DIFF
--- a/pkgs/standards/peagen/peagen/tui/app.py
+++ b/pkgs/standards/peagen/peagen/tui/app.py
@@ -203,10 +203,14 @@ class QueueDashboardApp(App):
     def refresh_data(self) -> None:
         tasks = list(self.client.tasks.values()) or self.backend.tasks
         if self.client.workers:
-            workers = {
-                wid: datetime.utcfromtimestamp(data.get("last_seen", datetime.utcnow().timestamp()))
-                for wid, data in self.client.workers.items()
-            }
+            workers = {}
+            for wid, data in self.client.workers.items():
+                ts_raw = data.get("last_seen", datetime.utcnow().timestamp())
+                try:
+                    ts = float(ts_raw)
+                except (TypeError, ValueError):
+                    ts = datetime.utcnow().timestamp()
+                workers[wid] = datetime.utcfromtimestamp(ts)
         else:
             workers = self.backend.workers
 


### PR DESCRIPTION
## Summary
- handle non-numeric `last_seen` values from worker events

## Testing
- `ruff check pkgs/standards/peagen`
- `uv run --package peagen --directory standards/peagen pytest -vvv` *(fails: Failed to fetch https://pypi.org/simple/pytest-timeout/)*

------
https://chatgpt.com/codex/tasks/task_e_684a7ec769748326bf6de95fbc03a417