### PR TITLE
Update peagen call flow diagrams

### DIFF
--- a/pkgs/standards/peagen/docs/call_flows/doe_to_eval_remote.mmd
+++ b/pkgs/standards/peagen/docs/call_flows/doe_to_eval_remote.mmd
@@ -1,0 +1,30 @@
+sequenceDiagram
+    %% Participants
+    participant U as **User**
+    participant DOE as **peagen remote doe gen**
+    participant FS as File System
+    participant PROC as **peagen remote process**
+    participant PE as Peagen Engine
+    participant EVAL as **peagen remote eval**
+    participant POOL as Evaluator Pool
+    
+    %% DOE GEN
+    U ->> DOE: `peagen remote doe gen spec.yml template.yml -o project_payloads.yaml`
+    DOE ->> FS: write **project_payloads.yaml**
+    DOE -->> U: Design matrix generated  
+    Note over FS: 🗎 Artifact ① `project_payloads.yaml`
+    
+    %% PROCESS
+    U ->> PROC: `peagen remote process project_payloads.yaml`
+    PROC ->> PE: init(env, templates, storage)
+    PE ->> FS: render workspace → `workspace/`, `*_manifest.json`
+    PROC -->> U: Generation done  
+    Note over FS: 🗎 Artifact ② workspace + manifest
+    
+    %% EVAL (same workspace)
+    U ->> EVAL: `peagen remote eval workspace/ --pool MyPool`
+    EVAL ->> POOL: evaluate_programs(programs)
+    POOL -->> EVAL: results[]
+    EVAL ->> FS: write `.peagen/eval_manifest.json`
+    EVAL -->> U: Evaluation complete  
+    Note over FS: 🗎 Artifact ③ `eval_manifest.json`

--- a/pkgs/standards/peagen/docs/call_flows/peagen_doe_gen_remote.mmd
+++ b/pkgs/standards/peagen/docs/call_flows/peagen_doe_gen_remote.mmd
@@ -1,0 +1,22 @@
+sequenceDiagram
+    participant User
+    participant CLI as peagen remote doe gen
+    participant YAML as YAML Loader
+    participant Schema as Schema Validator
+    participant Publisher
+    User ->> CLI: Run `peagen remote doe gen spec.yml template.yml -o project_payloads.yaml`
+    CLI ->> YAML: Load DOE spec YAML and base template YAML
+    CLI ->> Schema: Validate spec against DOE schema (unless --skip-validate)
+    CLI ->> CLI: Compute design points (cartesian product of factors)
+    CLI ->> CLI: For each design point: merge with base template, apply any patches
+    CLI ->> YAML: Assemble `project_payloads.yaml` bundle with all PROJECTS
+    CLI ->> User: List all design point IDs and factor values
+    alt --dry-run option
+        CLI -->> User: Outputs design matrix table (no file written)
+    else 
+        CLI ->> YAML: Write bundle to output file (or error if exists without --force)
+        CLI -->> User: Prints success and file size
+        opt if --notify specified
+            CLI ->> Publisher: Instantiate publisher and publish "peagen.experiment.done" event
+        end
+    end

--- a/pkgs/standards/peagen/docs/call_flows/peagen_eval_remote.mmd
+++ b/pkgs/standards/peagen/docs/call_flows/peagen_eval_remote.mmd
@@ -1,0 +1,46 @@
+sequenceDiagram
+    participant User
+    participant CLI as peagen remote eval
+    participant Config as Config Loader
+    participant Reg as PluginRegistry
+    participant Pool as EvaluatorPool
+    participant Prog as Program Class
+    User ->> CLI: Run `peagen remote eval <workspace_uri> [--pool PoolName] [options]`
+    CLI ->> Config: load_peagen_toml(Path(workspace_uri)) to get evaluation config
+    CLI ->> CLI: Determine pool_ref (from --pool or config)
+    alt If pool_ref specified
+        CLI ->> Reg: Check registry["evaluator_pools"] for pool_ref
+        alt found in registry
+            Reg -->> CLI: Return Pool Class
+        else not found
+            CLI ->> Python: Import module and get class for pool_ref string
+            Python -->> CLI: Return Pool Class
+        end
+    else (no pool specified)
+        CLI ->> CLI: Use DefaultEvaluatorPool class
+    end
+    CLI ->> Pool: Instantiate PoolCls and call initialize()
+    opt if workspace_uri is remote (contains "://")
+        CLI ->> FS: Create temp workspace directory:contentReference[oaicite:177]{index=177}
+        CLI ->> CLI: (Future) fetch remote workspace contents (using program fetch helpers)
+    end
+    CLI ->> FS: Resolve workspace_path (local Path)
+    CLI ->> FS: Glob find program files (e.g. `**/*.prog`) in workspace_path
+    loop for each program file found
+        CLI ->> Prog: Program.from_workspace(program_dir)
+        Prog -->> CLI: Return Program object
+        CLI ->> CLI: Add Program to list
+    end
+    CLI ->> Pool: evaluate_programs(list of Program objects)
+    Pool -->> CLI: Returns results list (scores & metadata)
+    CLI ->> CLI: Build eval manifest (schemaVersion, evaluators, results)
+    alt if --json output
+        CLI -->> User: Print JSON-formatted eval manifest
+    else
+        CLI ->> FS: Ensure output directory (default: `<workspace>/.peagen/`)
+        CLI ->> FS: Write eval_manifest.json to output directory
+        CLI -->> User: Print path to eval_manifest file
+    end
+    opt if --strict flag
+        CLI ->> CLI: "Check all result scores. if any 0, Exit with code 3"
+    end

--- a/pkgs/standards/peagen/docs/call_flows/peagen_extra-schemas_generate_remote.mmd
+++ b/pkgs/standards/peagen/docs/call_flows/peagen_extra-schemas_generate_remote.mmd
@@ -1,0 +1,15 @@
+sequenceDiagram
+    participant User
+    participant CLI as peagen remote extras-schemas generate
+    participant FS as File System
+    User ->> CLI: Run `peagen remote extras-schemas generate`
+    CLI ->> FS: Determine scaffold templates directory and output schemas directory
+    CLI ->> FS: Create/ensure `schemas/extras/` directory exists
+    CLI ->> FS: Find all `EXTRAS.md` files in templates subfolders
+    loop for each EXTRAS.md file found
+        CLI ->> FS: Read the markdown file
+        CLI ->> CLI: Parse lines for keys (bulleted list items)
+        CLI ->> CLI: Build JSON schema object with those keys as properties
+        CLI ->> FS: Write schema JSON to `schemas/extras/<set_name>.schema.v1.json`
+        CLI -->> User: Print "✅ Wrote <set_name>.schema.v1.json"
+    end

--- a/pkgs/standards/peagen/docs/call_flows/peagen_process_remote.mmd
+++ b/pkgs/standards/peagen/docs/call_flows/peagen_process_remote.mmd
@@ -1,0 +1,31 @@
+sequenceDiagram
+    participant User
+    participant CLI as peagen remote process
+    participant Config as Config Loader
+    participant Reg as PluginRegistry
+    participant Store as StorageAdapter
+    participant Peagen as Peagen Engine
+    participant Pub as Publisher
+    User ->> CLI: Run `peagen remote process projects.yaml [options]`
+    CLI ->> Config: load_peagen_toml (load .peagen.toml config)
+    CLI ->> Reg: Get plugin mode setting (plugins config)
+    CLI ->> Reg: (If --notify) Get Publisher class from registry
+    CLI ->> Pub: Instantiate publisher and publish "process.started" event
+    CLI ->> Reg: Get Storage Adapter class from registry
+    CLI ->> Store: Instantiate storage adapter (with org prefix)
+    CLI ->> CLI: Prepare environment (template sets, API key, agent prompt)
+    CLI ->> CLI: If --include-swarmauri, add swarmauri source package (git or bundle)
+    CLI ->> CLI: materialise_packages (fetch any source_packages to temp dir)
+    CLI ->> Peagen: Initialize Peagen(projects_payload, templates, agent_env, storage)
+    CLI ->> Peagen: Set logging level based on -v flags
+    note over CLI,Peagen: **Dispatch generation**
+    alt If --project-name given
+        CLI ->> Peagen: load_projects() to get specified project
+        Peagen -->> CLI: Returns project data
+        CLI ->> Peagen: process_single_project(project, [start_idx/file], transitive?)
+    else All projects
+    end
+    Peagen -->> CLI: Generation completed (files created in workspace)
+    CLI ->> User: Log "Done in Xs" upon completion
+    CLI ->> Pub: (If publisher) Publish "process.done" event with runtime
+    CLI -->> User: Exit (status 0 if successful)

--- a/pkgs/standards/peagen/docs/call_flows/peagen_program_diff_remote.mmd
+++ b/pkgs/standards/peagen/docs/call_flows/peagen_program_diff_remote.mmd
@@ -1,0 +1,23 @@
+sequenceDiagram
+    participant User
+    participant CLI as peagen remote program diff
+    participant Net as Manifest Source
+    participant FS as File System
+    User ->> CLI: Run `peagen remote program diff <left> <right> [--md file]`
+    CLI ->> CLI: For each of left/right:
+    alt if input is directory
+        CLI ->> FS: Use it as a workspace
+    else
+        CLI ->> Net: Download manifest & files (ensure workspace)
+        Net -->> CLI: Returns temp workspace directory
+    end
+    CLI ->> FS: Scan left workspace for all file paths
+    CLI ->> FS: Scan right workspace for all file paths
+    CLI ->> CLI: Determine added files (in right only), removed files (in left only)
+    CLI ->> CLI: For common files, compute hashes to find modified ones
+    CLI ->> CLI: Build diff table in Markdown format
+    alt if --md option provided
+        CLI ->> FS: Write diff table to output Markdown file
+    else
+        CLI -->> User: Print diff table to console
+    end

--- a/pkgs/standards/peagen/docs/call_flows/peagen_program_fetch_remote.mmd
+++ b/pkgs/standards/peagen/docs/call_flows/peagen_program_fetch_remote.mmd
@@ -1,0 +1,22 @@
+sequenceDiagram
+    participant User
+    participant CLI as peagen remote program fetch
+    participant Net as Manifest Source
+    participant Pip as PackageInstaller
+    participant Adapter as StorageAdapter
+    User ->> CLI: Run `peagen remote program fetch manifest.json [--out dir]`
+    CLI ->> FS: Create/prepare output directory (temp if not provided)
+    loop For each manifest in inputs
+        CLI ->> Net: _download_manifest(manifest URI or path)
+        Net -->> CLI: Returns manifest data (JSON)
+        alt if install_template_sets flag is true
+            CLI ->> Pip: Install each template-set listed in manifest (via pip)
+        end
+        alt if not no_source
+            loop for each spec in manifest["source_packages"]
+                CLI ->> Adapter: _materialise_source_pkg(spec, out_dir) (clone or copy source)
+            end
+        end
+        CLI ->> Adapter: _materialise_workspace(manifest, out_dir) (download all generated files)
+    end
+    CLI -->> User: Output "workspace: [out_dir]" path of reconstructed workspace

--- a/pkgs/standards/peagen/docs/call_flows/peagen_program_inspect_remote.mmd
+++ b/pkgs/standards/peagen/docs/call_flows/peagen_program_inspect_remote.mmd
@@ -1,0 +1,18 @@
+sequenceDiagram
+    participant User
+    participant CLI as peagen remote program patch
+    participant FS as File System
+    participant JSON as JsonPatch
+    User ->> CLI: Run `peagen remote program patch <workspace> [--overlay dir] [--patch file]`
+    CLI ->> FS: Resolve target workspace path
+    alt if --overlay is provided
+        CLI ->> FS: Read overlay’s `.peagen-delete` list (if exists) and remove those files from base
+        CLI ->> FS: Copy all files from overlay directory into base workspace (overwrite existing)
+        CLI -->> User: "overlay applied" confirmation
+    end
+    alt if --patch file is provided
+        CLI ->> FS: Read entire workspace into a JSON object (file tree)
+        CLI ->> JSON: Load patch operations from file and apply them to JSON object
+        CLI ->> FS: Write modified JSON content back to workspace files
+        CLI -->> User: "json-patch applied" confirmation
+    end

--- a/pkgs/standards/peagen/docs/call_flows/peagen_program_patch_remote.mmd
+++ b/pkgs/standards/peagen/docs/call_flows/peagen_program_patch_remote.mmd
@@ -1,0 +1,18 @@
+sequenceDiagram
+    participant User
+    participant CLI as peagen remote program patch
+    participant FS as File System
+    participant JSON as JsonPatch
+    User ->> CLI: Run `peagen remote program patch <workspace> [--overlay dir] [--patch file]`
+    CLI ->> FS: Resolve target workspace path
+    alt if --overlay is provided
+        CLI ->> FS: Read overlay’s `.peagen-delete` list (if exists) and remove those files from base
+        CLI ->> FS: Copy all files from overlay directory into base workspace (overwrite existing)
+        CLI -->> User: "overlay applied" confirmation
+    end
+    alt if --patch file is provided
+        CLI ->> FS: Read entire workspace into a JSON object (file tree)
+        CLI ->> JSON: Load patch operations from file and apply them to JSON object
+        CLI ->> FS: Write modified JSON content back to workspace files
+        CLI -->> User: "json-patch applied" confirmation
+    end

--- a/pkgs/standards/peagen/docs/call_flows/peagen_program_validate_remote.mmd
+++ b/pkgs/standards/peagen/docs/call_flows/peagen_program_validate_remote.mmd
@@ -1,0 +1,40 @@
+sequenceDiagram
+    participant User
+    participant CLI as peagen remote program validate
+    participant FS as File System
+    participant Schema as JSONSchema
+    User ->> CLI: Run `peagen remote program validate <target> [--license-allow X --license-deny Y]`
+    CLI ->> FS: Determine manifest file(s):
+    alt if target is a JSON file: 
+        CLI -->> FS: use it
+    else if target is a directory: 
+        CLI -->> FS: collect all `.peagen/*_manifest.json` files
+    end
+    CLI ->> FS: Read each manifest JSON
+    CLI ->> Schema: Validate manifest data against MANIFEST_V3_SCHEMA
+    Schema -->> CLI: Return validation result for each (errors if any)
+    alt if any schema errors
+        CLI -->> User: Print "[ERROR] ... <manifest>: <message>" for each error
+        CLI -->> User: Exit with failure code
+    else
+        CLI -->> User: Print "schema ✅" (schema valid)
+        opt unless --schema-only
+            CLI ->> FS: Scan workspace files for `SPDX-License-Identifier:` tags
+            CLI ->> CLI: Collect detected license identifiers
+            alt if --license-allow list provided
+                CLI ->> CLI: Check for any detected license *not* matching allowed patterns
+                alt if found:
+                   CLI -->> User: Error "[ERROR] licenses not allowed: [...]"
+                   CLI -->> User: Exit (failure)
+                end
+            end
+            alt if --license-deny list provided
+                CLI ->> CLI: Check for any detected license matching denied patterns
+                alt if found:
+                   CLI -->> User: Error "[ERROR] licenses explicitly denied: [...]"
+                   CLI -->> User: Exit (failure)
+                end
+            end
+            CLI -->> User: Print "license ✅" if all licenses pass rules
+        end
+    end

--- a/pkgs/standards/peagen/docs/call_flows/peagen_sort_remote.mmd
+++ b/pkgs/standards/peagen/docs/call_flows/peagen_sort_remote.mmd
@@ -1,0 +1,28 @@
+sequenceDiagram
+    participant User
+    participant CLI as peagen remote sort
+    participant Config as Config Loader
+    participant Peagen as Peagen Engine
+    participant Graph as DependencyGraph
+    User ->> CLI: Run `peagen remote sort projects.yaml [options]`
+    CLI ->> Config: load_peagen_toml() (load config for plugin mode, etc.)
+    CLI ->> CLI: Resolve plugin mode and LLM API key (if provider specified)
+    CLI ->> Peagen: Instantiate Peagen(dry_run=True) with projects file and env
+    CLI ->> Peagen: Set log level based on -v flags:
+    alt If --project-name is given
+        CLI ->> Peagen: load_projects()
+        Peagen -->> CLI: Returns list of projects
+        CLI ->> Peagen: process_single_project(selected project, start_idx/file)
+        Peagen -->> CLI: Returns sorted_records (file list)
+        CLI ->> User: Print sorted file order for the project (index and filename)
+        opt if --show-deps
+            CLI ->> Graph: get_immediate_dependencies(record, file)
+            Graph -->> CLI: Direct dependencies list
+            CLI ->> User: Print dependencies for each file
+        end
+    else (All projects)
+        CLI ->> Peagen: process_all_projects()
+        Peagen -->> CLI: Returns sorted_records list per project
+        CLI ->> User: For each project, print project name and its file sequence
+    end
+    CLI -->> User: Exit (0) after listing planned order

--- a/pkgs/standards/peagen/docs/call_flows/peagen_task_get_local.mmd
+++ b/pkgs/standards/peagen/docs/call_flows/peagen_task_get_local.mmd
@@ -1,0 +1,11 @@
+sequenceDiagram
+    participant User
+    participant CLI as peagen local task get
+    participant Worker as Local Worker
+    participant DB as Results DB
+    User ->> CLI: Run `peagen local task get <task-id>`
+    CLI ->> Worker: lookup task(task_id)
+    Worker ->> DB: read status/result
+    DB -->> Worker: task row
+    Worker -->> CLI: status/result JSON
+    CLI -->> User: Display formatted JSON

--- a/pkgs/standards/peagen/docs/call_flows/peagen_task_get_remote.mmd
+++ b/pkgs/standards/peagen/docs/call_flows/peagen_task_get_remote.mmd
@@ -1,0 +1,11 @@
+sequenceDiagram
+    participant User
+    participant CLI as peagen remote task get
+    participant GW as Gateway RPC
+    participant DB as Results DB
+    User ->> CLI: Run `peagen remote --gateway-url http://gateway/rpc task get <task-id>`
+    CLI ->> GW: JSON-RPC Task.get(task_id)
+    GW ->> DB: SELECT status, result WHERE id=task_id
+    DB -->> GW: task row
+    GW -->> CLI: task status/result JSON
+    CLI -->> User: Display formatted JSON

--- a/pkgs/standards/peagen/docs/call_flows/peagen_template-sets_add_remote.mmd
+++ b/pkgs/standards/peagen/docs/call_flows/peagen_template-sets_add_remote.mmd
@@ -1,0 +1,30 @@
+sequenceDiagram
+    participant User
+    participant CLI as peagen remote template-sets add
+    participant Pip as PipInstaller
+    participant Env as PythonEnv
+    User ->> CLI: Run `peagen remote template-sets add <SOURCE> [--from-bundle X] [--editable] [--force]`
+    CLI ->> CLI: Determine source type:
+    opt if local directory
+        CLI -->> CLI: prepare pip install (maybe -e)
+    end
+    opt if local wheel/tar
+        CLI -->> CLI: prepare pip install file path
+    end
+    opt if PyPI slug
+        CLI -->> CLI: prepare pip install <slug>
+    end
+    CLI ->> Pip: Invoke pip install (via subprocess)
+    Pip -->> CLI: Success or error (exception if fails)
+    alt if installation failed
+        CLI -->> User: Print "❌ Installation failed." and error output
+        CLI -->> User: Exit with error code
+    else
+        CLI ->> Env: Discover template-sets before vs after install
+        Env -->> CLI: Return set of newly added template-set names
+        alt if new_sets not empty
+            CLI -->> User: Print "✅ Installed template-set(s): X, Y..."
+        else
+            CLI -->> User: Print warning (no new set detected, possibly already installed)
+        end
+    end

--- a/pkgs/standards/peagen/docs/call_flows/peagen_template-sets_list_remote.mmd
+++ b/pkgs/standards/peagen/docs/call_flows/peagen_template-sets_list_remote.mmd
@@ -1,0 +1,19 @@
+sequenceDiagram
+    participant User
+    participant CLI as peagen remote template-sets list
+    participant Env as PythonEnv
+    participant FS as File System
+    User ->> CLI: Run `peagen remote template-sets list [-v]`
+    CLI ->> FS: Scan built-in template sets directories (peagen.templates/*)
+    CLI ->> Env: Load plugin entry_points for group "peagen.template_sets"
+    Env -->> CLI: Provide any additional template-set modules
+    CLI ->> CLI: Compile mapping of template-set name -> locations
+    alt if no template-sets found
+        CLI -->> User: Print warning "No template-sets found" and exit
+    else
+        CLI ->> User: Print "Available template-sets:" and each set name
+        opt if -v flag
+            CLI ->> User: For each set, list its directory path(s)
+        end
+        CLI ->> User: Print total count of sets found
+    end

--- a/pkgs/standards/peagen/docs/call_flows/peagen_template-sets_remove_remote.mmd
+++ b/pkgs/standards/peagen/docs/call_flows/peagen_template-sets_remove_remote.mmd
@@ -1,0 +1,42 @@
+sequenceDiagram
+    participant User
+    participant CLI as peagen remote template-sets remove
+    participant Env as PythonEnv
+    participant Pip as PipInstaller
+    User ->> CLI: Run `peagen remote template-sets remove <SET_NAME> [-y]`
+    CLI ->> Env: Scan installed distributions for entry_point matching SET_NAME in "peagen.template_sets"
+    Env -->> CLI: Return list of distribution names providing that template-set
+    alt if list is empty
+        CLI -->> User: Print "❌ Template-set 'name' not found" (nothing to remove)
+        CLI -->> User: Exit
+    end
+    CLI ->> CLI: Separate protected core distributions (e.g. peagen)
+    alt if only protected dists found
+        CLI -->> User: Print warning (cannot uninstall core template-set)
+        CLI -->> User: Exit
+    else
+        alt if both core and others found
+            CLI -->> User: Warn skipping core package, proceeding with others
+        end
+        opt if -y not given
+            CLI ->> User: Prompt confirmation "Uninstall distributions: X, Y?"
+            User -->> CLI: Confirm (yes or no)
+            alt if user cancels
+                CLI -->> User: "Aborted." (exit without changes)
+            end
+        end
+        CLI ->> Pip: Run pip uninstall for the target distribution(s) (non-interactive)
+        Pip -->> CLI: Success or error
+        alt if uninstall failed
+            CLI -->> User: Print "❌ Uninstall failed." and output error
+            CLI -->> User: Exit with error
+        else
+            CLI ->> Env: Discover template-sets again to verify removal
+            Env -->> CLI: Return whether SET_NAME is still present
+            alt if still present
+                CLI -->> User: Print "⚠️  ... still discoverable." (warning)
+            else
+                CLI -->> User: Print "✅ Removed template-set 'name'."
+            end
+        end
+    end

--- a/pkgs/standards/peagen/docs/call_flows/peagen_template-sets_show_remote.mmd
+++ b/pkgs/standards/peagen/docs/call_flows/peagen_template-sets_show_remote.mmd
@@ -1,0 +1,19 @@
+sequenceDiagram
+    participant User
+    participant CLI as peagen remote template-sets show
+    participant FS as File System
+    User ->> CLI: Run `peagen remote template-sets show <SET_NAME> [-v/-vv]`
+    CLI ->> CLI: Discover all template-sets (same as `list`)
+    CLI ->> CLI: Check if SET_NAME is in discovered sets
+    alt if SET_NAME not found
+        CLI -->> User: Print "❌ Template-set 'name' not found." and exit
+    else
+        CLI ->> FS: Get the directory location(s) of the template-set
+        alt if -vv (very verbose)
+            CLI ->> User: List all files with full paths in the template-set
+        else if -v (verbose)
+            CLI ->> User: List all file names in the template-set
+        else
+            CLI ->> User: Print high-level info (e.g. directory path) for the template-set
+        end
+    end

--- a/pkgs/standards/peagen/docs/call_flows/peagen_validate_remote.mmd
+++ b/pkgs/standards/peagen/docs/call_flows/peagen_validate_remote.mmd
@@ -1,0 +1,21 @@
+sequenceDiagram
+    participant User
+    participant CLI as peagen remote validate config
+    participant Config as Config Loader
+    participant Schema as JSONSchema
+    User ->> CLI: Run `peagen remote validate config [path]`
+    CLI ->> Config: load_peagen_toml(path or cwd)
+    Config -->> CLI: Return config dict or None
+    alt if no config found
+        CLI -->> User: "❌ No .peagen.toml found." (error)
+        CLI -->> User: Exit with error
+    else
+        CLI ->> Schema: _validate(config, PEAGEN_TOML_V1_SCHEMA, ".peagen.toml")
+        Schema -->> CLI: Validate or raise errors
+        alt if errors in config
+            CLI -->> User: Print each schema error ("<path> – <message>")
+            CLI -->> User: Exit with error
+        else
+            CLI -->> User: Print "✅ .peagen.toml is valid." (passes schema)
+        end
+    end

--- a/pkgs/standards/peagen/docs/call_flows/project_init_project_remote.mmd
+++ b/pkgs/standards/peagen/docs/call_flows/project_init_project_remote.mmd
@@ -1,0 +1,10 @@
+sequenceDiagram
+    participant User
+    participant CLI as peagen remote init project
+    participant FS as File System
+    participant Jinja as Template Engine
+    User ->> CLI: Run `peagen remote init project [path]`
+    CLI ->> FS: Check target directory (empty or --force)
+    CLI ->> Jinja: Render project scaffold templates (context: project name, provider, flags)
+    Jinja -->> FS: Write rendered files to `path` (project structure)
+    CLI -->> User: Outputs "✅ Scaffold created" and next command (e.g. `peagen remote process`)


### PR DESCRIPTION
## Summary
- generate separate flowcharts for remote execution
- add diagrams for `task get` in both remote and local modes

## Testing
- `uv run --package peagen --directory standards/peagen ruff check .` *(fails: Failed to fetch https://pypi.org/simple/jsonschema/)*
- `uv run --package peagen --directory standards/peagen pytest` *(fails: Failed to fetch https://pypi.org/simple/asyncpg/)*
- `peagen remote -q --gateway-url http://localhost:8000/rpc process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml --watch` *(fails: command not found)*
- `PYTHONPATH=pkgs/standards/peagen python -m peagen.cli local -q process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml --watch` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_684a81eb05608326b6e8d3ebb6b50fd6