### PR TITLE
Enhance peagen TUI task and worker info

### DIFF
--- a/pkgs/standards/peagen/peagen/tui/components/workers_view.py
+++ b/pkgs/standards/peagen/peagen/tui/components/workers_view.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Mapping
+from typing import Any, Mapping
 
 from textual.widgets import DataTable
 
@@ -9,11 +9,24 @@ from textual.widgets import DataTable
 class WorkersView(DataTable):
     """Display active pools and workers."""
 
-    def update_workers(self, workers: Mapping[str, datetime]) -> None:
+    def update_workers(self, workers: Mapping[str, Mapping[str, Any]]) -> None:
         """Refresh the table contents."""
+
         if not self.columns:
-            self.add_columns("Worker", "Last Seen")
+            self.add_columns("Worker", "Pool", "URL", "Last Seen")
+
         self.clear()
-        for name, ts in workers.items():
-            self.add_row(name, ts.isoformat(timespec="seconds"))
+        for wid, info in workers.items():
+            ts = info.get("last_seen")
+            if isinstance(ts, datetime):
+                ts_str = ts.isoformat(timespec="seconds")
+            else:
+                ts_str = str(ts) if ts is not None else ""
+
+            self.add_row(
+                wid,
+                str(info.get("pool", "")),
+                str(info.get("url", "")),
+                ts_str,
+            )
 


### PR DESCRIPTION
## Summary
- show all task information in the TUI
- include error messages in the error log table
- display more worker details in the pools view

## Testing
- `ruff check .`
- `uv run --package peagen --directory standards/peagen pytest -q` *(fails: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_684a85b9e0e083268ff6781384f8b974