### PR TITLE
Add label column in peagen TUI

### DIFF
--- a/pkgs/standards/peagen/peagen/tui/app.py
+++ b/pkgs/standards/peagen/peagen/tui/app.py
@@ -168,7 +168,7 @@ class QueueDashboardApp(App):
         self.file_tree = FileTree("tree", id="file_tree")
         self.templates_tree = TemplatesView(id="templates_tree")
         self.tasks_table = DataTable(id="tasks_table")
-        self.tasks_table.add_columns("ID", "Pool", "Status", "Action")
+        self.tasks_table.add_columns("ID", "Pool", "Status", "Action", "Labels")
 
         self.err_table = DataTable(id="err_table")
         self.err_table.add_columns("Task", "Log")
@@ -253,11 +253,13 @@ class QueueDashboardApp(App):
             action = (
                 getattr(t, "payload", t.get("payload", {})).get("action", "")
             )
+            labels = ",".join(getattr(t, "labels", t.get("labels", [])))
             self.tasks_table.add_row(
                 str(tid),
                 pool,
                 status,
                 action,
+                labels,
                 key=str(tid),
             )
 


### PR DESCRIPTION
## Summary
- show task labels in the textual dashboard

## Testing
- `ruff check pkgs/standards/peagen`
- `uv run --package peagen --directory standards/peagen pytest -q` *(fails: Failed to fetch https://pypi.org/simple/pytest/)*


------
https://chatgpt.com/codex/tasks/task_e_684a8a6407788326a941bb0bf2201c20