### PR TITLE
Improve peagen TUI connection handling

### DIFF
--- a/pkgs/standards/peagen/peagen/tui/components/__init__.py
+++ b/pkgs/standards/peagen/peagen/tui/components/__init__.py
@@ -6,6 +6,7 @@ from .log_view import LogView
 from .metrics_tab import MetricsTab
 from .workers_view import WorkersView
 from .templates_view import TemplatesView
+from .reconnect_screen import ReconnectScreen
 
 __all__ = [
     "DashboardFooter",
@@ -14,5 +15,6 @@ __all__ = [
     "MetricsTab",
     "WorkersView",
     "TemplatesView",
+    "ReconnectScreen",
 ]
 

--- a/pkgs/standards/peagen/peagen/tui/components/reconnect_screen.py
+++ b/pkgs/standards/peagen/peagen/tui/components/reconnect_screen.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.screen import Screen
+from textual.widgets import Button, Static
+
+
+class ReconnectScreen(Screen):
+    """Display a connection error with retry logic."""
+
+    def __init__(self, message: str, on_retry) -> None:
+        super().__init__(modal=True)
+        self.message = message
+        self.on_retry = on_retry
+        self._counter = 30
+
+    def compose(self) -> ComposeResult:  # pragma: no cover - ui code
+        yield Vertical(
+            Static(self.message, id="error-message"),
+            Horizontal(
+                Button("Retry", id="retry"),
+                Button("Close", id="close"),
+            ),
+            Static(f"Retrying in {self._counter}s", id="timer"),
+            id="reconnect-box",
+        )
+
+    def on_mount(self) -> None:  # pragma: no cover - ui code
+        self.set_interval(1.0, self._tick)
+
+    def _tick(self) -> None:  # pragma: no cover - ui code
+        self._counter -= 1
+        timer = self.query_one("#timer", Static)
+        timer.update(f"Retrying in {self._counter}s")
+        if self._counter <= 0:
+            self.dismiss()
+            self.on_retry()
+
+    async def on_button_pressed(self, event: Button.Pressed) -> None:  # pragma: no cover - ui code
+        if event.button.id == "retry":
+            self.dismiss()
+            self.on_retry()
+        elif event.button.id == "close":
+            self.app.exit()
+


### PR DESCRIPTION
## Summary
- prevent crashes when the gateway is unreachable
- display reconnect screen with Retry/Close and countdown

## Testing
- `ruff check pkgs/standards/peagen/peagen/tui/components/reconnect_screen.py`
- `ruff check pkgs/standards/peagen/peagen/tui/app.py`


------
https://chatgpt.com/codex/tasks/task_e_684a8e488b808326ac50f00ab2ad71b3