### PR TITLE
Fix copy shortcut in peagen TUI

### DIFF
--- a/pkgs/standards/peagen/peagen/tui/app.py
+++ b/pkgs/standards/peagen/peagen/tui/app.py
@@ -129,8 +129,7 @@ class QueueDashboardApp(App):
         ("5", "switch('templates')", "Templates"),
         ("ctrl+s", "save_file", "Save"),
         ("c", "toggle_children", "Collapse"),
-        ("y", "copy_id", "Copy"),
-
+        ("ctrl+c", "copy_id", "Copy"),
         ("s", "cycle_sort", "Sort"),
         ("f", "filter_by_cell", "Filter"),
         ("escape", "clear_filters", "Clear Filters"),
@@ -324,7 +323,9 @@ class QueueDashboardApp(App):
         if hasattr(self.tasks_table, "get_cell_at"):
             value = self.tasks_table.get_cell_at(row, col)
         else:
-            value = self.tasks_table.get_cell(row, col)  # pragma: no cover - old textual
+            value = self.tasks_table.get_cell(
+                row, col
+            )  # pragma: no cover - old textual
 
         col_label = self.tasks_table.columns[col].label
         if col_label == "Pool":
@@ -391,14 +392,11 @@ class QueueDashboardApp(App):
                 if t.get("payload", {}).get("action") == self.filter_action
             ]
         if self.filter_label:
-            tasks = [
-                t
-                for t in tasks
-                if self.filter_label in t.get("labels", [])
-            ]
+            tasks = [t for t in tasks if self.filter_label in t.get("labels", [])]
 
         # sort
         if self.sort_key:
+
             def _key(task):
                 if self.sort_key == "action":
                     return task.get("payload", {}).get("action")
@@ -430,8 +428,12 @@ class QueueDashboardApp(App):
             self.queue_len = sum(
                 1 for t in tasks if getattr(t, "status", t.get("status")) == "running"
             )
-        self.done_len = sum(1 for t in tasks if getattr(t, "status", t.get("status")) == "done")
-        self.fail_len = sum(1 for t in tasks if getattr(t, "status", t.get("status")) == "failed")
+        self.done_len = sum(
+            1 for t in tasks if getattr(t, "status", t.get("status")) == "done"
+        )
+        self.fail_len = sum(
+            1 for t in tasks if getattr(t, "status", t.get("status")) == "failed"
+        )
         self.worker_len = len(workers)
         self.workers_view.update_workers(workers)
 
@@ -491,12 +493,16 @@ class QueueDashboardApp(App):
                             child.get("payload", {}).get("action", ""),
                             c_labels,
                             (
-                                datetime.utcfromtimestamp(c_start).isoformat(timespec="seconds")
+                                datetime.utcfromtimestamp(c_start).isoformat(
+                                    timespec="seconds"
+                                )
                                 if c_start
                                 else ""
                             ),
                             (
-                                datetime.utcfromtimestamp(c_finish).isoformat(timespec="seconds")
+                                datetime.utcfromtimestamp(c_finish).isoformat(
+                                    timespec="seconds"
+                                )
                                 if c_finish
                                 else ""
                             ),
@@ -537,7 +543,9 @@ class QueueDashboardApp(App):
                         else ""
                     ),
                     (
-                        datetime.utcfromtimestamp(finished).isoformat(timespec="seconds")
+                        datetime.utcfromtimestamp(finished).isoformat(
+                            timespec="seconds"
+                        )
                         if finished
                         else ""
                     ),
@@ -579,7 +587,9 @@ class QueueDashboardApp(App):
             editor = TextArea(id=f"editor_{len(self.file_tabs.panes)}")
             editor.load_text(text)
             editor.language = "python"
-            await self.file_tabs.add_pane(TabPane(Path(file_path).name, editor, id=pane_id))
+            await self.file_tabs.add_pane(
+                TabPane(Path(file_path).name, editor, id=pane_id)
+            )
             self.file_tabs.display = True
         else:
             editor = self.file_tabs.query_one(f"#{pane_id} TextArea")


### PR DESCRIPTION
## Summary
- bind `ctrl+c` to the task ID copy action
- remove the custom `y` key binding

## Testing
- `uv run --package peagen --directory standards/peagen ruff format peagen/tui/app.py`
- `uv run --package peagen --directory standards/peagen ruff check peagen/tui/app.py`
- `uv run --package peagen --directory standards/peagen pytest -q`

Codex couldn't run peagen remote/local commands due to environment limitations.

------
https://chatgpt.com/codex/tasks/task_e_684a98ed96e4832689671fc8d381c507