### PR TITLE
Fix DOE generation to produce individual payloads

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/doe.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/doe.py
@@ -81,7 +81,11 @@ def run_gen(  # noqa: PLR0913
     task = _make_task(args, action="doe")
     result = asyncio.run(doe_handler(task))
 
-    typer.echo(json.dumps(result, indent=2) if json_out else f"✅  {result['output']}")
+    if json_out:
+        typer.echo(json.dumps(result, indent=2))
+    else:
+        outs = ", ".join(result.get("outputs", []))
+        typer.echo(f"✅  {outs}")
 
 
 # ─────────────────────────── remote submit ─────────────────────────────────

--- a/pkgs/standards/peagen/peagen/core/doe_core.py
+++ b/pkgs/standards/peagen/peagen/core/doe_core.py
@@ -239,31 +239,48 @@ def generate_payload(
         spec_name=spec_path.stem,
     )
 
-    bundle = {
-        "PROJECTS": projects,
-        "SOURCE": {
-            "spec": str(spec_path),
-            "template": str(template_path),
-            "spec_checksum": _sha256(spec_path),
-        },
-    }
+    bundles: List[Tuple[Path, Dict[str, Any]]] = []
+    for idx, proj_payload in enumerate(projects):
+        out_path = output_path.parent / (
+            f"{output_path.stem}_{idx:03d}{output_path.suffix}"
+        )
+
+        bundle = {
+            **proj_payload,
+            "SOURCE": {
+                "spec": str(spec_path),
+                "template": str(template_path),
+                "spec_checksum": _sha256(spec_path),
+            },
+        }
+
+        bundles.append((out_path, bundle))
 
     # 2. ------------ write file (unless dry-run) -------------------------
     bytes_written = 0
+    outputs: List[str] = []
     if not dry_run:
-        if output_path.exists() and not force:
-            raise FileExistsError(f"{output_path} exists – use force=True to overwrite")
-        output_path.write_text(yaml.safe_dump(bundle, sort_keys=False), encoding="utf-8")
-        bytes_written = output_path.stat().st_size
+        for out_path, bundle in bundles:
+            if out_path.exists() and not force:
+                raise FileExistsError(
+                    f"{out_path} exists – use force=True to overwrite"
+                )
+            out_path.write_text(
+                yaml.safe_dump(bundle, sort_keys=False), encoding="utf-8"
+            )
+            outputs.append(str(out_path))
+            bytes_written += out_path.stat().st_size
+    else:
+        outputs = [str(p) for p, _ in bundles]
 
     # 3. ------------ optional event publish ------------------------------
     if notify_uri:
-        _publish_event(notify_uri, output_path, len(projects), cfg_path)
+        _publish_event(notify_uri, output_path, len(bundles), cfg_path)
 
     # 4. ------------ summary ---------------------------------------------
     return {
-        "output": str(output_path),
-        "count": len(projects),
+        "outputs": outputs,
+        "count": len(bundles),
         "bytes": bytes_written,
         "llm_keys": llm_keys,
         "other_keys": other_keys,

--- a/pkgs/standards/peagen/peagen/core/doe_core.py
+++ b/pkgs/standards/peagen/peagen/core/doe_core.py
@@ -139,14 +139,16 @@ def generate_projects(
     spec_name: str,
 ) -> List[Dict[str, Any]]:
     projects: List[Dict[str, Any]] = []
+    base_proj = deepcopy(template_obj.get("PROJECTS", [{}])[0])
+    other_keys = {k: deepcopy(v) for k, v in template_obj.items() if k != "PROJECTS"}
     for idx, point in enumerate(design_points):
         ctx = {
             **point,
             "EXP_ID": f"{idx:03d}",
-            "BASE_NAME": template_obj.get("PROJECTS", [{}])[0].get("NAME"),
+            "BASE_NAME": base_proj.get("NAME"),
         }
 
-        proj = deepcopy(template_obj)
+        proj = {**other_keys, "PROJECTS": [deepcopy(base_proj)]}
 
         # per-factor patches
         for factor_def in spec_obj.get("FACTORS", {}).values():

--- a/pkgs/standards/peagen/peagen/core/process_core.py
+++ b/pkgs/standards/peagen/peagen/core/process_core.py
@@ -41,9 +41,22 @@ def load_projects_payload(
             maybe_path = Path(projects_payload)
             if maybe_path.is_file():
                 yaml_text = maybe_path.read_text(encoding="utf-8")
+            elif "://" in projects_payload:
+                from urllib.parse import urlparse, urlunparse
+                from peagen.plugins.storage_adapters import make_adapter_for_uri
+
+                parsed = urlparse(projects_payload)
+                if not parsed.scheme or not parsed.netloc:
+                    raise ValueError(f"Invalid URI: {projects_payload}")
+
+                dir_path, key = parsed.path.rsplit("/", 1)
+                root = urlunparse((parsed.scheme, parsed.netloc, dir_path, "", "", ""))
+                adapter = make_adapter_for_uri(root)
+                with adapter.download(key) as fh:  # type: ignore[attr-defined]
+                    yaml_text = fh.read().decode("utf-8")
             else:
                 yaml_text = projects_payload
-        except (OSError, TypeError):
+        except (OSError, TypeError, ValueError):
             yaml_text = projects_payload
         doc = yaml.safe_load(yaml_text)
 

--- a/pkgs/standards/peagen/peagen/core/process_core.py
+++ b/pkgs/standards/peagen/peagen/core/process_core.py
@@ -43,10 +43,12 @@ def load_projects_payload(
                 yaml_text = maybe_path.read_text(encoding="utf-8")
             elif "://" in projects_payload:
                 from urllib.parse import urlparse, urlunparse
+                from peagen.plugins import discover_and_register_plugins
+                discover_and_register_plugins()
                 from peagen.plugins.storage_adapters import make_adapter_for_uri
 
                 parsed = urlparse(projects_payload)
-                if not parsed.scheme or not parsed.netloc:
+                if not parsed.scheme:
                     raise ValueError(f"Invalid URI: {projects_payload}")
 
                 dir_path, key = parsed.path.rsplit("/", 1)

--- a/pkgs/standards/peagen/peagen/defaults.py
+++ b/pkgs/standards/peagen/peagen/defaults.py
@@ -32,4 +32,8 @@ CONFIG = {
     "ready_queue": "queue",          # prefix for per-pool ready queues
     "pubsub": "task:update",         # channel for task event broadcasts
     "task_key": "task:{}",           # Redis hash per task
+    # Sensible local defaults so `peagen local` works without a config file
+    "queues": {"default_queue": "in_memory", "adapters": {"in_memory": {"maxsize": 0}}},
+    "result_backends": {"default_backend": "local_fs", "adapters": {"local_fs": {"root_dir": "./task_runs"}}},
+    "storage": {"default_storage_adapter": "file", "adapters": {"file": {"output_dir": "./peagen_artifacts"}}},
 }

--- a/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
@@ -10,6 +10,9 @@ import yaml
 
 from peagen.core.doe_core import generate_payload
 from peagen.models import Task, Status
+from peagen._utils.config_loader import resolve_cfg
+from peagen.plugins import PluginManager
+from peagen.plugins.storage_adapters.file_storage_adapter import FileStorageAdapter
 from .fanout import fan_out
 
 
@@ -18,24 +21,46 @@ async def doe_process_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, 
     payload = task_or_dict.get("payload", {})
     args: Dict[str, Any] = payload.get("args", {})
 
+    cfg_path = Path(args["config"]).expanduser() if args.get("config") else None
+
     result = generate_payload(
         spec_path=Path(args["spec"]).expanduser(),
         template_path=Path(args["template"]).expanduser(),
         output_path=Path(args["output"]).expanduser(),
-        cfg_path=Path(args["config"]).expanduser() if args.get("config") else None,
+        cfg_path=cfg_path,
         notify_uri=args.get("notify"),
         dry_run=args.get("dry_run", False),
         force=args.get("force", False),
         skip_validate=args.get("skip_validate", False),
     )
 
+    cfg = resolve_cfg(toml_path=str(cfg_path) if cfg_path else ".peagen.toml")
+    pm = PluginManager(cfg)
+    try:
+        storage_adapter = pm.get("storage_adapters")
+    except Exception:
+        file_cfg = (
+            cfg.get("storage", {})
+            .get("adapters", {})
+            .get("file", {})
+        )
+        storage_adapter = FileStorageAdapter(**file_cfg) if file_cfg else None
+
     output_paths = result.get("outputs", [])
     projects: List[Tuple[str, Dict[str, Any]]] = []
+    uploaded: List[str] = []
     for p in output_paths:
         doc = yaml.safe_load(Path(p).read_text())
         proj = (doc.get("PROJECTS") or [None])[0]
+        uri = str(p)
+        if storage_adapter and not result.get("dry_run"):
+            key = f"{Path(p).name}"
+            with open(p, "rb") as fh:
+                uri = storage_adapter.upload(key, fh)  # type: ignore[attr-defined]
+        uploaded.append(uri)
         if proj is not None:
-            projects.append((p, proj))
+            projects.append((uri, proj))
+    result["outputs"] = uploaded
 
     pool = task_or_dict.get("pool", "default")
     children: List[Task] = []

--- a/pkgs/standards/peagen/tests/unit/test_doe_process_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_doe_process_handler.py
@@ -26,9 +26,11 @@ async def test_doe_process_handler_dispatches(monkeypatch, tmp_path):
     monkeypatch.setattr(fanout, "httpx", type("X", (), {"AsyncClient": DummyClient}))
 
     def fake_generate_payload(**kwargs):
-        p = tmp_path / "out.yaml"
-        p.write_text("PROJECTS:\n- NAME: A\n- NAME: B\n")
-        return {"output": str(p)}
+        p1 = tmp_path / "out_0.yaml"
+        p2 = tmp_path / "out_1.yaml"
+        p1.write_text("PROJECTS:\n- NAME: A\n")
+        p2.write_text("PROJECTS:\n- NAME: B\n")
+        return {"outputs": [str(p1), str(p2)]}
 
     monkeypatch.setattr(handler, "generate_payload", fake_generate_payload)
 

--- a/pkgs/standards/peagen/tests/unit/test_load_projects_payload.py
+++ b/pkgs/standards/peagen/tests/unit/test_load_projects_payload.py
@@ -1,0 +1,17 @@
+import io
+import yaml
+import pytest
+
+from peagen.core.process_core import load_projects_payload
+from peagen.plugins.storage_adapters.file_storage_adapter import FileStorageAdapter
+
+
+@pytest.mark.unit
+def test_load_projects_payload_remote(tmp_path):
+    data = {'PROJECTS': [{'NAME': 'A'}]}
+    yaml_text = yaml.safe_dump(data)
+    adapter = FileStorageAdapter(tmp_path)
+    uri = adapter.upload('pp.yaml', io.BytesIO(yaml_text.encode()))
+
+    projects = load_projects_payload(uri)
+    assert projects and projects[0]['NAME'] == 'A'


### PR DESCRIPTION
## Summary
- generate a separate projects_payload for each design point
- update CLI output handling for multiple payload files
- spawn process tasks for each generated payload file
- update unit test for new generator behavior

## Testing
- `ruff check -q .`


------
https://chatgpt.com/codex/tasks/task_e_684aa21daa008326a121602a4c67c58c