### PR TITLE
Update fan out logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+### Changed
+- Updated `fan_out` to submit child tasks using a JSON-RPC batch, reducing network chatter.
+

--- a/pkgs/standards/peagen/tests/unit/test_doe_process_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_doe_process_handler.py
@@ -35,7 +35,11 @@ async def test_doe_process_handler_dispatches(monkeypatch, tmp_path):
     task = {"id": "T0", "pool": "default", "payload": {"args": {"spec": "s", "template": "t", "output": str(tmp_path / "out.yaml")}}}
     result = await handler.doe_process_handler(task)
 
-    assert len(sent) == 4
-    assert sent[-1]["method"] == "Work.finished"
-    assert sent[-1]["params"]["status"] == "waiting"
+    assert len(sent) == 1
+    batch = sent[0]
+    assert isinstance(batch, list)
+    assert batch[-1]["method"] == "Work.finished"
+    assert batch[-1]["params"]["status"] == "waiting"
+    submits = [req for req in batch if req.get("method") == "Task.submit"]
+    assert len(submits) == 2
     assert result["children"] and len(result["children"]) == 2

--- a/pkgs/standards/peagen/tests/unit/test_evolve_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_evolve_handler.py
@@ -32,7 +32,10 @@ async def test_evolve_handler_fanout(monkeypatch, tmp_path):
     result = await handler.evolve_handler(task)
 
     assert result["jobs"] == 1
-    assert sent and sent[-1]["method"] == "Work.finished"
-    submit = sent[0]
+    assert len(sent) == 1
+    batch = sent[0]
+    assert isinstance(batch, list)
+    assert batch[-1]["method"] == "Work.finished"
+    submit = batch[0]
     assert submit["method"] == "Task.submit"
     assert "action" not in submit["params"]["payload"]


### PR DESCRIPTION
## Summary
- batch RPC calls when fanning out tasks
- update unit tests for batching behavior
- add changelog entry

## Checklist
- [x] `ruff check`
- [x] `pytest`
- [ ] Deploy gateway and worker for **remote** with Redis queue, Redis pubsub, MinIO storage and Postgres backend
- [x] Deploy gateway and worker for **local** with in-memory queue, no pubsub, local FS storage and results backend
- [x] Submit a task in each mode using `peagen -q` and wait for completion
- [x] Show `task get` output for each mode proving success

------
https://chatgpt.com/codex/tasks/task_e_684ad98cd7d883268d8243b2daa27f56