### PR TITLE
Enhance evolve CLI

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/evolve.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/evolve.py
@@ -5,12 +5,13 @@ import asyncio
 import json
 import uuid
 from pathlib import Path
+from typing import Optional
 
 import httpx
 import typer
 
 from peagen.handlers.evolve_handler import evolve_handler
-from peagen.models import Status, Task
+from peagen.models import Task
 
 local_evolve_app = typer.Typer(help="Expand evolve spec and run mutate tasks")
 remote_evolve_app = typer.Typer(help="Expand evolve spec and run mutate tasks")
@@ -20,22 +21,35 @@ def _build_task(args: dict) -> Task:
     return Task(
         id=str(uuid.uuid4()),
         pool="default",
-        action="evolve",
-        status=Status.waiting,
         payload={"action": "evolve", "args": args},
     )
 
 
 @local_evolve_app.command("evolve")
-def run(ctx: typer.Context, spec: Path = typer.Argument(..., exists=True), json_out: bool = typer.Option(False, "--json")):
+def run(
+    ctx: typer.Context,
+    spec: Path = typer.Argument(..., exists=True),
+    json_out: bool = typer.Option(False, "--json"),
+    out: Optional[Path] = typer.Option(None, "--out", help="Write results to file"),
+):
     args = {"evolve_spec": str(spec)}
     task = _build_task(args)
     result = asyncio.run(evolve_handler(task))
-    typer.echo(json.dumps(result, indent=2) if json_out else json.dumps(result, indent=2))
+    if json_out:
+        typer.echo(json.dumps(result, indent=2))
+    else:
+        out_file = out or spec.with_suffix(".evolve_result.json")
+        out_file.write_text(json.dumps(result, indent=2))
+        typer.echo(str(out_file))
 
 
 @remote_evolve_app.command("evolve")
-def submit(ctx: typer.Context, spec: Path = typer.Argument(..., exists=True)):
+def submit(
+    ctx: typer.Context,
+    spec: Path = typer.Argument(..., exists=True),
+    watch: bool = typer.Option(False, "--watch", "-w", help="Poll until finished"),
+    interval: float = typer.Option(2.0, "--interval", "-i", help="Seconds between polls"),
+):
     args = {"evolve_spec": str(spec)}
     task = _build_task(args)
     rpc_req = {
@@ -53,3 +67,24 @@ def submit(ctx: typer.Context, spec: Path = typer.Argument(..., exists=True)):
         )
         raise typer.Exit(1)
     typer.secho(f"Submitted task {task.id}", fg=typer.colors.GREEN)
+    if reply.get("result"):
+        typer.echo(json.dumps(reply["result"], indent=2))
+    if watch:
+        def _rpc_call() -> dict:
+            req = {
+                "jsonrpc": "2.0",
+                "id": str(uuid.uuid4()),
+                "method": "Task.get",
+                "params": {"taskId": task.id},
+            }
+            res = httpx.post(ctx.obj.get("gateway_url"), json=req, timeout=30.0).json()
+            return res["result"]
+
+        import time
+
+        while True:
+            task_reply = _rpc_call()
+            typer.echo(json.dumps(task_reply, indent=2))
+            if task_reply["status"] in {"finished", "failed"}:
+                break
+            time.sleep(interval)


### PR DESCRIPTION
## Summary
- expand `peagen evolve` CLI with file output and watch options
- support polling remote tasks to completion

## Testing
- `uv run --package peagen --directory standards/peagen pytest`


------
https://chatgpt.com/codex/tasks/task_e_684ad95c25dc8326a891c7a235a53194