### PR TITLE
Fix HTTP error handling in peagen fan_out

### DIFF
--- a/pkgs/standards/peagen/peagen/handlers/fanout.py
+++ b/pkgs/standards/peagen/peagen/handlers/fanout.py
@@ -55,6 +55,7 @@ async def fan_out(
     )
 
     async with httpx.AsyncClient(timeout=10.0) as client:
-        await client.post(gateway, json=batch)
+        response = await client.post(gateway, json=batch)
+        response.raise_for_status()
 
     return child_ids


### PR DESCRIPTION
## Summary
- ensure fan_out raises HTTP errors

## Testing
- `uv run --package peagen --directory standards/peagen ruff check`
- `uv run --package peagen --directory standards/peagen pytest -q tests/unit/test_doe_process_handler.py::test_doe_process_handler_dispatches`
- `uv run --package peagen --directory standards/peagen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684af11ce3848326a1aa5df1d91767ae