### PR TITLE
Implement plan lock and task chain features

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,4 @@
+[mypy]
+exclude = (pkgs/experimental|pkgs/.*/tests)
+ignore_missing_imports = True
+namespace_packages = True

--- a/pkgs/standards/peagen/peagen/core/__init__.py
+++ b/pkgs/standards/peagen/peagen/core/__init__.py
@@ -1,0 +1,6 @@
+"""Core utilities for the Peagen runtime."""
+
+from .lock_core import lock_plan
+from .chain_core import TaskChainer, chain_hash
+
+__all__ = ["lock_plan", "TaskChainer", "chain_hash"]

--- a/pkgs/standards/peagen/peagen/core/chain_core.py
+++ b/pkgs/standards/peagen/peagen/core/chain_core.py
@@ -1,0 +1,39 @@
+"""Helpers for chaining task and artifact hashes."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Dict, Optional
+
+
+def chain_hash(data: bytes, prev_hash: str | None = None) -> str:
+    """Return a chained SHA256 hash for *data* and *prev_hash*."""
+    h = hashlib.sha256()
+    if prev_hash:
+        h.update(prev_hash.encode("utf-8"))
+    h.update(data)
+    return h.hexdigest()
+
+
+class TaskChainer:
+    """Compute chained hashes for tasks and artifacts."""
+
+    def __init__(self, prev_hash: str | None = None) -> None:
+        self.prev_hash = prev_hash
+
+    def add_task(self, payload: Dict[str, Any]) -> str:
+        """Add a task payload and return the new chain hash."""
+        data = json.dumps(payload, sort_keys=True).encode("utf-8")
+        self.prev_hash = chain_hash(data, self.prev_hash)
+        return self.prev_hash
+
+    def add_artifact(self, artifact_data: bytes) -> str:
+        """Add artifact bytes to the chain and return the new hash."""
+        self.prev_hash = chain_hash(artifact_data, self.prev_hash)
+        return self.prev_hash
+
+    @property
+    def current_hash(self) -> Optional[str]:
+        """Return the most recent hash in the chain."""
+        return self.prev_hash

--- a/pkgs/standards/peagen/peagen/core/lock_core.py
+++ b/pkgs/standards/peagen/peagen/core/lock_core.py
@@ -1,0 +1,32 @@
+"""Utilities for locking plan files with a stable hash."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any, Dict, Union
+
+import yaml
+
+
+def _hash_bytes(data: bytes) -> str:
+    """Return a SHA256 hex digest for *data*."""
+    h = hashlib.sha256()
+    h.update(data)
+    return h.hexdigest()
+
+
+def lock_plan(plan: Union[str, Path, Dict[str, Any]]) -> str:
+    """Return a lock hash for a DOE, evaluation, evolve, or analysis plan.
+
+    Args:
+        plan: File path or mapping representing the plan contents.
+
+    Returns:
+        str: SHA256 hex digest of the plan.
+    """
+    if isinstance(plan, (str, Path)):
+        text = Path(plan).expanduser().read_text(encoding="utf-8")
+    else:
+        text = yaml.safe_dump(plan, sort_keys=True)
+    return _hash_bytes(text.encode("utf-8"))

--- a/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
@@ -6,9 +6,10 @@ from pathlib import Path
 from typing import Any, Dict, List
 import uuid
 
-import yaml
+import yaml  # type: ignore[import-untyped]
 
 from peagen.core.doe_core import generate_payload
+from peagen.core import lock_plan, TaskChainer, chain_hash
 from peagen.models import Task, Status
 from .fanout import fan_out
 
@@ -18,9 +19,12 @@ async def doe_process_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, 
     payload = task_or_dict.get("payload", {})
     args: Dict[str, Any] = payload.get("args", {})
 
+    spec_path = Path(args["spec"]).expanduser()
+    template_path = Path(args["template"]).expanduser()
+
     result = generate_payload(
-        spec_path=Path(args["spec"]).expanduser(),
-        template_path=Path(args["template"]).expanduser(),
+        spec_path=spec_path,
+        template_path=template_path,
         output_path=Path(args["output"]).expanduser(),
         cfg_path=Path(args["config"]).expanduser() if args.get("config") else None,
         notify_uri=args.get("notify"),
@@ -29,27 +33,36 @@ async def doe_process_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, 
         skip_validate=args.get("skip_validate", False),
     )
 
-    doc = yaml.safe_load(Path(result["output"]).read_text())
+    lock_hash = chain_hash(lock_plan(template_path).encode(), lock_plan(spec_path))
+    chainer = TaskChainer(lock_hash)
+    if isinstance(task_or_dict, Task):
+        task_or_dict.lock_hash = lock_hash
+        task_or_dict.chain_hash = lock_hash
+
+    artifact_data = Path(result["output"]).read_bytes()
+    chainer.add_artifact(artifact_data)
+    doc = yaml.safe_load(artifact_data)
     projects: List[Dict[str, Any]] = doc.get("PROJECTS", [])
 
     pool = task_or_dict.get("pool", "default")
     children: List[Task] = []
     for proj in projects:
-        children.append(
-            Task(
-                id=str(uuid.uuid4()),
-                pool=pool,
-                action="process",
-                status=Status.waiting,
-                payload={
-                    "action": "process",
-                    "args": {
-                        "projects_payload": result["output"],
-                        "project_name": proj.get("NAME"),
-                    },
+        child = Task(  # type: ignore[call-arg]
+            id=str(uuid.uuid4()),
+            pool=pool,
+            action="process",
+            status=Status.waiting,
+            payload={
+                "action": "process",
+                "args": {
+                    "projects_payload": result["output"],
+                    "project_name": proj.get("NAME"),
                 },
-            )
+            },
+            lock_hash=lock_hash,
         )
+        child.chain_hash = chainer.add_task(child.payload)
+        children.append(child)
 
     child_ids = await fan_out(task_or_dict, children, result=result, final_status=Status.waiting)
-    return {"children": child_ids, **result}
+    return {"children": child_ids, "lock_hash": lock_hash, "chain_hash": chainer.current_hash, **result}

--- a/pkgs/standards/peagen/peagen/models/schemas.py
+++ b/pkgs/standards/peagen/peagen/models/schemas.py
@@ -43,6 +43,8 @@ class Task(BaseModel):
     config_toml: str | None = None
     started_at: float | None = None
     finished_at: float | None = None
+    lock_hash: str | None = None
+    chain_hash: str | None = None
 
     @property
     def duration(self) -> int | None:

--- a/pkgs/standards/peagen/peagen/models/task_run.py
+++ b/pkgs/standards/peagen/peagen/models/task_run.py
@@ -35,6 +35,8 @@ class TaskRun(Base):
     in_degree    = Column(psql.INTEGER, nullable=False, default=0)
     config_toml  = Column(String, nullable=True)
     artifact_uri = Column(String, nullable=True)
+    lock_hash    = Column(String, nullable=True)
+    chain_hash   = Column(String, nullable=True)
     started_at   = Column(TIMESTAMP(timezone=True), default=dt.datetime.utcnow)
     finished_at  = Column(TIMESTAMP(timezone=True), nullable=True)
 
@@ -59,6 +61,8 @@ class TaskRun(Base):
                 if task.result and isinstance(task.result, dict)
                 else None
             ),
+            lock_hash=getattr(task, "lock_hash", None),
+            chain_hash=getattr(task, "chain_hash", None),
             started_at=(
                 dt.datetime.utcfromtimestamp(task.started_at)
                 if task.started_at
@@ -98,6 +102,8 @@ class TaskRun(Base):
             "in_degree": self.in_degree,
             "config_toml": self.config_toml,
             "artifact_uri": self.artifact_uri,
+            "lock_hash": self.lock_hash,
+            "chain_hash": self.chain_hash,
             "started_at": self.started_at,
             "finished_at": self.finished_at,
             "duration": (

--- a/pkgs/standards/peagen/tests/examples/locking_demo/README.md
+++ b/pkgs/standards/peagen/tests/examples/locking_demo/README.md
@@ -1,0 +1,3 @@
+These example files demonstrate a minimal DOE spec and accompanying template project.
+They are compatible and can be used together when testing plan locking and
+cryptographic chaining features.

--- a/pkgs/standards/peagen/tests/examples/locking_demo/doe_spec.yaml
+++ b/pkgs/standards/peagen/tests/examples/locking_demo/doe_spec.yaml
@@ -1,0 +1,10 @@
+schemaVersion: "1.0.1"
+FACTORS:
+  SUFFIX:
+    description: "Project suffix"
+    code: SFX
+    levels: [001, 002]
+    patches:
+      - op: replace
+        path: /PROJECTS/0/NAME
+        value: "ExampleParserProject-{{ SFX }}"

--- a/pkgs/standards/peagen/tests/examples/locking_demo/template_project.yaml
+++ b/pkgs/standards/peagen/tests/examples/locking_demo/template_project.yaml
@@ -1,0 +1,17 @@
+schemaVersion: "1.0.0"
+PROJECTS:
+- NAME: ExampleParserProject
+  ROOT: "swarmauri-sdk/pkgs"
+  TEMPLATE_SET: swarmauri_base
+  PACKAGES:
+  - NAME: "base/swarmauri_base"
+    MODULES:
+    - NAME: "ParserBase"
+      EXTRAS:
+        PURPOSE: "Provide a base implementation"
+        DESCRIPTION: "Base implementation"
+        REQUIREMENTS:
+        - "Should inherit from the interface first and ComponentBase second."
+        RESOURCE_KIND: "parsers"
+        INTERFACE_NAME: "IParser"
+        INTERFACE_FILE: "pkgs/core/swarmauri_core/parsers/IParser.py"

--- a/pkgs/standards/peagen/tests/unit/test_doe_process_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_doe_process_handler.py
@@ -31,6 +31,7 @@ async def test_doe_process_handler_dispatches(monkeypatch, tmp_path):
         return {"output": str(p)}
 
     monkeypatch.setattr(handler, "generate_payload", fake_generate_payload)
+    monkeypatch.setattr(handler, "lock_plan", lambda p: "LOCK")
 
     task = {"id": "T0", "pool": "default", "payload": {"args": {"spec": "s", "template": "t", "output": str(tmp_path / "out.yaml")}}}
     result = await handler.doe_process_handler(task)
@@ -39,3 +40,5 @@ async def test_doe_process_handler_dispatches(monkeypatch, tmp_path):
     assert sent[-1]["method"] == "Work.finished"
     assert sent[-1]["params"]["status"] == "waiting"
     assert result["children"] and len(result["children"]) == 2
+    assert result["lock_hash"]
+    assert result["chain_hash"]

--- a/pkgs/standards/peagen/tests/unit/test_lock_chain_core.py
+++ b/pkgs/standards/peagen/tests/unit/test_lock_chain_core.py
@@ -1,0 +1,35 @@
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from peagen.core import TaskChainer, chain_hash, lock_plan
+from peagen.models import Task, TaskRun
+
+
+@pytest.mark.unit
+def test_lock_plan_same_hash_for_file_and_mapping(tmp_path: Path) -> None:
+    plan = {"steps": [{"action": "a"}, {"action": "b"}]}
+    plan_file = tmp_path / "plan.yaml"
+    plan_file.write_text(yaml.safe_dump(plan, sort_keys=True), encoding="utf-8")
+    assert lock_plan(plan_file) == lock_plan(plan)
+
+
+@pytest.mark.unit
+def test_task_chainer_chains_tasks_and_artifacts() -> None:
+    chainer = TaskChainer()
+    payload = {"foo": 1}
+    expected = chain_hash(json.dumps(payload, sort_keys=True).encode())
+    assert chainer.add_task(payload) == expected
+    expected = chain_hash(b"artifact", expected)
+    assert chainer.add_artifact(b"artifact") == expected
+    assert chainer.current_hash == expected
+
+
+@pytest.mark.unit
+def test_taskrun_from_task_includes_hashes() -> None:
+    task = Task(pool="p", payload={}, lock_hash="L", chain_hash="C")
+    tr = TaskRun.from_task(task)
+    assert tr.lock_hash == "L"
+    assert tr.chain_hash == "C"


### PR DESCRIPTION
## Summary
- move doe spec and template example into `tests/examples/locking_demo`
- patch DOE process handler unit test to mock `lock_plan`

## Checklist
- [x] `ruff check`
- [x] `pytest`
- [ ] Deploy gateway and worker for **remote** with Redis queue, Redis pubsub, MinIO storage and Postgres backend
- [ ] Deploy gateway and worker for **local** with in-memory queue, no pubsub, local FS storage and results backend
- [ ] Submit a task in each mode using `peagen -q` and wait for completion
- [ ] Show `task get` output for each mode proving success

------
https://chatgpt.com/codex/tasks/task_e_684ada0f88b08326af633bf39df74d60