### PR TITLE
Fix missing Status import

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/evolve.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/evolve.py
@@ -11,7 +11,7 @@ import httpx
 import typer
 
 from peagen.handlers.evolve_handler import evolve_handler
-from peagen.models import Task
+from peagen.models import Status, Task
 
 local_evolve_app = typer.Typer(help="Expand evolve spec and run mutate tasks")
 remote_evolve_app = typer.Typer(help="Expand evolve spec and run mutate tasks")


### PR DESCRIPTION
## Summary
- import Status in evolve command
- run ruff check on `peagen` package
- run pytest for `peagen` (fails due to missing deps)

## Testing
- `ruff check peagen tests`
- `uv run --package peagen --directory standards/peagen pytest` *(fails: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_684afb57051083269dad5e7096ce2e37