### PR TITLE
Add hashing utilities with tests

### DIFF
--- a/docs/provenance.md
+++ b/docs/provenance.md
@@ -1,0 +1,15 @@
+# Provenance Hashing
+
+Peagen tracks task lineage using canonical SHA-256 hashes. YAML files are
+normalised to JSON with sorted keys before hashing. The resulting digest
+is stored as a lowercase hexadecimal string.
+
+```python
+from pathlib import Path
+from peagen.utils import hashing
+
+payload_h = hashing.payload_hash({"foo": "bar"})
+rev_h = hashing.revision_hash(None, payload_h)
+edge_h = hashing.edge_hash(rev_h, payload_h, "worker-1", None)
+root_h = hashing.fanout_root_hash([edge_h])
+```

--- a/pkgs/standards/peagen/peagen/utils/__init__.py
+++ b/pkgs/standards/peagen/peagen/utils/__init__.py
@@ -1,0 +1,23 @@
+"""Utility functions for Peagen."""
+
+from .hashing import (
+    design_hash,
+    plan_hash,
+    payload_hash,
+    revision_hash,
+    edge_hash,
+    fanout_root_hash,
+    artefact_cid,
+    status_hash,
+)
+
+__all__ = [
+    "design_hash",
+    "plan_hash",
+    "payload_hash",
+    "revision_hash",
+    "edge_hash",
+    "fanout_root_hash",
+    "artefact_cid",
+    "status_hash",
+]

--- a/pkgs/standards/peagen/peagen/utils/hashing.py
+++ b/pkgs/standards/peagen/peagen/utils/hashing.py
@@ -1,0 +1,80 @@
+"""Canonical SHA-256 hashing utilities for provenance.
+
+All functions return lowercase hexadecimal digests. YAML inputs are
+converted to JSON with sorted keys before hashing.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Iterable, Mapping
+
+import yaml
+
+_JSON_OPTS = {"sort_keys": True, "separators": (",", ":")}
+
+
+def _json_digest(obj: object) -> str:
+    text = json.dumps(obj, **_JSON_OPTS)
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _yaml_file_digest(path: Path) -> str:
+    """Return the canonical digest of a YAML document."""
+    data = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+    return _json_digest(data)
+
+
+def design_hash(path: Path) -> str:
+    """Return the canonical SHA-256 of a design spec."""
+    return _yaml_file_digest(path)
+
+
+def plan_hash(path: Path) -> str:
+    """Return the canonical SHA-256 of a plan file."""
+    return _yaml_file_digest(path)
+
+
+def payload_hash(payload: Mapping) -> str:
+    """Return the canonical SHA-256 of a payload mapping."""
+    return _json_digest(payload)
+
+
+def revision_hash(parent_rev: str | None, payload_hash: str) -> str:
+    """Return the SHA-256 of a revision node."""
+    data = {"parent": parent_rev, "payload": payload_hash}
+    return _json_digest(data)
+
+
+def edge_hash(
+    parent_rev: str,
+    child_payload_hash: str,
+    operator_id: str,
+    branch_tag: str | None,
+) -> str:
+    """Return the SHA-256 of an edge descriptor."""
+    data = {
+        "parent": parent_rev,
+        "child": child_payload_hash,
+        "operator": operator_id,
+        "branch": branch_tag,
+    }
+    return _json_digest(data)
+
+
+def fanout_root_hash(edge_hashes: Iterable[str]) -> str:
+    """Return the SHA-256 over sorted edge hashes."""
+    data = sorted(edge_hashes)
+    return _json_digest(data)
+
+
+def artefact_cid(data: bytes) -> str:
+    """Return the SHA-256 of binary artefact data."""
+    return hashlib.sha256(data).hexdigest()
+
+
+def status_hash(rev_hash: str, status: str, timestamp: str) -> str:
+    """Return the SHA-256 of a status record."""
+    data = {"rev": rev_hash, "status": status, "timestamp": timestamp}
+    return _json_digest(data)

--- a/pkgs/standards/peagen/tests/benchmarks/bench_hashing.py
+++ b/pkgs/standards/peagen/tests/benchmarks/bench_hashing.py
@@ -1,0 +1,9 @@
+import pytest
+
+from peagen.utils.hashing import payload_hash
+
+
+@pytest.mark.perf
+def test_payload_hash_benchmark(benchmark):
+    data = {"foo": "bar"}
+    benchmark(lambda: payload_hash(data))

--- a/pkgs/standards/peagen/tests/conftest.py
+++ b/pkgs/standards/peagen/tests/conftest.py
@@ -1,0 +1,30 @@
+import pytest
+
+try:
+    from pytest_socket import disable_socket
+except Exception:  # pragma: no cover - optional
+    disable_socket = None
+
+try:
+    import psutil
+except ImportError:  # pragma: no cover - optional
+    psutil = None
+
+
+@pytest.fixture(autouse=True)
+def _socket_guard() -> None:
+    if disable_socket:
+        disable_socket()
+
+
+@pytest.fixture
+def cpu_mem_profile():
+    if not psutil:
+        pytest.skip("psutil not available")
+    proc = psutil.Process()
+    before = proc.cpu_times().user
+    mem_before = proc.memory_info().rss
+    yield
+    after = proc.cpu_times().user
+    mem_after = proc.memory_info().rss
+    print(f"CPU(s): {after - before:.4f}  RSS: {mem_after - mem_before}")

--- a/pkgs/standards/peagen/tests/unit/test_hashing_utils.py
+++ b/pkgs/standards/peagen/tests/unit/test_hashing_utils.py
@@ -1,0 +1,66 @@
+import pytest
+from pathlib import Path
+
+from peagen.utils import hashing
+from peagen.utils.hashing import _yaml_file_digest
+
+
+@pytest.mark.unit
+def test_design_and_plan_hash(tmp_path: Path) -> None:
+    text = "a: 1\nb: 2\n"
+    design = tmp_path / "design.yaml"
+    plan = tmp_path / "plan.yaml"
+    design.write_text(text, encoding="utf-8")
+    plan.write_text(text, encoding="utf-8")
+    expected = "43258cff783fe7036d8a43033f830adfc60ec037382473548ac742b888292777"
+    assert hashing.design_hash(design) == expected
+    assert hashing.plan_hash(plan) == expected
+
+
+@pytest.mark.unit
+def test_yaml_file_digest(tmp_path: Path) -> None:
+    text = "foo: 3\nbar: 4\n"
+    path = tmp_path / "file.yaml"
+    path.write_text(text, encoding="utf-8")
+    expected = hashing.design_hash(path)
+    assert _yaml_file_digest(path) == expected
+
+
+@pytest.mark.unit
+def test_payload_hash() -> None:
+    data = {"foo": "bar", "num": 1}
+    assert (
+        hashing.payload_hash(data)
+        == "1159feb256de4d1d5a7fac1e031195f8ab6374e35efd9e9b830e353df0d84fa7"
+    )
+
+
+@pytest.mark.unit
+def test_revision_and_edge_hashes() -> None:
+    payload_h = "deadbeef"
+    rev_no_parent = hashing.revision_hash(None, payload_h)
+    assert rev_no_parent == "32c0f7b422237f274057f406117892bdf34d9d2346064989ebe0c5d109b9ec4f"
+    rev_with_parent = hashing.revision_hash("abc", payload_h)
+    assert rev_with_parent == "eb93c4bf3f294dce1ecd0d1c849bc05dcb235b42c5d184bea54b6085264caa4c"
+
+    edge1 = hashing.edge_hash("rev1", "child1", "op", None)
+    assert edge1 == "f47042d1ce66c280e2cf1dd882267777634bdcdab567960952ea9b1f2db6a186"
+    edge2 = hashing.edge_hash("rev1", "child1", "op", "dev")
+    assert edge2 == "c0a6ba0c9464f9bda7a63e95bdbb21bc88a3ba03a7bcf0cc1daa0bb8c2c7eeda"
+
+    fan = hashing.fanout_root_hash([edge2, edge1])
+    assert fan == "2471e2af92d6ee0aa7faa4c1480e335703bd33b0b39202918c916b0df93b16fe"
+
+
+@pytest.mark.unit
+def test_artefact_and_status_hash() -> None:
+    assert (
+        hashing.artefact_cid(b"hello")
+        == "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+    )
+    status = hashing.status_hash(
+        "abc",
+        "OK",
+        "2023-01-01T00:00:00Z",
+    )
+    assert status == "106ca506c299196dd938be65d162753f47f1a3f342bdefdcb3e2b7fc23363a54"


### PR DESCRIPTION
## Summary
- implement canonical SHA256 helpers under `peagen.utils`
- cover hashing helpers with unit tests
- add simple benchmark
- document provenance hashing usage
- refactor YAML hashing helper

## Testing
- `ruff check --fix pkgs/standards/peagen/peagen/utils/hashing.py pkgs/standards/peagen/tests/unit/test_hashing_utils.py`
- `pyright pkgs/standards/peagen/peagen/utils/hashing.py`
- ❌ `peagen remote -q --gateway-url http://127.0.0.1:8000/rpc process projects.yaml --watch` *(failed: Unsupported LLM provider)*

------
https://chatgpt.com/codex/tasks/task_e_684aebfd08b48326bfab05bcc1f37494