### PR TITLE
Implement gateway task revision chain

### DIFF
--- a/pkgs/standards/peagen/docs/gateway_task_revisions.md
+++ b/pkgs/standards/peagen/docs/gateway_task_revisions.md
@@ -1,0 +1,14 @@
+# Gateway Task Revisions
+
+The Peagen gateway now records every task update in an append-only
+`task_revision` table. Each revision stores the base64 encoded payload,
+its SHA-256 hash, the parent revision hash, and a computed `rev_hash` of
+`SHA256(parent_rev_hash‖payload_hash)`.
+
+Submitting a DOE specification also validates the provided
+`design_hash` and `plan_hash` values. These hashes are upserted into the
+`manifest` table so duplicate submissions reuse the same manifest row.
+
+Clients patch tasks by including `parent_rev_hash` in the JSON-RPC
+params. The gateway rejects mismatched hashes with
+`PeagenHashMismatchError`.

--- a/pkgs/standards/peagen/peagen/__init__.py
+++ b/pkgs/standards/peagen/peagen/__init__.py
@@ -15,5 +15,13 @@ except PackageNotFoundError:
 
 
 from .plugin_manager import PluginManager, resolve_plugin_spec
+from .errors import PeagenError, PeagenHashMismatchError
 
-__all__ = ["__package_name__", "__version__", "PluginManager", "resolve_plugin_spec"]
+__all__ = [
+    "__package_name__",
+    "__version__",
+    "PluginManager",
+    "resolve_plugin_spec",
+    "PeagenError",
+    "PeagenHashMismatchError",
+]

--- a/pkgs/standards/peagen/peagen/errors.py
+++ b/pkgs/standards/peagen/peagen/errors.py
@@ -1,0 +1,10 @@
+"""Peagen gateway exceptions."""
+from __future__ import annotations
+
+
+class PeagenError(Exception):
+    """Base exception for Peagen-related errors."""
+
+
+class PeagenHashMismatchError(PeagenError):
+    """Raised when a supplied hash does not match computed value."""

--- a/pkgs/standards/peagen/peagen/models/__init__.py
+++ b/pkgs/standards/peagen/peagen/models/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from peagen.models.task_run import Base, TaskRun
+from peagen.models.task_revision import Manifest, TaskRevision
 from peagen.models.schemas import (
     Role,
     Status,
@@ -8,4 +9,14 @@ from peagen.models.schemas import (
     User,
 )
 
-__all__ = ["Role", "Status", "Task", "Pool", "User", "Base", "TaskRun"]
+__all__ = [
+    "Role",
+    "Status",
+    "Task",
+    "Pool",
+    "User",
+    "Base",
+    "TaskRun",
+    "Manifest",
+    "TaskRevision",
+]

--- a/pkgs/standards/peagen/peagen/models/task_revision.py
+++ b/pkgs/standards/peagen/peagen/models/task_revision.py
@@ -1,0 +1,40 @@
+"""Database tables for task revisions and DOE manifests."""
+from __future__ import annotations
+
+from sqlalchemy import (
+    Column,
+    ForeignKey,
+    Integer,
+    String,
+    TIMESTAMP,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.dialects.postgresql import UUID
+
+from .task_run import Base
+
+
+class Manifest(Base):
+    """Unique DOE manifest fingerprint."""
+
+    __tablename__ = "manifest"
+    __table_args__ = (UniqueConstraint("design_hash", "plan_hash", name="uq_manifest_hashes"),)
+
+    id = Column(Integer, primary_key=True)
+    design_hash = Column(String, nullable=False)
+    plan_hash = Column(String, nullable=False)
+
+
+class TaskRevision(Base):
+    """Append-only task revision history."""
+
+    __tablename__ = "task_revision"
+
+    id = Column(Integer, primary_key=True)
+    task_id = Column(UUID(as_uuid=True), ForeignKey("task_runs.id", onupdate="RESTRICT", ondelete="RESTRICT"))
+    parent_hash = Column(String, nullable=True)
+    rev_hash = Column(String, nullable=False, unique=True)
+    payload_hash = Column(String, nullable=False)
+    payload_b64 = Column(String, nullable=False)
+    ts_created = Column(TIMESTAMP(timezone=True), nullable=False, server_default=func.now())

--- a/pkgs/standards/peagen/tests/unit/test_task_patch_status.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_patch_status.py
@@ -13,6 +13,29 @@ async def test_task_patch_updates_status(monkeypatch):
         async def store(self, task_run):
             pass
 
+    class DummySession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def execute(self, *args, **kwargs):
+            class _R:
+                def fetchone(self_inner):
+                    return None
+
+                def scalar_one(self_inner):
+                    return None
+
+                def scalar_one_or_none(self_inner):
+                    return None
+
+            return _R()
+
+        async def commit(self):
+            pass
+
     class StubPM:
         def __init__(self, cfg):
             pass
@@ -33,6 +56,10 @@ async def test_task_patch_updates_status(monkeypatch):
 
     monkeypatch.setattr(gw, "queue", q)
     monkeypatch.setattr(gw, "result_backend", DummyBackend())
+    monkeypatch.setattr(gw, "Session", lambda: DummySession())
+    monkeypatch.setattr(gw, "insert_revision", lambda *a, **kw: None)
+    monkeypatch.setattr(gw, "latest_revision", lambda *a, **kw: None)
+    monkeypatch.setattr(gw, "upsert_manifest", lambda *a, **kw: None)
 
     async def noop(*_args, **_kwargs):
         return None
@@ -47,6 +74,6 @@ async def test_task_patch_updates_status(monkeypatch):
     result = await task_submit(pool="p", payload={}, taskId=None)
     tid = result["taskId"]
 
-    await task_patch(taskId=tid, changes={"status": "success"})
+    await task_patch(taskId=tid, changes={"status": "success", "parent_rev_hash": None})
     patched = await task_get(tid)
     assert patched["status"] == "success"

--- a/proof.tsv
+++ b/proof.tsv
@@ -1,0 +1,3 @@
+component	hash
+pkgs/standards/peagen/peagen/errors.py	8c4f451e9e61e6dcf2dd5d99dcd1b6a5257c00c70badd17806791d4b335abb94
+pkgs/standards/peagen/peagen/models/task_revision.py	6bf5955baba6121d8caae8f2cc7c0709683367aaae581b4ffce69a0950d1af94


### PR DESCRIPTION
- add `PeagenError` hierarchy with `PeagenHashMismatchError`
- track task revisions and DOE manifests in new tables
- compute revision hashes during submit/patch
- update tests and docs



------
https://chatgpt.com/codex/tasks/task_e_684aed7965b08326b2e8ed077a5c1699