### PR TITLE
Add provenance API layer

### DIFF
--- a/docs/docs/provenance.md
+++ b/docs/docs/provenance.md
@@ -1,0 +1,27 @@
+# Provenance Tracking
+
+The gateway persists provenance information in four append-only tables:
+`task_revision`, `artefact_lineage`, `fanout_set`, and `status_log`.
+Each table records immutable facts about task execution.
+
+## API Layer
+
+All writes to these tables are routed through helpers in
+`peagen.db.api`.  The helpers accept typed dataclass instances and
+perform parameterized inserts using the gateway or worker's database
+session.  Any attempt to update or delete rows raises an error at the
+database layer.
+
+Example usage:
+
+```python
+from peagen.db.models import TaskRevision
+from peagen.db.api import insert_task_revision
+
+# assuming `session` is an `AsyncSession`
+revision = TaskRevision(rev_hash="abc123", task_id=task_id)
+await insert_task_revision(session, revision)
+```
+
+If a child revision references a parent hash that does not exist,
+`PeagenHashMismatchError` is raised.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -121,6 +121,7 @@ nav:
   - guide/index.md
   - Installation: guide/installation.md
   - Usage: guide/usage.md
+  - Provenance: provenance.md
   - Courses:
     - guide/index.md
     - Entry: guide/course/1.md

--- a/pkgs/standards/peagen/peagen/db/__init__.py
+++ b/pkgs/standards/peagen/peagen/db/__init__.py
@@ -1,0 +1,24 @@
+"""Database models and insert helpers for provenance tracking."""
+
+from .models import TaskRevision, ArtefactLineage, FanoutSet, StatusLog, asdict
+from .api import (
+    insert_task_revision,
+    insert_artefact_lineage,
+    insert_fanout_set,
+    insert_status_log,
+)
+from .errors import PeagenError, PeagenHashMismatchError
+
+__all__ = [
+    "TaskRevision",
+    "ArtefactLineage",
+    "FanoutSet",
+    "StatusLog",
+    "insert_task_revision",
+    "insert_artefact_lineage",
+    "insert_fanout_set",
+    "insert_status_log",
+    "PeagenError",
+    "PeagenHashMismatchError",
+    "asdict",
+]

--- a/pkgs/standards/peagen/peagen/db/api.py
+++ b/pkgs/standards/peagen/peagen/db/api.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .models import (
+    ArtefactLineage,
+    FanoutSet,
+    StatusLog,
+    TaskRevision,
+    asdict,
+)
+from .errors import PeagenError, PeagenHashMismatchError
+
+
+async def _execute_insert(session: AsyncSession, stmt: str, params: dict[str, Any]) -> None:
+    try:
+        await session.execute(text(stmt), params)
+    except IntegrityError as exc:  # duplicate key or FK violation
+        raise PeagenError(str(exc)) from exc
+
+
+async def insert_task_revision(session: AsyncSession, row: TaskRevision) -> None:
+    if row.parent_hash:
+        res = await session.execute(
+            text("SELECT 1 FROM task_revision WHERE rev_hash = :h"),
+            {"h": row.parent_hash},
+        )
+        if res.scalar() is None:
+            raise PeagenHashMismatchError(f"parent hash {row.parent_hash} not found")
+
+    stmt = (
+        "INSERT INTO task_revision (rev_hash, task_id, parent_hash, ts_created) "
+        "VALUES (:rev_hash, :task_id, :parent_hash, :ts_created)"
+    )
+    await _execute_insert(session, stmt, asdict(row))
+
+
+async def insert_artefact_lineage(session: AsyncSession, row: ArtefactLineage) -> None:
+    stmt = (
+        "INSERT INTO artefact_lineage (edge_hash, parent_hash, child_hash, ts_logged) "
+        "VALUES (:edge_hash, :parent_hash, :child_hash, :ts_logged)"
+    )
+    await _execute_insert(session, stmt, asdict(row))
+
+
+async def insert_fanout_set(session: AsyncSession, row: FanoutSet) -> None:
+    stmt = (
+        "INSERT INTO fanout_set (rev_hash, child_hash, ts_logged) "
+        "VALUES (:rev_hash, :child_hash, :ts_logged)"
+    )
+    await _execute_insert(session, stmt, asdict(row))
+
+
+async def insert_status_log(session: AsyncSession, row: StatusLog) -> None:
+    stmt = (
+        "INSERT INTO status_log (rev_hash, status, ts_logged) "
+        "VALUES (:rev_hash, :status, :ts_logged)"
+    )
+    await _execute_insert(session, stmt, asdict(row))

--- a/pkgs/standards/peagen/peagen/db/errors.py
+++ b/pkgs/standards/peagen/peagen/db/errors.py
@@ -1,0 +1,6 @@
+class PeagenError(Exception):
+    """Base class for provenance API errors."""
+
+
+class PeagenHashMismatchError(PeagenError):
+    """Raised when a parent hash reference is invalid."""

--- a/pkgs/standards/peagen/peagen/db/models.py
+++ b/pkgs/standards/peagen/peagen/db/models.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from datetime import datetime
+from typing import Optional
+from uuid import UUID
+
+from peagen.models.schemas import Status
+
+
+@dataclass(slots=True)
+class TaskRevision:
+    """Typed representation of a row in ``task_revision``."""
+
+    rev_hash: str
+    task_id: UUID
+    parent_hash: Optional[str] = None
+    ts_created: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass(slots=True)
+class ArtefactLineage:
+    """Typed representation of a row in ``artefact_lineage``."""
+
+    edge_hash: str
+    parent_hash: str
+    child_hash: str
+    ts_logged: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass(slots=True)
+class FanoutSet:
+    """Typed representation of a row in ``fanout_set``."""
+
+    rev_hash: str
+    child_hash: str
+    ts_logged: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass(slots=True)
+class StatusLog:
+    """Typed representation of a row in ``status_log``."""
+
+    rev_hash: str
+    status: Status
+    ts_logged: datetime = field(default_factory=datetime.utcnow)
+
+
+__all__ = [
+    "TaskRevision",
+    "ArtefactLineage",
+    "FanoutSet",
+    "StatusLog",
+    "asdict",
+]

--- a/pkgs/standards/peagen/tests/unit/test_provenance_api.py
+++ b/pkgs/standards/peagen/tests/unit/test_provenance_api.py
@@ -1,0 +1,83 @@
+import uuid
+import pytest
+
+from peagen.db.api import (
+    insert_task_revision,
+    insert_artefact_lineage,
+    insert_fanout_set,
+    insert_status_log,
+)
+from peagen.db.errors import PeagenError, PeagenHashMismatchError
+from peagen.db.models import (
+    ArtefactLineage,
+    FanoutSet,
+    StatusLog,
+    TaskRevision,
+)
+from peagen.models.schemas import Status
+from sqlalchemy.exc import IntegrityError
+
+
+class DummyResult:
+    def __init__(self, value=None):
+        self._value = value
+
+    def scalar(self):
+        return self._value
+
+
+class DummySession:
+    def __init__(self, parent_exists=True, fail_exc=None):
+        self.parent_exists = parent_exists
+        self.fail_exc = fail_exc
+        self.queries = []
+        self.params = []
+
+    async def execute(self, stmt, params):
+        self.queries.append(str(stmt))
+        self.params.append(params)
+        if self.fail_exc:
+            raise self.fail_exc
+        if "SELECT 1 FROM task_revision" in str(stmt):
+            return DummyResult(1 if self.parent_exists else None)
+        return DummyResult()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_insert_task_revision_success():
+    s = DummySession()
+    row = TaskRevision(rev_hash="h1", task_id=uuid.uuid4())
+    await insert_task_revision(s, row)
+    assert any("INSERT INTO task_revision" in q for q in s.queries)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_insert_task_revision_bad_parent():
+    s = DummySession(parent_exists=False)
+    row = TaskRevision(rev_hash="h1", task_id=uuid.uuid4(), parent_hash="nope")
+    with pytest.raises(PeagenHashMismatchError):
+        await insert_task_revision(s, row)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_insert_helpers_propagate_integrity_error():
+    exc = IntegrityError("dup", {}, None)
+    s = DummySession(fail_exc=exc)
+    row = FanoutSet(rev_hash="h1", child_hash="c")
+    with pytest.raises(PeagenError):
+        await insert_fanout_set(s, row)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_insert_other_tables():
+    s = DummySession()
+    await insert_artefact_lineage(
+        s, ArtefactLineage(edge_hash="e", parent_hash="p", child_hash="c")
+    )
+    await insert_fanout_set(s, FanoutSet(rev_hash="r", child_hash="c"))
+    await insert_status_log(s, StatusLog(rev_hash="r", status=Status.success))
+    assert len(s.queries) == 3


### PR DESCRIPTION
- implement dataclasses for provenance tables
- add insertion helpers using async SQL
- expose helpers via new db package
- document provenance API and update docs navigation
- add unit tests for new helpers

------
https://chatgpt.com/codex/tasks/task_e_684aee2c55148326916ab8fa96a3f26c