### PR TITLE
Add textual to peagen dev dependencies

### DIFF
--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -114,6 +114,7 @@ dev = [
     "pytest-timeout>=2.3.1",
     "ruff>=0.9.9",
     "pytest-benchmark>=4.0.0",
+    "textual>=3.3.0",
 ]
 
 [project.entry-points."peagen.template_sets"]


### PR DESCRIPTION
## Summary
- add `textual` as a dev dependency in the `peagen` project

## Testing
- `ruff check pkgs/standards/peagen`

------
https://chatgpt.com/codex/tasks/task_e_684affe7d3d88326afc51e9630548f5d