### PR TITLE
Fix peagen PG enum creation and adjust tests

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/db_helpers.py
+++ b/pkgs/standards/peagen/peagen/gateway/db_helpers.py
@@ -58,7 +58,7 @@ async def ensure_status_enum(engine) -> None:
         if not exists.scalar():
             enum_values = ", ".join(f"'{v}'" for v in values)
             await conn.execute(
-                text(f"CREATE TYPE IF NOT EXISTS status AS ENUM ({enum_values})")
+                text(f"CREATE TYPE status AS ENUM ({enum_values})")
             )
         else:
             res = await conn.execute(

--- a/pkgs/standards/peagen/tests/unit/test_db_helpers.py
+++ b/pkgs/standards/peagen/tests/unit/test_db_helpers.py
@@ -55,7 +55,7 @@ async def test_ensure_status_enum_creates_if_missing():
     conn = DummyConn(exists=False)
     engine = DummyEngine(conn)
     await ensure_status_enum(engine)
-    assert any("CREATE TYPE IF NOT EXISTS status" in q for q in conn.queries)
+    assert any("CREATE TYPE status" in q for q in conn.queries)
 
 
 @pytest.mark.unit

--- a/pkgs/standards/peagen/tests/unit/test_doe_core_patch_error.py
+++ b/pkgs/standards/peagen/tests/unit/test_doe_core_patch_error.py
@@ -7,8 +7,9 @@ from peagen.errors import PatchTargetMissingError
 
 @pytest.mark.unit
 def test_generate_payload_missing_patch(tmp_path: Path):
-    spec = Path("pkgs/standards/peagen/tests/examples/doe_specs/doe_spec.yaml")
-    template = Path("pkgs/standards/peagen/docs/examples/base_example_project.yaml")
+    root = Path(__file__).resolve().parents[2]
+    spec = root / "tests/examples/doe_specs/doe_spec.yaml"
+    template = root / "docs/examples/base_example_project.yaml"
     output = tmp_path / "out.yaml"
     with pytest.raises(PatchTargetMissingError):
         generate_payload(


### PR DESCRIPTION
## Summary
- support PostgreSQL 16 by dropping `IF NOT EXISTS` from enum creation
- update unit test expectations for enum creation
- fix DOE core test paths so they work when run from `pkgs`

## Testing
- `ruff check pkgs/standards/peagen`
- `uv run --package peagen --directory standards/peagen pytest`
- `uv run --package peagen --directory pkgs/standards/peagen peagen local -q doe process <spec> <template>`
- `uv run --package peagen --directory pkgs/standards/peagen peagen remote -q --gateway-url http://127.0.0.1:8000/rpc doe process <spec> <template>`


------
https://chatgpt.com/codex/tasks/task_e_684b012fabb0832682cf0d51741fe5fb