### PR TITLE
Add local config for peagen examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ pkgs/community/swarmauri_vectorstore_annoy/test_annoy.ann
 /pkgs/standards/ptree_dag/pkgs
 *secrets/*
 !.gitkeep          # keep the empty dir in repo
+peagen_artifacts/
+gateway.db

--- a/pkgs/standards/peagen/tests/examples/peagen_tomls/local_minimal.toml
+++ b/pkgs/standards/peagen/tests/examples/peagen_tomls/local_minimal.toml
@@ -1,0 +1,7 @@
+[queues]
+default_queue = "in_memory"
+
+[result_backends]
+default_backend = "local_fs"
+[result_backends.adapters.local_fs]
+root_dir = "./task_runs"


### PR DESCRIPTION
## Summary
- add a minimal `.peagen.toml` for local testing in the peagen examples
- ignore peagen artifacts and gateway DB
- omit unused project payload ignore rule

## Testing
- `uv run --package peagen --directory standards/peagen ruff check`

------
https://chatgpt.com/codex/tasks/task_e_684b04c0f9e883269a254ed838e3f98a