### PR TITLE
Fix DOE template use of module context

### DIFF
--- a/pkgs/standards/peagen/peagen/template_sets/swarmauri_base/ptree.yaml.j2
+++ b/pkgs/standards/peagen/peagen/template_sets/swarmauri_base/ptree.yaml.j2
@@ -20,7 +20,7 @@
   AGENT_PROMPT_TEMPLATE: "agent_default.j2"
   PROJECT_NAME: "{{ PROJ.NAME }}"
   PACKAGE_NAME: "{{ PKG.NAME }}"
-  MODULE_NAME: null
+  MODULE_NAME: "{{ MOD.NAME }}"
   EXTRAS:
     PURPOSE: "Initializes the source package for {{ PKG.NAME }}."
     DESCRIPTION: "This file makes the directory a Python package."


### PR DESCRIPTION
## Summary
- update Swarmauri base template to set `MODULE_NAME` when referencing module context

## Testing
- `ruff check pkgs/standards/peagen`
- `uv run --package peagen --directory standards/peagen pytest`
- `peagen local -q process project_payloads_000.yaml`

------
https://chatgpt.com/codex/tasks/task_e_684b0689ee1483268e0164e408d7c15e