### PR TITLE
Include example YAMLs in Peagen package

### DIFF
--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -155,3 +155,7 @@ in_memory = "peagen.plugins.queues.in_memory_queue:InMemoryQueue"
 
 [tool.setuptools.package-data]
 "peagen.schemas" = ["*.json", "extras/*.json"]
+"peagen" = [
+  "tests/examples/locking_demo/*",
+  "tests/examples/peagen_tomls/*",
+]


### PR DESCRIPTION
## Summary
- package example YAMLs so they are installed with `peagen`

## Testing
- `ruff check .`
- `uv run --package peagen --directory standards/peagen pytest`
- `DQ_GATEWAY=https://gw.peagen.com/rpc uv run --package peagen --directory pkgs/standards/peagen peagen local -q doe process tests/examples/locking_demo/doe_spec.yaml tests/examples/locking_demo/template_project.yaml -c tests/examples/peagen_tomls/local_minimal.toml --force`
- `uv run --package peagen --directory pkgs/standards/peagen peagen remote -q --gateway-url https://gw.peagen.com/rpc doe process tests/examples/locking_demo/doe_spec.yaml tests/examples/locking_demo/template_project.yaml --force` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684b29f4433083268f297c13c1364375