### PR TITLE
Add S3FS storage adapter

### DIFF
--- a/pkgs/standards/peagen/README.md
+++ b/pkgs/standards/peagen/README.md
@@ -368,7 +368,7 @@ result, idx = pea.process_single_project(projects[0], start_idx=0)
 
 ### Storage Adapters & Publishers
 
-Peagen's artifact output and event publishing are pluggable. Use the `storage_adapter` argument to control where files are saved and optionally provide a publisher for notifications. Built‑ins live under the `peagen.plugins` namespace. Available adapters include `FileStorageAdapter` and `MinioStorageAdapter`, while publisher options cover `RedisPublisher`, `RabbitMQPublisher`, and `WebhookPublisher`. See [docs/storage_adapters_and_publishers.md](docs/storage_adapters_and_publishers.md) for details.
+Peagen's artifact output and event publishing are pluggable. Use the `storage_adapter` argument to control where files are saved and optionally provide a publisher for notifications. Built‑ins live under the `peagen.plugins` namespace. Available adapters include `FileStorageAdapter`, `MinioStorageAdapter`, and `S3FSStorageAdapter`, while publisher options cover `RedisPublisher`, `RabbitMQPublisher`, and `WebhookPublisher`. See [docs/storage_adapters_and_publishers.md](docs/storage_adapters_and_publishers.md) for details.
 
 
 For the event schema and routing key conventions, see [docs/eda_protocol.md](docs/eda_protocol.md). Events can also be emitted directly from the CLI using `--notify`:
@@ -385,16 +385,18 @@ renders files concurrently while still honoring dependency order. Leaving the
 flag unset or `0` processes files sequentially.
 
 Artifact locations are resolved via the `--artifacts` flag. Targets may be a
-local directory (`file:///./peagen_artifacts`) using `FileStorageAdapter` or an
-S3/MinIO endpoint (`s3://host:9000`) handled by `MinioStorageAdapter`. Custom
+local directory (`file:///./peagen_artifacts`) using `FileStorageAdapter`, an
+S3/MinIO endpoint (`s3://host:9000`) handled by `MinioStorageAdapter`, or a
+standard AWS bucket (`s3://bucket`) via `S3FSStorageAdapter`. Custom
 adapters and publishers can be supplied programmatically:
 
 ```python
 from peagen.core import Peagen
 from peagen.plugins.storage_adapters.minio_storage_adapter import MinioStorageAdapter
+from peagen.plugins.storage_adapters.s3fs_storage_adapter import S3FSStorageAdapter
 from peagen.plugins.publishers.webhook_publisher import WebhookPublisher
 
-store = MinioStorageAdapter.from_uri("s3://localhost:9000", bucket="peagen")
+store = S3FSStorageAdapter.from_uri("s3://my-bucket")
 bus = WebhookPublisher("https://example.com/peagen")
 ```
 

--- a/pkgs/standards/peagen/docs/storage_adapters_and_publishers.md
+++ b/pkgs/standards/peagen/docs/storage_adapters_and_publishers.md
@@ -4,10 +4,11 @@ Peagen writes artifacts to a pluggable storage backend and can publish events du
 
 ## Storage Adapters
 
-`Peagen` accepts a `storage_adapter` implementing simple `upload()` and `download()` methods. Four adapters ship with the SDK:
+`Peagen` accepts a `storage_adapter` implementing simple `upload()` and `download()` methods. Five adapters ship with the SDK:
 
 - `FileStorageAdapter` – stores artifacts on the local filesystem.
 - `MinioStorageAdapter` – targets S3 compatible object stores.
+- `S3FSStorageAdapter` – uses the `s3fs` library for AWS S3.
 - `GithubStorageAdapter` – saves files into a GitHub repository.
 - `GithubReleaseStorageAdapter` – uploads artifacts as release assets and
   exposes a `root_uri` like `ghrel://org/repo/tag/` for retrieval.

--- a/pkgs/standards/peagen/peagen/plugins/storage_adapters/__init__.py
+++ b/pkgs/standards/peagen/peagen/plugins/storage_adapters/__init__.py
@@ -6,6 +6,7 @@ from .file_storage_adapter import FileStorageAdapter
 from .minio_storage_adapter import MinioStorageAdapter
 from .github_storage_adapter import GithubStorageAdapter
 from .gh_release_storage_adapter import GithubReleaseStorageAdapter
+from .s3fs_storage_adapter import S3FSStorageAdapter
 from peagen.plugins import registry
 
 
@@ -25,5 +26,6 @@ __all__ = [
     "MinioStorageAdapter",
     "GithubStorageAdapter",
     "GithubReleaseStorageAdapter",
+    "S3FSStorageAdapter",
     "make_adapter_for_uri",
 ]

--- a/pkgs/standards/peagen/peagen/plugins/storage_adapters/s3fs_storage_adapter.py
+++ b/pkgs/standards/peagen/peagen/plugins/storage_adapters/s3fs_storage_adapter.py
@@ -1,0 +1,102 @@
+"""S3-compatible storage adapter implemented with s3fs."""
+
+from __future__ import annotations
+
+import io
+import os
+import shutil
+from pathlib import Path
+from typing import BinaryIO
+
+import s3fs
+
+
+class S3FSStorageAdapter:
+    """Store and retrieve artifacts using an S3 bucket via s3fs."""
+
+    def __init__(self, bucket: str, *, prefix: str = "", **fs_kwargs) -> None:
+        self._bucket = bucket
+        self._prefix = prefix.lstrip("/")
+        self._fs = s3fs.S3FileSystem(**fs_kwargs)
+
+    # ------------------------------------------------------------------
+    def _full_key(self, key: str) -> str:
+        key = key.lstrip("/")
+        if self._prefix:
+            return f"{self._prefix.rstrip('/')}/{key}"
+        return key
+
+    @property
+    def root_uri(self) -> str:
+        """Return the base ``s3://`` URI for this adapter."""
+        base = f"s3://{self._bucket}"
+        uri = f"{base}/{self._prefix.rstrip('/')}" if self._prefix else base
+        return uri.rstrip("/") + "/"
+
+    # ------------------------------------------------------------------
+    def upload(self, key: str, data: BinaryIO) -> str:
+        """Upload ``data`` to ``bucket/prefix/key`` and return the artifact URI."""
+        dest = f"{self._bucket}/{self._full_key(key)}"
+        data.seek(0)
+        with self._fs.open(dest, "wb") as fh:
+            shutil.copyfileobj(data, fh)
+        return f"{self.root_uri}{key.lstrip('/')}"
+
+    # ------------------------------------------------------------------
+    def download(self, key: str) -> BinaryIO:
+        """Return the contents of ``bucket/prefix/key`` as a ``BytesIO``."""
+        path = f"{self._bucket}/{self._full_key(key)}"
+        if not self._fs.exists(path):
+            raise FileNotFoundError(path)
+        with self._fs.open(path, "rb") as fh:
+            buffer = io.BytesIO(fh.read())
+        buffer.seek(0)
+        return buffer
+
+    # ------------------------------------------------------------------
+    def upload_dir(self, src: str | os.PathLike, *, prefix: str = "") -> None:
+        """Recursively upload all files under ``src`` using an optional prefix."""
+        base = Path(src)
+        for path in base.rglob("*"):
+            if path.is_file():
+                rel = path.relative_to(base).as_posix()
+                key = f"{prefix.rstrip('/')}/{rel}" if prefix else rel
+                with path.open("rb") as fh:
+                    self.upload(key, fh)
+
+    # ------------------------------------------------------------------
+    def iter_prefix(self, prefix: str):
+        """Yield stored keys beginning with ``prefix``."""
+        base = self._full_key(prefix).rstrip("/")
+        prefix_path = f"{self._bucket}/{base}" if base else self._bucket
+        for path in self._fs.find(prefix_path):
+            key = path[len(f"{self._bucket}/") :]
+            if self._prefix and key.startswith(self._prefix.rstrip("/") + "/"):
+                key = key[len(self._prefix.rstrip("/")) + 1 :]
+            yield key
+
+    # ------------------------------------------------------------------
+    def download_prefix(self, prefix: str, dest_dir: str | os.PathLike) -> None:
+        """Download all objects under ``prefix`` into ``dest_dir``."""
+        dest = Path(dest_dir)
+        for rel_key in self.iter_prefix(prefix):
+            target = dest / rel_key
+            target.parent.mkdir(parents=True, exist_ok=True)
+            data = self.download(rel_key)
+            with target.open("wb") as fh:
+                shutil.copyfileobj(data, fh)
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_uri(cls, uri: str, **fs_kwargs) -> "S3FSStorageAdapter":
+        """Instantiate the adapter from an ``s3://`` URI."""
+        from urllib.parse import urlparse
+
+        p = urlparse(uri)
+        bucket, *rest = p.path.lstrip("/").split("/", 1)
+        prefix = rest[0] if rest else ""
+        return cls(bucket=bucket or p.netloc, prefix=prefix, **fs_kwargs)
+
+
+__all__ = ["S3FSStorageAdapter"]
+

--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -139,6 +139,7 @@ minio   = "peagen.plugins.storage_adapters.minio_storage_adapter:MinioStorageAda
 file    = "peagen.plugins.storage_adapters.file_storage_adapter:FileStorageAdapter"
 github    = "peagen.plugins.storage_adapters.github_storage_adapter:GithubStorageAdapter"
 gh_release    = "peagen.plugins.storage_adapters.gh_release_storage_adapter:GithubReleaseStorageAdapter"
+s3    = "peagen.plugins.storage_adapters.s3fs_storage_adapter:S3FSStorageAdapter"
 
 [project.entry-points."peagen.plugins.publishers"]
 redis   = "peagen.plugins.publishers.redis_publisher:RedisPublisher"


### PR DESCRIPTION
## Summary
- implement `S3FSStorageAdapter` for AWS S3 buckets
- register the adapter in storage adapter factory and entry points
- document new adapter in README and docs

## Testing
- `ruff check`
- `uv run --package peagen --directory standards pytest` *(fails: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_684d80f3ea70832693f0a07a739958e6