### PR TITLE
Add git-http storage adapter

### DIFF
--- a/pkgs/standards/peagen/README.md
+++ b/pkgs/standards/peagen/README.md
@@ -368,7 +368,7 @@ result, idx = pea.process_single_project(projects[0], start_idx=0)
 
 ### Storage Adapters & Publishers
 
-Peagen's artifact output and event publishing are pluggable. Use the `storage_adapter` argument to control where files are saved and optionally provide a publisher for notifications. Built‑ins live under the `peagen.plugins` namespace. Available adapters include `FileStorageAdapter` and `MinioStorageAdapter`, while publisher options cover `RedisPublisher`, `RabbitMQPublisher`, and `WebhookPublisher`. See [docs/storage_adapters_and_publishers.md](docs/storage_adapters_and_publishers.md) for details.
+Peagen's artifact output and event publishing are pluggable. Use the `storage_adapter` argument to control where files are saved and optionally provide a publisher for notifications. Built‑ins live under the `peagen.plugins` namespace. Available adapters include `FileStorageAdapter`, `MinioStorageAdapter`, and `GitHttpStorageAdapter`, while publisher options cover `RedisPublisher`, `RabbitMQPublisher`, and `WebhookPublisher`. See [docs/storage_adapters_and_publishers.md](docs/storage_adapters_and_publishers.md) for details.
 
 
 For the event schema and routing key conventions, see [docs/eda_protocol.md](docs/eda_protocol.md). Events can also be emitted directly from the CLI using `--notify`:
@@ -391,10 +391,12 @@ adapters and publishers can be supplied programmatically:
 
 ```python
 from peagen.core import Peagen
-from peagen.plugins.storage_adapters.minio_storage_adapter import MinioStorageAdapter
+from peagen.plugins.storage_adapters.git_http_storage_adapter import GitHttpStorageAdapter
 from peagen.plugins.publishers.webhook_publisher import WebhookPublisher
 
-store = MinioStorageAdapter.from_uri("s3://localhost:9000", bucket="peagen")
+store = GitHttpStorageAdapter.from_uri(
+    "git+http://example.com/repo.git#main/artifacts"
+)
 bus = WebhookPublisher("https://example.com/peagen")
 ```
 

--- a/pkgs/standards/peagen/docs/storage_adapters_and_publishers.md
+++ b/pkgs/standards/peagen/docs/storage_adapters_and_publishers.md
@@ -11,6 +11,8 @@ Peagen writes artifacts to a pluggable storage backend and can publish events du
 - `GithubStorageAdapter` – saves files into a GitHub repository.
 - `GithubReleaseStorageAdapter` – uploads artifacts as release assets and
   exposes a `root_uri` like `ghrel://org/repo/tag/` for retrieval.
+- `GitHttpStorageAdapter` – pushes to and fetches from a git HTTP server using
+  URIs like `git+http://host/repo.git#branch/prefix`.
 
 Enable any of these via `.peagen.toml` using the `[storage.adapters.<name>]`
 tables. For example:

--- a/pkgs/standards/peagen/peagen/plugins/storage_adapters/__init__.py
+++ b/pkgs/standards/peagen/peagen/plugins/storage_adapters/__init__.py
@@ -6,6 +6,7 @@ from .file_storage_adapter import FileStorageAdapter
 from .minio_storage_adapter import MinioStorageAdapter
 from .github_storage_adapter import GithubStorageAdapter
 from .gh_release_storage_adapter import GithubReleaseStorageAdapter
+from .git_http_storage_adapter import GitHttpStorageAdapter
 from peagen.plugins import registry
 
 
@@ -25,5 +26,6 @@ __all__ = [
     "MinioStorageAdapter",
     "GithubStorageAdapter",
     "GithubReleaseStorageAdapter",
+    "GitHttpStorageAdapter",
     "make_adapter_for_uri",
 ]

--- a/pkgs/standards/peagen/peagen/plugins/storage_adapters/git_http_storage_adapter.py
+++ b/pkgs/standards/peagen/peagen/plugins/storage_adapters/git_http_storage_adapter.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+"""Storage adapter using a git HTTP server."""
+
+import io
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import BinaryIO
+from urllib.parse import urlparse
+
+import requests
+
+
+class GitHttpStorageAdapter:
+    """Upload artifacts via ``git push`` and fetch them with HTTP GET."""
+
+    def __init__(self, repo_url: str, branch: str = "main", *, prefix: str = "") -> None:
+        self._repo_url = repo_url.rstrip("/")
+        self._branch = branch
+        self._prefix = prefix.lstrip("/")
+
+    # ------------------------------------------------------------------ helpers
+    def _full_key(self, key: str) -> str:
+        key = key.lstrip("/")
+        if self._prefix:
+            return f"{self._prefix.rstrip('/')}/{key}"
+        return key
+
+    @property
+    def root_uri(self) -> str:
+        base = f"git+{self._repo_url}#{self._branch}"
+        if self._prefix:
+            return f"{base}/{self._prefix.rstrip('/')}".rstrip("/") + "/"
+        return base + "/"
+
+    # -------------------------------------------------------------------- upload
+    def upload(self, key: str, data: BinaryIO) -> str:
+        """Push ``data`` to the repository under ``key`` and return the URI."""
+        full = self._full_key(key)
+        with tempfile.TemporaryDirectory() as tmp:
+            subprocess.run(["git", "clone", self._repo_url, tmp], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            subprocess.run(["git", "-C", tmp, "checkout", self._branch], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            dest = Path(tmp, full)
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            with open(dest, "wb") as fh:
+                shutil.copyfileobj(data, fh)
+            subprocess.run(["git", "-C", tmp, "add", dest.relative_to(tmp).as_posix()], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            subprocess.run(["git", "-C", tmp, "commit", "-m", f"Add {full}"], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            subprocess.run(["git", "-C", tmp, "push", "origin", self._branch], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        return f"{self.root_uri}{key.lstrip('/')}"
+
+    # ------------------------------------------------------------------- download
+    def download(self, key: str) -> BinaryIO:
+        """Return ``BytesIO`` contents of ``key`` via HTTP GET."""
+        full = self._full_key(key)
+        url = f"{self._repo_url}/raw/{self._branch}/{full}"
+        resp = requests.get(url)
+        if resp.status_code != 200:
+            raise FileNotFoundError(f"{url}: {resp.status_code}")
+        buf = io.BytesIO(resp.content)
+        buf.seek(0)
+        return buf
+
+    # ------------------------------------------------------------------ from_uri
+    @classmethod
+    def from_uri(cls, uri: str) -> "GitHttpStorageAdapter":
+        p = urlparse(uri)
+        repo_scheme = p.scheme.split("+", 1)[1] if "+" in p.scheme else p.scheme
+        repo_url = f"{repo_scheme}://{p.netloc}{p.path}"
+        branch = "main"
+        prefix = ""
+        if p.fragment:
+            branch_part, _, prefix = p.fragment.partition("/")
+            branch = branch_part or branch
+        return cls(repo_url=repo_url, branch=branch, prefix=prefix)
+
+
+__all__ = ["GitHttpStorageAdapter"]

--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -139,6 +139,7 @@ minio   = "peagen.plugins.storage_adapters.minio_storage_adapter:MinioStorageAda
 file    = "peagen.plugins.storage_adapters.file_storage_adapter:FileStorageAdapter"
 github    = "peagen.plugins.storage_adapters.github_storage_adapter:GithubStorageAdapter"
 gh_release    = "peagen.plugins.storage_adapters.gh_release_storage_adapter:GithubReleaseStorageAdapter"
+"git+http"    = "peagen.plugins.storage_adapters.git_http_storage_adapter:GitHttpStorageAdapter"
 
 [project.entry-points."peagen.plugins.publishers"]
 redis   = "peagen.plugins.publishers.redis_publisher:RedisPublisher"


### PR DESCRIPTION
## Summary
- add `GitHttpStorageAdapter` that uses git push and HTTP GET
- register new scheme in adapter factory and entry-points
- document the adapter in the README and docs

## Testing
- `uv run --package peagen --directory standards/peagen ruff format .` *(fails: Failed to fetch)*
- `uv run --package peagen --directory standards/peagen ruff check .` *(fails: Failed to fetch)*
- `uv run --package peagen --directory standards/peagen pytest` *(fails: Failed to fetch)*
- `peagen remote -q --gateway-url http://localhost:8000/rpc process projects_payload.yaml --watch` *(fails: command not found)*
- `peagen local -q process projects_payload.yaml --watch` *(fails: command not found)*
- `peagen remote -q --gateway-url http://localhost:8000/rpc task get 1` *(fails: command not found)*
- `peagen local -q task get 1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d81922f6483268e53c3c7e0f4be72