### PR TITLE
Update README for webhook publisher

### DIFF
--- a/pkgs/standards/swarmauri_publisher_webhook/README.md
+++ b/pkgs/standards/swarmauri_publisher_webhook/README.md
@@ -5,8 +5,7 @@ A Swarmauri component for publishing messages to an HTTP webhook endpoint.
 ## Installation
 
 ```bash
-# TODO: Add installation instructions once packaged
-pip install swarmauri-publisher-webhook
+pip install swarmauri_publisher_webhook
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary
- remove TODO in swarmauri_publisher_webhook README
- add actual `pip install` instructions

## Testing
- `ruff check pkgs/standards/swarmauri_publisher_webhook`
- `uv run --package swarmauri_publisher_webhook --directory standards/swarmauri_publisher_webhook pytest`

------
https://chatgpt.com/codex/tasks/task_e_684d8896cf80832686c8de0c3ea6bcf1