### PR TITLE
Add root contribution guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Contribution Guide
+
+Follow these high-level steps when updating this repository:
+
+- **Style and Linting** – run `uv run --directory <member> --package <name> ruff format .` followed by `ruff check . --fix` inside each changed package under `pkgs/`.
+- **Tests** – execute tests in isolation from `pkgs/` with `uv run --package <name> --directory <member> pytest`.
+- **Documentation and Style** – keep code consistent with [STYLE_GUIDE.md](STYLE_GUIDE.md).
+- **Pull Requests** – ensure commits are well described and reference related issues if applicable.
+
+Changes to the **peagen** package require additional validation steps detailed in `pkgs/standards/peagen/AGENTS.md`.
+


### PR DESCRIPTION
## Summary
- add a brief AGENTS guide in the repo root

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d88c484c88326be09985bff502137