### PR TITLE
Implement git S3 filters

### DIFF
--- a/pkgs/standards/peagen/README.md
+++ b/pkgs/standards/peagen/README.md
@@ -418,6 +418,11 @@ bus.publish("peagen.events", {"type": "process.started"})
 pea.process_all_projects()
 ```
 
+Large artifacts can be stored outside the Git repository using S3-backed
+filters. Call `setup_s3fs_filters()` once in a repository to register the
+`s3fs` clean and smudge commands. Files matching your `.gitattributes` rules
+will be replaced with tiny JSON pointers referencing the uploaded object.
+
 ### Contributing & Extending Templates
 
 * **Template Conventions:** Place new Jinja2 files under your `TEMPLATE_BASE_DIR` as `*.j2`, using the same context variables (`projects`, `packages`, `modules`) that core templates rely on.

--- a/pkgs/standards/peagen/docs/storage_adapters_and_publishers.md
+++ b/pkgs/standards/peagen/docs/storage_adapters_and_publishers.md
@@ -12,6 +12,11 @@ Peagen writes artifacts to a pluggable storage backend and can publish events du
 - `GithubReleaseStorageAdapter` – uploads artifacts as release assets and
   exposes a `root_uri` like `ghrel://org/repo/tag/` for retrieval.
 
+To offload large files transparently, use the `setup_s3fs_filters()` helper
+which registers Git clean/smudge filters. After adding patterns to
+`.gitattributes`, committed files are replaced by small JSON pointers such as:
+`{"s3": "bucket/ab/digest.ext", "sha256": "..."}`.
+
 Enable any of these via `.peagen.toml` using the `[storage.adapters.<name>]`
 tables. For example:
 

--- a/pkgs/standards/peagen/peagen/__init__.py
+++ b/pkgs/standards/peagen/peagen/__init__.py
@@ -15,6 +15,7 @@ except PackageNotFoundError:
 
 from .plugin_manager import PluginManager, resolve_plugin_spec
 from .errors import PatchTargetMissingError
+from .git.filters import setup_s3fs_filters
 
 __all__ = [
     "__package_name__",
@@ -22,4 +23,5 @@ __all__ = [
     "PluginManager",
     "resolve_plugin_spec",
     "PatchTargetMissingError",
+    "setup_s3fs_filters",
 ]

--- a/pkgs/standards/peagen/peagen/git/filters.py
+++ b/pkgs/standards/peagen/peagen/git/filters.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from peagen.plugins.storage_adapters import make_adapter_for_uri
+
+
+def _get_adapter() -> Any:
+    uri = os.environ.get("PEAGEN_S3_URI") or os.environ.get("PEAGEN_ARTIFACTS_URI")
+    if not uri:
+        raise RuntimeError("PEAGEN_S3_URI environment variable not set")
+    return make_adapter_for_uri(uri)
+
+
+def _object_exists(adapter: Any, key: str) -> bool:
+    client = getattr(adapter, "_client", None)
+    bucket = getattr(adapter, "_bucket", None)
+    if client and bucket:
+        try:  # type: ignore[attr-defined]
+            client.stat_object(bucket, adapter._full_key(key))  # type: ignore[attr-defined]
+            return True
+        except Exception:
+            return False
+    return False
+
+
+def s3_clean_main() -> None:
+    if len(sys.argv) < 2:
+        raise SystemExit("usage: s3_clean <file>")
+    s3_clean(sys.argv[1])
+
+
+def s3_clean(path: str) -> None:
+    file_path = Path(path)
+    data = file_path.read_bytes()
+    digest = hashlib.sha256(data).hexdigest()
+    key = f"artefacts/{digest[:2]}/{digest}{file_path.suffix}"
+    adapter = _get_adapter()
+    if not _object_exists(adapter, key):
+        adapter.upload(key, io.BytesIO(data))
+    pointer = {"s3": f"{adapter.root_uri}{key}", "sha256": digest}
+    sys.stdout.write(json.dumps(pointer))
+
+
+def s3_smudge_main() -> None:
+    if len(sys.argv) < 2:
+        raise SystemExit("usage: s3_smudge <file>")
+    s3_smudge(sys.argv[1])
+
+
+def s3_smudge(path: str) -> None:
+    pointer = json.load(sys.stdin)
+    uri = pointer.get("s3")
+    if not uri:
+        sys.stdout.write(json.dumps(pointer))
+        return
+    key = uri.rsplit("/", 1)[1]
+    adapter = make_adapter_for_uri(uri.rsplit("/", 1)[0] + "/")
+    data = adapter.download(key)
+    sys.stdout.buffer.write(data.read())
+
+
+def setup_s3fs_filters(repo: str | Path = ".", name: str = "s3fs") -> None:
+    repo_path = Path(repo)
+    subprocess.check_call([
+        "git",
+        "config",
+        "--local",
+        f"filter.{name}.clean",
+        "peagen-s3-clean %f",
+    ], cwd=repo_path)
+    subprocess.check_call([
+        "git",
+        "config",
+        "--local",
+        f"filter.{name}.smudge",
+        "peagen-s3-smudge %f",
+    ], cwd=repo_path)
+    subprocess.check_call([
+        "git",
+        "config",
+        "--local",
+        f"filter.{name}.required",
+        "true",
+    ], cwd=repo_path)

--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -97,6 +97,8 @@ asyncio_default_fixture_loop_scope = "function"
 
 [project.scripts]
 peagen = "peagen.cli:app"
+peagen-s3-clean = "peagen.git.filters:s3_clean_main"
+peagen-s3-smudge = "peagen.git.filters:s3_smudge_main"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
## Summary
- add git filter helpers to upload and smudge from S3
- expose `setup_s3fs_filters` in package init
- register `peagen-s3-clean` and `peagen-s3-smudge` console scripts
- document S3-backed git filters in README and docs

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff check .`
- `uv run --package peagen --directory pkgs/standards/peagen pytest`
- `peagen remote -q --gateway-url http://localhost:8000/rpc process projects_payload.yaml --watch` *(fails: connection refused)*
- `peagen remote -q --gateway-url http://localhost:8000/rpc task get foo` *(fails: connection refused)*
- `peagen local -q process projects_payload.yaml --watch` *(fails: option not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e27f3ee8c8326bf0fa69ffaeaaf1a