### PR TITLE
Add git repo helper to peagen

### DIFF
--- a/pkgs/standards/peagen/peagen/git/__init__.py
+++ b/pkgs/standards/peagen/peagen/git/__init__.py
@@ -1,0 +1,1 @@
+from .repo import get_repo as get_repo

--- a/pkgs/standards/peagen/peagen/git/repo.py
+++ b/pkgs/standards/peagen/peagen/git/repo.py
@@ -1,0 +1,28 @@
+"""Utilities for working with Git repositories."""
+
+from pathlib import Path
+from typing import Optional
+
+from git import InvalidGitRepositoryError, NoSuchPathError, Repo
+
+
+def get_repo(path: str | Path, remote_url: Optional[str] = None) -> Repo:
+    """Return a Git repository, initializing one if necessary.
+
+    Args:
+        path: Target directory for the repository.
+        remote_url: Optional URL for the ``origin`` remote when creating a new
+            repository.
+
+    Returns:
+        Repo: Initialized or existing Git repository.
+    """
+
+    repo_path = Path(path)
+    try:
+        repo = Repo(repo_path)
+    except (InvalidGitRepositoryError, NoSuchPathError):
+        repo = Repo.init(repo_path)
+        if remote_url:
+            repo.create_remote("origin", remote_url)
+    return repo

--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -66,6 +66,7 @@ dependencies = [
     # artifacts
     "PyGithub", # this storage adapter needs to be pushed to its own standalone
     "minio", # this storage adapter needs to be pushed to its own standalone
+    "GitPython",
 
 ]
 

--- a/pkgs/standards/peagen/tests/unit/test_git_repo.py
+++ b/pkgs/standards/peagen/tests/unit/test_git_repo.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+import pytest
+
+from peagen.git.repo import get_repo
+
+
+@pytest.mark.unit
+def test_get_repo_initializes(tmp_path: Path):
+    repo = get_repo(tmp_path)
+    assert (tmp_path / ".git").is_dir()
+    assert repo.working_tree_dir == str(tmp_path)
+
+
+@pytest.mark.unit
+def test_get_repo_reuses_existing(tmp_path: Path):
+    first = get_repo(tmp_path)
+    second = get_repo(tmp_path)
+    assert first.git_dir == second.git_dir


### PR DESCRIPTION
## Summary
- add `get_repo` utility in peagen to initialize or open Git repositories
- export the helper in package init
- depend on GitPython
- test the new helper

## Testing
- `ruff check pkgs/standards/peagen/peagen/git/__init__.py pkgs/standards/peagen/tests/unit/test_git_repo.py`
- `uv run --package peagen --directory standards/peagen pytest` *(fails: unsuccessful tunnel)*
- `peagen remote -q --gateway-url http://localhost:8000/rpc process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml --watch` *(fails: command not found)*
- `peagen local -q process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml --watch` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853ed647a9083268be714b8a7d6de0b