### PR TITLE
Add git ref constants

### DIFF
--- a/pkgs/standards/peagen/peagen/__init__.py
+++ b/pkgs/standards/peagen/peagen/__init__.py
@@ -15,6 +15,15 @@ except PackageNotFoundError:
 
 from .plugin_manager import PluginManager, resolve_plugin_spec
 from .errors import PatchTargetMissingError
+from .git import (
+    PEAGEN_REFS_PREFIX,
+    FACTOR_REF,
+    RUN_REF,
+    ANALYSIS_REF,
+    EVO_REF,
+    PROMOTED_REF,
+    pea_ref,
+)
 
 __all__ = [
     "__package_name__",
@@ -22,4 +31,11 @@ __all__ = [
     "PluginManager",
     "resolve_plugin_spec",
     "PatchTargetMissingError",
+    "PEAGEN_REFS_PREFIX",
+    "FACTOR_REF",
+    "RUN_REF",
+    "ANALYSIS_REF",
+    "EVO_REF",
+    "PROMOTED_REF",
+    "pea_ref",
 ]

--- a/pkgs/standards/peagen/peagen/git/__init__.py
+++ b/pkgs/standards/peagen/peagen/git/__init__.py
@@ -1,0 +1,31 @@
+"""Git reference helpers used by peagen workflows."""
+
+from __future__ import annotations
+
+# Base prefix for all peagen-managed refs
+PEAGEN_REFS_PREFIX = "refs/pea"
+
+# Common ref namespaces
+FACTOR_REF = f"{PEAGEN_REFS_PREFIX}/factor"
+RUN_REF = f"{PEAGEN_REFS_PREFIX}/run"
+ANALYSIS_REF = f"{PEAGEN_REFS_PREFIX}/analysis"
+EVO_REF = f"{PEAGEN_REFS_PREFIX}/evo"
+PROMOTED_REF = f"{PEAGEN_REFS_PREFIX}/promoted"
+
+
+def pea_ref(*parts: str) -> str:
+    """Return a fully qualified reference under :data:`PEAGEN_REFS_PREFIX`."""
+    if not parts:
+        raise ValueError("at least one ref component required")
+    joined = "/".join(part.strip("/") for part in parts)
+    return f"{PEAGEN_REFS_PREFIX}/{joined}"
+
+__all__ = [
+    "PEAGEN_REFS_PREFIX",
+    "FACTOR_REF",
+    "RUN_REF",
+    "ANALYSIS_REF",
+    "EVO_REF",
+    "PROMOTED_REF",
+    "pea_ref",
+]

--- a/pkgs/standards/peagen/tests/unit/test_git_refs.py
+++ b/pkgs/standards/peagen/tests/unit/test_git_refs.py
@@ -1,0 +1,36 @@
+import pytest
+
+from peagen.git import (
+    PEAGEN_REFS_PREFIX,
+    FACTOR_REF,
+    RUN_REF,
+    ANALYSIS_REF,
+    EVO_REF,
+    PROMOTED_REF,
+    pea_ref,
+)
+
+
+@pytest.mark.unit
+def test_constants():
+    assert PEAGEN_REFS_PREFIX == "refs/pea"
+    assert FACTOR_REF == "refs/pea/factor"
+    assert RUN_REF == "refs/pea/run"
+    assert ANALYSIS_REF == "refs/pea/analysis"
+    assert EVO_REF == "refs/pea/evo"
+    assert PROMOTED_REF == "refs/pea/promoted"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "parts,expected",
+    [
+        (("run", "abc"), "refs/pea/run/abc"),
+        (("analysis", "res"), "refs/pea/analysis/res"),
+    ],
+)
+def test_pea_ref(parts, expected):
+    assert pea_ref(*parts) == expected
+
+    with pytest.raises(ValueError):
+        pea_ref()


### PR DESCRIPTION
## Summary
- add `peagen.git` module with git ref helpers
- re-export constants in peagen package
- test the new git ref utilities

## Testing
- `ruff check pkgs/standards/peagen/peagen/git/__init__.py`
- `ruff check pkgs/standards/peagen/peagen/__init__.py`
- `ruff check pkgs/standards/peagen/tests/unit/test_git_refs.py`


------
https://chatgpt.com/codex/tasks/task_e_6853ed6fb7d4832696f08faf81b6b415