### PR TITLE
Fix fetch_handler test failures

### DIFF
--- a/pkgs/standards/peagen/peagen/handlers/fetch_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/fetch_handler.py
@@ -33,5 +33,7 @@ async def fetch_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, Any]:
     summary = fetch_many(
         workspace_uris=uris,
         out_dir=Path(args["out_dir"]).expanduser() if args.get("out_dir") else None,
+        install_template_sets_flag=args.get("install_template_sets", True),
+        no_source=args.get("no_source", False),
     )
     return summary


### PR DESCRIPTION
## Summary
- fix handler to forward flags in peagen fetch

## Testing
- `uv run --package peagen --directory standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_6854380fe3b48326b88651fec5329ba0