### PR TITLE
Add TUI launcher

### DIFF
--- a/pkgs/standards/peagen/README.md
+++ b/pkgs/standards/peagen/README.md
@@ -426,7 +426,7 @@ pea.process_all_projects()
 
 ### Textual TUI
 
-Run `python -m peagen.tui.app` to launch an experimental dashboard that
+Run `peagen tui` to launch an experimental dashboard that
 subscribes to the gateway's `/ws/tasks` WebSocket. The gateway now emits
 `task.update`, `worker.update` and `queue.update` events. Use the tab keys to
 switch between task lists, logs and opened files. The footer shows system

--- a/pkgs/standards/peagen/peagen/cli/__init__.py
+++ b/pkgs/standards/peagen/peagen/cli/__init__.py
@@ -38,6 +38,7 @@ from .commands import (
     remote_task_app,
     remote_template_sets_app,
     remote_validate_app,
+    dashboard_app,
 )
 
 app = typer.Typer(help="CLI tool for processing project files using Peagen.")
@@ -146,6 +147,7 @@ def _global_remote_ctx(  # noqa: D401
 
 app.add_typer(local_app, name="local")
 app.add_typer(remote_app, name="remote")
+app.add_typer(dashboard_app)
 
 
 local_app.add_typer(local_doe_app, name="doe")

--- a/pkgs/standards/peagen/peagen/cli/commands/__init__.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/__init__.py
@@ -12,6 +12,7 @@ from .evolve import local_evolve_app, remote_evolve_app
 from .sort import local_sort_app, remote_sort_app
 from .task import remote_task_app
 from .templates import local_template_sets_app, remote_template_sets_app
+from .tui import dashboard_app
 from .validate import local_validate_app, remote_validate_app
 
 __all__ = [
@@ -39,4 +40,5 @@ __all__ = [
     "remote_template_sets_app",
     "local_validate_app",
     "remote_validate_app",
+    "dashboard_app",
 ]

--- a/pkgs/standards/peagen/peagen/cli/commands/tui.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/tui.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import typer
+
+from peagen.tui.app import QueueDashboardApp
+
+DEFAULT_GATEWAY = "http://localhost:8000"
+
+
+dashboard_app = typer.Typer(help="Launch the Textual dashboard to monitor tasks.")
+
+
+@dashboard_app.command("tui")
+def run_dashboard(
+    gateway_url: str = typer.Option(
+        DEFAULT_GATEWAY,
+        "--gateway-url",
+        help="Base URL of the Peagen gateway",
+    )
+) -> None:
+    """Start the dashboard pointed at ``gateway_url``."""
+    QueueDashboardApp(gateway_url=gateway_url).run()
+


### PR DESCRIPTION
## Summary
- expose a new `tui` command in the Peagen CLI
- register dashboard command in the command registry
- document how to launch the dashboard via `peagen tui`

## Testing
- `ruff check .`
- Tests skipped per instructions

------
https://chatgpt.com/codex/tasks/task_e_685441f88ecc8326b9c2076493c30539