### PR TITLE
Add factorSets support in peagen

### DIFF
--- a/pkgs/standards/peagen/peagen/core/doe_core.py
+++ b/pkgs/standards/peagen/peagen/core/doe_core.py
@@ -104,6 +104,19 @@ def _matrix_v2(factors: List[dict[str, Any]]) -> List[dict[str, str]]:
         lists.append(pairs)
     return [dict(p) for p in itertools.product(*lists)]
 
+def _matrix_factor_sets(factor_sets: List[dict[str, Any]]) -> List[dict[str, str]]:
+    """Expand *factor_sets* into a list of design points."""
+    points: list[dict[str, str]] = []
+    for fs in factor_sets:
+        cp = fs.get("cartesianProduct", {})
+        if not cp:
+            continue
+        names = list(cp.keys())
+        values = [cp[n] for n in names]
+        for combo in itertools.product(*values):
+            points.append(dict(zip(names, combo)))
+    return points
+
 def _factor_index(factors: List[dict[str, Any]]) -> dict[str, dict[str, Any]]:
     idx = {}
     for fac in factors:
@@ -311,7 +324,11 @@ def generate_payload(
 
     factors = spec_obj.get("factors", [])
     factor_idx = _factor_index(factors)
-    design_points = _matrix_v2(factors)
+    factor_sets = spec_obj.get("factorSets", [])
+    if factor_sets:
+        design_points = _matrix_factor_sets(factor_sets)
+    else:
+        design_points = _matrix_v2(factors)
     llm_keys: List[str] = []
     other_keys = [f["name"] for f in factors]
 

--- a/pkgs/standards/peagen/tests/unit/test_factor_sets.py
+++ b/pkgs/standards/peagen/tests/unit/test_factor_sets.py
@@ -1,0 +1,74 @@
+import yaml
+from pathlib import Path
+
+from peagen.core.doe_core import _matrix_factor_sets, generate_payload
+
+
+def test_matrix_factor_sets():
+    fs = [
+        {
+            "name": "s1",
+            "cartesianProduct": {"a": ["x", "y"], "b": ["1"]},
+            "uriTemplate": "{a}-{b}",
+        }
+    ]
+    points = _matrix_factor_sets(fs)
+    assert points == [{"a": "x", "b": "1"}, {"a": "y", "b": "1"}]
+
+
+def test_generate_payload_factor_sets(tmp_path: Path):
+    patch = tmp_path / "p.yaml"
+    patch.write_text("{}\n")
+    spec = {
+        "version": "v2",
+        "meta": {"name": "t"},
+        "factors": [
+            {
+                "name": "opt",
+                "levels": [
+                    {
+                        "id": "adam",
+                        "patchRef": patch.name,
+                        "output_path": "art",
+                        "patchKind": "json-merge",
+                    },
+                    {
+                        "id": "sgd",
+                        "patchRef": patch.name,
+                        "output_path": "art",
+                        "patchKind": "json-merge",
+                    },
+                ],
+            },
+            {
+                "name": "lr",
+                "levels": [
+                    {
+                        "id": "small",
+                        "patchRef": patch.name,
+                        "output_path": "art",
+                        "patchKind": "json-merge",
+                    },
+                    {
+                        "id": "big",
+                        "patchRef": patch.name,
+                        "output_path": "art",
+                        "patchKind": "json-merge",
+                    },
+                ],
+            },
+        ],
+        "factorSets": [
+            {
+                "name": "subset",
+                "cartesianProduct": {"opt": ["adam"], "lr": ["small", "big"]},
+                "uriTemplate": "{opt}-{lr}",
+            }
+        ],
+    }
+    spec_path = tmp_path / "spec.yaml"
+    spec_path.write_text(yaml.safe_dump(spec))
+    tmpl = Path(__file__).resolve().parents[2] / "docs/examples/base_example_project.yaml"
+    out = tmp_path / "out.yaml"
+    res = generate_payload(spec_path=spec_path, template_path=tmpl, output_path=out, dry_run=True, skip_validate=True)
+    assert res["count"] == 2


### PR DESCRIPTION
## Summary
- add `_matrix_factor_sets` helper in `doe_core`
- use factor sets in `generate_payload` if provided
- test expansion of DOE factor sets

## Testing
- `ruff check pkgs/standards/peagen`

------
https://chatgpt.com/codex/tasks/task_e_68553b3ded28832693322bb7d3a95190