### PR TITLE
Add factor set expansion in peagen

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_doe_factor_sets.py
+++ b/pkgs/standards/peagen/tests/unit/test_doe_factor_sets.py
@@ -1,0 +1,87 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from peagen.core.doe_core import generate_payload
+
+
+@pytest.mark.unit
+def test_factor_sets_expand_design_points(tmp_path: Path) -> None:
+    spec = {
+        "version": "v2",
+        "meta": {"name": "t"},
+        "baseArtifact": "base.yaml",
+        "factors": [
+            {
+                "name": "dataset",
+                "levels": [
+                    {
+                        "id": "news",
+                        "patchRef": "p.yaml",
+                        "output_path": "artifact.yaml",
+                    }
+                ],
+            },
+            {
+                "name": "provider",
+                "levels": [
+                    {
+                        "id": "openai",
+                        "patchRef": "p.yaml",
+                        "output_path": "artifact.yaml",
+                    },
+                    {
+                        "id": "groq",
+                        "patchRef": "p.yaml",
+                        "output_path": "artifact.yaml",
+                    },
+                ],
+            },
+            {
+                "name": "temperature",
+                "levels": [
+                    {
+                        "id": "0.2",
+                        "patchRef": "p.yaml",
+                        "output_path": "artifact.yaml",
+                    },
+                    {
+                        "id": "0.7",
+                        "patchRef": "p.yaml",
+                        "output_path": "artifact.yaml",
+                    },
+                ],
+            },
+        ],
+        "factorSets": [
+            {
+                "name": "llm",
+                "cartesianProduct": {
+                    "provider": ["openai", "groq"],
+                    "temperature": ["0.2", "0.7"],
+                },
+                "uriTemplate": "x",
+            }
+        ],
+    }
+
+    (tmp_path / "base.yaml").write_text("a: 1\n", encoding="utf-8")
+    (tmp_path / "p.yaml").write_text("- op: add\n  path: /b\n  value: 2\n", encoding="utf-8")
+
+    spec_path = tmp_path / "spec.yaml"
+    spec_path.write_text(json.dumps(spec))
+    template = tmp_path / "t.yaml"
+    template.write_text("PROJECTS:\n  - {}\n")
+    out = tmp_path / "out.yaml"
+
+    result = generate_payload(
+        spec_path=spec_path,
+        template_path=template,
+        output_path=out,
+        skip_validate=True,
+    )
+
+    assert result["count"] == 4
+    assert set(result["llm_keys"]) == {"provider", "temperature"}
+    assert result["other_keys"] == ["dataset"]


### PR DESCRIPTION
## Summary
- support factor sets in DOE generator
- detect llm factors from doe_spec/evolve_spec
- test factor set based design points

## Testing
- `ruff check standards/peagen`
- `uv run --package peagen --directory standards/peagen pytest -k test_doe_factor_sets -q`
- `peagen local -q process standards/peagen/tests/examples/projects_payloads/project_payloads.yaml --start-idx 0 --transitive --output-base tmp_out`
- `peagen remote -q --gateway-url http://localhost:8000/rpc process standards/peagen/tests/examples/projects_payloads/project_payloads.yaml --start-idx 0 --transitive --output-base tmp_out` *(fails: ConnectError)*

------
https://chatgpt.com/codex/tasks/task_e_68554e6658448326a98e6fa0f5edca92