### PR TITLE
Fix DOE spec scaffolding

### DIFF
--- a/pkgs/standards/peagen/peagen/_utils/_init.py
+++ b/pkgs/standards/peagen/peagen/_utils/_init.py
@@ -8,10 +8,13 @@ import typer
 
 from peagen.handlers.init_handler import init_handler
 from peagen.models.schemas import Task
+from peagen.plugins import discover_and_register_plugins
 
 
 def _call_handler(args: Dict[str, Any]) -> Dict[str, Any]:
     """Invoke ``init_handler`` synchronously."""
+    # Ensure plugin templates are registered before invoking handlers
+    discover_and_register_plugins()
     task = Task(
         id=str(uuid.uuid4()),
         pool="default",

--- a/pkgs/standards/peagen/peagen/core/init_core.py
+++ b/pkgs/standards/peagen/peagen/core/init_core.py
@@ -15,12 +15,14 @@ from typing import Any, Dict, Optional
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape, Template
 
-from peagen.plugins import registry
+from peagen.plugins import registry, discover_and_register_plugins
+from peagen.core.doe_core import _sha256
 
 
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
 
 def _ensure_empty_or_force(dst: Path, force: bool) -> None:
     """Create *dst* if empty or *force* is True."""
@@ -29,7 +31,9 @@ def _ensure_empty_or_force(dst: Path, force: bool) -> None:
     dst.mkdir(parents=True, exist_ok=True)
 
 
-def _render_scaffold(src_root: Path, dst: Path, context: Dict[str, Any], force: bool) -> None:
+def _render_scaffold(
+    src_root: Path, dst: Path, context: Dict[str, Any], force: bool
+) -> None:
     """Render a scaffold tree from *src_root* into *dst* using *context*."""
     if not src_root.exists():
         raise FileNotFoundError(f"Scaffold folder '{src_root}' missing.")
@@ -66,6 +70,7 @@ def _render_scaffold(src_root: Path, dst: Path, context: Dict[str, Any], force: 
 # Public API
 # ---------------------------------------------------------------------------
 
+
 def init_project(
     *,
     path: Path,
@@ -97,11 +102,13 @@ def init_project(
     _render_scaffold(src_root, path, context, force)
 
     from peagen.plugins.vcs import GitVCS
+
     vcs = GitVCS.ensure_repo(path, remote_url=git_remote)
     vcs.commit(["."], "initial commit")
 
     if filter_uri:
         from peagen._utils.git_filter import add_filter, init_git_filter
+
         init_git_filter(vcs.repo, filter_uri)
         if add_filter_config:
             add_filter(filter_uri, config=path / ".peagen.toml")
@@ -141,6 +148,7 @@ def init_doe_spec(
     force: bool = False,
 ) -> Dict[str, Any]:
     """Create a DOE-spec stub."""
+    discover_and_register_plugins()
     tmpl_mod = registry["template_sets"].get("init-doe-spec")
     if tmpl_mod is None:
         raise ValueError("Template-set 'init-doe-spec' not found.")
@@ -153,7 +161,21 @@ def init_doe_spec(
     }
 
     _render_scaffold(src_root, path, context, force)
-    return {"created": str(path), "next": "peagen experiment --spec ... --template project.yaml"}
+
+    spec_file = path / "doe_spec.yml"
+    checksum = _sha256(spec_file)
+    meta_file = path / "spec.yaml"
+    if meta_file.exists():
+        import yaml
+
+        meta = yaml.safe_load(meta_file.read_text(encoding="utf-8"))
+        meta["checksum"] = checksum
+        meta_file.write_text(yaml.safe_dump(meta, sort_keys=False), encoding="utf-8")
+
+    return {
+        "created": str(path),
+        "next": "peagen experiment --spec ... --template project.yaml",
+    }
 
 
 def init_ci(

--- a/pkgs/standards/peagen/peagen/template_scaffold/doe_spec/README.md
+++ b/pkgs/standards/peagen/peagen/template_scaffold/doe_spec/README.md
@@ -10,7 +10,8 @@
 
 ## Editing guidelines
 
-1. **Change factors** in `doe_spec.yml` – keep snake-case keys.
-2. Run `peagen validate doe-spec doe_spec.yml` to check schema + checksum.
-3. Bump the **version** in `spec.yaml` when you publish a new design.
-4. Never mutate a version that has already been used in production runs.
+1. **Edit `doe_spec.yml`** to adjust factors or factor sets.
+2. Ensure `version: v2` remains unchanged; older schemas are deprecated.
+3. Run `peagen validate doe-spec doe_spec.yml` to check schema + checksum.
+4. Bump the **version** in `spec.yaml` when you publish a new design.
+5. Never mutate a version that has already been used in production runs.

--- a/pkgs/standards/peagen/peagen/template_scaffold/doe_spec/doe_spec.yml.j2
+++ b/pkgs/standards/peagen/peagen/template_scaffold/doe_spec/doe_spec.yml.j2
@@ -1,27 +1,33 @@
-# Factor table – edit levels or add new factors as needed.
-
-LLM_FACTORS:
-  # these keys will end up under META.LLM_FACTORS in the payload
-  temperature:
-    - 0.2
-    - 0.7
-  model:
-    - gpt-4o-mini
-    - gpt-4o-max
-
-FACTORS:
-  # other non-LLM experimental knobs
-  dataset:
-    - news
-    - tweets
-
-PATCHES:
-  # Example: override provider when model == gpt-4o-max
-  - when:
-      model: gpt-4o-max
-    apply:
-      - op:   replace
-        path: /PROJECTS/0/PKGS/0/PROVIDER
-        value: azure-openai
-
-  # …add your own patches…
+version: v2
+meta:
+  name: {{ spec_name }}
+  description: "Design of Experiments for {{ spec_name }}"
+  seed: 1
+baseArtifact: base.yaml
+factors:
+  - name: model
+    levels:
+      - id: gpt-4o-mini
+        patchRef: patches/model_gpt-4o-mini.yaml
+        output_path: artifact.yaml
+        patchKind: json-merge
+      - id: gpt-4o-max
+        patchRef: patches/model_gpt-4o-max.yaml
+        output_path: artifact.yaml
+        patchKind: json-merge
+  - name: dataset
+    levels:
+      - id: news
+        patchRef: patches/dataset_news.yaml
+        output_path: artifact.yaml
+        patchKind: json-merge
+      - id: tweets
+        patchRef: patches/dataset_tweets.yaml
+        output_path: artifact.yaml
+        patchKind: json-merge
+factorSets:
+  - name: grid
+    cartesianProduct:
+      model: [gpt-4o-mini, gpt-4o-max]
+      dataset: [news, tweets]
+    uriTemplate: "{model}-{dataset}"


### PR DESCRIPTION
## Summary
- register plugins when invoking `peagen init` helpers
- compute checksum for generated DOE spec
- scaffold DOE spec in new `v2` format
- update README instructions

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format peagen/core/init_core.py peagen/_utils/_init.py`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check peagen/core/init_core.py peagen/_utils/_init.py`
- `peagen local -q init doe-spec new_doe_spec`

------
https://chatgpt.com/codex/tasks/task_e_685566a0376c832690ddeced0e487063