### PR TITLE
Add analysis step and Git ours merge

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/__init__.py
+++ b/pkgs/standards/peagen/peagen/cli/__init__.py
@@ -38,6 +38,8 @@ from .commands import (
     remote_task_app,
     remote_template_sets_app,
     remote_validate_app,
+    local_analysis_app,
+    remote_analysis_app,
     dashboard_app,
 )
 
@@ -160,6 +162,7 @@ local_app.add_typer(local_process_app)
 local_app.add_typer(local_mutate_app)
 local_app.add_typer(local_evolve_app)
 local_app.add_typer(local_sort_app)
+local_app.add_typer(local_analysis_app)
 local_app.add_typer(local_template_sets_app, name="template-set")
 local_app.add_typer(local_validate_app)
 
@@ -172,6 +175,7 @@ remote_app.add_typer(remote_mutate_app)
 remote_app.add_typer(remote_evolve_app)
 remote_app.add_typer(remote_sort_app)
 remote_app.add_typer(remote_task_app, name="task")
+remote_app.add_typer(remote_analysis_app, name="analysis")
 remote_app.add_typer(remote_template_sets_app, name="template-set")
 remote_app.add_typer(remote_validate_app)
 

--- a/pkgs/standards/peagen/peagen/cli/commands/__init__.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/__init__.py
@@ -11,6 +11,7 @@ from .mutate import local_mutate_app, remote_mutate_app
 from .evolve import local_evolve_app, remote_evolve_app
 from .sort import local_sort_app, remote_sort_app
 from .task import remote_task_app
+from .analysis import local_analysis_app, remote_analysis_app
 from .templates import local_template_sets_app, remote_template_sets_app
 from .tui import dashboard_app
 from .validate import local_validate_app, remote_validate_app
@@ -36,6 +37,8 @@ __all__ = [
     "local_sort_app",
     "remote_sort_app",
     "remote_task_app",
+    "local_analysis_app",
+    "remote_analysis_app",
     "local_template_sets_app",
     "remote_template_sets_app",
     "local_validate_app",

--- a/pkgs/standards/peagen/peagen/cli/commands/analysis.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/analysis.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from pathlib import Path
+from typing import List
+
+import httpx
+import typer
+
+from peagen.handlers.analysis_handler import analysis_handler
+from peagen.models import Status, Task
+
+DEFAULT_GATEWAY = "http://localhost:8000/rpc"
+local_analysis_app = typer.Typer(help="Aggregate run evaluation results.")
+remote_analysis_app = typer.Typer(help="Aggregate run evaluation results.")
+
+
+def _build_task(args: dict) -> Task:
+    return Task(
+        id=str(uuid.uuid4()),
+        pool="default",
+        action="analysis",
+        status=Status.waiting,
+        payload={"args": args},
+    )
+
+
+@local_analysis_app.command("analysis")
+def run(
+    ctx: typer.Context,
+    run_dirs: List[Path] = typer.Argument(..., exists=True, dir_okay=True),
+    spec_name: str = typer.Option(..., "--spec-name", "-s"),
+    json_out: bool = typer.Option(False, "--json"),
+) -> None:
+    args = {"run_dirs": [str(p) for p in run_dirs], "spec_name": spec_name}
+    task = _build_task(args)
+    result = asyncio.run(analysis_handler(task))
+    typer.echo(json.dumps(result, indent=2) if json_out else json.dumps(result, indent=2))
+
+
+@remote_analysis_app.command("analysis")
+def submit(
+    ctx: typer.Context,
+    run_dirs: List[Path] = typer.Argument(..., exists=True, dir_okay=True),
+    spec_name: str = typer.Option(..., "--spec-name", "-s"),
+) -> None:
+    args = {"run_dirs": [str(p) for p in run_dirs], "spec_name": spec_name}
+    task = _build_task(args)
+    rpc_req = {
+        "jsonrpc": "2.0",
+        "id": task.id,
+        "method": "Task.submit",
+        "params": {"taskId": task.id, "pool": task.pool, "payload": task.payload},
+    }
+    with httpx.Client(timeout=30.0) as client:
+        reply = client.post(ctx.obj.get("gateway_url"), json=rpc_req).json()
+    if "error" in reply:
+        typer.secho(
+            f"Remote error {reply['error']['code']}: {reply['error']['message']}",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(1)
+    typer.secho(f"Submitted task {task.id}", fg=typer.colors.GREEN)
+    typer.echo(json.dumps(reply.get("result", {}), indent=2))

--- a/pkgs/standards/peagen/peagen/core/__init__.py
+++ b/pkgs/standards/peagen/peagen/core/__init__.py
@@ -1,0 +1,6 @@
+"""Expose core submodules at package level for testing convenience."""
+from importlib import import_module as _import_module
+
+doe_core = _import_module(".doe_core", __name__)
+
+__all__ = ["doe_core"]

--- a/pkgs/standards/peagen/peagen/core/analysis_core.py
+++ b/pkgs/standards/peagen/peagen/core/analysis_core.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+import statistics
+
+
+def aggregate_evaluations(run_dirs: List[Path]) -> List[Dict[str, Any]]:
+    """Return evaluation summaries for each run directory."""
+    summaries: List[Dict[str, Any]] = []
+    for rd in run_dirs:
+        report_path = rd / ".peagen" / "eval_results.json"
+        if not report_path.exists():
+            continue
+        data = json.loads(report_path.read_text())
+        scores = [r.get("score", 0.0) for r in data.get("results", [])]
+        avg_score = statistics.mean(scores) if scores else float("inf")
+        summaries.append({
+            "run_dir": str(rd),
+            "avg_score": avg_score,
+            "detail": data,
+        })
+    return summaries
+
+
+def analyze_runs(run_dirs: List[Path], *, spec_name: str) -> Dict[str, Any]:
+    """Aggregate evaluation results and pick the best run."""
+    summaries = aggregate_evaluations(run_dirs)
+    summaries.sort(key=lambda s: s["avg_score"])
+    winner = summaries[0]["run_dir"] if summaries else None
+    result = {"runs": summaries, "winner": winner}
+    if run_dirs:
+        out_file = run_dirs[0].parent / f"{spec_name}_analysis.json"
+        out_file.write_text(json.dumps(result, indent=2))
+        result["results_file"] = str(out_file)
+    return result

--- a/pkgs/standards/peagen/peagen/handlers/analysis_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/analysis_handler.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+from peagen.core.analysis_core import analyze_runs
+from peagen.models import Task
+from peagen._utils.config_loader import resolve_cfg
+from peagen.plugins import PluginManager
+from peagen.plugins.vcs import pea_ref
+
+
+async def analysis_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, Any]:
+    payload = task_or_dict.get("payload", {})
+    args: Dict[str, Any] = payload.get("args", {})
+
+    run_dirs = [Path(p) for p in args.get("run_dirs", [])]
+    spec_name = args.get("spec_name", "analysis")
+
+    result = analyze_runs(run_dirs, spec_name=spec_name)
+
+    cfg = resolve_cfg()
+    pm = PluginManager(cfg)
+    try:
+        vcs = pm.get("vcs")
+    except Exception:  # pragma: no cover - optional
+        vcs = None
+
+    if vcs:
+        analysis_branch = pea_ref("analysis", spec_name)
+        vcs.create_branch(analysis_branch, "HEAD", checkout=True)
+        for rd in run_dirs:
+            run_branch = pea_ref("run", Path(rd).name)
+            vcs.merge_ours(run_branch, f"merge {run_branch}")
+        if result.get("results_file"):
+            repo_root = Path(vcs.repo.working_tree_dir)
+            rel = Path(result["results_file"]).resolve().relative_to(repo_root)
+            vcs.commit([str(rel)], f"analysis {spec_name}")
+        vcs.switch("HEAD")
+        result["analysis_branch"] = analysis_branch
+    return result

--- a/pkgs/standards/peagen/peagen/plugins/vcs/git_vcs.py
+++ b/pkgs/standards/peagen/peagen/plugins/vcs/git_vcs.py
@@ -92,6 +92,11 @@ class GitVCS:
         self.repo.git.commit("-m", message)
         return self.repo.head.commit.hexsha
 
+    def merge_ours(self, ref: str, message: str) -> str:
+        """Merge ``ref`` using the ``ours`` strategy and commit."""
+        self.repo.git.merge("--no-ff", "-s", "ours", ref, "-m", message)
+        return self.repo.head.commit.hexsha
+
     def tag(self, name: str) -> None:
         self.repo.create_tag(name)
 


### PR DESCRIPTION
## Summary
- add `merge_ours` method to `GitVCS`
- expose `doe_core` module from `peagen.core`
- implement analysis core and handler
- add CLI command for analysis

## Testing
- `ruff check pkgs/standards/peagen/peagen/plugins/vcs/git_vcs.py pkgs/standards/peagen/peagen/core/analysis_core.py pkgs/standards/peagen/peagen/handlers/analysis_handler.py pkgs/standards/peagen/peagen/cli/commands/analysis.py pkgs/standards/peagen/peagen/cli/commands/__init__.py pkgs/standards/peagen/peagen/cli/__init__.py > /tmp/ruff.log && tail -n 20 /tmp/ruff.log`
- `uv run --package peagen --directory standards/peagen pytest -q > /tmp/pytest.log && tail -n 20 /tmp/pytest.log` (fails: tests unit)`

------
https://chatgpt.com/codex/tasks/task_e_68556740eee48326967ec03940c55a40