### PR TITLE
Fix test import for create_run_branches

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_doe_git_branches.py
+++ b/pkgs/standards/peagen/tests/unit/test_doe_git_branches.py
@@ -1,7 +1,11 @@
 import yaml
 from pathlib import Path
 from peagen.plugins.vcs import GitVCS, pea_ref
-from peagen.core.doe_core import create_factor_branches, _matrix_v2
+from peagen.core.doe_core import (
+    create_factor_branches,
+    create_run_branches,
+    _matrix_v2,
+)
 import peagen.core.doe_core as dc
 
 import pytest


### PR DESCRIPTION
## Summary
- update imports in `test_doe_git_branches`

## Testing
- `uv run --package peagen --directory standards/peagen pytest`


------
https://chatgpt.com/codex/tasks/task_e_6855938c6c7483268398e0b06ed685b7