### PR TITLE
Add selector and result backend base classes

### DIFF
--- a/pkgs/standards/peagen/peagen/plugins/result_backends/__init__.py
+++ b/pkgs/standards/peagen/peagen/plugins/result_backends/__init__.py
@@ -1,8 +1,10 @@
+from .base import ResultBackendBase
 from .localfs_backend import LocalFsResultBackend
 from .postgres_backend import PostgresResultBackend
 from .in_memory_backend import InMemoryResultBackend
 
 __all__ = [
+    "ResultBackendBase",
     "LocalFsResultBackend",
     "PostgresResultBackend",
     "InMemoryResultBackend",

--- a/pkgs/standards/peagen/peagen/plugins/result_backends/base.py
+++ b/pkgs/standards/peagen/peagen/plugins/result_backends/base.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+from peagen.models import TaskRun
+
+
+class ResultBackendBase:
+    """Default functionality shared by result backend implementations."""
+
+    async def store(self, task_run: TaskRun) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    async def list_tasks(self) -> List[Dict[str, Any]]:
+        """Return all stored TaskRun objects as dictionaries."""
+        out: List[Dict[str, Any]] = []
+        if hasattr(self, "tasks"):
+            for t in getattr(self, "tasks").values():
+                data = t.to_dict() if hasattr(t, "to_dict") else t
+                data["id"] = str(data.get("id"))
+                if data.get("started_at") is not None:
+                    data["started_at"] = str(data["started_at"])
+                out.append(data)
+            return out
+        if hasattr(self, "root"):
+            for path in Path(getattr(self, "root")).glob("*.json"):
+                try:
+                    out.append(json.loads(path.read_text()))
+                except Exception:
+                    continue
+            return out
+        return out

--- a/pkgs/standards/peagen/peagen/plugins/result_backends/in_memory_backend.py
+++ b/pkgs/standards/peagen/peagen/plugins/result_backends/in_memory_backend.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from peagen.models import TaskRun
+from .base import ResultBackendBase
 
 
-class InMemoryResultBackend:
+class InMemoryResultBackend(ResultBackendBase):
     """Store TaskRun objects in memory for testing."""
 
     def __init__(self, **_: object) -> None:

--- a/pkgs/standards/peagen/peagen/plugins/result_backends/localfs_backend.py
+++ b/pkgs/standards/peagen/peagen/plugins/result_backends/localfs_backend.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from peagen.models import TaskRun
+from .base import ResultBackendBase
 
-class LocalFsResultBackend:
+class LocalFsResultBackend(ResultBackendBase):
     """Persist TaskRun rows as JSON files in a local directory."""
 
     def __init__(self, root_dir: str = "./task_runs", **_: object) -> None:

--- a/pkgs/standards/peagen/peagen/plugins/result_backends/postgres_backend.py
+++ b/pkgs/standards/peagen/peagen/plugins/result_backends/postgres_backend.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from peagen.models import TaskRun
+from .base import ResultBackendBase
 
 Session = None
 upsert_task = None
@@ -16,7 +17,7 @@ def _ensure_deps() -> None:
         upsert_task = _upsert_task
 
 
-class PostgresResultBackend:
+class PostgresResultBackend(ResultBackendBase):
     """Store TaskRun rows in Postgres using the gateway's engine."""
 
     def __init__(self, dsn: str | None = None, **_: object) -> None:

--- a/pkgs/standards/peagen/peagen/plugins/selectors/__init__.py
+++ b/pkgs/standards/peagen/peagen/plugins/selectors/__init__.py
@@ -1,16 +1,13 @@
-# peagen/plugins/storage_adapters/__init__.py
-"""Factory helpers for storage adapters."""
+"""Built-in selector plugins."""
 
-from urllib.parse import urlparse
-from peagen.plugins import registry
+from .selector_base import SelectorBase
+from .result_backend_selector import ResultBackendSelector
+from .bootstrap_selector import BootstrapSelector
+from .input_selector import InputSelector
 
-
-def make_adapter_for_uri(uri: str):
-    scheme = urlparse(uri).scheme or "file"  # 'file' if path like /home/...
-    try:
-        adapter_cls = registry["storage_adapters"][scheme]
-    except KeyError:
-        raise ValueError(f"No storage adapter registered for scheme '{scheme}'")
-    if not hasattr(adapter_cls, "from_uri"):
-        raise TypeError(f"{adapter_cls.__name__} lacks required from_uri()")
-    return adapter_cls.from_uri(uri)
+__all__ = [
+    "SelectorBase",
+    "ResultBackendSelector",
+    "BootstrapSelector",
+    "InputSelector",
+]

--- a/pkgs/standards/peagen/peagen/plugins/selectors/bootstrap_selector.py
+++ b/pkgs/standards/peagen/peagen/plugins/selectors/bootstrap_selector.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from .result_backend_selector import ResultBackendSelector
+
+
+class BootstrapSelector(ResultBackendSelector):
+    """Gen0 candidates come from a bootstrap list."""
+
+    def __init__(self, backend: Any, bootstrap: List[Dict[str, Any]], num_candidates: int = 1) -> None:
+        super().__init__(backend, num_candidates)
+        self.bootstrap = bootstrap
+        self._used_bootstrap = False
+
+    async def select(self) -> Dict[str, Any]:
+        if not self._used_bootstrap:
+            self._used_bootstrap = True
+            return {"leader": None, "candidates": self.bootstrap}
+        return await super().select()

--- a/pkgs/standards/peagen/peagen/plugins/selectors/input_selector.py
+++ b/pkgs/standards/peagen/peagen/plugins/selectors/input_selector.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .result_backend_selector import ResultBackendSelector
+
+
+class InputSelector(ResultBackendSelector):
+    """Gen0 candidate provided by the user."""
+
+    def __init__(self, backend: Any, initial_candidate: Dict[str, Any], num_candidates: int = 1) -> None:
+        super().__init__(backend, num_candidates)
+        self.initial_candidate = initial_candidate
+        self._used_input = False
+
+    async def select(self) -> Dict[str, Any]:
+        if not self._used_input:
+            self._used_input = True
+            return {"leader": None, "candidates": [self.initial_candidate]}
+        return await super().select()

--- a/pkgs/standards/peagen/peagen/plugins/selectors/result_backend_selector.py
+++ b/pkgs/standards/peagen/peagen/plugins/selectors/result_backend_selector.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .selector_base import SelectorBase
+
+
+class ResultBackendSelector(SelectorBase):
+    """Select candidates based on the results backend."""
+
+    def __init__(self, backend: Any, num_candidates: int = 1) -> None:
+        super().__init__(backend, num_candidates)

--- a/pkgs/standards/peagen/peagen/plugins/selectors/selector_base.py
+++ b/pkgs/standards/peagen/peagen/plugins/selectors/selector_base.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from peagen.models.task_run import Status
+from peagen.plugins.result_backends import ResultBackendBase
+
+
+class SelectorBase:
+    """Common candidate selection logic."""
+
+    def __init__(self, backend: ResultBackendBase, num_candidates: int = 1) -> None:
+        self.backend = backend
+        self.num_candidates = num_candidates
+
+    # ---------------------------------------------------------------
+    async def get_tasks(self) -> List[Dict[str, Any]]:
+        return await self.backend.list_tasks()
+
+    async def get_leader(self, tasks: List[Dict[str, Any]]) -> Dict[str, Any] | None:
+        successes = [t for t in tasks if t.get("status") == Status.success.value]
+        if successes:
+            successes.sort(key=lambda d: d.get("result", {}).get("score", float("inf")))
+            return successes[0]
+        return None
+
+    async def get_running_candidates(self, tasks: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        running = [t for t in tasks if t.get("status") == Status.running.value]
+        running.sort(key=lambda d: str(d.get("started_at") or ""))
+        return running[: self.num_candidates]
+
+    async def select(self) -> Dict[str, Any]:
+        tasks = await self.get_tasks()
+        leader = await self.get_leader(tasks)
+        candidates = await self.get_running_candidates(tasks)
+        return {"leader": leader, "candidates": candidates}

--- a/pkgs/standards/peagen/peagen/schemas/evolve_spec.schema.v1.json
+++ b/pkgs/standards/peagen/peagen/schemas/evolve_spec.schema.v1.json
@@ -94,6 +94,18 @@
           }
         },
 
+        "selectors": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "allOf": [
+              { "$ref": "#/$defs/operatorCore" },
+              { "additionalProperties": true }
+            ]
+          },
+          "description": "Candidate selection operators"
+        },
+
         "fitness": {
           "allOf": [
             { "$ref": "#/$defs/operatorCore" },

--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -163,6 +163,11 @@ in_memory = "peagen.plugins.result_backends.in_memory_backend:InMemoryResultBack
 redis = "peagen.plugins.queues.redis_queue:RedisQueue"
 in_memory = "peagen.plugins.queues.in_memory_queue:InMemoryQueue"
 
+[project.entry-points."peagen.plugins.selectors"]
+result_backend = "peagen.plugins.selectors.result_backend_selector:ResultBackendSelector"
+bootstrap = "peagen.plugins.selectors.bootstrap_selector:BootstrapSelector"
+input = "peagen.plugins.selectors.input_selector:InputSelector"
+
 [tool.setuptools.package-data]
 "peagen.schemas" = ["*.json", "extras/*.json"]
 "peagen" = [

--- a/pkgs/standards/peagen/tests/unit/test_doe_git_branches.py
+++ b/pkgs/standards/peagen/tests/unit/test_doe_git_branches.py
@@ -1,8 +1,11 @@
 import yaml
 from pathlib import Path
 from peagen.plugins.vcs import GitVCS, pea_ref
-from peagen.core.doe_core import create_factor_branches, _matrix_v2
-import peagen.core.doe_core as dc
+from peagen.core.doe_core import (
+    create_factor_branches,
+    create_run_branches,
+    _matrix_v2,
+)
 
 import pytest
 
@@ -17,7 +20,7 @@ def test_factor_and_run_branches(tmp_path: Path, monkeypatch) -> None:
 
     monkeypatch.setattr(vcs, "switch", safe_switch)
 
-    def run_branches_allow_empty(vcs_obj, points):
+    def run_branches_allow_empty(vcs_obj, points, *_args, **_kwargs):
         branches = []
         for point in points:
             label = "_".join(f"{k}-{v}" for k, v in point.items())
@@ -32,7 +35,6 @@ def test_factor_and_run_branches(tmp_path: Path, monkeypatch) -> None:
         vcs_obj.switch("HEAD")
         return branches
 
-    monkeypatch.setattr(dc, "create_run_branches", run_branches_allow_empty)
     base = repo_dir / "base.yaml"
     base.write_text("a: 1\n", encoding="utf-8")
     vcs.commit(["base.yaml"], "base")
@@ -78,7 +80,7 @@ def test_factor_and_run_branches(tmp_path: Path, monkeypatch) -> None:
     assert data["b"] == 2
 
     points = _matrix_v2(spec["factors"])
-    create_run_branches(vcs, points, spec, repo_dir)
+    create_run_branches(vcs, points, spec, repo_dir)  # noqa: F821
     vcs.checkout(pea_ref("run", "opt-adam_lr-small"))
     data = yaml.safe_load((repo_dir / "artifact.yaml").read_text())
     assert data["b"] == 2 and data["c"] == 3

--- a/pkgs/standards/peagen/tests/unit/test_selectors.py
+++ b/pkgs/standards/peagen/tests/unit/test_selectors.py
@@ -1,0 +1,60 @@
+import uuid
+import pytest
+
+from peagen.plugins.selectors import (
+    ResultBackendSelector,
+    BootstrapSelector,
+    InputSelector,
+)
+from peagen.plugins.result_backends.in_memory_backend import InMemoryResultBackend
+from peagen.models.task_run import TaskRun, Status
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_result_backend_selector_picks_leader_and_running_candidates():
+    backend = InMemoryResultBackend()
+    tr1 = TaskRun(id=uuid.uuid4(), pool="p", task_type="t", status=Status.running, payload={}, result=None)
+    tr2 = TaskRun(id=uuid.uuid4(), pool="p", task_type="t", status=Status.success, payload={}, result={"score": 1})
+    tr3 = TaskRun(id=uuid.uuid4(), pool="p", task_type="t", status=Status.running, payload={}, result=None)
+    await backend.store(tr1)
+    await backend.store(tr2)
+    await backend.store(tr3)
+
+    selector = ResultBackendSelector(backend, num_candidates=2)
+    result = await selector.select()
+
+    assert result["leader"]["id"] == str(tr2.id)
+    ids = {c["id"] for c in result["candidates"]}
+    assert ids == {str(tr1.id), str(tr3.id)}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_bootstrap_selector_switches_after_first_call():
+    backend = InMemoryResultBackend()
+    tr = TaskRun(id=uuid.uuid4(), pool="p", task_type="t", status=Status.running, payload={}, result=None)
+    await backend.store(tr)
+    selector = BootstrapSelector(backend, bootstrap=[{"id": "boot"}], num_candidates=1)
+
+    first = await selector.select()
+    assert first == {"leader": None, "candidates": [{"id": "boot"}]}
+
+    second = await selector.select()
+    assert second["candidates"][0]["id"] == str(tr.id)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_input_selector_uses_initial_candidate_once():
+    backend = InMemoryResultBackend()
+    tr = TaskRun(id=uuid.uuid4(), pool="p", task_type="t", status=Status.running, payload={}, result=None)
+    await backend.store(tr)
+
+    selector = InputSelector(backend, {"id": "user"}, num_candidates=1)
+
+    first = await selector.select()
+    assert first == {"leader": None, "candidates": [{"id": "user"}]}
+
+    second = await selector.select()
+    assert second["candidates"][0]["id"] == str(tr.id)


### PR DESCRIPTION
## Summary
- implement `SelectorBase` with default candidate selection logic
- implement `ResultBackendBase` with generic task listing
- update selector plugins to inherit from `SelectorBase`
- update result backends to inherit from `ResultBackendBase`
- register selector plugins and extend unit tests

## Testing
- `ruff check pkgs/standards/peagen`
- `uv run --package peagen --directory standards/peagen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855932393c48326bd66f4b12cfcb549