### PR TITLE
Fix DOE process example and update tests

### DIFF
--- a/pkgs/standards/peagen/tests/examples/locking_demo/doe_spec.yaml
+++ b/pkgs/standards/peagen/tests/examples/locking_demo/doe_spec.yaml
@@ -1,10 +1,19 @@
-schemaVersion: "1.0.1"
-FACTORS:
-  SUFFIX:
-    description: "Project suffix"
-    code: SFX
-    levels: [001, 002]
-    patches:
-      - op: replace
-        path: /PROJECTS/0/NAME
-        value: "ExampleParserProject-{{ SFX }}"
+version: v2
+meta:
+  name: locking-demo
+factors:
+  - name: suffix
+    levels:
+      - id: "001"
+        patchRef: patches/suffix_001.yaml
+        output_path: template_project.yaml
+        patchKind: json-merge
+      - id: "002"
+        patchRef: patches/suffix_002.yaml
+        output_path: template_project.yaml
+        patchKind: json-merge
+factorSets:
+  - name: grid
+    cartesianProduct:
+      suffix: ["001", "002"]
+    uriTemplate: "{suffix}"

--- a/pkgs/standards/peagen/tests/examples/locking_demo/patches/suffix_001.yaml
+++ b/pkgs/standards/peagen/tests/examples/locking_demo/patches/suffix_001.yaml
@@ -1,0 +1,2 @@
+PROJECTS:
+  - NAME: ExampleParserProject-001

--- a/pkgs/standards/peagen/tests/examples/locking_demo/patches/suffix_002.yaml
+++ b/pkgs/standards/peagen/tests/examples/locking_demo/patches/suffix_002.yaml
@@ -1,0 +1,2 @@
+PROJECTS:
+  - NAME: ExampleParserProject-002

--- a/pkgs/standards/peagen/tests/unit/test_doe_git_branches.py
+++ b/pkgs/standards/peagen/tests/unit/test_doe_git_branches.py
@@ -4,9 +4,7 @@ from peagen.plugins.vcs import GitVCS, pea_ref
 from peagen.core.doe_core import (
     create_factor_branches,
     create_run_branches,
-    _matrix_v2,
 )
-import peagen.core.doe_core as dc
 
 
 import pytest
@@ -81,8 +79,7 @@ def test_factor_and_run_branches(tmp_path: Path, monkeypatch) -> None:
     data = yaml.safe_load((repo_dir / "artifact.yaml").read_text())
     assert data["b"] == 2
 
-    points = _matrix_v2(spec["factors"])
-    create_run_branches(vcs, points, spec, repo_dir)  # noqa: F821
+    create_run_branches(vcs, spec, repo_dir)
     vcs.checkout(pea_ref("run", "opt-adam_lr-small"))
     data = yaml.safe_load((repo_dir / "artifact.yaml").read_text())
     assert data["b"] == 2 and data["c"] == 3


### PR DESCRIPTION
## Summary
- fix undefined variable in doe_core
- update DOE example to v2 schema and add patch files
- adjust doe git branches test to match create_run_branches signature
- add patches for example

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff check -q .`
- `uv run --package peagen --directory pkgs/standards/peagen pytest -q`
- `DQ_GATEWAY=https://gw.peagen.com/rpc uv run --package peagen --directory pkgs/standards/peagen peagen local -q doe process tests/examples/locking_demo/doe_spec.yaml tests/examples/locking_demo/template_project.yaml -c tests/examples/peagen_tomls/local_minimal.toml --force --skip-validate`
- `uv run --package peagen --directory pkgs/standards/peagen peagen remote -q --gateway-url https://gw.peagen.com/rpc doe process tests/examples/locking_demo/doe_spec.yaml tests/examples/locking_demo/template_project.yaml --force --skip-validate`
- `DQ_GATEWAY=https://gw.peagen.com/rpc uv run --package peagen --directory pkgs/standards/peagen peagen remote -q --gateway-url https://gw.peagen.com/rpc task get $TASK_ID`

------
https://chatgpt.com/codex/tasks/task_e_68559f36dda883268057498ffe93f807