### PR TITLE
Fix remote evolve path resolution

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/evolve.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/evolve.py
@@ -51,7 +51,21 @@ def submit(
     watch: bool = typer.Option(False, "--watch", "-w", help="Poll until finished"),
     interval: float = typer.Option(2.0, "--interval", "-i", help="Seconds between polls"),
 ):
-    args = {"evolve_spec": str(spec)}
+    def _git_root(path: Path) -> Path:
+        for p in [path] + list(path.parents):
+            if (p / ".git").exists():
+                return p
+        return path
+
+    root = _git_root(Path.cwd())
+
+    def _canonical(p: Path) -> str:
+        try:
+            return str(p.resolve().relative_to(root))
+        except ValueError:
+            return str(p.resolve())
+
+    args = {"evolve_spec": _canonical(spec)}
     task = _build_task(args)
     rpc_req = {
         "jsonrpc": "2.0",

--- a/pkgs/standards/peagen/peagen/schemas/doe_spec.schema.v2.json
+++ b/pkgs/standards/peagen/peagen/schemas/doe_spec.schema.v2.json
@@ -56,7 +56,7 @@
       "description": "Common structure that carries a name plus an optional lock flag.",
       "type":        "object",
       "required":    ["name"],
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "name": { "type": "string" },
         "lock": { "type": "boolean", "default": false }


### PR DESCRIPTION
## Summary
- allow additional properties in `namedLockable` schema so DOE specs validate
- canonicalize spec paths for `remote evolve` like other remote commands

## Testing
- `ruff check pkgs/standards/peagen`
- `uv run --package peagen --directory standards/peagen pytest`
- `DQ_GATEWAY=https://gw.peagen.com/rpc uv run --package peagen --directory pkgs/standards/peagen peagen local -q doe process tests/examples/locking_demo/doe_spec.yaml tests/examples/locking_demo/template_project.yaml -c tests/examples/peagen_tomls/local_minimal.toml --force`
- `uv run --package peagen --directory pkgs/standards/peagen peagen remote -q --gateway-url https://gw.peagen.com/rpc doe process tests/examples/locking_demo/doe_spec.yaml tests/examples/locking_demo/template_project.yaml --force`
- `uv run --package peagen --directory pkgs/standards/peagen peagen remote -q --gateway-url https://gw.peagen.com/rpc evolve tests/examples/locking_demo/doe_spec.yaml`

------
https://chatgpt.com/codex/tasks/task_e_6855a4c5950c83268e9592f5cb748720