### PR TITLE
Fix evolve handler payload

### DIFF
--- a/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
@@ -41,9 +41,8 @@ async def evolve_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, Any]:
             Task(
                 id=str(uuid.uuid4()),
                 pool=pool,
-                action="mutate",
                 status=Status.waiting,
-                payload={"args": job},
+                payload={"action": "mutate", "args": job},
             )
         )
 

--- a/pkgs/standards/peagen/tests/unit/test_evolve_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_evolve_handler.py
@@ -47,5 +47,5 @@ async def test_evolve_handler_fanout(monkeypatch, tmp_path):
     assert sent and sent[-1]["method"] == "Work.finished"
     submit = sent[0]
     assert submit["method"] == "Task.submit"
-    assert "action" not in submit["params"]["payload"]
+    assert submit["params"]["payload"]["action"] == "mutate"
     assert submit["params"]["payload"]["args"].get("mutations")


### PR DESCRIPTION
## Summary
- ensure mutate child tasks include `action` in payload
- update evolve handler unit test

## Testing
- `ruff check .`
- `uv run --package peagen --directory standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_6855ad475ce88326b71544b286a48f03