### PR TITLE
Add gateway demo example

### DIFF
--- a/pkgs/standards/peagen/tests/examples/gateway_demo/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/gateway_demo/.peagen.toml
@@ -1,0 +1,12 @@
+[queues]
+default_queue = "in_memory"
+
+[storage]
+default_filter = "file"
+[storage.filters.file]
+output_dir = "./peagen_artifacts"
+
+[result_backends]
+default_backend = "local_fs"
+[result_backends.adapters.local_fs]
+root_dir = "./task_runs"

--- a/pkgs/standards/peagen/tests/examples/gateway_demo/README.md
+++ b/pkgs/standards/peagen/tests/examples/gateway_demo/README.md
@@ -1,0 +1,9 @@
+This example demonstrates a minimal setup for running the Peagen gateway and worker in a local development environment.
+
+Files in this directory:
+
+* `doe_spec.yaml` - Design-of-experiments specification used to generate project payloads.
+* `template_project.yaml` - Base project template consumed by the DOE process.
+* `.peagen.toml` - Minimal configuration that uses in-memory queues and the local filesystem for results and artifacts.
+
+Use these files when starting the gateway and worker or when submitting a DOE processing task via `peagen remote`.

--- a/pkgs/standards/peagen/tests/examples/gateway_demo/doe_spec.yaml
+++ b/pkgs/standards/peagen/tests/examples/gateway_demo/doe_spec.yaml
@@ -1,0 +1,19 @@
+version: v2
+meta:
+  name: locking-demo
+factors:
+  - name: suffix
+    levels:
+      - id: "001"
+        patchRef: patches/suffix_001.yaml
+        output_path: template_project.yaml
+        patchKind: json-merge
+      - id: "002"
+        patchRef: patches/suffix_002.yaml
+        output_path: template_project.yaml
+        patchKind: json-merge
+factorSets:
+  - name: grid
+    cartesianProduct:
+      suffix: ["001", "002"]
+    uriTemplate: "{suffix}"

--- a/pkgs/standards/peagen/tests/examples/gateway_demo/template_project.yaml
+++ b/pkgs/standards/peagen/tests/examples/gateway_demo/template_project.yaml
@@ -1,0 +1,17 @@
+schemaVersion: "1.0.0"
+PROJECTS:
+- NAME: ExampleParserProject
+  ROOT: "swarmauri-sdk/pkgs"
+  TEMPLATE_SET: swarmauri_base
+  PACKAGES:
+  - NAME: "base/swarmauri_base"
+    MODULES:
+    - NAME: "ParserBase"
+      EXTRAS:
+        PURPOSE: "Provide a base implementation"
+        DESCRIPTION: "Base implementation"
+        REQUIREMENTS:
+        - "Should inherit from the interface first and ComponentBase second."
+        RESOURCE_KIND: "parsers"
+        INTERFACE_NAME: "IParser"
+        INTERFACE_FILE: "pkgs/core/swarmauri_core/parsers/IParser.py"


### PR DESCRIPTION
## Summary
- add gateway_demo example with minimal `.peagen.toml`, DOE spec and template
- document how to use the files for local gateway/worker testing

## Testing
- `ruff check`
- `uv run --package peagen --directory standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_6855ae20c1988326a83f39276d428272