### PR TITLE
Add evolve example and fix handler

### DIFF
--- a/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
@@ -41,9 +41,8 @@ async def evolve_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, Any]:
             Task(
                 id=str(uuid.uuid4()),
                 pool=pool,
-                action="mutate",
                 status=Status.waiting,
-                payload={"args": job},
+                payload={"action": "mutate", "args": job},
             )
         )
 

--- a/pkgs/standards/peagen/tests/examples/evolve_example_2/README.md
+++ b/pkgs/standards/peagen/tests/examples/evolve_example_2/README.md
@@ -1,0 +1,8 @@
+# Evolve Example 2
+
+This example demonstrates running the `peagen evolve` command both locally and through a gateway.
+
+The `cfg` directory contains two example configuration files:
+
+- `local.toml` – uses the in-memory queue and filesystem storage for quick local runs.
+- `remote.toml` – expects Redis, PostgreSQL and MinIO credentials in the environment for remote execution via the gateway.

--- a/pkgs/standards/peagen/tests/examples/evolve_example_2/cfg/local.toml
+++ b/pkgs/standards/peagen/tests/examples/evolve_example_2/cfg/local.toml
@@ -1,0 +1,18 @@
+[queues]
+default_queue = "in_memory"
+
+[storage]
+default_filter = "minio"
+
+[storage.filters.file]
+output_dir = "./peagen_artifacts"
+[storage.filters.minio]
+bucket = "test"
+access_key = "${MINIO_ACCESS_KEY}"
+secret_key = "${MINIO_SECRET_KEY}"
+secure = false
+
+[result_backends]
+default_backend = "local_fs"
+[result_backends.adapters.local_fs]
+root_dir = "./task_runs"

--- a/pkgs/standards/peagen/tests/examples/evolve_example_2/cfg/remote.toml
+++ b/pkgs/standards/peagen/tests/examples/evolve_example_2/cfg/remote.toml
@@ -1,0 +1,29 @@
+[queues]
+default_queue = "redis"
+
+[queues.adapters.redis]
+uri = "${REDIS_URL}"
+
+[result_backends]
+default_backend = "postgres"
+[result_backends.adapters.postgres]
+dsn = "${PG_DSN}"
+
+[storage]
+default_storage_adapter = "minio"
+
+[storage.adapters.minio]
+endpoint = "${MINIO_ENDPOINT}"
+bucket = "test"
+access_key = "${MINIO_ACCESS_KEY}"
+secret_key = "${MINIO_SECRET_KEY}"
+secure = false
+
+[evaluation]
+pool = "peagen.plugins.evaluator_pools.default:DefaultEvaluatorPool"
+max_workers = 1
+async = false
+strict = true
+
+[evaluation.evaluators]
+performance = "peagen.plugins.evaluators.performance_evaluator:PerformanceEvaluator"

--- a/pkgs/standards/peagen/tests/examples/evolve_example_2/evolve_spec.yaml
+++ b/pkgs/standards/peagen/tests/examples/evolve_example_2/evolve_spec.yaml
@@ -1,0 +1,10 @@
+JOBS:
+  - workspace_uri: /workspace/swarmauri-sdk/pkgs/standards/peagen/tests/examples/evolve_example_2/workspace
+    target_file: main.py
+    import_path: workspace.main
+    entry_fn: add
+    config: pkgs/standards/peagen/tests/examples/evolve_example_2/cfg/remote.toml
+operators:
+  mutation:
+    - kind: echo_mutator
+      probability: 1

--- a/pkgs/standards/peagen/tests/examples/evolve_example_2/workspace/main.py
+++ b/pkgs/standards/peagen/tests/examples/evolve_example_2/workspace/main.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+def add(x: int, y: int) -> int:
+    """Return the sum of x and y."""
+    return x + y

--- a/pkgs/standards/peagen/tests/unit/test_evolve_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_evolve_handler.py
@@ -47,5 +47,5 @@ async def test_evolve_handler_fanout(monkeypatch, tmp_path):
     assert sent and sent[-1]["method"] == "Work.finished"
     submit = sent[0]
     assert submit["method"] == "Task.submit"
-    assert "action" not in submit["params"]["payload"]
+    assert submit["params"]["payload"]["action"] == "mutate"
     assert submit["params"]["payload"]["args"].get("mutations")


### PR DESCRIPTION
## Summary
- fix `evolve_handler` so child tasks include the mutate action
- update tests to expect the action field
- add new evolve example with local and remote configuration

## Testing
- `ruff check pkgs/standards/peagen`
- `uv run --package peagen --directory standards/peagen pytest`
- `peagen local -q --config pkgs/standards/peagen/tests/examples/evolve_example_2/cfg/local.toml evolve pkgs/standards/peagen/tests/examples/evolve_example_2/evolve_spec.yaml`
- `peagen remote -q --gateway-url http://localhost:8000/rpc evolve pkgs/standards/peagen/tests/examples/evolve_example_2/evolve_spec.yaml --watch`

------
https://chatgpt.com/codex/tasks/task_e_6855b04e3ae483269f069b0b21549034