### PR TITLE
Add inline evolve spec support

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/evolve.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/evolve.py
@@ -51,21 +51,7 @@ def submit(
     watch: bool = typer.Option(False, "--watch", "-w", help="Poll until finished"),
     interval: float = typer.Option(2.0, "--interval", "-i", help="Seconds between polls"),
 ):
-    def _git_root(path: Path) -> Path:
-        for p in [path] + list(path.parents):
-            if (p / ".git").exists():
-                return p
-        return path
-
-    root = _git_root(Path.cwd())
-
-    def _canonical(p: Path) -> str:
-        try:
-            return str(p.resolve().relative_to(root))
-        except ValueError:
-            return str(p.resolve())
-
-    args = {"evolve_spec": _canonical(spec)}
+    args = {"evolve_spec": spec.read_text()}
     task = _build_task(args)
     rpc_req = {
         "jsonrpc": "2.0",

--- a/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
@@ -16,6 +16,17 @@ from peagen.plugins import PluginManager
 from peagen.plugins.vcs import pea_ref
 
 
+def _load_spec(path_or_text: str) -> tuple[Path | None, dict]:
+    """Return a tuple of (Path | None, parsed YAML)."""
+    path = Path(path_or_text).expanduser()
+    if path.exists():
+        return path, yaml.safe_load(path.read_text())
+    alt = Path(__file__).resolve().parents[2] / path_or_text
+    if alt.exists():
+        return alt, yaml.safe_load(alt.read_text())
+    return None, yaml.safe_load(path_or_text)
+
+
 async def evolve_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, Any]:
     payload = task_or_dict.get("payload", {})
     args: Dict[str, Any] = payload.get("args", {})
@@ -27,8 +38,7 @@ async def evolve_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, Any]:
     except Exception:  # pragma: no cover - optional
         vcs = None
 
-    spec_path = Path(args["evolve_spec"]).expanduser()
-    doc = yaml.safe_load(spec_path.read_text())
+    spec_path, doc = _load_spec(args["evolve_spec"])
     jobs: List[Dict[str, Any]] = doc.get("JOBS", [])
     mutations = doc.get("operators", {}).get("mutation")
 
@@ -49,11 +59,11 @@ async def evolve_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, Any]:
     child_ids = await fan_out(
         task_or_dict,
         children,
-        result={"evolve_spec": str(spec_path)},
+        result={"evolve_spec": args["evolve_spec"]},
         final_status=Status.waiting,
     )
 
-    if vcs:
+    if vcs and spec_path:
         repo_root = Path(vcs.repo.working_tree_dir)
         rel_spec = os.path.relpath(spec_path, repo_root)
         vcs.commit([rel_spec], f"evolve {spec_path.stem}")

--- a/pkgs/standards/peagen/tests/examples/simple_evolve_demo/README.md
+++ b/pkgs/standards/peagen/tests/examples/simple_evolve_demo/README.md
@@ -1,0 +1,33 @@
+# Simple Evolve Demo
+
+This example provides a minimal workspace and evolve specification for testing the `peagen evolve` command.
+
+## Local execution
+
+Run the spec locally using the `local` subcommand:
+
+```bash
+DQ_GATEWAY=http://127.0.0.1:8000/rpc \
+uv run --package peagen --directory pkgs/standards/peagen \
+  peagen local -q evolve tests/examples/simple_evolve_demo/evolve_spec.yaml
+```
+
+This writes the result JSON next to the spec file.
+
+## Remote execution
+
+Start a gateway and worker and then submit the job remotely:
+
+```bash
+uv run --package peagen --directory pkgs/standards/peagen \
+  peagen remote -q --gateway-url http://127.0.0.1:8000/rpc \
+  evolve tests/examples/simple_evolve_demo/evolve_spec.yaml
+```
+
+You can fetch the task result with:
+
+```bash
+uv run --package peagen --directory pkgs/standards/peagen \
+  peagen remote -q --gateway-url http://127.0.0.1:8000/rpc \
+  task get <task-id>
+```

--- a/pkgs/standards/peagen/tests/examples/simple_evolve_demo/cfg/local.toml
+++ b/pkgs/standards/peagen/tests/examples/simple_evolve_demo/cfg/local.toml
@@ -1,0 +1,18 @@
+[queues]
+default_queue = "in_memory"
+
+[storage]
+default_filter = "minio"
+
+[storage.filters.file]
+output_dir = "./peagen_artifacts"
+[storage.filters.minio]
+bucket = "test"
+access_key = "${MINIO_ACCESS_KEY}"
+secret_key = "${MINIO_SECRET_KEY}"
+secure = false
+
+[result_backends]
+default_backend = "local_fs"
+[result_backends.adapters.local_fs]
+root_dir = "./task_runs"

--- a/pkgs/standards/peagen/tests/examples/simple_evolve_demo/cfg/remote.toml
+++ b/pkgs/standards/peagen/tests/examples/simple_evolve_demo/cfg/remote.toml
@@ -1,0 +1,29 @@
+[queues]
+default_queue = "redis"
+
+[queues.adapters.redis]
+uri = "${REDIS_URL}"
+
+[result_backends]
+default_backend = "postgres"
+[result_backends.adapters.postgres]
+dsn = "${PG_DSN}"
+
+[storage]
+default_storage_adapter = "minio"
+
+[storage.adapters.minio]
+endpoint = "${MINIO_ENDPOINT}"
+bucket = "test"
+access_key = "${MINIO_ACCESS_KEY}"
+secret_key = "${MINIO_SECRET_KEY}"
+secure = false
+
+[evaluation]
+pool = "peagen.plugins.evaluator_pools.default:DefaultEvaluatorPool"
+max_workers = 1
+async = false
+strict = true
+
+[evaluation.evaluators]
+performance = "peagen.plugins.evaluators.performance_evaluator:PerformanceEvaluator"

--- a/pkgs/standards/peagen/tests/examples/simple_evolve_demo/evolve_spec.yaml
+++ b/pkgs/standards/peagen/tests/examples/simple_evolve_demo/evolve_spec.yaml
@@ -1,0 +1,10 @@
+JOBS:
+  - workspace_uri: workspace
+    target_file: main.py
+    import_path: workspace.main
+    entry_fn: greet
+    config: pkgs/standards/peagen/tests/examples/simple_evolve_demo/cfg/remote.toml
+operators:
+  mutation:
+    - kind: echo_mutator
+      probability: 1

--- a/pkgs/standards/peagen/tests/examples/simple_evolve_demo/workspace/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/simple_evolve_demo/workspace/.peagen.toml
@@ -1,0 +1,31 @@
+schemaVersion = "1.0.3"
+[queues]
+default_queue = "in_memory"
+[queues.adapters.in_memory]
+
+[result_backends]
+default_backend = "local_fs"
+[result_backends.adapters.local_fs]
+root_dir = "./task_runs"
+
+[storage]
+default_filter = "file"
+[storage.filters.file]
+output_dir = "./peagen_artifacts"
+
+[evaluation]
+pool = "peagen.plugins.evaluator_pools.default:DefaultEvaluatorPool"
+max_workers = 1
+async = false
+strict = true
+
+[mutators]
+default_mutator = "peagen.plugins.mutators.default_mutator:DefaultMutator"
+
+[evaluation.evaluators]
+performance = "peagen.plugins.evaluators.performance_evaluator:PerformanceEvaluator"
+
+[llm]
+default_provider = "groq"
+[llm.groq]
+API_KEY = "${GROQ_API_KEY}"

--- a/pkgs/standards/peagen/tests/examples/simple_evolve_demo/workspace/main.py
+++ b/pkgs/standards/peagen/tests/examples/simple_evolve_demo/workspace/main.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+def greet(name: str) -> str:
+    """Return a greeting for the provided name."""
+    return f"Hello, {name}!"
+
+if __name__ == "__main__":
+    print(greet("World"))


### PR DESCRIPTION
## Summary
- support inline evolve spec text so remote tasks don't require local files
- update evolve command to send file content
- document how to test the evolve demo locally and with a gateway

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff check .`
- `uv run --package peagen --directory pkgs/standards/peagen pytest`
- `DQ_GATEWAY=http://127.0.0.1:8000/rpc uv run --package peagen --directory pkgs/standards/peagen peagen local -q evolve tests/examples/simple_evolve_demo/evolve_spec.yaml`
- `uv run --package peagen --directory pkgs/standards/peagen peagen remote -q --gateway-url http://127.0.0.1:8000/rpc evolve tests/examples/simple_evolve_demo/evolve_spec.yaml`
- `uv run --package peagen --directory pkgs/standards/peagen peagen remote -q --gateway-url http://127.0.0.1:8000/rpc task get 190291f8-60b7-4589-a59d-6f85f77c0af4`


------
https://chatgpt.com/codex/tasks/task_e_6855ba7cdc0883268f050c432339794c