### PR TITLE
Add 2x2Grid DOE example

### DIFF
--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -179,4 +179,5 @@ llm_prog_rewrite = "peagen.plugins.mutators.llm_prog_rewrite:LlmProgRewrite"
 "peagen" = [
   "tests/examples/locking_demo/*",
   "tests/examples/peagen_tomls/*",
+  "tests/examples/2x2Grid/*",
 ]

--- a/pkgs/standards/peagen/tests/examples/2x2Grid/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/2x2Grid/.peagen.toml
@@ -1,0 +1,12 @@
+[queues]
+default_queue = "in_memory"
+
+[storage]
+default_filter = "file"
+[storage.filters.file]
+output_dir = "./peagen_artifacts"
+
+[result_backends]
+default_backend = "local_fs"
+[result_backends.adapters.local_fs]
+root_dir = "./task_runs"

--- a/pkgs/standards/peagen/tests/examples/2x2Grid/README.md
+++ b/pkgs/standards/peagen/tests/examples/2x2Grid/README.md
@@ -1,0 +1,10 @@
+# 2x2Grid Example
+
+This project demonstrates a minimal DOE specification with two factors,
+each having two levels (A/B and C/D). The `grid` factor set generates
+four runs: `AC`, `AD`, `BC`, and `BD`. Each factor level applies its
+patch to `template_project.yaml`, producing patched artifacts in the
+same directory.
+
+Use the included `.peagen.toml` for local testing or adapt it for remote
+execution.

--- a/pkgs/standards/peagen/tests/examples/2x2Grid/doe_spec.yaml
+++ b/pkgs/standards/peagen/tests/examples/2x2Grid/doe_spec.yaml
@@ -1,0 +1,30 @@
+version: v2
+meta:
+  name: 2x2-grid-demo
+factors:
+  - name: first
+    levels:
+      - id: A
+        patchRef: patches/factor1_A.yaml
+        output_path: template_project.yaml
+        patchKind: json-merge
+      - id: B
+        patchRef: patches/factor1_B.yaml
+        output_path: template_project.yaml
+        patchKind: json-merge
+  - name: second
+    levels:
+      - id: C
+        patchRef: patches/factor2_C.yaml
+        output_path: template_project.yaml
+        patchKind: json-merge
+      - id: D
+        patchRef: patches/factor2_D.yaml
+        output_path: template_project.yaml
+        patchKind: json-merge
+factorSets:
+  - name: grid
+    cartesianProduct:
+      first: ["A", "B"]
+      second: ["C", "D"]
+    uriTemplate: "{first}{second}"

--- a/pkgs/standards/peagen/tests/examples/2x2Grid/patches/factor1_A.yaml
+++ b/pkgs/standards/peagen/tests/examples/2x2Grid/patches/factor1_A.yaml
@@ -1,0 +1,2 @@
+PROJECTS:
+  - NAME: BaseProject-A

--- a/pkgs/standards/peagen/tests/examples/2x2Grid/patches/factor1_B.yaml
+++ b/pkgs/standards/peagen/tests/examples/2x2Grid/patches/factor1_B.yaml
@@ -1,0 +1,2 @@
+PROJECTS:
+  - NAME: BaseProject-B

--- a/pkgs/standards/peagen/tests/examples/2x2Grid/patches/factor2_C.yaml
+++ b/pkgs/standards/peagen/tests/examples/2x2Grid/patches/factor2_C.yaml
@@ -1,0 +1,5 @@
+PROJECTS:
+  - PACKAGES:
+    - MODULES:
+      - EXTRAS:
+          EXTRA_SETTING: C

--- a/pkgs/standards/peagen/tests/examples/2x2Grid/patches/factor2_D.yaml
+++ b/pkgs/standards/peagen/tests/examples/2x2Grid/patches/factor2_D.yaml
@@ -1,0 +1,5 @@
+PROJECTS:
+  - PACKAGES:
+    - MODULES:
+      - EXTRAS:
+          EXTRA_SETTING: D

--- a/pkgs/standards/peagen/tests/examples/2x2Grid/template_project.yaml
+++ b/pkgs/standards/peagen/tests/examples/2x2Grid/template_project.yaml
@@ -1,0 +1,17 @@
+schemaVersion: "1.0.0"
+PROJECTS:
+- NAME: BaseProject
+  ROOT: "swarmauri-sdk/pkgs"
+  TEMPLATE_SET: swarmauri_base
+  PACKAGES:
+  - NAME: "base/swarmauri_base"
+    MODULES:
+    - NAME: "ParserBase"
+      EXTRAS:
+        PURPOSE: "Provide a base implementation"
+        DESCRIPTION: "Base implementation"
+        REQUIREMENTS:
+        - "Should inherit from the interface first and ComponentBase second."
+        RESOURCE_KIND: "parsers"
+        INTERFACE_NAME: "IParser"
+        INTERFACE_FILE: "pkgs/core/swarmauri_core/parsers/IParser.py"


### PR DESCRIPTION
## Summary
- provide a minimal DOE spec demonstrating a 2x2 factor grid
- include supporting patches and template
- expose example data in package config

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff check .`
- `uv run --package peagen --directory pkgs/standards/peagen pytest`
- `uv run --package peagen --directory pkgs/standards/peagen peagen remote -q --gateway-url http://127.0.0.1:8000/rpc doe gen tests/examples/2x2Grid/doe_spec.yaml tests/examples/2x2Grid/template_project.yaml -o tests/examples/2x2Grid/project_payloads.yaml --config tests/examples/2x2Grid/.peagen.toml`
- `uv run --package peagen --directory pkgs/standards/peagen peagen remote -q --gateway-url http://127.0.0.1:8000/rpc task get 0e155f14-8439-4ae4-bb5f-ed3c6f014e09`
- `uv run --package peagen --directory pkgs/standards/peagen peagen local -q doe gen tests/examples/2x2Grid/doe_spec.yaml tests/examples/2x2Grid/template_project.yaml -o tests/examples/2x2Grid/local_payloads.yaml --config tests/examples/2x2Grid/.peagen.toml`


------
https://chatgpt.com/codex/tasks/task_e_6855d1080f188326837c512ee49462a2