### PR TITLE
Update evolve spec validation

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/evolve.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/evolve.py
@@ -12,6 +12,7 @@ import typer
 
 from peagen.handlers.evolve_handler import evolve_handler
 from peagen.models import Status, Task
+from peagen.core.validate_core import validate_evolve_spec
 
 local_evolve_app = typer.Typer(help="Expand evolve spec and run mutate tasks")
 remote_evolve_app = typer.Typer(help="Expand evolve spec and run mutate tasks")
@@ -35,6 +36,12 @@ def run(
     repo: Optional[str] = typer.Option(None, "--repo", help="Git repository URI"),
     ref: str = typer.Option("HEAD", "--ref", help="Git ref or commit SHA"),
 ):
+    validation = validate_evolve_spec(spec)
+    if not validation.get("ok", False):
+        for err in validation.get("errors", []):
+            typer.echo(f"   • {err}", err=True)
+        raise typer.Exit(1)
+
     args = {"evolve_spec": str(spec)}
     if repo:
         args.update({"repo": repo, "ref": ref})
@@ -57,6 +64,12 @@ def submit(
     repo: Optional[str] = typer.Option(None, "--repo", help="Git repository URI"),
     ref: str = typer.Option("HEAD", "--ref", help="Git ref or commit SHA"),
 ):
+    validation = validate_evolve_spec(spec)
+    if not validation.get("ok", False):
+        for err in validation.get("errors", []):
+            typer.echo(f"   • {err}", err=True)
+        raise typer.Exit(1)
+
     def _git_root(path: Path) -> Path:
         for p in [path] + list(path.parents):
             if (p / ".git").exists():

--- a/pkgs/standards/peagen/peagen/cli/commands/validate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/validate.py
@@ -19,7 +19,7 @@ def run_validate(
     ctx: typer.Context,
     kind: str = typer.Argument(
         ...,
-        help="Kind of artifact to validate (config, doe, ptree, projects_payload).",
+        help="Kind of artifact to validate (config, evolve, doe, ptree, projects_payload).",
     ),
     path: str = typer.Option(
         None, help="Path to the file to validate (not required for config)."
@@ -63,7 +63,7 @@ def submit_validate(
     ctx: typer.Context,
     kind: str = typer.Argument(
         ...,
-        help="Kind of artifact to validate (config, doe, ptree, projects_payload).",
+        help="Kind of artifact to validate (config, evolve, doe, ptree, projects_payload).",
     ),
     path: str = typer.Option(
         None, help="Path to the file to validate (not required for config)."

--- a/pkgs/standards/peagen/peagen/core/validate_core.py
+++ b/pkgs/standards/peagen/peagen/core/validate_core.py
@@ -15,6 +15,7 @@ from peagen.schemas import (
     DOE_SPEC_V2_SCHEMA,
     PTREE_V1_SCHEMA,
     PROJECTS_PAYLOAD_V1_SCHEMA,
+    EVOLVE_SPEC_V2_SCHEMA,
 )
 
 
@@ -72,6 +73,21 @@ def validate_doe_spec(path: Path) -> Dict[str, Any]:
     return {"ok": not errs, "errors": errs}
 
 
+def validate_evolve_spec(path: Path) -> Dict[str, Any]:
+    data = _load_yaml(path)
+    if data is None or isinstance(data, dict) and "_yaml_error" in data:
+        return {"ok": False, "errors": [data.get("_yaml_error", "YAML error")]}  # type: ignore[union-attr]
+
+    if data.get("version") != "2.0.0":
+        return {
+            "ok": False,
+            "errors": [f"unsupported evolve spec version: {data.get('version')!r}"]
+        }
+
+    errs = _collect_errors(data, EVOLVE_SPEC_V2_SCHEMA)
+    return {"ok": not errs, "errors": errs}
+
+
 
 def validate_ptree(path: Path) -> Dict[str, Any]:
     data = _load_yaml(path)
@@ -97,6 +113,8 @@ def validate_artifact(kind: str, path: Optional[Path]) -> Dict[str, Any]:
         return {"ok": False, "errors": ["path is required"]}
     if kind == "doe":
         return validate_doe_spec(path)
+    if kind == "evolve":
+        return validate_evolve_spec(path)
     if kind == "ptree":
         return validate_ptree(path)
     if kind == "projects_payload":

--- a/pkgs/standards/peagen/peagen/schemas/__init__.py
+++ b/pkgs/standards/peagen/peagen/schemas/__init__.py
@@ -57,6 +57,12 @@ EVOLVE_SPEC_V1_SCHEMA = json.loads(
     .read_text(encoding="utf-8")
 )
 
+EVOLVE_SPEC_V2_SCHEMA = json.loads(
+    res.files(__package__)
+    .joinpath("evolve_spec.schema.v2.json")
+    .read_text(encoding="utf-8")
+)
+
 LLM_PATCH_V1_SCHEMA = json.loads(
     res.files(__package__).joinpath("llm_patch.schema.v1.json").read_text(encoding="utf-8")
 )
@@ -81,6 +87,7 @@ __all__ = [
     "PROJECTS_PAYLOAD_V1_SCHEMA",
     "EVENT_V1_SCHEMA",
     "EVOLVE_SPEC_V1_SCHEMA",
+    "EVOLVE_SPEC_V2_SCHEMA",
     "LLM_PATCH_V1_SCHEMA",
     "EXTRAS_SCHEMAS",
 ]

--- a/pkgs/standards/peagen/peagen/schemas/evolve_spec.schema.v2.json
+++ b/pkgs/standards/peagen/peagen/schemas/evolve_spec.schema.v2.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schema/evolve_spec.schema.json",
+  "title": "EVOLVE_SPEC",
+  "$comment": "Evolution specification - schema v2.0.0",
+  "type": "object",
+  "required": ["version", "JOBS", "operators"],
+  "additionalProperties": true,
+  "properties": {
+    "version": { "const": "2.0.0" },
+    "meta": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "factors": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/factor" }
+    },
+    "JOBS": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/job" }
+    },
+    "operators": {
+      "type": "object",
+      "required": ["mutation"],
+      "additionalProperties": true,
+      "properties": {
+        "mutation": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/mutator" }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "job": {
+      "type": "object",
+      "required": ["workspace_uri", "target_file", "import_path", "entry_fn", "config"],
+      "additionalProperties": true,
+      "properties": {
+        "workspace_uri": { "type": "string" },
+        "target_file": { "type": "string" },
+        "import_path": { "type": "string" },
+        "entry_fn": { "type": "string" },
+        "config": { "type": "string" }
+      }
+    },
+    "mutator": {
+      "type": "object",
+      "required": ["kind", "probability"],
+      "additionalProperties": true,
+      "properties": {
+        "kind": { "type": "string" },
+        "probability": { "type": "number", "exclusiveMinimum": 0, "maximum": 1 },
+        "patchRef": { "type": "string" },
+        "patchKind": { "type": "string" },
+        "output_path": { "type": "string" }
+      }
+    },
+    "level": {
+      "type": "object",
+      "required": ["id", "patchRef", "output_path"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string" },
+        "patchRef": { "type": "string" },
+        "output_path": { "type": "string" },
+        "patchKind": { "type": "string" }
+      }
+    },
+    "factor": {
+      "type": "object",
+      "required": ["name", "levels"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "lock": { "type": "boolean", "default": false },
+        "levels": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/level" } }
+      }
+    }
+  }
+}

--- a/pkgs/standards/peagen/tests/examples/evolve_example_2/evolve_spec.yaml
+++ b/pkgs/standards/peagen/tests/examples/evolve_example_2/evolve_spec.yaml
@@ -1,3 +1,6 @@
+version: "2.0.0"
+meta:
+  name: evolve-example-2
 JOBS:
   - workspace_uri: /workspace/swarmauri-sdk/pkgs/standards/peagen/tests/examples/evolve_example_2/workspace
     target_file: main.py

--- a/pkgs/standards/peagen/tests/examples/peagen_local_demo/test_evolve_spec.yaml
+++ b/pkgs/standards/peagen/tests/examples/peagen_local_demo/test_evolve_spec.yaml
@@ -1,3 +1,6 @@
+version: "2.0.0"
+meta:
+  name: peagen-local-demo
 JOBS:
   - workspace_uri: test_workspace
     target_file: main.py

--- a/pkgs/standards/peagen/tests/examples/simple_evolve_demo/evolve_spec.yaml
+++ b/pkgs/standards/peagen/tests/examples/simple_evolve_demo/evolve_spec.yaml
@@ -1,3 +1,13 @@
+version: "2.0.0"
+meta:
+  name: simple-evolve-demo
+factors:
+  - name: suffix
+    levels:
+      - id: "001"
+        patchRef: patches/suffix_001.yaml
+        output_path: template_project.yaml
+        patchKind: json-merge
 JOBS:
   - workspace_uri: workspace
     target_file: main.py

--- a/pkgs/standards/peagen/tests/examples/simple_evolve_demo/patches/suffix_001.yaml
+++ b/pkgs/standards/peagen/tests/examples/simple_evolve_demo/patches/suffix_001.yaml
@@ -1,0 +1,2 @@
+PROJECTS:
+  - NAME: ExampleParserProject-001

--- a/pkgs/standards/peagen/tests/examples/simple_evolve_demo/template_project.yaml
+++ b/pkgs/standards/peagen/tests/examples/simple_evolve_demo/template_project.yaml
@@ -1,0 +1,13 @@
+schemaVersion: "1.0.0"
+PROJECTS:
+- NAME: ExampleWorkspace
+  ROOT: "workspace"
+  TEMPLATE_SET: swarmauri_base
+  PACKAGES:
+  - NAME: "workspace"
+    MODULES:
+    - NAME: "main"
+      EXTRAS:
+        PURPOSE: "Demo module"
+        DESCRIPTION: "Demo module"
+        RESOURCE_KIND: "workspace"


### PR DESCRIPTION
## Summary
- add evolve spec v2 schema
- validate evolve spec before submitting tasks
- update validation CLI help
- switch example evolve specs to version 2.0.0

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855d88f262083268ae8e8a4bd291fda