### PR TITLE
Integrate apply_patch as patch kind

### DIFF
--- a/pkgs/standards/peagen/peagen/core/patch_core.py
+++ b/pkgs/standards/peagen/peagen/core/patch_core.py
@@ -23,6 +23,7 @@ from peagen.errors import PatchTargetMissingError
 # JSON patch helpers
 # ---------------------------------------------------------------------------
 
+
 def _apply_json_patch(doc: Any, ops: list[dict[str, Any]]) -> Any:
     """Return ``doc`` after applying RFC6902 operations."""
     try:
@@ -34,6 +35,7 @@ def _apply_json_patch(doc: Any, ops: list[dict[str, Any]]) -> Any:
 # ---------------------------------------------------------------------------
 # JSON merge (RFC 7386)
 # ---------------------------------------------------------------------------
+
 
 def _apply_json_merge(doc: Any, patch: Any) -> Any:
     if not isinstance(patch, dict) or not isinstance(doc, dict):
@@ -59,7 +61,14 @@ def _apply_yaml_overlay(doc: Any, patch: Any) -> Any:
 # Git patch application
 # ---------------------------------------------------------------------------
 
-def _apply_git_patch(base: bytes, patch_path: Path, *, user_name: str | None = None, user_email: str | None = None) -> bytes:
+
+def _apply_git_patch(
+    base: bytes,
+    patch_path: Path,
+    *,
+    user_name: str | None = None,
+    user_email: str | None = None,
+) -> bytes:
     """Apply a Git patch using a scratch repository."""
     user_name = user_name or os.getenv("GIT_AUTHOR_NAME", "nobody")
     user_email = user_email or os.getenv("GIT_AUTHOR_EMAIL", "nobody@example.com")
@@ -69,11 +78,41 @@ def _apply_git_patch(base: bytes, patch_path: Path, *, user_name: str | None = N
         tgt = tmp / "file.txt"
         tgt.write_bytes(base)
 
-        subprocess.run(["git", "init"], cwd=tmp, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        subprocess.run(["git", "config", "user.email", user_email], cwd=tmp, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        subprocess.run(["git", "config", "user.name", user_name], cwd=tmp, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        subprocess.run(["git", "add", "file.txt"], cwd=tmp, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        subprocess.run(["git", "commit", "-m", "base"], cwd=tmp, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        subprocess.run(
+            ["git", "init"],
+            cwd=tmp,
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        subprocess.run(
+            ["git", "config", "user.email", user_email],
+            cwd=tmp,
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", user_name],
+            cwd=tmp,
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        subprocess.run(
+            ["git", "add", "file.txt"],
+            cwd=tmp,
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "base"],
+            cwd=tmp,
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
         try:
             subprocess.run(
                 ["git", "apply", str(patch_path)],
@@ -109,8 +148,31 @@ def _apply_git_patch(base: bytes, patch_path: Path, *, user_name: str | None = N
 
 
 # ---------------------------------------------------------------------------
+# apply_patch CLI application
+# ---------------------------------------------------------------------------
+
+
+def _apply_cli_patch(base: bytes, patch_path: Path) -> bytes:
+    """Apply a Codex-format patch using the ``apply_patch`` command."""
+    with TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        tgt = tmp / "file.txt"
+        tgt.write_bytes(base)
+        patch_text = patch_path.read_text(encoding="utf-8")
+        subprocess.run(
+            ["apply_patch", patch_text],
+            cwd=tmp,
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        return tgt.read_bytes()
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
+
 
 def apply_patch(base: bytes, patch_path: Path, kind: str) -> bytes:
     """Apply *patch_path* of type *kind* to ``base`` and return new bytes."""
@@ -130,6 +192,8 @@ def apply_patch(base: bytes, patch_path: Path, kind: str) -> bytes:
         return yaml.safe_dump(patched, sort_keys=False).encode("utf-8")
     if kind == "git":
         return _apply_git_patch(base, patch_path)
+    if kind == "apply_patch":
+        return _apply_cli_patch(base, patch_path)
     raise ValueError(f"unknown patch kind: {kind}")
 
 

--- a/pkgs/standards/peagen/peagen/schemas/doe_spec.schema.v2.json
+++ b/pkgs/standards/peagen/peagen/schemas/doe_spec.schema.v2.json
@@ -78,7 +78,7 @@
         "artifactRef": { "type": "string", "format": "uri-reference" },
         "patchKind": {
           "type": "string",
-          "enum": ["git", "json-patch", "json-merge", "yaml-overlay"]
+          "enum": ["git", "json-patch", "json-merge", "yaml-overlay", "apply_patch"]
         },
         "replicates": {
           "type": "integer",

--- a/pkgs/standards/peagen/tests/unit/test_patch_core.py
+++ b/pkgs/standards/peagen/tests/unit/test_patch_core.py
@@ -26,6 +26,29 @@ def test_apply_patch_git(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
+def test_apply_patch_cli(tmp_path: Path) -> None:
+    base = tmp_path / "file.txt"
+    base.write_text("hello\n")
+    patch = tmp_path / "p.patch"
+    patch.write_text(
+        "\n".join(
+            [
+                "*** Begin Patch",
+                "*** Update File: file.txt",
+                "@@",
+                "-hello",
+                "+goodbye",
+                "*** End Patch",
+            ]
+        )
+        + "\n"
+    )
+
+    out = apply_patch(base.read_bytes(), patch, "apply_patch")
+    assert out.decode().strip() == "goodbye"
+
+
+@pytest.mark.unit
 def test_apply_patch_unknown(tmp_path: Path) -> None:
     base = tmp_path / "f.txt"
     patch = tmp_path / "p.patch"


### PR DESCRIPTION
## Summary
- support applying patches via the `apply_patch` CLI
- extend DOE spec schema to allow the new patch kind
- test the new functionality in `test_patch_core`

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format peagen/core/patch_core.py tests/unit/test_patch_core.py`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/core/patch_core.py tests/unit/test_patch_core.py --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_patch_core.py -q`
- `uv run --package peagen --directory pkgs/standards/peagen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855f7b9095483269ff65ec04f9a35c0