### PR TITLE
Add infra test skip logic for peagen

### DIFF
--- a/pkgs/conftest.py
+++ b/pkgs/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "infra: infrastructure tests requiring external services",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    markexpr = getattr(config.option, "markexpr", "")
+    if markexpr and "infra" in markexpr:
+        return
+    skip_infra = pytest.mark.skip(reason="skip infra tests (use -m infra to run)")
+    for item in items:
+        if "infra" in item.keywords:
+            item.add_marker(skip_infra)

--- a/pkgs/standards/peagen/tests/conftest.py
+++ b/pkgs/standards/peagen/tests/conftest.py
@@ -1,0 +1,20 @@
+import pytest
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        "infra: infrastructure tests requiring external services",
+    )
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    markexpr = getattr(config.option, "markexpr", "")
+    if markexpr and "infra" in markexpr:
+        return
+    skip_infra = pytest.mark.skip(reason="skip infra tests (use -m infra to run)")
+    for item in items:
+        if "infra" in item.keywords:
+            item.add_marker(skip_infra)

--- a/pkgs/standards/peagen/tests/infra/test_simple_evolve_demo.py
+++ b/pkgs/standards/peagen/tests/infra/test_simple_evolve_demo.py
@@ -1,0 +1,32 @@
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SPEC_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "tests"
+    / "examples"
+    / "simple_evolve_demo"
+    / "evolve_spec.yaml"
+)
+
+
+@pytest.mark.infra
+def test_remote_evolve_gateway(tmp_path):
+    """Run the simple evolve demo against a local gateway."""
+    cmd = [
+        "peagen",
+        "remote",
+        "-q",
+        "--gateway-url",
+        "http://localhost:8000/rpc",
+        "evolve",
+        str(SPEC_PATH),
+        "--watch",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=60)
+    last_line = result.stdout.strip().splitlines()[-1]
+    data = json.loads(last_line)
+    assert data["status"] == "success"


### PR DESCRIPTION
## Summary
- remove dummy infra test
- add simple evolve demo infra test that exercises the peagen CLI

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format tests/infra/test_simple_evolve_demo.py tests/conftest.py`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check tests/infra/test_simple_evolve_demo.py tests/conftest.py --fix`

------
https://chatgpt.com/codex/tasks/task_e_6855f6531e5883269db39b953959faca