### PR TITLE
Fix peagen.tui runtime warning

### DIFF
--- a/pkgs/standards/peagen/peagen/tui/__init__.py
+++ b/pkgs/standards/peagen/peagen/tui/__init__.py
@@ -1,8 +1,6 @@
 """Textual user interface helpers for Peagen."""
 
-from .app import QueueDashboardApp
-from .ws_client import TaskStreamClient
-from .fileops import download_remote, upload_remote
+from typing import TYPE_CHECKING
 
 __all__ = [
     "QueueDashboardApp",
@@ -10,3 +8,28 @@ __all__ = [
     "download_remote",
     "upload_remote",
 ]
+
+if TYPE_CHECKING:  # pragma: no cover - used only for type checkers
+    from .app import QueueDashboardApp
+    from .ws_client import TaskStreamClient
+    from .fileops import download_remote, upload_remote
+
+
+def __getattr__(name: str):
+    if name == "QueueDashboardApp":
+        from .app import QueueDashboardApp as _QueueDashboardApp
+
+        return _QueueDashboardApp
+    if name == "TaskStreamClient":
+        from .ws_client import TaskStreamClient as _TaskStreamClient
+
+        return _TaskStreamClient
+    if name == "download_remote":
+        from .fileops import download_remote as _download_remote
+
+        return _download_remote
+    if name == "upload_remote":
+        from .fileops import upload_remote as _upload_remote
+
+        return _upload_remote
+    raise AttributeError(name)


### PR DESCRIPTION
## Summary
- avoid importing `peagen.tui.app` during package import so that `python -m peagen.tui.app` doesn't warn

## Testing
- `uv run --package peagen --directory peagen ruff check peagen/tui/__init__.py --fix`
- `uv run --package peagen --directory peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_685606060ddc8326b93b999c2dbf3f0c