### PR TITLE
Fix evolve handler path logic

### DIFF
--- a/pkgs/standards/peagen/tests/examples/simple_evolve_demo/evolve_spec.yaml
+++ b/pkgs/standards/peagen/tests/examples/simple_evolve_demo/evolve_spec.yaml
@@ -15,9 +15,7 @@ factors:
         output_path: template_project.yaml
         patchKind: json-merge
 JOBS:
-  - repo: https://github.com/swarmauri/swarmauri-sdk.git
-    ref: HEAD
-    workspace_uri: workspace
+  - workspace_uri: workspace
     target_file: main.py
     import_path: workspace.main
     entry_fn: greet


### PR DESCRIPTION
## Summary
- make `_load_spec` search additional parent directories to find spec files
- preserve workspace paths when repo is specified
- simplify example evolve spec

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen pytest`
- `DQ_GATEWAY=https://gw.peagen.com/rpc uv run --package peagen --directory pkgs/standards/peagen peagen local -q evolve tests/examples/simple_evolve_demo/evolve_spec.yaml`
- `uv run --package peagen --directory pkgs/standards/peagen peagen remote -q --gateway-url https://gw.peagen.com/rpc evolve tests/examples/simple_evolve_demo/evolve_spec.yaml`
- `uv run --package peagen --directory pkgs/standards/peagen peagen remote -q --gateway-url https://gw.peagen.com/rpc task get ee22b620-8fb4-49df-a5fe-e5ad72e37b8c`

------
https://chatgpt.com/codex/tasks/task_e_68563a3bd2e883269743c0b57fd2a9f6