### PR TITLE
Implement key audit helper

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_git_vcs.py
+++ b/pkgs/standards/peagen/tests/unit/test_git_vcs.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import json
 
 from peagen.plugins.vcs import GitVCS, pea_ref
+from peagen.secrets import SecretDriverBase
 
 
 def test_gitvcs_promote(tmp_path: Path):
@@ -55,3 +56,16 @@ def test_fast_import_json_ref(tmp_path: Path):
     sha = vcs.fast_import_json_ref(ref, payload)
     stored = vcs.repo.git.show(f"{sha}:audit.json")
     assert json.loads(stored) == payload
+
+
+def test_record_key_audit(tmp_path: Path):
+    repo_dir = tmp_path / "ka"
+    vcs = GitVCS.ensure_repo(repo_dir)
+    secret = b"topsecret"
+    sha = vcs.record_key_audit(secret, "UFPR", "GFPR")
+    stored = vcs.repo.git.show(f"{sha}:audit.json")
+    data = json.loads(stored)
+    assert data["user_fpr"] == "UFPR"
+    assert data["gateway_fp"] == "GFPR"
+    ref = pea_ref("key_audit", SecretDriverBase.audit_hash(secret))
+    assert vcs.repo.rev_parse(ref) == sha


### PR DESCRIPTION
## Summary
- add `record_key_audit` method to `GitVCS`
- verify `record_key_audit` via unit tests

## Testing
- `uv run --package peagen ruff format peagen/plugins/vcs/git_vcs.py tests/unit/test_git_vcs.py`
- `uv run --package peagen ruff check peagen/plugins/vcs/git_vcs.py tests/unit/test_git_vcs.py --fix`
- `uv run --package peagen pytest tests/unit/test_git_vcs.py -q`
- `uv run --package peagen pytest -q`
- `peagen local -q process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml > /tmp/local_run.log 2>&1` *(failed: NameResolutionError)*

------
https://chatgpt.com/codex/tasks/task_e_685657f04c68832682920c7d54ead76b