### PR TITLE
Implement key upload feedback and decrypt helper

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/__init__.py
+++ b/pkgs/standards/peagen/peagen/cli/__init__.py
@@ -146,7 +146,7 @@ def _global_remote_ctx(  # noqa: D401
 
 # ─────────────────────────── SUB-COMMAND REGISTRY ───────────────────────────
 
-app.add_typer(login_app, name="login")
+app.add_typer(login_app)
 app.add_typer(keys_app, name="keys")
 app.add_typer(local_app, name="local")
 app.add_typer(remote_app, name="remote")

--- a/pkgs/standards/peagen/peagen/cli/commands/login.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/login.py
@@ -11,10 +11,10 @@ import typer
 from peagen.secrets import AutoGpgDriver
 
 
-login_app = typer.Typer(help="Authenticate and upload your public key.")
+login_app = typer.Typer(name="login", help="Authenticate and upload your public key.")
 
 
-@login_app.command("login")
+@login_app.callback()
 def login(
     ctx: typer.Context,
     passphrase: Optional[str] = typer.Option(None, "--passphrase", hide_input=True),
@@ -24,5 +24,14 @@ def login(
     """Ensure keys exist and upload the public key."""
     drv = AutoGpgDriver(key_dir=key_dir, passphrase=passphrase)
     pubkey = drv.pub_path.read_text()
-    httpx.post(f"{gateway_url}/keys", json={"public_key": pubkey}, timeout=10.0)
+    try:
+        res = httpx.post(
+            f"{gateway_url}/keys", json={"public_key": pubkey}, timeout=10.0
+        )
+    except httpx.RequestError as e:  # pragma: no cover - network errors
+        typer.echo(f"HTTP error: {e}", err=True)
+        raise typer.Exit(1)
+    if res.status_code >= 400:
+        typer.echo(f"Failed to upload key: {res.status_code} {res.text}", err=True)
+        raise typer.Exit(1)
     typer.echo("Logged in and uploaded public key")

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -20,7 +20,8 @@ import time
 from json.decoder import JSONDecodeError
 from typing import Optional
 
-from fastapi import FastAPI, Request, Response
+import pgpy
+from fastapi import Body, FastAPI, Request, Response
 from peagen.plugins.queues import QueueBase
 
 from peagen.transport import RPCDispatcher, RPCRequest, RPCError
@@ -74,6 +75,10 @@ try:
     result_backend = pm.get("result_backends")
 except KeyError:
     result_backend = None
+
+# ──────────────── Simple key & secret stores ────────────────
+TRUSTED_USERS: dict[str, str] = {}
+SECRET_STORE: dict[str, str] = {}
 
 # ─────────────────────────── Workers ────────────────────────────
 # workers are stored as hashes:  queue.hset worker:<id> pool url advertises last_seen
@@ -573,6 +578,46 @@ async def scheduler():
                 log.warning("dispatch failed (%s) for %s; re-queueing", exc, task.id)
                 await queue.rpush(queue_key, task_raw)  # retry later
                 await _publish_queue_length(pool)
+
+
+# ────────────────────────── Key Management ──────────────────────────
+@app.post("/keys", tags=["keys"])
+async def upload_key(public_key: str = Body(..., embed=True)) -> dict:
+    key = pgpy.PGPKey()
+    key.parse(public_key)
+    TRUSTED_USERS[key.fingerprint] = public_key
+    return {"fingerprint": key.fingerprint}
+
+
+@app.get("/keys", tags=["keys"])
+async def list_keys() -> dict:
+    return {"keys": list(TRUSTED_USERS.keys())}
+
+
+@app.delete("/keys/{fingerprint}", tags=["keys"])
+async def delete_key(fingerprint: str) -> dict:
+    TRUSTED_USERS.pop(fingerprint, None)
+    return {"removed": fingerprint}
+
+
+# ────────────────────────── Secret Endpoints ─────────────────────────
+@app.post("/secrets", tags=["secrets"])
+async def add_secret(name: str = Body(...), secret: str = Body(...)) -> dict:
+    SECRET_STORE[name] = secret
+    return {"stored": name}
+
+
+@app.get("/secrets/{name}", tags=["secrets"])
+async def get_secret(name: str) -> dict:
+    if name not in SECRET_STORE:
+        return {"error": "not found"}
+    return {"secret": SECRET_STORE[name]}
+
+
+@app.delete("/secrets/{name}", tags=["secrets"])
+async def delete_secret(name: str) -> dict:
+    SECRET_STORE.pop(name, None)
+    return {"removed": name}
 
 
 # ─────────────────────────────── Healthcheck ───────────────────────────────

--- a/pkgs/standards/peagen/tests/unit/test_secret_driver.py
+++ b/pkgs/standards/peagen/tests/unit/test_secret_driver.py
@@ -17,3 +17,15 @@ def test_sign_multi_recipient(tmp_path):
     # drv2 should decrypt
     out = drv2.decrypt(cipher)
     assert out == b"secret"
+
+
+def test_decrypt_and_verify(tmp_path):
+    sender = AutoGpgDriver(key_dir=tmp_path / "sender")
+    recipient = AutoGpgDriver(key_dir=tmp_path / "recipient")
+    cipher = sender.encrypt(b"ping", [str(recipient.pub_path)])
+    out = AutoGpgDriver.decrypt_and_verify(
+        cipher,
+        priv_key=str(recipient.priv_path),
+        user_pub=str(sender.pub_path),
+    )
+    assert out == b"ping"


### PR DESCRIPTION
## Summary
- simplify `login` command integration and validate key upload
- expose new `decrypt_and_verify` helper on `AutoGpgDriver`
- remove unused crypto_helpers file
- test decrypt_and_verify

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format peagen/secrets/driver.py tests/unit/test_secret_driver.py peagen/cli/commands/login.py peagen/cli/__init__.py`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check peagen/cli/commands/login.py peagen/cli/__init__.py peagen/secrets/driver.py tests/unit/test_secret_driver.py --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest`


------
https://chatgpt.com/codex/tasks/task_e_6856589d916883269277b2e3951a3349