### PR TITLE
Implement JSON-RPC handlers for secrets & keys

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/login.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/login.py
@@ -24,5 +24,10 @@ def login(
     """Ensure keys exist and upload the public key."""
     drv = AutoGpgDriver(key_dir=key_dir, passphrase=passphrase)
     pubkey = drv.pub_path.read_text()
-    httpx.post(f"{gateway_url}/keys", json={"public_key": pubkey}, timeout=10.0)
+    payload = {
+        "jsonrpc": "2.0",
+        "method": "Keys.upload",
+        "params": {"public_key": pubkey},
+    }
+    httpx.post(gateway_url, json=payload, timeout=10.0)
     typer.echo("Logged in and uploaded public key")

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -36,6 +36,7 @@ from peagen.core.migrate_core import alembic_upgrade
 import peagen.defaults as defaults
 
 from peagen.core.task_core import get_task_result
+import pgpy
 
 TASK_KEY = defaults.CONFIG["task_key"]
 
@@ -74,6 +75,10 @@ try:
     result_backend = pm.get("result_backends")
 except KeyError:
     result_backend = None
+
+# ─────────────────────────── Key/Secret store ───────────────────
+TRUSTED_KEYS: dict[str, str] = {}
+SECRETS: dict[str, str] = {}
 
 # ─────────────────────────── Workers ────────────────────────────
 # workers are stored as hashes:  queue.hset worker:<id> pool url advertises last_seen
@@ -260,6 +265,57 @@ async def rpc_endpoint(request: Request):
         log.warning(f"{method} '{resp['error']}'")
     log.debug("RPC out -> %s", resp)
     return resp
+
+
+# ─────────────────────────── Key/Secret RPC ─────────────────────
+
+
+@rpc.method("Keys.upload")
+async def keys_upload(public_key: str) -> dict:
+    """Store a trusted public key."""
+    key = pgpy.PGPKey()
+    key.parse(public_key)
+    TRUSTED_KEYS[key.fingerprint] = public_key
+    log.info("key uploaded: %s", key.fingerprint)
+    return {"fingerprint": key.fingerprint}
+
+
+@rpc.method("Keys.fetch")
+async def keys_fetch() -> dict:
+    """Return all trusted keys indexed by fingerprint."""
+    return TRUSTED_KEYS
+
+
+@rpc.method("Keys.delete")
+async def keys_delete(fingerprint: str) -> dict:
+    """Remove a public key by its fingerprint."""
+    TRUSTED_KEYS.pop(fingerprint, None)
+    log.info("key removed: %s", fingerprint)
+    return {"ok": True}
+
+
+@rpc.method("Secrets.add")
+async def secrets_add(name: str, secret: str) -> dict:
+    """Store an encrypted secret."""
+    SECRETS[name] = secret
+    log.info("secret stored: %s", name)
+    return {"ok": True}
+
+
+@rpc.method("Secrets.get")
+async def secrets_get(name: str) -> dict:
+    """Retrieve an encrypted secret."""
+    if name not in SECRETS:
+        raise RPCError(code=-32000, message="secret not found")
+    return {"secret": SECRETS[name]}
+
+
+@rpc.method("Secrets.delete")
+async def secrets_delete(name: str) -> dict:
+    """Remove a secret by name."""
+    SECRETS.pop(name, None)
+    log.info("secret removed: %s", name)
+    return {"ok": True}
 
 
 # ─────────────────────────── Pool RPCs ──────────────────────────


### PR DESCRIPTION
## Summary
- refactor gateway key and secret endpoints to use JSON-RPC methods
- update CLI commands to call the new RPC methods
- verify remote secret/keys workflow with running gateway and worker

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format peagen/cli/commands/login.py peagen/cli/commands/keys.py peagen/cli/commands/secrets.py peagen/gateway/__init__.py`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check peagen/cli/commands/login.py peagen/cli/commands/keys.py peagen/cli/commands/secrets.py peagen/gateway/__init__.py --fix`
- ✅ `peagen login login --gateway-url http://127.0.0.1:8000/rpc`
- ✅ `peagen remote -q secrets add TEST_SECRET secretvalue --gateway-url http://127.0.0.1:8000/rpc`
- ✅ `peagen remote -q secrets get TEST_SECRET --gateway-url http://127.0.0.1:8000/rpc`
- ✅ `peagen remote -q secrets remove TEST_SECRET --gateway-url http://127.0.0.1:8000/rpc`
- ✅ `peagen keys fetch-server --gateway-url http://127.0.0.1:8000/rpc`
- ✅ `peagen keys remove <fingerprint> --gateway-url http://127.0.0.1:8000/rpc`
- ✅ `peagen remote -q --gateway-url http://127.0.0.1:8000/rpc process /tmp/projects_payload.yaml --watch`
- ✅ `peagen local -q process /tmp/projects_payload.yaml`


------
https://chatgpt.com/codex/tasks/task_e_685658710060832695d5986bce4294db