### PR TITLE
Add show command module

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/__init__.py
+++ b/pkgs/standards/peagen/peagen/cli/__init__.py
@@ -27,7 +27,7 @@ from .commands import (
     local_sort_app,
     local_template_sets_app,
     local_validate_app,
-  
+    show_app,
     remote_doe_app,
     remote_eval_app,
     remote_fetch_app,
@@ -44,12 +44,8 @@ from .commands import (
 )
 
 app = typer.Typer(help="CLI tool for processing project files using Peagen.")
-local_app = typer.Typer(
-    help="Commands executed locally on this machine."
-)
-remote_app = typer.Typer(
-    help="Commands that submit tasks to a JSON-RPC gateway."
-)
+local_app = typer.Typer(help="Commands executed locally on this machine.")
+remote_app = typer.Typer(help="Commands that submit tasks to a JSON-RPC gateway.")
 
 
 # ───────────────────── LOCAL GLOBAL CALLBACK ───────────────────────────────
@@ -153,11 +149,15 @@ app.add_typer(dashboard_app)
 
 
 local_app.add_typer(local_doe_app, name="doe")
-local_app.add_typer(local_eval_app,)
+local_app.add_typer(
+    local_eval_app,
+)
 local_app.add_typer(local_extras_app, name="extras-schemas")
-local_app.add_typer(local_fetch_app,)
+local_app.add_typer(
+    local_fetch_app,
+)
 local_app.add_typer(local_db_app, name="db")
-local_app.add_typer(local_init_app,          name="init")
+local_app.add_typer(local_init_app, name="init")
 local_app.add_typer(local_process_app)
 local_app.add_typer(local_mutate_app)
 local_app.add_typer(local_evolve_app)
@@ -165,6 +165,7 @@ local_app.add_typer(local_sort_app)
 local_app.add_typer(local_analysis_app)
 local_app.add_typer(local_template_sets_app, name="template-set")
 local_app.add_typer(local_validate_app)
+local_app.add_typer(show_app, name="git")
 
 
 remote_app.add_typer(remote_doe_app, name="doe")

--- a/pkgs/standards/peagen/peagen/cli/commands/__init__.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/__init__.py
@@ -15,6 +15,7 @@ from .analysis import local_analysis_app, remote_analysis_app
 from .templates import local_template_sets_app, remote_template_sets_app
 from .tui import dashboard_app
 from .validate import local_validate_app, remote_validate_app
+from .show import show_app
 
 __all__ = [
     "local_doe_app",
@@ -43,5 +44,6 @@ __all__ = [
     "remote_template_sets_app",
     "local_validate_app",
     "remote_validate_app",
+    "show_app",
     "dashboard_app",
 ]

--- a/pkgs/standards/peagen/peagen/cli/commands/show.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/show.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import typer
+
+from peagen.plugins.vcs.git_vcs import GitVCS
+
+
+show_app = typer.Typer(help="Inspect git objects.")
+
+
+@show_app.command("show")
+def show(
+    oid: str = typer.Argument(..., help="Object ID"),
+    repo: Path = typer.Option(".", "--repo", help="Repository path"),
+) -> None:
+    """Print type, size and pretty content for *OID*."""
+    vcs = GitVCS.open(repo)
+    info = {
+        "type": vcs.object_type(oid),
+        "size": vcs.object_size(oid),
+        "pretty": vcs.object_pretty(oid),
+    }
+    typer.echo(json.dumps(info, indent=2))

--- a/pkgs/standards/peagen/peagen/plugins/vcs/git_vcs.py
+++ b/pkgs/standards/peagen/peagen/plugins/vcs/git_vcs.py
@@ -146,6 +146,19 @@ class GitVCS:
         """Return the object ID for ``path`` at ``ref``."""
         return self.repo.git.rev_parse(f"{ref}:{path}")
 
+    # ------------------------------------------------------------------ oid helpers
+    def object_type(self, oid: str) -> str:
+        """Return the git object type for ``oid``."""
+        return self.repo.git.cat_file("-t", oid).strip()
+
+    def object_size(self, oid: str) -> int:
+        """Return the size of ``oid`` in bytes."""
+        return int(self.repo.git.cat_file("-s", oid).strip())
+
+    def object_pretty(self, oid: str) -> str:
+        """Return the pretty-printed content for ``oid``."""
+        return self.repo.git.cat_file("-p", oid)
+
     # ------------------------------------------------------------------ clean/reset
     def clean_reset(self) -> None:
         self.repo.git.reset("--hard")


### PR DESCRIPTION
## Summary
- rename `git` command module to `show`
- expose `show_app` from command package

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format peagen/cli/__init__.py peagen/cli/commands/__init__.py peagen/cli/commands/show.py`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/cli/__init__.py peagen/cli/commands/__init__.py peagen/cli/commands/show.py peagen/plugins/vcs/git_vcs.py --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest`
- `uv run --package peagen --directory pkgs/standards/peagen peagen local -q git show HEAD --repo ../../../`
- `uv run --package peagen --directory pkgs/standards/peagen peagen remote -q --gateway-url http://127.0.0.1:8000/rpc task get 700ff019-424b-45db-b3d6-1ff6d1cc58b8 --watch` *(fails: No plugin name provided for group 'mutators')*


------
https://chatgpt.com/codex/tasks/task_e_68565aae99848326b00f50ec75a474e6