### PR TITLE
Fix login and gateway variable names

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/login.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/login.py
@@ -29,7 +29,8 @@ def login(
         "method": "Keys.upload",
         "params": {"public_key": pubkey},
     }
-
+    try:
+        res = httpx.post(gateway_url, json=payload, timeout=10.0)
     except httpx.RequestError as e:  # pragma: no cover - network errors
         typer.echo(f"HTTP error: {e}", err=True)
         raise typer.Exit(1)

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -37,7 +37,6 @@ from peagen.core.migrate_core import alembic_upgrade
 import peagen.defaults as defaults
 
 from peagen.core.task_core import get_task_result
-import pgpy
 
 TASK_KEY = defaults.CONFIG["task_key"]
 
@@ -637,38 +636,38 @@ async def scheduler():
 async def upload_key(public_key: str = Body(..., embed=True)) -> dict:
     key = pgpy.PGPKey()
     key.parse(public_key)
-    TRUSTED_USERS[key.fingerprint] = public_key
+    TRUSTED_KEYS[key.fingerprint] = public_key
     return {"fingerprint": key.fingerprint}
 
 
 @app.get("/keys", tags=["keys"])
 async def list_keys() -> dict:
-    return {"keys": list(TRUSTED_USERS.keys())}
+    return {"keys": list(TRUSTED_KEYS.keys())}
 
 
 @app.delete("/keys/{fingerprint}", tags=["keys"])
 async def delete_key(fingerprint: str) -> dict:
-    TRUSTED_USERS.pop(fingerprint, None)
+    TRUSTED_KEYS.pop(fingerprint, None)
     return {"removed": fingerprint}
 
 
 # ────────────────────────── Secret Endpoints ─────────────────────────
 @app.post("/secrets", tags=["secrets"])
 async def add_secret(name: str = Body(...), secret: str = Body(...)) -> dict:
-    SECRET_STORE[name] = secret
+    SECRETS[name] = secret
     return {"stored": name}
 
 
 @app.get("/secrets/{name}", tags=["secrets"])
 async def get_secret(name: str) -> dict:
-    if name not in SECRET_STORE:
+    if name not in SECRETS:
         return {"error": "not found"}
-    return {"secret": SECRET_STORE[name]}
+    return {"secret": SECRETS[name]}
 
 
 @app.delete("/secrets/{name}", tags=["secrets"])
 async def delete_secret(name: str) -> dict:
-    SECRET_STORE.pop(name, None)
+    SECRETS.pop(name, None)
     return {"removed": name}
 
 


### PR DESCRIPTION
## Summary
- handle network errors correctly in `peagen login`
- use the correct key and secret stores in `peagen.gateway`

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff check peagen/cli/commands/login.py peagen/cli/commands/keys.py peagen/cli/commands/secrets.py peagen/gateway/__init__.py --fix`
- `peagen login --gateway-url http://127.0.0.1:8000/rpc` *(fails: missing command)*
- `peagen remote -q secrets add TEST_SECRET secretvalue --gateway-url http://127.0.0.1:8000/rpc` *(fails: connection refused)*
- `peagen remote -q secrets get TEST_SECRET --gateway-url http://127.0.0.1:8000/rpc` *(fails: connection refused)*
- `peagen remote -q secrets remove TEST_SECRET --gateway-url http://127.0.0.1:8000/rpc` *(fails: connection refused)*
- `peagen keys fetch-server --gateway-url http://127.0.0.1:8000/rpc` *(fails: connection refused)*
- `peagen keys remove testfingerprint --gateway-url http://127.0.0.1:8000/rpc` *(fails: connection refused)*
- `peagen remote -q --gateway-url http://127.0.0.1:8000/rpc process /tmp/projects_payload.yaml --watch` *(fails: file not found)*
- `peagen local -q process /tmp/projects_payload.yaml` *(fails: missing config)*


------
https://chatgpt.com/codex/tasks/task_e_6856686d3cc88326b2ff0ae06d13b90a