### PR TITLE
Fix login command invocation

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/login.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/login.py
@@ -11,7 +11,7 @@ import typer
 from peagen.secrets import AutoGpgDriver
 
 
-login_app = typer.Typer(name="login", help="Authenticate and upload your public key.")
+login_app = typer.Typer(help="Authenticate and upload your public key.")
 
 
 @login_app.command("login")

--- a/pkgs/standards/peagen/peagen/cli/commands/login.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/login.py
@@ -14,7 +14,7 @@ from peagen.secrets import AutoGpgDriver
 login_app = typer.Typer(name="login", help="Authenticate and upload your public key.")
 
 
-@login_app.callback()
+@login_app.command("login")
 def login(
     ctx: typer.Context,
     passphrase: Optional[str] = typer.Option(None, "--passphrase", hide_input=True),


### PR DESCRIPTION
## Summary
- fix the peagen `login` command so it can be invoked as `peagen login login`

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format peagen/cli/commands/login.py peagen/cli/commands/keys.py peagen/cli/commands/secrets.py peagen/gateway/__init__.py`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check peagen/cli/commands/login.py peagen/cli/commands/keys.py peagen/cli/commands/secrets.py peagen/gateway/__init__.py --fix`
- `peagen login login --gateway-url http://127.0.0.1:8000/rpc`
- `peagen remote -q secrets add TEST_SECRET secretvalue --gateway-url http://127.0.0.1:8000/rpc`
- `peagen remote -q secrets get TEST_SECRET --gateway-url http://127.0.0.1:8000/rpc`
- `peagen remote -q secrets remove TEST_SECRET --gateway-url http://127.0.0.1:8000/rpc`
- `peagen keys fetch-server --gateway-url http://127.0.0.1:8000/rpc`
- `peagen keys remove 79BD99BAFA353F00D8438700717B8798EC45230E --gateway-url http://127.0.0.1:8000/rpc`
- `peagen remote -q --gateway-url http://127.0.0.1:8000/rpc process /tmp/projects_payload.yaml --watch` *(fails: No LLM provider specified)*
- `peagen local -q process /tmp/projects_payload.yaml` *(fails: No LLM provider specified)*

------
https://chatgpt.com/codex/tasks/task_e_68566d80db648326bf4c176b080da6db