### PR TITLE
Fix simple evolve demo paths

### DIFF
--- a/pkgs/standards/peagen/tests/examples/simple_evolve_demo/README.md
+++ b/pkgs/standards/peagen/tests/examples/simple_evolve_demo/README.md
@@ -12,7 +12,7 @@ Run the spec locally using the `local` subcommand:
 ```bash
 DQ_GATEWAY=http://127.0.0.1:8000/rpc \
 uv run --package peagen --directory pkgs/standards/peagen \
-  peagen local -q evolve tests/examples/simple_evolve_demo/evolve_spec.yaml
+  peagen local -q evolve tests/examples/simple_evolve_demo/evolve_spec_local.yaml
 ```
 
 This writes the result JSON next to the spec file.
@@ -24,7 +24,7 @@ Start a gateway and worker and then submit the job remotely:
 ```bash
 uv run --package peagen --directory pkgs/standards/peagen \
   peagen remote -q --gateway-url http://127.0.0.1:8000/rpc \
-  evolve tests/examples/simple_evolve_demo/evolve_spec.yaml
+  evolve tests/examples/simple_evolve_demo/evolve_remote_spec.yaml
 ```
 
 You can fetch the task result with:

--- a/pkgs/standards/peagen/tests/infra/test_simple_evolve_demo.py
+++ b/pkgs/standards/peagen/tests/infra/test_simple_evolve_demo.py
@@ -9,7 +9,7 @@ SPEC_PATH = (
     / "tests"
     / "examples"
     / "simple_evolve_demo"
-    / "evolve_spec.yaml"
+    / "evolve_remote_spec.yaml"
 )
 
 


### PR DESCRIPTION
## Summary
- update README spec paths
- update simple evolve demo test to reference remote spec

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen pytest`
- `uv run --package peagen --directory pkgs/standards/peagen peagen remote -q --gateway-url https://gw.peagen.com/rpc evolve tests/examples/simple_evolve_demo/evolve_remote_spec.yaml`
- `uv run --package peagen --directory pkgs/standards/peagen peagen remote -q --gateway-url https://gw.peagen.com/rpc task get de0a669b-ff4a-4d77-8e2b-d47b64f93186`

------
https://chatgpt.com/codex/tasks/task_e_6856689bf4d4832685df9f520beb0a9a