### PR TITLE
Add RuffEvaluator plugin

### DIFF
--- a/pkgs/standards/peagen/peagen/plugins/evaluators/__init__.py
+++ b/pkgs/standards/peagen/peagen/plugins/evaluators/__init__.py
@@ -1,4 +1,7 @@
 from .performance_evaluator import PerformanceEvaluator
+from .ruff_evaluator import RuffEvaluator
 
-__all__ = ["PerformanceEvaluator"]
-
+__all__ = [
+    "PerformanceEvaluator",
+    "RuffEvaluator",
+]

--- a/pkgs/standards/peagen/peagen/plugins/evaluators/ruff_evaluator.py
+++ b/pkgs/standards/peagen/peagen/plugins/evaluators/ruff_evaluator.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, Tuple, Literal
+
+from swarmauri_base.evaluators.EvaluatorBase import EvaluatorBase
+from swarmauri_core.ComponentBase import ComponentBase
+from swarmauri_core.programs.IProgram import IProgram as Program
+
+
+@ComponentBase.register_model()
+class RuffEvaluator(EvaluatorBase):
+    """Evaluator that scores code based on Ruff lint violations."""
+
+    type: Literal["RuffEvaluator"] = "RuffEvaluator"
+    max_violations: int = 200
+
+    def _compute_score(
+        self, program: Program, **kwargs: Any
+    ) -> Tuple[float, Dict[str, Any]]:
+        root = Path(getattr(program, "path", Path.cwd()))
+
+        proc = subprocess.run(
+            ["ruff", "check", "--quiet", str(root)],
+            capture_output=True,
+            text=True,
+        )
+        violations = [line for line in proc.stdout.splitlines() if line.strip()]
+        n_violations = len(violations)
+
+        if n_violations > self.max_violations:
+            score = float("-inf")
+        else:
+            score = -float(n_violations)
+
+        metadata = {"n_violations": n_violations, "violations": violations}
+        return score, metadata

--- a/pkgs/standards/peagen/tests/unit/test_ruff_evaluator.py
+++ b/pkgs/standards/peagen/tests/unit/test_ruff_evaluator.py
@@ -1,0 +1,31 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from peagen.plugins.evaluators.ruff_evaluator import RuffEvaluator
+from swarmauri_core.programs.IProgram import IProgram
+
+
+@pytest.fixture
+def mock_program(tmp_path):
+    program = MagicMock(spec=IProgram)
+    program.path = tmp_path
+    return program
+
+
+def test_score_no_violations(mock_program):
+    (mock_program.path / "good.py").write_text(
+        "def foo():\n    pass\n", encoding="utf-8"
+    )
+    ev = RuffEvaluator()
+    score, meta = ev._compute_score(mock_program)
+    assert meta["n_violations"] == 0
+    assert score == 0
+
+
+def test_score_with_violations(mock_program):
+    (mock_program.path / "bad.py").write_text("import os\n", encoding="utf-8")
+    ev = RuffEvaluator()
+    score, meta = ev._compute_score(mock_program)
+    assert meta["n_violations"] >= 1
+    assert score <= 0


### PR DESCRIPTION
## Summary
- add new RuffEvaluator plugin for lint-based fitness evaluation
- expose RuffEvaluator via plugin registry
- test RuffEvaluator behavior

## Testing
- `uv run --package peagen --directory . pytest tests/unit/test_ruff_evaluator.py -q`
- `uv run --package peagen --directory pkgs/standards/peagen peagen local -q process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml` *(fails: ValueError)*
- `uv run --package peagen --directory pkgs/standards/peagen peagen remote -q --gateway-url http://localhost:8000/rpc process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml --watch` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_685674e527208326acb480de39c195ae