### PR TITLE
Add Pytest fitness evaluator

### DIFF
--- a/pkgs/standards/peagen/peagen/plugins/evaluators/__init__.py
+++ b/pkgs/standards/peagen/peagen/plugins/evaluators/__init__.py
@@ -1,4 +1,5 @@
 from .performance_evaluator import PerformanceEvaluator
+from .pytest_evaluator import PytestEvaluator
 
-__all__ = ["PerformanceEvaluator"]
+__all__ = ["PerformanceEvaluator", "PytestEvaluator"]
 

--- a/pkgs/standards/peagen/peagen/plugins/evaluators/pytest_evaluator.py
+++ b/pkgs/standards/peagen/peagen/plugins/evaluators/pytest_evaluator.py
@@ -1,0 +1,54 @@
+"""Pytest-based fitness evaluator."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, Literal, Tuple
+
+from swarmauri_base.ComponentBase import ComponentBase
+from swarmauri_base.evaluators.EvaluatorBase import EvaluatorBase
+from swarmauri_core.programs.IProgram import IProgram as Program
+
+
+@ComponentBase.register_model()
+class PytestEvaluator(EvaluatorBase):
+    """Run pytest in a workspace and score by pass ratio."""
+
+    type: Literal["PytestEvaluator"] = "PytestEvaluator"
+    test_timeout: float = 60.0
+    partial: Literal["all", "touched"] = "all"
+
+    def _compute_score(
+        self, program: Program, **kwargs: Any
+    ) -> Tuple[float, Dict[str, Any]]:
+        """Execute pytest and return the pass ratio as fitness."""
+        workspace = Path(kwargs.get("workspace", Path.cwd()))
+
+        cmd = ["pytest", "--json-report", "--maxfail=1", "-q"]
+        if self.partial == "touched":
+            cmd.append("--last-failed")
+
+        proc = subprocess.run(
+            cmd,
+            cwd=workspace,
+            capture_output=True,
+            text=True,
+            timeout=self.test_timeout,
+        )
+
+        report_file = workspace / ".report.json"
+        if not report_file.exists():
+            return 0.0, {"stdout": proc.stdout, "stderr": proc.stderr}
+
+        data = json.loads(report_file.read_text())
+        summary = data.get("summary", {})
+        passed = summary.get("passed", 0)
+        failed = summary.get("failed", 0)
+        errors = summary.get("errors", 0)
+        total = passed + failed + errors
+        ratio = passed / total if total else 0.0
+        metadata = {"passed": passed, "failed": failed, "errors": errors}
+        report_file.unlink(missing_ok=True)
+        return ratio, metadata

--- a/pkgs/standards/peagen/tests/unit/test_pytest_evaluator.py
+++ b/pkgs/standards/peagen/tests/unit/test_pytest_evaluator.py
@@ -1,0 +1,15 @@
+import pytest
+from peagen.plugins.evaluators.pytest_evaluator import PytestEvaluator
+from swarmauri_standard.programs.Program import Program
+
+
+@pytest.mark.unit
+def test_pytest_evaluator_pass(tmp_path):
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_ok.py").write_text("def test_ok():\n    assert True\n")
+    program = Program.from_workspace(tmp_path)
+    evaluator = PytestEvaluator(test_timeout=10.0)
+    score, meta = evaluator.evaluate(program, workspace=tmp_path)
+    assert score == 1.0
+    assert meta["passed"] == 1


### PR DESCRIPTION
## Summary
- implement `PytestEvaluator` plugin in the peagen package
- expose new evaluator from the plugin package
- test that evaluator reports full pass ratio

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format .`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest`
- `uv run --package peagen peagen remote -q --gateway-url http://localhost:8000/rpc process projects_payload.yaml --watch` *(fails: File not found)*
- `uv run --package peagen peagen local -q process projects_payload.yaml --watch` *(fails: no such option)*

------
https://chatgpt.com/codex/tasks/task_e_685674ef8e9883268721f2baf71908fd