### PR TITLE
Add Hyperfine performance evaluator

### DIFF
--- a/pkgs/standards/peagen/peagen/plugins/evaluators/__init__.py
+++ b/pkgs/standards/peagen/peagen/plugins/evaluators/__init__.py
@@ -1,4 +1,4 @@
 from .performance_evaluator import PerformanceEvaluator
+from .hyperfine_evaluator import HyperfineEvaluator
 
-__all__ = ["PerformanceEvaluator"]
-
+__all__ = ["PerformanceEvaluator", "HyperfineEvaluator"]

--- a/pkgs/standards/peagen/peagen/plugins/evaluators/hyperfine_evaluator.py
+++ b/pkgs/standards/peagen/peagen/plugins/evaluators/hyperfine_evaluator.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+import shlex
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, Tuple, Literal
+
+from swarmauri_base.evaluators.EvaluatorBase import EvaluatorBase
+from swarmauri_core.ComponentBase import ComponentBase
+from swarmauri_core.programs.IProgram import IProgram as Program
+
+
+@ComponentBase.register_model()
+class HyperfineEvaluator(EvaluatorBase):
+    """Evaluator that measures command performance via `hyperfine`."""
+
+    type: Literal["HyperfineEvaluator"] = "HyperfineEvaluator"
+
+    bench_cmd: str
+    runs: int = 6
+    warmup: int = 1
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _to_ms(value: float, unit: str) -> float:
+        if unit.startswith("nano"):
+            return value / 1_000_000
+        if unit.startswith("micro"):
+            return value / 1_000
+        if unit.startswith("milli"):
+            return value
+        return value * 1_000
+
+    # ------------------------------------------------------------------
+    def _compute_score(
+        self, program: Program, **kwargs: Any
+    ) -> Tuple[float, Dict[str, Any]]:
+        tmp_dir = tempfile.mkdtemp()
+        try:
+            for rel, text in program.get_source_files().items():
+                dst = Path(tmp_dir) / rel
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                dst.write_text(text, encoding="utf-8")
+
+            json_path = Path(tmp_dir) / "hyperfine.json"
+            cmd = (
+                f"hyperfine -i -m {self.runs} --warmup {self.warmup} --export-json {json_path} "
+                f"{self.bench_cmd}"
+            )
+            proc = subprocess.run(
+                shlex.split(cmd), cwd=tmp_dir, capture_output=True, text=True
+            )
+            if proc.returncode != 0:
+                raise RuntimeError(proc.stderr.strip())
+
+            data = json.loads(json_path.read_text())
+            unit = data.get("time_unit", "second")
+            results = data.get("results", [])
+            median = results[0].get("median") if results else None
+            if median is None:
+                raise RuntimeError("No hyperfine results")
+            ms = self._to_ms(median, unit)
+            score = -ms
+            return score, {"median_ms": ms}
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)

--- a/pkgs/standards/peagen/tests/unit/test_hyperfine_evaluator.py
+++ b/pkgs/standards/peagen/tests/unit/test_hyperfine_evaluator.py
@@ -1,0 +1,37 @@
+import json
+from types import SimpleNamespace
+from pathlib import Path
+
+import pytest
+
+from peagen.plugins.evaluators.hyperfine_evaluator import HyperfineEvaluator
+from swarmauri_standard.programs.Program import Program
+
+
+@pytest.mark.unit
+def test_hyperfine_evaluator_runs(monkeypatch, tmp_path: Path):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    (workspace / "app.py").write_text("print('hi')", encoding="utf-8")
+    program = Program.from_workspace(workspace)
+
+    def fake_run(cmd, cwd=None, capture_output=True, text=True):
+        (Path(cwd) / "hyperfine.json").write_text(
+            json.dumps(
+                {
+                    "time_unit": "second",
+                    "results": [{"median": 0.05}],
+                }
+            ),
+            encoding="utf-8",
+        )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    import peagen.plugins.evaluators.hyperfine_evaluator as hf_mod
+
+    monkeypatch.setattr(hf_mod.subprocess, "run", fake_run)
+
+    evaluator = HyperfineEvaluator(bench_cmd="python app.py")
+    score, meta = evaluator.evaluate(program)
+    assert score == pytest.approx(-50.0)
+    assert meta["median_ms"] == pytest.approx(50.0)


### PR DESCRIPTION
## Summary
- add `HyperfineEvaluator` plugin to measure command runtime via hyperfine
- expose it from the evaluator plugin package
- test the new evaluator

## Testing
- `uv run --directory standards --package peagen ruff format peagen/peagen/plugins/evaluators/hyperfine_evaluator.py peagen/peagen/plugins/evaluators/__init__.py peagen/tests/unit/test_hyperfine_evaluator.py`
- `uv run --directory standards --package peagen ruff check peagen/peagen/plugins/evaluators/hyperfine_evaluator.py peagen/peagen/plugins/evaluators/__init__.py peagen/tests/unit/test_hyperfine_evaluator.py --fix`
- `uv run --directory standards --package peagen pytest peagen/tests/unit/test_hyperfine_evaluator.py -q`
- `uv run --directory standards --package peagen peagen remote -q --gateway-url http://localhost:8000/rpc process peagen/tests/examples/projects_payloads/projects_payload.yaml --watch` *(fails: ConnectError)*
- `uv run --directory standards --package peagen peagen local -q process peagen/tests/examples/projects_payloads/projects_payload.yaml` *(fails: No LLM provider specified)*

------
https://chatgpt.com/codex/tasks/task_e_685674f7adb083268261e99c4e46bc6d