### PR TITLE
Add composite evaluator for multi-objective support

### DIFF
--- a/pkgs/standards/peagen/peagen/plugins/evaluators/__init__.py
+++ b/pkgs/standards/peagen/peagen/plugins/evaluators/__init__.py
@@ -1,4 +1,4 @@
 from .performance_evaluator import PerformanceEvaluator
+from .composite_evaluator import CompositeEvaluator
 
-__all__ = ["PerformanceEvaluator"]
-
+__all__ = ["PerformanceEvaluator", "CompositeEvaluator"]

--- a/pkgs/standards/peagen/peagen/plugins/evaluators/composite_evaluator.py
+++ b/pkgs/standards/peagen/peagen/plugins/evaluators/composite_evaluator.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Sequence, Tuple, Literal
+
+from peagen.plugin_manager import resolve_plugin_spec
+from swarmauri_base.evaluators.EvaluatorBase import EvaluatorBase
+from swarmauri_core.ComponentBase import ComponentBase
+from swarmauri_core.programs.IProgram import IProgram as Program
+
+
+@ComponentBase.register_model()
+class CompositeEvaluator(EvaluatorBase):
+    """Combine multiple evaluators with optional weights."""
+
+    type: Literal["CompositeEvaluator"] = "CompositeEvaluator"
+
+    def __init__(
+        self,
+        evaluators: Sequence[Any],
+        weights: Sequence[float] | None = None,
+        **data: Any,
+    ) -> None:
+        super().__init__(**data)
+        self.evaluator_refs = list(evaluators)
+        self.weights = (
+            list(weights) if weights is not None else [1.0] * len(self.evaluator_refs)
+        )
+        self.sub_evaluators: List[EvaluatorBase] = []
+        for ev in self.evaluator_refs:
+            if isinstance(ev, str):
+                cls = resolve_plugin_spec("evaluators", ev)
+                self.sub_evaluators.append(cls())
+            elif isinstance(ev, type) and issubclass(ev, EvaluatorBase):
+                self.sub_evaluators.append(ev())
+            elif isinstance(ev, EvaluatorBase):
+                self.sub_evaluators.append(ev)
+            else:
+                raise TypeError(f"Invalid evaluator reference: {ev!r}")
+        if len(self.weights) < len(self.sub_evaluators):
+            self.weights.extend([1.0] * (len(self.sub_evaluators) - len(self.weights)))
+
+    def _compute_score(
+        self, program: Program, **kwargs: Any
+    ) -> Tuple[float, Dict[str, Any]]:
+        scores: List[float] = []
+        metadata: List[Dict[str, Any]] = []
+        for ev in self.sub_evaluators:
+            s, m = ev.evaluate(program, **kwargs)
+            scores.append(s)
+            metadata.append(m)
+        total_w = sum(self.weights) or 1.0
+        weighted = sum(s * w for s, w in zip(scores, self.weights)) / total_w
+        meta = {"scores": scores, "weights": self.weights, "sub_metadata": metadata}
+        return weighted, meta

--- a/pkgs/standards/peagen/tests/unit/test_composite_evaluator.py
+++ b/pkgs/standards/peagen/tests/unit/test_composite_evaluator.py
@@ -1,0 +1,25 @@
+import pytest
+from peagen.plugins.evaluators.composite_evaluator import CompositeEvaluator
+from swarmauri_base.evaluators.EvaluatorBase import EvaluatorBase
+from swarmauri_standard.programs.Program import Program
+
+
+class EvalA(EvaluatorBase):
+    def _compute_score(self, program: Program, **kwargs):
+        return 1.0, {"name": "A"}
+
+
+class EvalB(EvaluatorBase):
+    def _compute_score(self, program: Program, **kwargs):
+        return 3.0, {"name": "B"}
+
+
+@pytest.mark.unit
+def test_composite_weighting():
+    program = Program()
+    evaluator = CompositeEvaluator([EvalA, EvalB], weights=[0.25, 0.75])
+    score, meta = evaluator.evaluate(program)
+    expected = (1.0 * 0.25 + 3.0 * 0.75) / (0.25 + 0.75)
+    assert score == pytest.approx(expected)
+    assert meta["scores"] == [1.0, 3.0]
+    assert meta["weights"] == [0.25, 0.75]


### PR DESCRIPTION
## Summary
- implement `CompositeEvaluator` plugin for peagen
- expose new evaluator in plugin module
- cover weighting logic with a unit test

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format peagen/plugins/evaluators/composite_evaluator.py peagen/plugins/evaluators/__init__.py tests/unit/test_composite_evaluator.py`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check peagen/plugins/evaluators/composite_evaluator.py peagen/plugins/evaluators/__init__.py tests/unit/test_composite_evaluator.py --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_composite_evaluator.py -q`
- `uv run --package peagen --directory pkgs/standards/peagen peagen local -q process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml` *(failed: ValueError: Payload must contain a top-level 'PROJECTS' list)*
- `uv run --package peagen --directory pkgs/standards/peagen peagen remote -q --gateway-url http://localhost:8000/rpc process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml --watch` *(failed: File not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856750846b48326a4e996ecd5e4caaf