### PR TITLE
Add BYOK notes for Peagen docs

### DIFF
--- a/pkgs/standards/peagen/docs/byok_private_repo.md
+++ b/pkgs/standards/peagen/docs/byok_private_repo.md
@@ -1,0 +1,12 @@
+# BYOK and Private Repository Impact
+
+Peagen's fitness evaluators only read code from the workspace, so the BYOK
+(Bring Your Own Key) model does not require additional credentials for Ruff or
+Pytest checks. Performance benchmarks may need API tokens if they interact with
+external services. Use the same secret resolution flow described in
+`secret_refs.md` by supplying a `secretRef` for the required key.
+
+Large Ruff and Pytest logs should be stored as Git artifacts. When a log file is
+under 1&nbsp;MB it can be committed directly. Bigger logs are uploaded through the
+configured git filter and the resulting object ID is appended to the task
+metadata so the gateway can retrieve it later.


### PR DESCRIPTION
## Summary
- document how BYOK and private repos interact with evaluators

## Testing
- `uv run --directory standards/peagen --package peagen ruff format .`
- `uv run --directory standards/peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest`
- `uv run --directory pkgs/standards/peagen --package peagen peagen remote -q --gateway-url http://localhost:8000/rpc process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml` *(failed: File not found)*
- `uv run --directory pkgs/standards/peagen --package peagen peagen local process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml` *(failed: Payload must contain 'PROJECTS')*

------
https://chatgpt.com/codex/tasks/task_e_6856762a5e6c8326bf5793efff1eeb60