### PR TITLE
Add simple_time evaluator

### DIFF
--- a/pkgs/standards/peagen/peagen/evaluators/__init__.py
+++ b/pkgs/standards/peagen/peagen/evaluators/__init__.py
@@ -1,0 +1,6 @@
+"""Built-in fitness evaluators for Peagen."""
+
+from .base import Evaluator
+from .simple_time import SimpleTimeEvaluator
+
+__all__ = ["Evaluator", "SimpleTimeEvaluator"]

--- a/pkgs/standards/peagen/peagen/evaluators/base.py
+++ b/pkgs/standards/peagen/peagen/evaluators/base.py
@@ -1,0 +1,19 @@
+"""Base classes for peagen fitness evaluators."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+
+class Evaluator:
+    """Minimal evaluator interface capturing the last run result."""
+
+    last_result: Dict[str, Any] | None
+
+    def __init__(self) -> None:
+        self.last_result = None
+
+    def run(self, workspace: Path, bench_cmd: str, runs: int = 1, **kw: Any) -> float:
+        """Run the evaluator and return a fitness score."""
+        raise NotImplementedError

--- a/pkgs/standards/peagen/peagen/evaluators/simple_time.py
+++ b/pkgs/standards/peagen/peagen/evaluators/simple_time.py
@@ -1,0 +1,38 @@
+"""Measure wall-clock runtime of a command without pytest instrumentation.
+
+The evaluator executes *bench_cmd* inside *workspace* using :func:`time.perf_counter`
+to record runtime. It repeats the command ``runs`` times and returns the negated
+median of the observed runtimes in milliseconds. A lower execution time therefore
+produces a higher fitness score. The last run's details are stored in
+:attr:`Evaluator.last_result`.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import time
+from pathlib import Path
+from statistics import median
+from typing import Any
+
+from .base import Evaluator
+
+
+class SimpleTimeEvaluator(Evaluator):
+    """Wall-clock timing based fitness evaluator."""
+
+    def run(self, workspace: Path, bench_cmd: str, runs: int = 1, **kw: Any) -> float:
+        times = []
+        for _ in range(max(1, runs)):
+            start = time.perf_counter()
+            subprocess.run(
+                bench_cmd,
+                shell=True,
+                cwd=workspace,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            times.append((time.perf_counter() - start) * 1000)
+        med = median(times)
+        self.last_result = {"median_ms": med, "runs": runs}
+        return -med

--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -174,6 +174,9 @@ echo_mutator = "peagen.plugins.mutators.echo_mutator:EchoMutator"
 llm_prompt = "peagen.plugins.mutators.llm_prompt:LlmRewrite"
 llm_prog_rewrite = "peagen.plugins.mutators.llm_prog_rewrite:LlmProgRewrite"
 
+[project.entry-points."peagen.evaluators"]
+simple_time = "peagen.evaluators.simple_time:SimpleTimeEvaluator"
+
 [tool.setuptools.package-data]
 "peagen.schemas" = ["*.json", "extras/*.json"]
 "peagen" = [


### PR DESCRIPTION
## Summary
- implement minimal Evaluator base
- implement SimpleTimeEvaluator measuring wall-clock runtime
- expose new evaluator via entry point

## Testing
- `ruff format peagen/evaluators`
- `ruff check peagen/evaluators --fix`

------
https://chatgpt.com/codex/tasks/task_e_68567d81173c832683b71301b70038e1