### PR TITLE
Add simple_time evaluator

### DIFF
--- a/pkgs/standards/peagen/peagen/evaluators/__init__.py
+++ b/pkgs/standards/peagen/peagen/evaluators/__init__.py
@@ -1,0 +1,5 @@
+"""Built-in fitness evaluators."""
+
+from .simple_time import SimpleTimeEvaluator
+
+__all__ = ["SimpleTimeEvaluator"]

--- a/pkgs/standards/peagen/peagen/evaluators/simple_time.py
+++ b/pkgs/standards/peagen/peagen/evaluators/simple_time.py
@@ -1,0 +1,45 @@
+"""Measure wall-clock runtime of a command using :func:`time.perf_counter`.\n\nThe evaluator runs ``bench_cmd`` inside ``workspace`` ``runs`` times and\nrecords each duration in milliseconds. The median runtime is negated and\nreturned as the fitness score so that faster executions yield higher\nfitness. Details of each run are stored in :attr:`last_result`.\n"""
+
+from __future__ import annotations
+
+import statistics
+import subprocess
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+@dataclass
+class Evaluator:
+    """Base class for Peagen fitness evaluators."""
+
+    last_result: Dict[str, Any] = field(default_factory=dict, init=False)
+
+    def run(self, workspace: Path, bench_cmd: str, runs: int = 1, **kw: Any) -> float:
+        raise NotImplementedError
+
+
+class SimpleTimeEvaluator(Evaluator):
+    """Median wall-clock time of a command (lower is better)."""
+
+    def run(self, workspace: Path, bench_cmd: str, runs: int = 1, **kw: Any) -> float:
+        durations: List[float] = []
+        for _ in range(max(1, runs)):
+            start = time.perf_counter()
+            subprocess.run(
+                bench_cmd,
+                shell=True,
+                cwd=workspace,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            durations.append((time.perf_counter() - start) * 1000)
+
+        median_ms = statistics.median(durations)
+        self.last_result = {
+            "runs": len(durations),
+            "times_ms": [round(t, 3) for t in durations],
+            "median_ms": round(median_ms, 3),
+        }
+        return -median_ms

--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -174,6 +174,9 @@ echo_mutator = "peagen.plugins.mutators.echo_mutator:EchoMutator"
 llm_prompt = "peagen.plugins.mutators.llm_prompt:LlmRewrite"
 llm_prog_rewrite = "peagen.plugins.mutators.llm_prog_rewrite:LlmProgRewrite"
 
+[project.entry-points."peagen.evaluators"]
+simple_time = "peagen.evaluators.simple_time:SimpleTimeEvaluator"
+
 [tool.setuptools.package-data]
 "peagen.schemas" = ["*.json", "extras/*.json"]
 "peagen" = [

--- a/pkgs/standards/peagen/tests/unit/test_simple_time_evaluator.py
+++ b/pkgs/standards/peagen/tests/unit/test_simple_time_evaluator.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+from peagen.evaluators.simple_time import SimpleTimeEvaluator
+
+
+def test_simple_time_runs_command(tmp_path: Path) -> None:
+    script = tmp_path / "sleep.py"
+    script.write_text("import time; time.sleep(0.01)", encoding="utf-8")
+
+    ev = SimpleTimeEvaluator()
+    score = ev.run(tmp_path, f"python {script.name}", runs=2)
+
+    assert "median_ms" in ev.last_result
+    assert ev.last_result["runs"] == 2
+    # runtime should be >=10ms
+    assert ev.last_result["median_ms"] >= 10
+    # score is negative median
+    assert abs(score + ev.last_result["median_ms"]) < 1e-3


### PR DESCRIPTION
## Summary
- implement `simple_time` evaluator and export from package
- register `simple_time` under the new `peagen.evaluators` entry point
- add tests for the evaluator

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen pytest --json-report -q`

------
https://chatgpt.com/codex/tasks/task_e_68567d81173c832683b71301b70038e1