### PR TITLE
Add benchmark evaluator

### DIFF
--- a/pkgs/standards/peagen/peagen/evaluators/__init__.py
+++ b/pkgs/standards/peagen/peagen/evaluators/__init__.py
@@ -1,0 +1,6 @@
+"""Built-in fitness evaluators shipped with peagen."""
+
+from .base import Evaluator
+from .benchmark import PytestBenchmarkEvaluator
+
+__all__ = ["Evaluator", "PytestBenchmarkEvaluator"]

--- a/pkgs/standards/peagen/peagen/evaluators/base.py
+++ b/pkgs/standards/peagen/peagen/evaluators/base.py
@@ -1,0 +1,19 @@
+"""Base classes for peagen fitness evaluators."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+
+class Evaluator:
+    """Abstract evaluator interface."""
+
+    last_result: Dict[str, Any] | None
+
+    def __init__(self) -> None:
+        self.last_result = None
+
+    def run(self, workspace: Path, bench_cmd: str, runs: int = 1, **kw: Any) -> float:
+        """Execute the evaluator and return a fitness score."""
+        raise NotImplementedError

--- a/pkgs/standards/peagen/peagen/evaluators/benchmark.py
+++ b/pkgs/standards/peagen/peagen/evaluators/benchmark.py
@@ -1,0 +1,57 @@
+"""benchmark.py
+
+Measure median wall-clock time per pytest test using pytest-benchmark.
+
+The evaluator runs ``pytest`` with the benchmark plugin enabled and reads
+``benchmark.json`` to obtain the median runtime for each test. The median
+across all tests and runs is negated so that lower values correspond to
+higher fitness.
+"""
+
+from __future__ import annotations
+
+import json
+import shlex
+import statistics
+import subprocess
+from pathlib import Path
+from typing import Any, List
+
+from .base import Evaluator
+
+
+class PytestBenchmarkEvaluator(Evaluator):
+    """Run pytest-benchmark and score by median time."""
+
+    def run(self, workspace: Path, bench_cmd: str, runs: int = 1, **kw: Any) -> float:
+        workspace = Path(workspace)
+        times: List[float] = []
+        bench_args = [
+            "pytest",
+            "--benchmark-only",
+            "--benchmark-json=benchmark.json",
+            "--json-report",
+            "-q",
+        ]
+        bench_args.extend(shlex.split(bench_cmd))
+
+        for _ in range(max(1, runs)):
+            subprocess.run(bench_args, cwd=workspace, capture_output=True, text=True)
+            bench_file = workspace / "benchmark.json"
+            if bench_file.exists():
+                data = json.loads(bench_file.read_text())
+                for entry in data.get("benchmarks", []):
+                    median_s = entry.get("stats", {}).get("median")
+                    if isinstance(median_s, (int, float)):
+                        times.append(median_s * 1000)
+                bench_file.unlink()
+            report_file = workspace / ".report.json"
+            report_file.unlink(missing_ok=True)
+
+        if not times:
+            self.last_result = {"median_ms": None}
+            return float("-inf")
+
+        median_ms = statistics.median(times)
+        self.last_result = {"median_ms": median_ms, "runs": len(times)}
+        return -median_ms

--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -174,6 +174,9 @@ echo_mutator = "peagen.plugins.mutators.echo_mutator:EchoMutator"
 llm_prompt = "peagen.plugins.mutators.llm_prompt:LlmRewrite"
 llm_prog_rewrite = "peagen.plugins.mutators.llm_prog_rewrite:LlmProgRewrite"
 
+[project.entry-points."peagen.evaluators"]
+benchmark = "peagen.evaluators.benchmark:PytestBenchmarkEvaluator"
+
 [tool.setuptools.package-data]
 "peagen.schemas" = ["*.json", "extras/*.json"]
 "peagen" = [


### PR DESCRIPTION
## Summary
- implement PytestBenchmarkEvaluator in new `peagen.evaluators` package
- export evaluator through new `peagen.evaluators` entry point

## Testing
- `uv run --directory peagen --package peagen ruff format .`
- `uv run --directory peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest -q`
- `uv run --package peagen --directory . peagen remote -q --gateway-url http://localhost:8000/rpc process projects_payload.yaml --watch` *(fails: Invalid value: File not found)*
- `uv run --package peagen --directory . peagen local -q process projects_payload.yaml --watch` *(fails: No such option)*

------
https://chatgpt.com/codex/tasks/task_e_68567d4141a483269b3edd08baee4b02