### PR TITLE
Rename profiling evaluator to clarify pytest usage

### DIFF
--- a/pkgs/standards/peagen/peagen/evaluators/__init__.py
+++ b/pkgs/standards/peagen/peagen/evaluators/__init__.py
@@ -1,0 +1,4 @@
+from .base import Evaluator
+from .pytest_profiling import PytestProfilingEvaluator
+
+__all__ = ["Evaluator", "PytestProfilingEvaluator"]

--- a/pkgs/standards/peagen/peagen/evaluators/base.py
+++ b/pkgs/standards/peagen/peagen/evaluators/base.py
@@ -1,0 +1,20 @@
+"""Simple evaluator base class for benchmark runners."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+
+class Evaluator:
+    """Abstract evaluator that runs a benchmark command inside a workspace."""
+
+    last_result: Dict[str, Any] | None = None
+
+    def run(self, workspace: Path, bench_cmd: str, runs: int = 1, **kw: Any) -> float:
+        """Run the benchmark and return a scalar fitness score."""
+        raise NotImplementedError
+
+    def reset(self) -> None:
+        """Clear stored result between runs."""
+        self.last_result = None

--- a/pkgs/standards/peagen/peagen/evaluators/pytest_profiling.py
+++ b/pkgs/standards/peagen/peagen/evaluators/pytest_profiling.py
@@ -1,0 +1,64 @@
+"""Measure CPU time using :mod:`pytest-profiling` and :mod:`pytest-json-report`.
+
+This evaluator profiles each test run with ``pytest --profile`` and parses the
+generated ``prof/combined.prof`` file. The cumulative CPU seconds (``tottime``)
+across all functions represent the test suite's CPU cost. The returned fitness
+is the negative median CPU time from all runs. ``last_result`` contains a small
+JSON-serialisable summary with per-run details.
+"""
+
+from __future__ import annotations
+
+import json
+import shlex
+import subprocess
+from pathlib import Path
+from statistics import median
+from typing import Any, Dict, List
+import pstats
+
+from .base import Evaluator
+
+
+class PytestProfilingEvaluator(Evaluator):
+    """Fitness based on CPU time recorded by pytest-profiling."""
+
+    def run(self, workspace: Path, bench_cmd: str, runs: int = 1, **kw: Any) -> float:
+        cmd_base = shlex.split(bench_cmd)
+        scores: List[float] = []
+        details: List[Dict[str, Any]] = []
+
+        for _ in range(max(1, runs)):
+            cmd = cmd_base + ["--profile", "--json-report", "-q"]
+            subprocess.run(cmd, cwd=workspace, capture_output=True, text=True)
+
+            prof_path = workspace / "prof" / "combined.prof"
+            if not prof_path.exists():
+                continue
+            stats = pstats.Stats(str(prof_path))
+            cpu_s = stats.total_tt
+            scores.append(cpu_s)
+
+            report_file = workspace / ".report.json"
+            if report_file.exists():
+                report_data = json.loads(report_file.read_text())
+                summary = report_data.get("summary", {})
+                details.append({"cpu_s": cpu_s, **summary})
+                report_file.unlink()
+            else:
+                details.append({"cpu_s": cpu_s})
+
+            prof_path.unlink()
+            prof_path.parent.rmdir()
+
+        if not scores:
+            self.last_result = {"error": "profiling_failed"}
+            return 0.0
+
+        median_cpu = median(scores)
+        self.last_result = {
+            "runs": len(scores),
+            "median_cpu_s": median_cpu,
+            "runs_detail": details,
+        }
+        return -median_cpu

--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -174,6 +174,9 @@ echo_mutator = "peagen.plugins.mutators.echo_mutator:EchoMutator"
 llm_prompt = "peagen.plugins.mutators.llm_prompt:LlmRewrite"
 llm_prog_rewrite = "peagen.plugins.mutators.llm_prog_rewrite:LlmProgRewrite"
 
+[project.entry-points."peagen.evaluators"]
+pytest_profiling = "peagen.evaluators.pytest_profiling:PytestProfilingEvaluator"
+
 [tool.setuptools.package-data]
 "peagen.schemas" = ["*.json", "extras/*.json"]
 "peagen" = [


### PR DESCRIPTION
## Summary
- rename evaluator file to `pytest_profiling.py`
- rename class to `PytestProfilingEvaluator`
- update exports and entry point registration

## Testing
- `uv run --package peagen --directory peagen ruff format peagen/evaluators/__init__.py peagen/evaluators/pytest_profiling.py pyproject.toml`
- `uv run --package peagen --directory peagen ruff check peagen/evaluators/__init__.py peagen/evaluators/pytest_profiling.py pyproject.toml --fix`
- `uv run --package peagen --directory standards pytest` *(fails: 57 errors during collection)*
- `uv run --directory standards --package peagen peagen remote -q --gateway-url http://localhost:8000/rpc process ../standards/peagen/tests/examples/projects_payloads/linked_example_project.yaml --watch` *(fails: connection refused)*
- `uv run --directory standards --package peagen peagen local process ../standards/peagen/tests/examples/projects_payloads/linked_example_project.yaml` *(fails: No LLM provider specified)*

------
https://chatgpt.com/codex/tasks/task_e_68567d5055d88326b65a6b29407f1371