### PR TITLE
Add monitor evaluator to peagen

### DIFF
--- a/pkgs/standards/peagen/peagen/evaluators/__init__.py
+++ b/pkgs/standards/peagen/peagen/evaluators/__init__.py
@@ -1,0 +1,6 @@
+"""Peagen fitness evaluators."""
+
+from .base import Evaluator
+from .pytest_monitor import PytestMonitorEvaluator
+
+__all__ = ["Evaluator", "PytestMonitorEvaluator"]

--- a/pkgs/standards/peagen/peagen/evaluators/base.py
+++ b/pkgs/standards/peagen/peagen/evaluators/base.py
@@ -1,0 +1,26 @@
+"""Common evaluator base classes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+class Evaluator:
+    """Abstract evaluator interface."""
+
+    last_result: Optional[Dict[str, Any]] = None
+
+    def run(self, workspace: Path, bench_cmd: str, runs: int = 1, **kw: Any) -> float:
+        """Execute the evaluator.
+
+        Args:
+            workspace: Path to the workspace containing tests or bench script.
+            bench_cmd: Command to run for benchmarking.
+            runs: Number of times to execute the benchmark.
+            **kw: Extra options for derived evaluators.
+
+        Returns:
+            A scalar fitness score where higher is better.
+        """
+        raise NotImplementedError

--- a/pkgs/standards/peagen/peagen/evaluators/pytest_monitor.py
+++ b/pkgs/standards/peagen/peagen/evaluators/pytest_monitor.py
@@ -1,0 +1,55 @@
+"""Capture resource usage from pytest runs via the pytest-monitor plugin.
+
+The evaluator launches pytest with ``pytest-monitor`` enabled and reads the
+``.pymon.sqlite`` database produced for each run. It reports either the peak
+resident set size (RSS) or mean CPU utilisation across all collected tests.
+Smaller resource consumption yields higher fitness by default.
+"""
+
+from __future__ import annotations
+
+import shlex
+import sqlite3
+import statistics
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from .base import Evaluator
+
+
+class PytestMonitorEvaluator(Evaluator):
+    """Evaluate resource usage using pytest-monitor."""
+
+    def __init__(self, metric: str = "rss", inverse: bool = True) -> None:
+        self.metric = metric
+        self.inverse = inverse
+
+    def _collect_metric(self, db_path: Path) -> float:
+        with sqlite3.connect(db_path) as conn:
+            rows = conn.execute(
+                "SELECT MEM_USAGE, CPU_USAGE FROM TEST_METRICS"
+            ).fetchall()
+        rss_vals = [r[0] for r in rows]
+        cpu_vals = [r[1] for r in rows]
+        peak_rss = max(rss_vals) if rss_vals else 0.0
+        mean_cpu = sum(cpu_vals) / len(cpu_vals) if cpu_vals else 0.0
+        return peak_rss if self.metric == "rss" else mean_cpu
+
+    def run(self, workspace: Path, bench_cmd: str, runs: int = 1, **kw: Any) -> float:
+        values = []
+        for _ in range(runs):
+            cmd = shlex.split(bench_cmd) + ["--json-report", "--db", ".pymon.sqlite"]
+            subprocess.run(cmd, cwd=workspace, check=False, capture_output=True)
+            metric = self._collect_metric(workspace / ".pymon.sqlite")
+            (workspace / ".pymon.sqlite").unlink(missing_ok=True)
+            values.append(metric)
+        median_v = statistics.median(values)
+        score = -median_v if self.inverse else median_v
+        self.last_result = {
+            "metric": self.metric,
+            "runs": runs,
+            "values": values,
+            "median": median_v,
+        }
+        return score

--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -68,6 +68,7 @@ dependencies = [
     "minio", # this storage adapter needs to be pushed to its own standalone
     "GitPython",
     "s3fs",
+    "pytest-monitor>=1.6.6",
 ]
 
 
@@ -173,6 +174,9 @@ default_mutator = "peagen.plugins.mutators.default_mutator:DefaultMutator"
 echo_mutator = "peagen.plugins.mutators.echo_mutator:EchoMutator"
 llm_prompt = "peagen.plugins.mutators.llm_prompt:LlmRewrite"
 llm_prog_rewrite = "peagen.plugins.mutators.llm_prog_rewrite:LlmProgRewrite"
+
+[project.entry-points."peagen.evaluators"]
+monitor = "peagen.evaluators.pytest_monitor:PytestMonitorEvaluator"
 
 [tool.setuptools.package-data]
 "peagen.schemas" = ["*.json", "extras/*.json"]

--- a/pkgs/standards/peagen/tests/unit/test_monitor_evaluator.py
+++ b/pkgs/standards/peagen/tests/unit/test_monitor_evaluator.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+import pytest
+
+from peagen.evaluators.pytest_monitor import PytestMonitorEvaluator
+
+
+@pytest.mark.unit
+def test_monitor_evaluator(tmp_path: Path):
+    tests = tmp_path / "tests"
+    tests.mkdir()
+    (tests / "test_ok.py").write_text(
+        "def test_ok():\n    assert True\n", encoding="utf-8"
+    )
+    ev = PytestMonitorEvaluator()
+    score = ev.run(tmp_path, "pytest -q")
+    assert isinstance(score, float)
+    assert ev.last_result is not None
+    assert "median" in ev.last_result


### PR DESCRIPTION
## Summary
- create `Evaluator` base class
- implement `MonitorEvaluator` using pytest-monitor
- expose new entry point `peagen.evaluators`
- depend on `pytest-monitor`
- test monitor evaluator
- rename evaluator class and module

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format peagen/evaluators/pytest_monitor.py peagen/evaluators/__init__.py tests/unit/test_monitor_evaluator.py pyproject.toml`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check peagen/evaluators/pytest_monitor.py peagen/evaluators/__init__.py tests/unit/test_monitor_evaluator.py pyproject.toml --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest -q tests/unit/test_monitor_evaluator.py`
- `uv run --package peagen --directory pkgs/standards/peagen pytest -q`
- `uv run --package peagen --directory pkgs/standards/peagen peagen local -q process tests/examples/projects_payloads/projects_payload.yaml` *(fails: No LLM provider specified)*
- `uv run --package peagen --directory pkgs/standards/peagen peagen remote -q --gateway-url http://127.0.0.1:8000/rpc process tests/examples/projects_payloads/projects_payload.yaml --watch` *(fails: No LLM provider specified)*

------
https://chatgpt.com/codex/tasks/task_e_68567d5d28cc8326831b9e7d70944598