### PR TITLE
Add memray fitness evaluator

### DIFF
--- a/pkgs/standards/peagen/peagen/evaluators/__init__.py
+++ b/pkgs/standards/peagen/peagen/evaluators/__init__.py
@@ -1,0 +1,3 @@
+from .pytest_memray_evaluator import PytestMemrayEvaluator
+
+__all__ = ["PytestMemrayEvaluator"]

--- a/pkgs/standards/peagen/peagen/evaluators/pytest_memray_evaluator.py
+++ b/pkgs/standards/peagen/peagen/evaluators/pytest_memray_evaluator.py
@@ -1,0 +1,66 @@
+"""Measure peak heap allocation per test via pytest-memray.
+
+This evaluator runs pytest with the ``pytest-memray`` plugin enabled. Memory
+allocation metadata is collected for each test and the largest ``peak_memory``
+value across all tests is used to compute the fitness score. Smaller memory
+usage results in a higher score.
+"""
+
+from __future__ import annotations
+
+import json
+import pickle
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, Tuple, Literal
+
+from swarmauri_base.evaluators.EvaluatorBase import EvaluatorBase
+from swarmauri_core.ComponentBase import ComponentBase
+from swarmauri_core.programs.IProgram import IProgram as Program
+
+
+@ComponentBase.register_model()
+class PytestMemrayEvaluator(EvaluatorBase):
+    """Return fitness based on peak heap usage recorded by pytest-memray."""
+
+    type: Literal["PytestMemrayEvaluator"] = "PytestMemrayEvaluator"
+
+    def _compute_score(
+        self, program: Program, **kwargs: Any
+    ) -> Tuple[float, Dict[str, Any]]:
+        workspace = Path(getattr(program, "path", Path.cwd()))
+        bin_dir = workspace / ".memray_bins"
+        if bin_dir.exists():
+            shutil.rmtree(bin_dir, ignore_errors=True)
+        cmd = [
+            "pytest",
+            "--memray",
+            f"--memray-bin-path={bin_dir}",
+            "--json-report",
+            "-q",
+        ]
+        subprocess.run(cmd, cwd=workspace, check=False)
+
+        peak_bytes = 0
+        meta_dir = bin_dir / "metadata"
+        if meta_dir.exists():
+            for meta_file in meta_dir.glob("*.metadata"):
+                with open(meta_file, "rb") as fh:
+                    result = pickle.load(fh)
+                    peak_bytes = max(peak_bytes, result.metadata.peak_memory)
+
+        report_file = workspace / ".report.json"
+        summary = {}
+        if report_file.exists():
+            data = json.loads(report_file.read_text())
+            summary = data.get("summary", {})
+            report_file.unlink()
+
+        peak_mib = peak_bytes / (1024 * 1024)
+        details = {
+            "peak_mib": peak_mib,
+            "passed": summary.get("passed", 0),
+            "failed": summary.get("failed", 0),
+        }
+        return -peak_mib, details

--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -174,6 +174,9 @@ echo_mutator = "peagen.plugins.mutators.echo_mutator:EchoMutator"
 llm_prompt = "peagen.plugins.mutators.llm_prompt:LlmRewrite"
 llm_prog_rewrite = "peagen.plugins.mutators.llm_prog_rewrite:LlmProgRewrite"
 
+[project.entry-points."peagen.evaluators"]
+memray = "peagen.evaluators.pytest_memray_evaluator:PytestMemrayEvaluator"
+
 [tool.setuptools.package-data]
 "peagen.schemas" = ["*.json", "extras/*.json"]
 "peagen" = [

--- a/pkgs/standards/peagen/tests/unit/test_pytest_memray_evaluator.py
+++ b/pkgs/standards/peagen/tests/unit/test_pytest_memray_evaluator.py
@@ -1,0 +1,17 @@
+import pytest
+from peagen.evaluators.pytest_memray_evaluator import PytestMemrayEvaluator
+from swarmauri_standard.programs.Program import Program
+
+
+@pytest.mark.unit
+def test_pytest_memray_evaluator(tmp_path):
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_ok.py").write_text(
+        "def test_ok():\n    x=[0]*10\n    assert x\n"
+    )
+    program = Program.from_workspace(tmp_path)
+    evaluator = PytestMemrayEvaluator()
+    score, meta = evaluator.evaluate(program, workspace=tmp_path)
+    assert "peak_mib" in meta
+    assert score <= 0


### PR DESCRIPTION
## Summary
- implement `PytestMemrayEvaluator` using pytest-memray
- expose it via the `peagen.evaluators` entry point
- test PytestMemrayEvaluator

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format peagen/evaluators/pytest_memray_evaluator.py peagen/evaluators/__init__.py pyproject.toml tests/unit/test_pytest_memray_evaluator.py`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/evaluators/pytest_memray_evaluator.py peagen/evaluators/__init__.py pyproject.toml tests/unit/test_pytest_memray_evaluator.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_68567d6725348326893e6eaa9a247382