### PR TITLE
Add customizable fitness evaluator option

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/mutate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/mutate.py
@@ -36,6 +36,11 @@ def run(
     import_path: str = typer.Option(..., help="Module import path"),
     entry_fn: str = typer.Option(..., help="Benchmark function"),
     profile_mod: Optional[str] = typer.Option(None, help="Profile helper module"),
+    fitness: str = typer.Option(
+        "peagen.plugins.evaluators.performance_evaluator:PerformanceEvaluator",
+        "--fitness",
+        help="Evaluator plugin reference",
+    ),
     gens: int = typer.Option(1, help="Number of generations"),
     json_out: bool = typer.Option(
         False, "--json", help="Print results to stdout instead of a file"
@@ -54,6 +59,7 @@ def run(
         "entry_fn": entry_fn,
         "profile_mod": profile_mod,
         "gens": gens,
+        "evaluator_ref": fitness,
     }
     task = _build_task(args)
     result = asyncio.run(mutate_handler(task))
@@ -74,6 +80,11 @@ def submit(
     import_path: str = typer.Option(..., help="Module import path"),
     entry_fn: str = typer.Option(..., help="Benchmark function"),
     profile_mod: Optional[str] = typer.Option(None, help="Profile helper module"),
+    fitness: str = typer.Option(
+        "peagen.plugins.evaluators.performance_evaluator:PerformanceEvaluator",
+        "--fitness",
+        help="Evaluator plugin reference",
+    ),
     gens: int = typer.Option(1, help="Number of generations"),
     repo: Optional[str] = typer.Option(None, "--repo", help="Git repository URI"),
     ref: str = typer.Option("HEAD", "--ref", help="Git ref or commit SHA"),
@@ -86,6 +97,7 @@ def submit(
         "entry_fn": entry_fn,
         "profile_mod": profile_mod,
         "gens": gens,
+        "evaluator_ref": fitness,
     }
     task = _build_task(args)
 
@@ -115,4 +127,3 @@ def submit(
     typer.secho(f"Submitted task {task.id}", fg=typer.colors.GREEN)
     if reply.get("result"):
         typer.echo(json.dumps(reply["result"], indent=2))
-

--- a/pkgs/standards/peagen/peagen/evaluators/__init__.py
+++ b/pkgs/standards/peagen/peagen/evaluators/__init__.py
@@ -1,4 +1,3 @@
-
 """Peagen evaluators."""
 
 from .base import Evaluator
@@ -13,5 +12,13 @@ from .benchmark import PytestBenchmarkEvaluator
 from .simple_time import SimpleTimeEvaluator
 
 
-__all__ = ["Evaluator", "PytestBenchmarkEvaluator", "SimpleTimeEvaluator", "PytestProfilingEvaluator", 
-           "PytestMonitorEvaluator", "PytestMemrayEvaluator", "PytestPerfRegressionEvaluator", "PsutilIOEvaluator"]]
+__all__ = [
+    "Evaluator",
+    "PytestBenchmarkEvaluator",
+    "SimpleTimeEvaluator",
+    "PytestProfilingEvaluator",
+    "PytestMonitorEvaluator",
+    "PytestMemrayEvaluator",
+    "PytestPerfRegressionEvaluator",
+    "PsutilIOEvaluator",
+]

--- a/pkgs/standards/peagen/peagen/handlers/mutate_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/mutate_handler.py
@@ -41,6 +41,10 @@ async def mutate_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, Any]:
         profile_mod=args.get("profile_mod"),
         cfg_path=Path(args["config"]) if args.get("config") else None,
         mutations=args.get("mutations"),
+        evaluator_ref=args.get(
+            "evaluator_ref",
+            "peagen.plugins.evaluators.performance_evaluator:PerformanceEvaluator",
+        ),
     )
 
     cfg = resolve_cfg()

--- a/pkgs/standards/peagen/tests/unit/test_mutate_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_mutate_handler.py
@@ -10,7 +10,7 @@ async def test_mutate_handler_invokes_core(monkeypatch):
 
     def fake_mutate_workspace(**kwargs):
         captured.update(kwargs)
-        return {"winner": "w.py", "score": "1"}
+        return {"winner": "w.py", "score": "1", "meta": {"ok": True}}
 
     monkeypatch.setattr(handler, "mutate_workspace", fake_mutate_workspace)
 
@@ -23,14 +23,16 @@ async def test_mutate_handler_invokes_core(monkeypatch):
         "profile_mod": None,
         "config": None,
         "mutations": [{"kind": "echo_mutator", "probability": 1}],
+        "evaluator_ref": "ev",
     }
 
     result = await handler.mutate_handler({"payload": {"args": args}})
 
-    assert result == {"winner": "w.py", "score": "1"}
+    assert result == {"winner": "w.py", "score": "1", "meta": {"ok": True}}
     assert captured["workspace_uri"] == "ws"
     assert captured["target_file"] == "t.py"
     assert captured["import_path"] == "mod"
     assert captured["entry_fn"] == "f"
     assert captured["gens"] == 3
     assert captured["mutations"] == [{"kind": "echo_mutator", "probability": 1}]
+    assert captured["evaluator_ref"] == "ev"

--- a/pkgs/standards/peagen/tests/unit/test_mutate_handler_repo.py
+++ b/pkgs/standards/peagen/tests/unit/test_mutate_handler_repo.py
@@ -19,6 +19,7 @@ async def test_mutate_handler_repo(tmp_path: Path, monkeypatch):
         return {
             "winner": str(Path(kwargs["workspace_uri"]) / "winner.py"),
             "score": "0",
+            "meta": {"ok": True},
         }
 
     monkeypatch.setattr(handler, "mutate_workspace", fake_mutate_workspace)
@@ -31,11 +32,13 @@ async def test_mutate_handler_repo(tmp_path: Path, monkeypatch):
         "import_path": "mod",
         "entry_fn": "bench",
         "gens": 1,
+        "evaluator_ref": "ev",
     }
 
     result = await handler.mutate_handler({"payload": {"args": args}})
 
     assert not Path(captured["workspace_uri"]).exists()
     assert result["score"] == "0"
+    assert result["meta"] == {"ok": True}
     assert result["commit"] is None
     assert "winner_oid" not in result


### PR DESCRIPTION
## Summary
- add `--fitness` flag to `peagen mutate` command
- support evaluator selection in `mutate_workspace`
- expose evaluator reference through mutate handler
- ensure evaluator metadata is returned
- update tests for new argument and result data

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff check peagen/cli/commands/mutate.py peagen/core/mutate_core.py peagen/handlers/mutate_handler.py --fix`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check tests/unit/test_mutate_handler.py tests/unit/test_mutate_handler_repo.py --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856913e451c832688542fd448851e98