### PR TITLE
Add deploy key support with pygit2

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/__init__.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/__init__.py
@@ -18,6 +18,7 @@ from .validate import local_validate_app, remote_validate_app
 from .login import login_app
 from .keys import keys_app
 from .secrets import local_secrets_app, remote_secrets_app
+from .deploy import deploy_app
 
 __all__ = [
     "local_doe_app",
@@ -51,4 +52,5 @@ __all__ = [
     "keys_app",
     "local_secrets_app",
     "remote_secrets_app",
+    "deploy_app",
 ]

--- a/pkgs/standards/peagen/peagen/cli/commands/deploy.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/deploy.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import paramiko
+import pygit2
+import typer
+
+from peagen.secrets import AutoGpgDriver
+from peagen.cli.commands.secrets import _load, _save
+
+
+deploy_app = typer.Typer(help="Manage SSH deploy keys and push commits.")
+
+
+@deploy_app.command("add-key")
+def add_key(name: str, key_file: Path) -> None:
+    """Encrypt *key_file* and store it under *name*."""
+    drv = AutoGpgDriver()
+    secret = drv.encrypt(key_file.read_bytes(), []).decode()
+    data = _load()
+    data[name] = secret
+    _save(data)
+    typer.echo(f"Stored deploy key secret '{name}'")
+
+
+@deploy_app.command("push")
+def push(
+    repo_path: Path = Path("."),
+    secret_name: str = "DEPLOY_KEY",
+    branch: str = "main",
+    remote: str = "origin",
+) -> None:
+    """Push *branch* to *remote* using *secret_name* deploy key."""
+    data = _load()
+    cipher = data.get(secret_name)
+    if not cipher:
+        raise typer.BadParameter(f"Unknown secret {secret_name}")
+
+    drv = AutoGpgDriver()
+    key_text = drv.decrypt(cipher.encode()).decode()
+    key = paramiko.PKey.from_private_key(io.StringIO(key_text))
+    pub = f"{key.get_name()} {key.get_base64()}"
+
+    callbacks = pygit2.RemoteCallbacks(
+        credentials=pygit2.KeypairFromMemory("git", pub, key_text, "")
+    )
+
+    repo = pygit2.Repository(str(repo_path))
+    repo.remotes[remote].push([f"refs/heads/{branch}"], callbacks=callbacks)
+    typer.echo(f"Pushed {branch} using deploy key '{secret_name}'")

--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -35,6 +35,8 @@ dependencies = [
     "jinja2>=3.1.6", # should come with j2prompttemplate, but is it required anywhere else on its own?
     "inflect", # should come with j2prompttemplate, but is it required anywhere else on its own?
     "pgpy>=0.6.0",
+    "paramiko>=3.4",
+    "pygit2>=1.13",
 
     "typer",   # for cli
     "colorama",# for cli


### PR DESCRIPTION
## Summary
- add `deploy_app` CLI for encrypting SSH deploy keys and pushing commits
- export new command in `peagen.cli.commands`
- include `paramiko` and `pygit2` dependencies

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format peagen/cli/commands/deploy.py peagen/cli/commands/__init__.py pyproject.toml`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/cli/commands/deploy.py peagen/cli/commands/__init__.py pyproject.toml --fix`
- `uv run --directory pkgs/standards/peagen --package peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_68569f9ef9748326858bb7225ae8db6c