### PR TITLE
Fix parent task finalization logic

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -399,6 +399,11 @@ async def task_patch(taskId: str, changes: dict) -> dict:
     await _save_task(task)
     await _persist(task)
     await _publish_task(task)
+    if "result" in changes and isinstance(changes["result"], dict):
+        children = changes["result"].get("children")
+        if children:
+            for cid in children:
+                await _finalize_parent_tasks(cid)
     log.info("task %s patched with %s", taskId, ",".join(changes.keys()))
     return task.model_dump()
 

--- a/pkgs/standards/peagen/tests/unit/test_task_patch_finalize.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_patch_finalize.py
@@ -1,0 +1,55 @@
+import uuid
+import pytest
+from peagen.plugins.queues.in_memory_queue import InMemoryQueue
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_task_patch_triggers_finalize(monkeypatch):
+    q = InMemoryQueue()
+
+    class DummyBackend:
+        async def store(self, task_run):
+            pass
+
+    class StubPM:
+        def __init__(self, cfg):
+            pass
+
+        def get(self, group):
+            if group == "queues":
+                return q
+            if group == "result_backends":
+                return DummyBackend()
+            return None
+
+    import importlib
+    import peagen.plugins
+
+    monkeypatch.setattr(peagen.plugins, "PluginManager", StubPM)
+    import peagen.gateway as gw
+
+    importlib.reload(gw)
+
+    monkeypatch.setattr(gw, "queue", q)
+    monkeypatch.setattr(gw, "result_backend", DummyBackend())
+
+    async def noop(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(gw, "_persist", noop)
+    monkeypatch.setattr(gw, "_publish_event", noop)
+
+    task_submit = gw.task_submit
+    task_patch = gw.task_patch
+    task_get = gw.task_get
+    work_finished = gw.work_finished
+
+    parent_id = (await task_submit(pool="p", payload={}, taskId=None))["taskId"]
+    child_id = str(uuid.uuid4())
+    await task_submit(pool="p", payload={}, taskId=child_id)
+    await work_finished(taskId=child_id, status="success", result=None)
+
+    await task_patch(taskId=parent_id, changes={"result": {"children": [child_id]}})
+    parent = await task_get(parent_id)
+    assert parent["status"] == "success"


### PR DESCRIPTION
## Summary
- ensure Task.patch triggers parent finalization for already completed children
- cover the behavior with a new unit test

## Testing
- `ruff format peagen/gateway/__init__.py`
- `ruff check peagen/gateway/__init__.py --fix`
- `ruff format tests/unit/test_task_patch_finalize.py`
- `ruff check tests/unit/test_task_patch_finalize.py --fix`
- `uv run --directory peagen --package peagen pytest tests/unit/test_task_patch_status.py -q` *(fails: Failed to fetch https://pypi.org/simple/ruff/)*
- `pytest tests/unit/test_task_patch_finalize.py -q` *(fails: ModuleNotFoundError: No module named 'jsonpatch')*

------
https://chatgpt.com/codex/tasks/task_e_6856a0ab577c832686146febec3897d0