### PR TITLE
Add deploy key secret handling for git pushes

### DIFF
--- a/pkgs/standards/peagen/docs/secure_secrets_tutorial.md
+++ b/pkgs/standards/peagen/docs/secure_secrets_tutorial.md
@@ -38,4 +38,20 @@ peagen remote secrets add OPENAI_API_KEY sk-... --gateway-url http://localhost:8
 peagen remote --gateway-url http://localhost:8000/rpc process projects.yaml --watch
 ```
 
+## 4. Push commits using a deploy key
+
+Store your private deploy key as an encrypted secret on the gateway:
+
+```bash
+peagen remote secrets add DEPLOY_KEY "$(cat ~/.ssh/id_rsa)" --gateway-url http://localhost:8000/rpc
+```
+
+Configure your worker with the secret name so pushes use the key:
+
+```bash
+export DEPLOY_KEY_SECRET=DEPLOY_KEY
+```
+
+Workers will automatically fetch the deploy key secret when pushing.
+
 See [call_flows/peagen_secure_secrets_arch.mmd](call_flows/peagen_secure_secrets_arch.mmd) for the encryption architecture.

--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -69,6 +69,8 @@ dependencies = [
     "PyGithub", # this storage adapter needs to be pushed to its own standalone
     "minio", # this storage adapter needs to be pushed to its own standalone
     "GitPython",
+    "paramiko",
+    "pygit2",
     "s3fs",
     "pytest-monitor>=1.6.6",
 ]


### PR DESCRIPTION
## Summary
- remove unused `git-push` CLI command
- document worker usage of `DEPLOY_KEY_SECRET`
- allow `GitVCS.push()` to fetch a deploy key secret and push with pygit2

## Testing
- `uv run --directory pkgs/standards --package peagen ruff format peagen/peagen/cli/__init__.py peagen/peagen/cli/commands/__init__.py peagen/peagen/plugins/vcs/git_vcs.py`
- `uv run --directory pkgs/standards --package peagen ruff check peagen/peagen/cli/__init__.py peagen/peagen/cli/commands/__init__.py peagen/peagen/plugins/vcs/git_vcs.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_6856a5ee24b88326a411dd03b6fdda73