### PR TITLE
Fix status enum constant

### DIFF
--- a/pkgs/standards/peagen/peagen/models/schemas.py
+++ b/pkgs/standards/peagen/peagen/models/schemas.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from enum import Enum
-from typing import List, Optional
+from typing import List, Optional, ClassVar, FrozenSet
 from pydantic import BaseModel, Field
 import uuid
 
@@ -27,7 +27,9 @@ class Status(str, Enum):
     failed = "failed"
     cancelled = "cancelled"
 
-    TERMINAL_STATES = frozenset({"success", "failed", "cancelled", "rejected"})
+    TERMINAL_STATES: ClassVar[FrozenSet[str]] = frozenset(
+        {"success", "failed", "cancelled", "rejected"}
+    )
 
     @classmethod
     def is_terminal(cls, state: str | "Status") -> bool:


### PR DESCRIPTION
## Summary
- prevent the TERMINAL_STATES constant from becoming a Postgres enum value

## Testing
- `uv run --package peagen --directory . pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68577eda39088326a39d1e7d43c3efb9