### PR TITLE
Fix Status.is_terminal

### DIFF
--- a/pkgs/standards/peagen/peagen/models/schemas.py
+++ b/pkgs/standards/peagen/peagen/models/schemas.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from enum import Enum
-from typing import List, Optional, ClassVar, FrozenSet
+from typing import List, Optional, FrozenSet
 from pydantic import BaseModel, Field
 import uuid
 
@@ -27,15 +27,14 @@ class Status(str, Enum):
     failed = "failed"
     cancelled = "cancelled"
 
-    TERMINAL_STATES: ClassVar[FrozenSet[str]] = frozenset(
-        {"success", "failed", "cancelled", "rejected"}
-    )
-
     @classmethod
     def is_terminal(cls, state: str | "Status") -> bool:
         """Return True if *state* represents completion."""
+        terminal_states: FrozenSet[str] = frozenset(
+            {"success", "failed", "cancelled", "rejected"}
+        )
         value = state.value if isinstance(state, Status) else state
-        return value in cls.TERMINAL_STATES
+        return value in terminal_states
 
 
 class Task(BaseModel):


### PR DESCRIPTION
## Summary
- drop TERMINAL_STATES constant in `Status`
- keep terminal set inside `Status.is_terminal`

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format peagen/models/schemas.py`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check peagen/models/schemas.py --fix`

------
https://chatgpt.com/codex/tasks/task_e_68579140fd3083269ca4b03ef45d0289