### PR TITLE
Store commit hexsha in peagen results

### DIFF
--- a/pkgs/standards/peagen/migrations/versions/a6cc5b24ad5c_commit_hexsha.py
+++ b/pkgs/standards/peagen/migrations/versions/a6cc5b24ad5c_commit_hexsha.py
@@ -1,0 +1,22 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+revision = "a6cc5b24ad5c"
+down_revision = "ae1de73e4143"
+
+
+def upgrade():
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    cols = {c["name"] for c in inspector.get_columns("task_runs")}
+    if "commit_hexsha" not in cols:
+        op.add_column("task_runs", sa.Column("commit_hexsha", sa.String()))
+
+
+def downgrade():
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    cols = {c["name"] for c in inspector.get_columns("task_runs")}
+    if "commit_hexsha" in cols:
+        op.drop_column("task_runs", "commit_hexsha")

--- a/pkgs/standards/peagen/peagen/core/task_core.py
+++ b/pkgs/standards/peagen/peagen/core/task_core.py
@@ -12,6 +12,7 @@ from typing import Dict
 from peagen.gateway.db import Session
 from peagen.models import TaskRun
 
+
 async def get_task_result(task_id: str) -> Dict:
     """
     Return a JSON-serialisable dict:
@@ -31,6 +32,7 @@ async def get_task_result(task_id: str) -> Dict:
             "status": tr.status,
             "result": tr.result,
             "artifact_uri": tr.artifact_uri,
+            "commit_hexsha": tr.commit_hexsha,
             "started_at": tr.started_at.isoformat() if tr.started_at else None,
             "finished_at": tr.finished_at.isoformat() if tr.finished_at else None,
             "duration": (

--- a/pkgs/standards/peagen/tests/unit/test_alembic_integration.py
+++ b/pkgs/standards/peagen/tests/unit/test_alembic_integration.py
@@ -11,7 +11,6 @@ def test_alembic_upgrade_and_current(tmp_path):
     alembic_ini = Path(__file__).resolve().parents[2] / "alembic.ini"
     repo_root = Path(__file__).resolve().parents[5]
 
-
     env = os.environ.copy()
     env.setdefault("REDIS_URL", "redis://localhost:6379/0")
     env.pop("PG_HOST", None)
@@ -52,3 +51,6 @@ def test_alembic_upgrade_and_current(tmp_path):
             "SELECT name FROM sqlite_master WHERE type='table' AND name='task_runs'"
         )
         assert cur.fetchone() is not None
+        cur = conn.execute("PRAGMA table_info(task_runs)")
+        cols = {row[1] for row in cur.fetchall()}
+        assert "commit_hexsha" in cols

--- a/pkgs/standards/peagen/tests/unit/test_task_metadata.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_metadata.py
@@ -3,6 +3,7 @@ import pytest
 from peagen.models import Task, TaskRun
 from peagen.plugins.queues.in_memory_queue import InMemoryQueue
 
+
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_task_model_roundtrip():
@@ -27,13 +28,22 @@ async def test_task_model_roundtrip():
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_taskrun_from_task():
-    t = Task(pool="p", payload={}, deps=["a"], edge_pred="e", labels=["l"], in_degree=1, config_toml="c")
+    t = Task(
+        pool="p",
+        payload={},
+        deps=["a"],
+        edge_pred="e",
+        labels=["l"],
+        in_degree=1,
+        config_toml="c",
+    )
     tr = TaskRun.from_task(t)
     assert tr.deps == ["a"]
     assert tr.edge_pred == "e"
     assert tr.labels == ["l"]
     assert tr.in_degree == 1
     assert tr.config_toml == "c"
+    assert tr.commit_hexsha is None
 
 
 @pytest.mark.unit
@@ -61,10 +71,12 @@ async def test_task_submit_roundtrip(monkeypatch):
 
     monkeypatch.setattr(peagen.plugins, "PluginManager", StubPM)
     import peagen.gateway as gw
+
     importlib.reload(gw)
 
     monkeypatch.setattr(gw, "queue", q)
     monkeypatch.setattr(gw, "result_backend", DummyBackend())
+
     async def noop(*_args, **_kwargs):
         return None
 


### PR DESCRIPTION
## Summary
- track commit hexsha on `TaskRun`
- expose the new field via `get_task_result`
- create Alembic migration to add `commit_hexsha`
- test database column and model default

## Testing
- `uv run --package peagen --directory standards -- pytest /workspace/swarmauri-sdk/pkgs/standards/peagen/tests/unit/test_task_metadata.py /workspace/swarmauri-sdk/pkgs/standards/peagen/tests/unit/test_alembic_integration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685793fe3454832690a88db7ef9599b1