### PR TITLE
Improve peagen fetch error messages

### DIFF
--- a/pkgs/standards/peagen/peagen/core/fetch_core.py
+++ b/pkgs/standards/peagen/peagen/core/fetch_core.py
@@ -19,6 +19,7 @@ from typing import List, Optional
 
 from peagen.plugins.storage_adapters import make_adapter_for_uri  # deprecated
 from peagen.plugins.vcs import GitVCS
+from peagen.errors import WorkspaceNotFoundError
 
 
 # ─────────────────────────── low-level helpers ────────────────────────────
@@ -43,7 +44,7 @@ def _materialise_workspace(uri: str, dest: Path) -> None:
 
     path = Path(uri)
     if not path.exists():
-        raise FileNotFoundError(uri)
+        raise WorkspaceNotFoundError(uri)
     if path.is_dir():
         shutil.copytree(path, dest, dirs_exist_ok=True)
     else:

--- a/pkgs/standards/peagen/peagen/errors.py
+++ b/pkgs/standards/peagen/peagen/errors.py
@@ -3,6 +3,17 @@
 Exception classes used by the Peagen package.
 """
 
+
 class PatchTargetMissingError(ValueError):
     """Patch operation refers to a non-existent path in the template."""
 
+
+class WorkspaceNotFoundError(FileNotFoundError):
+    """Raised when a workspace path cannot be materialised."""
+
+    def __init__(self, workspace: str) -> None:
+        super().__init__(workspace)
+        self.workspace = workspace
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return f"Workspace '{self.workspace}' does not exist or is not accessible"


### PR DESCRIPTION
## Summary
- add `WorkspaceNotFoundError` for clearer fetch failures
- raise the new error in `fetch_core._materialise_workspace`

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen pytest`


------
https://chatgpt.com/codex/tasks/task_e_68579287dcf48326aceec4d2c3612ca1