### PR TITLE
Add HttpSigMiddleware standard package

### DIFF
--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -66,6 +66,7 @@ members = [
     "standards/swarmauri_middleware_logging",
     "standards/swarmauri_middleware_ratelimit",
     "standards/swarmauri_middleware_securityheaders",
+    "standards/swarmauri_middleware_httpsig",
     "standards/swarmauri_middleware_session",
     "standards/swarmauri_middleware_time",
     "standards/swarmauri_prompt_j2prompttemplate",
@@ -176,6 +177,7 @@ swarmauri_middleware_llamaguard = { workspace = true }
 swarmauri_middleware_logging = { workspace = true }
 swarmauri_middleware_ratelimit = { workspace = true }
 swarmauri_middleware_sercurityheaders = { workspace = true }
+swarmauri_middleware_httpsig = { workspace = true }
 swarmauri_middleware_session = { workspace = true }
 swarmauri_middleware_time = { workspace = true }
 swarmauri_middleware_circuitbreaker = { workspace = true }

--- a/pkgs/standards/swarmauri_middleware_httpsig/LICENSE
+++ b/pkgs/standards/swarmauri_middleware_httpsig/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/standards/swarmauri_middleware_httpsig/README.md
+++ b/pkgs/standards/swarmauri_middleware_httpsig/README.md
@@ -1,0 +1,35 @@
+![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_middleware_httpsig/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_middleware_httpsig" alt="PyPI - Downloads"/>
+    </a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_middleware_httpsig/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_middleware_httpsig.svg"/>
+    </a>
+    <a href="https://pypi.org/project/swarmauri_middleware_httpsig/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_middleware_httpsig" alt="PyPI - Python Version"/>
+    </a>
+    <a href="https://pypi.org/project/swarmauri_middleware_httpsig/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_middleware_httpsig" alt="PyPI - License"/>
+    </a>
+    <a href="https://pypi.org/project/swarmauri_middleware_httpsig/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_middleware_httpsig?label=swarmauri_middleware_httpsig&color=green" alt="PyPI - swarmauri_middleware_httpsig"/>
+    </a>
+</p>
+
+---
+
+# Swarmauri Middleware HttpSig
+
+Middleware for verifying HTTP signatures in Swarmauri applications.
+
+## Installation
+
+```bash
+pip install swarmauri_middleware_httpsig
+```
+
+## Want to help?
+
+If you want to contribute to swarmauri-sdk, read up on our [guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/contributing.md) that will help you get started.

--- a/pkgs/standards/swarmauri_middleware_httpsig/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_httpsig/pyproject.toml
@@ -1,0 +1,70 @@
+[project]
+name = "swarmauri_middleware_httpsig"
+version = "0.6.2.dev3"
+description = "HTTP signature verification middleware for Swarmauri"
+license = "Apache-2.0"
+readme = "README.md"
+repository = "http://github.com/swarmauri/swarmauri-sdk/pkgs/pkgs/swarmauri_middleware_httpsig/"
+requires-python = ">=3.10,<3.13"
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Development Status :: 3 - Alpha",
+]
+authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
+dependencies = [
+    "fastapi",
+    "swarmauri_core",
+    "swarmauri_base",
+    "swarmauri_standard",
+]
+
+[tool.uv.sources]
+swarmauri_core = { workspace = true }
+swarmauri_base = { workspace = true }
+swarmauri_standard = { workspace = true }
+
+[tool.pytest.ini_options]
+norecursedirs = ["combined", "scripts"]
+markers = [
+    "test: standard test",
+    "unit: Unit tests",
+    "i9n: Integration tests",
+    "r8n: Regression tests",
+    "timeout: mark test to timeout after X seconds",
+    "xpass: Expected passes",
+    "xfail: Expected failures",
+    "acceptance: Acceptance tests",
+    "perf: Performance tests that measure execution time and resource usage",
+]
+timeout = 300
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "python-dotenv",
+    "requests>=2.32.3",
+    "flake8>=7.0",
+    "pytest-timeout>=2.3.1",
+    "ruff>=0.9.9",
+    "pytest-benchmark>=4.0.0",
+]
+
+[project.entry-points.'swarmauri.middlewares']
+HttpSigMiddleware = "swarmauri_middleware_httpsig:HttpSigMiddleware"

--- a/pkgs/standards/swarmauri_middleware_httpsig/swarmauri_middleware_httpsig/HttpSigMiddleware.py
+++ b/pkgs/standards/swarmauri_middleware_httpsig/swarmauri_middleware_httpsig/HttpSigMiddleware.py
@@ -1,0 +1,70 @@
+"""Middleware for verifying HTTP signatures."""
+
+import base64
+import hashlib
+import hmac
+import logging
+from typing import Any, Callable, Literal, Optional
+
+from fastapi import HTTPException, Request
+from pydantic import Field
+from swarmauri_base.ComponentBase import ComponentBase
+from swarmauri_base.middlewares.MiddlewareBase import MiddlewareBase
+
+logger = logging.getLogger(__name__)
+
+
+@ComponentBase.register_type(MiddlewareBase, "HttpSigMiddleware")
+class HttpSigMiddleware(MiddlewareBase, ComponentBase):
+    """Verify HTTP signatures on incoming requests.
+
+    This middleware validates an HMAC-SHA256 signature included in request
+    headers. The signature is computed over the request body using a shared
+    secret key.
+
+    Attributes:
+        type: Literal["HttpSigMiddleware"] = "HttpSigMiddleware"
+        secret_key: str -- Shared secret used for HMAC calculation
+        header_name: str -- Header containing the signature (default ``X-Signature``)
+    """
+
+    type: Literal["HttpSigMiddleware"] = "HttpSigMiddleware"
+    secret_key: Optional[str] = None
+    header_name: Optional[str] = "X-Signature"
+    logger: logging.Logger = Field(default_factory=lambda: logger, exclude=True)
+
+    def __init__(self, secret_key: str, header_name: str = "X-Signature", **kwargs: Any) -> None:
+        """Initialize the middleware with a secret key and header name."""
+        super().__init__(**kwargs)
+        self.secret_key = secret_key
+        self.header_name = header_name
+        self.logger = logger
+
+    async def dispatch(self, request: Request, call_next: Callable[[Request], Any]) -> Any:
+        """Dispatch the request after verifying the signature.
+
+        Args:
+            request: The incoming request object.
+            call_next: Callable that invokes the next middleware.
+
+        Returns:
+            The response returned by the next middleware.
+
+        Raises:
+            HTTPException: If the signature header is missing or invalid.
+        """
+        signature = request.headers.get(self.header_name)
+        if not signature:
+            self.logger.warning("Missing signature header")
+            raise HTTPException(status_code=401, detail="Missing signature")
+
+        body = await request.body()
+        expected = base64.b64encode(
+            hmac.new(self.secret_key.encode(), body, hashlib.sha256).digest()
+        ).decode()
+
+        if not hmac.compare_digest(signature, expected):
+            self.logger.warning("Invalid HTTP signature")
+            raise HTTPException(status_code=401, detail="Invalid signature")
+
+        return await call_next(request)

--- a/pkgs/standards/swarmauri_middleware_httpsig/swarmauri_middleware_httpsig/__init__.py
+++ b/pkgs/standards/swarmauri_middleware_httpsig/swarmauri_middleware_httpsig/__init__.py
@@ -1,0 +1,13 @@
+from .HttpSigMiddleware import HttpSigMiddleware
+
+__all__ = ["HttpSigMiddleware"]
+
+try:
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError:  # pragma: no cover - fall back for older Python
+    from importlib_metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("swarmauri_middleware_httpsig")
+except PackageNotFoundError:  # pragma: no cover - package not installed
+    __version__ = "0.0.0"

--- a/pkgs/standards/swarmauri_middleware_httpsig/tests/unit/test_HttpSigMiddleware.py
+++ b/pkgs/standards/swarmauri_middleware_httpsig/tests/unit/test_HttpSigMiddleware.py
@@ -1,0 +1,67 @@
+import base64
+import hashlib
+import hmac
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from fastapi import HTTPException
+from swarmauri_middleware_httpsig.HttpSigMiddleware import HttpSigMiddleware
+
+
+@pytest.fixture
+def middleware():
+    return HttpSigMiddleware(secret_key="secret")
+
+
+@pytest.fixture
+def mock_request():
+    request = Mock()
+    request.headers = {}
+    request.body = AsyncMock(return_value=b"payload")
+    return request
+
+
+@pytest.mark.unit
+def test_ubc_type(middleware):
+    assert middleware.type == "HttpSigMiddleware"
+
+
+@pytest.mark.unit
+def test_ubc_resource(middleware):
+    assert middleware.resource == "Middleware"
+
+
+@pytest.mark.unit
+def test_serialization(middleware):
+    serialized = middleware.model_dump_json()
+    assert HttpSigMiddleware.model_validate_json(serialized).id == middleware.id
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dispatch_valid_signature(middleware, mock_request):
+    digest = hmac.new(b"secret", b"payload", hashlib.sha256).digest()
+    mock_request.headers[middleware.header_name] = base64.b64encode(digest).decode()
+    call_next = AsyncMock(return_value="ok")
+    result = await middleware.dispatch(mock_request, call_next)
+    assert result == "ok"
+    call_next.assert_called_once_with(mock_request)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dispatch_missing_signature(middleware, mock_request):
+    call_next = AsyncMock()
+    with pytest.raises(HTTPException):
+        await middleware.dispatch(mock_request, call_next)
+    call_next.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dispatch_invalid_signature(middleware, mock_request):
+    mock_request.headers[middleware.header_name] = "invalid"
+    call_next = AsyncMock()
+    with pytest.raises(HTTPException):
+        await middleware.dispatch(mock_request, call_next)
+    call_next.assert_not_called()


### PR DESCRIPTION
## Summary
- implement `HttpSigMiddleware` for verifying HTTP signatures
- include tests and packaging metadata
- document new middleware with logo branding
- add new package to workspace configuration

## Testing
- `uv run --package swarmauri_middleware_httpsig --directory standards/swarmauri_middleware_httpsig -- pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857bf7a20588326977938d9b0555e7e