### PR TITLE
Support multiple recipients for remote secret add

### DIFF
--- a/pkgs/standards/peagen/docs/secure_secrets_tutorial.md
+++ b/pkgs/standards/peagen/docs/secure_secrets_tutorial.md
@@ -29,7 +29,10 @@ peagen local secrets add OPENAI_API_KEY sk-... \
 To keep the secret on the gateway, run:
 
 ```bash
-peagen remote secrets add OPENAI_API_KEY sk-... --gateway-url http://localhost:8000/rpc
+peagen remote secrets add OPENAI_API_KEY sk-... \
+  --recipients /path/to/gateway_pub.asc \
+  --recipients /path/to/worker_pub.asc \
+  --gateway-url http://localhost:8000/rpc
 ```
 
 ## 3. Submit a run
@@ -43,7 +46,9 @@ peagen remote --gateway-url http://localhost:8000/rpc process projects.yaml --wa
 Store your private deploy key as an encrypted secret on the gateway:
 
 ```bash
-peagen remote secrets add DEPLOY_KEY "$(cat ~/.ssh/id_rsa)" --gateway-url http://localhost:8000/rpc
+peagen remote secrets add DEPLOY_KEY "$(cat ~/.ssh/id_rsa)" \
+  --recipients /path/to/gateway_pub.asc \
+  --gateway-url http://localhost:8000/rpc
 ```
 
 Configure your worker with the secret name so pushes use the key:

--- a/pkgs/standards/peagen/peagen/cli/commands/secrets.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/secrets.py
@@ -65,11 +65,13 @@ def remote_add(
     ctx: typer.Context,
     name: str,
     value: str,
+    recipients: List[Path] = typer.Option([], "--recipients"),
     gateway_url: str = typer.Option("http://localhost:8000/rpc", "--gateway-url"),
 ) -> None:
     """Upload an encrypted secret to the gateway."""
     drv = AutoGpgDriver()
-    cipher = drv.encrypt(value.encode(), []).decode()
+    pubkeys = [p.read_text() for p in recipients]
+    cipher = drv.encrypt(value.encode(), pubkeys).decode()
     envelope = {
         "jsonrpc": "2.0",
         "method": "Secrets.add",


### PR DESCRIPTION
## Summary
- allow passing `--recipients` to `peagen remote secrets add`
- document multi-recipient usage in the secure secrets tutorial

## Testing
- `ruff format pkgs/standards/peagen/peagen/cli/commands/secrets.py`
- `ruff check pkgs/standards/peagen/peagen/cli/commands/secrets.py --fix`
- `uv run --directory standards/peagen --package peagen pytest` *(fails: Failed to fetch pypi packages)*

------
https://chatgpt.com/codex/tasks/task_e_6857a042617c8326af76849a4e877de9