### PR TITLE
Add recipients flag to remote secrets

### DIFF
--- a/pkgs/standards/peagen/docs/secure_secrets_tutorial.md
+++ b/pkgs/standards/peagen/docs/secure_secrets_tutorial.md
@@ -29,7 +29,8 @@ peagen local secrets add OPENAI_API_KEY sk-... \
 To keep the secret on the gateway, run:
 
 ```bash
-peagen remote secrets add OPENAI_API_KEY sk-... --gateway-url http://localhost:8000/rpc
+peagen remote secrets add OPENAI_API_KEY sk-... \
+  --recipient worker_pub.asc --gateway-url http://localhost:8000/rpc
 ```
 
 ## 3. Submit a run
@@ -43,7 +44,8 @@ peagen remote --gateway-url http://localhost:8000/rpc process projects.yaml --wa
 Store your private deploy key as an encrypted secret on the gateway:
 
 ```bash
-peagen remote secrets add DEPLOY_KEY "$(cat ~/.ssh/id_rsa)" --gateway-url http://localhost:8000/rpc
+peagen remote secrets add DEPLOY_KEY "$(cat ~/.ssh/id_rsa)" \
+  --recipient worker_pub.asc --gateway-url http://localhost:8000/rpc
 ```
 
 Configure your worker with the secret name so pushes use the key:

--- a/pkgs/standards/peagen/peagen/cli/commands/secrets.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/secrets.py
@@ -17,6 +17,28 @@ remote_secrets_app = typer.Typer(help="Manage secrets via gateway.")
 STORE_FILE = Path.home() / ".peagen" / "secret_store.json"
 
 
+def _pool_worker_pubs(pool: str, gateway_url: str) -> list[str]:
+    """Return public keys advertised by workers in ``pool``."""
+    envelope = {
+        "jsonrpc": "2.0",
+        "method": "Worker.list",
+        "params": {"pool": pool},
+    }
+    try:
+        res = httpx.post(gateway_url, json=envelope, timeout=10.0)
+        res.raise_for_status()
+    except Exception:
+        return []
+    workers = res.json().get("result", [])
+    keys = []
+    for w in workers:
+        advert = w.get("advertises") or {}
+        key = advert.get("public_key") or advert.get("pubkey")
+        if key:
+            keys.append(key)
+    return keys
+
+
 def _load() -> dict:
     if STORE_FILE.exists():
         return json.loads(STORE_FILE.read_text())
@@ -65,11 +87,15 @@ def remote_add(
     ctx: typer.Context,
     name: str,
     value: str,
+    recipient: List[Path] = typer.Option([], "--recipient"),
+    pool: str = typer.Option("default", "--pool"),
     gateway_url: str = typer.Option("http://localhost:8000/rpc", "--gateway-url"),
 ) -> None:
     """Upload an encrypted secret to the gateway."""
     drv = AutoGpgDriver()
-    cipher = drv.encrypt(value.encode(), []).decode()
+    pubs = [p.read_text() for p in recipient]
+    pubs.extend(_pool_worker_pubs(pool, gateway_url))
+    cipher = drv.encrypt(value.encode(), pubs).decode()
     envelope = {
         "jsonrpc": "2.0",
         "method": "Secrets.add",


### PR DESCRIPTION
## Summary
- allow `remote secrets add` to encrypt for additional recipients and worker pubs
- document new `--recipient` flag in secure secrets tutorial

## Testing
- `uv run --package peagen --directory pkgs/standards ruff format peagen/peagen/cli/commands/secrets.py`
- `uv run --package peagen --directory pkgs/standards ruff check peagen/peagen/cli/commands/secrets.py --fix`
- `uv run --package peagen --directory pkgs/standards pytest` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6857a092c2c0832687e3f252ce911d86