### PR TITLE
Implement namespaced secret IDs with versioning

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/secrets.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/secrets.py
@@ -63,8 +63,9 @@ def remove(name: str) -> None:
 @remote_secrets_app.command("add")
 def remote_add(
     ctx: typer.Context,
-    name: str,
+    secret_id: str,
     value: str,
+    version: int = typer.Option(0, "--version"),
     gateway_url: str = typer.Option("http://localhost:8000/rpc", "--gateway-url"),
 ) -> None:
     """Upload an encrypted secret to the gateway."""
@@ -73,16 +74,16 @@ def remote_add(
     envelope = {
         "jsonrpc": "2.0",
         "method": "Secrets.add",
-        "params": {"name": name, "secret": cipher},
+        "params": {"id": secret_id, "secret": cipher, "version": version},
     }
     httpx.post(gateway_url, json=envelope, timeout=10.0)
-    typer.echo(f"Uploaded secret {name}")
+    typer.echo(f"Uploaded secret {secret_id}")
 
 
 @remote_secrets_app.command("get")
 def remote_get(
     ctx: typer.Context,
-    name: str,
+    secret_id: str,
     gateway_url: str = typer.Option("http://localhost:8000/rpc", "--gateway-url"),
 ) -> None:
     """Retrieve and decrypt a secret from the gateway."""
@@ -90,7 +91,7 @@ def remote_get(
     envelope = {
         "jsonrpc": "2.0",
         "method": "Secrets.get",
-        "params": {"name": name},
+        "params": {"id": secret_id},
     }
     res = httpx.post(gateway_url, json=envelope, timeout=10.0)
     cipher = res.json()["result"]["secret"].encode()
@@ -100,14 +101,15 @@ def remote_get(
 @remote_secrets_app.command("remove")
 def remote_remove(
     ctx: typer.Context,
-    name: str,
+    secret_id: str,
+    version: int = typer.Option(None, "--version"),
     gateway_url: str = typer.Option("http://localhost:8000/rpc", "--gateway-url"),
 ) -> None:
     """Delete a secret on the gateway."""
     envelope = {
         "jsonrpc": "2.0",
         "method": "Secrets.delete",
-        "params": {"name": name},
+        "params": {"id": secret_id, "version": version},
     }
     httpx.post(gateway_url, json=envelope, timeout=10.0)
-    typer.echo(f"Removed secret {name}")
+    typer.echo(f"Removed secret {secret_id}")

--- a/pkgs/standards/peagen/tests/unit/test_secret_store_versioning.py
+++ b/pkgs/standards/peagen/tests/unit/test_secret_store_versioning.py
@@ -1,0 +1,23 @@
+import pytest
+from peagen.gateway import secrets_add, secrets_get, secrets_delete, SECRET_STORE
+
+
+@pytest.mark.asyncio
+async def test_secret_versioning():
+    SECRET_STORE.clear()
+
+    res = await secrets_add("ns/test", "a", version=0)
+    assert res == {"version": 1}
+
+    val = await secrets_get("ns/test")
+    assert val == {"secret": "a", "version": 1}
+
+    with pytest.raises(TypeError):
+        await secrets_add("ns/test", "b", version=0)
+
+    res = await secrets_add("ns/test", "b", version=1)
+    assert res == {"version": 2}
+
+    await secrets_delete("ns/test", version=2)
+    with pytest.raises(TypeError):
+        await secrets_get("ns/test")


### PR DESCRIPTION
## Summary
- add version-tracked secret store in gateway
- extend secret RPCs and HTTP endpoints for optimistic locking
- update CLI to support new secret ID and version parameters
- test secret versioning behaviour

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format peagen/gateway/__init__.py peagen/cli/commands/secrets.py tests/unit/test_secret_store_versioning.py`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/gateway/__init__.py peagen/cli/commands/secrets.py tests/unit/test_secret_store_versioning.py --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_secret_store_versioning.py`
- `uv run --package peagen --directory pkgs/standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_6857a09dd1f88326b67db3dd3cf7844c