### PR TITLE
Add cycle detection to DAG sort

### DIFF
--- a/pkgs/standards/peagen/peagen/_utils/_graph.py
+++ b/pkgs/standards/peagen/peagen/_utils/_graph.py
@@ -113,7 +113,9 @@ def _topological_sort(payload: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
 
     # Check if all nodes were sorted (detect cycles or references to missing dependencies).
     if len(sorted_names) != len(in_degree):
-        raise Exception("Cyclic or missing dependencies detected among file entries.")
+        leftovers = [n for n, deg in in_degree.items() if deg > 0]
+        hint = ", ".join(sorted(leftovers))
+        raise ValueError(f"Cyclic dependencies detected among file entries: {hint}")
 
     # Map sorted file names back to their payload records.
     entry_map = {e["RENDERED_FILE_NAME"]: e for e in payload}

--- a/pkgs/standards/peagen/tests/unit/test_utils_graph.py
+++ b/pkgs/standards/peagen/tests/unit/test_utils_graph.py
@@ -30,3 +30,22 @@ def test_topological_sort():
 def test_transitive_dependency_sort():
     order = [e["RENDERED_FILE_NAME"] for e in _transitive_dependency_sort(PAYLOAD, "d")]
     assert order == ["a", "b", "c", "d"]
+
+
+@pytest.mark.unit
+def test_topological_sort_cycle():
+    cycle_payload = [
+        {"RENDERED_FILE_NAME": "a", "EXTRAS": {"DEPENDENCIES": ["a"]}},
+    ]
+    with pytest.raises(ValueError, match="Cyclic dependencies detected"):
+        _topological_sort(cycle_payload)
+
+
+@pytest.mark.unit
+def test_topological_sort_two_node_cycle():
+    cycle_payload = [
+        {"RENDERED_FILE_NAME": "a", "EXTRAS": {"DEPENDENCIES": ["b"]}},
+        {"RENDERED_FILE_NAME": "b", "EXTRAS": {"DEPENDENCIES": ["a"]}},
+    ]
+    with pytest.raises(ValueError, match="Cyclic dependencies detected"):
+        _topological_sort(cycle_payload)


### PR DESCRIPTION
## Summary
- detect and report remaining nodes when `_topological_sort` fails
- add regression tests for cycles and self-dependencies

## Testing
- `uv run --directory standards/peagen --package peagen pytest tests/unit/test_utils_graph.py::test_topological_sort_cycle tests/unit/test_utils_graph.py::test_topological_sort_two_node_cycle`

------
https://chatgpt.com/codex/tasks/task_e_6857a297934083268e896734f7c9f275