### PR TITLE
Fix CLI exit code on dashboard cancel

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/tui.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/tui.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import typer
 
 from peagen.tui.app import QueueDashboardApp
@@ -16,8 +17,10 @@ def run_dashboard(
         DEFAULT_GATEWAY,
         "--gateway-url",
         help="Base URL of the Peagen gateway",
-    )
+    ),
 ) -> None:
     """Start the dashboard pointed at ``gateway_url``."""
-    QueueDashboardApp(gateway_url=gateway_url).run()
-
+    try:
+        QueueDashboardApp(gateway_url=gateway_url).run()
+    except (asyncio.CancelledError, KeyboardInterrupt):
+        raise typer.Exit(1)


### PR DESCRIPTION
## Summary
- ensure `peagen tui` returns a non-zero exit code when cancelled

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format peagen/cli/commands/tui.py`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/cli/commands/tui.py --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_6857a2e652bc83269a354efc4f347e5c