### PR TITLE
Add normalized dependencies table

### DIFF
--- a/pkgs/standards/peagen/migrations/versions/c3f9a1d1855a_task_run_deps.py
+++ b/pkgs/standards/peagen/migrations/versions/c3f9a1d1855a_task_run_deps.py
@@ -1,0 +1,57 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect, text
+
+revision = "c3f9a1d1855a"
+down_revision = "b4b95933c789"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+
+    if "task_run_deps" not in inspector.get_table_names():
+        op.create_table(
+            "task_run_deps",
+            sa.Column(
+                "task_id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True
+            ),
+            sa.Column(
+                "dep_id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True
+            ),
+        )
+
+    if "task_runs" in inspector.get_table_names():
+        cols = {c["name"] for c in inspector.get_columns("task_runs")}
+        if "deps" in cols:
+            rows = list(bind.execute(text("SELECT id, deps FROM task_runs")))
+            for row in rows:
+                deps = row[1] or []
+                for dep in deps:
+                    bind.execute(
+                        text(
+                            "INSERT INTO task_run_deps (task_id, dep_id) VALUES (:t, :d) ON CONFLICT DO NOTHING"
+                        ),
+                        {"t": row[0], "d": dep},
+                    )
+            op.drop_column("task_runs", "deps")
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    if "task_run_deps" in inspector.get_table_names():
+        op.add_column(
+            "task_runs",
+            sa.Column("deps", sa.JSON(), nullable=False, server_default="[]"),
+        )
+        rows = list(bind.execute(text("SELECT task_id, dep_id FROM task_run_deps")))
+        for task_id, dep_id in rows:
+            bind.execute(
+                text(
+                    "UPDATE task_runs SET deps = COALESCE(deps, '[]'::jsonb) || to_jsonb(:d) WHERE id = :t"
+                ),
+                {"t": task_id, "d": dep_id},
+            )
+        op.alter_column("task_runs", "deps", server_default=None)
+        op.drop_table("task_run_deps")

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -43,6 +43,7 @@ import peagen.defaults as defaults
 
 from peagen.core.task_core import get_task_result
 from sqlalchemy import select
+from sqlalchemy.orm import selectinload
 
 TASK_KEY = defaults.CONFIG["task_key"]
 
@@ -225,7 +226,15 @@ async def _reload_state() -> None:
     if engine.url.get_backend_name() == "sqlite":
         return
     async with Session() as session:
-        rows = (await session.execute(select(TaskRun))).scalars().all()
+        rows = (
+            (
+                await session.execute(
+                    select(TaskRun).options(selectinload(TaskRun._deps_rel))
+                )
+            )
+            .scalars()
+            .all()
+        )
     for row in rows:
         if Status.is_terminal(row.status):
             continue
@@ -359,7 +368,6 @@ async def keys_delete(fingerprint: str) -> dict:
 
 
 @rpc.method("Secrets.add")
-
 async def secrets_add(
     name: str,
     secret: str,

--- a/pkgs/standards/peagen/peagen/models/__init__.py
+++ b/pkgs/standards/peagen/peagen/models/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from peagen.models.task_run import Base, TaskRun
+from peagen.models.task_run import Base, TaskRun, TaskRunDep
 from peagen.models.secret import Secret
 from peagen.models.schemas import (
     Role,
@@ -9,4 +9,14 @@ from peagen.models.schemas import (
     User,
 )
 
-__all__ = ["Role", "Status", "Task", "Pool", "User", "Base", "TaskRun", "Secret"]
+__all__ = [
+    "Role",
+    "Status",
+    "Task",
+    "Pool",
+    "User",
+    "Base",
+    "TaskRun",
+    "TaskRunDep",
+    "Secret",
+]


### PR DESCRIPTION
## Summary
- add `task_run_deps` migration for normalized dependencies
- store dependencies via association table in `TaskRun`
- update gateway reload logic to load dependencies
- ensure Postgres upserts manage dependency rows

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format peagen/models/task_run.py peagen/models/__init__.py peagen/gateway/db_helpers.py peagen/gateway/__init__.py migrations/versions/c3f9a1d1855a_task_run_deps.py`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check peagen/models/task_run.py peagen/models/__init__.py peagen/gateway/db_helpers.py peagen/gateway/__init__.py migrations/versions/c3f9a1d1855a_task_run_deps.py --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_6857dca3ec9c83268864a05ea46a28f3