### PR TITLE
Fix peagen alembic path

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/db.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/db.py
@@ -1,4 +1,3 @@
-
 """Database management commands."""
 
 from __future__ import annotations
@@ -11,7 +10,9 @@ import typer
 from peagen.handlers.migrate_handler import migrate_handler
 from peagen.models import Task
 
-ALEMBIC_CFG = Path(__file__).resolve().parents[3] / "alembic.ini"
+# ``alembic.ini`` lives in the package root next to ``migrations``. Using
+# ``parents[2]`` works whether running from source or an installed wheel.
+ALEMBIC_CFG = Path(__file__).resolve().parents[2] / "alembic.ini"
 
 local_db_app = typer.Typer(help="Database utilities.")
 
@@ -20,7 +21,13 @@ local_db_app = typer.Typer(help="Database utilities.")
 def upgrade() -> None:
     """Apply Alembic migrations up to HEAD."""
     typer.echo(f"Running alembic -c {ALEMBIC_CFG} upgrade head …")
-    task = Task(pool="default", payload={"action": "migrate", "args": {"op": "upgrade", "alembic_ini": str(ALEMBIC_CFG)}})
+    task = Task(
+        pool="default",
+        payload={
+            "action": "migrate",
+            "args": {"op": "upgrade", "alembic_ini": str(ALEMBIC_CFG)},
+        },
+    )
     result = asyncio.run(migrate_handler(task))
     if not result.get("ok", False):
         typer.echo(f"[ERROR] {result.get('error')}")
@@ -42,7 +49,14 @@ def revision(
     )
     task = Task(
         pool="default",
-        payload={"action": "migrate", "args": {"op": "revision", "message": message, "alembic_ini": str(ALEMBIC_CFG)}},
+        payload={
+            "action": "migrate",
+            "args": {
+                "op": "revision",
+                "message": message,
+                "alembic_ini": str(ALEMBIC_CFG),
+            },
+        },
     )
     result = asyncio.run(migrate_handler(task))
     if not result.get("ok", False):
@@ -54,7 +68,13 @@ def revision(
 def downgrade() -> None:
     """Downgrade the database by one revision."""
     typer.echo(f"Running alembic -c {ALEMBIC_CFG} downgrade -1 …")
-    task = Task(pool="default", payload={"action": "migrate", "args": {"op": "downgrade", "alembic_ini": str(ALEMBIC_CFG)}})
+    task = Task(
+        pool="default",
+        payload={
+            "action": "migrate",
+            "args": {"op": "downgrade", "alembic_ini": str(ALEMBIC_CFG)},
+        },
+    )
     result = asyncio.run(migrate_handler(task))
     if not result.get("ok", False):
         typer.echo(f"[ERROR] {result.get('error')}")

--- a/pkgs/standards/peagen/peagen/core/migrate_core.py
+++ b/pkgs/standards/peagen/peagen/core/migrate_core.py
@@ -5,19 +5,25 @@ from pathlib import Path
 from typing import Any, Dict
 
 
-ALEMBIC_CFG = Path(__file__).resolve().parents[3] / "alembic.ini"
+# ``alembic.ini`` sits alongside the ``migrations`` directory in the package
+# root. ``parents[2]`` reliably resolves to that location for both source and
+# installed packages.
+ALEMBIC_CFG = Path(__file__).resolve().parents[2] / "alembic.ini"
 
 
 def alembic_upgrade(cfg: Path = ALEMBIC_CFG) -> Dict[str, Any]:
     """Apply migrations up to HEAD using *cfg*."""
     try:
-        subprocess.run([
-            "alembic",
-            "-c",
-            str(cfg),
-            "upgrade",
-            "head",
-        ], check=True)
+        subprocess.run(
+            [
+                "alembic",
+                "-c",
+                str(cfg),
+                "upgrade",
+                "head",
+            ],
+            check=True,
+        )
     except subprocess.CalledProcessError as exc:  # noqa: BLE001
         return {"ok": False, "error": str(exc)}
     return {"ok": True}
@@ -26,13 +32,16 @@ def alembic_upgrade(cfg: Path = ALEMBIC_CFG) -> Dict[str, Any]:
 def alembic_downgrade(cfg: Path = ALEMBIC_CFG) -> Dict[str, Any]:
     """Downgrade the database by one revision using *cfg*."""
     try:
-        subprocess.run([
-            "alembic",
-            "-c",
-            str(cfg),
-            "downgrade",
-            "-1",
-        ], check=True)
+        subprocess.run(
+            [
+                "alembic",
+                "-c",
+                str(cfg),
+                "downgrade",
+                "-1",
+            ],
+            check=True,
+        )
     except subprocess.CalledProcessError as exc:  # noqa: BLE001
         return {"ok": False, "error": str(exc)}
     return {"ok": True}
@@ -41,15 +50,18 @@ def alembic_downgrade(cfg: Path = ALEMBIC_CFG) -> Dict[str, Any]:
 def alembic_revision(message: str, cfg: Path = ALEMBIC_CFG) -> Dict[str, Any]:
     """Create a new revision with *message* using *cfg*."""
     try:
-        subprocess.run([
-            "alembic",
-            "-c",
-            str(cfg),
-            "revision",
-            "--autogenerate",
-            "-m",
-            message,
-        ], check=True)
+        subprocess.run(
+            [
+                "alembic",
+                "-c",
+                str(cfg),
+                "revision",
+                "--autogenerate",
+                "-m",
+                message,
+            ],
+            check=True,
+        )
     except subprocess.CalledProcessError as exc:  # noqa: BLE001
         return {"ok": False, "error": str(exc)}
     return {"ok": True}


### PR DESCRIPTION
## Summary
- ensure alembic.ini path works from installed packages
- document path reasoning in migrate_core and CLI

## Testing
- `uv run --package peagen --directory standards/peagen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857e1c9aa348326b41321c914e68571