### PR TITLE
Add login, keys, and secrets core handlers

### DIFF
--- a/pkgs/standards/peagen/peagen/core/keys_core.py
+++ b/pkgs/standards/peagen/peagen/core/keys_core.py
@@ -1,0 +1,65 @@
+"""Utility helpers for key pair management."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import httpx
+
+from peagen.secrets import AutoGpgDriver
+
+DEFAULT_GATEWAY = "http://localhost:8000/rpc"
+
+
+def create_keypair(
+    key_dir: Path | None = None, passphrase: Optional[str] = None
+) -> dict:
+    """Create a GPG key pair.
+
+    Args:
+        key_dir (Path | None): Destination directory for the keys.
+        passphrase (Optional[str]): Optional passphrase for the private key.
+
+    Returns:
+        dict: Paths of the generated key files.
+    """
+    drv = AutoGpgDriver(key_dir=key_dir, passphrase=passphrase)
+    return {"private": str(drv.priv_path), "public": str(drv.pub_path)}
+
+
+def upload_public_key(
+    key_dir: Path | None = None,
+    gateway_url: str = DEFAULT_GATEWAY,
+) -> dict:
+    """Upload the local public key to the gateway."""
+    drv = AutoGpgDriver(key_dir=key_dir)
+    pubkey = drv.pub_path.read_text()
+    envelope = {
+        "jsonrpc": "2.0",
+        "method": "Keys.upload",
+        "params": {"public_key": pubkey},
+    }
+    res = httpx.post(gateway_url, json=envelope, timeout=10.0)
+    res.raise_for_status()
+    return res.json()
+
+
+def remove_public_key(fingerprint: str, gateway_url: str = DEFAULT_GATEWAY) -> dict:
+    """Remove a stored public key on the gateway."""
+    envelope = {
+        "jsonrpc": "2.0",
+        "method": "Keys.delete",
+        "params": {"fingerprint": fingerprint},
+    }
+    res = httpx.post(gateway_url, json=envelope, timeout=10.0)
+    res.raise_for_status()
+    return res.json()
+
+
+def fetch_server_keys(gateway_url: str = DEFAULT_GATEWAY) -> dict:
+    """Fetch trusted keys from the gateway."""
+    envelope = {"jsonrpc": "2.0", "method": "Keys.fetch"}
+    res = httpx.post(gateway_url, json=envelope, timeout=10.0)
+    res.raise_for_status()
+    return res.json().get("result", {})

--- a/pkgs/standards/peagen/peagen/core/login_core.py
+++ b/pkgs/standards/peagen/peagen/core/login_core.py
@@ -1,0 +1,39 @@
+"""Helpers for user authentication."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import httpx
+
+from peagen.secrets import AutoGpgDriver
+
+DEFAULT_GATEWAY = "http://localhost:8000/rpc"
+
+
+def login(
+    key_dir: Path | None = None,
+    passphrase: Optional[str] = None,
+    gateway_url: str = DEFAULT_GATEWAY,
+) -> dict:
+    """Ensure a key pair exists and upload the public key.
+
+    Args:
+        key_dir (Path | None): Directory containing the key pair.
+        passphrase (Optional[str]): Optional private key passphrase.
+        gateway_url (str): JSON-RPC endpoint for the gateway.
+
+    Returns:
+        dict: JSON response from the gateway.
+    """
+    drv = AutoGpgDriver(key_dir=key_dir, passphrase=passphrase)
+    pubkey = drv.pub_path.read_text()
+    payload = {
+        "jsonrpc": "2.0",
+        "method": "Keys.upload",
+        "params": {"public_key": pubkey},
+    }
+    res = httpx.post(gateway_url, json=payload, timeout=10.0)
+    res.raise_for_status()
+    return res.json()

--- a/pkgs/standards/peagen/peagen/core/secrets_core.py
+++ b/pkgs/standards/peagen/peagen/core/secrets_core.py
@@ -1,0 +1,128 @@
+"""Utility helpers for managing encrypted secrets."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List, Optional
+
+import httpx
+
+from peagen.secrets import AutoGpgDriver
+
+DEFAULT_GATEWAY = "http://localhost:8000/rpc"
+STORE_FILE = Path.home() / ".peagen" / "secret_store.json"
+
+
+def _pool_worker_pubs(pool: str, gateway_url: str) -> list[str]:
+    envelope = {
+        "jsonrpc": "2.0",
+        "method": "Worker.list",
+        "params": {"pool": pool},
+    }
+    try:
+        res = httpx.post(gateway_url, json=envelope, timeout=10.0)
+        res.raise_for_status()
+    except Exception:
+        return []
+    workers = res.json().get("result", [])
+    keys = []
+    for w in workers:
+        advert = w.get("advertises") or {}
+        key = advert.get("public_key") or advert.get("pubkey")
+        if key:
+            keys.append(key)
+    return keys
+
+
+def _load() -> dict:
+    if STORE_FILE.exists():
+        return json.loads(STORE_FILE.read_text())
+    return {}
+
+
+def _save(data: dict) -> None:
+    STORE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    STORE_FILE.write_text(json.dumps(data, indent=2))
+
+
+def add_local_secret(
+    name: str, value: str, recipients: List[Path] | None = None
+) -> None:
+    """Encrypt and store a secret locally."""
+    drv = AutoGpgDriver()
+    pubkeys = [p.read_text() for p in recipients or []]
+    cipher = drv.encrypt(value.encode(), pubkeys).decode()
+    data = _load()
+    data[name] = cipher
+    _save(data)
+
+
+def get_local_secret(name: str) -> str:
+    """Decrypt and return a locally stored secret."""
+    drv = AutoGpgDriver()
+    val = _load().get(name)
+    if val is None:
+        raise KeyError("Unknown secret")
+    return drv.decrypt(val.encode()).decode()
+
+
+def remove_local_secret(name: str) -> None:
+    """Remove a secret from the local store."""
+    data = _load()
+    data.pop(name, None)
+    _save(data)
+
+
+def add_remote_secret(
+    secret_id: str,
+    value: str,
+    gateway_url: str = DEFAULT_GATEWAY,
+    *,
+    version: int = 0,
+    recipients: List[Path] | None = None,
+    pool: str = "default",
+) -> dict:
+    """Upload an encrypted secret to the gateway."""
+    drv = AutoGpgDriver()
+    pubs = [p.read_text() for p in recipients or []]
+    pubs.extend(_pool_worker_pubs(pool, gateway_url))
+    cipher = drv.encrypt(value.encode(), pubs).decode()
+    envelope = {
+        "jsonrpc": "2.0",
+        "method": "Secrets.add",
+        "params": {"id": secret_id, "secret": cipher, "version": version},
+    }
+    res = httpx.post(gateway_url, json=envelope, timeout=10.0)
+    res.raise_for_status()
+    return res.json()
+
+
+def get_remote_secret(secret_id: str, gateway_url: str = DEFAULT_GATEWAY) -> str:
+    """Retrieve and decrypt a secret from the gateway."""
+    drv = AutoGpgDriver()
+    envelope = {
+        "jsonrpc": "2.0",
+        "method": "Secrets.get",
+        "params": {"id": secret_id},
+    }
+    res = httpx.post(gateway_url, json=envelope, timeout=10.0)
+    res.raise_for_status()
+    cipher = res.json()["result"]["secret"].encode()
+    return drv.decrypt(cipher).decode()
+
+
+def remove_remote_secret(
+    secret_id: str,
+    gateway_url: str = DEFAULT_GATEWAY,
+    version: Optional[int] = None,
+) -> dict:
+    """Delete a secret stored on the gateway."""
+    envelope = {
+        "jsonrpc": "2.0",
+        "method": "Secrets.delete",
+        "params": {"id": secret_id, "version": version},
+    }
+    res = httpx.post(gateway_url, json=envelope, timeout=10.0)
+    res.raise_for_status()
+    return res.json()

--- a/pkgs/standards/peagen/peagen/handlers/keys_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/keys_handler.py
@@ -1,0 +1,41 @@
+"""Async entry point for key management tasks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+from peagen.core import keys_core
+from peagen.models import Task
+
+
+async def keys_handler(task: Dict[str, Any] | Task) -> Dict[str, Any]:
+    """Handle key management actions."""
+    payload = task.get("payload", {})
+    action = payload.get("action")
+    args: Dict[str, Any] = payload.get("args", {})
+
+    if action == "create":
+        return keys_core.create_keypair(
+            key_dir=Path(args.get("key_dir")) if args.get("key_dir") else None,
+            passphrase=args.get("passphrase"),
+        )
+
+    if action == "upload":
+        return keys_core.upload_public_key(
+            key_dir=Path(args.get("key_dir")) if args.get("key_dir") else None,
+            gateway_url=args.get("gateway_url", keys_core.DEFAULT_GATEWAY),
+        )
+
+    if action == "remove":
+        return keys_core.remove_public_key(
+            args["fingerprint"],
+            gateway_url=args.get("gateway_url", keys_core.DEFAULT_GATEWAY),
+        )
+
+    if action == "fetch-server":
+        return keys_core.fetch_server_keys(
+            gateway_url=args.get("gateway_url", keys_core.DEFAULT_GATEWAY)
+        )
+
+    raise ValueError(f"Unknown action '{action}'")

--- a/pkgs/standards/peagen/peagen/handlers/login_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/login_handler.py
@@ -1,0 +1,24 @@
+"""Async entry point for login operations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from peagen.core.login_core import login
+from peagen.models import Task
+
+
+async def login_handler(task: Dict[str, Any] | Task) -> Dict[str, Any]:
+    """Handle a login task."""
+    payload = task.get("payload", {})
+    args: Dict[str, Any] = payload.get("args", {})
+    key_dir = args.get("key_dir")
+    passphrase: Optional[str] = args.get("passphrase")
+    gateway_url = args.get("gateway_url", "http://localhost:8000/rpc")
+    result = login(
+        key_dir=Path(key_dir) if key_dir else None,
+        passphrase=passphrase,
+        gateway_url=gateway_url,
+    )
+    return result

--- a/pkgs/standards/peagen/peagen/handlers/secrets_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/secrets_handler.py
@@ -1,0 +1,55 @@
+"""Async entry point for secret management."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+from peagen.core import secrets_core
+from peagen.models import Task
+
+
+async def secrets_handler(task: Dict[str, Any] | Task) -> Dict[str, Any]:
+    """Dispatch secret management actions."""
+    payload = task.get("payload", {})
+    action = payload.get("action")
+    args: Dict[str, Any] = payload.get("args", {})
+
+    if action == "local-add":
+        recipients = [Path(p) for p in args.get("recipients", [])]
+        secrets_core.add_local_secret(args["name"], args["value"], recipients)
+        return {"ok": True}
+
+    if action == "local-get":
+        return {"secret": secrets_core.get_local_secret(args["name"])}
+
+    if action == "local-remove":
+        secrets_core.remove_local_secret(args["name"])
+        return {"ok": True}
+
+    if action == "remote-add":
+        recipients = [Path(p) for p in args.get("recipient", [])]
+        return secrets_core.add_remote_secret(
+            args["secret_id"],
+            args["value"],
+            gateway_url=args.get("gateway_url", secrets_core.DEFAULT_GATEWAY),
+            version=int(args.get("version", 0)),
+            recipients=recipients,
+            pool=args.get("pool", "default"),
+        )
+
+    if action == "remote-get":
+        secret = secrets_core.get_remote_secret(
+            args["secret_id"],
+            gateway_url=args.get("gateway_url", secrets_core.DEFAULT_GATEWAY),
+        )
+        return {"secret": secret}
+
+    if action == "remote-remove":
+        return secrets_core.remove_remote_secret(
+            args["secret_id"],
+            gateway_url=args.get("gateway_url", secrets_core.DEFAULT_GATEWAY),
+            version=args.get("version"),
+        )
+
+    raise ValueError(f"Unknown action '{action}'")


### PR DESCRIPTION
## Summary
- implement core logic for uploading keys and managing secrets
- add async handlers for login, keys, and secrets

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format peagen/core/login_core.py peagen/core/keys_core.py peagen/core/secrets_core.py peagen/handlers/login_handler.py peagen/handlers/keys_handler.py peagen/handlers/secrets_handler.py`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check peagen/core/login_core.py peagen/core/keys_core.py peagen/core/secrets_core.py peagen/handlers/login_handler.py peagen/handlers/keys_handler.py peagen/handlers/secrets_handler.py --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_6857d5f6a8448326a9ad433113d89850