### PR TITLE
Fix secrets table conflict

### DIFF
--- a/pkgs/standards/peagen/peagen/models/__init__.py
+++ b/pkgs/standards/peagen/peagen/models/__init__.py
@@ -2,17 +2,15 @@ from __future__ import annotations
 
 from peagen.models.task_run import Base, TaskRun
 
-from peagen.models.secret import Secret
 from peagen.models.schemas import (
     Role,
     Status,
-    Task,
     Pool,
     User,
 )
-  from peagen.models.core_models import (
+from peagen.models.core_models import (
     Tenant,
-    User,
+    User as DbUser,
     PublicKey,
     Secret,
     Task,

--- a/pkgs/standards/peagen/peagen/models/core_models.py
+++ b/pkgs/standards/peagen/peagen/models/core_models.py
@@ -77,6 +77,7 @@ class Secret(Base, _TenantBase):
 
     __table_args__ = (
         UniqueConstraint("tenant_id", "name", name="uq_secrets_tenant_name"),
+        {"extend_existing": True},
     )
 
 

--- a/pkgs/standards/peagen/peagen/models/secret.py
+++ b/pkgs/standards/peagen/peagen/models/secret.py
@@ -9,6 +9,7 @@ from .task_run import Base
 
 class Secret(Base):
     __tablename__ = "secrets"
+    __table_args__ = {"extend_existing": True}
 
     tenant_id = Column(String, primary_key=True)
     owner_fpr = Column(String, nullable=False)


### PR DESCRIPTION
## Summary
- avoid duplicate metadata errors by allowing existing `secrets` table
- clean up imports in peagen models

## Testing
- `uv run --directory standards --package peagen ruff check peagen/peagen/models/secret.py peagen/peagen/models/core_models.py peagen/peagen/models/__init__.py --fix`
- `uv run --package peagen --directory standards pytest -q` *(fails: ModuleNotFoundError: No module named 'peagen.plugin_registry')*

------
https://chatgpt.com/codex/tasks/task_e_6857e03553d08326b4514b1c1c360058