### PR TITLE
Run ruff and fix model exports

### DIFF
--- a/pkgs/standards/peagen/migrations/versions/b4b95933c789_secrets_table.py
+++ b/pkgs/standards/peagen/migrations/versions/b4b95933c789_secrets_table.py
@@ -3,7 +3,7 @@ import sqlalchemy as sa
 from sqlalchemy import inspect
 
 revision = "b4b95933c789"
-down_revision = "a6cc5b24ad5c"
+down_revision = "0001"
 
 
 def upgrade() -> None:

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -29,7 +29,8 @@ from peagen.models import Task, Status, Base, TaskRun
 
 from peagen.gateway.ws_server import router as ws_router
 
-from peagen.gateway.db import engine, Session
+from importlib import reload
+from peagen.gateway import db as _db
 from peagen.plugins import PluginManager
 from peagen._utils.config_loader import resolve_cfg
 from peagen.gateway.db_helpers import (
@@ -40,8 +41,11 @@ from peagen.gateway.db_helpers import (
 )
 from peagen.core.migrate_core import alembic_upgrade
 import peagen.defaults as defaults
-
 from peagen.core.task_core import get_task_result
+
+_db = reload(_db)
+engine = _db.engine
+Session = _db.Session
 
 TASK_KEY = defaults.CONFIG["task_key"]
 
@@ -313,7 +317,6 @@ async def keys_delete(fingerprint: str) -> dict:
 
 
 @rpc.method("Secrets.add")
-
 async def secrets_add(
     name: str,
     secret: str,

--- a/pkgs/standards/peagen/peagen/models/__init__.py
+++ b/pkgs/standards/peagen/peagen/models/__init__.py
@@ -1,24 +1,8 @@
 from __future__ import annotations
 
 from peagen.models.task_run import Base, TaskRun
-
+from peagen.models.schemas import Role, Status, Task, Pool, User
 from peagen.models.secret import Secret
-from peagen.models.schemas import (
-    Role,
-    Status,
-    Task,
-    Pool,
-    User,
-)
-  from peagen.models.core_models import (
-    Tenant,
-    User,
-    PublicKey,
-    Secret,
-    Task,
-    Artifact,
-    DeployKey,
-)
 
 __all__ = [
     "Role",
@@ -28,11 +12,5 @@ __all__ = [
     "User",
     "Base",
     "TaskRun",
-    "Tenant",
-    "DbUser",
-    "PublicKey",
     "Secret",
-    "Task",
-    "Artifact",
-    "DeployKey",
 ]

--- a/pkgs/standards/peagen/tests/unit/test_secret_store.py
+++ b/pkgs/standards/peagen/tests/unit/test_secret_store.py
@@ -3,8 +3,8 @@ import importlib
 import pytest
 
 from peagen.models import Base
-from peagen.gateway.db import engine
 import peagen.gateway as gw
+import peagen.gateway.db as db
 
 
 @pytest.mark.unit
@@ -12,7 +12,8 @@ import peagen.gateway as gw
 async def test_secret_roundtrip(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     importlib.reload(gw)
-    async with engine.begin() as conn:
+    importlib.reload(db)
+    async with db.engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
 
     await gw.secrets_add(name="foo", secret="bar")

--- a/pkgs/standards/peagen/tests/unit/test_secret_store_versioning.py
+++ b/pkgs/standards/peagen/tests/unit/test_secret_store_versioning.py
@@ -3,8 +3,8 @@ import importlib
 import pytest
 
 from peagen.models import Base
-from peagen.gateway.db import engine
 import peagen.gateway as gw
+import peagen.gateway.db as db
 
 
 @pytest.mark.asyncio
@@ -12,7 +12,8 @@ async def test_secret_roundtrip(tmp_path, monkeypatch):
     """Validate storing, retrieving and deleting secrets."""
     monkeypatch.chdir(tmp_path)
     importlib.reload(gw)
-    async with engine.begin() as conn:
+    importlib.reload(db)
+    async with db.engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
 
     await gw.secrets_add(name="ns/test", secret="a")


### PR DESCRIPTION
## Summary
- run ruff on peagen
- cleanup `peagen.models` export list
- reload gateway DB module for tmp dirs
- fix alembic revision chain
- update secret store tests

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_6857d3782440832688a1a0e200433221