### PR TITLE
Fix alembic config path for peagen

### DIFF
--- a/pkgs/standards/peagen/alembic.ini
+++ b/pkgs/standards/peagen/alembic.ini
@@ -1,5 +1,7 @@
 [alembic]
-script_location = pkgs/standards/peagen/migrations
+# Resolve migrations relative to this configuration file so the paths work
+# from both the source tree and installed wheels.
+script_location = %(here)s/migrations
 
 [loggers]
 keys = root

--- a/pkgs/standards/peagen/peagen/core/migrate_core.py
+++ b/pkgs/standards/peagen/peagen/core/migrate_core.py
@@ -6,9 +6,12 @@ from typing import Any, Dict
 
 
 # ``alembic.ini`` sits alongside the ``migrations`` directory in the package
-# root. ``parents[2]`` reliably resolves to that location for both source and
-# installed packages.
-ALEMBIC_CFG = Path(__file__).resolve().parents[2] / "alembic.ini"
+# root. When running from source this lives two levels up from this file, while
+# an installed wheel places it one level up. Check both locations for
+# robustness.
+_src_cfg = Path(__file__).resolve().parents[2] / "alembic.ini"
+_pkg_cfg = Path(__file__).resolve().parents[1] / "alembic.ini"
+ALEMBIC_CFG = _src_cfg if _src_cfg.exists() else _pkg_cfg
 
 
 def alembic_upgrade(cfg: Path = ALEMBIC_CFG) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- ensure alembic.ini path works from source and wheel
- make alembic.ini reference migrations relative to itself

## Testing
- `uv run --directory standards/peagen --package peagen ruff format peagen/core/migrate_core.py`
- `uv run --directory standards/peagen --package peagen ruff check peagen/core/migrate_core.py --fix`
- `uv run --directory standards/peagen --package peagen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857e4c498a88326b4c8869b73622b89