### PR TITLE
Fix lint errors in peagen models

### DIFF
--- a/pkgs/standards/peagen/peagen/models/__init__.py
+++ b/pkgs/standards/peagen/peagen/models/__init__.py
@@ -1,24 +1,8 @@
 from __future__ import annotations
 
 from peagen.models.task_run import Base, TaskRun, TaskRunDep
-from peagen.models.schemas import Role, Status, Task, Pool, User
 from peagen.models.secret import Secret
-
-from peagen.models.schemas import (
-    Role,
-    Status,
-    Pool,
-    User,
-)
-from peagen.models.core_models import (
-    Tenant,
-    User as DbUser,
-    PublicKey,
-    Secret,
-    Task,
-    Artifact,
-    DeployKey,
-)
+from peagen.models.schemas import Pool, Role, Status, Task, User
 
 __all__ = [
     "Role",

--- a/pkgs/standards/peagen/peagen/models/task_run.py
+++ b/pkgs/standards/peagen/peagen/models/task_run.py
@@ -1,11 +1,11 @@
 import datetime as dt
 import uuid
-from typing import Any, Dict, Iterable, Optional
+from typing import Any, Dict, Iterable, Optional, List
 
-from sqlalchemy import JSON, TIMESTAMP, String
+from sqlalchemy import JSON, TIMESTAMP, String, Column, ForeignKey
 from sqlalchemy.dialects import postgresql as psql
 from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 from peagen.models.schemas import Status
 
 
@@ -68,7 +68,7 @@ class TaskRun(Base):
         super().__init__(**kwargs)
 
     @property
-    def deps(self) -> List[str]:
+    def deps(self) -> List[str]:  # noqa: F811 - overrides the mapped column
         if getattr(self, "_raw_deps", None):
             return self._raw_deps
         return [str(d.id) for d in self._deps_rel]


### PR DESCRIPTION
## Summary
- remove duplicate imports in peagen.models
- add missing imports and ignore redeclaration warning

## Testing
- `uv run --package peagen --directory . ruff format peagen/models/__init__.py peagen/models/task_run.py`
- `uv run --package peagen --directory . ruff check peagen/models/__init__.py peagen/models/task_run.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_6857e7d358a08326a169991d3e605c8d