### PR TITLE
Fix alembic invocation in Dockerfile.gw

### DIFF
--- a/infra/Dockerfile.gw
+++ b/infra/Dockerfile.gw
@@ -34,4 +34,4 @@ ENV \
     MINIO_USER="" \
     MINIO_ROOT_PASSWORD=""
     
-CMD ["sh", "-c", "alembic -c pkgs/standards/peagen/alembic.ini upgrade head && python -c 'import uvicorn; uvicorn.run(\"peagen.gateway:app\", host=\"0.0.0.0\", port=8000, log_level=\"info\")'"]
+CMD ["sh", "-c", "python -m alembic -c pkgs/standards/peagen/alembic.ini upgrade head && python -c 'import uvicorn; uvicorn.run(\"peagen.gateway:app\", host=\"0.0.0.0\", port=8000, log_level=\"info\")'"]


### PR DESCRIPTION
## Summary
- use module invocation when running alembic in `infra/Dockerfile.gw`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857ed47c78083269ffb214abf07b583