### PR TITLE
Fix TaskRun oids column

### DIFF
--- a/pkgs/standards/peagen/migrations/versions/c1a2b3c4d5e6_rename_artifact_uri_to_oids.py
+++ b/pkgs/standards/peagen/migrations/versions/c1a2b3c4d5e6_rename_artifact_uri_to_oids.py
@@ -3,7 +3,7 @@ import sqlalchemy as sa
 from sqlalchemy import inspect
 
 revision = "c1a2b3c4d5e6"
-down_revision = "a6cc5b24ad5c"
+down_revision = "c3f9a1d1855a"
 
 
 def upgrade():

--- a/pkgs/standards/peagen/peagen/models/task_run.py
+++ b/pkgs/standards/peagen/peagen/models/task_run.py
@@ -46,7 +46,7 @@ class TaskRun(Base):
     labels: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
     in_degree: Mapped[int] = mapped_column(psql.INTEGER, nullable=False, default=0)
     config_toml: Mapped[str | None] = mapped_column(String, nullable=True)
-    artifact_uri: Mapped[str | None] = mapped_column(String, nullable=True)
+    oids: Mapped[list[str] | None] = mapped_column(JSON, nullable=True)
     commit_hexsha: Mapped[str | None] = mapped_column(String, nullable=True)
     started_at: Mapped[dt.datetime] = mapped_column(
         TIMESTAMP(timezone=True), default=dt.datetime.utcnow
@@ -72,6 +72,7 @@ class TaskRun(Base):
         if getattr(self, "_raw_deps", None):
             return self._raw_deps
         return [str(d.id) for d in self._deps_rel]
+
     # ──────────────────────────────────────────────────────────────
     @classmethod
     def from_task(cls, task) -> "TaskRun":


### PR DESCRIPTION
## Summary
- adjust migration chain for peagen
- add `oids` JSON column to `TaskRun`

## Testing
- `uv run --package peagen --directory standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_6857ef43dd0c83268d7cb4ca968756c4