### PR TITLE
Add Alembic DB commands to peagen

### DIFF
--- a/pkgs/standards/peagen/peagen/alembic.ini
+++ b/pkgs/standards/peagen/peagen/alembic.ini
@@ -1,0 +1,26 @@
+[alembic]
+script_location = %(here)s/migrations
+sqlalchemy.url = sqlite:///peagen.db
+
+[loggers]
+keys = root
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/pkgs/standards/peagen/peagen/cli.py
+++ b/pkgs/standards/peagen/peagen/cli.py
@@ -15,6 +15,7 @@ from peagen.commands import (
     validate_app,
     extras_app,
     eval_app,
+    db_app,
 )
 
 _print_banner()
@@ -31,6 +32,7 @@ app.add_typer(template_sets_app, name="template-set")
 app.add_typer(extras_app, name="extras-schemas")
 app.add_typer(validate_app, name="validate")
 app.add_typer(eval_app, name="eval")
+app.add_typer(db_app, name="db")
 
 if __name__ == "__main__":
     app()

--- a/pkgs/standards/peagen/peagen/commands/__init__.py
+++ b/pkgs/standards/peagen/peagen/commands/__init__.py
@@ -10,6 +10,7 @@ from peagen.commands.program import program_app
 from peagen.commands.validate import validate_app
 from peagen.commands.extras import extras_app
 from peagen.commands.eval import eval_app
+from peagen.commands.db import db_app
 
 __all__ = [
     "init_app",
@@ -22,4 +23,5 @@ __all__ = [
     "validate_app",
     "extras_app",
     "eval_app",
+    "db_app",
 ]

--- a/pkgs/standards/peagen/peagen/commands/db.py
+++ b/pkgs/standards/peagen/peagen/commands/db.py
@@ -1,0 +1,36 @@
+"""Database migration commands for Peagen."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+from alembic import command
+from alembic.config import Config
+
+
+db_app = typer.Typer(help="Manage Peagen database migrations.")
+
+
+def _alembic_config() -> Config:
+    """Return Alembic Config pointing to package alembic.ini."""
+    ini_path = Path(__file__).resolve().parents[1] / "alembic.ini"
+    return Config(str(ini_path))
+
+
+@db_app.command("upgrade")
+def upgrade(revision: str = "head") -> None:
+    """Upgrade local database to a given revision (default: head)."""
+    cfg = _alembic_config()
+    typer.echo(f"Upgrading local database to {revision} …")
+    command.upgrade(cfg, revision)
+    typer.echo("✅  Upgrade complete.")
+
+
+@db_app.command("downgrade")
+def downgrade(revision: str = "-1") -> None:
+    """Downgrade local database to a given revision (default: -1)."""
+    cfg = _alembic_config()
+    typer.echo(f"Downgrading local database to {revision} …")
+    command.downgrade(cfg, revision)
+    typer.echo("✅  Downgrade complete.")

--- a/pkgs/standards/peagen/peagen/migrations/env.py
+++ b/pkgs/standards/peagen/peagen/migrations/env.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+config = context.config
+
+# Default to sqlite database in current working directory
+if not config.get_main_option("sqlalchemy.url"):
+    config.set_main_option("sqlalchemy.url", "sqlite:///peagen.db")
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in offline mode."""
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(url=url, literal_binds=True, compare_type=True)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in online mode."""
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=None, compare_type=True)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/pkgs/standards/peagen/peagen/migrations/versions/README.md
+++ b/pkgs/standards/peagen/peagen/migrations/versions/README.md
@@ -1,0 +1,1 @@
+# Alembic versions

--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -30,6 +30,8 @@ dependencies = [
     "swarmauri",
     "swarmauri_prompt_j2prompttemplate",
     "pika",
+    "alembic",
+    "sqlalchemy>=2.0",
 ]
 
 
@@ -98,3 +100,5 @@ rabbitmq = "peagen.publishers.rabbitmq_publisher:RabbitMQPublisher"
 
 [tool.setuptools.package-data]
 "peagen.schemas" = ["*.json", "extras/*.json"]
+"peagen" = ["alembic.ini"]
+"peagen.migrations" = ["*.py", "versions/*.py"]


### PR DESCRIPTION
## Summary
- add `peagen db` subcommands for upgrade and downgrade
- include Alembic config inside package
- expose db_app via CLI
- register new package data and dependencies

## Testing
- `pip install -e pkgs/standards/peagen`
- `uv run --package peagen --directory pkgs/standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_6857f468e85c832682d770568268a895