### PR TITLE
Use plugin manager for secret drivers

### DIFF
--- a/pkgs/standards/peagen/docs/secret_refs.md
+++ b/pkgs/standards/peagen/docs/secret_refs.md
@@ -5,8 +5,8 @@ hardcoding them in your configuration files. Any LLM definition may specify a
 `secretRef` like `env:OPENAI_API_KEY` in place of an `api_key` value.
 
 When Peagen encounters a `secretRef` it resolves the value using the configured
-secret provider. The default provider `EnvSecret` reads from environment
-variables. You can register custom providers under the
+secret provider. The default provider `AutoGpgDriver` manages encrypted
+secrets on disk. You can register custom providers under the
 `peagen.plugins.secret_drivers` entry point group.
 
 ```yaml

--- a/pkgs/standards/peagen/peagen/cli/commands/secrets.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/secrets.py
@@ -9,7 +9,8 @@ from typing import List
 import httpx
 import typer
 
-from peagen.plugins.secret_drivers import AutoGpgDriver
+from peagen import resolve_plugin_spec
+from peagen._utils.config_loader import resolve_cfg
 
 
 local_secrets_app = typer.Typer(help="Manage local secret store.")
@@ -53,7 +54,10 @@ def _save(data: dict) -> None:
 @local_secrets_app.command("add")
 def add(name: str, value: str, recipients: List[Path] = typer.Option([])) -> None:
     """Encrypt and store a secret locally."""
-    drv = AutoGpgDriver()
+    cfg = resolve_cfg()
+    plugin_name = cfg.get("secrets", {}).get("default_secret", "autogpg")
+    Driver = resolve_plugin_spec("secrets", plugin_name)
+    drv = Driver()
     pubkeys = [p.read_text() for p in recipients]
     cipher = drv.encrypt(value.encode(), pubkeys).decode()
     data = _load()
@@ -65,7 +69,10 @@ def add(name: str, value: str, recipients: List[Path] = typer.Option([])) -> Non
 @local_secrets_app.command("get")
 def get(name: str) -> None:
     """Decrypt and print a secret."""
-    drv = AutoGpgDriver()
+    cfg = resolve_cfg()
+    plugin_name = cfg.get("secrets", {}).get("default_secret", "autogpg")
+    Driver = resolve_plugin_spec("secrets", plugin_name)
+    drv = Driver()
     val = _load().get(name)
     if not val:
         raise typer.BadParameter("Unknown secret")
@@ -96,7 +103,10 @@ def remote_add(
     gateway_url = gateway_url.rstrip("/")
     if not gateway_url.endswith("/rpc"):
         gateway_url += "/rpc"
-    drv = AutoGpgDriver()
+    cfg = resolve_cfg()
+    plugin_name = cfg.get("secrets", {}).get("default_secret", "autogpg")
+    Driver = resolve_plugin_spec("secrets", plugin_name)
+    drv = Driver()
     pubs = [p.read_text() for p in recipient]
     pubs.extend(_pool_worker_pubs(pool, gateway_url))
     cipher = drv.encrypt(value.encode(), pubs).decode()
@@ -125,7 +135,10 @@ def remote_get(
     gateway_url = gateway_url.rstrip("/")
     if not gateway_url.endswith("/rpc"):
         gateway_url += "/rpc"
-    drv = AutoGpgDriver()
+    cfg = resolve_cfg()
+    plugin_name = cfg.get("secrets", {}).get("default_secret", "autogpg")
+    Driver = resolve_plugin_spec("secrets", plugin_name)
+    drv = Driver()
     envelope = {
         "jsonrpc": "2.0",
         "method": "Secrets.get",

--- a/pkgs/standards/peagen/peagen/core/login_core.py
+++ b/pkgs/standards/peagen/peagen/core/login_core.py
@@ -7,7 +7,8 @@ from typing import Optional
 
 import httpx
 
-from peagen.plugins.secret_drivers import AutoGpgDriver
+from peagen import resolve_plugin_spec
+from peagen._utils.config_loader import resolve_cfg
 
 DEFAULT_GATEWAY = "http://localhost:8000/rpc"
 
@@ -27,7 +28,10 @@ def login(
     Returns:
         dict: JSON response from the gateway.
     """
-    drv = AutoGpgDriver(key_dir=key_dir, passphrase=passphrase)
+    cfg = resolve_cfg()
+    plugin_name = cfg.get("secrets", {}).get("default_secret", "autogpg")
+    Driver = resolve_plugin_spec("secrets", plugin_name)
+    drv = Driver(key_dir=key_dir, passphrase=passphrase)
     pubkey = drv.pub_path.read_text()
     payload = {
         "jsonrpc": "2.0",

--- a/pkgs/standards/peagen/peagen/defaults.py
+++ b/pkgs/standards/peagen/peagen/defaults.py
@@ -44,5 +44,11 @@ CONFIG = {
         "default_filter": "file",
         "filters": {"file": {"output_dir": "./peagen_artifacts"}},
     },
-    "secrets": {"default_secret": "env", "adapters": {"env": {"prefix": ""}}},
+    "secrets": {
+        "default_secret": "autogpg",
+        "adapters": {
+            "autogpg": {},
+            "env": {"prefix": ""},
+        },
+    },
 }

--- a/pkgs/standards/peagen/peagen/plugins/vcs/git_vcs.py
+++ b/pkgs/standards/peagen/peagen/plugins/vcs/git_vcs.py
@@ -12,7 +12,8 @@ import paramiko
 import pygit2
 
 from git import Repo
-from peagen.plugins.secret_drivers import AutoGpgDriver
+from peagen import resolve_plugin_spec
+from peagen._utils.config_loader import resolve_cfg
 
 from .constants import PEAGEN_REFS_PREFIX
 
@@ -157,7 +158,10 @@ class GitVCS:
         res.raise_for_status()
         cipher = res.json()["result"]["secret"].encode()
 
-        drv = AutoGpgDriver()
+        cfg = resolve_cfg()
+        plugin_name = cfg.get("secrets", {}).get("default_secret", "autogpg")
+        Driver = resolve_plugin_spec("secrets", plugin_name)
+        drv = Driver()
         key_text = drv.decrypt(cipher).decode()
 
         pkey = paramiko.RSAKey.from_private_key(io.StringIO(key_text))

--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -173,6 +173,10 @@ result_backend = "peagen.plugins.selectors.result_backend_selector:ResultBackend
 bootstrap = "peagen.plugins.selectors.bootstrap_selector:BootstrapSelector"
 input = "peagen.plugins.selectors.input_selector:InputSelector"
 
+[project.entry-points."peagen.plugins.secret_drivers"]
+autogpg = "peagen.plugins.secret_drivers.autogpg_secretdriver:AutoGpgDriver"
+env = "peagen.plugins.secret_drivers.env_secret:EnvSecret"
+
 [project.entry-points."peagen.plugins.mutators"]
 default_mutator = "peagen.plugins.mutators.default_mutator:DefaultMutator"
 echo_mutator = "peagen.plugins.mutators.echo_mutator:EchoMutator"


### PR DESCRIPTION
## Summary
- register secret drivers in pyproject
- make AutoGpgDriver the default secret plugin
- load secret driver via plugin manager in login/keys/secrets helpers
- update git VCS secret handling
- document new default secret provider

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`

------
https://chatgpt.com/codex/tasks/task_e_6857f6142aa08326b248d7a1d10296cf