### PR TITLE
Fix alembic path for peagen db commands

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/db.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/db.py
@@ -10,9 +10,11 @@ import typer
 from peagen.handlers.migrate_handler import migrate_handler
 from peagen.models import Task
 
-# ``alembic.ini`` lives in the package root next to ``migrations``. Using
-# ``parents[2]`` works whether running from source or an installed wheel.
-ALEMBIC_CFG = Path(__file__).resolve().parents[2] / "alembic.ini"
+# ``alembic.ini`` lives in ``pkgs/standards/peagen`` next to ``migrations``.
+# ``db.py`` sits under ``peagen/cli/commands``. Climbing three directories
+# resolves to the package root whether running from source or an installed
+# wheel.
+ALEMBIC_CFG = Path(__file__).resolve().parents[3] / "alembic.ini"
 
 local_db_app = typer.Typer(help="Database utilities.")
 


### PR DESCRIPTION
## Summary
- ensure `peagen local db` commands locate `alembic.ini` correctly
- run ruff and pytest for `peagen` package

## Testing
- `uv run --package peagen --directory . ruff format peagen/cli/commands/db.py`
- `uv run --package peagen --directory . ruff check peagen/cli/commands/db.py --fix`
- `uv run --package peagen --directory . pytest -q`
- `uv run peagen local db upgrade`
- `uv run peagen local db downgrade`

------
https://chatgpt.com/codex/tasks/task_e_6857faeb6a088326a2fe010118b2b5f6