### PR TITLE
Fix gateway-url defaults and duplication

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/__init__.py
+++ b/pkgs/standards/peagen/peagen/cli/__init__.py
@@ -10,6 +10,8 @@ from pathlib import Path
 
 import typer
 
+import peagen.defaults as defaults
+
 # ─── Banner helper (printed unless –quiet) ────────────────────────────────
 from ._banner import _print_banner
 
@@ -116,7 +118,9 @@ def __global_local_ctx(  # noqa: D401
 def _global_remote_ctx(  # noqa: D401
     ctx: typer.Context,
     gateway_url: str = typer.Option(
-        "http://localhost:8000/rpc", "--gateway-url", help="JSON-RPC gateway endpoint"
+        defaults.CONFIG["gateway_url"],
+        "--gateway-url",
+        help="JSON-RPC gateway endpoint",
     ),
     override: str = typer.Option(
         None, "--override", help="JSON string to merge into cfg on the worker."

--- a/pkgs/standards/peagen/peagen/cli/commands/extras.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/extras.py
@@ -56,14 +56,12 @@ def run_extras(
 
 @remote_extras_app.command("extras")
 def submit_extras(
+    ctx: typer.Context,
     templates_root: Optional[Path] = typer.Option(
         None, "--templates-root", help="Directory containing template sets"
     ),
     schemas_dir: Optional[Path] = typer.Option(
         None, "--schemas-dir", help="Destination for generated schema files"
-    ),
-    gateway_url: str = typer.Option(
-        "http://localhost:8000/rpc", "--gateway-url", help="JSON-RPC gateway endpoint"
     ),
 ) -> None:
     """Submit EXTRAS schema generation as a background task."""
@@ -72,6 +70,7 @@ def submit_extras(
         "schemas_dir": str(schemas_dir.expanduser()) if schemas_dir else None,
     }
     task = _build_task(args)
+    gateway_url = ctx.obj.get("gateway_url")
 
     envelope = {
         "jsonrpc": "2.0",

--- a/pkgs/standards/peagen/peagen/cli/commands/init.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/init.py
@@ -152,9 +152,6 @@ def remote_init_project(
     add_filter_config: bool = typer.Option(
         False, "--add-filter-config", help="Also record filter in .peagen.toml"
     ),
-    gateway_url: str = typer.Option(
-        DEFAULT_GATEWAY, "--gateway-url", help="JSON-RPC gateway endpoint"
-    ),
 ):
     """Submit a project scaffold task via JSON-RPC."""
     args = {
@@ -168,6 +165,7 @@ def remote_init_project(
         "git_remote": git_remote,
         "filter_uri": filter_uri,
     }
+    gateway_url = ctx.obj.get("gateway_url")
     _submit_task(args, gateway_url, "init project")
 
 
@@ -218,9 +216,6 @@ def remote_init_template_set(
     force: bool = typer.Option(
         False, "--force", help="Overwrite destination if not empty"
     ),
-    gateway_url: str = typer.Option(
-        DEFAULT_GATEWAY, "--gateway-url", help="JSON-RPC gateway endpoint"
-    ),
 ):
     """Submit a template-set scaffold task via JSON-RPC."""
     args = {
@@ -231,6 +226,7 @@ def remote_init_template_set(
         "use_uv": use_uv,
         "force": force,
     }
+    gateway_url = ctx.obj.get("gateway_url")
     _submit_task(args, gateway_url, "init template-set")
 
 
@@ -273,9 +269,6 @@ def remote_init_doe_spec(
     force: bool = typer.Option(
         False, "--force", help="Overwrite destination if not empty"
     ),
-    gateway_url: str = typer.Option(
-        DEFAULT_GATEWAY, "--gateway-url", help="JSON-RPC gateway endpoint"
-    ),
 ):
     """Submit a DOE-spec scaffold task via JSON-RPC."""
     args = {
@@ -285,6 +278,7 @@ def remote_init_doe_spec(
         "org": org,
         "force": force,
     }
+    gateway_url = ctx.obj.get("gateway_url")
     _submit_task(args, gateway_url, "init doe-spec")
 
 
@@ -328,9 +322,6 @@ def remote_init_ci(
     force: bool = typer.Option(
         False, "--force", help="Overwrite destination if not empty"
     ),
-    gateway_url: str = typer.Option(
-        DEFAULT_GATEWAY, "--gateway-url", help="JSON-RPC gateway endpoint"
-    ),
 ):
     """Submit a CI pipeline scaffold task via JSON-RPC."""
     args = {
@@ -339,18 +330,17 @@ def remote_init_ci(
         "github": github,
         "force": force,
     }
+    gateway_url = ctx.obj.get("gateway_url")
     _submit_task(args, gateway_url, "init ci")
 
 
 @remote_init_app.command("repo")
 def remote_init_repo(
+    ctx: typer.Context,
     repo: str = typer.Argument(..., help="tenant/repo"),
     pat: str = typer.Option(..., envvar="GITHUB_PAT", help="GitHub PAT"),
     description: str = typer.Option("", help="Repository description"),
     deploy_key: Path = typer.Option(None, "--deploy-key", help="Existing private key"),
-    gateway_url: str = typer.Option(
-        DEFAULT_GATEWAY, "--gateway-url", help="JSON-RPC gateway endpoint"
-    ),
 ) -> None:
     """Create a GitHub repository via JSON-RPC."""
     args = {
@@ -360,4 +350,5 @@ def remote_init_repo(
         "description": description,
         "deploy_key": str(deploy_key) if deploy_key else None,
     }
+    gateway_url = ctx.obj.get("gateway_url")
     _submit_task(args, gateway_url, "init repo")

--- a/pkgs/standards/peagen/peagen/cli/commands/keys.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/keys.py
@@ -9,6 +9,8 @@ from typing import Optional
 import httpx
 import typer
 
+import peagen.defaults as defaults
+
 from peagen.plugins.secret_drivers import AutoGpgDriver
 
 
@@ -31,7 +33,7 @@ def create(
 def upload(
     ctx: typer.Context,
     key_dir: Path = typer.Option(Path.home() / ".peagen" / "keys", "--key-dir"),
-    gateway_url: str = typer.Option("http://localhost:8000/rpc", "--gateway-url"),
+    gateway_url: str = typer.Option(defaults.CONFIG["gateway_url"], "--gateway-url"),
 ) -> None:
     """Upload the public key to the gateway."""
     drv = AutoGpgDriver(key_dir=key_dir)
@@ -49,7 +51,7 @@ def upload(
 def remove(
     ctx: typer.Context,
     fingerprint: str,
-    gateway_url: str = typer.Option("http://localhost:8000/rpc", "--gateway-url"),
+    gateway_url: str = typer.Option(defaults.CONFIG["gateway_url"], "--gateway-url"),
 ) -> None:
     """Remove a public key from the gateway."""
     envelope = {
@@ -64,7 +66,7 @@ def remove(
 @keys_app.command("fetch-server")
 def fetch_server(
     ctx: typer.Context,
-    gateway_url: str = typer.Option("http://localhost:8000/rpc", "--gateway-url"),
+    gateway_url: str = typer.Option(defaults.CONFIG["gateway_url"], "--gateway-url"),
 ) -> None:
     """Fetch trusted public keys from the gateway."""
     envelope = {"jsonrpc": "2.0", "method": "Keys.fetch"}

--- a/pkgs/standards/peagen/peagen/cli/commands/login.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/login.py
@@ -8,6 +8,8 @@ from typing import Optional
 import httpx
 import typer
 
+import peagen.defaults as defaults
+
 from peagen.plugins.secret_drivers import AutoGpgDriver
 
 
@@ -23,7 +25,7 @@ def login(
         hide_input=True,
     ),
     key_dir: Path = typer.Option(Path.home() / ".peagen" / "keys", "--key-dir"),
-    gateway_url: str = typer.Option("http://localhost:8000/rpc", "--gateway-url"),
+    gateway_url: str = typer.Option(defaults.CONFIG["gateway_url"], "--gateway-url"),
 ) -> None:
     """Ensure keys exist and upload the public key."""
     gateway_url = gateway_url.rstrip("/")

--- a/pkgs/standards/peagen/peagen/cli/commands/secrets.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/secrets.py
@@ -90,12 +90,9 @@ def remote_add(
     version: int = typer.Option(0, "--version"),
     recipient: List[Path] = typer.Option([], "--recipient"),
     pool: str = typer.Option("default", "--pool"),
-    gateway_url: str = typer.Option("http://localhost:8000/rpc", "--gateway-url"),
 ) -> None:
     """Upload an encrypted secret to the gateway."""
-    gateway_url = gateway_url.rstrip("/")
-    if not gateway_url.endswith("/rpc"):
-        gateway_url += "/rpc"
+    gateway_url = ctx.obj.get("gateway_url")
     drv = AutoGpgDriver()
     pubs = [p.read_text() for p in recipient]
     pubs.extend(_pool_worker_pubs(pool, gateway_url))
@@ -119,12 +116,9 @@ def remote_add(
 def remote_get(
     ctx: typer.Context,
     secret_id: str,
-    gateway_url: str = typer.Option("http://localhost:8000/rpc", "--gateway-url"),
 ) -> None:
     """Retrieve and decrypt a secret from the gateway."""
-    gateway_url = gateway_url.rstrip("/")
-    if not gateway_url.endswith("/rpc"):
-        gateway_url += "/rpc"
+    gateway_url = ctx.obj.get("gateway_url")
     drv = AutoGpgDriver()
     envelope = {
         "jsonrpc": "2.0",
@@ -147,12 +141,9 @@ def remote_remove(
     ctx: typer.Context,
     secret_id: str,
     version: int = typer.Option(None, "--version"),
-    gateway_url: str = typer.Option("http://localhost:8000/rpc", "--gateway-url"),
 ) -> None:
     """Delete a secret on the gateway."""
-    gateway_url = gateway_url.rstrip("/")
-    if not gateway_url.endswith("/rpc"):
-        gateway_url += "/rpc"
+    gateway_url = ctx.obj.get("gateway_url")
     envelope = {
         "jsonrpc": "2.0",
         "method": "Secrets.delete",

--- a/pkgs/standards/peagen/peagen/cli/commands/templates.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/templates.py
@@ -8,11 +8,13 @@ from typing import Any, Dict, Optional
 import httpx
 import typer
 
+import peagen.defaults as defaults
+
 from peagen.handlers.templates_handler import templates_handler
 from peagen.models import Task
 
 # ──────────────────────────────────────
-DEFAULT_GATEWAY = "http://localhost:8000/rpc"
+DEFAULT_GATEWAY = defaults.CONFIG["gateway_url"]
 
 local_template_sets_app = typer.Typer(
     help="Manage Peagen template-sets locally.",
@@ -64,12 +66,11 @@ def run_list():
 
 @remote_template_sets_app.command("list", help="Submit a list task via gateway.")
 def submit_list(
-    gateway_url: str = typer.Option(
-        DEFAULT_GATEWAY, "--gateway-url", help="JSON-RPC gateway endpoint"
-    ),
+    ctx: typer.Context,
 ):
     """Enqueue a template-set listing task on the gateway."""
     args = {"operation": "list"}
+    gateway_url = ctx.obj.get("gateway_url")
     try:
         task_id = _submit_task(args, gateway_url)
         typer.echo(f"Submitted list → taskId={task_id}")
@@ -106,13 +107,12 @@ def run_show(
 
 @remote_template_sets_app.command("show", help="Submit a show task via gateway.")
 def submit_show(
+    ctx: typer.Context,
     name: str = typer.Argument(..., metavar="SET_NAME"),
-    gateway_url: str = typer.Option(
-        DEFAULT_GATEWAY, "--gateway-url", help="JSON-RPC gateway endpoint"
-    ),
 ):
     """Request detailed information about a template-set."""
     args = {"operation": "show", "name": name}
+    gateway_url = ctx.obj.get("gateway_url")
     try:
         task_id = _submit_task(args, gateway_url)
         typer.echo(f"Submitted show → taskId={task_id}")
@@ -184,6 +184,7 @@ def run_add(
 
 @remote_template_sets_app.command("add", help="Submit an add task via gateway.")
 def submit_add(
+    ctx: typer.Context,
     source: str = typer.Argument(..., metavar="PKG|WHEEL|DIR"),
     from_bundle: Optional[str] = typer.Option(
         None, "--from-bundle", help="Install from bundled archive"
@@ -194,9 +195,6 @@ def submit_add(
     force: bool = typer.Option(
         False, "--force", help="Re-install even if already present"
     ),
-    gateway_url: str = typer.Option(
-        DEFAULT_GATEWAY, "--gateway-url", help="JSON-RPC gateway endpoint"
-    ),
 ):
     """Submit a template-set installation job via JSON-RPC."""
     args = {
@@ -206,6 +204,7 @@ def submit_add(
         "editable": editable,
         "force": force,
     }
+    gateway_url = ctx.obj.get("gateway_url")
     try:
         task_id = _submit_task(args, gateway_url)
         typer.echo(f"Submitted add → taskId={task_id}")
@@ -244,11 +243,9 @@ def run_remove(
 
 @remote_template_sets_app.command("remove", help="Submit a remove task via gateway.")
 def submit_remove(
+    ctx: typer.Context,
     name: str = typer.Argument(..., metavar="SET_NAME"),
     yes: bool = typer.Option(False, "-y", "--yes", help="Skip confirmation prompt."),
-    gateway_url: str = typer.Option(
-        DEFAULT_GATEWAY, "--gateway-url", help="JSON-RPC gateway endpoint"
-    ),
 ):
     """Submit a template-set removal job via JSON-RPC."""
     if not yes:
@@ -257,6 +254,7 @@ def submit_remove(
             raise typer.Exit()
 
     args = {"operation": "remove", "name": name}
+    gateway_url = ctx.obj.get("gateway_url")
     try:
         task_id = _submit_task(args, gateway_url)
         typer.echo(f"Submitted remove → taskId={task_id}")

--- a/pkgs/standards/peagen/peagen/cli/commands/tui.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/tui.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import asyncio
 import typer
 
+import peagen.defaults as defaults
+
 from peagen.tui.app import QueueDashboardApp
 
-DEFAULT_GATEWAY = "http://localhost:8000"
+DEFAULT_GATEWAY = defaults.CONFIG["gateway_url"].rsplit("/", 1)[0]
 
 
 dashboard_app = typer.Typer(help="Launch the Textual dashboard to monitor tasks.")


### PR DESCRIPTION
## Summary
- avoid duplicate `--gateway-url` arguments in several commands
- read gateway default from `peagen.defaults`
- update dashboard default to match new constant

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/cli/__init__.py peagen/cli/commands/login.py peagen/cli/commands/keys.py peagen/cli/commands/extras.py peagen/cli/commands/templates.py peagen/cli/commands/init.py peagen/cli/commands/secrets.py peagen/cli/commands/tui.py --fix`
- `uv run --package peagen --directory pkgs/standards pytest` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6857f6170a04832681e2aada393efe39