### PR TITLE
Fix peagen db command

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/db.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/db.py
@@ -10,9 +10,12 @@ import typer
 from peagen.handlers.migrate_handler import migrate_handler
 from peagen.models import Task
 
-# ``alembic.ini`` lives in the package root next to ``migrations``. Using
-# ``parents[2]`` works whether running from source or an installed wheel.
-ALEMBIC_CFG = Path(__file__).resolve().parents[2] / "alembic.ini"
+# ``alembic.ini`` lives in the package root next to ``migrations``.
+# When running from source the module sits one directory deeper than
+# an installed wheel. Check both possible locations for robustness.
+_src_cfg = Path(__file__).resolve().parents[3] / "alembic.ini"
+_pkg_cfg = Path(__file__).resolve().parents[2] / "alembic.ini"
+ALEMBIC_CFG = _src_cfg if _src_cfg.exists() else _pkg_cfg
 
 local_db_app = typer.Typer(help="Database utilities.")
 


### PR DESCRIPTION
## Summary
- fix lookup for `alembic.ini` when running peagen db commands

## Testing
- `uv run --package peagen --directory peagen ruff format peagen/cli/commands/db.py`
- `uv run --package peagen --directory peagen ruff check peagen/cli/commands/db.py --fix`
- `uv run --package peagen --directory peagen pytest`
- `uv run --package peagen --directory pkgs/standards/peagen peagen local -q db upgrade`
- `uv run --package peagen --directory pkgs/standards/peagen peagen local -q db downgrade`


------
https://chatgpt.com/codex/tasks/task_e_6857faeb6a088326a2fe010118b2b5f6