### PR TITLE
Fix driver imports for CLI

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/keys.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/keys.py
@@ -8,6 +8,7 @@ from typing import Optional
 
 import httpx
 import typer
+from peagen.plugins.secret_drivers import AutoGpgDriver  # noqa: F401
 
 from peagen import resolve_plugin_spec
 from peagen._utils.config_loader import resolve_cfg
@@ -26,7 +27,11 @@ def create(
     """Generate a new key pair."""
     cfg = resolve_cfg()
     plugin_name = cfg.get("secrets", {}).get("default_secret", "autogpg")
-    Driver = resolve_plugin_spec("secrets", plugin_name)
+    Driver = (
+        AutoGpgDriver
+        if plugin_name == "autogpg"
+        else resolve_plugin_spec("secrets", plugin_name)
+    )
     Driver(key_dir=key_dir, passphrase=passphrase)
     typer.echo(f"Created key pair in {key_dir}")
 
@@ -40,7 +45,11 @@ def upload(
     """Upload the public key to the gateway."""
     cfg = resolve_cfg()
     plugin_name = cfg.get("secrets", {}).get("default_secret", "autogpg")
-    Driver = resolve_plugin_spec("secrets", plugin_name)
+    Driver = (
+        AutoGpgDriver
+        if plugin_name == "autogpg"
+        else resolve_plugin_spec("secrets", plugin_name)
+    )
     drv = Driver(key_dir=key_dir)
     pubkey = drv.pub_path.read_text()
     envelope = {

--- a/pkgs/standards/peagen/peagen/cli/commands/login.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/login.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 import httpx
 import typer
+from peagen.plugins.secret_drivers import AutoGpgDriver  # noqa: F401
 
 from peagen import resolve_plugin_spec
 from peagen._utils.config_loader import resolve_cfg
@@ -32,7 +33,11 @@ def login(
         gateway_url += "/rpc"
     cfg = resolve_cfg()
     plugin_name = cfg.get("secrets", {}).get("default_secret", "autogpg")
-    Driver = resolve_plugin_spec("secrets", plugin_name)
+    Driver = (
+        AutoGpgDriver
+        if plugin_name == "autogpg"
+        else resolve_plugin_spec("secrets", plugin_name)
+    )
     drv = Driver(key_dir=key_dir, passphrase=passphrase)
     pubkey = drv.pub_path.read_text()
     payload = {

--- a/pkgs/standards/peagen/peagen/cli/commands/secrets.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/secrets.py
@@ -8,6 +8,7 @@ from typing import List
 
 import httpx
 import typer
+from peagen.plugins.secret_drivers import AutoGpgDriver  # noqa: F401
 
 from peagen import resolve_plugin_spec
 from peagen._utils.config_loader import resolve_cfg
@@ -56,7 +57,11 @@ def add(name: str, value: str, recipients: List[Path] = typer.Option([])) -> Non
     """Encrypt and store a secret locally."""
     cfg = resolve_cfg()
     plugin_name = cfg.get("secrets", {}).get("default_secret", "autogpg")
-    Driver = resolve_plugin_spec("secrets", plugin_name)
+    Driver = (
+        AutoGpgDriver
+        if plugin_name == "autogpg"
+        else resolve_plugin_spec("secrets", plugin_name)
+    )
     drv = Driver()
     pubkeys = [p.read_text() for p in recipients]
     cipher = drv.encrypt(value.encode(), pubkeys).decode()
@@ -71,7 +76,11 @@ def get(name: str) -> None:
     """Decrypt and print a secret."""
     cfg = resolve_cfg()
     plugin_name = cfg.get("secrets", {}).get("default_secret", "autogpg")
-    Driver = resolve_plugin_spec("secrets", plugin_name)
+    Driver = (
+        AutoGpgDriver
+        if plugin_name == "autogpg"
+        else resolve_plugin_spec("secrets", plugin_name)
+    )
     drv = Driver()
     val = _load().get(name)
     if not val:
@@ -105,7 +114,11 @@ def remote_add(
         gateway_url += "/rpc"
     cfg = resolve_cfg()
     plugin_name = cfg.get("secrets", {}).get("default_secret", "autogpg")
-    Driver = resolve_plugin_spec("secrets", plugin_name)
+    Driver = (
+        AutoGpgDriver
+        if plugin_name == "autogpg"
+        else resolve_plugin_spec("secrets", plugin_name)
+    )
     drv = Driver()
     pubs = [p.read_text() for p in recipient]
     pubs.extend(_pool_worker_pubs(pool, gateway_url))
@@ -137,7 +150,11 @@ def remote_get(
         gateway_url += "/rpc"
     cfg = resolve_cfg()
     plugin_name = cfg.get("secrets", {}).get("default_secret", "autogpg")
-    Driver = resolve_plugin_spec("secrets", plugin_name)
+    Driver = (
+        AutoGpgDriver
+        if plugin_name == "autogpg"
+        else resolve_plugin_spec("secrets", plugin_name)
+    )
     drv = Driver()
     envelope = {
         "jsonrpc": "2.0",


### PR DESCRIPTION
## Summary
- update login, keys, and secrets commands to expose `AutoGpgDriver`
- resolve the default driver using `AutoGpgDriver` when configured for `autogpg`

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/cli/commands/login.py peagen/cli/commands/keys.py peagen/cli/commands/secrets.py --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest`


------
https://chatgpt.com/codex/tasks/task_e_6857fea7206c8326abb510ccbb19dbc9