### PR TITLE
Add remote db CLI

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/__init__.py
+++ b/pkgs/standards/peagen/peagen/cli/__init__.py
@@ -20,6 +20,7 @@ from .commands import (
     local_extras_app,
     local_fetch_app,
     local_db_app,
+    remote_db_app,
     local_init_app,
     local_process_app,
     local_mutate_app,
@@ -178,6 +179,7 @@ local_app.add_typer(show_app, name="git")
 remote_app.add_typer(remote_doe_app, name="doe")
 remote_app.add_typer(remote_eval_app)
 remote_app.add_typer(remote_fetch_app)
+remote_app.add_typer(remote_db_app, name="db")
 remote_app.add_typer(remote_process_app)
 remote_app.add_typer(remote_mutate_app)
 remote_app.add_typer(remote_evolve_app)

--- a/pkgs/standards/peagen/peagen/cli/commands/__init__.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/__init__.py
@@ -4,7 +4,7 @@ from .doe import local_doe_app, remote_doe_app
 from .eval import local_eval_app, remote_eval_app
 from .extras import local_extras_app, remote_extras_app
 from .fetch import local_fetch_app, remote_fetch_app
-from .db import local_db_app
+from .db import local_db_app, remote_db_app
 from .init import local_init_app, remote_init_app
 from .process import local_process_app, remote_process_app
 from .mutate import local_mutate_app, remote_mutate_app
@@ -34,6 +34,7 @@ __all__ = [
     "local_fetch_app",
     "remote_fetch_app",
     "local_db_app",
+    "remote_db_app",
     "local_init_app",
     "remote_init_app",
     "local_process_app",

--- a/pkgs/standards/peagen/peagen/cli/commands/db.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/db.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from pathlib import Path
+
+import httpx
 
 import typer
 
@@ -17,6 +20,7 @@ from peagen.models import Task
 ALEMBIC_CFG = Path(__file__).resolve().parents[3] / "alembic.ini"
 
 local_db_app = typer.Typer(help="Database utilities.")
+remote_db_app = typer.Typer(help="Database utilities via JSON-RPC.")
 
 
 @local_db_app.command("upgrade")
@@ -81,3 +85,55 @@ def downgrade() -> None:
     if not result.get("ok", False):
         typer.echo(f"[ERROR] {result.get('error')}")
         raise typer.Exit(1)
+
+
+def _submit(ctx: typer.Context, op: str, message: str | None = None) -> str:
+    args = {"op": op, "alembic_ini": str(ALEMBIC_CFG)}
+    if message:
+        args["message"] = message
+    task = Task(pool="default", payload={"action": "migrate", "args": args})
+    envelope = {
+        "jsonrpc": "2.0",
+        "method": "Task.submit",
+        "params": {"taskId": task.id, "pool": task.pool, "payload": task.payload},
+    }
+    resp = httpx.post(ctx.obj.get("gateway_url"), json=envelope, timeout=30.0)
+    resp.raise_for_status()
+    reply = resp.json()
+    if "error" in reply:
+        typer.secho(
+            f"Remote error {reply['error']['code']}: {reply['error']['message']}",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(1)
+    typer.secho(f"Submitted task {task.id}", fg=typer.colors.GREEN)
+    if reply.get("result"):
+        typer.echo(json.dumps(reply["result"], indent=2))
+    return task.id
+
+
+@remote_db_app.command("upgrade")
+def remote_upgrade(ctx: typer.Context) -> None:
+    """Submit an upgrade task via JSON-RPC."""
+    _submit(ctx, "upgrade")
+
+
+@remote_db_app.command("revision")
+def remote_revision(
+    ctx: typer.Context,
+    message: str = typer.Option(
+        "init",
+        "--message",
+        "-m",
+        help="Message for the new revision",
+    ),
+) -> None:
+    """Submit a revision task via JSON-RPC."""
+    _submit(ctx, "revision", message)
+
+
+@remote_db_app.command("downgrade")
+def remote_downgrade(ctx: typer.Context) -> None:
+    """Submit a downgrade task via JSON-RPC."""
+    _submit(ctx, "downgrade")


### PR DESCRIPTION
## Summary
- add `remote_db_app` with upgrade, revision and downgrade commands
- expose remote db commands in CLI

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_6857fd671aa48326bdc19ca70aece266