### PR TITLE
Add remote db commands

### DIFF
--- a/pkgs/standards/peagen/README.md
+++ b/pkgs/standards/peagen/README.md
@@ -240,6 +240,12 @@ this step on startup, but the command is available for manual upgrades.
 peagen db upgrade
 ```
 
+Run migrations on a gateway instance:
+
+```bash
+peagen remote --gateway-url http://localhost:8000/rpc db upgrade
+```
+
 ---
 
 ## Examples & Walkthroughs

--- a/pkgs/standards/peagen/peagen/cli/__init__.py
+++ b/pkgs/standards/peagen/peagen/cli/__init__.py
@@ -35,6 +35,7 @@ from .commands import (
     remote_eval_app,
     remote_fetch_app,
     remote_process_app,
+    remote_db_app,
     remote_mutate_app,
     remote_evolve_app,
     remote_sort_app,
@@ -178,6 +179,7 @@ local_app.add_typer(show_app, name="git")
 remote_app.add_typer(remote_doe_app, name="doe")
 remote_app.add_typer(remote_eval_app)
 remote_app.add_typer(remote_fetch_app)
+remote_app.add_typer(remote_db_app, name="db")
 remote_app.add_typer(remote_process_app)
 remote_app.add_typer(remote_mutate_app)
 remote_app.add_typer(remote_evolve_app)

--- a/pkgs/standards/peagen/peagen/cli/commands/__init__.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/__init__.py
@@ -4,7 +4,7 @@ from .doe import local_doe_app, remote_doe_app
 from .eval import local_eval_app, remote_eval_app
 from .extras import local_extras_app, remote_extras_app
 from .fetch import local_fetch_app, remote_fetch_app
-from .db import local_db_app
+from .db import local_db_app, remote_db_app
 from .init import local_init_app, remote_init_app
 from .process import local_process_app, remote_process_app
 from .mutate import local_mutate_app, remote_mutate_app
@@ -34,6 +34,7 @@ __all__ = [
     "local_fetch_app",
     "remote_fetch_app",
     "local_db_app",
+    "remote_db_app",
     "local_init_app",
     "remote_init_app",
     "local_process_app",

--- a/pkgs/standards/peagen/peagen/cli/commands/db.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/db.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
+import uuid
+
+import httpx
 
 import typer
 
@@ -16,7 +19,33 @@ from peagen.models import Task
 # wheel.
 ALEMBIC_CFG = Path(__file__).resolve().parents[3] / "alembic.ini"
 
+DEFAULT_GATEWAY = "http://localhost:8000/rpc"
+
 local_db_app = typer.Typer(help="Database utilities.")
+remote_db_app = typer.Typer(help="Database utilities via JSON-RPC.")
+
+
+def _submit_task(op: str, gateway_url: str, message: str | None = None) -> str:
+    """Submit a migration *op* via JSON-RPC and return the task id."""
+    args = {"op": op, "alembic_ini": str(ALEMBIC_CFG)}
+    if message:
+        args["message"] = message
+    task = Task(
+        id=str(uuid.uuid4()),
+        pool="default",
+        payload={"action": "migrate", "args": args},
+    )
+    envelope = {
+        "jsonrpc": "2.0",
+        "method": "Task.submit",
+        "params": {"pool": task.pool, "payload": task.payload},
+    }
+    resp = httpx.post(gateway_url, json=envelope, timeout=10.0)
+    resp.raise_for_status()
+    data = resp.json()
+    if data.get("error"):
+        raise RuntimeError(data["error"])
+    return str(data.get("id", task.id))
 
 
 @local_db_app.command("upgrade")
@@ -80,4 +109,52 @@ def downgrade() -> None:
     result = asyncio.run(migrate_handler(task))
     if not result.get("ok", False):
         typer.echo(f"[ERROR] {result.get('error')}")
+        raise typer.Exit(1)
+
+
+@remote_db_app.command("upgrade")
+def remote_upgrade(
+    gateway_url: str = typer.Option(
+        DEFAULT_GATEWAY, "--gateway-url", help="JSON-RPC gateway endpoint"
+    ),
+) -> None:
+    """Submit an upgrade task via JSON-RPC."""
+    try:
+        task_id = _submit_task("upgrade", gateway_url)
+        typer.echo(f"Submitted upgrade → taskId={task_id}")
+    except Exception as exc:  # noqa: BLE001
+        typer.echo(f"[ERROR] {exc}")
+        raise typer.Exit(1)
+
+
+@remote_db_app.command("revision")
+def remote_revision(
+    message: str = typer.Option(
+        "init", "--message", "-m", help="Message for the new revision"
+    ),
+    gateway_url: str = typer.Option(
+        DEFAULT_GATEWAY, "--gateway-url", help="JSON-RPC gateway endpoint"
+    ),
+) -> None:
+    """Submit a revision task via JSON-RPC."""
+    try:
+        task_id = _submit_task("revision", gateway_url, message)
+        typer.echo(f"Submitted revision → taskId={task_id}")
+    except Exception as exc:  # noqa: BLE001
+        typer.echo(f"[ERROR] {exc}")
+        raise typer.Exit(1)
+
+
+@remote_db_app.command("downgrade")
+def remote_downgrade(
+    gateway_url: str = typer.Option(
+        DEFAULT_GATEWAY, "--gateway-url", help="JSON-RPC gateway endpoint"
+    ),
+) -> None:
+    """Submit a downgrade task via JSON-RPC."""
+    try:
+        task_id = _submit_task("downgrade", gateway_url)
+        typer.echo(f"Submitted downgrade → taskId={task_id}")
+    except Exception as exc:  # noqa: BLE001
+        typer.echo(f"[ERROR] {exc}")
         raise typer.Exit(1)


### PR DESCRIPTION
## Summary
- extend `peagen` CLI with `remote db` subcommands for database management
- register the new subcommands in CLI initialization
- document running migrations remotely via the gateway

## Testing
- `uv run --package peagen --directory standards/peagen ruff format .`
- `uv run --package peagen --directory standards/peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest`


------
https://chatgpt.com/codex/tasks/task_e_6857fd671aa48326bdc19ca70aece266