### PR TITLE
Fix Path import in peagen CLI

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/db.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/db.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import asyncio
 
+from pathlib import Path
+
 import typer
 
-# Lazy import resolves alembic.ini in both source and installed locations
 from peagen.handlers.migrate_handler import migrate_handler
 from peagen.models import Task
-from peagen.core.migrate_core import ALEMBIC_CFG
 
 # ``alembic.ini`` lives in the package root next to ``migrations``.
 # When running from source the module sits one directory deeper than


### PR DESCRIPTION
## Summary
- fix undefined `Path` in `peagen` db CLI

## Testing
- `uv run --package peagen --directory standards/peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685801ede6f083268e63944bd9711c8f