### PR TITLE
Fix Peagen DB upgrade via gateway

### DIFF
--- a/pkgs/standards/peagen/peagen/_utils/_init.py
+++ b/pkgs/standards/peagen/peagen/_utils/_init.py
@@ -31,7 +31,11 @@ def _submit_task(args: Dict[str, Any], gateway_url: str, tag: str) -> None:
     envelope = {
         "jsonrpc": "2.0",
         "method": "Task.submit",
-        "params": {"pool": task.pool, "payload": task.payload},
+        "params": {
+            "pool": task.pool,
+            "payload": task.payload,
+            "taskId": task.id,
+        },
     }
 
     try:
@@ -43,7 +47,7 @@ def _submit_task(args: Dict[str, Any], gateway_url: str, tag: str) -> None:
         if data.get("error"):
             typer.echo(f"[ERROR] {data['error']}")
             raise typer.Exit(1)
-        typer.echo(f"Submitted {tag} → taskId={data['id']}")
+        typer.echo(f"Submitted {tag} → taskId={data['result']['taskId']}")
     except Exception as exc:  # noqa: BLE001
         typer.echo(f"[ERROR] Could not reach gateway at {gateway_url}: {exc}")
         raise typer.Exit(1)

--- a/pkgs/standards/peagen/peagen/cli/commands/templates.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/templates.py
@@ -36,14 +36,18 @@ def _submit_task(args: Dict[str, Any], gateway_url: str) -> str:
     envelope = {
         "jsonrpc": "2.0",
         "method": "Task.submit",
-        "params": {"pool": task.pool, "payload": task.payload},
+        "params": {
+            "pool": task.pool,
+            "payload": task.payload,
+            "taskId": task.id,
+        },
     }
     resp = httpx.post(gateway_url, json=envelope, timeout=10.0)
     resp.raise_for_status()
     data = resp.json()
     if data.get("error"):
         raise RuntimeError(data["error"])
-    return str(data.get("id", task.id))
+    return str(data.get("result", {}).get("taskId", task.id))
 
 
 # ─── list ──────────────────────────────


### PR DESCRIPTION
## Summary
- include taskId when submitting DB migration tasks
- propagate result.taskId when sending init and templates actions
- remove unused import in CLI

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format peagen/cli/commands/db.py peagen/_utils/_init.py peagen/cli/commands/templates.py`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/cli/commands/db.py peagen/_utils/_init.py peagen/cli/commands/templates.py --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685805711c648326aacc7d9e7380514d