### PR TITLE
Add missing in_degree migration

### DIFF
--- a/pkgs/standards/peagen/peagen/migrations/versions/e5cf4f2a1b2c_in_degree_column.py
+++ b/pkgs/standards/peagen/peagen/migrations/versions/e5cf4f2a1b2c_in_degree_column.py
@@ -1,0 +1,28 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+revision = "e5cf4f2a1b2c"
+down_revision = "8c6e6abe8f9d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    cols = {c["name"] for c in inspector.get_columns("task_runs")}
+    if "in_degree" not in cols:
+        op.add_column(
+            "task_runs",
+            sa.Column("in_degree", sa.Integer(), nullable=False, server_default="0"),
+        )
+        op.alter_column("task_runs", "in_degree", server_default=None)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    cols = {c["name"] for c in inspector.get_columns("task_runs")}
+    if "in_degree" in cols:
+        op.drop_column("task_runs", "in_degree")


### PR DESCRIPTION
## Summary
- add an alembic revision to ensure `task_runs.in_degree` exists

## Testing
- `ruff format pkgs/standards/peagen/peagen/migrations/versions/e5cf4f2a1b2c_in_degree_column.py`
- `ruff check pkgs/standards/peagen/peagen/migrations/versions/e5cf4f2a1b2c_in_degree_column.py --fix`
- `uv run --package peagen --directory standards pytest` *(fails: Failed to fetch https://pypi.org/simple/pika/)*
- `python -m peagen.cli local -q process ...` *(fails: ModuleNotFoundError: No module named 'jsonpatch')*
- `python -m peagen.cli remote -q ...` *(fails: ModuleNotFoundError: No module named 'jsonpatch')*


------
https://chatgpt.com/codex/tasks/task_e_685816125fac8326afe1898cd82a1af9