### PR TITLE
Add missing config_toml column migration

### DIFF
--- a/pkgs/standards/peagen/peagen/migrations/versions/f2a4b3c5d6e7_config_toml_column.py
+++ b/pkgs/standards/peagen/peagen/migrations/versions/f2a4b3c5d6e7_config_toml_column.py
@@ -1,0 +1,24 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+revision = "f2a4b3c5d6e7"
+down_revision = "e5cf4f2a1b2c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    cols = {c["name"] for c in inspector.get_columns("task_runs")}
+    if "config_toml" not in cols:
+        op.add_column("task_runs", sa.Column("config_toml", sa.String()))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    cols = {c["name"] for c in inspector.get_columns("task_runs")}
+    if "config_toml" in cols:
+        op.drop_column("task_runs", "config_toml")


### PR DESCRIPTION
## Summary
- add Alembic migration to ensure `config_toml` column exists for `task_runs`

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_685819bbfe088326b78a0546357ae31e