### PR TITLE
Fix pending status migration

### DIFF
--- a/pkgs/standards/peagen/peagen/migrations/versions/f86f5297311a_replace_pending_with_waiting.py
+++ b/pkgs/standards/peagen/peagen/migrations/versions/f86f5297311a_replace_pending_with_waiting.py
@@ -1,0 +1,21 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = "f86f5297311a"
+down_revision = "f2a4b3c5d6e7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    bind.execute(
+        sa.text("UPDATE task_runs SET status='waiting' WHERE status='pending'")
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    bind.execute(
+        sa.text("UPDATE task_runs SET status='pending' WHERE status='waiting'")
+    )


### PR DESCRIPTION
## Summary
- add migration replacing `pending` task status with `waiting`

## Testing
- `uv run --package peagen --directory standards/peagen ruff check peagen/migrations/versions/f86f5297311a_replace_pending_with_waiting.py --fix`
- `uv run --package peagen --directory standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_68581bfcee6883269d4f29493e9c5f68