### PR TITLE
Fix waiting status migration

### DIFF
--- a/pkgs/standards/peagen/peagen/migrations/versions/f86f5297311a_replace_pending_with_waiting.py
+++ b/pkgs/standards/peagen/peagen/migrations/versions/f86f5297311a_replace_pending_with_waiting.py
@@ -8,13 +8,18 @@ depends_on = None
 
 
 def upgrade() -> None:
+    """Add ``waiting`` to the enum and migrate rows."""
+
     bind = op.get_bind()
+    bind.execute(sa.text("ALTER TYPE status ADD VALUE IF NOT EXISTS 'waiting'"))
     bind.execute(
         sa.text("UPDATE task_runs SET status='waiting' WHERE status='pending'")
     )
 
 
 def downgrade() -> None:
+    """Revert row updates; keep enum values intact."""
+
     bind = op.get_bind()
     bind.execute(
         sa.text("UPDATE task_runs SET status='pending' WHERE status='waiting'")


### PR DESCRIPTION
## Summary
- update pending->waiting migration to ensure enum contains `waiting`

## Testing
- `uv run --package peagen --directory peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_6858323c025c8326ac37b39e5dbb6fc1