### PR TITLE
Fix connection stalling

### DIFF
--- a/pkgs/standards/peagen/peagen/plugins/queues/redis_queue.py
+++ b/pkgs/standards/peagen/peagen/plugins/queues/redis_queue.py
@@ -8,7 +8,11 @@ class RedisQueue:
     """Wrapper providing Redis-like async queue operations."""
 
     def __init__(self, uri: str, **_: object) -> None:
-        self.client = Redis.from_url(uri, decode_responses=True)
+        self.client = Redis.from_url(
+            uri,
+            decode_responses=True,
+            socket_connect_timeout=5.0,
+        )
 
     def get_client(self) -> "RedisQueue":
         return self


### PR DESCRIPTION
## Summary
- set a 5 second Redis connection timeout to avoid hangs when gateway starts

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format peagen/plugins/queues/redis_queue.py`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/plugins/queues/redis_queue.py --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_6858323c025c8326ac37b39e5dbb6fc1