### PR TITLE
Fix alembic migration for SQLite

### DIFF
--- a/pkgs/standards/peagen/peagen/migrations/versions/f86f5297311a_replace_pending_with_waiting.py
+++ b/pkgs/standards/peagen/peagen/migrations/versions/f86f5297311a_replace_pending_with_waiting.py
@@ -11,7 +11,8 @@ def upgrade() -> None:
     """Add ``waiting`` to the enum and migrate rows."""
 
     bind = op.get_bind()
-    bind.execute(sa.text("ALTER TYPE status ADD VALUE IF NOT EXISTS 'waiting'"))
+    if bind.dialect.name == "postgresql":
+        bind.execute(sa.text("ALTER TYPE status ADD VALUE IF NOT EXISTS 'waiting'"))
     bind.execute(
         sa.text("UPDATE task_runs SET status='waiting' WHERE status='pending'")
     )


### PR DESCRIPTION
## Summary
- add dialect guard when adding enum value to handle SQLite

## Testing
- `uv run --package peagen --directory standards/peagen pytest -k test_alembic_upgrade_and_current -vv`

------
https://chatgpt.com/codex/tasks/task_e_685837ff1f50832691230922309f438f