### PR TITLE
Fix alembic env import

### DIFF
--- a/pkgs/standards/peagen/peagen/migrations/env.py
+++ b/pkgs/standards/peagen/peagen/migrations/env.py
@@ -4,8 +4,21 @@ from logging.config import fileConfig
 from alembic import context
 from sqlalchemy.ext.asyncio import AsyncEngine
 
-from peagen.gateway.db import engine
+from sqlalchemy.ext.asyncio import create_async_engine
+from peagen.gateway.runtime_cfg import settings
 from peagen.models import Base
+
+if settings.pg_host and settings.pg_db and settings.pg_user:
+    dsn = settings.apg_dsn
+else:
+    dsn = "sqlite+aiosqlite:///./gateway.db"
+
+engine = create_async_engine(
+    dsn,
+    pool_size=10,
+    max_overflow=20,
+    echo=False,
+)
 
 config = context.config
 if config.config_file_name is not None:


### PR DESCRIPTION
## Summary
- avoid importing full gateway package when running migrations
- create async engine directly in Alembic env

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format peagen/migrations/env.py`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/migrations/env.py --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_68583d0af080832689c89b13c43d2f65