### PR TITLE
Update Peagen Postgres defaults

### DIFF
--- a/infra/peagen_docker-compose.yml
+++ b/infra/peagen_docker-compose.yml
@@ -65,9 +65,9 @@ services:
       POSTGRES_USER:      ${POSTGRES_USER}
       POSTGRES_PASSWORD:  ${POSTGRES_PASSWORD}
       POSTGRES_DB:        ${POSTGRES_DB}
-      PGPORT:             5342
+      PGPORT:             5432
     ports: 
-      - 5342
+      - 5432
     volumes:
       - "${DATA_ROOT}/postgres:/var/lib/postgresql/data"
     healthcheck:
@@ -109,7 +109,7 @@ services:
       - "6379:6379"
     environment:
       DB_POSTGRES_HOST:     postgres
-      DB_POSTGRES_PORT:     5342
+      DB_POSTGRES_PORT:     5432
       DB_POSTGRES_USER:     ${POSTGRES_USER}
       DB_POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       DB_POSTGRES_NAME:     ${POSTGRES_DB}
@@ -140,11 +140,11 @@ services:
       - 8000
     environment:
       PG_HOST:              postgres
-      PG_PORT:              5342
+      PG_PORT:              5432
       PG_DB:                ${POSTGRES_DB}
       PG_USER:              ${POSTGRES_USER}
       PG_PASS:              ${POSTGRES_PASSWORD}
-      PG_DSN:               postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5342/${POSTGRES_DB}
+      PG_DSN:               postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
       REDIS_HOST:           redis
       REDIS_PASSWORD:       ${REDIS_PASSWORD}
       REDIS_URL:            redis://:${REDIS_PASSWORD}@redis:6379/0

--- a/pkgs/standards/peagen/peagen/gateway/runtime_cfg.py
+++ b/pkgs/standards/peagen/peagen/gateway/runtime_cfg.py
@@ -24,7 +24,7 @@ class Settings(BaseSettings):
 
     # ───────── Postgres results-backend ─────────
     pg_host: Optional[str] = Field(default=os.environ.get("PG_HOST"))
-    pg_port: int = Field(default=int(os.environ.get("PG_PORT", "5342")))
+    pg_port: int = Field(default=int(os.environ.get("PG_PORT", "5432")))
     pg_db: Optional[str] = Field(default=os.environ.get("PG_DB"))
     pg_user: Optional[str] = Field(default=os.environ.get("PG_USER"))
     pg_pass: Optional[str] = Field(default=os.environ.get("PG_PASS"))
@@ -50,5 +50,6 @@ class Settings(BaseSettings):
     class Config:
         # No env_file needed since we already called load_dotenv().
         pass
+
 
 settings = Settings()


### PR DESCRIPTION
## Summary
- set default PG_PORT to 5432
- update docker compose examples for the Peagen stack

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format peagen/gateway/runtime_cfg.py`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/gateway/runtime_cfg.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_68583ea68ba4832681ca6778f8dfade7