### PR TITLE
Remove automatic DB migration

### DIFF
--- a/pkgs/standards/peagen/README.md
+++ b/pkgs/standards/peagen/README.md
@@ -233,8 +233,8 @@ and evaluator-pool variations.
 
 ### `peagen db upgrade`
 
-Apply Alembic migrations to the latest version. The gateway automatically runs
-this step on startup, but the command is available for manual upgrades.
+Apply Alembic migrations to the latest version. Run this command before
+starting the gateway to ensure the database schema is current.
 
 ```bash
 peagen db upgrade

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -39,7 +39,6 @@ from peagen.gateway.db_helpers import (
     fetch_secret,
     delete_secret,
 )
-from peagen.core.migrate_core import alembic_upgrade
 import peagen.defaults as defaults
 from peagen.core.task_core import get_task_result
 from sqlalchemy import select
@@ -794,9 +793,6 @@ async def health() -> dict:
 async def _on_start():
     if engine.url.get_backend_name() != "sqlite":
         # ensure schema is up to date for Postgres deployments
-        result = alembic_upgrade()
-        if not result.get("ok", True):
-            log.warning("alembic upgrade failed: %s", result.get("error"))
         await ensure_status_enum(engine)
     else:
         async with engine.begin() as conn:


### PR DESCRIPTION
## Summary
- avoid running Alembic migrations automatically on gateway startup
- update docs for manual `peagen db upgrade`

## Testing
- `uv run --package peagen --directory standards/peagen ruff format .`
- `uv run --package peagen --directory standards/peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_685844eca554832684a4c4e26200c64b