### PR TITLE
Capture Alembic output

### DIFF
--- a/pkgs/standards/peagen/peagen/core/migrate_core.py
+++ b/pkgs/standards/peagen/peagen/core/migrate_core.py
@@ -17,7 +17,7 @@ ALEMBIC_CFG = _src_cfg if _src_cfg.exists() else _pkg_cfg
 def alembic_upgrade(cfg: Path = ALEMBIC_CFG) -> Dict[str, Any]:
     """Apply migrations up to HEAD using *cfg*."""
     try:
-        subprocess.run(
+        result = subprocess.run(
             [
                 "alembic",
                 "-c",
@@ -26,16 +26,23 @@ def alembic_upgrade(cfg: Path = ALEMBIC_CFG) -> Dict[str, Any]:
                 "head",
             ],
             check=True,
+            capture_output=True,
+            text=True,
         )
     except subprocess.CalledProcessError as exc:  # noqa: BLE001
-        return {"ok": False, "error": str(exc)}
-    return {"ok": True}
+        return {
+            "ok": False,
+            "error": str(exc),
+            "stdout": exc.stdout,
+            "stderr": exc.stderr,
+        }
+    return {"ok": True, "stdout": result.stdout, "stderr": result.stderr}
 
 
 def alembic_downgrade(cfg: Path = ALEMBIC_CFG) -> Dict[str, Any]:
     """Downgrade the database by one revision using *cfg*."""
     try:
-        subprocess.run(
+        result = subprocess.run(
             [
                 "alembic",
                 "-c",
@@ -44,16 +51,23 @@ def alembic_downgrade(cfg: Path = ALEMBIC_CFG) -> Dict[str, Any]:
                 "-1",
             ],
             check=True,
+            capture_output=True,
+            text=True,
         )
     except subprocess.CalledProcessError as exc:  # noqa: BLE001
-        return {"ok": False, "error": str(exc)}
-    return {"ok": True}
+        return {
+            "ok": False,
+            "error": str(exc),
+            "stdout": exc.stdout,
+            "stderr": exc.stderr,
+        }
+    return {"ok": True, "stdout": result.stdout, "stderr": result.stderr}
 
 
 def alembic_revision(message: str, cfg: Path = ALEMBIC_CFG) -> Dict[str, Any]:
     """Create a new revision with *message* using *cfg*."""
     try:
-        subprocess.run(
+        result = subprocess.run(
             [
                 "alembic",
                 "-c",
@@ -64,7 +78,14 @@ def alembic_revision(message: str, cfg: Path = ALEMBIC_CFG) -> Dict[str, Any]:
                 message,
             ],
             check=True,
+            capture_output=True,
+            text=True,
         )
     except subprocess.CalledProcessError as exc:  # noqa: BLE001
-        return {"ok": False, "error": str(exc)}
-    return {"ok": True}
+        return {
+            "ok": False,
+            "error": str(exc),
+            "stdout": exc.stdout,
+            "stderr": exc.stderr,
+        }
+    return {"ok": True, "stdout": result.stdout, "stderr": result.stderr}

--- a/pkgs/standards/peagen/tests/unit/test_migrate_core.py
+++ b/pkgs/standards/peagen/tests/unit/test_migrate_core.py
@@ -8,15 +8,21 @@ from peagen.core import migrate_core
 def test_alembic_upgrade_invokes_subprocess(monkeypatch, tmp_path: Path):
     calls = {}
 
-    def fake_run(cmd, check):
+    def fake_run(cmd, check, capture_output=True, text=True):
         calls["cmd"] = cmd
+
+        class Result:
+            stdout = "stdout"
+            stderr = ""
+
+        return Result()
 
     monkeypatch.setattr(migrate_core.subprocess, "run", fake_run)
 
     cfg = tmp_path / "al.ini"
     result = migrate_core.alembic_upgrade(cfg)
 
-    assert result == {"ok": True}
+    assert result == {"ok": True, "stdout": "stdout", "stderr": ""}
     assert calls["cmd"] == ["alembic", "-c", str(cfg), "upgrade", "head"]
 
 
@@ -24,15 +30,21 @@ def test_alembic_upgrade_invokes_subprocess(monkeypatch, tmp_path: Path):
 def test_alembic_revision_invokes_subprocess(monkeypatch, tmp_path: Path):
     calls = {}
 
-    def fake_run(cmd, check):
+    def fake_run(cmd, check, capture_output=True, text=True):
         calls["cmd"] = cmd
+
+        class Result:
+            stdout = "out"
+            stderr = "err"
+
+        return Result()
 
     monkeypatch.setattr(migrate_core.subprocess, "run", fake_run)
 
     cfg = tmp_path / "al.ini"
     result = migrate_core.alembic_revision("msg", cfg)
 
-    assert result == {"ok": True}
+    assert result == {"ok": True, "stdout": "out", "stderr": "err"}
     assert calls["cmd"] == [
         "alembic",
         "-c",


### PR DESCRIPTION
## Summary
- capture stdout/stderr from Alembic in migrate_core functions
- test migrate_core returns command output

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format peagen/core/migrate_core.py tests/unit/test_migrate_core.py`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check peagen/core/migrate_core.py tests/unit/test_migrate_core.py --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_migrate_core.py`
- `uv run --package peagen --directory pkgs/standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_68584561f1a88326ba03570bc17c622d