### PR TITLE
Update migrate_core to capture alembic std streams

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_migrate_core.py
+++ b/pkgs/standards/peagen/tests/unit/test_migrate_core.py
@@ -8,15 +8,21 @@ from peagen.core import migrate_core
 def test_alembic_upgrade_invokes_subprocess(monkeypatch, tmp_path: Path):
     calls = {}
 
-    def fake_run(cmd, check):
+    def fake_run(cmd, check, capture_output, text):
         calls["cmd"] = cmd
+
+        class Result:
+            stdout = ""
+            stderr = ""
+
+        return Result()
 
     monkeypatch.setattr(migrate_core.subprocess, "run", fake_run)
 
     cfg = tmp_path / "al.ini"
     result = migrate_core.alembic_upgrade(cfg)
 
-    assert result == {"ok": True}
+    assert result == {"ok": True, "stdout": "", "stderr": ""}
     assert calls["cmd"] == ["alembic", "-c", str(cfg), "upgrade", "head"]
 
 
@@ -24,15 +30,21 @@ def test_alembic_upgrade_invokes_subprocess(monkeypatch, tmp_path: Path):
 def test_alembic_revision_invokes_subprocess(monkeypatch, tmp_path: Path):
     calls = {}
 
-    def fake_run(cmd, check):
+    def fake_run(cmd, check, capture_output, text):
         calls["cmd"] = cmd
+
+        class Result:
+            stdout = ""
+            stderr = ""
+
+        return Result()
 
     monkeypatch.setattr(migrate_core.subprocess, "run", fake_run)
 
     cfg = tmp_path / "al.ini"
     result = migrate_core.alembic_revision("msg", cfg)
 
-    assert result == {"ok": True}
+    assert result == {"ok": True, "stdout": "", "stderr": ""}
     assert calls["cmd"] == [
         "alembic",
         "-c",


### PR DESCRIPTION
## Summary
- capture stdout/stderr from alembic subprocess calls
- expose new helper `_run_alembic`
- adjust unit tests for new return values

## Testing
- `uv run --directory standards --package peagen ruff check peagen/peagen/core/migrate_core.py peagen/tests/unit/test_migrate_core.py --fix`

------
https://chatgpt.com/codex/tasks/task_e_685846c4711c8326b5fc67cb447f9238