### PR TITLE
Set default PG_PORT to 5432

### DIFF
--- a/infra/Dockerfile.gw
+++ b/infra/Dockerfile.gw
@@ -25,7 +25,7 @@ EXPOSE 8000
 
 ENV \
     PG_HOST="" \
-    PG_PORT="" \
+    PG_PORT="5432" \
     PG_DB="" \
     PG_USER="" \
     PG_PASS="" \

--- a/infra/Dockerfile.worker
+++ b/infra/Dockerfile.worker
@@ -25,6 +25,7 @@ EXPOSE 8001
 ENV \
     DQ_POOL=""\
     DQ_GATEWAY=""\
-    PORT="8001"
+    PORT="8001" \
+    PG_PORT="5432"
 
 CMD ["sh", "-c", "python -c 'import uvicorn; uvicorn.run(\"peagen.worker:app\", host=\"0.0.0.0\", port=8001, log_level=\"info\")'"]


### PR DESCRIPTION
## Summary
- ensure the gateway Dockerfile sets `PG_PORT` to 5432
- set the same default for workers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685847f596b8832691657ceea1e82ca9