### PR TITLE
Expose Alembic output in CLI

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/db.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/db.py
@@ -7,7 +7,6 @@ import uuid
 
 import httpx
 
-from peagen import defaults
 
 from pathlib import Path
 
@@ -27,8 +26,7 @@ DEFAULT_GATEWAY = (
     "http://localhost:8000/rpc"  # replace with peagen.defaults to make consistency
 )
 
-#DEFAULT_GATEWAY = defaults.CONFIG["gateway_url"] 
-
+# DEFAULT_GATEWAY = defaults.CONFIG["gateway_url"]
 
 
 local_db_app = typer.Typer(help="Database utilities.")
@@ -74,6 +72,10 @@ def upgrade() -> None:
         },
     )
     result = asyncio.run(migrate_handler(task))
+    if stdout := result.get("stdout"):
+        typer.echo(stdout)
+    if stderr := result.get("stderr"):
+        typer.echo(stderr, err=True)
     if not result.get("ok", False):
         typer.echo(f"[ERROR] {result.get('error')}")
         raise typer.Exit(1)
@@ -104,6 +106,10 @@ def revision(
         },
     )
     result = asyncio.run(migrate_handler(task))
+    if stdout := result.get("stdout"):
+        typer.echo(stdout)
+    if stderr := result.get("stderr"):
+        typer.echo(stderr, err=True)
     if not result.get("ok", False):
         typer.echo(f"[ERROR] {result.get('error')}")
         raise typer.Exit(1)
@@ -121,6 +127,10 @@ def downgrade() -> None:
         },
     )
     result = asyncio.run(migrate_handler(task))
+    if stdout := result.get("stdout"):
+        typer.echo(stdout)
+    if stderr := result.get("stderr"):
+        typer.echo(stderr, err=True)
     if not result.get("ok", False):
         typer.echo(f"[ERROR] {result.get('error')}")
         raise typer.Exit(1)

--- a/pkgs/standards/peagen/tests/unit/test_cli_db.py
+++ b/pkgs/standards/peagen/tests/unit/test_cli_db.py
@@ -1,0 +1,19 @@
+import pytest
+from typer.testing import CliRunner
+
+from peagen.cli import app
+from peagen.cli.commands import db as db_mod
+
+
+@pytest.mark.unit
+def test_local_db_upgrade_prints_output(monkeypatch):
+    async def fake_handler(task):
+        return {"ok": True, "stdout": "OUT", "stderr": "ERR"}
+
+    monkeypatch.setattr(db_mod, "migrate_handler", fake_handler)
+    runner = CliRunner()
+    result = runner.invoke(app, ["local", "db", "upgrade"])
+
+    assert result.exit_code == 0
+    assert "OUT" in result.output
+    assert "ERR" in result.output


### PR DESCRIPTION
## Summary
- expose stdout/stderr from migrate handler in peagen DB CLI commands
- add unit test for CLI

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen pytest -q tests/unit/test_cli_db.py`
- `uv run --package peagen --directory pkgs/standards/peagen pytest -q`
- `peagen remote -q --gateway-url http://localhost:8000/rpc process projects_payload.yaml --watch` *(fails: command not found)*
- `peagen local -q process projects_payload.yaml --watch` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68584846f7748326934789e448ebe227