### PR TITLE
Update gateway startup

### DIFF
--- a/infra/Dockerfile.gw
+++ b/infra/Dockerfile.gw
@@ -34,4 +34,4 @@ ENV \
     MINIO_USER="" \
     MINIO_ROOT_PASSWORD=""
     
-CMD ["sh", "-c", "peagen local db upgrade && python -c 'import uvicorn; uvicorn.run(\"peagen.gateway:app\", host=\"0.0.0.0\", port=8000, log_level=\"info\")'"]
+CMD ["sh", "-c", "python -c 'import uvicorn; uvicorn.run(\"peagen.gateway:app\", host=\"0.0.0.0\", port=8000, log_level=\"info\")'"]


### PR DESCRIPTION
## Summary
- drop `peagen local db upgrade` from the gateway Dockerfile
- run Alembic migrations at application startup

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_685847cb431c8326af820b502509c737