### PR TITLE
Fix migration for pending status

### DIFF
--- a/pkgs/standards/peagen/peagen/migrations/versions/f86f5297311a_replace_pending_with_waiting.py
+++ b/pkgs/standards/peagen/peagen/migrations/versions/f86f5297311a_replace_pending_with_waiting.py
@@ -14,7 +14,7 @@ def upgrade() -> None:
     if bind.dialect.name == "postgresql":
         bind.execute(sa.text("ALTER TYPE status ADD VALUE IF NOT EXISTS 'waiting'"))
     bind.execute(
-        sa.text("UPDATE task_runs SET status='waiting' WHERE status='pending'")
+        sa.text("UPDATE task_runs SET status='waiting' WHERE status::text='pending'")
     )
 
 
@@ -23,5 +23,5 @@ def downgrade() -> None:
 
     bind = op.get_bind()
     bind.execute(
-        sa.text("UPDATE task_runs SET status='pending' WHERE status='waiting'")
+        sa.text("UPDATE task_runs SET status='pending' WHERE status::text='waiting'")
     )


### PR DESCRIPTION
## Summary
- fix migration query to avoid enum mismatch

## Testing
- `uv run --package peagen --directory peagen ruff check migrations/versions/f86f5297311a_replace_pending_with_waiting.py --fix`
- `uv run --package peagen --directory peagen pytest`
- `curl -s http://localhost:8000/healthz`


------
https://chatgpt.com/codex/tasks/task_e_68584d5fa9a88326a27a155dd162ce0f