### PR TITLE
Add Peagen gateway smoke tests

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/secrets.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/secrets.py
@@ -33,7 +33,14 @@ def _pool_worker_pubs(pool: str, gateway_url: str) -> list[str]:
     keys = []
     for w in workers:
         advert = w.get("advertises") or {}
-        key = advert.get("public_key") or advert.get("pubkey")
+        if isinstance(advert, str):
+            try:
+                advert = json.loads(advert)
+            except Exception:
+                advert = {}
+        key = None
+        if isinstance(advert, dict):
+            key = advert.get("public_key") or advert.get("pubkey")
         if key:
             keys.append(key)
     return keys
@@ -103,7 +110,7 @@ def remote_add(
     envelope = {
         "jsonrpc": "2.0",
         "method": "Secrets.add",
-        "params": {"id": secret_id, "secret": cipher, "version": version},
+        "params": {"name": secret_id, "secret": cipher, "version": version},
     }
     res = httpx.post(gateway_url, json=envelope, timeout=10.0)
     if getattr(res, "status_code", 200) >= 400:
@@ -129,7 +136,7 @@ def remote_get(
     envelope = {
         "jsonrpc": "2.0",
         "method": "Secrets.get",
-        "params": {"id": secret_id},
+        "params": {"name": secret_id},
     }
     res = httpx.post(gateway_url, json=envelope, timeout=10.0)
     if getattr(res, "status_code", 200) >= 400:
@@ -156,7 +163,7 @@ def remote_remove(
     envelope = {
         "jsonrpc": "2.0",
         "method": "Secrets.delete",
-        "params": {"id": secret_id, "version": version},
+        "params": {"name": secret_id, "version": version},
     }
 
     res = httpx.post(gateway_url, json=envelope, timeout=10.0)

--- a/pkgs/standards/peagen/tests/smoke/test_gateway_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_gateway_cli.py
@@ -1,0 +1,57 @@
+import json
+import subprocess
+
+import pytest
+
+GATEWAY = "https://gw.peagen.com/rpc"
+
+
+@pytest.mark.i9n
+def test_login_and_fetch_keys(tmp_path):
+    subprocess.run(
+        ["peagen", "login", "--gateway-url", GATEWAY],
+        check=True,
+        timeout=60,
+    )
+
+    result = subprocess.run(
+        ["peagen", "keys", "fetch-server", "--gateway-url", GATEWAY],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=60,
+    )
+    data = json.loads(result.stdout)
+    assert isinstance(data, dict)
+
+
+@pytest.mark.i9n
+def test_secret_roundtrip(tmp_path):
+    subprocess.run(
+        [
+            "peagen",
+            "remote",
+            "secrets",
+            "add",
+            "smoke-secret",
+            "value",
+            "--gateway-url",
+            GATEWAY,
+        ],
+        check=True,
+        timeout=60,
+    )
+
+    subprocess.run(
+        [
+            "peagen",
+            "remote",
+            "secrets",
+            "remove",
+            "smoke-secret",
+            "--gateway-url",
+            GATEWAY,
+        ],
+        check=True,
+        timeout=60,
+    )


### PR DESCRIPTION
## Summary
- update `_pool_worker_pubs` for string worker adverts
- fix secret command parameter names
- add integration smoke tests using public Peagen gateway

## Testing
- `ruff format pkgs/standards/peagen`
- `ruff check pkgs/standards/peagen --fix`
- `uv run --package peagen --directory standards/peagen pytest -k smoke -q`

------
https://chatgpt.com/codex/tasks/task_e_68585a13207c832682e506e4259bd2fa