### PR TITLE
Update login smoke test

### DIFF
--- a/pkgs/standards/peagen/tests/smoke/test_gateway_login_keys_secrets_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_gateway_login_keys_secrets_cli.py
@@ -8,8 +8,18 @@ GATEWAY = "https://gw.peagen.com/rpc"
 
 @pytest.mark.i9n
 def test_login_and_fetch_keys(tmp_path):
+    key_dir = tmp_path / "keys"
     subprocess.run(
-        ["peagen", "login", "--gateway-url", GATEWAY],
+        [
+            "peagen",
+            "login",
+            "--gateway-url",
+            GATEWAY,
+            "--key-dir",
+            str(key_dir),
+            "--passphrase",
+            "testpass",
+        ],
         check=True,
         timeout=60,
     )


### PR DESCRIPTION
## Summary
- run `peagen login` in the smoke test with custom key directory and passphrase

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/smoke/test_gateway_login_keys_secrets_cli.py -k login_and_fetch_keys -q`

------
https://chatgpt.com/codex/tasks/task_e_68585e0864508326b7af0f870c845980