### PR TITLE
Fix secrets add with worker advert string

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/secrets.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/secrets.py
@@ -33,6 +33,11 @@ def _pool_worker_pubs(pool: str, gateway_url: str) -> list[str]:
     keys = []
     for w in workers:
         advert = w.get("advertises") or {}
+        if isinstance(advert, str):
+            try:
+                advert = json.loads(advert)
+            except json.JSONDecodeError:
+                advert = {}
         key = advert.get("public_key") or advert.get("pubkey")
         if key:
             keys.append(key)

--- a/pkgs/standards/peagen/peagen/core/secrets_core.py
+++ b/pkgs/standards/peagen/peagen/core/secrets_core.py
@@ -29,6 +29,11 @@ def _pool_worker_pubs(pool: str, gateway_url: str) -> list[str]:
     keys = []
     for w in workers:
         advert = w.get("advertises") or {}
+        if isinstance(advert, str):
+            try:
+                advert = json.loads(advert)
+            except json.JSONDecodeError:
+                advert = {}
         key = advert.get("public_key") or advert.get("pubkey")
         if key:
             keys.append(key)

--- a/pkgs/standards/peagen/tests/unit/test_secrets_cli.py
+++ b/pkgs/standards/peagen/tests/unit/test_secrets_cli.py
@@ -59,6 +59,22 @@ def test_pool_worker_pubs_handles_error(monkeypatch):
     assert keys == []
 
 
+def test_pool_worker_pubs_parses_json(monkeypatch):
+    def fake_post(url, json=None, timeout=None):
+        class Res:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"result": [{"advertises": '{"public_key": "X"}'}]}
+
+        return Res()
+
+    monkeypatch.setattr(secrets_cli.httpx, "post", fake_post)
+    keys = secrets_cli._pool_worker_pubs("p", "http://gw")
+    assert keys == ["X"]
+
+
 def test_local_add_stores_secret(monkeypatch, tmp_path):
     store = tmp_path / "store.json"
     monkeypatch.setattr(secrets_cli, "STORE_FILE", store)


### PR DESCRIPTION
## Summary
- handle serialized `advertises` fields when collecting worker public keys
- add regression test for JSON string adverts

## Testing
- `ruff format pkgs/standards/peagen/peagen/cli/commands/secrets.py pkgs/standards/peagen/peagen/core/secrets_core.py pkgs/standards/peagen/tests/unit/test_secrets_cli.py`
- `ruff check pkgs/standards/peagen/peagen/cli/commands/secrets.py pkgs/standards/peagen/peagen/core/secrets_core.py pkgs/standards/peagen/tests/unit/test_secrets_cli.py --fix`
- `uv run --package peagen --directory standards/peagen pytest` *(fails: test_alembic_upgrade_and_current)*
- `/workspace/swarmauri-sdk/pkgs/.venv/bin/peagen remote -q --gateway-url http://localhost:8000/rpc process standards/peagen/tests/examples/projects_payloads/projects_payload.yaml --watch` *(fails: connection refused)*
- `/workspace/swarmauri-sdk/pkgs/.venv/bin/peagen local -q process standards/peagen/tests/examples/projects_payloads/projects_payload.yaml` *(fails: No LLM provider specified)*

------
https://chatgpt.com/codex/tasks/task_e_68585d4984108326bffa04847bde555e