### PR TITLE
Fix secret advert parsing and add dialect-aware migration

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/secrets.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/secrets.py
@@ -33,6 +33,11 @@ def _pool_worker_pubs(pool: str, gateway_url: str) -> list[str]:
     keys = []
     for w in workers:
         advert = w.get("advertises") or {}
+        if isinstance(advert, str):
+            try:
+                advert = json.loads(advert)
+            except Exception:
+                advert = {}
         key = advert.get("public_key") or advert.get("pubkey")
         if key:
             keys.append(key)

--- a/pkgs/standards/peagen/peagen/core/secrets_core.py
+++ b/pkgs/standards/peagen/peagen/core/secrets_core.py
@@ -29,6 +29,11 @@ def _pool_worker_pubs(pool: str, gateway_url: str) -> list[str]:
     keys = []
     for w in workers:
         advert = w.get("advertises") or {}
+        if isinstance(advert, str):
+            try:
+                advert = json.loads(advert)
+            except Exception:
+                advert = {}
         key = advert.get("public_key") or advert.get("pubkey")
         if key:
             keys.append(key)

--- a/pkgs/standards/peagen/peagen/migrations/versions/f91bd40d0972_dialect_aware_waiting_update.py
+++ b/pkgs/standards/peagen/peagen/migrations/versions/f91bd40d0972_dialect_aware_waiting_update.py
@@ -1,0 +1,39 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = "f91bd40d0972"
+down_revision = "f86f5297311a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Update pending statuses for SQLite and Postgres."""
+
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        bind.execute(
+            sa.text(
+                "UPDATE task_runs SET status='waiting' WHERE status::text='pending'"
+            )
+        )
+    else:
+        bind.execute(
+            sa.text("UPDATE task_runs SET status='waiting' WHERE status='pending'")
+        )
+
+
+def downgrade() -> None:
+    """Revert row updates."""
+
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        bind.execute(
+            sa.text(
+                "UPDATE task_runs SET status='pending' WHERE status::text='waiting'"
+            )
+        )
+    else:
+        bind.execute(
+            sa.text("UPDATE task_runs SET status='pending' WHERE status='waiting'")
+        )

--- a/pkgs/standards/peagen/tests/unit/test_secrets_cli.py
+++ b/pkgs/standards/peagen/tests/unit/test_secrets_cli.py
@@ -59,6 +59,22 @@ def test_pool_worker_pubs_handles_error(monkeypatch):
     assert keys == []
 
 
+def test_pool_worker_pubs_parses_json(monkeypatch):
+    def fake_post(url, json=None, timeout=None):
+        class Res:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"result": [{"advertises": '{"public_key": "Z"}'}]}
+
+        return Res()
+
+    monkeypatch.setattr(secrets_cli.httpx, "post", fake_post)
+    keys = secrets_cli._pool_worker_pubs("p", "http://gw")
+    assert keys == ["Z"]
+
+
 def test_local_add_stores_secret(monkeypatch, tmp_path):
     store = tmp_path / "store.json"
     monkeypatch.setattr(secrets_cli, "STORE_FILE", store)


### PR DESCRIPTION
## Summary
- parse advertised worker metadata when returned as JSON strings
- add new migration to handle waiting status update on SQLite

## Testing
- `ruff format peagen`
- `ruff check peagen --fix`


------
https://chatgpt.com/codex/tasks/task_e_68585d4984108326bffa04847bde555e