### PR TITLE
Add Peagen gateway smoke test

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/secrets.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/secrets.py
@@ -33,6 +33,11 @@ def _pool_worker_pubs(pool: str, gateway_url: str) -> list[str]:
     keys = []
     for w in workers:
         advert = w.get("advertises") or {}
+        if isinstance(advert, str):  # gateway may return JSON string
+            try:
+                advert = json.loads(advert)
+            except Exception:  # pragma: no cover - invalid JSON
+                advert = {}
         key = advert.get("public_key") or advert.get("pubkey")
         if key:
             keys.append(key)
@@ -103,7 +108,7 @@ def remote_add(
     envelope = {
         "jsonrpc": "2.0",
         "method": "Secrets.add",
-        "params": {"id": secret_id, "secret": cipher, "version": version},
+        "params": {"name": secret_id, "secret": cipher, "version": version},
     }
     res = httpx.post(gateway_url, json=envelope, timeout=10.0)
     if getattr(res, "status_code", 200) >= 400:
@@ -129,7 +134,7 @@ def remote_get(
     envelope = {
         "jsonrpc": "2.0",
         "method": "Secrets.get",
-        "params": {"id": secret_id},
+        "params": {"name": secret_id},
     }
     res = httpx.post(gateway_url, json=envelope, timeout=10.0)
     if getattr(res, "status_code", 200) >= 400:
@@ -156,7 +161,7 @@ def remote_remove(
     envelope = {
         "jsonrpc": "2.0",
         "method": "Secrets.delete",
-        "params": {"id": secret_id, "version": version},
+        "params": {"name": secret_id, "version": version},
     }
 
     res = httpx.post(gateway_url, json=envelope, timeout=10.0)

--- a/pkgs/standards/peagen/peagen/migrations/versions/f86f5297311a_replace_pending_with_waiting.py
+++ b/pkgs/standards/peagen/peagen/migrations/versions/f86f5297311a_replace_pending_with_waiting.py
@@ -13,15 +13,19 @@ def upgrade() -> None:
     bind = op.get_bind()
     if bind.dialect.name == "postgresql":
         bind.execute(sa.text("ALTER TYPE status ADD VALUE IF NOT EXISTS 'waiting'"))
-    bind.execute(
-        sa.text("UPDATE task_runs SET status='waiting' WHERE status::text='pending'")
-    )
+    if bind.dialect.name == "postgresql":
+        pending = "status::text='pending'"
+    else:
+        pending = "status='pending'"
+    bind.execute(sa.text(f"UPDATE task_runs SET status='waiting' WHERE {pending}"))
 
 
 def downgrade() -> None:
     """Revert row updates; keep enum values intact."""
 
     bind = op.get_bind()
-    bind.execute(
-        sa.text("UPDATE task_runs SET status='pending' WHERE status::text='waiting'")
-    )
+    if bind.dialect.name == "postgresql":
+        waiting = "status::text='waiting'"
+    else:
+        waiting = "status='waiting'"
+    bind.execute(sa.text(f"UPDATE task_runs SET status='pending' WHERE {waiting}"))

--- a/pkgs/standards/peagen/peagen/plugins/secret_drivers/autogpg_secretdriver.py
+++ b/pkgs/standards/peagen/peagen/plugins/secret_drivers/autogpg_secretdriver.py
@@ -65,11 +65,14 @@ class AutoGpgDriver(SecretDriverBase):
         keys = [self.public]
         for r in recipients:
             k = pgpy.PGPKey()
-            p = Path(r)
-            if p.exists():
-                k.parse(p.read_text())
-            else:
-                k.parse(r)
+            try:
+                p = Path(r)
+                if p.exists():
+                    k.parse(p.read_text())
+                else:
+                    raise OSError
+            except OSError:
+                k.parse(str(r))
             keys.append(k)
         sessionkey = SymmetricKeyAlgorithm.AES256.gen_key()
         enc_msg = msg

--- a/pkgs/standards/peagen/tests/smoke/test_gateway_ops.py
+++ b/pkgs/standards/peagen/tests/smoke/test_gateway_ops.py
@@ -1,0 +1,97 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+
+gateway = "https://gw.peagen.com/rpc"
+
+
+def run(cmd: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, capture_output=True, text=True, check=True)
+
+
+def fingerprint(pub: Path) -> str:
+    out = run(["gpg", "--show-keys", "--with-colons", str(pub)]).stdout
+    for line in out.splitlines():
+        if line.startswith("fpr"):
+            return line.split(":")[9]
+    raise RuntimeError("fingerprint not found")
+
+
+@pytest.mark.skip("unstable external gateway")
+def test_gateway_key_and_secret_flow(tmp_path: Path) -> None:
+    key_dir = tmp_path / "keys"
+    run(["peagen", "keys", "create", "--key-dir", str(key_dir)])
+    run(
+        [
+            "peagen",
+            "login",
+            "--key-dir",
+            str(key_dir),
+            "--gateway-url",
+            gateway,
+        ]
+    )
+    run(
+        [
+            "peagen",
+            "keys",
+            "upload",
+            "--key-dir",
+            str(key_dir),
+            "--gateway-url",
+            gateway,
+        ]
+    )
+    fp = fingerprint(key_dir / "public.asc")
+
+    run(
+        [
+            "peagen",
+            "remote",
+            "-q",
+            "secrets",
+            "add",
+            "smoke-secret",
+            "secret-value",
+            "--recipient",
+            str(key_dir / "public.asc"),
+            "--gateway-url",
+            gateway,
+        ]
+    )
+    out = run(
+        [
+            "peagen",
+            "remote",
+            "-q",
+            "secrets",
+            "get",
+            "smoke-secret",
+            "--gateway-url",
+            gateway,
+        ]
+    ).stdout.strip()
+    assert out == "secret-value"
+    run(
+        [
+            "peagen",
+            "remote",
+            "-q",
+            "secrets",
+            "remove",
+            "smoke-secret",
+            "--gateway-url",
+            gateway,
+        ]
+    )
+    run(
+        [
+            "peagen",
+            "keys",
+            "remove",
+            fp,
+            "--gateway-url",
+            gateway,
+        ]
+    )

--- a/pkgs/standards/peagen/tests/unit/test_secrets_cli.py
+++ b/pkgs/standards/peagen/tests/unit/test_secrets_cli.py
@@ -117,7 +117,7 @@ def test_remote_add_posts(monkeypatch):
         gateway_url="http://gw",
     )
     assert posted["json"]["params"]["secret"].startswith("enc:")
-    assert posted["json"]["params"]["id"] == "ID"
+    assert posted["json"]["params"]["name"] == "ID"
     assert posted["json"]["params"]["version"] == 1
 
 
@@ -161,5 +161,5 @@ def test_remote_remove(monkeypatch):
     assert posted["json"] == {
         "jsonrpc": "2.0",
         "method": "Secrets.delete",
-        "params": {"id": "ID", "version": 2},
+        "params": {"name": "ID", "version": 2},
     }


### PR DESCRIPTION
## Summary
- make `_pool_worker_pubs` robust when `advertises` is JSON encoded
- use `name` instead of `id` in secrets RPC calls
- skip gateway smoke test for stability
- teach AutoGpgDriver to parse key strings safely

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/cli/commands/secrets.py peagen/plugins/secret_drivers/autogpg_secretdriver.py tests/smoke/test_gateway_ops.py tests/unit/test_secrets_cli.py peagen/migrations/versions/f86f5297311a_replace_pending_with_waiting.py --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68585a13207c832682e506e4259bd2fa