### PR TITLE
Implement abuse tracking in Peagen gateway

### DIFF
--- a/pkgs/standards/peagen/peagen/migrations/versions/9b2c3d4e5f6a_abuse_records_table.py
+++ b/pkgs/standards/peagen/peagen/migrations/versions/9b2c3d4e5f6a_abuse_records_table.py
@@ -1,0 +1,32 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+revision = "9b2c3d4e5f6a"
+down_revision = "f86f5297311a"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    if "abuse_records" not in inspector.get_table_names():
+        op.create_table(
+            "abuse_records",
+            sa.Column("ip", sa.String(), primary_key=True),
+            sa.Column("count", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column(
+                "first_seen",
+                sa.TIMESTAMP(timezone=True),
+                nullable=False,
+            ),
+            sa.Column(
+                "banned", sa.Boolean(), nullable=False, server_default=sa.text("false")
+            ),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    if "abuse_records" in inspector.get_table_names():
+        op.drop_table("abuse_records")

--- a/pkgs/standards/peagen/peagen/models/__init__.py
+++ b/pkgs/standards/peagen/peagen/models/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from peagen.models.task_run import Base, TaskRun, TaskRunDep
 from peagen.models.secret import Secret
+from peagen.models.abuse import AbuseRecord
 from peagen.models.schemas import Pool, Role, Status, Task, User
 
 __all__ = [
@@ -14,4 +15,5 @@ __all__ = [
     "TaskRun",
     "Secret",
     "TaskRunDep",
+    "AbuseRecord",
 ]

--- a/pkgs/standards/peagen/peagen/models/abuse.py
+++ b/pkgs/standards/peagen/peagen/models/abuse.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import datetime as dt
+
+from sqlalchemy import Boolean, Integer, String, TIMESTAMP
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .task_run import Base
+
+
+class AbuseRecord(Base):
+    """Database model tracking abusive clients by IP address."""
+
+    __tablename__ = "abuse_records"
+
+    ip: Mapped[str] = mapped_column(String, primary_key=True)
+    count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    first_seen: Mapped[dt.datetime] = mapped_column(
+        TIMESTAMP(timezone=True), default=dt.datetime.utcnow
+    )
+    banned: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)


### PR DESCRIPTION
## Summary
- add `AbuseRecord` model for tracking abusive IP addresses
- store unknown handler occurrences in database
- load banned IPs on startup and mark IPs as banned when threshold reached

## Testing
- `uv run --directory peagen --package peagen ruff format gateway/db_helpers.py gateway/__init__.py models/__init__.py models/abuse.py`
- `uv run --directory peagen --package peagen ruff check gateway/db_helpers.py gateway/__init__.py models/__init__.py models/abuse.py --fix`
- `uv run --package peagen --directory peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_6858734d15808326a879a5fdf0f4dda9