### PR TITLE
Handle unknown task handlers at gateway

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_task_id_collision.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_id_collision.py
@@ -2,6 +2,7 @@ import pytest
 
 from peagen.plugins.queues.in_memory_queue import InMemoryQueue
 
+
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_task_submit_id_collision(monkeypatch):
@@ -27,10 +28,12 @@ async def test_task_submit_id_collision(monkeypatch):
 
     monkeypatch.setattr(peagen.plugins, "PluginManager", StubPM)
     import peagen.gateway as gw
+
     importlib.reload(gw)
 
     monkeypatch.setattr(gw, "queue", q)
     monkeypatch.setattr(gw, "result_backend", DummyBackend())
+
     async def noop(*_args, **_kwargs):
         return None
 
@@ -39,8 +42,7 @@ async def test_task_submit_id_collision(monkeypatch):
 
     task_submit = gw.task_submit
 
-    r1 = await task_submit(pool="p", payload={}, taskId="dup")
-    r2 = await task_submit(pool="p", payload={}, taskId="dup")
+    r1 = await task_submit(pool="p", payload={"action": "noop"}, taskId="dup")
+    r2 = await task_submit(pool="p", payload={"action": "noop"}, taskId="dup")
     assert r1["taskId"] == "dup"
     assert r2["taskId"] != "dup"
-

--- a/pkgs/standards/peagen/tests/unit/test_task_patch_finalize.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_patch_finalize.py
@@ -45,9 +45,11 @@ async def test_task_patch_triggers_finalize(monkeypatch):
     task_get = gw.task_get
     work_finished = gw.work_finished
 
-    parent_id = (await task_submit(pool="p", payload={}, taskId=None))["taskId"]
+    parent_id = (await task_submit(pool="p", payload={"action": "noop"}, taskId=None))[
+        "taskId"
+    ]
     child_id = str(uuid.uuid4())
-    await task_submit(pool="p", payload={}, taskId=child_id)
+    await task_submit(pool="p", payload={"action": "noop"}, taskId=child_id)
     await work_finished(taskId=child_id, status="success", result=None)
 
     await task_patch(taskId=parent_id, changes={"result": {"children": [child_id]}})
@@ -98,9 +100,11 @@ async def test_task_patch_triggers_finalize_rejected(monkeypatch):
     task_get = gw.task_get
     work_finished = gw.work_finished
 
-    parent_id = (await task_submit(pool="p", payload={}, taskId=None))["taskId"]
+    parent_id = (await task_submit(pool="p", payload={"action": "noop"}, taskId=None))[
+        "taskId"
+    ]
     child_id = str(uuid.uuid4())
-    await task_submit(pool="p", payload={}, taskId=child_id)
+    await task_submit(pool="p", payload={"action": "noop"}, taskId=child_id)
     await work_finished(taskId=child_id, status="rejected", result=None)
 
     await task_patch(taskId=parent_id, changes={"result": {"children": [child_id]}})

--- a/pkgs/standards/peagen/tests/unit/test_task_patch_status.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_patch_status.py
@@ -29,6 +29,7 @@ async def test_task_patch_updates_status(monkeypatch):
 
     monkeypatch.setattr(peagen.plugins, "PluginManager", StubPM)
     import peagen.gateway as gw
+
     importlib.reload(gw)
 
     monkeypatch.setattr(gw, "queue", q)
@@ -44,7 +45,7 @@ async def test_task_patch_updates_status(monkeypatch):
     task_patch = gw.task_patch
     task_get = gw.task_get
 
-    result = await task_submit(pool="p", payload={}, taskId=None)
+    result = await task_submit(pool="p", payload={"action": "noop"}, taskId=None)
     tid = result["taskId"]
 
     await task_patch(taskId=tid, changes={"status": "success"})


### PR DESCRIPTION
## Summary
- fetch worker capabilities from `/well-known` when registering
- reject `Task.submit` if action missing or unsupported
- record abuses and ban after threshold
- adjust tests for new behavior
- add regression test for unsupported handler

## Testing
- `uv run --package peagen --directory . ruff format ...` *(within `pkgs/standards/peagen`)*
- `uv run --package peagen --directory . ruff check ... --fix`
- `uv run --package peagen --directory . pytest tests/unit/test_task_patch_status.py tests/unit/test_task_patch_labels.py tests/unit/test_task_id_collision.py tests/unit/test_task_patch_finalize.py tests/unit/test_unknown_handler.py -q`
- `uv run --package peagen --directory pkgs/standards/peagen pytest`


------
https://chatgpt.com/codex/tasks/task_e_68587e204f608326b1cc203e81351378