### PR TITLE
Expand abuse tracking for invalid JSON-RPC

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_gateway_abuse.py
+++ b/pkgs/standards/peagen/tests/unit/test_gateway_abuse.py
@@ -101,3 +101,57 @@ async def test_prevalidate_unknown_method(monkeypatch):
     payload = {"id": "1", "method": "Foo.Bar"}
     resp = await gw._prevalidate(payload, "2.2.2.2")
     assert resp["error"]["code"] == -32601
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_prevalidate_bad_version(monkeypatch):
+    q = InMemoryQueue()
+
+    class DummyBackend:
+        async def store(self, task_run):
+            pass
+
+    counts = {}
+    banned = {}
+
+    async def fake_record(session, ip):
+        counts[ip] = counts.get(ip, 0) + 1
+        return counts[ip]
+
+    async def fake_mark(session, ip):
+        banned[ip] = True
+
+    class StubPM:
+        def __init__(self, cfg):
+            pass
+
+        def get(self, group):
+            if group == "queues":
+                return q
+            if group == "result_backends":
+                return DummyBackend()
+            return None
+
+    import importlib
+    import peagen.plugins
+
+    monkeypatch.setattr(peagen.plugins, "PluginManager", StubPM)
+    import peagen.gateway as gw
+
+    importlib.reload(gw)
+
+    monkeypatch.setattr(gw, "queue", q)
+    monkeypatch.setattr(gw, "result_backend", DummyBackend())
+    monkeypatch.setattr(gw, "record_unknown_handler", fake_record)
+    monkeypatch.setattr(gw, "mark_ip_banned", fake_mark)
+
+    payload = {"id": "1", "jsonrpc": "1.0", "method": "Foo.Bar"}
+    for _ in range(9):
+        resp = await gw._prevalidate(payload, "3.3.3.3")
+        assert resp["error"]["code"] == -32600
+    assert "3.3.3.3" not in banned
+
+    resp = await gw._prevalidate(payload, "3.3.3.3")
+    assert resp["error"]["code"] == -32600
+    assert banned.get("3.3.3.3") is True


### PR DESCRIPTION
## Summary
- ban malformed JSON-RPC requests in the gateway
- extend abuse checking to handle invalid request errors
- add unit test for bad version requests

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff check peagen/gateway/__init__.py tests/unit/test_gateway_abuse.py --fix`
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_gateway_abuse.py::test_prevalidate_bad_version -q`

------
https://chatgpt.com/codex/tasks/task_e_6858881a3b3c8326b59230a972f9ff41