### PR TITLE
Fix handler dispatch selection

### DIFF
--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -294,6 +294,7 @@ class WorkerBase:
                 "pool": self.POOL,
                 "url": self.url_self,
                 "advertises": {"cpu": True},
+                "handlers": self.supported_handlers(),
             },
         )
         self.log.info(

--- a/pkgs/standards/peagen/tests/unit/test_scheduler_worker_selection.py
+++ b/pkgs/standards/peagen/tests/unit/test_scheduler_worker_selection.py
@@ -1,0 +1,15 @@
+import json
+import pytest
+
+import peagen.gateway as gw
+
+
+@pytest.mark.unit
+def test_pick_worker_handles_handlers():
+    workers = [
+        {"url": "http://w1", "handlers": json.dumps(["a", "b"])},
+        {"url": "http://w2", "handlers": json.dumps(["c"])},
+    ]
+
+    assert gw._pick_worker(workers, "c")["url"] == "http://w2"
+    assert gw._pick_worker(workers, "x") is None

--- a/pkgs/standards/peagen/tests/unit/test_worker_register_handlers.py
+++ b/pkgs/standards/peagen/tests/unit/test_worker_register_handlers.py
@@ -1,0 +1,52 @@
+import json
+import importlib
+import pytest
+
+from peagen.plugins.queues.in_memory_queue import InMemoryQueue
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_worker_register_records_handlers(monkeypatch):
+    q = InMemoryQueue()
+
+    class DummyBackend:
+        async def store(self, task_run):
+            pass
+
+    class StubPM:
+        def __init__(self, cfg):
+            pass
+
+        def get(self, group):
+            if group == "queues":
+                return q
+            if group == "result_backends":
+                return DummyBackend()
+            return None
+
+    import peagen.plugins
+
+    monkeypatch.setattr(peagen.plugins, "PluginManager", StubPM)
+    import peagen.gateway as gw
+
+    importlib.reload(gw)
+
+    monkeypatch.setattr(gw, "queue", q)
+    monkeypatch.setattr(gw, "result_backend", DummyBackend())
+
+    async def noop(*_args, **_kw):
+        return None
+
+    monkeypatch.setattr(gw, "_persist", noop)
+    monkeypatch.setattr(gw, "_publish_event", noop)
+
+    await gw.worker_register(
+        workerId="w1",
+        pool="p",
+        url="http://w1/rpc",
+        advertises={},
+        handlers=["demo"],
+    )
+    data = await q.hgetall("worker:w1")
+    assert json.loads(data["handlers"]) == ["demo"]


### PR DESCRIPTION
## Summary
- send supported handlers during worker registration
- match task action to worker handlers in the scheduler
- unit test worker handler storage and worker selection logic

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_worker_register_handlers.py tests/unit/test_scheduler_worker_selection.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685887bebc588326855e51b819648550