### PR TITLE
Fix RPCError inheritance

### DIFF
--- a/pkgs/standards/peagen/peagen/transport/schemas.py
+++ b/pkgs/standards/peagen/peagen/transport/schemas.py
@@ -4,10 +4,14 @@ from typing import Any, Dict, Optional, Union, Literal
 from pydantic import BaseModel, Field
 
 
-class RPCError(BaseModel):
+class RPCError(Exception, BaseModel):
     code: int = Field(..., example=-32601)
     message: str = Field(..., example="Method not found")
     data: Optional[Any] = Field(None, example={"detail": "extra info"})
+
+    def __init__(self, **data):
+        BaseModel.__init__(self, **data)
+        Exception.__init__(self, self.message)
 
 
 class RPCRequest(BaseModel):


### PR DESCRIPTION
## Summary
- make `RPCError` a real exception so it can be raised and caught

## Testing
- `ruff format peagen/transport/schemas.py`
- `ruff check peagen/transport/schemas.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_68588eca092483268c94b58068c23f2a