### PR TITLE
Handle malformed payloads in gateway

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_gateway_abuse.py
+++ b/pkgs/standards/peagen/tests/unit/test_gateway_abuse.py
@@ -155,3 +155,65 @@ async def test_prevalidate_bad_version(monkeypatch):
     resp = await gw._prevalidate(payload, "3.3.3.3")
     assert resp["error"]["code"] == -32600
     assert banned.get("3.3.3.3") is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_rpc_parse_error_counts_and_bans(monkeypatch):
+    q = InMemoryQueue()
+
+    class DummyBackend:
+        async def store(self, task_run):
+            pass
+
+    counts = {}
+    banned = {}
+
+    async def fake_record(session, ip):
+        counts[ip] = counts.get(ip, 0) + 1
+        return counts[ip]
+
+    async def fake_mark(session, ip):
+        banned[ip] = True
+
+    class StubPM:
+        def __init__(self, cfg):
+            pass
+
+        def get(self, group):
+            if group == "queues":
+                return q
+            if group == "result_backends":
+                return DummyBackend()
+            return None
+
+    import importlib
+    import peagen.plugins
+
+    monkeypatch.setattr(peagen.plugins, "PluginManager", StubPM)
+    import peagen.gateway as gw
+
+    importlib.reload(gw)
+
+    monkeypatch.setattr(gw, "queue", q)
+    monkeypatch.setattr(gw, "result_backend", DummyBackend())
+    monkeypatch.setattr(gw, "record_unknown_handler", fake_record)
+    monkeypatch.setattr(gw, "mark_ip_banned", fake_mark)
+
+    class BadRequest:
+        def __init__(self, host: str):
+            self.client = type("C", (), {"host": host})()
+
+        async def json(self):
+            from json.decoder import JSONDecodeError
+
+            raise JSONDecodeError("bad", "", 0)
+
+    for _ in range(9):
+        resp = await gw.rpc_endpoint(BadRequest("4.4.4.4"))
+        assert resp.status_code == 400
+    assert "4.4.4.4" not in banned
+
+    resp = await gw.rpc_endpoint(BadRequest("4.4.4.4"))
+    assert resp.status_code == 400
+    assert banned.get("4.4.4.4") is True


### PR DESCRIPTION
## Summary
- track parse errors as abuse in `rpc_endpoint`
- test gateway bans IPs on repeated malformed payloads

## Testing
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_gateway_abuse.py::test_rpc_parse_error_counts_and_bans -q`

------
https://chatgpt.com/codex/tasks/task_e_6858902b25548326893690bc6d009cbe