### PR TITLE
Fix JSON-RPC error handling and tests

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_secret_store.py
+++ b/pkgs/standards/peagen/tests/unit/test_secret_store.py
@@ -20,5 +20,5 @@ async def test_secret_roundtrip(tmp_path, monkeypatch):
     res = await gw.secrets_get(name="foo")
     assert res["secret"] == "bar"
     await gw.secrets_delete(name="foo")
-    with pytest.raises(TypeError):
+    with pytest.raises(gw.RPCException):
         await gw.secrets_get(name="foo")

--- a/pkgs/standards/peagen/tests/unit/test_secret_store_versioning.py
+++ b/pkgs/standards/peagen/tests/unit/test_secret_store_versioning.py
@@ -25,5 +25,5 @@ async def test_secret_roundtrip(tmp_path, monkeypatch):
     assert val == {"secret": "b"}
 
     await gw.secrets_delete(name="ns/test")
-    with pytest.raises(TypeError):
+    with pytest.raises(gw.RPCException):
         await gw.secrets_get(name="ns/test")


### PR DESCRIPTION
## Summary
- add `RPCException` and update dispatcher to use it
- accept unused `version` on secret RPCs
- fix gateway prevalidation rules
- update tests to expect `RPCException`

## Testing
- `uv run --package peagen --directory pkgs/standards ruff check peagen --fix`
- `uv run --package peagen --directory pkgs/standards/peagen env PEAGEN_TEST_GATEWAY=http://localhost:1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685890e9a44c83269ba6bebe18c1a9b1