### PR TITLE
Fix RPC error handling and secret RPC parameters

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -460,6 +460,7 @@ async def secrets_add(
     secret: str,
     tenant_id: str = "default",
     owner_fpr: str = "unknown",
+    version: int | None = None,
 ) -> dict:
     """Store an encrypted secret."""
     async with Session() as session:
@@ -480,7 +481,11 @@ async def secrets_get(name: str, tenant_id: str = "default") -> dict:
 
 
 @rpc.method("Secrets.delete")
-async def secrets_delete(name: str, tenant_id: str = "default") -> dict:
+async def secrets_delete(
+    name: str,
+    tenant_id: str = "default",
+    version: int | None = None,
+) -> dict:
     """Remove a secret by name."""
     async with Session() as session:
         await delete_secret(session, tenant_id, name)

--- a/pkgs/standards/peagen/peagen/transport/__init__.py
+++ b/pkgs/standards/peagen/peagen/transport/__init__.py
@@ -1,3 +1,4 @@
 from .jsonrpc import RPCDispatcher
-from .schemas import RPCRequest, RPCResponse, RPCError
-__all__ = ["RPCDispatcher", "RPCRequest", "RPCResponse", "RPCError"]
+from .schemas import RPCRequest, RPCResponse, RPCError, RPCErrorData
+
+__all__ = ["RPCDispatcher", "RPCRequest", "RPCResponse", "RPCError", "RPCErrorData"]

--- a/pkgs/standards/peagen/peagen/transport/schemas.py
+++ b/pkgs/standards/peagen/peagen/transport/schemas.py
@@ -4,10 +4,21 @@ from typing import Any, Dict, Optional, Union, Literal
 from pydantic import BaseModel, Field
 
 
-class RPCError(BaseModel):
+class RPCErrorData(BaseModel):
     code: int = Field(..., example=-32601)
     message: str = Field(..., example="Method not found")
     data: Optional[Any] = Field(None, example={"detail": "extra info"})
+
+
+class RPCError(Exception):
+    """Exception carrying JSON-RPC error details."""
+
+    def __init__(self, *, code: int, message: str, data: Any | None = None) -> None:
+        self.error = RPCErrorData(code=code, message=message, data=data)
+        super().__init__(message)
+
+    def model_dump(self) -> Dict[str, Any]:
+        return self.error.model_dump()
 
 
 class RPCRequest(BaseModel):
@@ -26,4 +37,4 @@ class RPCResponse(BaseModel):
     id: Union[int, str, None] = Field(..., example=1)
     # exactly one of result / error is present
     result: Optional[Any] = Field(None, example={"taskId": "01HX..."})
-    error: Optional[RPCError] = None
+    error: Optional[RPCErrorData] = None


### PR DESCRIPTION
## Summary
- update RPC error handling by separating data model from exception
- allow optional `version` parameter in secret RPC handlers
- expose `RPCErrorData` through transport package

## Testing
- `uv run --directory standards --package peagen ruff check peagen/transport/schemas.py peagen/transport/__init__.py peagen/gateway/__init__.py --fix`
- `uv run --package peagen --directory standards pytest` *(fails: ModuleNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_685890e9a44c83269ba6bebe18c1a9b1