### PR TITLE
Add IP logging middleware to peagen gateway

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -69,6 +69,14 @@ app = FastAPI(title="Peagen Pool Manager Gateway")
 app.include_router(ws_router)  # 1-liner, no prefix
 READY = False
 
+
+@app.middleware("http")
+async def _log_ip(request: Request, call_next):
+    """Log the originating IP for every HTTP request."""
+    log.info("%s %s from %s", request.method, request.url.path, request.client.host)
+    return await call_next(request)
+
+
 cfg = resolve_cfg()
 CONTROL_QUEUE = cfg.get("control_queue", defaults.CONFIG["control_queue"])
 READY_QUEUE = cfg.get("ready_queue", defaults.CONFIG["ready_queue"])


### PR DESCRIPTION
## Summary
- log every client IP via HTTP middleware in the peagen gateway

## Testing
- `uv run --package peagen --directory standards/peagen ruff check peagen/gateway/__init__.py --fix`
- `uv run --package peagen --directory standards/peagen pytest` *(fails: test_secret_roundtrip)*
- `uv run --package peagen --directory pkgs/standards/peagen peagen remote -q --gateway-url http://localhost:8000/rpc process projects_payload.yaml --watch` *(fails: connection refused)*
- `uv run --package peagen --directory pkgs/standards/peagen peagen local -q process projects_payload.yaml` *(fails: no LLM provider)*

------
https://chatgpt.com/codex/tasks/task_e_68589524c7d08326a4d2117a63a38661