### PR TITLE
Add coverage for worker handler discovery and unknown task actions

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_task_submit_unknown.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_submit_unknown.py
@@ -1,0 +1,56 @@
+import importlib
+import pytest
+
+from peagen.plugins.queues.in_memory_queue import InMemoryQueue
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_task_submit_unknown_action(monkeypatch):
+    q = InMemoryQueue()
+
+    class DummyBackend:
+        async def store(self, task_run):
+            pass
+
+    class StubPM:
+        def __init__(self, cfg):
+            pass
+
+        def get(self, group):
+            if group == "queues":
+                return q
+            if group == "result_backends":
+                return DummyBackend()
+            return None
+
+    import peagen.plugins
+
+    monkeypatch.setattr(peagen.plugins, "PluginManager", StubPM)
+    import peagen.gateway as gw
+    import peagen
+
+    importlib.reload(gw)
+
+    monkeypatch.setattr(gw, "queue", q)
+    monkeypatch.setattr(gw, "result_backend", DummyBackend())
+
+    async def noop(*_args, **_kw):
+        return None
+
+    monkeypatch.setattr(gw, "_persist", noop)
+    monkeypatch.setattr(gw, "_publish_event", noop)
+
+    await gw.worker_register(
+        workerId="w1",
+        pool="p",
+        url="http://w1/rpc",
+        advertises={},
+        handlers=["foo"],
+    )
+
+    with pytest.raises(gw.RPCException) as exc:
+        await gw.task_submit(pool="p", payload={"action": "bar"}, taskId=None)
+    assert exc.value.code == -32601
+    items = await q.lrange("ready:p", 0, -1)
+    assert items == []

--- a/pkgs/standards/peagen/tests/unit/test_worker_register_well_known.py
+++ b/pkgs/standards/peagen/tests/unit/test_worker_register_well_known.py
@@ -1,0 +1,73 @@
+import json
+import importlib
+import pytest
+
+from peagen.plugins.queues.in_memory_queue import InMemoryQueue
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_worker_register_fetches_well_known(monkeypatch):
+    q = InMemoryQueue()
+
+    class DummyBackend:
+        async def store(self, task_run):
+            pass
+
+    class StubPM:
+        def __init__(self, cfg):
+            pass
+
+        def get(self, group):
+            if group == "queues":
+                return q
+            if group == "result_backends":
+                return DummyBackend()
+            return None
+
+    import peagen.plugins
+
+    monkeypatch.setattr(peagen.plugins, "PluginManager", StubPM)
+    import peagen.gateway as gw
+
+    importlib.reload(gw)
+
+    monkeypatch.setattr(gw, "queue", q)
+    monkeypatch.setattr(gw, "result_backend", DummyBackend())
+
+    async def fake_get(self, url):
+        class R:
+            status_code = 200
+
+            def json(self):
+                return {"handlers": ["a", "b"]}
+
+        return R()
+
+    class DummyClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def get(self, url):
+            return await fake_get(self, url)
+
+    monkeypatch.setattr(gw.httpx, "AsyncClient", DummyClient)
+
+    async def noop(*_args, **_kw):
+        return None
+
+    monkeypatch.setattr(gw, "_persist", noop)
+    monkeypatch.setattr(gw, "_publish_event", noop)
+
+    await gw.worker_register(
+        workerId="w1", pool="p", url="http://w1/rpc", advertises={}
+    )
+    data = await q.hgetall("worker:w1")
+    handlers = json.loads(data["handlers"])
+    assert handlers == ["a", "b"]


### PR DESCRIPTION
## Summary
- add unit test verifying gateway fetches handlers from worker's `/well-known`
- add unit test ensuring `Task.submit` rejects unknown actions

## Testing
- `uv run --directory standards/peagen --package peagen ruff format tests/unit/test_worker_register_well_known.py tests/unit/test_task_submit_unknown.py`
- `uv run --directory standards/peagen --package peagen ruff check tests/unit/test_worker_register_well_known.py tests/unit/test_task_submit_unknown.py --fix`
- `uv run --package peagen --directory standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_685899303f4c8326b31a6808e6fc7d29