### PR TITLE
Add worker advertise & handler fields to Pools

### DIFF
--- a/pkgs/standards/peagen/peagen/tui/components/workers_view.py
+++ b/pkgs/standards/peagen/peagen/tui/components/workers_view.py
@@ -13,7 +13,14 @@ class WorkersView(DataTable):
         """Refresh the table contents."""
 
         if not self.columns:
-            self.add_columns("Worker", "Pool", "URL", "Last Seen")
+            self.add_columns(
+                "Worker",
+                "Pool",
+                "URL",
+                "Last Seen",
+                "Advertises",
+                "Handlers",
+            )
 
         self.clear()
         for wid, info in workers.items():
@@ -28,5 +35,8 @@ class WorkersView(DataTable):
                 str(info.get("pool", "")),
                 str(info.get("url", "")),
                 ts_str,
+                str(info.get("advertises", "")),
+                ",".join(info.get("handlers", []))
+                if isinstance(info.get("handlers"), list)
+                else str(info.get("handlers", "")),
             )
-


### PR DESCRIPTION
## Summary
- extend the pool screen of the Peagen TUI dashboard
- show advertised capabilities and registered handlers for each worker

## Testing
- `uv run --package peagen ruff format peagen/tui/components/workers_view.py`
- `uv run --package peagen ruff check peagen/tui/components/workers_view.py --fix`
- `uv run --package peagen --directory standards/peagen pytest`
- `uv run --package peagen --directory pkgs/standards/peagen peagen local process tests/examples/projects_payloads/projects_payload.yaml` *(fails: No LLM provider specified)*

------
https://chatgpt.com/codex/tasks/task_e_6858a8c7f3a48326a07800d9e0f3437e