### PR TITLE
Add remote mutate smoke test

### DIFF
--- a/pkgs/standards/peagen/tests/smoke/test_remote_mutate_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_mutate_cli.py
@@ -1,0 +1,50 @@
+import os
+import subprocess
+
+import httpx
+import pytest
+
+GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
+
+
+def _gateway_available(url: str) -> bool:
+    """Return ``True`` if the gateway URL responds successfully."""
+    try:
+        response = httpx.get(url, timeout=5)
+    except Exception:
+        return False
+    return response.status_code < 500
+
+
+@pytest.mark.i9n
+def test_remote_mutate_submit(tmp_path: str) -> None:
+    if not _gateway_available(GATEWAY):
+        pytest.skip("gateway not reachable")
+
+    repo = "https://github.com/swarmauri/swarmauri-sdk.git"
+    workspace = "pkgs/standards/peagen/tests/examples/peagen_local_demo/test_workspace"
+
+    result = subprocess.run(
+        [
+            "peagen",
+            "remote",
+            "mutate",
+            workspace,
+            "--target-file",
+            "main.py",
+            "--import-path",
+            "main",
+            "--entry-fn",
+            "main",
+            "--repo",
+            repo,
+            "--gateway-url",
+            GATEWAY,
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=60,
+    )
+
+    assert "Submitted task" in result.stdout


### PR DESCRIPTION
## Summary
- add a smoke test verifying `peagen remote mutate` works with the public gateway

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format tests/smoke/test_remote_mutate_cli.py`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check tests/smoke/test_remote_mutate_cli.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_6858abd283108326871c81d5f68cb521