### PR TITLE
Add remote DOE smoke tests

### DIFF
--- a/pkgs/standards/peagen/tests/smoke/test_gateway_remote_doe.py
+++ b/pkgs/standards/peagen/tests/smoke/test_gateway_remote_doe.py
@@ -1,0 +1,108 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import httpx
+import pytest
+
+GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
+
+
+def _gateway_available(url: str) -> bool:
+    try:
+        response = httpx.get(url, timeout=5)
+    except Exception:
+        return False
+    return response.status_code < 500
+
+
+@pytest.mark.i9n
+def test_remote_login(tmp_path: Path) -> None:
+    if not _gateway_available(GATEWAY):
+        pytest.skip("gateway not reachable")
+
+    subprocess.run(
+        ["peagen", "login", "--gateway-url", GATEWAY],
+        check=True,
+        timeout=60,
+    )
+
+
+@pytest.mark.i9n
+def test_remote_keys_fetch(tmp_path: Path) -> None:
+    if not _gateway_available(GATEWAY):
+        pytest.skip("gateway not reachable")
+
+    result = subprocess.run(
+        ["peagen", "keys", "fetch-server", "--gateway-url", GATEWAY],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=60,
+    )
+    data = json.loads(result.stdout)
+    assert isinstance(data, dict)
+
+
+@pytest.mark.i9n
+def test_remote_secret_roundtrip(tmp_path: Path) -> None:
+    if not _gateway_available(GATEWAY):
+        pytest.skip("gateway not reachable")
+
+    subprocess.run(
+        [
+            "peagen",
+            "remote",
+            "secrets",
+            "add",
+            "smoke-secret",
+            "value",
+            "--gateway-url",
+            GATEWAY,
+        ],
+        check=True,
+        timeout=60,
+    )
+
+    subprocess.run(
+        [
+            "peagen",
+            "remote",
+            "secrets",
+            "remove",
+            "smoke-secret",
+            "--gateway-url",
+            GATEWAY,
+        ],
+        check=True,
+        timeout=60,
+    )
+
+
+@pytest.mark.i9n
+def test_remote_doe_process(tmp_path: Path) -> None:
+    if not _gateway_available(GATEWAY):
+        pytest.skip("gateway not reachable")
+
+    root = Path(__file__).resolve().parents[2]
+    spec = root / "tests" / "examples" / "gateway_demo" / "doe_spec.yaml"
+    template = root / "tests" / "examples" / "gateway_demo" / "template_project.yaml"
+
+    gateway = GATEWAY[:-4] if GATEWAY.endswith("/rpc") else GATEWAY
+
+    subprocess.run(
+        [
+            "peagen",
+            "remote",
+            "--gateway-url",
+            gateway,
+            "doe",
+            "process",
+            str(spec),
+            str(template),
+            "--dry-run",
+        ],
+        check=True,
+        timeout=60,
+    )


### PR DESCRIPTION
## Summary
- add smoke test suite exercising remote login, key fetching, secrets and DOE processing

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen pytest`


------
https://chatgpt.com/codex/tasks/task_e_6858ac012bc48326b89d08ce7a1cf955