### PR TITLE
Fix real client IP detection in gateway

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_gateway_client_ip.py
+++ b/pkgs/standards/peagen/tests/unit/test_gateway_client_ip.py
@@ -1,0 +1,26 @@
+import pytest
+
+from peagen.gateway import _get_client_ip
+
+
+class DummyClient:
+    def __init__(self, host: str):
+        self.host = host
+
+
+class DummyRequest:
+    def __init__(self, headers: dict[str, str], host: str = "192.168.0.1"):
+        self.headers = headers
+        self.client = DummyClient(host)
+
+
+@pytest.mark.unit
+def test_get_client_ip_forwarded():
+    req = DummyRequest({"x-forwarded-for": "203.0.113.7, 10.0.0.1"})
+    assert _get_client_ip(req) == "203.0.113.7"
+
+
+@pytest.mark.unit
+def test_get_client_ip_fallback():
+    req = DummyRequest({}, "10.1.1.1")
+    assert _get_client_ip(req) == "10.1.1.1"


### PR DESCRIPTION
## Summary
- retrieve true client IP via forwarding headers
- add unit tests for IP extraction

## Testing
- `uv run --directory standards --package peagen ruff check peagen/peagen/gateway/__init__.py peagen/tests/unit/test_gateway_client_ip.py --fix`
- `uv run --directory standards --package peagen pytest peagen/tests/unit/test_gateway_client_ip.py -vv`
- `uv run --directory standards --package peagen pytest` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6858ad4246148326b6e8f6f1aa14b65b