### PR TITLE
Fix Postgres result backend

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/db_helpers.py
+++ b/pkgs/standards/peagen/peagen/gateway/db_helpers.py
@@ -35,13 +35,13 @@ def _coerce(row_dict: Dict[str, Any]) -> Dict[str, Any]:
 
 
 async def upsert_task(session: AsyncSession, row: TaskRun) -> None:
-    data = _coerce(row.to_dict(exclude={"deps"}))
+    data = _coerce(row.to_dict(exclude={"deps", "duration"}))
     stmt = (
         pg_insert(TaskRun)
         .values(**data)
         .on_conflict_do_update(
             index_elements=["id"],
-            set_=_coerce(row.to_dict(exclude={"id", "deps"})),
+            set_=_coerce(row.to_dict(exclude={"id", "deps", "duration"})),
         )
     )
     result = await session.execute(stmt)


### PR DESCRIPTION
## Summary
- fix inserting `duration` column in Postgres upsert

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/gateway/db_helpers.py --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_6858ad03f25c83269bbf86bc4e9211ce