### PR TITLE
Add remote smoke test

### DIFF
--- a/pkgs/standards/peagen/tests/smoke/test_remote_full_flow.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_full_flow.py
@@ -1,0 +1,106 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import httpx
+import pytest
+
+GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
+BASE = Path(__file__).resolve().parents[2] / "tests" / "examples"
+DOE_SPEC = BASE / "gateway_demo" / "doe_spec.yaml"
+DOE_TEMPLATE = BASE / "gateway_demo" / "template_project.yaml"
+EVOLVE_SPEC = BASE / "simple_evolve_demo" / "evolve_remote_spec.yaml"
+
+
+def _gateway_available(url: str) -> bool:
+    try:
+        response = httpx.get(url, timeout=5)
+    except Exception:
+        return False
+    return response.status_code < 500
+
+
+@pytest.mark.i9n
+def test_remote_full_flow(tmp_path: Path) -> None:
+    if not _gateway_available(GATEWAY):
+        pytest.skip("gateway not reachable")
+
+    subprocess.run(
+        ["peagen", "login", "--gateway-url", GATEWAY], check=True, timeout=60
+    )
+
+    result = subprocess.run(
+        ["peagen", "keys", "fetch-server", "--gateway-url", GATEWAY],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=60,
+    )
+    assert isinstance(json.loads(result.stdout), dict)
+
+    subprocess.run(
+        [
+            "peagen",
+            "remote",
+            "secrets",
+            "add",
+            "smoke-secret",
+            "value",
+            "--gateway-url",
+            GATEWAY,
+        ],
+        check=True,
+        timeout=60,
+    )
+
+    gateway = GATEWAY[:-4] if GATEWAY.endswith("/rpc") else GATEWAY
+    subprocess.run(
+        [
+            "peagen",
+            "remote",
+            "--gateway-url",
+            gateway,
+            "doe",
+            "process",
+            str(DOE_SPEC),
+            str(DOE_TEMPLATE),
+            "--dry-run",
+        ],
+        check=True,
+        timeout=60,
+    )
+
+    result = subprocess.run(
+        [
+            "peagen",
+            "remote",
+            "-q",
+            "--gateway-url",
+            GATEWAY,
+            "evolve",
+            str(EVOLVE_SPEC),
+            "--watch",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=60,
+    )
+    last_line = result.stdout.strip().splitlines()[-1]
+    data = json.loads(last_line)
+    assert data["status"] == "success"
+
+    subprocess.run(
+        [
+            "peagen",
+            "remote",
+            "secrets",
+            "remove",
+            "smoke-secret",
+            "--gateway-url",
+            GATEWAY,
+        ],
+        check=True,
+        timeout=60,
+    )


### PR DESCRIPTION
## Summary
- add smoke test covering remote login, key fetch, secret roundtrip, DOE process and evolve

## Testing
- `ruff format` and `ruff check`

------
https://chatgpt.com/codex/tasks/task_e_6858b4a022048326949186b104e81e0c