### PR TITLE
Fix cryptography deprecation warnings

### DIFF
--- a/pkgs/standards/peagen/peagen/plugins/secret_drivers/autogpg_secretdriver.py
+++ b/pkgs/standards/peagen/peagen/plugins/secret_drivers/autogpg_secretdriver.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Iterable
+import warnings
 
+from cryptography.utils import CryptographyDeprecationWarning
 import pgpy
 from pgpy.constants import (
     CompressionAlgorithm,
@@ -11,8 +13,11 @@ from pgpy.constants import (
     PubKeyAlgorithm,
     SymmetricKeyAlgorithm,
 )
-
 from .base import SecretDriverBase
+
+warnings.filterwarnings(
+    "ignore", category=CryptographyDeprecationWarning, module="pgpy.constants"
+)
 
 
 class AutoGpgDriver(SecretDriverBase):


### PR DESCRIPTION
## Summary
- suppress deprecated algorithm warnings in `AutoGpgDriver`

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff check peagen/plugins/secret_drivers/autogpg_secretdriver.py --fix`
- `PEAGEN_TEST_GATEWAY=https://example.invalid uv run --package peagen --directory pkgs/standards/peagen pytest -k 'not secret_roundtrip'`

------
https://chatgpt.com/codex/tasks/task_e_6858b427752c83269d49e3d9d6db8619