### PR TITLE
Enable forwarded IP in gateway

### DIFF
--- a/infra/Dockerfile.gw
+++ b/infra/Dockerfile.gw
@@ -34,4 +34,4 @@ ENV \
     MINIO_USER="" \
     MINIO_ROOT_PASSWORD=""
     
-CMD ["sh", "-c", "python -c 'import uvicorn; uvicorn.run(\"peagen.gateway:app\", host=\"0.0.0.0\", port=8000, log_level=\"info\")'"]
+CMD ["sh", "-c", "python -c 'import uvicorn; uvicorn.run(\"peagen.gateway:app\", host=\"0.0.0.0\", port=8000, log_level=\"info\", proxy_headers=True, forwarded_allow_ips=\"*\")'"]


### PR DESCRIPTION
## Summary
- ensure gateway container respects `X-Forwarded-For` by enabling `proxy_headers`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6858cb29a99483269a986d0790c30425