### PR TITLE
Update gateway to respect real client IP

### DIFF
--- a/infra/Dockerfile.gw
+++ b/infra/Dockerfile.gw
@@ -34,4 +34,4 @@ ENV \
     MINIO_USER="" \
     MINIO_ROOT_PASSWORD=""
     
-CMD ["sh", "-c", "python -c 'import uvicorn; uvicorn.run(\"peagen.gateway:app\", host=\"0.0.0.0\", port=8000, log_level=\"info\")'"]
+CMD ["sh", "-c", "python -c 'import uvicorn; uvicorn.run(\"peagen.gateway:app\", host=\"0.0.0.0\", port=8000, log_level=\"info\", proxy_headers=True, forwarded_allow_ips=\"*\")'"]

--- a/pkgs/standards/peagen/AGENTS.md
+++ b/pkgs/standards/peagen/AGENTS.md
@@ -50,7 +50,7 @@ dsn = "${PG_DSN}"
 3. Start the gateway with Uvicorn:
 
 ```bash
-uvicorn peagen.gateway:app --host 0.0.0.0 --port 8000
+uvicorn peagen.gateway:app --host 0.0.0.0 --port 8000 --proxy-headers --forwarded-allow-ips="*"
 ```
 
 The gateway exposes a JSON‑RPC endpoint at `/rpc` and a WebSocket at `/ws/tasks`.
@@ -62,7 +62,7 @@ FROM python:3.12-slim
 WORKDIR /app
 COPY . .
 RUN pip install peagen
-CMD ["uvicorn", "peagen.gateway:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "peagen.gateway:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers", "--forwarded-allow-ips=*"]
 ```
 
 ## Running a Worker

--- a/pkgs/standards/peagen/tests/examples/gateway_demo/README.md
+++ b/pkgs/standards/peagen/tests/examples/gateway_demo/README.md
@@ -5,7 +5,7 @@ This example demonstrates a minimal setup for running the Peagen gateway and wor
 1. Start the gateway:
 
    ```bash
-   uvicorn peagen.gateway:app --host 0.0.0.0 --port 8000
+   uvicorn peagen.gateway:app --host 0.0.0.0 --port 8000 --proxy-headers --forwarded-allow-ips="*"
    ```
 
 2. Launch a worker connected to the gateway:


### PR DESCRIPTION
## Summary
- forward proxy headers in gateway Dockerfile
- document proxy header usage in Peagen deployment guide and gateway demo

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format .`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest` *(fails: subprocess.CalledProcessError)*

------
https://chatgpt.com/codex/tasks/task_e_6858cb1aa5b8832696f08e8d822e72de