### PR TITLE
Implement pool-based secret isolation

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/secrets.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/secrets.py
@@ -108,7 +108,12 @@ def remote_add(
     envelope = {
         "jsonrpc": "2.0",
         "method": "Secrets.add",
-        "params": {"name": secret_id, "secret": cipher, "version": version},
+        "params": {
+            "name": secret_id,
+            "secret": cipher,
+            "version": version,
+            "tenant_id": pool,
+        },
     }
     res = httpx.post(gateway_url, json=envelope, timeout=10.0)
     if getattr(res, "status_code", 200) >= 400:
@@ -125,6 +130,7 @@ def remote_get(
     ctx: typer.Context,
     secret_id: str,
     gateway_url: str = typer.Option("http://localhost:8000/rpc", "--gateway-url"),
+    pool: str = typer.Option("default", "--pool"),
 ) -> None:
     """Retrieve and decrypt a secret from the gateway."""
     gateway_url = gateway_url.rstrip("/")
@@ -134,7 +140,7 @@ def remote_get(
     envelope = {
         "jsonrpc": "2.0",
         "method": "Secrets.get",
-        "params": {"name": secret_id},
+        "params": {"name": secret_id, "tenant_id": pool},
     }
     res = httpx.post(gateway_url, json=envelope, timeout=10.0)
     if getattr(res, "status_code", 200) >= 400:
@@ -153,6 +159,7 @@ def remote_remove(
     secret_id: str,
     version: int = typer.Option(None, "--version"),
     gateway_url: str = typer.Option("http://localhost:8000/rpc", "--gateway-url"),
+    pool: str = typer.Option("default", "--pool"),
 ) -> None:
     """Delete a secret on the gateway."""
     gateway_url = gateway_url.rstrip("/")
@@ -161,7 +168,7 @@ def remote_remove(
     envelope = {
         "jsonrpc": "2.0",
         "method": "Secrets.delete",
-        "params": {"name": secret_id, "version": version},
+        "params": {"name": secret_id, "version": version, "tenant_id": pool},
     }
 
     res = httpx.post(gateway_url, json=envelope, timeout=10.0)

--- a/pkgs/standards/peagen/peagen/core/secrets_core.py
+++ b/pkgs/standards/peagen/peagen/core/secrets_core.py
@@ -91,20 +91,30 @@ def add_remote_secret(
     envelope = {
         "jsonrpc": "2.0",
         "method": "Secrets.add",
-        "params": {"id": secret_id, "secret": cipher, "version": version},
+        "params": {
+            "name": secret_id,
+            "secret": cipher,
+            "version": version,
+            "tenant_id": pool,
+        },
     }
     res = httpx.post(gateway_url, json=envelope, timeout=10.0)
     res.raise_for_status()
     return res.json()
 
 
-def get_remote_secret(secret_id: str, gateway_url: str = DEFAULT_GATEWAY) -> str:
+def get_remote_secret(
+    secret_id: str,
+    gateway_url: str = DEFAULT_GATEWAY,
+    *,
+    pool: str = "default",
+) -> str:
     """Retrieve and decrypt a secret from the gateway."""
     drv = AutoGpgDriver()
     envelope = {
         "jsonrpc": "2.0",
         "method": "Secrets.get",
-        "params": {"id": secret_id},
+        "params": {"name": secret_id, "tenant_id": pool},
     }
     res = httpx.post(gateway_url, json=envelope, timeout=10.0)
     res.raise_for_status()
@@ -116,12 +126,14 @@ def remove_remote_secret(
     secret_id: str,
     gateway_url: str = DEFAULT_GATEWAY,
     version: Optional[int] = None,
+    *,
+    pool: str = "default",
 ) -> dict:
     """Delete a secret stored on the gateway."""
     envelope = {
         "jsonrpc": "2.0",
         "method": "Secrets.delete",
-        "params": {"id": secret_id, "version": version},
+        "params": {"name": secret_id, "version": version, "tenant_id": pool},
     }
     res = httpx.post(gateway_url, json=envelope, timeout=10.0)
     res.raise_for_status()

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -109,6 +109,7 @@ TASK_TTL = 24 * 3600  # 24 h, adjust as needed
 BAN_THRESHOLD = 10
 KNOWN_IPS: set[str] = set()
 BANNED_IPS: set[str] = set()
+SECRET_NOT_FOUND_CODE = -32004
 
 
 def _supports(method: str | None) -> bool:
@@ -445,16 +446,27 @@ async def rpc_endpoint(request: Request):
                     await mark_ip_banned(session, ip)
                 log.warning("banned ip %s", ip)
 
+    status = 200
+
+    def _not_found(r: dict) -> bool:
+        return r.get("error", {}).get("code") == SECRET_NOT_FOUND_CODE
+
     if isinstance(resp, dict) and "error" in resp:
         method = payload.get("method") if isinstance(payload, dict) else "batch"
         log.warning(f"{method} '{resp['error']}'")
         await _check_unknown(resp, method)
+        if _not_found(resp):
+            status = 404
     elif isinstance(resp, list):
         for r in resp:
             if isinstance(r, dict) and "error" in r:
                 await _check_unknown(r, "batch")
+                if _not_found(r):
+                    status = 404
     log.debug("RPC out -> %s", resp)
-    return resp
+    return Response(
+        content=json.dumps(resp), status_code=status, media_type="application/json"
+    )
 
 
 # ─────────────────────────── Key/Secret RPC ─────────────────────
@@ -506,7 +518,7 @@ async def secrets_get(name: str, tenant_id: str = "default") -> dict:
     async with Session() as session:
         row = await fetch_secret(session, tenant_id, name)
     if not row:
-        raise RPCException(code=-32000, message="secret not found")
+        raise RPCException(code=SECRET_NOT_FOUND_CODE, message="secret not found")
     return {"secret": row.cipher}
 
 

--- a/pkgs/standards/peagen/peagen/handlers/secrets_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/secrets_handler.py
@@ -42,6 +42,7 @@ async def secrets_handler(task: Dict[str, Any] | Task) -> Dict[str, Any]:
         secret = secrets_core.get_remote_secret(
             args["secret_id"],
             gateway_url=args.get("gateway_url", secrets_core.DEFAULT_GATEWAY),
+            pool=args.get("pool", "default"),
         )
         return {"secret": secret}
 
@@ -50,6 +51,7 @@ async def secrets_handler(task: Dict[str, Any] | Task) -> Dict[str, Any]:
             args["secret_id"],
             gateway_url=args.get("gateway_url", secrets_core.DEFAULT_GATEWAY),
             version=args.get("version"),
+            pool=args.get("pool", "default"),
         )
 
     raise ValueError(f"Unknown action '{action}'")

--- a/pkgs/standards/peagen/tests/unit/test_secrets_cli.py
+++ b/pkgs/standards/peagen/tests/unit/test_secrets_cli.py
@@ -122,7 +122,11 @@ def test_remote_add_posts(monkeypatch):
 
 
 def test_remote_get(monkeypatch):
+    posted = {}
+
     def fake_post(url, json=None, timeout=None):
+        posted["json"] = json
+
         class Res:
             def json(self):
                 return {"result": {"secret": "enc:value"}}
@@ -136,8 +140,14 @@ def test_remote_get(monkeypatch):
         None,
         "ID",
         gateway_url="http://gw",
+        pool="default",
     )
     assert out == ["value"]
+    assert posted["json"] == {
+        "jsonrpc": "2.0",
+        "method": "Secrets.get",
+        "params": {"name": "ID", "tenant_id": "default"},
+    }
 
 
 def test_remote_remove(monkeypatch):
@@ -157,9 +167,10 @@ def test_remote_remove(monkeypatch):
         "ID",
         version=2,
         gateway_url="http://gw",
+        pool="default",
     )
     assert posted["json"] == {
         "jsonrpc": "2.0",
         "method": "Secrets.delete",
-        "params": {"name": "ID", "version": 2},
+        "params": {"name": "ID", "version": 2, "tenant_id": "default"},
     }


### PR DESCRIPTION
## Summary
- ensure Secrets CLI sends tenant_id for remote operations
- wire pool info through secrets handler and core utilities
- return HTTP 404 for missing secrets
- update unit tests for multitenant secret behaviour

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_secrets_cli.py::test_remote_get tests/unit/test_secrets_cli.py::test_remote_remove -q`


------
https://chatgpt.com/codex/tasks/task_e_6858c9038edc8326a83e1bfc29521484