### PR TITLE
Add forwarded IP support in peagen CLI

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/__init__.py
+++ b/pkgs/standards/peagen/peagen/cli/__init__.py
@@ -130,6 +130,11 @@ def _global_remote_ctx(  # noqa: D401
         resolve_path=True,
         help="Path to a *second* .peagen.toml that is sent to the worker.",
     ),
+    client_ip: str = typer.Option(
+        None,
+        "--client-ip",
+        help="Forward this IP via X-Real-IP to the gateway",
+    ),
     verbose: int = typer.Option(0, "-v", "--verbose", count=True),
     quiet: bool = typer.Option(False, "-q", "--quiet"),
 ) -> None:
@@ -140,12 +145,14 @@ def _global_remote_ctx(  # noqa: D401
     gw_url = gateway_url.rstrip("/")
     if not gw_url.endswith("/rpc"):
         gw_url += "/rpc"
+    headers = {"X-Real-IP": client_ip} if client_ip else {}
     ctx.obj.update(
         verbosity=verbose,
         gateway_url=gw_url,
         task_override_inline=override,
         task_override_file=override_file,
         quiet=quiet,
+        headers=headers,
     )
 
 

--- a/pkgs/standards/peagen/peagen/cli/commands/analysis.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/analysis.py
@@ -37,7 +37,9 @@ def run(
     args = {"run_dirs": [str(p) for p in run_dirs], "spec_name": spec_name}
     task = _build_task(args)
     result = asyncio.run(analysis_handler(task))
-    typer.echo(json.dumps(result, indent=2) if json_out else json.dumps(result, indent=2))
+    typer.echo(
+        json.dumps(result, indent=2) if json_out else json.dumps(result, indent=2)
+    )
 
 
 @remote_analysis_app.command("analysis")
@@ -54,8 +56,11 @@ def submit(
         "method": "Task.submit",
         "params": {"taskId": task.id, "pool": task.pool, "payload": task.payload},
     }
+    headers = ctx.obj.get("headers") or None
     with httpx.Client(timeout=30.0) as client:
-        reply = client.post(ctx.obj.get("gateway_url"), json=rpc_req).json()
+        reply = client.post(
+            ctx.obj.get("gateway_url"), json=rpc_req, headers=headers
+        ).json()
     if "error" in reply:
         typer.secho(
             f"Remote error {reply['error']['code']}: {reply['error']['message']}",

--- a/pkgs/standards/peagen/peagen/cli/commands/doe.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/doe.py
@@ -158,8 +158,11 @@ def submit_gen(  # noqa: PLR0913
         "params": {"taskId": task.id, "pool": task.pool, "payload": task.payload},
     }
 
+    headers = ctx.obj.get("headers") or None
     with httpx.Client(timeout=30.0) as client:
-        reply = client.post(ctx.obj.get("gateway_url"), json=rpc_req).json()
+        reply = client.post(
+            ctx.obj.get("gateway_url"), json=rpc_req, headers=headers
+        ).json()
 
     if "error" in reply:
         typer.secho(
@@ -313,8 +316,11 @@ def submit_process(  # noqa: PLR0913
         "params": {"taskId": task.id, "pool": task.pool, "payload": task.payload},
     }
 
+    headers = ctx.obj.get("headers") or None
     with httpx.Client(timeout=30.0) as client:
-        reply = client.post(ctx.obj.get("gateway_url"), json=rpc_req).json()
+        reply = client.post(
+            ctx.obj.get("gateway_url"), json=rpc_req, headers=headers
+        ).json()
 
     if "error" in reply:
         typer.secho(
@@ -334,7 +340,9 @@ def submit_process(  # noqa: PLR0913
                 "method": "Task.get",
                 "params": {"taskId": tid},
             }
-            res = httpx.post(ctx.obj.get("gateway_url"), json=req, timeout=30.0).json()
+            res = httpx.post(
+                ctx.obj.get("gateway_url"), json=req, timeout=30.0, headers=headers
+            ).json()
             return res["result"]
 
         while True:

--- a/pkgs/standards/peagen/peagen/cli/commands/eval.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/eval.py
@@ -23,8 +23,13 @@ from peagen.handlers.eval_handler import eval_handler
 from peagen.models import Status, Task
 
 DEFAULT_GATEWAY = "http://localhost:8000/rpc"
-local_eval_app = typer.Typer(help="Evaluate workspace programs against an EvaluatorPool.")
-remote_eval_app = typer.Typer(help="Evaluate workspace programs against an EvaluatorPool.")
+local_eval_app = typer.Typer(
+    help="Evaluate workspace programs against an EvaluatorPool."
+)
+remote_eval_app = typer.Typer(
+    help="Evaluate workspace programs against an EvaluatorPool."
+)
+
 
 # ───────────────────────── helpers ─────────────────────────────────────────
 def _build_task(args: dict) -> Task:
@@ -84,12 +89,8 @@ def run(  # noqa: PLR0913 – CLI needs many options
 @remote_eval_app.command("eval")
 def submit(  # noqa: PLR0913
     ctx: typer.Context,
-    workspace_uri: str = typer.Argument(
-        ..., help="Workspace path or URI"
-    ),
-    program_glob: str = typer.Argument(
-        "**/*.*", help="Glob pattern for program files"
-    ),
+    workspace_uri: str = typer.Argument(..., help="Workspace path or URI"),
+    program_glob: str = typer.Argument("**/*.*", help="Glob pattern for program files"),
     pool: Optional[str] = typer.Option(
         None, "--pool", "-p", help="EvaluatorPool reference"
     ),
@@ -123,8 +124,9 @@ def submit(  # noqa: PLR0913
         "params": {"taskId": task.id, "pool": task.pool, "payload": task.payload},
     }
 
+    headers = ctx.obj.get("headers") or None
     with httpx.Client(timeout=30.0) as client:
-        resp = client.post(ctx.obj.get("gateway_url"), json=rpc_req)
+        resp = client.post(ctx.obj.get("gateway_url"), json=rpc_req, headers=headers)
         resp.raise_for_status()
         reply = resp.json()
 

--- a/pkgs/standards/peagen/peagen/cli/commands/evolve.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/evolve.py
@@ -110,8 +110,11 @@ def submit(
         "method": "Task.submit",
         "params": {"taskId": task.id, "pool": task.pool, "payload": task.payload},
     }
+    headers = ctx.obj.get("headers") or None
     with httpx.Client(timeout=30.0) as client:
-        reply = client.post(ctx.obj.get("gateway_url"), json=rpc_req).json()
+        reply = client.post(
+            ctx.obj.get("gateway_url"), json=rpc_req, headers=headers
+        ).json()
     if "error" in reply:
         typer.secho(
             f"Remote error {reply['error']['code']}: {reply['error']['message']}",
@@ -131,7 +134,9 @@ def submit(
                 "method": "Task.get",
                 "params": {"taskId": task.id},
             }
-            res = httpx.post(ctx.obj.get("gateway_url"), json=req, timeout=30.0).json()
+            res = httpx.post(
+                ctx.obj.get("gateway_url"), json=req, timeout=30.0, headers=headers
+            ).json()
             return res["result"]
 
         import time

--- a/pkgs/standards/peagen/peagen/cli/commands/extras.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/extras.py
@@ -56,6 +56,7 @@ def run_extras(
 
 @remote_extras_app.command("extras")
 def submit_extras(
+    ctx: typer.Context,
     templates_root: Optional[Path] = typer.Option(
         None, "--templates-root", help="Directory containing template sets"
     ),
@@ -85,7 +86,11 @@ def submit_extras(
     try:
         import httpx
 
-        resp = httpx.post(gateway_url, json=envelope, timeout=10.0)
+        headers = ctx.obj.get("headers") or None
+        kwargs = {"json": envelope, "timeout": 10.0}
+        if headers:
+            kwargs["headers"] = headers
+        resp = httpx.post(gateway_url, **kwargs)
         resp.raise_for_status()
         data = resp.json()
         if data.get("error"):

--- a/pkgs/standards/peagen/peagen/cli/commands/fetch.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/fetch.py
@@ -26,6 +26,7 @@ DEFAULT_GATEWAY = "http://localhost:8000/rpc"
 local_fetch_app = typer.Typer(help="Materialise Peagen workspaces from URIs.")
 remote_fetch_app = typer.Typer(help="Materialise Peagen workspaces from URIs.")
 
+
 # ───────────────────────── helpers ─────────────────────────
 def _build_task(args: dict) -> Task:
     """Construct a Task with the fetch action embedded in the payload."""
@@ -72,7 +73,9 @@ def run(
     ref: str = typer.Option("HEAD", "--ref", help="Git ref or commit SHA"),
 ):
     """Synchronously build the workspace on this machine."""
-    args = _collect_args(workspaces or [], no_source, install_template_sets_flag, repo, ref)
+    args = _collect_args(
+        workspaces or [], no_source, install_template_sets_flag, repo, ref
+    )
     task = _build_task(args)
 
     result = asyncio.run(fetch_handler(task))
@@ -96,7 +99,9 @@ def submit(
     ref: str = typer.Option("HEAD", "--ref", help="Git ref or commit SHA"),
 ):
     """Enqueue the fetch task on a worker farm and return immediately."""
-    args = _collect_args(workspaces or [], no_source, install_template_sets_flag, repo, ref)
+    args = _collect_args(
+        workspaces or [], no_source, install_template_sets_flag, repo, ref
+    )
     task = _build_task(args)
 
     rpc_req = {
@@ -106,8 +111,9 @@ def submit(
         "params": {"taskId": task.id, "pool": task.pool, "payload": task.payload},
     }
 
+    headers = ctx.obj.get("headers") or None
     with httpx.Client(timeout=30.0) as client:
-        resp = client.post(ctx.obj.get("gateway_url"), json=rpc_req)
+        resp = client.post(ctx.obj.get("gateway_url"), json=rpc_req, headers=headers)
         resp.raise_for_status()
         reply = resp.json()
 

--- a/pkgs/standards/peagen/peagen/cli/commands/keys.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/keys.py
@@ -41,7 +41,11 @@ def upload(
         "method": "Keys.upload",
         "params": {"public_key": pubkey},
     }
-    httpx.post(gateway_url, json=envelope, timeout=10.0)
+    headers = ctx.obj.get("headers") or None
+    kwargs = {"json": envelope, "timeout": 10.0}
+    if headers:
+        kwargs["headers"] = headers
+    httpx.post(gateway_url, **kwargs)
     typer.echo("Uploaded public key")
 
 
@@ -57,7 +61,11 @@ def remove(
         "method": "Keys.delete",
         "params": {"fingerprint": fingerprint},
     }
-    httpx.post(gateway_url, json=envelope, timeout=10.0)
+    headers = ctx.obj.get("headers") or None
+    kwargs = {"json": envelope, "timeout": 10.0}
+    if headers:
+        kwargs["headers"] = headers
+    httpx.post(gateway_url, **kwargs)
     typer.echo(f"Removed key {fingerprint}")
 
 
@@ -68,5 +76,9 @@ def fetch_server(
 ) -> None:
     """Fetch trusted public keys from the gateway."""
     envelope = {"jsonrpc": "2.0", "method": "Keys.fetch"}
-    res = httpx.post(gateway_url, json=envelope, timeout=10.0)
+    headers = ctx.obj.get("headers") or None
+    kwargs = {"json": envelope, "timeout": 10.0}
+    if headers:
+        kwargs["headers"] = headers
+    res = httpx.post(gateway_url, **kwargs)
     typer.echo(json.dumps(res.json().get("result", {}), indent=2))

--- a/pkgs/standards/peagen/peagen/cli/commands/login.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/login.py
@@ -36,8 +36,12 @@ def login(
         "method": "Keys.upload",
         "params": {"public_key": pubkey},
     }
+    headers = ctx.obj.get("headers") or None
+    kwargs = {"json": payload, "timeout": 10.0}
+    if headers:
+        kwargs["headers"] = headers
     try:
-        res = httpx.post(gateway_url, json=payload, timeout=10.0)
+        res = httpx.post(gateway_url, **kwargs)
     except httpx.RequestError as e:  # pragma: no cover - network errors
         typer.echo(f"HTTP error: {e}", err=True)
         raise typer.Exit(1)

--- a/pkgs/standards/peagen/peagen/cli/commands/mutate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/mutate.py
@@ -111,8 +111,9 @@ def submit(
         },
     }
 
+    headers = ctx.obj.get("headers") or None
     with httpx.Client(timeout=30.0) as client:
-        resp = client.post(ctx.obj.get("gateway_url"), json=rpc_req)
+        resp = client.post(ctx.obj.get("gateway_url"), json=rpc_req, headers=headers)
         resp.raise_for_status()
         reply = resp.json()
 

--- a/pkgs/standards/peagen/peagen/cli/commands/process.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/process.py
@@ -194,8 +194,9 @@ def submit(  # noqa: PLR0913 – CLI signature needs many options
         "method": "Task.submit",
         "params": {"taskId": task.id, "pool": task.pool, "payload": task.payload},
     }
+    headers = ctx.obj.get("headers") or None
     with httpx.Client(timeout=30.0) as client:
-        resp = client.post(ctx.obj.get("gateway_url"), json=rpc_req)
+        resp = client.post(ctx.obj.get("gateway_url"), json=rpc_req, headers=headers)
         resp.raise_for_status()
         reply = resp.json()
 
@@ -219,7 +220,9 @@ def submit(  # noqa: PLR0913 – CLI signature needs many options
                 "method": "Task.get",
                 "params": {"taskId": task.id},
             }
-            res = httpx.post(ctx.obj.get("gateway_url"), json=req, timeout=30.0).json()
+            res = httpx.post(
+                ctx.obj.get("gateway_url"), json=req, timeout=30.0, headers=headers
+            ).json()
             return res["result"]
 
         while True:

--- a/pkgs/standards/peagen/peagen/cli/commands/sort.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/sort.py
@@ -127,18 +127,17 @@ def submit_sort(
     envelope = {
         "jsonrpc": "2.0",
         "method": "Task.submit",
-        "params": {
-            "taskId": task.id,
-            "pool": task.pool,
-            "payload": task.payload
-        },
+        "params": {"taskId": task.id, "pool": task.pool, "payload": task.payload},
     }
 
     # 3) POST to gateway
     try:
         import httpx
 
-        resp = httpx.post(ctx.obj.get("gateway_url"), json=envelope, timeout=10.0)
+        headers = ctx.obj.get("headers") or None
+        resp = httpx.post(
+            ctx.obj.get("gateway_url"), json=envelope, timeout=10.0, headers=headers
+        )
         resp.raise_for_status()
         data = resp.json()
         if data.get("error"):

--- a/pkgs/standards/peagen/peagen/cli/commands/task.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/task.py
@@ -34,7 +34,10 @@ def get(  # noqa: D401
             "method": "Task.get",
             "params": {"taskId": task_id},
         }
-        res = httpx.post(ctx.obj.get("gateway_url"), json=req, timeout=30.0).json()
+        headers = ctx.obj.get("headers") or None
+        res = httpx.post(
+            ctx.obj.get("gateway_url"), json=req, timeout=30.0, headers=headers
+        ).json()
         return res["result"]
 
     while True:
@@ -61,7 +64,10 @@ def patch_task(
         "method": "Task.patch",
         "params": {"taskId": task_id, "changes": payload},
     }
-    res = httpx.post(ctx.obj.get("gateway_url"), json=req, timeout=30.0).json()
+    headers = ctx.obj.get("headers") or None
+    res = httpx.post(
+        ctx.obj.get("gateway_url"), json=req, timeout=30.0, headers=headers
+    ).json()
     typer.echo(json.dumps(res["result"], indent=2))
 
 
@@ -72,7 +78,10 @@ def _simple_call(ctx: typer.Context, method: str, selector: str) -> None:
         "method": method,
         "params": {"selector": selector},
     }
-    res = httpx.post(ctx.obj.get("gateway_url"), json=req, timeout=30.0).json()
+    headers = ctx.obj.get("headers") or None
+    res = httpx.post(
+        ctx.obj.get("gateway_url"), json=req, timeout=30.0, headers=headers
+    ).json()
     typer.echo(json.dumps(res["result"], indent=2))
 
 

--- a/pkgs/standards/peagen/peagen/cli/commands/validate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/validate.py
@@ -14,6 +14,7 @@ remote_validate_app = typer.Typer(help="Validate Peagen artifacts via JSON-RPC."
 
 # ────────────────────────────── local validate ────────────────────────────────────
 
+
 @local_validate_app.command("validate")
 def run_validate(
     ctx: typer.Context,
@@ -99,7 +100,10 @@ def submit_validate(
     try:
         import httpx
 
-        resp = httpx.post(ctx.obj.get("gateway_url"), json=envelope, timeout=10.0)
+        headers = ctx.obj.get("headers") or None
+        resp = httpx.post(
+            ctx.obj.get("gateway_url"), json=envelope, timeout=10.0, headers=headers
+        )
         resp.raise_for_status()
         data = resp.json()
         if data.get("error"):


### PR DESCRIPTION
## Summary
- forward `--client-ip` in peagen CLI so gateway logs true client IP
- include X-Real-IP header on gateway requests from CLI commands
- update commands to add optional headers

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format peagen/cli/__init__.py peagen/cli/commands/*.py`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/cli/__init__.py $(ls pkgs/standards/peagen/peagen/cli/commands/*.py | sed 's|pkgs/standards/peagen/||') --fix`
- `uv run --directory pkgs/standards/peagen --package peagen pytest` *(fails: subprocess.CalledProcessError)*

------
https://chatgpt.com/codex/tasks/task_e_6858cd4fce748326958d5e8a594979c1