### PR TITLE
Fix peagen ruff and test issues

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/secrets.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/secrets.py
@@ -120,7 +120,7 @@ def remote_add(
         typer.echo(
             f"Error {getattr(res, 'status_code', 'unknown')}: {getattr(res, 'text', '')}",
             err=True,
-        
+        )
         raise typer.Exit(1)
     typer.echo(f"Uploaded secret {secret_id}")
 


### PR DESCRIPTION
## Summary
- close missing paren on `typer.echo` in secrets command
- run formatting and tests for peagen

## Testing
- `uv run --directory pkgs/standards --package peagen ruff check peagen --fix`
- `uv run --package peagen --directory standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_6858d53f7e608326afe574ec059d2028