### PR TITLE
Fix gateway persist log

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -291,7 +291,7 @@ async def _select_tasks(selector: str) -> list[Task]:
 
 async def _persist(task: Task) -> None:
     try:
-        log.info(f"Writing {task}")
+        log.info("persisting %s", task.id)
         await result_backend.store(TaskRun.from_task(task))
     except Exception as e:
         log.warning(f"_persist error '{e}'")


### PR DESCRIPTION
## Summary
- log the task id when persisting results in Peagen gateway

## Testing
- `uv run --package peagen --directory standards/peagen pytest`
- `peagen remote -q --gateway-url http://localhost:8000/rpc process projects_payload.yaml --watch` *(fails: connection refused)*
- `peagen local -q process projects_payload.yaml` *(fails: no LLM provider specified)*

------
https://chatgpt.com/codex/tasks/task_e_6858cb904448832691494a3c8b92e785