### PR TITLE
Fix persist log message

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -291,7 +291,7 @@ async def _select_tasks(selector: str) -> list[Task]:
 
 async def _persist(task: Task) -> None:
     try:
-        log.info(f"Writing {task}")
+        log.info("persisting task %s", task.id)
         await result_backend.store(TaskRun.from_task(task))
     except Exception as e:
         log.warning(f"_persist error '{e}'")


### PR DESCRIPTION
## Summary
- log the task ID in `_persist`

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format peagen/gateway/__init__.py`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check peagen/gateway/__init__.py --fix`
- `uv run --package peagen --directory standards/peagen pytest` *(fails: subprocess.CalledProcessError)*

------
https://chatgpt.com/codex/tasks/task_e_6858cb904448832691494a3c8b92e785