### PR TITLE
Fix remote DOE process path resolution

### DIFF
--- a/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
@@ -44,13 +44,6 @@ async def doe_process_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, 
             alt = Path(__file__).resolve().parents[2] / path_str
             return alt if alt.exists() else path
 
-    def _resolve_existing(path_str: str) -> Path:
-        path = Path(path_str).expanduser()
-        if path.exists():
-            return path
-        alt = Path(__file__).resolve().parents[2] / path_str
-        return alt if alt.exists() else path
-
     cfg_path = _resolve_existing(args["config"]) if args.get("config") else None
 
     result = generate_payload(


### PR DESCRIPTION
## Summary
- fix duplicated `_resolve_existing` function in `doe_process_handler`
- run formatting and tests for `peagen`

## Testing
- `uv run --package peagen --directory . ruff format .`
- `uv run --package peagen --directory . ruff check . --fix`
- `uv run --package peagen --directory standards pytest peagen/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_6858dfddaac08326a022dac62edae723