### PR TITLE
Fix Task.submit optional task ID

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -18,7 +18,7 @@ import json
 import httpx
 import time
 from json.decoder import JSONDecodeError
-from typing import Optional
+
 
 import pgpy
 from fastapi import Body, FastAPI, Request, Response, HTTPException
@@ -566,7 +566,7 @@ async def pool_join(name: str):
 async def task_submit(
     pool: str,
     payload: dict,
-    taskId: Optional[str],
+    taskId: str | None = None,
     deps: list[str] | None = None,
     edge_pred: str | None = None,
     labels: list[str] | None = None,


### PR DESCRIPTION
## Summary
- make `Task.submit` accept missing `taskId`
- remove unused Optional import
- run `ruff` and tests

## Testing
- `uv run --directory peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_6858e036d1ec8326bb2576dedbcc3ae5