### PR TITLE
Fix peagen smoke tests to POST to /rpc

### DIFF
--- a/pkgs/standards/peagen/tests/smoke/test_gateway_login_keys_secrets_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_gateway_login_keys_secrets_cli.py
@@ -9,9 +9,10 @@ GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
 
 
 def _gateway_available(url: str) -> bool:
-    """Return ``True`` if the gateway URL responds successfully."""
+    """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
+    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
     try:
-        response = httpx.get(url, timeout=5)
+        response = httpx.post(url, json=envelope, timeout=5)
     except Exception:
         return False
     return response.status_code < 500

--- a/pkgs/standards/peagen/tests/smoke/test_gateway_remote_doe.py
+++ b/pkgs/standards/peagen/tests/smoke/test_gateway_remote_doe.py
@@ -10,8 +10,10 @@ GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
 
 
 def _gateway_available(url: str) -> bool:
+    """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
+    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
     try:
-        response = httpx.get(url, timeout=5)
+        response = httpx.post(url, json=envelope, timeout=5)
     except Exception:
         return False
     return response.status_code < 500

--- a/pkgs/standards/peagen/tests/smoke/test_remote_doe_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_doe_cli.py
@@ -9,9 +9,10 @@ GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
 
 
 def _gateway_available(url: str) -> bool:
-    """Return ``True`` if the gateway URL responds successfully."""
+    """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
+    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
     try:
-        response = httpx.get(url, timeout=5)
+        response = httpx.post(url, json=envelope, timeout=5)
     except Exception:
         return False
     return response.status_code == 200

--- a/pkgs/standards/peagen/tests/smoke/test_remote_doe_process_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_doe_process_cli.py
@@ -13,8 +13,10 @@ TEMPLATE = BASE / "template_project.yaml"
 
 
 def _gateway_available(url: str) -> bool:
+    """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
+    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
     try:
-        response = httpx.get(url, timeout=5)
+        response = httpx.post(url, json=envelope, timeout=5)
     except Exception:
         return False
     return response.status_code == 200

--- a/pkgs/standards/peagen/tests/smoke/test_remote_eval_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_eval_cli.py
@@ -11,9 +11,10 @@ GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
 
 
 def _gateway_available(url: str) -> bool:
-    """Return ``True`` if the gateway URL responds successfully."""
+    """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
+    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
     try:
-        response = httpx.get(url, timeout=5)
+        response = httpx.post(url, json=envelope, timeout=5)
     except Exception:
         return False
     return response.status_code == 200

--- a/pkgs/standards/peagen/tests/smoke/test_remote_evolve.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_evolve.py
@@ -18,9 +18,10 @@ SPEC_PATH = (
 
 
 def _gateway_available(url: str) -> bool:
-    """Return ``True`` if the gateway URL responds successfully."""
+    """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
+    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
     try:
-        resp = httpx.get(url, timeout=5)
+        resp = httpx.post(url, json=envelope, timeout=5)
     except Exception:
         return False
     return resp.status_code == 200

--- a/pkgs/standards/peagen/tests/smoke/test_remote_full_flow.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_full_flow.py
@@ -14,8 +14,10 @@ EVOLVE_SPEC = BASE / "simple_evolve_demo" / "evolve_remote_spec.yaml"
 
 
 def _gateway_available(url: str) -> bool:
+    """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
+    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
     try:
-        response = httpx.get(url, timeout=5)
+        response = httpx.post(url, json=envelope, timeout=5)
     except Exception:
         return False
     return response.status_code == 200

--- a/pkgs/standards/peagen/tests/smoke/test_remote_mutate_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_mutate_cli.py
@@ -9,9 +9,10 @@ GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
 
 
 def _gateway_available(url: str) -> bool:
-    """Return ``True`` if the gateway URL responds successfully."""
+    """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
+    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
     try:
-        response = httpx.get(url, timeout=5)
+        response = httpx.post(url, json=envelope, timeout=5)
     except Exception:
         return False
     return response.status_code == 200

--- a/pkgs/standards/peagen/tests/smoke/test_remote_process_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_process_cli.py
@@ -15,9 +15,10 @@ PROJECTS_FILE = (
 
 
 def _gateway_available(url: str) -> bool:
-    """Return ``True`` if the gateway URL responds successfully."""
+    """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
+    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
     try:
-        response = httpx.get(url, timeout=5)
+        response = httpx.post(url, json=envelope, timeout=5)
     except Exception:
         return False
     return response.status_code < 500

--- a/pkgs/standards/peagen/tests/smoke/test_remote_sort_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_sort_cli.py
@@ -11,9 +11,10 @@ BASE_URL = GATEWAY.removesuffix("/rpc")
 
 
 def _gateway_available(url: str) -> bool:
-    """Return ``True`` if the gateway URL responds successfully."""
+    """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
+    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
     try:
-        resp = httpx.get(url, timeout=5)
+        resp = httpx.post(url, json=envelope, timeout=5)
     except Exception:
         return False
     return resp.status_code < 500


### PR DESCRIPTION
## Summary
- update smoke tests to POST /rpc for gateway checks
- format tests with ruff

## Testing
- `uv run --package peagen --directory . ruff check tests/smoke/*.py --fix`

------
https://chatgpt.com/codex/tasks/task_e_6858dfb78ee48326955f93553ad284f3