### PR TITLE
Redeploy only gateway and worker

### DIFF
--- a/.github/workflows/peagen_ci.yml
+++ b/.github/workflows/peagen_ci.yml
@@ -40,8 +40,7 @@ jobs:
       run: |
         # sudo -E docker-compose -f infra/peagen_docker-compose.yml pull   # optional
         sudo docker system prune -f
-        sudo -E docker-compose -f infra/peagen_docker-compose.yml down --remove-orphans
-        sudo -E docker-compose -f infra/peagen_docker-compose.yml up -d --force-recreate --build
+        sudo -E docker-compose -f infra/peagen_docker-compose.yml up -d --force-recreate --build gateway worker
 
     # Collect logs only when *any* previous step failed (deploy or later)
     - name: Get container logs on failure


### PR DESCRIPTION
## Summary
- limit `peagen_ci` workflow to rebuild only the gateway and worker services

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6858e422f1e883268922ed32cf6e1dda