### PR TITLE
Fix CLI task payloads

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/analysis.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/analysis.py
@@ -21,9 +21,8 @@ def _build_task(args: dict) -> Task:
     return Task(
         id=str(uuid.uuid4()),
         pool="default",
-        action="analysis",
         status=Status.waiting,
-        payload={"args": args},
+        payload={"action": "analysis", "args": args},
     )
 
 

--- a/pkgs/standards/peagen/peagen/cli/commands/eval.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/eval.py
@@ -36,9 +36,8 @@ def _build_task(args: dict) -> Task:
     return Task(
         id=str(uuid.uuid4()),
         pool="default",
-        action="eval",
         status=Status.waiting,
-        payload={"args": args},
+        payload={"action": "eval", "args": args},
     )
 
 

--- a/pkgs/standards/peagen/peagen/cli/commands/templates.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/templates.py
@@ -26,13 +26,21 @@ remote_template_sets_app = typer.Typer(
 
 # ─── helpers ───────────────────────────
 def _run_handler(args: Dict[str, Any]) -> Dict[str, Any]:
-    task = Task(id=str(uuid.uuid4()), pool="default", payload={"args": args})
+    task = Task(
+        id=str(uuid.uuid4()),
+        pool="default",
+        payload={"action": "templates", "args": args},
+    )
     return asyncio.run(templates_handler(task))
 
 
 def _submit_task(args: Dict[str, Any], gateway_url: str) -> str:
     """Submit a templates task via JSON-RPC."""
-    task = Task(id=str(uuid.uuid4()), pool="default", payload={"args": args})
+    task = Task(
+        id=str(uuid.uuid4()),
+        pool="default",
+        payload={"action": "templates", "args": args},
+    )
     envelope = {
         "jsonrpc": "2.0",
         "method": "Task.submit",


### PR DESCRIPTION
## Summary
- ensure CLI subcommands include `action` in payloads for worker dispatch
- run formatting, linting, and tests

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `PEAGEN_TEST_GATEWAY=http://127.0.0.1:9 uv run --directory pkgs/standards/peagen --package peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_6858e5d3ef7c8326b9fd90140ec15a2a