### PR TITLE
Add smoke tests for invalid remote RPC calls

### DIFF
--- a/pkgs/standards/peagen/tests/smoke/test_remote_invalid_params.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_invalid_params.py
@@ -1,0 +1,52 @@
+import os
+import httpx
+import pytest
+
+GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
+
+
+def _gateway_available(url: str) -> bool:
+    """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
+    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    try:
+        response = httpx.post(url, json=envelope, timeout=5)
+    except Exception:
+        return False
+    return response.status_code == 200
+
+
+@pytest.mark.i9n
+def test_invalid_request_structure() -> None:
+    if not _gateway_available(GATEWAY):
+        pytest.skip("gateway not reachable")
+    resp = httpx.post(GATEWAY, json={}, timeout=5)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["error"]["code"] == -32600
+
+
+@pytest.mark.i9n
+def test_method_not_found() -> None:
+    if not _gateway_available(GATEWAY):
+        pytest.skip("gateway not reachable")
+    payload = {"jsonrpc": "2.0", "method": "Nope", "params": {}, "id": "1"}
+    resp = httpx.post(GATEWAY, json=payload, timeout=5)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["error"]["code"] == -32601
+
+
+@pytest.mark.i9n
+def test_task_submit_unknown_action() -> None:
+    if not _gateway_available(GATEWAY):
+        pytest.skip("gateway not reachable")
+    payload = {
+        "jsonrpc": "2.0",
+        "method": "Task.submit",
+        "params": {"pool": "default", "payload": {"action": "bogus"}},
+        "id": "1",
+    }
+    resp = httpx.post(GATEWAY, json=payload, timeout=5)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["error"]["code"] == -32601


### PR DESCRIPTION
## Summary
- add smoke tests verifying error responses for malformed RPC requests to the public Peagen gateway

## Testing
- `uv run --package peagen --directory standards/peagen ruff format .`
- `uv run --package peagen --directory standards/peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest` *(fails: subprocess errors)*

------
https://chatgpt.com/codex/tasks/task_e_685900e638c883269089dc4a58cacf0f