### PR TITLE
Fix WebSocket disconnect handling

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/ws_server.py
+++ b/pkgs/standards/peagen/peagen/gateway/ws_server.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, WebSocket
+from starlette.websockets import WebSocketDisconnect
 from redis.asyncio import Redis
 from peagen.gateway.runtime_cfg import settings
 from peagen.defaults import CONFIG as defaults
@@ -49,6 +50,9 @@ async def ws_tasks(ws: WebSocket):
     try:
         async for msg in pubsub.listen():
             if msg["type"] == "message":
-                await ws.send_text(msg["data"])
+                try:
+                    await ws.send_text(msg["data"])
+                except WebSocketDisconnect:
+                    break
     finally:
         await pubsub.unsubscribe(defaults["pubsub"])


### PR DESCRIPTION
## Summary
- gracefully stop streaming when clients disconnect from the gateway

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format .`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_6859012836ec8326af4a8a9d1743c4d2