### PR TITLE
Add chaos tests for Peagen remote gateway

### DIFF
--- a/pkgs/conftest.py
+++ b/pkgs/conftest.py
@@ -6,13 +6,21 @@ def pytest_configure(config):
         "markers",
         "infra: infrastructure tests requiring external services",
     )
+    config.addinivalue_line(
+        "markers",
+        "chaos: chaos tests targeting the remote gateway",
+    )
 
 
 def pytest_collection_modifyitems(config, items):
     markexpr = getattr(config.option, "markexpr", "")
-    if markexpr and "infra" in markexpr:
-        return
-    skip_infra = pytest.mark.skip(reason="skip infra tests (use -m infra to run)")
-    for item in items:
-        if "infra" in item.keywords:
-            item.add_marker(skip_infra)
+    if "infra" not in markexpr:
+        skip_infra = pytest.mark.skip(reason="skip infra tests (use -m infra to run)")
+        for item in items:
+            if "infra" in item.keywords:
+                item.add_marker(skip_infra)
+    if "chaos" not in markexpr:
+        skip_chaos = pytest.mark.skip(reason="skip chaos tests (use -m chaos to run)")
+        for item in items:
+            if "chaos" in item.keywords:
+                item.add_marker(skip_chaos)

--- a/pkgs/standards/peagen/tests/chaos/test_remote_gateway_chaos.py
+++ b/pkgs/standards/peagen/tests/chaos/test_remote_gateway_chaos.py
@@ -1,0 +1,64 @@
+import asyncio
+import os
+
+import httpx
+import pytest
+
+GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
+
+
+def _gateway_available(url: str) -> bool:
+    """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
+    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    try:
+        response = httpx.post(url, json=envelope, timeout=5)
+    except Exception:
+        return False
+    return response.status_code == 200
+
+
+@pytest.mark.chaos
+def test_remote_gateway_invalid_method() -> None:
+    if not _gateway_available(GATEWAY):
+        pytest.skip("gateway not reachable")
+
+    envelope = {"jsonrpc": "2.0", "method": "Nope.nothing", "params": {}, "id": 1}
+    response = httpx.post(GATEWAY, json=envelope, timeout=5)
+    assert response.status_code == 200
+    data = response.json()
+    assert "error" in data
+
+
+async def _worker_list(client: httpx.AsyncClient) -> bool:
+    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    resp = await client.post(GATEWAY, json=envelope, timeout=5)
+    return resp.status_code == 200
+
+
+@pytest.mark.chaos
+@pytest.mark.asyncio
+async def test_remote_gateway_worker_list_heavy_load() -> None:
+    if not _gateway_available(GATEWAY):
+        pytest.skip("gateway not reachable")
+
+    async with httpx.AsyncClient() as client:
+        results = await asyncio.gather(*[_worker_list(client) for _ in range(10)])
+    assert all(results)
+
+
+@pytest.mark.chaos
+def test_remote_gateway_large_payload() -> None:
+    if not _gateway_available(GATEWAY):
+        pytest.skip("gateway not reachable")
+
+    large = "x" * 10000
+    envelope = {
+        "jsonrpc": "2.0",
+        "method": "Task.submit",
+        "params": {"pool": "default", "payload": {"data": large}},
+        "id": 2,
+    }
+    response = httpx.post(GATEWAY, json=envelope, timeout=5)
+    assert response.status_code == 200
+    data = response.json()
+    assert "result" in data or "error" in data

--- a/pkgs/standards/peagen/tests/conftest.py
+++ b/pkgs/standards/peagen/tests/conftest.py
@@ -6,15 +6,23 @@ def pytest_configure(config: pytest.Config) -> None:
         "markers",
         "infra: infrastructure tests requiring external services",
     )
+    config.addinivalue_line(
+        "markers",
+        "chaos: chaos tests targeting the remote gateway",
+    )
 
 
 def pytest_collection_modifyitems(
     config: pytest.Config, items: list[pytest.Item]
 ) -> None:
     markexpr = getattr(config.option, "markexpr", "")
-    if markexpr and "infra" in markexpr:
-        return
-    skip_infra = pytest.mark.skip(reason="skip infra tests (use -m infra to run)")
-    for item in items:
-        if "infra" in item.keywords:
-            item.add_marker(skip_infra)
+    if "infra" not in markexpr:
+        skip_infra = pytest.mark.skip(reason="skip infra tests (use -m infra to run)")
+        for item in items:
+            if "infra" in item.keywords:
+                item.add_marker(skip_infra)
+    if "chaos" not in markexpr:
+        skip_chaos = pytest.mark.skip(reason="skip chaos tests (use -m chaos to run)")
+        for item in items:
+            if "chaos" in item.keywords:
+                item.add_marker(skip_chaos)


### PR DESCRIPTION
## Summary
- add new chaos test suite hitting the Peagen remote gateway
- register `chaos` marker in global and Peagen-specific conftests

## Testing
- `uv run --directory pkgs --package swarmauri-monorepo ruff format conftest.py standards/peagen/tests/conftest.py standards/peagen/tests/chaos/test_remote_gateway_chaos.py`
- `uv run --directory pkgs --package swarmauri-monorepo ruff check conftest.py standards/peagen/tests/conftest.py standards/peagen/tests/chaos/test_remote_gateway_chaos.py --fix`
- `uv run --directory pkgs/standards/peagen --package peagen ruff format tests/conftest.py tests/chaos/test_remote_gateway_chaos.py`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check tests/conftest.py tests/chaos/test_remote_gateway_chaos.py --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest` *(fails: subprocess.CalledProcessError)*

------
https://chatgpt.com/codex/tasks/task_e_685902328dac8326939aeb80b7485379