### PR TITLE
Fix worker liveness check

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -217,7 +217,7 @@ async def _publish_queue_length(pool: str) -> None:
 async def _live_workers_by_pool(pool: str) -> list[dict]:
     keys = await queue.keys("worker:*")
     workers = []
-    now = int(asyncio.get_event_loop().time())
+    now = int(time.time())
     for k in keys:
         w = await queue.hgetall(k)
         if not w:  # TTL expired or never registered
@@ -798,7 +798,7 @@ async def worker_list(pool: str | None = None) -> list[dict]:
 
     keys = await queue.keys("worker:*")
     workers = []
-    now = int(asyncio.get_event_loop().time())
+    now = int(time.time())
     for key in keys:
         w = await queue.hgetall(key)
         if not w:


### PR DESCRIPTION
## Summary
- fix time base in worker liveness checks
- confirm local `evolve` run
- confirm remote task submission

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest -q` *(fails: tests.something)*
- `DQ_GATEWAY=http://127.0.0.1:8000/rpc uv run --package peagen --directory pkgs/standards/peagen peagen local -q evolve tests/examples/simple_evolve_demo/evolve_spec_local.yaml`
- `uv run --package peagen --directory pkgs/standards/peagen peagen remote -q --gateway-url https://gw.peagen.com/rpc doe gen /workspace/swarmauri-sdk/pkgs/standards/peagen/tests/examples/locking_demo/doe_spec.yaml /workspace/swarmauri-sdk/pkgs/standards/peagen/tests/examples/locking_demo/template_project.yaml --output /tmp/payloads.yaml`

------
https://chatgpt.com/codex/tasks/task_e_68590064c408832683e3144860e4ac25