### PR TITLE
Improve task id validation

### DIFF
--- a/pkgs/standards/peagen/peagen/core/task_core.py
+++ b/pkgs/standards/peagen/peagen/core/task_core.py
@@ -11,6 +11,7 @@ from typing import Dict
 
 from peagen.gateway.db import Session
 from peagen.models import TaskRun
+from sqlalchemy.exc import DataError
 
 
 async def get_task_result(task_id: str) -> Dict:
@@ -24,7 +25,10 @@ async def get_task_result(task_id: str) -> Dict:
          "finished_at":   "... | None"}
     """
     async with Session() as s:
-        tr: TaskRun | None = await s.get(TaskRun, task_id)
+        try:
+            tr: TaskRun | None = await s.get(TaskRun, task_id)
+        except DataError:
+            raise ValueError(f"Task '{task_id}' not found") from None
         if tr is None:
             raise ValueError(f"Task '{task_id}' not found")
 

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -708,6 +708,10 @@ async def task_patch(taskId: str, changes: dict) -> dict:
 
 @rpc.method("Task.get")
 async def task_get(taskId: str):
+    try:
+        uuid.UUID(taskId)
+    except ValueError:
+        raise RPCException(code=-32602, message="Invalid task id")
     # hot cache
     if t := await _load_task(taskId):
         data = t.model_dump()


### PR DESCRIPTION
## Summary
- validate taskId in RPC call
- catch DB driver errors when retrieving task results

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest -q` *(fails: test_eval_submit_returns_error_when_no_handler, test_remote_fetch_repo, test_remote_fetch_uri, test_rpc_watch_remote_process, test_tui_pagination_actions)*
- `uv run --directory pkgs/standards/peagen --package peagen peagen remote -q --gateway-url https://gw.peagen.com/rpc process tests/examples/projects_payloads/projects_payload.yaml --watch`
- `uv run --directory pkgs/standards/peagen --package peagen peagen local -q process tests/examples/projects_payloads/projects_payload.yaml`

------
https://chatgpt.com/codex/tasks/task_e_6859bb0fb41c832690870f4bde1f50e4