### PR TITLE
Fix push errors

### DIFF
--- a/pkgs/standards/peagen/docs/task_git_ops.md
+++ b/pkgs/standards/peagen/docs/task_git_ops.md
@@ -14,7 +14,7 @@ This document summarises which Peagen tasks interact with Git and why.
 
 ## process
 - Commits rendered or copied files for each project when a VCS plugin is configured.
-- Pushes the active branch to the origin remote if possible.
+- Pushes the active branch to the origin remote; failures raise an exception.
 - Result payload includes the commit SHA.
 
 ## analysis and DOE

--- a/pkgs/standards/peagen/peagen/core/process_core.py
+++ b/pkgs/standards/peagen/peagen/core/process_core.py
@@ -463,10 +463,7 @@ def process_single_project(
                 oids.append(vcs.blob_oid(rel, ref=commit_sha))
             except Exception:
                 pass
-        try:
-            vcs.push(vcs.repo.active_branch.name)
-        except Exception:  # pragma: no cover - push may fail
-            pass
+        vcs.push(vcs.repo.active_branch.name)
     if logger:
         logger.info(f"========== Completed project '{project_name}' ==========\n")
     return sorted_records, next_idx, commit_sha, oids

--- a/pkgs/standards/peagen/peagen/handlers/analysis_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/analysis_handler.py
@@ -38,9 +38,6 @@ async def analysis_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, Any
             commit_sha = vcs.commit([str(rel)], f"analysis {spec_name}")
             result["commit"] = commit_sha
         vcs.switch("HEAD")
-        try:
-            vcs.push(analysis_branch)
-        except Exception:  # pragma: no cover - push may fail
-            pass
+        vcs.push(analysis_branch)
         result["analysis_branch"] = analysis_branch
     return result

--- a/pkgs/standards/peagen/peagen/handlers/doe_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/doe_handler.py
@@ -47,10 +47,7 @@ async def doe_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, Any]:
         if rel_paths:
             commit_sha = vcs.commit(rel_paths, f"doe {Path(args['spec']).stem}")
             result["commit"] = commit_sha
-            try:
-                vcs.push(vcs.repo.active_branch.name)
-            except Exception:  # pragma: no cover - push may fail
-                pass
+            vcs.push(vcs.repo.active_branch.name)
 
         spec_obj = yaml.safe_load(Path(args["spec"]).read_text())
         if spec_obj.get("baseArtifact"):

--- a/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
@@ -124,10 +124,7 @@ async def evolve_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, Any]:
         branches = [pea_ref("run", cid) for cid in child_ids]
         vcs.fan_out("HEAD", branches)
         for b in branches:
-            try:
-                vcs.push(b)
-            except Exception:  # pragma: no cover - push may fail
-                pass
+            vcs.push(b)
         fan_res["commit"] = commit_sha
     result = {"children": child_ids, "jobs": len(jobs), **fan_res}
     if tmp_dir:

--- a/pkgs/standards/peagen/peagen/handlers/mutate_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/mutate_handler.py
@@ -70,10 +70,7 @@ async def mutate_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, Any]:
             commit_sha = None
         branch = pea_ref("run", winner_path.stem)
         vcs.create_branch(branch, checkout=False)
-        try:
-            vcs.push(branch)
-        except Exception:  # pragma: no cover - push may fail
-            pass
+        vcs.push(branch)
         result["commit"] = commit_sha
         result["branch"] = branch
     if tmp_dir:

--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -230,8 +230,9 @@ class WorkerBase:
                 except Exception:
                     branch = "HEAD"
                 vcs.push(branch)
-            except Exception:  # pragma: no cover - push best effort
-                pass
+            except Exception:
+                # Surface push failures to the caller so tasks can fail loudly
+                raise
             status = result.pop("_final_status", "success")
             await self._notify(status, task_id, result)
         except Exception as exc:

--- a/pkgs/standards/peagen/tests/unit/test_mutate_handler_repo.py
+++ b/pkgs/standards/peagen/tests/unit/test_mutate_handler_repo.py
@@ -12,6 +12,9 @@ async def test_mutate_handler_repo(tmp_path: Path, monkeypatch):
     (repo_dir / "t.py").write_text("x = 1", encoding="utf-8")
     vcs.commit(["t.py"], "init")
 
+    # Prevent push errors for the local repo without a remote
+    monkeypatch.setattr(GitVCS, "push", lambda self, branch: None)
+
     captured = {}
 
     def fake_mutate_workspace(**kwargs):

--- a/pkgs/standards/peagen/tests/unit/test_tui_pagination.py
+++ b/pkgs/standards/peagen/tests/unit/test_tui_pagination.py
@@ -4,8 +4,9 @@ from peagen.tui.app import QueueDashboardApp
 
 
 @pytest.mark.unit
-def test_pagination_actions():
+def test_pagination_actions(monkeypatch):
     app = QueueDashboardApp()
+    monkeypatch.setattr(app, "run_worker", lambda *a, **k: None)
     app.limit = 10
     app.offset = 0
     app.action_next_page()


### PR DESCRIPTION
## Summary
- stop silencing Git push errors across Peagen handlers
- mention push exceptions in docs
- patch pagination test to avoid async worker
- mock Git push in mutate handler test

## Testing
- `uv run --directory standards/peagen --package peagen ruff check . --fix`
- `PEAGEN_TEST_GATEWAY=http://localhost:0 uv run --directory standards/peagen --package peagen pytest`
- `uv run --directory standards/peagen --package peagen peagen local -q process tests/examples/projects_payloads/projects_payload.yaml` *(fails: No LLM provider specified)*

------
https://chatgpt.com/codex/tasks/task_e_6859bab4922883268253731415eaddab