### PR TITLE
Fix TUI gateway URL handling

### DIFF
--- a/pkgs/standards/peagen/README.md
+++ b/pkgs/standards/peagen/README.md
@@ -435,8 +435,9 @@ pea.process_all_projects()
 
 ### Textual TUI
 
-Run `peagen tui` to launch an experimental dashboard that
-subscribes to the gateway's `/ws/tasks` WebSocket. The gateway now emits
+Run `peagen tui` to launch an experimental dashboard that connects to the
+gateway's WebSocket stream. Pass the gateway's **base URL** (without the `/rpc`
+suffix) via `--gateway-url`. The dashboard subscribes to `/ws/tasks` and emits
 `task.update`, `worker.update` and `queue.update` events. Use the tab keys to
 switch between task lists, logs and opened files. The footer shows system
 metrics and current time. Remote artifact paths are downloaded via their git

--- a/pkgs/standards/peagen/peagen/tui/app.py
+++ b/pkgs/standards/peagen/peagen/tui/app.py
@@ -269,9 +269,14 @@ class QueueDashboardApp(App):
 
     def __init__(self, gateway_url: str = "http://localhost:8000") -> None:
         super().__init__()
-        ws_url = gateway_url.replace("http", "ws").rstrip("/") + "/ws/tasks"
+
+        cleaned = gateway_url.rstrip("/")
+        if cleaned.endswith("/rpc"):
+            cleaned = cleaned.rsplit("/", 1)[0]
+
+        ws_url = cleaned.replace("http", "ws", 1).rstrip("/") + "/ws/tasks"
         self.client = TaskStreamClient(ws_url)
-        self.backend = RemoteBackend(gateway_url)
+        self.backend = RemoteBackend(cleaned)
         self.sort_key = "time"
         self.sort_reverse = False
         self.filter_id: str | None = None


### PR DESCRIPTION
## Summary
- strip trailing `/rpc` from gateway URL when launching TUI
- document that `--gateway-url` expects a base URL

## Testing
- `uv run --directory . --package peagen ruff format .`
- `uv run --directory . --package peagen ruff check . --fix`
- `uv run --package peagen --directory . pytest` *(fails: test_eval_submit_returns_error_when_no_handler, test_remote_fetch_repo, test_remote_fetch_uri)*

------
https://chatgpt.com/codex/tasks/task_e_6859b9bb9c5483269f4bfbe347721383