### PR TITLE
Fix doe_process dry-run behavior

### DIFF
--- a/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
@@ -58,6 +58,14 @@ async def doe_process_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, 
         evaluate_runs=args.get("evaluate_runs", False),
     )
 
+    # Short-circuit if this was a dry-run to avoid reading or uploading files
+    if result.get("dry_run"):
+        if tmp_dir:
+            import shutil
+
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+        return result
+
     cfg = resolve_cfg(toml_path=str(cfg_path) if cfg_path else ".peagen.toml")
     pm = PluginManager(cfg)
     try:


### PR DESCRIPTION
## Summary
- avoid opening generated payload files during `doe_process` dry-runs

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format peagen/handlers/doe_process_handler.py`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check peagen/handlers/doe_process_handler.py --fix`
- `uv run --package peagen --directory standards pytest` *(fails: 57 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6859b99353e48326927ea09c8d49cba1