### PR TITLE
Handle dry runs in peagen DOE process

### DIFF
--- a/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
@@ -58,6 +58,14 @@ async def doe_process_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, 
         evaluate_runs=args.get("evaluate_runs", False),
     )
 
+    if result.get("dry_run"):
+        final = {"children": [], "_final_status": Status.success.value, **result}
+        if tmp_dir:
+            import shutil
+
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+        return final
+
     cfg = resolve_cfg(toml_path=str(cfg_path) if cfg_path else ".peagen.toml")
     pm = PluginManager(cfg)
     try:

--- a/pkgs/standards/peagen/peagen/tui/app.py
+++ b/pkgs/standards/peagen/peagen/tui/app.py
@@ -963,21 +963,25 @@ class QueueDashboardApp(App):
 
     def action_next_page(self) -> None:
         self.offset += self.limit
-        self.run_worker(
-            self.backend.refresh(limit=self.limit, offset=self.offset),
-            exclusive=True,
-            group="data_refresh_worker",
-        )
+        coro = self.backend.refresh(limit=self.limit, offset=self.offset)
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            asyncio.run(coro)
+        else:
+            self.run_worker(coro, exclusive=True, group="data_refresh_worker")
         self.trigger_data_processing(debounce=False)
 
     def action_prev_page(self) -> None:
         if self.offset >= self.limit:
             self.offset -= self.limit
-            self.run_worker(
-                self.backend.refresh(limit=self.limit, offset=self.offset),
-                exclusive=True,
-                group="data_refresh_worker",
-            )
+            coro = self.backend.refresh(limit=self.limit, offset=self.offset)
+            try:
+                asyncio.get_running_loop()
+            except RuntimeError:
+                asyncio.run(coro)
+            else:
+                self.run_worker(coro, exclusive=True, group="data_refresh_worker")
             self.trigger_data_processing(debounce=False)
 
     async def on_data_table_cell_selected(self, event: DataTable.CellSelected) -> None:


### PR DESCRIPTION
## Summary
- avoid child tasks when DOE process is `--dry-run`
- fall back to sync refresh when TUI pagination lacks a running loop
- test that DOE process handler exits cleanly on dry run

## Testing
- `uv run --package peagen --directory pkgs/standards ruff format .`
- `uv run --package peagen --directory pkgs/standards ruff check . --fix`
- `PEAGEN_TEST_GATEWAY=http://127.0.0.1:9 uv run --package peagen --directory pkgs/standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_6859b99353e48326927ea09c8d49cba1