### PR TITLE
Fix secrets CLI tests to use HTTPS gateway

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_secrets_cli.py
+++ b/pkgs/standards/peagen/tests/unit/test_secrets_cli.py
@@ -145,7 +145,7 @@ def test_remote_get(monkeypatch):
     secrets_cli.remote_get(
         ctx,
         "ID",
-        gateway_url="http://gw.peagen.com",
+        gateway_url="https://gw.peagen.com",
         pool="default",
     )
     assert out == ["value"]
@@ -173,7 +173,7 @@ def test_remote_remove(monkeypatch):
         ctx,
         "ID",
         version=2,
-        gateway_url="http://gw.peagen.com",
+        gateway_url="https://gw.peagen.com",
         pool="default",
     )
     assert posted["json"] == {


### PR DESCRIPTION
## Summary
- update secrets CLI unit tests to use https://gw.peagen.com

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen pytest` *(fails: 11 failed, 235 passed, 9 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6859d1c9f09083268afaa08cdf4541bf