### PR TITLE
Configure GitHub VCS in .peagen files

### DIFF
--- a/.peagen.toml
+++ b/.peagen.toml
@@ -5,6 +5,9 @@ org          = "test"
 template_set = "default"
 workers      = 4
 
+[vcs]
+provider = "github"
+
 # ─────────────────────────── LLM  ───────────────────────────────────────
 [llm]
 default_provider    = "groq"

--- a/infra/.gw.peagen.toml
+++ b/infra/.gw.peagen.toml
@@ -5,6 +5,9 @@ schemaVersion = "1.0.3"
 org          = "swarmauri"
 workers      = 4
 
+[vcs]
+provider = "github"
+
 # ────────────────────────── Storage Adapters ───────────────────────────
 # gateway doesn't write to storage
 # this should be delete in the future to ensure we can set no storage_adapter.

--- a/infra/.worker.peagen.toml
+++ b/infra/.worker.peagen.toml
@@ -5,6 +5,9 @@ schemaVersion = "1.0.3"
 org          = "swarmauri"
 workers      = 4
 
+[vcs]
+provider = "github"
+
 # ─────────────────────────── LLM  ───────────────────────────────────────
 [llm]
 default_provider    = "groq"

--- a/pkgs/standards/peagen/peagen/defaults.py
+++ b/pkgs/standards/peagen/peagen/defaults.py
@@ -45,4 +45,5 @@ CONFIG = {
         "filters": {"file": {"output_dir": "./peagen_artifacts"}},
     },
     "secrets": {"default_secret": "env", "adapters": {"env": {"prefix": ""}}},
+    "vcs": {"provider": "github"},
 }

--- a/pkgs/standards/peagen/tests/examples/2x2Grid/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/2x2Grid/.peagen.toml
@@ -1,3 +1,6 @@
+[vcs]
+provider = "github"
+
 [queues]
 default_queue = "in_memory"
 

--- a/pkgs/standards/peagen/tests/examples/gateway_demo/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/gateway_demo/.peagen.toml
@@ -1,3 +1,6 @@
+[vcs]
+provider = "github"
+
 [queues]
 default_queue = "in_memory"
 

--- a/pkgs/standards/peagen/tests/examples/peagen_local_demo/test_workspace/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/peagen_local_demo/test_workspace/.peagen.toml
@@ -1,4 +1,6 @@
 schemaVersion = "1.0.3"
+[vcs]
+provider = "github"
 [queues]
 default_queue = "in_memory"
 [queues.adapters.in_memory]

--- a/pkgs/standards/peagen/tests/examples/peagen_tomls/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/peagen_tomls/.peagen.toml
@@ -5,6 +5,9 @@ org          = "test"
 template_set = "default"
 workers      = 4
 
+[vcs]
+provider = "github"
+
 # ─────────────────────────── LLM  ───────────────────────────────────────
 [llm]
 default_provider    = "groq"

--- a/pkgs/standards/peagen/tests/examples/simple_evolve_demo/workspace/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/simple_evolve_demo/workspace/.peagen.toml
@@ -1,4 +1,6 @@
 schemaVersion = "1.0.3"
+[vcs]
+provider = "github"
 [queues]
 default_queue = "in_memory"
 [queues.adapters.in_memory]


### PR DESCRIPTION
## Summary
- set default VCS provider to GitHub in built‑ins
- configure `[vcs]` section with GitHub provider in all `.peagen.toml` files

## Testing
- `uv run --directory . --package peagen ruff format .`
- `uv run --directory . --package peagen ruff check . --fix`

------
https://chatgpt.com/codex/tasks/task_e_6859d4d6e7d483269173cf7189f28e44