### PR TITLE
Configure VCS for workers

### DIFF
--- a/.peagen.toml
+++ b/.peagen.toml
@@ -86,3 +86,7 @@ strict = true
 
 [evaluation.evaluators]
 performance = "peagen.plugins.evaluators.performance_evaluator:PerformanceEvaluator"
+
+[vcs]
+provider = "git"
+default_vcs = "git"

--- a/pkgs/standards/peagen/peagen/defaults.py
+++ b/pkgs/standards/peagen/peagen/defaults.py
@@ -44,5 +44,6 @@ CONFIG = {
         "default_filter": "file",
         "filters": {"file": {"output_dir": "./peagen_artifacts"}},
     },
+    "vcs": {"default_vcs": "git"},
     "secrets": {"default_secret": "env", "adapters": {"env": {"prefix": ""}}},
 }

--- a/pkgs/standards/peagen/tests/examples/2x2Grid/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/2x2Grid/.peagen.toml
@@ -10,3 +10,7 @@ output_dir = "./peagen_artifacts"
 default_backend = "local_fs"
 [result_backends.adapters.local_fs]
 root_dir = "./task_runs"
+
+[vcs]
+provider = "git"
+default_vcs = "git"

--- a/pkgs/standards/peagen/tests/examples/gateway_demo/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/gateway_demo/.peagen.toml
@@ -10,3 +10,7 @@ output_dir = "./peagen_artifacts"
 default_backend = "local_fs"
 [result_backends.adapters.local_fs]
 root_dir = "./task_runs"
+
+[vcs]
+provider = "git"
+default_vcs = "git"

--- a/pkgs/standards/peagen/tests/examples/peagen_local_demo/test_workspace/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/peagen_local_demo/test_workspace/.peagen.toml
@@ -29,3 +29,7 @@ performance = "peagen.plugins.evaluators.performance_evaluator:PerformanceEvalua
 default_provider = "groq"
 [llm.groq]
 API_KEY = "${GROQ_API_KEY}"
+
+[vcs]
+provider = "git"
+default_vcs = "git"

--- a/pkgs/standards/peagen/tests/examples/peagen_tomls/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/peagen_tomls/.peagen.toml
@@ -77,3 +77,7 @@ cls = "swarmauri_evaluatorpool_accessibility:AutomatedReadabilityIndexEvaluator"
 [evaluation.evaluators.ColemanLiauIndexEvaluator]
 cls = "swarmauri_evaluatorpool_accessibility:ColemanLiauIndexEvaluator"
 target_grade_level = 12
+
+[vcs]
+provider = "git"
+default_vcs = "git"

--- a/pkgs/standards/peagen/tests/examples/simple_evolve_demo/workspace/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/simple_evolve_demo/workspace/.peagen.toml
@@ -29,3 +29,7 @@ performance = "peagen.plugins.evaluators.performance_evaluator:PerformanceEvalua
 default_provider = "groq"
 [llm.groq]
 API_KEY = "${GROQ_API_KEY}"
+
+[vcs]
+provider = "git"
+default_vcs = "git"


### PR DESCRIPTION
## Summary
- add Git as default VCS provider
- define default VCS in worker `.peagen.toml` files

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_6859d4b825fc8326bcae25662601de70