### PR TITLE
Update Peagen IP abuse ban threshold

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -106,7 +106,7 @@ WORKER_TTL = 15  # seconds before a worker is considered dead
 TASK_TTL = 24 * 3600  # 24 h, adjust as needed
 
 # ─────────────────────────── IP tracking ─────────────────────────
-BAN_THRESHOLD = 10
+BAN_THRESHOLD = 1000
 KNOWN_IPS: set[str] = set()
 BANNED_IPS: set[str] = set()
 SECRET_NOT_FOUND_CODE = -32004


### PR DESCRIPTION
## Summary
- increase `BAN_THRESHOLD` to 1000 in the peagen gateway

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format pkgs/standards/peagen`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory standards pytest` *(fails: ModuleNotFoundError)*
- `uv run --directory standards --package peagen -- peagen remote -q --gateway-url http://localhost:8000/rpc process /workspace/swarmauri-sdk/pkgs/standards/peagen/peagen/template_sets/python_orm/example.payload.yaml --watch` *(fails: ConnectionRefusedError)*
- `uv run --directory standards --package peagen -- peagen local process /workspace/swarmauri-sdk/pkgs/standards/peagen/peagen/template_sets/python_orm/example.payload.yaml` *(fails: ValueError, no LLM provider)*

------
https://chatgpt.com/codex/tasks/task_e_685a31436df08326b2263664c6e6407e