### PR TITLE
Fix gateway login skip

### DIFF
--- a/pkgs/standards/peagen/tests/smoke/test_gateway_login_keys_secrets_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_gateway_login_keys_secrets_cli.py
@@ -15,7 +15,7 @@ def _gateway_available(url: str) -> bool:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:
         return False
-    return response.status_code < 500
+    return response.status_code == 200
 
 
 @pytest.mark.i9n


### PR DESCRIPTION
## Summary
- ensure we skip gateway auth smoke tests when the remote endpoint doesn't respond with HTTP 200

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --directory pkgs/standards/peagen --package peagen pytest` *(fails: test_eval_submit_returns_error_when_no_handler, test_remote_full_flow, test_rpc_watch_remote_process, test_submit_posts_request)*

------
https://chatgpt.com/codex/tasks/task_e_685a316ca01883268f5e7cce569a8adc