### PR TITLE
Fix gateway skip condition

### DIFF
--- a/pkgs/standards/peagen/tests/smoke/test_gateway_remote_doe.py
+++ b/pkgs/standards/peagen/tests/smoke/test_gateway_remote_doe.py
@@ -16,7 +16,7 @@ def _gateway_available(url: str) -> bool:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:
         return False
-    return response.status_code < 500
+    return response.status_code == 200
 
 
 @pytest.mark.i9n


### PR DESCRIPTION
## Summary
- ensure remote gateway tests only run when RPC calls return 200

## Testing
- `uv run --package peagen --directory standards/peagen pytest tests/smoke/test_gateway_remote_doe.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685a3181a8c48326a8094910b05df647