### PR TITLE
Fix fetch CLI tests

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/fetch.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/fetch.py
@@ -18,7 +18,6 @@ import typer
 from peagen.handlers.fetch_handler import fetch_handler
 from peagen.models import Status, Task
 
-DEFAULT_GATEWAY = "http://localhost:8000/rpc"
 fetch_app = typer.Typer(help="Materialise Peagen workspaces from URIs.")
 
 


### PR DESCRIPTION
## Summary
- drop the remote fetch functionality and related CLI wiring
- remove JSON‑RPC fetch tests in favor of repo/ref option checks

## Testing
- `uv run --directory standards/peagen --package peagen ruff format .`
- `uv run --directory standards/peagen --package peagen ruff check . --fix`
- `uv run --directory standards/peagen --package peagen pytest tests/unit/test_fetch_cli.py::test_fetch_repo_ref_argument -vv`

------
https://chatgpt.com/codex/tasks/task_e_685a3122b2f48326bfdccaebf6bea984