### PR TITLE
Fix peagen CLI dependency

### DIFF
--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "inflect",
     "typer",
     "colorama",
+    "jsonschema>=4.18.5",
     "httpx>=0.27.0",
     "swarmauri_core",
     "swarmauri_base",


### PR DESCRIPTION
## Summary
- update peagen's package dependencies to include `jsonschema`

## Testing
- `ruff check pkgs/standards/peagen`
- `uv run --package peagen --directory standards/peagen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a3959bef8832680c66e376c68d405