### PR TITLE
Add wscat example

### DIFF
--- a/pkgs/standards/peagen/README.md
+++ b/pkgs/standards/peagen/README.md
@@ -442,5 +442,17 @@ switch between task lists, logs and opened files. The footer shows system
 metrics and current time. Remote artifact paths are downloaded via their git
 filter and re-uploaded when saving.
 
+### Streaming Events with wscat
+
+Use the [`wscat`](https://github.com/websockets/wscat) CLI to inspect the
+gateway's WebSocket events directly from the terminal:
+
+```bash
+npx wscat -c https://gw.peagen.com/ws/tasks
+```
+
+Incoming JSON messages mirror those displayed in the TUI, providing a quick way
+to monitor `task.update`, `worker.update`, and `queue.update` events.
+
 ## Results Backends
 Peagen supports pluggable results backends. Built-in options include `local_fs`, `postgres`, and `in_memory`.


### PR DESCRIPTION
## Summary
- document using `wscat` to stream gateway events

## Testing
- `uv run --package peagen --directory standards/peagen ruff format .`
- `uv run --package peagen --directory standards/peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest -q` *(fails: eval_submit_returns_error_when_no_handler, remote_evolve, remote_full_flow, rpc_watch_remote_process, test_prevalidate_rejects_and_bans, test_prevalidate_bad_version)*

------
https://chatgpt.com/codex/tasks/task_e_685a3a8b54bc8326ad5bd4f9047f175f