### PR TITLE
Add i18n prototype for peagen

### DIFF
--- a/pkgs/standards/peagen/README.md
+++ b/pkgs/standards/peagen/README.md
@@ -32,8 +32,11 @@
 #### Built‑In Dependency Management  
 - The CLI’s `--transitive` flag toggles between strict and transitive dependency sorts, so you can include or exclude indirect dependencies in your generation run.
 
-#### Seamless LLM Integration  
+#### Seamless LLM Integration
 - In GENERATE mode, the CLI automatically fills agent‑prompt templates with context and dependency examples, calls your configured LLM (e.g. OpenAI’s GPT‑4), and writes back the generated content. All model parameters (provider, model name, temperature) flow through CLI flags and environment variables—no extra scripting needed.
+
+#### Internationalization Ready
+- Core CLI messages are namespaced by language, making it easy to ship localized versions.
 
 ---
 

--- a/pkgs/standards/peagen/peagen/__init__.py
+++ b/pkgs/standards/peagen/peagen/__init__.py
@@ -17,6 +17,7 @@ from .plugin_manager import PluginManager, resolve_plugin_spec
 from .errors import PatchTargetMissingError
 from .core.patch_core import apply_patch
 from .plugins.secret_drivers import AutoGpgDriver, SecretDriverBase
+from .i18n import get_message, set_language
 
 __all__ = [
     "__package_name__",
@@ -27,4 +28,6 @@ __all__ = [
     "apply_patch",
     "SecretDriverBase",
     "AutoGpgDriver",
+    "get_message",
+    "set_language",
 ]

--- a/pkgs/standards/peagen/peagen/cli/__init__.py
+++ b/pkgs/standards/peagen/peagen/cli/__init__.py
@@ -9,6 +9,7 @@ import sys
 from pathlib import Path
 
 import typer
+from peagen.i18n import get_message
 
 # ─── Banner helper (printed unless –quiet) ────────────────────────────────
 from ._banner import _print_banner
@@ -47,7 +48,7 @@ from .commands import (
     dashboard_app,
 )
 
-app = typer.Typer(help="CLI tool for processing project files using Peagen.")
+app = typer.Typer(help=get_message("cli.app_help"))
 local_app = typer.Typer(help="Commands executed locally on this machine.")
 remote_app = typer.Typer(help="Commands that submit tasks to a JSON-RPC gateway.")
 

--- a/pkgs/standards/peagen/peagen/cli/commands/init.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/init.py
@@ -16,15 +16,15 @@ import typer
 from peagen._utils._init import _call_handler, _submit_task, _summary
 from peagen._utils.git_filter import add_filter, init_git_filter
 from swarmauri_standard.loggers.Logger import Logger
+from peagen.i18n import get_message
 
 DEFAULT_GATEWAY = "http://localhost:8000/rpc"
 
 # ── Typer root ───────────────────────────────────────────────────────────────
-local_init_app = typer.Typer(
-    help="Bootstrap Peagen artefacts (project, template-set …) locally"
-)
+
+local_init_app = typer.Typer(help=get_message("cli.init.local_help"))
 remote_init_app = typer.Typer(
-    help="Bootstrap Peagen artefacts (project, template-set …) via JSON-RPC",
+    help=get_message("cli.init.remote_help"),
 )
 
 

--- a/pkgs/standards/peagen/peagen/i18n.py
+++ b/pkgs/standards/peagen/peagen/i18n.py
@@ -1,0 +1,33 @@
+"""Simple internationalization helpers for Peagen."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+
+_MESSAGES: Dict[str, Dict[str, str]] = {
+    "en": {
+        "cli.app_help": "CLI tool for processing project files using Peagen.",
+        "cli.init.local_help": "Bootstrap Peagen artefacts (project, template-set …) locally",
+        "cli.init.remote_help": "Bootstrap Peagen artefacts (project, template-set …) via JSON-RPC",
+    },
+    "es": {
+        "cli.app_help": "Herramienta CLI para procesar archivos de proyecto con Peagen.",
+        "cli.init.local_help": "Crea artefactos de Peagen (proyecto, conjunto de plantillas…) localmente",
+        "cli.init.remote_help": "Crea artefactos de Peagen (proyecto, conjunto de plantillas…) vía JSON-RPC",
+    },
+}
+
+_language = "en"
+
+
+def set_language(lang: str) -> None:
+    """Set the active language namespace."""
+    global _language
+    if lang in _MESSAGES:
+        _language = lang
+
+
+def get_message(key: str) -> str:
+    """Return the message for ``key`` in the active language."""
+    return _MESSAGES.get(_language, {}).get(key, _MESSAGES["en"].get(key, key))

--- a/pkgs/standards/peagen/tests/unit/test_i18n.py
+++ b/pkgs/standards/peagen/tests/unit/test_i18n.py
@@ -1,0 +1,9 @@
+from peagen.i18n import get_message, set_language
+
+
+def test_get_message_in_spanish() -> None:
+    set_language("es")
+    try:
+        assert get_message("cli.app_help").startswith("Herramienta CLI")
+    finally:
+        set_language("en")


### PR DESCRIPTION
## Summary
- implement a simple internationalization layer
- integrate i18n with CLI help messages
- document i18n feature
- test message lookup

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest`
- `peagen remote --gateway-url https://gw.peagen.com/rpc -q process pkgs/standards/peagen/tests/examples/projects_payloads/project_payloads.yaml`
- `peagen remote --gateway-url https://gw.peagen.com/rpc -q process pkgs/standards/peagen/tests/examples/projects_payloads/project_payloads.yaml --watch --interval 1`
- `peagen local process pkgs/standards/peagen/tests/examples/projects_payloads/project_payloads.yaml`

------
https://chatgpt.com/codex/tasks/task_e_685a3d43efc083268e8b6365470c7a53