### PR TITLE
Fix missing VCS config in Peagen images

### DIFF
--- a/infra/.gw.peagen.toml
+++ b/infra/.gw.peagen.toml
@@ -41,3 +41,8 @@ default_backend = "postgres"
 [result_backends.adapters.postgres]
 dsn = "${PG_DSN}"
 
+# --- VCS ------------------------------------------------------------
+[vcs]
+provider = "git"
+default_vcs = "git"
+

--- a/infra/.worker.peagen.toml
+++ b/infra/.worker.peagen.toml
@@ -72,3 +72,8 @@ cls = "swarmauri_evaluatorpool_accessibility:AutomatedReadabilityIndexEvaluator"
 cls = "swarmauri_evaluatorpool_accessibility:ColemanLiauIndexEvaluator"
 target_grade_level = 12
 
+# --- VCS ------------------------------------------------------------
+[vcs]
+provider = "git"
+default_vcs = "git"
+


### PR DESCRIPTION
## Summary
- ensure gateway and worker images include a `[vcs]` configuration

The failure was caused by Peagen tasks running with configs that lacked the `vcs` section, leading to `No plugin configured for group 'vcs'` errors.

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --directory pkgs/standards/peagen --package peagen pytest` *(fails: test_eval_submit_returns_error_when_no_handler, test_remote_evolve, test_rpc_watch_remote_process, test_prevalidate_rejects_and_bans, test_prevalidate_bad_version)*

------
https://chatgpt.com/codex/tasks/task_e_685a3e7af4888326a2f81cf0527323d3