### PR TITLE
Fix TUI to refresh on websocket events

### DIFF
--- a/pkgs/standards/peagen/peagen/tui/app.py
+++ b/pkgs/standards/peagen/peagen/tui/app.py
@@ -292,6 +292,7 @@ class QueueDashboardApp(App):
     async def on_mount(self):
         # Register for connection status changes
         self.client.on_connection_change(self.on_websocket_connection_change)
+        self.client.on_event(self.handle_ws_event)
 
         self.run_worker(
             self.client.listen(), exclusive=True, group="websocket_listener"
@@ -315,6 +316,10 @@ class QueueDashboardApp(App):
                 await self._dismiss_reconnect()
                 self.toast("Connection re-established", duration=2.0)
                 self.trigger_data_processing(debounce=False)
+
+    async def handle_ws_event(self, event: dict) -> None:
+        """Process WebSocket events and refresh the UI."""
+        self.trigger_data_processing(debounce=False)
 
     async def _refresh_backend_and_ui(self) -> None:
         if self._reconnect_screen:

--- a/pkgs/standards/peagen/tests/unit/test_tui_ws_event.py
+++ b/pkgs/standards/peagen/tests/unit/test_tui_ws_event.py
@@ -1,0 +1,19 @@
+import pytest
+from peagen.tui.app import QueueDashboardApp
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ws_event_triggers_refresh(monkeypatch):
+    app = QueueDashboardApp()
+
+    called = {}
+
+    def fake_trigger(debounce=True):
+        called["count"] = called.get("count", 0) + 1
+
+    monkeypatch.setattr(app, "trigger_data_processing", fake_trigger)
+
+    await app.handle_ws_event({"type": "task.update", "data": {"id": "1"}})
+
+    assert called.get("count") == 1


### PR DESCRIPTION
## Summary
- refresh task list when websocket events arrive in peagen TUI
- add regression test for websocket event refresh

## Testing
- `uv run --directory standards --package peagen ruff format peagen`
- `uv run --directory standards --package peagen ruff check peagen --fix`
- `uv run --package peagen --directory standards pytest peagen/tests/unit/test_tui_ws_event.py`

------
https://chatgpt.com/codex/tasks/task_e_685a3f5d39e48326bcdff869fd8fea61