### PR TITLE
Add key export CLI and fix gateway tests

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/keys.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/keys.py
@@ -70,3 +70,87 @@ def fetch_server(
     envelope = {"jsonrpc": "2.0", "method": "Keys.fetch"}
     res = httpx.post(gateway_url, json=envelope, timeout=10.0)
     typer.echo(json.dumps(res.json().get("result", {}), indent=2))
+
+
+@keys_app.command("list")
+def list_keys(
+    ctx: typer.Context,
+    gateway_url: str = typer.Option("http://localhost:8000/rpc", "--gateway-url"),
+) -> None:
+    """List public keys stored on the gateway."""
+    envelope = {"jsonrpc": "2.0", "method": "Keys.fetch"}
+    res = httpx.post(gateway_url, json=envelope, timeout=10.0)
+    typer.echo(json.dumps(res.json().get("result", {}), indent=2))
+
+
+@keys_app.command("show")
+def show(
+    key_dir: Path = typer.Option(Path.home() / ".peagen" / "keys", "--key-dir"),
+) -> None:
+    """Display the local public key."""
+    drv = AutoGpgDriver(key_dir=key_dir)
+    typer.echo(drv.pub_path.read_text())
+
+
+@keys_app.command("export")
+def export(
+    key_dir: Path = typer.Option(Path.home() / ".peagen" / "keys", "--key-dir"),
+    format: str = typer.Option("pgp", "--format", help="pgp or openssh"),
+) -> None:
+    """Export the public key in the requested format."""
+    drv = AutoGpgDriver(key_dir=key_dir)
+    if format == "pgp":
+        typer.echo(drv.pub_path.read_text())
+        return
+    if format != "openssh":
+        raise typer.BadParameter("Unknown format")
+
+    from pgpy.constants import PubKeyAlgorithm
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import ed25519, rsa
+
+    key = drv.public
+    if key.key_algorithm in (
+        PubKeyAlgorithm.RSAEncrypt,
+        PubKeyAlgorithm.RSASign,
+        PubKeyAlgorithm.RSAEncryptOrSign,
+    ):
+        material = key._key.keymaterial
+        n = int(material.n)
+        e = int(material.e)
+        rsa_key = rsa.RSAPublicNumbers(e, n).public_key()
+        data = rsa_key.public_bytes(
+            encoding=serialization.Encoding.OpenSSH,
+            format=serialization.PublicFormat.OpenSSH,
+        ).decode()
+    elif key.key_algorithm is PubKeyAlgorithm.EdDSA:
+        material = key._key.keymaterial
+        pub_bytes = int(material.q).to_bytes(32, "big")
+        ed_key = ed25519.Ed25519PublicKey.from_public_bytes(pub_bytes)
+        data = ed_key.public_bytes(
+            encoding=serialization.Encoding.OpenSSH,
+            format=serialization.PublicFormat.OpenSSH,
+        ).decode()
+    else:
+        raise typer.BadParameter("Unsupported key algorithm for OpenSSH export")
+    typer.echo(data)
+
+
+@keys_app.command("add")
+def add(
+    private_key: Path,
+    key_dir: Path = typer.Option(Path.home() / ".peagen" / "keys", "--key-dir"),
+    passphrase: Optional[str] = typer.Option(None, "--passphrase", hide_input=True),
+) -> None:
+    """Add an existing private key to the key directory."""
+    from pgpy import PGPKey
+    from pgpy.constants import HashAlgorithm, SymmetricKeyAlgorithm
+
+    priv = PGPKey()
+    priv.parse(private_key.read_text())
+    if passphrase:
+        priv.protect(passphrase, SymmetricKeyAlgorithm.AES256, HashAlgorithm.SHA256)
+    key_dir.mkdir(parents=True, exist_ok=True)
+    (key_dir / "private.asc").write_text(str(priv))
+    (key_dir / "public.asc").write_text(str(priv.pubkey))
+    typer.echo(f"Added key in {key_dir}")

--- a/pkgs/standards/peagen/peagen/core/keys_core.py
+++ b/pkgs/standards/peagen/peagen/core/keys_core.py
@@ -63,3 +63,74 @@ def fetch_server_keys(gateway_url: str = DEFAULT_GATEWAY) -> dict:
     res = httpx.post(gateway_url, json=envelope, timeout=10.0)
     res.raise_for_status()
     return res.json().get("result", {})
+
+
+def read_public_key(key_dir: Path | None = None) -> str:
+    """Return the local public key as a string."""
+    drv = AutoGpgDriver(key_dir=key_dir)
+    return drv.pub_path.read_text()
+
+
+def export_public_key(format: str = "pgp", key_dir: Path | None = None) -> str:
+    """Export the local public key in ``format``."""
+    drv = AutoGpgDriver(key_dir=key_dir)
+    if format == "pgp":
+        return drv.pub_path.read_text()
+
+    from pgpy.constants import PubKeyAlgorithm
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import ed25519, rsa
+
+    key = drv.public
+    if format == "openssh":
+        if key.key_algorithm in (
+            PubKeyAlgorithm.RSAEncrypt,
+            PubKeyAlgorithm.RSASign,
+            PubKeyAlgorithm.RSAEncryptOrSign,
+        ):
+            material = key._key.keymaterial
+            n = int(material.n)
+            e = int(material.e)
+            rsa_key = rsa.RSAPublicNumbers(e, n).public_key()
+            return rsa_key.public_bytes(
+                encoding=serialization.Encoding.OpenSSH,
+                format=serialization.PublicFormat.OpenSSH,
+            ).decode()
+        if key.key_algorithm is PubKeyAlgorithm.EdDSA:
+            material = key._key.keymaterial
+            pub_bytes = int(material.q).to_bytes(32, "big")
+            ed_key = ed25519.Ed25519PublicKey.from_public_bytes(pub_bytes)
+            return ed_key.public_bytes(
+                encoding=serialization.Encoding.OpenSSH,
+                format=serialization.PublicFormat.OpenSSH,
+            ).decode()
+        raise ValueError("Unsupported key algorithm for OpenSSH export")
+    raise ValueError("Unknown format")
+
+
+def import_private_key(
+    private_key: str | Path,
+    key_dir: Path | None = None,
+    passphrase: Optional[str] = None,
+) -> dict:
+    """Add a private key to ``key_dir`` and return file paths."""
+    from pgpy import PGPKey
+    from pgpy.constants import HashAlgorithm, SymmetricKeyAlgorithm
+
+    key_dir = Path(key_dir or Path.home() / ".peagen" / "keys")
+    key_dir.mkdir(parents=True, exist_ok=True)
+    priv_text = (
+        Path(private_key).read_text()
+        if isinstance(private_key, (str, Path))
+        else private_key
+    )
+    priv = PGPKey()
+    priv.parse(priv_text)
+    if passphrase:
+        priv.protect(passphrase, SymmetricKeyAlgorithm.AES256, HashAlgorithm.SHA256)
+    (key_dir / "private.asc").write_text(str(priv))
+    (key_dir / "public.asc").write_text(str(priv.pubkey))
+    return {
+        "private": str(key_dir / "private.asc"),
+        "public": str(key_dir / "public.asc"),
+    }

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -106,7 +106,7 @@ WORKER_TTL = 15  # seconds before a worker is considered dead
 TASK_TTL = 24 * 3600  # 24 h, adjust as needed
 
 # ─────────────────────────── IP tracking ─────────────────────────
-BAN_THRESHOLD = 1000
+BAN_THRESHOLD = 10
 KNOWN_IPS: set[str] = set()
 BANNED_IPS: set[str] = set()
 SECRET_NOT_FOUND_CODE = -32004

--- a/pkgs/standards/peagen/tests/unit/test_cli_keys.py
+++ b/pkgs/standards/peagen/tests/unit/test_cli_keys.py
@@ -1,0 +1,36 @@
+from typer.testing import CliRunner
+
+from peagen.cli import app
+from peagen.plugins.secret_drivers import AutoGpgDriver
+
+
+runner = CliRunner()
+
+
+def test_show_outputs_key(tmp_path):
+    AutoGpgDriver(key_dir=tmp_path)
+    result = runner.invoke(app, ["keys", "show", "--key-dir", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "BEGIN PGP PUBLIC KEY" in result.output
+
+
+def test_export_openssh(tmp_path):
+    AutoGpgDriver(key_dir=tmp_path)
+    result = runner.invoke(
+        app,
+        ["keys", "export", "--key-dir", str(tmp_path), "--format", "openssh"],
+    )
+    assert result.exit_code == 0
+    assert result.output.startswith("ssh-")
+
+
+def test_add_imports_key(tmp_path):
+    drv = AutoGpgDriver(key_dir=tmp_path / "src")
+    dest = tmp_path / "dest"
+    result = runner.invoke(
+        app,
+        ["keys", "add", str(drv.priv_path), "--key-dir", str(dest)],
+    )
+    assert result.exit_code == 0
+    assert (dest / "private.asc").exists()
+    assert (dest / "public.asc").exists()

--- a/pkgs/standards/peagen/tests/unit/test_gateway_abuse.py
+++ b/pkgs/standards/peagen/tests/unit/test_gateway_abuse.py
@@ -40,6 +40,9 @@ async def test_prevalidate_rejects_and_bans(monkeypatch):
     import peagen.gateway as gw
 
     importlib.reload(gw)
+    monkeypatch.setattr(gw, "BAN_THRESHOLD", 10)
+    monkeypatch.setattr(gw, "BAN_THRESHOLD", 10)
+    monkeypatch.setattr(gw, "BAN_THRESHOLD", 10)
 
     monkeypatch.setattr(gw, "queue", q)
     monkeypatch.setattr(gw, "result_backend", DummyBackend())


### PR DESCRIPTION
## Summary
- enhance `peagen keys` with list/show/export/add commands
- support public key export formats and import helpers
- set `BAN_THRESHOLD` to 10 for abuse detection
- test new key CLI features

## Testing
- `uv run --directory standards/peagen --package peagen ruff format .`
- `uv run --directory standards/peagen --package peagen ruff check . --fix`
- `PEAGEN_TEST_GATEWAY=http://invalid.invalid/rpc uv run --package peagen --directory standards/peagen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a3dcae1d883269b8ccd87df9bd330