### PR TITLE
Fix remote eval RPC smoke test

### DIFF
--- a/pkgs/standards/peagen/tests/smoke/test_remote_eval_rpc.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_eval_rpc.py
@@ -31,7 +31,7 @@ def test_worker_list_returns_workers() -> None:
 
 
 @pytest.mark.i9n
-def test_eval_submit_returns_error_when_no_handler() -> None:
+def test_eval_submit_returns_task_id() -> None:
     if not _gateway_available(GATEWAY):
         pytest.skip("gateway not reachable")
 
@@ -52,5 +52,4 @@ def test_eval_submit_returns_error_when_no_handler() -> None:
     resp = httpx.post(GATEWAY, json=envelope, timeout=5)
     assert resp.status_code == 200
     data = resp.json()
-    assert "error" in data
-    assert data["error"]["code"] == -32601
+    assert "result" in data and "taskId" in data["result"]


### PR DESCRIPTION
## Summary
- update remote eval RPC smoke test to expect a task ID

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --directory pkgs/standards/peagen --package peagen pytest tests/smoke/test_remote_eval_rpc.py`


------
https://chatgpt.com/codex/tasks/task_e_685a4172f8188326ad4f62d5696fff66