### PR TITLE
Fix secret driver plugins

### DIFF
--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -179,6 +179,10 @@ echo_mutator = "peagen.plugins.mutators.echo_mutator:EchoMutator"
 llm_prompt = "peagen.plugins.mutators.llm_prompt:LlmRewrite"
 llm_prog_rewrite = "peagen.plugins.mutators.llm_prog_rewrite:LlmProgRewrite"
 
+[project.entry-points."peagen.plugins.secret_drivers"]
+env = "peagen.plugins.secret_drivers.env_secret:EnvSecret"
+autogpg = "peagen.plugins.secret_drivers.autogpg_secretdriver:AutoGpgDriver"
+
 [project.entry-points."peagen.evaluators"]
 psutil_io = "peagen.evaluators.psutil_io:PsutilIOEvaluator"
 perf_regression = "peagen.evaluators.pytest_perf_regression:PytestPerfRegressionEvaluator"


### PR DESCRIPTION
## Summary
- register secret driver entrypoints in peagen

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest -q` *(fails: test_eval_submit_returns_error_when_no_handler, test_remote_evolve, test_remote_full_flow, test_rpc_watch_remote_process)*

------
https://chatgpt.com/codex/tasks/task_e_685a430b0aac8326b15e7b014838c142