### PR TITLE
Add git VCS entry point

### DIFF
--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -154,6 +154,9 @@ s3fs    = "peagen.plugins.git_filters.s3fs_filter:S3FSFilter"
 [project.entry-points."peagen.plugins.vcs"]
 git = "peagen.plugins.vcs.git_vcs:GitVCS"
 
+[project.entry-points."peagen.vcs"]
+git = "peagen.plugins.vcs.git_vcs:GitVCS"
+
 [project.entry-points."peagen.plugins.publishers"]
 redis   = "peagen.plugins.publishers.redis_publisher:RedisPublisher"
 webhook = "peagen.plugins.publishers.webhook_publisher:WebhookPublisher"


### PR DESCRIPTION
## Summary
- add `peagen.vcs` entry point to expose Git VCS plugin

## Testing
- `uv run --package peagen --directory standards/peagen ruff format .`
- `uv run --package peagen --directory standards/peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest` *(fails: 6 failed, 242 passed)*
- `peagen remote -q --gateway-url http://localhost:8000/rpc process standards/peagen/tests/examples/projects_payloads/projects_payload.yaml --watch` *(fails: connection refused)*
- `peagen local -q process standards/peagen/tests/examples/projects_payloads/projects_payload.yaml` *(fails: no LLM provider specified)*

------
https://chatgpt.com/codex/tasks/task_e_685a468202dc832695d1ffde2d53c617