### PR TITLE
Fix TUI websocket task display

### DIFF
--- a/pkgs/standards/peagen/peagen/tui/app.py
+++ b/pkgs/standards/peagen/peagen/tui/app.py
@@ -420,13 +420,12 @@ class QueueDashboardApp(App):
     async def async_process_and_update_data(self) -> None:
         all_tasks_from_client = list(self.client.tasks.values())
         all_tasks_from_backend = list(self.backend.tasks)
-        allowed_ids = {str(t.get("id")) for t in all_tasks_from_backend}
-        combined_tasks_dict: Dict[str, Any] = {
-            task.get("id"): task for task in all_tasks_from_backend
-        }
-        for task in all_tasks_from_client:
-            if str(task.get("id")) in allowed_ids:
-                combined_tasks_dict[task.get("id")] = task
+
+        combined_tasks_dict: Dict[str, Any] = {}
+        for task in all_tasks_from_backend + all_tasks_from_client:
+            tid = task.get("id")
+            if tid is not None:
+                combined_tasks_dict[tid] = task
         all_tasks = list(combined_tasks_dict.values())
 
         for task in all_tasks:


### PR DESCRIPTION
## Summary
- merge tasks from HTTP and websocket sources

## Testing
- `uv run --directory standards/peagen --package peagen ruff format .`
- `uv run --directory standards/peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest` *(fails: AssertionError in network-dependent tests)*

------
https://chatgpt.com/codex/tasks/task_e_685a3f5d39e48326bcdff869fd8fea61