### PR TITLE
Use plugin manager for secrets driver

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -109,7 +109,6 @@ TASK_TTL = 24 * 3600  # 24 h, adjust as needed
 
 # ─────────────────────────── IP tracking ─────────────────────────
 
-BAN_THRESHOLD = 10
 KNOWN_IPS: set[str] = set()
 BANNED_IPS: set[str] = set()
 

--- a/pkgs/standards/peagen/tests/unit/test_keys_core.py
+++ b/pkgs/standards/peagen/tests/unit/test_keys_core.py
@@ -1,0 +1,66 @@
+import tempfile
+from pathlib import Path
+
+
+from peagen.core import keys_core
+
+
+class DummyDriver:
+    def __init__(self, key_dir: Path, passphrase: str | None = None) -> None:
+        self.key_dir = key_dir
+        self.passphrase = passphrase
+        self.priv_path = key_dir / "private.asc"
+        self.pub_path = key_dir / "public.asc"
+        self.priv_path.write_text("priv")
+        self.pub_path.write_text("pub")
+
+    def _ensure_keys(self) -> None:
+        pass
+
+    def list_keys(self) -> dict[str, str]:
+        return {"FP": str(self.pub_path)}
+
+    def export_public_key(self, fingerprint: str, fmt: str = "armor") -> str:
+        assert fingerprint == "FP"
+        return "KEY"
+
+    def add_key(
+        self,
+        public_key: Path,
+        *,
+        private_key: Path | None = None,
+        name: str | None = None,
+    ) -> dict:
+        return {"fingerprint": "FP", "path": str(self.key_dir)}
+
+
+class DummyPM:
+    def __init__(self, _cfg: dict) -> None:
+        self.called = False
+
+    def get(self, group: str, name: str | None = None):
+        assert group == "secrets"
+        self.called = True
+        return DummyDriver(Path(tempfile.mkdtemp()))
+
+
+def test_create_keypair_uses_plugin_manager(monkeypatch):
+    monkeypatch.setattr(keys_core, "load_peagen_toml", lambda *a, **k: {})
+    pm = DummyPM({})
+    monkeypatch.setattr(keys_core, "PluginManager", lambda cfg: pm)
+    out = keys_core.create_keypair()
+    assert pm.called
+    assert out["private"].endswith("private.asc")
+    assert out["public"].endswith("public.asc")
+
+
+def test_export_public_key_delegates(monkeypatch, tmp_path):
+    monkeypatch.setattr(keys_core, "load_peagen_toml", lambda *a, **k: {})
+
+    class PM(DummyPM):
+        def get(self, group: str, name: str | None = None):
+            return DummyDriver(tmp_path)
+
+    monkeypatch.setattr(keys_core, "PluginManager", PM)
+    text = keys_core.export_public_key("FP", key_root=tmp_path)
+    assert text == "KEY"


### PR DESCRIPTION
## Summary
- refactor keys_core to use PluginManager for selecting a secrets driver
- extend AutoGpgDriver with helper methods for key management
- fix duplicate `BAN_THRESHOLD` constant in gateway
- add unit tests for keys_core plugin manager integration

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format .`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest` *(fails: tests/smoke/test_remote_evolve.py::test_remote_evolve)*

------
https://chatgpt.com/codex/tasks/task_e_685a47b05f3483268b9be6ba9c1874c1