### PR TITLE
Fix F811 in peagen gateway

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -109,7 +109,6 @@ TASK_TTL = 24 * 3600  # 24 h, adjust as needed
 
 # ─────────────────────────── IP tracking ─────────────────────────
 
-BAN_THRESHOLD = 10
 KNOWN_IPS: set[str] = set()
 BANNED_IPS: set[str] = set()
 


### PR DESCRIPTION
## Summary
- remove duplicate `BAN_THRESHOLD` constant in `peagen.gateway`

## Testing
- `uv run --directory standards/peagen --package peagen ruff check . --fix`
- `PEAGEN_TEST_GATEWAY=http://127.0.0.1:9999 uv run --package peagen --directory standards/peagen pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a49a7e6c083268b72c5b2aa6a0269