### PR TITLE
Add default mutator plugin settings

### DIFF
--- a/pkgs/standards/peagen/peagen/defaults/__init__.py
+++ b/pkgs/standards/peagen/peagen/defaults/__init__.py
@@ -26,6 +26,9 @@ CONFIG = {
         "default_filter": "file",
         "filters": {"file": {"output_dir": "./peagen_artifacts"}},
     },
+    "mutators": {
+        "default_mutator": "peagen.plugins.mutators.default_mutator:DefaultMutator",
+    },
     "vcs": {"default_vcs": "git"},
     "secrets": {"default_secret": "env", "adapters": {"env": {"prefix": ""}}},
 }

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -109,7 +109,6 @@ TASK_TTL = 24 * 3600  # 24 h, adjust as needed
 
 # ─────────────────────────── IP tracking ─────────────────────────
 
-BAN_THRESHOLD = 10
 KNOWN_IPS: set[str] = set()
 BANNED_IPS: set[str] = set()
 


### PR DESCRIPTION
## Summary
- add mutators plugin group to peagen default config
- remove redundant BAN_THRESHOLD from gateway implementation

## Testing
- `uv run --directory . --package peagen ruff format .`
- `uv run --directory . --package peagen ruff check . --fix`
- `PEAGEN_TEST_GATEWAY=http://localhost:9999 uv run --package peagen --directory standards/peagen pytest`
- `peagen remote -q --gateway-url http://localhost:8000/rpc process standards/peagen/tests/examples/projects_payloads/projects_payload.yaml --watch` *(fails: Connection refused)*
- `peagen local -q process standards/peagen/tests/examples/projects_payloads/projects_payload.yaml --watch` *(fails: No such option --watch)*

------
https://chatgpt.com/codex/tasks/task_e_685a4abb78608326bc80f84c88be34d3