### PR TITLE
Update secrets driver plugin group

### DIFF
--- a/pkgs/standards/peagen/peagen/core/keys_core.py
+++ b/pkgs/standards/peagen/peagen/core/keys_core.py
@@ -17,7 +17,12 @@ def _get_driver(key_dir: Path | None = None, passphrase: str | None = None) -> A
     """Instantiate the configured secrets driver."""
     cfg = load_peagen_toml()
     pm = PluginManager(cfg)
-    drv = pm.get("secrets")
+    try:
+        drv = pm.get("secrets_drivers")
+    except KeyError:
+        from peagen.plugins.secret_drivers import AutoGpgDriver
+
+        drv = AutoGpgDriver()
     if key_dir is not None and hasattr(drv, "key_dir"):
         drv.key_dir = Path(key_dir)
         drv.priv_path = drv.key_dir / "private.asc"

--- a/pkgs/standards/peagen/peagen/plugins/__init__.py
+++ b/pkgs/standards/peagen/peagen/plugins/__init__.py
@@ -26,7 +26,7 @@ GROUPS = {
     "git_filters": ("peagen.plugins.git_filters", object),
     "vcs": ("peagen.plugins.vcs", object),
     "selectors": ("peagen.plugins.selectors", object),
-    "secrets": ("peagen.plugins.secret_drivers", object),
+    "secrets_drivers": ("peagen.plugins.secret_drivers", object),
     # template sets remain in the top-level package
     "template_sets": ("peagen.template_sets", None),
 }
@@ -175,7 +175,7 @@ class PluginManager:
             "items": "plugins",
             "default": "default_selector",
         },
-        "secrets": {
+        "secrets_drivers": {
             "section": "secrets",
             "items": "adapters",
             "default": "default_secret",

--- a/pkgs/standards/peagen/tests/unit/test_keys_core.py
+++ b/pkgs/standards/peagen/tests/unit/test_keys_core.py
@@ -39,7 +39,7 @@ class DummyPM:
         self.called = False
 
     def get(self, group: str, name: str | None = None):
-        assert group == "secrets"
+        assert group == "secrets_drivers"
         self.called = True
         return DummyDriver(Path(tempfile.mkdtemp()))
 


### PR DESCRIPTION
## Summary
- rename plugin group from `secrets` to `secrets_drivers`
- default to `AutoGpgDriver` when secrets driver config missing
- adjust keys_core tests for new plugin group

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format .`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`
- `PEAGEN_TEST_GATEWAY=http://localhost:59999 uv run --package peagen --directory pkgs/standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_685a4d6ec4008326969925720b0685a3