### PR TITLE
Align Peagen key option names

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/keys.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/keys.py
@@ -75,11 +75,11 @@ def fetch_server(
 
 @keys_app.command("list")
 def list_keys(
-    key_root: Path = typer.Option(Path.home() / ".peagen" / "keys", "--key-root"),
+    key_dir: Path = typer.Option(Path.home() / ".peagen" / "keys", "--key-dir"),
 ) -> None:
     """List fingerprints of locally stored keys."""
 
-    data = keys_core.list_local_keys(key_root)
+    data = keys_core.list_local_keys(key_dir)
     typer.echo(json.dumps(data, indent=2))
 
 
@@ -87,11 +87,11 @@ def list_keys(
 def show(
     fingerprint: str,
     fmt: str = typer.Option("armor", "--format"),
-    key_root: Path = typer.Option(Path.home() / ".peagen" / "keys", "--key-root"),
+    key_dir: Path = typer.Option(Path.home() / ".peagen" / "keys", "--key-dir"),
 ) -> None:
     """Output a public key in the requested format."""
 
-    out = keys_core.export_public_key(fingerprint, key_root=key_root, fmt=fmt)
+    out = keys_core.export_public_key(fingerprint, key_dir=key_dir, fmt=fmt)
     typer.echo(out)
 
 
@@ -99,7 +99,7 @@ def show(
 def add(
     public_key: Path,
     private_key: Optional[Path] = typer.Option(None, "--private"),
-    key_root: Path = typer.Option(Path.home() / ".peagen" / "keys", "--key-root"),
+    key_dir: Path = typer.Option(Path.home() / ".peagen" / "keys", "--key-dir"),
     name: Optional[str] = typer.Option(None, "--name"),
 ) -> None:
     """Add an existing key pair to the key store."""
@@ -107,7 +107,7 @@ def add(
     info = keys_core.add_key(
         public_key,
         private_key=private_key,
-        key_root=key_root,
+        key_dir=key_dir,
         name=name,
     )
     typer.echo(json.dumps(info))

--- a/pkgs/standards/peagen/peagen/core/keys_core.py
+++ b/pkgs/standards/peagen/peagen/core/keys_core.py
@@ -82,22 +82,22 @@ def fetch_server_keys(gateway_url: str = DEFAULT_GATEWAY) -> dict:
     return res.json().get("result", {})
 
 
-def list_local_keys(key_root: Path | None = None) -> Dict[str, str]:
+def list_local_keys(key_dir: Path | None = None) -> Dict[str, str]:
     """Return a mapping of key fingerprints to public key paths."""
 
-    drv = _get_driver(key_dir=key_root)
+    drv = _get_driver(key_dir=key_dir)
     return drv.list_keys()
 
 
 def export_public_key(
     fingerprint: str,
     *,
-    key_root: Path | None = None,
+    key_dir: Path | None = None,
     fmt: str = "armor",
 ) -> str:
     """Return ``fingerprint`` key in the requested ``fmt``."""
 
-    drv = _get_driver(key_dir=key_root)
+    drv = _get_driver(key_dir=key_dir)
     return drv.export_public_key(fingerprint, fmt=fmt)
 
 
@@ -105,10 +105,10 @@ def add_key(
     public_key: Path,
     *,
     private_key: Path | None = None,
-    key_root: Path | None = None,
+    key_dir: Path | None = None,
     name: str | None = None,
 ) -> dict:
-    """Store ``public_key`` (and optional ``private_key``) under ``key_root``."""
+    """Store ``public_key`` (and optional ``private_key``) under ``key_dir``."""
 
-    drv = _get_driver(key_dir=key_root)
+    drv = _get_driver(key_dir=key_dir)
     return drv.add_key(public_key, private_key=private_key, name=name)

--- a/pkgs/standards/peagen/tests/unit/test_keys_cli.py
+++ b/pkgs/standards/peagen/tests/unit/test_keys_cli.py
@@ -103,20 +103,20 @@ def test_fetch_server_prints_response(monkeypatch, capsys):
 @pytest.mark.unit
 def test_list_keys(monkeypatch, capsys):
     monkeypatch.setattr(keys_mod.keys_core, "list_local_keys", lambda p: {"f": "p"})
-    keys_mod.list_keys(key_root=Path("x"))
+    keys_mod.list_keys(key_dir=Path("x"))
     out = capsys.readouterr().out
     assert json.loads(out) == {"f": "p"}
 
 
 @pytest.mark.unit
 def test_show_key(monkeypatch, capsys):
-    def fake_export(fpr, *, key_root, fmt):
-        assert key_root == Path("x")
+    def fake_export(fpr, *, key_dir, fmt):
+        assert key_dir == Path("x")
         assert fmt == "openssh"
         return "ssh"
 
     monkeypatch.setattr(keys_mod.keys_core, "export_public_key", fake_export)
-    keys_mod.show("abc", fmt="openssh", key_root=Path("x"))
+    keys_mod.show("abc", fmt="openssh", key_dir=Path("x"))
     out = capsys.readouterr().out
     assert out.strip() == "ssh"
 
@@ -126,6 +126,6 @@ def test_add_key(monkeypatch, capsys):
     monkeypatch.setattr(
         keys_mod.keys_core, "add_key", lambda *a, **k: {"fingerprint": "f", "path": "p"}
     )
-    keys_mod.add(Path("pub"), key_root=Path("x"), name="n")
+    keys_mod.add(Path("pub"), key_dir=Path("x"), name="n")
     out = capsys.readouterr().out
     assert json.loads(out) == {"fingerprint": "f", "path": "p"}

--- a/pkgs/standards/peagen/tests/unit/test_keys_core.py
+++ b/pkgs/standards/peagen/tests/unit/test_keys_core.py
@@ -62,5 +62,5 @@ def test_export_public_key_delegates(monkeypatch, tmp_path):
             return DummyDriver(tmp_path)
 
     monkeypatch.setattr(keys_core, "PluginManager", PM)
-    text = keys_core.export_public_key("FP", key_root=tmp_path)
+    text = keys_core.export_public_key("FP", key_dir=tmp_path)
     assert text == "KEY"


### PR DESCRIPTION
## Summary
- normalize key directory flag across `peagen keys` commands
- update key management helpers to use `key_dir`
- adjust unit tests for new parameter names

## Testing
- `uv run --directory standards/peagen --package peagen ruff format .`
- `uv run --directory standards/peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest` *(fails: tests/smoke/test_remote_evolve.py)*
- `uv run --package peagen --directory /workspace/swarmauri-sdk/pkgs/standards/peagen peagen remote -q --gateway-url http://127.0.0.1:8000/rpc process tests/examples/projects_payloads/projects_payload.yaml` *(fails: connection refused)*
- `uv run --package peagen --directory /workspace/swarmauri-sdk/pkgs/standards/peagen peagen local -q process tests/examples/projects_payloads/projects_payload.yaml` *(fails: ValueError: No LLM provider specified)*

------
https://chatgpt.com/codex/tasks/task_e_685a4da47c448326b4fe6cba5de04df4