### PR TITLE
Fix GitVCS default path and update configs

### DIFF
--- a/pkgs/standards/peagen/peagen/plugins/vcs/git_vcs.py
+++ b/pkgs/standards/peagen/peagen/plugins/vcs/git_vcs.py
@@ -20,7 +20,9 @@ from .constants import PEAGEN_REFS_PREFIX
 class GitVCS:
     """Lightweight wrapper around :class:`git.Repo`."""
 
-    def __init__(self, path: str | Path, *, remote_url: str | None = None) -> None:
+    def __init__(
+        self, path: str | Path = ".", *, remote_url: str | None = None
+    ) -> None:
         p = Path(path)
         if (p / ".git").exists():
             self.repo = Repo(p)

--- a/pkgs/standards/peagen/tests/examples/2x2Grid/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/2x2Grid/.peagen.toml
@@ -13,4 +13,5 @@ root_dir = "./task_runs"
 
 [vcs]
 provider = "git"
+provider_params = { path = "." }
 default_vcs = "git"

--- a/pkgs/standards/peagen/tests/examples/gateway_demo/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/gateway_demo/.peagen.toml
@@ -13,4 +13,5 @@ root_dir = "./task_runs"
 
 [vcs]
 provider = "git"
+provider_params = { path = "." }
 default_vcs = "git"

--- a/pkgs/standards/peagen/tests/examples/peagen_local_demo/test_workspace/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/peagen_local_demo/test_workspace/.peagen.toml
@@ -32,4 +32,5 @@ API_KEY = "${GROQ_API_KEY}"
 
 [vcs]
 provider = "git"
+provider_params = { path = "." }
 default_vcs = "git"

--- a/pkgs/standards/peagen/tests/examples/peagen_tomls/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/peagen_tomls/.peagen.toml
@@ -80,4 +80,5 @@ target_grade_level = 12
 
 [vcs]
 provider = "git"
+provider_params = { path = "." }
 default_vcs = "git"

--- a/pkgs/standards/peagen/tests/examples/simple_evolve_demo/cfg/local.toml
+++ b/pkgs/standards/peagen/tests/examples/simple_evolve_demo/cfg/local.toml
@@ -23,5 +23,10 @@ max_workers = 1
 async = false
 strict = true
 
+[vcs]
+provider = "git"
+provider_params = { path = "." }
+default_vcs = "git"
+
 [evaluation.evaluators]
 performance = "peagen.plugins.evaluators.performance_evaluator:PerformanceEvaluator"

--- a/pkgs/standards/peagen/tests/examples/simple_evolve_demo/cfg/remote.toml
+++ b/pkgs/standards/peagen/tests/examples/simple_evolve_demo/cfg/remote.toml
@@ -25,5 +25,10 @@ max_workers = 1
 async = false
 strict = true
 
+[vcs]
+provider = "git"
+provider_params = { path = "." }
+default_vcs = "git"
+
 [evaluation.evaluators]
 performance = "peagen.plugins.evaluators.performance_evaluator:PerformanceEvaluator"

--- a/pkgs/standards/peagen/tests/examples/simple_evolve_demo/workspace/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/simple_evolve_demo/workspace/.peagen.toml
@@ -32,4 +32,5 @@ API_KEY = "${GROQ_API_KEY}"
 
 [vcs]
 provider = "git"
+provider_params = { path = "." }
 default_vcs = "git"


### PR DESCRIPTION
## Summary
- avoid instantiating GitVCS without a path by defaulting to '.'
- include `provider_params.path` in several example configs so VCS works

## Testing
- `PEAGEN_TEST_GATEWAY=http://localhost:9999/rpc uv run --package peagen --directory standards/peagen pytest`


------
https://chatgpt.com/codex/tasks/task_e_685a5317adf483268ae57102e0340156