### PR TITLE
Fix DOE handler config path fallback

### DIFF
--- a/pkgs/standards/peagen/peagen/handlers/doe_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/doe_handler.py
@@ -20,7 +20,7 @@ async def doe_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, Any]:
     payload = task_or_dict.get("payload", {})
     args: Dict[str, Any] = payload.get("args", {})
 
-    cfg = resolve_cfg(toml_path=args.get("config", ".peagen.toml"))
+    cfg = resolve_cfg(toml_path=args.get("config") or ".peagen.toml")
     pm = PluginManager(cfg)
     try:
         vcs = pm.get("vcs")


### PR DESCRIPTION
## Summary
- ensure `peagen` DOE handler falls back to `.peagen.toml` when `--config` is not provided
- run formatting, linting, and tests

## Testing
- `uv run --directory standards/peagen --package peagen ruff format .`
- `uv run --directory standards/peagen --package peagen ruff check . --fix`
- `PEAGEN_TEST_GATEWAY=http://localhost:9 uv run --directory standards/peagen --package peagen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a55511b288326aff7d7ec0a336dc1