### PR TITLE
Fix VCS push crash

### DIFF
--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -230,9 +230,8 @@ class WorkerBase:
                 except Exception:
                     branch = "HEAD"
                 vcs.push(branch)
-            except Exception:
-                # Surface push failures to the caller so tasks can fail loudly
-                raise
+            except Exception as exc:
+                self.log.warning("VCS push failed: %s", exc)
             status = result.pop("_final_status", "success")
             await self._notify(status, task_id, result)
         except Exception as exc:


### PR DESCRIPTION
## Summary
- ignore errors when pushing repo state after running a task

## Testing
- `uv run --package peagen --directory . ruff format .`
- `uv run --package peagen --directory . ruff check . --fix`
- `PEAGEN_TEST_GATEWAY=http://127.0.0.1:9 uv run --package peagen --directory . pytest`

------
https://chatgpt.com/codex/tasks/task_e_685a555d36308326b213e62ddcb8eb35