### PR TITLE
Fix peagen keys list when env secret driver active

### DIFF
--- a/pkgs/standards/peagen/peagen/core/keys_core.py
+++ b/pkgs/standards/peagen/peagen/core/keys_core.py
@@ -23,6 +23,12 @@ def _get_driver(key_dir: Path | None = None, passphrase: str | None = None) -> A
         from peagen.plugins.secret_drivers import AutoGpgDriver
 
         drv = AutoGpgDriver()
+
+    # fallback to AutoGpgDriver if the driver lacks key management helpers
+    if not hasattr(drv, "list_keys"):
+        from peagen.plugins.secret_drivers import AutoGpgDriver
+
+        drv = AutoGpgDriver()
     if key_dir is not None and hasattr(drv, "key_dir"):
         drv.key_dir = Path(key_dir)
         drv.priv_path = drv.key_dir / "private.asc"


### PR DESCRIPTION
## Summary
- fix fallback logic in `keys_core._get_driver` when `EnvSecret` is used
- run `ruff format` and `ruff check`
- test `peagen` package

## Testing
- `PEAGEN_TEST_GATEWAY=http://127.0.0.1:9 uv run --directory standards/peagen --package peagen pytest`


------
https://chatgpt.com/codex/tasks/task_e_685a5be0fc608326a21d7aeb6ad4042a