### PR TITLE
Fix peagen DOE output dir handling

### DIFF
--- a/pkgs/standards/peagen/peagen/core/doe_core.py
+++ b/pkgs/standards/peagen/peagen/core/doe_core.py
@@ -383,6 +383,9 @@ def generate_payload(
         spec_name=spec_path.stem,
     )
 
+    # ensure the output directory exists before generating files
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
     bundles: List[Tuple[Path, Dict[str, Any]]] = []
     for idx, proj_payload in enumerate(projects):
         out_path = output_path.parent / (


### PR DESCRIPTION
## Summary
- ensure DOE output directory is created before writing bundle files

## Testing
- `uv run --package peagen --directory standards/peagen ruff format .`
- `uv run --package peagen --directory standards/peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest` *(fails: test_remote_evolve, test_remote_full_flow)*
- `peagen remote -q --gateway-url https://gw.peagen.com/rpc doe process standards/peagen/tests/examples/gateway_demo/doe_spec.yaml standards/peagen/tests/examples/gateway_demo/template_project.yaml --output project_payloads.yaml --repo https://github.com/swarmauri/swarmauri-sdk.git --ref mono/dev --dry-run --watch` *(fails: file not found)*
- `peagen local -q doe process standards/peagen/tests/examples/gateway_demo/doe_spec.yaml standards/peagen/tests/examples/gateway_demo/template_project.yaml --output /tmp/test_doepatch/output.yaml` *(fails: ConnectError)*

------
https://chatgpt.com/codex/tasks/task_e_685a607e698483269d7f3955a70779ca