### PR TITLE
Adjust fetch CLI registration

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/__init__.py
+++ b/pkgs/standards/peagen/peagen/cli/__init__.py
@@ -153,7 +153,7 @@ def _global_remote_ctx(  # noqa: D401
 app.add_typer(login_app)
 app.add_typer(keys_app, name="keys")
 app.add_typer(local_init_app, name="init")
-app.add_typer(fetch_app, name="fetch")
+app.add_typer(fetch_app)
 app.add_typer(local_app, name="local")
 app.add_typer(remote_app, name="remote")
 app.add_typer(dashboard_app)


### PR DESCRIPTION
## Summary
- remove redundant `name="fetch"` when registering `fetch_app`

## Testing
- `uv run --directory standards/peagen --package peagen ruff format .`
- `uv run --directory standards/peagen --package peagen ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_685a62c9c5488326ac8948709593142c