### PR TITLE
Fix remote evolve repo detection

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/evolve.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/evolve.py
@@ -7,6 +7,7 @@ import json
 import uuid
 from pathlib import Path
 from typing import Optional
+import subprocess
 
 import httpx
 import typer
@@ -58,6 +59,17 @@ def run(
             return str(p.resolve())
 
     args = {"evolve_spec": _canonical(spec)}
+    if not repo:
+        try:
+            repo = subprocess.check_output(
+                ["git", "config", "--get", "remote.origin.url"],
+                text=True,
+            ).strip()
+            ref = subprocess.check_output(
+                ["git", "rev-parse", "HEAD"], text=True
+            ).strip()
+        except Exception:  # pragma: no cover - git not available
+            repo = None
     if repo:
         args.update({"repo": repo, "ref": ref})
     task = _build_task(args)


### PR DESCRIPTION
## Summary
- autodetect git repo and commit SHA for `peagen remote evolve`

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `PEAGEN_TEST_GATEWAY=http://localhost:9999/rpc uv run --package peagen --directory pkgs/standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_685a63bd70048326afd2fa4f31349943