### PR TITLE
Disable default peagen smoke tests

### DIFF
--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -93,6 +93,7 @@ markers = [
     "xfail: Expected failures",
     "acceptance: Acceptance tests",
     "perf: Performance tests that measure execution time and resource usage",
+    "smoke: Smoke tests for remote peagen functionality",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/peagen/tests/conftest.py
+++ b/pkgs/standards/peagen/tests/conftest.py
@@ -6,15 +6,28 @@ def pytest_configure(config: pytest.Config) -> None:
         "markers",
         "infra: infrastructure tests requiring external services",
     )
+    config.addinivalue_line(
+        "markers",
+        "smoke: end-to-end smoke tests for the Peagen CLI and gateway",
+    )
 
 
 def pytest_collection_modifyitems(
     config: pytest.Config, items: list[pytest.Item]
 ) -> None:
     markexpr = getattr(config.option, "markexpr", "")
-    if markexpr and "infra" in markexpr:
+    if markexpr and ("infra" in markexpr or "smoke" in markexpr):
         return
+
     skip_infra = pytest.mark.skip(reason="skip infra tests (use -m infra to run)")
+    skip_smoke = pytest.mark.skip(reason="skip smoke tests (use -m smoke to run)")
+
     for item in items:
+        if "smoke" not in item.keywords and "tests/smoke" in str(item.fspath):
+            item.add_marker(pytest.mark.smoke)
+
         if "infra" in item.keywords:
             item.add_marker(skip_infra)
+
+        if "smoke" in item.keywords:
+            item.add_marker(skip_smoke)


### PR DESCRIPTION
## Summary
- add `smoke` marker to peagen tests
- skip smoke tests unless explicitly selected

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_685a67e80c9083269fa6bedb3d795c77