### PR TITLE
Fix gateway_demo DOE config

### DIFF
--- a/pkgs/standards/peagen/tests/examples/gateway_demo/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/gateway_demo/.peagen.toml
@@ -11,7 +11,3 @@ default_backend = "local_fs"
 [result_backends.adapters.local_fs]
 root_dir = "./task_runs"
 
-[vcs]
-provider = "git"
-provider_params = { path = "." }
-default_vcs = "git"


### PR DESCRIPTION
## Summary
- disable VCS settings in gateway_demo example so local runs don't attempt Git

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `PEAGEN_TEST_GATEWAY=http://127.0.0.1:8000/rpc uv run --package peagen --directory pkgs/standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_685a6974733c8326a02371cddc9672c7