### PR TITLE
Implement dummy LLM provider

### DIFF
--- a/pkgs/standards/peagen/peagen/core/_llm.py
+++ b/pkgs/standards/peagen/peagen/core/_llm.py
@@ -48,6 +48,7 @@ class GenericLLM:
         "deepseek": "DeepSeekModel",
         "ai21studio": "AI21StudioModel",
         "hyperbolic": "HyperbolicModel",
+        "dummy": "DummyModel",
         "cerebras": "CerebrasModel",
     }
 
@@ -119,8 +120,8 @@ class GenericLLM:
             env_var = f"{provider.upper()}_API_KEY"
             api_key = os.environ.get(env_var)
 
-        # 4️⃣ Error if no API key found
-        if api_key is None:
+        # 4️⃣ Error if no API key found (skip check for the dummy provider)
+        if provider != "dummy" and api_key is None:
             raise ValueError(
                 f"No API key provided for {provider}. "
                 f"Please provide it via --api-key, .peagen.toml [llm.{provider}].API_KEY, or set the {env_var} environment variable."

--- a/pkgs/standards/peagen/tests/examples/gateway_demo/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/gateway_demo/.peagen.toml
@@ -15,3 +15,6 @@ root_dir = "./task_runs"
 provider = "git"
 provider_params = { path = "." }
 default_vcs = "git"
+
+[llm]
+default_provider = "dummy"

--- a/pkgs/swarmauri_standard/swarmauri_standard/llms/DummyModel.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/llms/DummyModel.py
@@ -1,0 +1,55 @@
+from typing import AsyncIterator, Iterator, List
+from swarmauri_base.ComponentBase import ComponentBase
+from swarmauri_base.llms.LLMBase import LLMBase
+from swarmauri_standard.messages.AgentMessage import AgentMessage
+
+
+@ComponentBase.register_type(LLMBase, "DummyModel")
+class DummyModel(LLMBase):
+    """A no-op LLM provider for testing."""
+
+    def predict(
+        self,
+        conversation,
+        temperature: float = 0.0,
+        max_tokens: int = 0,
+        enable_json: bool = False,
+        stop: List[str] | None = None,
+    ):
+        conversation.add_message(AgentMessage(content="dummy"))
+        return conversation
+
+    async def apredict(
+        self,
+        conversation,
+        temperature: float = 0.0,
+        max_tokens: int = 0,
+        enable_json: bool = False,
+        stop: List[str] | None = None,
+    ):
+        conversation.add_message(AgentMessage(content="dummy"))
+        return conversation
+
+    def stream(
+        self,
+        conversation,
+        temperature: float = 0.0,
+        max_tokens: int = 0,
+        stop: List[str] | None = None,
+    ) -> Iterator[str]:
+        yield "dummy"
+
+    async def astream(
+        self,
+        conversation,
+        temperature: float = 0.0,
+        max_tokens: int = 0,
+        stop: List[str] | None = None,
+    ) -> AsyncIterator[str]:
+        yield "dummy"
+
+    def batch(self, *args, **kwargs):
+        return ["dummy"]
+
+    async def abatch(self, *args, **kwargs):
+        return ["dummy"]

--- a/pkgs/swarmauri_standard/tests/unit/utils/retry_decorator_test.py
+++ b/pkgs/swarmauri_standard/tests/unit/utils/retry_decorator_test.py
@@ -14,7 +14,9 @@ async def test_retry_async_exhausts_retries():
         call_count += 1
         request = httpx.Request("GET", "http://test")
         response = httpx.Response(status_code=429, request=request)
-        raise httpx.HTTPStatusError("Too Many Requests", request=request, response=response)
+        raise httpx.HTTPStatusError(
+            "Too Many Requests", request=request, response=response
+        )
 
     with pytest.raises(Exception) as exc_info:
         await failing()
@@ -34,7 +36,9 @@ def test_retry_sync_eventual_success():
         if call_count < 3:
             request = httpx.Request("GET", "http://test")
             response = httpx.Response(status_code=429, request=request)
-            raise httpx.HTTPStatusError("Too Many Requests", request=request, response=response)
+            raise httpx.HTTPStatusError(
+                "Too Many Requests", request=request, response=response
+            )
         return "ok"
 
     assert sometimes_fails() == "ok"


### PR DESCRIPTION
## Summary
- add a DummyModel LLM for local testing
- register dummy provider and skip API key check
- configure example gateway demo to use dummy provider
- update retry decorator test formatting

## Testing
- `ruff format .`
- `ruff check . --fix`
- `PEAGEN_TEST_GATEWAY=http://127.0.0.1:8000/rpc uv run --package peagen --directory pkgs/standards/peagen pytest -k "not remote_full_flow and not remote_evolve and not remote_doe_process_cli"`


------
https://chatgpt.com/codex/tasks/task_e_685a698f88fc832698b81224c8fdba9e