### PR TITLE
Add READMEs for peagen test directories

### DIFF
--- a/pkgs/standards/peagen/tests/README.md
+++ b/pkgs/standards/peagen/tests/README.md
@@ -1,0 +1,13 @@
+# Peagen Test Suite
+
+This directory holds all automated tests for the **peagen** package. The tests are grouped by purpose so contributors can run only what they need.
+
+| Subfolder | Purpose |
+|-----------|---------|
+| `unit`    | Isolated unit tests for individual modules |
+| `smoke`   | Lightweight CLI and RPC tests that verify core flows |
+| `infra`   | Minimal infrastructure tests exercising remote evolve demos |
+| `perf`    | Benchmarks for queues, backends, gateway and other components |
+| `examples`| Test fixtures and project templates used across the suite |
+
+Each subdirectory contains a README with more detail.

--- a/pkgs/standards/peagen/tests/examples/README.md
+++ b/pkgs/standards/peagen/tests/examples/README.md
@@ -1,0 +1,11 @@
+# Example Fixtures
+
+This directory contains sample projects, specifications, and payload files used by the test suite and documentation. Each subfolder focuses on a particular scenario.
+
+**Goals**
+- Provide realistic data for unit, smoke, and infrastructure tests
+- Serve as reference material for the README and docs
+
+**Non-goals**
+- Complete production-ready templates
+- Performance benchmarking data

--- a/pkgs/standards/peagen/tests/infra/README.md
+++ b/pkgs/standards/peagen/tests/infra/README.md
@@ -1,0 +1,13 @@
+# Infrastructure Tests
+
+**Purpose**: verify that a basic gateway and worker setup can run tasks end-to-end.
+
+**Description**: these tests spin up a local gateway and use the sample `simple_evolve_demo` specification to ensure remote execution works.
+
+**Goals**
+- Validate remote task submission against a running gateway
+- Ensure the evolve workflow completes successfully
+
+**Non-goals**
+- Exhaustive functional coverage of all features
+- Performance measurement or stress testing

--- a/pkgs/standards/peagen/tests/perf/README.md
+++ b/pkgs/standards/peagen/tests/perf/README.md
@@ -1,0 +1,13 @@
+# Performance Tests
+
+**Purpose**: benchmark key components such as queues, result backends, and the gateway.
+
+**Description**: these tests run with pytest-benchmark and other tools to measure throughput, latency, and resource usage. They help track performance regressions over time.
+
+**Goals**
+- Provide baseline metrics for core components
+- Detect slowdowns introduced by code changes
+
+**Non-goals**
+- Functional correctness checks
+- Comprehensive integration coverage

--- a/pkgs/standards/peagen/tests/smoke/README.md
+++ b/pkgs/standards/peagen/tests/smoke/README.md
@@ -1,0 +1,13 @@
+# Smoke Tests
+
+**Purpose**: provide quick assurance that the main CLI commands and RPC flows are operational.
+
+**Description**: these tests run small tasks against a reachable gateway and exercise commands like `process`, `eval`, and `mutate`. They expect minimal configuration and should finish fast.
+
+**Goals**
+- Confirm that the CLI can talk to the gateway
+- Verify that common workflows succeed without errors
+
+**Non-goals**
+- Deep integration coverage
+- Benchmarking or resource measurement

--- a/pkgs/standards/peagen/tests/unit/README.md
+++ b/pkgs/standards/peagen/tests/unit/README.md
@@ -1,0 +1,13 @@
+# Unit Tests
+
+**Purpose**: exercise individual functions and classes in isolation.
+
+**Description**: the bulk of Peagen's coverage lives here. Tests import modules directly and avoid network or file system side effects where possible.
+
+**Goals**
+- Ensure internal logic behaves as expected
+- Catch regressions quickly with fast execution
+
+**Non-goals**
+- Testing full CLI workflows or external services
+- Measuring performance


### PR DESCRIPTION
## Summary
- document peagen test subsets under `pkgs/standards/peagen/tests`
- describe infra, smoke, unit, perf and example fixtures

## Testing
- `uv run --package peagen --directory standards/peagen ruff format .`
- `uv run --package peagen --directory standards/peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest` *(fails: tests/smoke/test_remote_evolve.py::test_remote_evolve)*
- `uv run --package peagen --directory pkgs/standards/peagen peagen local -q evolve tests/examples/simple_evolve_demo/evolve_spec_local.yaml` *(fails: ConnectError)*


------
https://chatgpt.com/codex/tasks/task_e_685a6e11ee0c8326953a8efe4b06aa27