### PR TITLE
Fix mutate config loading

### DIFF
--- a/pkgs/standards/peagen/peagen/core/mutate_core.py
+++ b/pkgs/standards/peagen/peagen/core/mutate_core.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional, List, Tuple
 import random
 
-from peagen._utils.config_loader import load_peagen_toml
+from peagen._utils.config_loader import resolve_cfg
 from peagen.plugin_manager import PluginManager, resolve_plugin_spec
 from swarmauri_standard.programs.Program import Program
 import logging
@@ -35,11 +35,7 @@ def mutate_workspace(
 ) -> Dict[str, Optional[str]]:
     """Run a minimal evolutionary loop on ``target_file`` inside ``workspace_uri``."""
 
-    cfg = (
-        load_peagen_toml(cfg_path)
-        if cfg_path
-        else load_peagen_toml(Path(workspace_uri) / ".peagen.toml")
-    )
+    cfg = resolve_cfg(toml_path=str(cfg_path or Path(workspace_uri) / ".peagen.toml"))
     pm = PluginManager(cfg)
     if mutations:
         mutators: List[Tuple[float, Any]] = []


### PR DESCRIPTION
## Summary
- use `resolve_cfg` instead of `load_peagen_toml` in `mutate_workspace`
- add evaluation defaults to built‑in config

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format peagen/core/mutate_core.py`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/core/mutate_core.py --fix`
- `uv run --directory pkgs/standards/peagen --package peagen ruff format peagen/defaults/__init__.py`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/defaults/__init__.py --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit`

------
https://chatgpt.com/codex/tasks/task_e_685a699b98248326b7e8e7a0deeb721a