### PR TITLE
Fix mutate config merging

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/mutate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/mutate.py
@@ -6,11 +6,12 @@ import asyncio
 import json
 import uuid
 from pathlib import Path
-from typing import Optional
+from typing import Any, Dict, Optional
 
 import httpx
 
 import typer
+from peagen._utils.config_loader import load_peagen_toml
 
 from peagen.handlers.mutate_handler import mutate_handler
 from peagen.models import Task
@@ -62,6 +63,16 @@ def run(
         "evaluator_ref": fitness,
     }
     task = _build_task(args)
+
+    # ─────────────────────── cfg override  ──────────────────────────────
+    inline = ctx.obj.get("task_override_inline")  # JSON string or None
+    file_ = ctx.obj.get("task_override_file")  # Path or None
+    cfg_override: Dict[str, Any] = {}
+    if inline:
+        cfg_override = json.loads(inline)
+    if file_:
+        cfg_override.update(load_peagen_toml(Path(file_), required=True))
+    task.payload["cfg_override"] = cfg_override
     result = asyncio.run(mutate_handler(task))
 
     if json_out:
@@ -100,6 +111,16 @@ def submit(
         "evaluator_ref": fitness,
     }
     task = _build_task(args)
+
+    # ─────────────────────── cfg override  ──────────────────────────────
+    inline = ctx.obj.get("task_override_inline")  # JSON string or None
+    file_ = ctx.obj.get("task_override_file")  # Path or None
+    cfg_override: Dict[str, Any] = {}
+    if inline:
+        cfg_override = json.loads(inline)
+    if file_:
+        cfg_override.update(load_peagen_toml(Path(file_), required=True))
+    task.payload["cfg_override"] = cfg_override
 
     rpc_req = {
         "jsonrpc": "2.0",

--- a/pkgs/standards/peagen/peagen/core/mutate_core.py
+++ b/pkgs/standards/peagen/peagen/core/mutate_core.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional, List, Tuple
 import random
 
-from peagen._utils.config_loader import load_peagen_toml
+from peagen._utils.config_loader import resolve_cfg
 from peagen.plugin_manager import PluginManager, resolve_plugin_spec
 from swarmauri_standard.programs.Program import Program
 import logging
@@ -35,10 +35,10 @@ def mutate_workspace(
 ) -> Dict[str, Optional[str]]:
     """Run a minimal evolutionary loop on ``target_file`` inside ``workspace_uri``."""
 
-    cfg = (
-        load_peagen_toml(cfg_path)
+    cfg = resolve_cfg(
+        toml_path=str(cfg_path)
         if cfg_path
-        else load_peagen_toml(Path(workspace_uri) / ".peagen.toml")
+        else str(Path(workspace_uri) / ".peagen.toml")
     )
     pm = PluginManager(cfg)
     if mutations:


### PR DESCRIPTION
## Summary
- load mutate workspace config via resolve_cfg so defaults apply

## Testing
- `uv run --directory peagen --package peagen ruff format .`
- `uv run --directory peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest -q` *(fails: subprocess.CalledProcessError)*

------
https://chatgpt.com/codex/tasks/task_e_685a70e361d88326b1461e633ecea76b