### PR TITLE
Remove dry-run from peagen remote DOE

### DIFF
--- a/pkgs/standards/peagen/docs/call_flows/peagen_doe_gen_remote.mmd
+++ b/pkgs/standards/peagen/docs/call_flows/peagen_doe_gen_remote.mmd
@@ -11,12 +11,8 @@ sequenceDiagram
     CLI ->> CLI: For each design point: merge with base template, apply any patches
     CLI ->> YAML: Assemble `project_payloads.yaml` bundle with all PROJECTS
     CLI ->> User: List all design point IDs and factor values
-    alt --dry-run option
-        CLI -->> User: Outputs design matrix table (no file written)
-    else 
-        CLI ->> YAML: Write bundle to output file (or error if exists without --force)
-        CLI -->> User: Prints success and file size
-        opt if --notify specified
-            CLI ->> Publisher: Instantiate publisher and publish "peagen.experiment.done" event
-        end
+    CLI ->> YAML: Write bundle to output file (or error if exists without --force)
+    CLI -->> User: Prints success and file size
+    opt if --notify specified
+        CLI ->> Publisher: Instantiate publisher and publish "peagen.experiment.done" event
     end

--- a/pkgs/standards/peagen/peagen/cli/commands/doe.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/doe.py
@@ -121,9 +121,6 @@ def submit_gen(  # noqa: PLR0913
     notify: Optional[str] = typer.Option(
         None, "--notify", help="Webhook URL for completion notification"
     ),
-    dry_run: bool = typer.Option(
-        False, "--dry-run", help="Simulate the run without writing files"
-    ),
     force: bool = typer.Option(
         False, "--force", help="Overwrite output even if it exists"
     ),
@@ -142,8 +139,6 @@ def submit_gen(  # noqa: PLR0913
         "template": str(template),
         "output": str(output),
         "config": str(config) if config else None,
-        "notify": notify,
-        "dry_run": dry_run,
         "force": force,
         "skip_validate": skip_validate,
         "evaluate_runs": evaluate_runs,
@@ -257,9 +252,6 @@ def submit_process(  # noqa: PLR0913
     notify: Optional[str] = typer.Option(
         None, "--notify", help="Webhook URL for completion notification"
     ),
-    dry_run: bool = typer.Option(
-        False, "--dry-run", help="Simulate the run without writing files"
-    ),
     force: bool = typer.Option(
         False, "--force", help="Overwrite output even if it exists"
     ),
@@ -298,7 +290,6 @@ def submit_process(  # noqa: PLR0913
         "output": str(output),
         "config": str(config) if config else None,
         "notify": notify,
-        "dry_run": dry_run,
         "force": force,
         "skip_validate": skip_validate,
         "evaluate_runs": evaluate_runs,

--- a/pkgs/standards/peagen/tests/smoke/test_gateway_remote_doe.py
+++ b/pkgs/standards/peagen/tests/smoke/test_gateway_remote_doe.py
@@ -103,7 +103,6 @@ def test_remote_doe_process(tmp_path: Path) -> None:
             "process",
             str(spec),
             str(template),
-            "--dry-run",
         ],
         check=True,
         timeout=60,

--- a/pkgs/standards/peagen/tests/smoke/test_remote_full_flow.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_full_flow.py
@@ -67,7 +67,6 @@ def test_remote_full_flow(tmp_path: Path) -> None:
             "process",
             str(DOE_SPEC),
             str(DOE_TEMPLATE),
-            "--dry-run",
         ],
         check=True,
         timeout=60,


### PR DESCRIPTION
## Summary
- drop `--dry-run` parameter from remote DOE CLI commands
- update smoke tests accordingly
- trim dry-run branch from remote DOE docs

## Testing
- `uv run --directory peagen --package peagen ruff format .`
- `uv run --directory peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory peagen pytest -q`
- `peagen remote -q --gateway-url http://localhost:8000/rpc doe process pkgs/standards/peagen/tests/examples/gateway_demo/doe_spec.yaml pkgs/standards/peagen/tests/examples/gateway_demo/template_project.yaml --watch` *(fails: Connection refused)*
- `peagen local -q doe process pkgs/standards/peagen/tests/examples/gateway_demo/doe_spec.yaml pkgs/standards/peagen/tests/examples/gateway_demo/template_project.yaml --dry-run`

------
https://chatgpt.com/codex/tasks/task_e_685a779c8b648326812b181d0cc72117