### PR TITLE
Fix evaluator and mutator config

### DIFF
--- a/.peagen.toml
+++ b/.peagen.toml
@@ -65,8 +65,8 @@ default_queue = "redis"
 uri = "${REDIS_URL}"
 
 # ─────────────────────────────── Mutators ───────────────────────────────
-[mutators]
-default_mutator = "peagen.plugins.mutators.default_mutator:DefaultMutator"
+[mutation.mutators]
+default_mutator = "DefaultMutator"
 
 
 # ───────────────────────────── Result Backends ─────────────────────────
@@ -85,7 +85,10 @@ async = false
 strict = true
 
 [evaluation.evaluators]
-performance = "peagen.plugins.evaluators.performance_evaluator:PerformanceEvaluator"
+default_evaluator = "performance"
+
+[evaluation.evaluators.performance]
+# parameters for the built-in performance evaluator can go here
 
 [vcs]
 provider = "git"

--- a/infra/.worker.peagen.toml
+++ b/infra/.worker.peagen.toml
@@ -65,11 +65,12 @@ max_workers = 4
 async = false
 strict = true
 
+[evaluation.evaluators]
+default_evaluator = "ColemanLiauIndexEvaluator"
+
 [evaluation.evaluators.AutomatedReadabilityIndexEvaluator]
-cls = "swarmauri_evaluatorpool_accessibility:AutomatedReadabilityIndexEvaluator"
 
 [evaluation.evaluators.ColemanLiauIndexEvaluator]
-cls = "swarmauri_evaluatorpool_accessibility:ColemanLiauIndexEvaluator"
 target_grade_level = 12
 
 # --- VCS ------------------------------------------------------------

--- a/pkgs/standards/peagen/docs/pea-ips/ip-0004.md
+++ b/pkgs/standards/peagen/docs/pea-ips/ip-0004.md
@@ -71,18 +71,14 @@ async       = false       # true = asyncio pool.
 strict      = true        # Fail the run if any score == 0.
 
 [evaluation.evaluators]
-# Key names = evaluator IDs that will appear in the report
-# Each subsection MUST include a class reference and MAY include kwargs.
+default_evaluator = "bleu"
 
 [evaluation.evaluators.bleu]
-cls  = "my_pkg.metrics.BLEUEvaluator"
 ngram = 4                 # Arbitrary kwargs passed to __init__
 
 [evaluation.evaluators.rouge]
-cls  = "my_pkg.metrics.ROUGEEvaluator"
 
 [evaluation.evaluators.latency]
-cls  = "peagen.metrics.LatencyEvaluator"
 percentile = 95
 ```
 
@@ -107,7 +103,8 @@ If the same key appears multiple times the **earlier** entry wins, ensuring CLI 
 * Optional keys: `max_workers` (int ≥ 1), `async` (bool), `strict` (bool).
 * **Sub-object** `evaluation.evaluators` with pattern-property `^[A-Za-z0-9_-]+$`.
 
-  * Each property value is an object **requiring** `cls` (string) and **optionally** any additional arguments (free-form).
+  * Includes a `default_evaluator` string choosing which evaluator to run by default.
+  * Each property value is an object of keyword arguments passed to the evaluator class registered under that key.
 * All strings continue to allow environment-variable interpolation `${FOO}` exactly as other TOML fields do.
 
 ### 5.2 `eval_report.schema.v1.json` (new)

--- a/pkgs/standards/peagen/peagen/defaults/__init__.py
+++ b/pkgs/standards/peagen/peagen/defaults/__init__.py
@@ -26,8 +26,8 @@ CONFIG = {
         "default_filter": "file",
         "filters": {"file": {"output_dir": "./peagen_artifacts"}},
     },
-    "mutators": {
-        "default_mutator": "peagen.plugins.mutators.default_mutator:DefaultMutator",
+    "mutation": {
+        "mutators": {"default_mutator": "DefaultMutator"},
     },
     "vcs": {"default_vcs": "git"},
     "secrets": {"default_secret": "env", "adapters": {"env": {"prefix": ""}}},

--- a/pkgs/standards/peagen/peagen/plugins/__init__.py
+++ b/pkgs/standards/peagen/peagen/plugins/__init__.py
@@ -138,7 +138,7 @@ class PluginManager:
         "evaluators": {
             "section": "evaluation",
             "items": "evaluators",
-            "default": None,
+            "default": "default_evaluator",
         },
         "evaluator_pools": {
             "section": "evaluation",
@@ -156,8 +156,8 @@ class PluginManager:
             "default": "default_consumer",
         },
         "mutators": {
-            "section": "mutators",
-            "items": "plugins",
+            "section": "mutation",
+            "items": "mutators",
             "default": "default_mutator",
         },
         "programs": {

--- a/pkgs/standards/peagen/tests/examples/evolve_example_2/cfg/remote.toml
+++ b/pkgs/standards/peagen/tests/examples/evolve_example_2/cfg/remote.toml
@@ -26,4 +26,6 @@ async = false
 strict = true
 
 [evaluation.evaluators]
-performance = "peagen.plugins.evaluators.performance_evaluator:PerformanceEvaluator"
+default_evaluator = "performance"
+
+[evaluation.evaluators.performance]

--- a/pkgs/standards/peagen/tests/examples/peagen_local_demo/test_workspace/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/peagen_local_demo/test_workspace/.peagen.toml
@@ -19,11 +19,13 @@ max_workers = 1
 async = false
 strict = true
 
-[mutators]
-default_mutator = "peagen.plugins.mutators.default_mutator:DefaultMutator"
+[mutation.mutators]
+default_mutator = "DefaultMutator"
 
 [evaluation.evaluators]
-performance = "peagen.plugins.evaluators.performance_evaluator:PerformanceEvaluator"
+default_evaluator = "performance"
+
+[evaluation.evaluators.performance]
 
 [llm]
 default_provider = "groq"

--- a/pkgs/standards/peagen/tests/examples/peagen_tomls/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/peagen_tomls/.peagen.toml
@@ -71,11 +71,12 @@ max_workers = 4
 async = false
 strict = true
 
+[evaluation.evaluators]
+default_evaluator = "ColemanLiauIndexEvaluator"
+
 [evaluation.evaluators.AutomatedReadabilityIndexEvaluator]
-cls = "swarmauri_evaluatorpool_accessibility:AutomatedReadabilityIndexEvaluator"
 
 [evaluation.evaluators.ColemanLiauIndexEvaluator]
-cls = "swarmauri_evaluatorpool_accessibility:ColemanLiauIndexEvaluator"
 target_grade_level = 12
 
 [vcs]

--- a/pkgs/standards/peagen/tests/examples/simple_evolve_demo/cfg/local.toml
+++ b/pkgs/standards/peagen/tests/examples/simple_evolve_demo/cfg/local.toml
@@ -29,4 +29,8 @@ provider_params = { path = "." }
 default_vcs = "git"
 
 [evaluation.evaluators]
-performance = "peagen.plugins.evaluators.performance_evaluator:PerformanceEvaluator"
+default_evaluator = "performance"
+
+[evaluation.evaluators.performance]
+import_path = "sort_alg"
+entry_fn = "bad_sort"

--- a/pkgs/standards/peagen/tests/examples/simple_evolve_demo/cfg/remote.toml
+++ b/pkgs/standards/peagen/tests/examples/simple_evolve_demo/cfg/remote.toml
@@ -31,4 +31,8 @@ provider_params = { path = "." }
 default_vcs = "git"
 
 [evaluation.evaluators]
-performance = "peagen.plugins.evaluators.performance_evaluator:PerformanceEvaluator"
+default_evaluator = "performance"
+
+[evaluation.evaluators.performance]
+import_path = "sort_alg"
+entry_fn = "bad_sort"

--- a/pkgs/standards/peagen/tests/examples/simple_evolve_demo/workspace/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/simple_evolve_demo/workspace/.peagen.toml
@@ -19,11 +19,15 @@ max_workers = 1
 async = false
 strict = true
 
-[mutators]
-default_mutator = "peagen.plugins.mutators.default_mutator:DefaultMutator"
+[mutation.mutators]
+default_mutator = "DefaultMutator"
 
 [evaluation.evaluators]
-performance = "peagen.plugins.evaluators.performance_evaluator:PerformanceEvaluator"
+default_evaluator = "performance"
+
+[evaluation.evaluators.performance]
+import_path = "sort_alg"
+entry_fn = "bad_sort"
 
 [llm]
 default_provider = "groq"


### PR DESCRIPTION
## Summary
- adjust plugin manager layout for evaluators and mutators
- support new evaluator schema with `default_evaluator`
- update default configuration
- refresh docs and example TOML files

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `PEAGEN_TEST_GATEWAY=http://localhost:9 uv run --package peagen --directory pkgs/standards/peagen pytest`
- `uv run --package peagen --directory pkgs/standards/peagen peagen remote --gateway-url https://gw.peagen.com eval pkgs/standards/peagen/tests/examples/simple_evolve_demo/workspace` *(fails: Method not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a72118a9c8326b564f40e8acc5fa5