### PR TITLE
Fix mutator config sections

### DIFF
--- a/.peagen.toml
+++ b/.peagen.toml
@@ -65,8 +65,8 @@ default_queue = "redis"
 uri = "${REDIS_URL}"
 
 # ─────────────────────────────── Mutators ───────────────────────────────
-[mutation.mutators]
-default_mutator = "DefaultMutator"
+[mutation]
+default_mutator = "default_mutator"
 
 
 # ───────────────────────────── Result Backends ─────────────────────────

--- a/pkgs/standards/peagen/peagen/cli/commands/mutate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/mutate.py
@@ -41,6 +41,11 @@ def run(
         "--fitness",
         help="Evaluator plugin reference",
     ),
+    mutator: str = typer.Option(
+        "default_mutator",
+        "--mutator",
+        help="Mutator plugin name",
+    ),
     gens: int = typer.Option(1, help="Number of generations"),
     json_out: bool = typer.Option(
         False, "--json", help="Print results to stdout instead of a file"
@@ -60,6 +65,7 @@ def run(
         "profile_mod": profile_mod,
         "gens": gens,
         "evaluator_ref": fitness,
+        "mutations": [{"kind": mutator}],
     }
     task = _build_task(args)
     result = asyncio.run(mutate_handler(task))
@@ -85,6 +91,11 @@ def submit(
         "--fitness",
         help="Evaluator plugin reference",
     ),
+    mutator: str = typer.Option(
+        "default_mutator",
+        "--mutator",
+        help="Mutator plugin name",
+    ),
     gens: int = typer.Option(1, help="Number of generations"),
     repo: Optional[str] = typer.Option(None, "--repo", help="Git repository URI"),
     ref: str = typer.Option("HEAD", "--ref", help="Git ref or commit SHA"),
@@ -98,6 +109,7 @@ def submit(
         "profile_mod": profile_mod,
         "gens": gens,
         "evaluator_ref": fitness,
+        "mutations": [{"kind": mutator}],
     }
     task = _build_task(args)
 

--- a/pkgs/standards/peagen/tests/examples/peagen_local_demo/test_workspace/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/peagen_local_demo/test_workspace/.peagen.toml
@@ -19,8 +19,8 @@ max_workers = 1
 async = false
 strict = true
 
-[mutation.mutators]
-default_mutator = "DefaultMutator"
+[mutation]
+default_mutator = "default_mutator"
 
 [evaluation.evaluators]
 default_evaluator = "performance"

--- a/pkgs/standards/peagen/tests/examples/simple_evolve_demo/workspace/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/simple_evolve_demo/workspace/.peagen.toml
@@ -19,8 +19,8 @@ max_workers = 1
 async = false
 strict = true
 
-[mutation.mutators]
-default_mutator = "DefaultMutator"
+[mutation]
+default_mutator = "default_mutator"
 
 [evaluation.evaluators]
 default_evaluator = "performance"


### PR DESCRIPTION
## Summary
- drop deprecated `[mutation.mutators]` from configs
- keep `[mutation]` blocks with `default_mutator`

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_685a7ec52eb083268026be43180e0b15