### PR TITLE
Improve peagen error messages

### DIFF
--- a/pkgs/standards/peagen/peagen/errors.py
+++ b/pkgs/standards/peagen/peagen/errors.py
@@ -29,3 +29,25 @@ class GitRemoteMissingError(RuntimeError):
     """Raised when an expected git remote is not configured."""
 
     pass
+
+
+class SpecFileNotFoundError(FileNotFoundError):
+    """Raised when the DOE spec file is missing."""
+
+    def __init__(self, path: str) -> None:
+        super().__init__(path)
+        self.path = path
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return f"DOE spec file not found: {self.path}"
+
+
+class TemplateFileNotFoundError(FileNotFoundError):
+    """Raised when the project template file is missing."""
+
+    def __init__(self, path: str) -> None:
+        super().__init__(path)
+        self.path = path
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return f"Template file not found: {self.path}"


### PR DESCRIPTION
## Summary
- add `SpecFileNotFoundError` and `TemplateFileNotFoundError`
- raise these new exceptions in `generate_payload`

## Testing
- `uv run --directory standards/peagen --package peagen ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_685a8c15546483269a1013df24e6540a