### PR TITLE
Improve peagen file error handling

### DIFF
--- a/pkgs/standards/peagen/peagen/__init__.py
+++ b/pkgs/standards/peagen/peagen/__init__.py
@@ -14,7 +14,11 @@ except PackageNotFoundError:
 
 
 from .plugin_manager import PluginManager, resolve_plugin_spec
-from .errors import PatchTargetMissingError
+from .errors import (
+    PatchTargetMissingError,
+    SpecFileNotFoundError,
+    TemplateFileNotFoundError,
+)
 from .core.patch_core import apply_patch
 from .plugins.secret_drivers import AutoGpgDriver, SecretDriverBase
 
@@ -24,6 +28,8 @@ __all__ = [
     "PluginManager",
     "resolve_plugin_spec",
     "PatchTargetMissingError",
+    "SpecFileNotFoundError",
+    "TemplateFileNotFoundError",
     "apply_patch",
     "SecretDriverBase",
     "AutoGpgDriver",

--- a/pkgs/standards/peagen/peagen/core/doe_core.py
+++ b/pkgs/standards/peagen/peagen/core/doe_core.py
@@ -27,7 +27,11 @@ from urllib.parse import urlparse
 
 from peagen._utils.config_loader import load_peagen_toml
 from peagen.plugin_manager import resolve_plugin_spec
-from peagen.errors import PatchTargetMissingError
+from peagen.errors import (
+    PatchTargetMissingError,
+    SpecFileNotFoundError,
+    TemplateFileNotFoundError,
+)
 from peagen.schemas import DOE_SPEC_V2_SCHEMA
 from peagen.plugins.vcs import pea_ref
 from peagen._utils._validation import _validate
@@ -52,8 +56,16 @@ def _sha256(path: Path) -> str:
     return h.hexdigest()
 
 
-def _load_yaml(uri: str | Path) -> Dict[str, Any]:
-    return yaml.safe_load(Path(uri).expanduser().read_text(encoding="utf-8"))
+def _load_yaml(uri: str | Path, *, kind: str | None = None) -> Dict[str, Any]:
+    path = Path(uri).expanduser()
+    try:
+        return yaml.safe_load(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        if kind == "spec":
+            raise SpecFileNotFoundError(str(path)) from exc
+        if kind == "template":
+            raise TemplateFileNotFoundError(str(path)) from exc
+        raise
 
 
 def _apply_json_patch(doc: Dict, patch_ops: List[Dict]) -> Dict:
@@ -354,8 +366,8 @@ def generate_payload(
     Returns a JSON-serialisable summary; writes *output_path* unless dry-run.
     """
     # 1. ------------ load + validate -------------------------------------
-    spec_obj = _load_yaml(spec_path)
-    template_obj = _load_yaml(template_path)
+    spec_obj = _load_yaml(spec_path, kind="spec")
+    template_obj = _load_yaml(template_path, kind="template")
 
     if "version" not in spec_obj:
         raise ValueError("legacy DOE specs are no longer supported")

--- a/pkgs/standards/peagen/peagen/errors.py
+++ b/pkgs/standards/peagen/peagen/errors.py
@@ -19,6 +19,28 @@ class WorkspaceNotFoundError(FileNotFoundError):
         return f"Workspace '{self.workspace}' does not exist or is not accessible"
 
 
+class SpecFileNotFoundError(FileNotFoundError):
+    """Raised when the DOE specification file is missing."""
+
+    def __init__(self, spec_path: str) -> None:
+        super().__init__(spec_path)
+        self.spec_path = spec_path
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return f"DOE spec file not found: {self.spec_path}"
+
+
+class TemplateFileNotFoundError(FileNotFoundError):
+    """Raised when the project template file is missing."""
+
+    def __init__(self, template_path: str) -> None:
+        super().__init__(template_path)
+        self.template_path = template_path
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return f"Template file not found: {self.template_path}"
+
+
 class GitOperationError(RuntimeError):
     """Raised when a git command fails."""
 


### PR DESCRIPTION
## Summary
- add `SpecFileNotFoundError` and `TemplateFileNotFoundError`
- raise new errors when DOE spec or template files are missing
- export new exceptions from package

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest`
- `uv run --package peagen --directory pkgs/standards/peagen peagen local -q evolve tests/examples/simple_evolve_demo/evolve_spec_local.yaml` *(fails: All connection attempts failed)*

------
https://chatgpt.com/codex/tasks/task_e_685a8c15546483269a1013df24e6540a