### PR TITLE
Improve plugin spec error handling

### DIFF
--- a/pkgs/standards/peagen/peagen/errors.py
+++ b/pkgs/standards/peagen/peagen/errors.py
@@ -29,3 +29,17 @@ class GitRemoteMissingError(RuntimeError):
     """Raised when an expected git remote is not configured."""
 
     pass
+
+
+class InvalidPluginSpecError(ValueError):
+    """Raised when a plugin reference cannot be parsed."""
+
+    def __init__(self, spec: str) -> None:
+        super().__init__(spec)
+        self.spec = spec
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return (
+            f"Invalid plugin specification '{self.spec}'. "
+            "Expected 'module.Class' or 'module:Class'."
+        )

--- a/pkgs/standards/peagen/peagen/plugins/__init__.py
+++ b/pkgs/standards/peagen/peagen/plugins/__init__.py
@@ -7,6 +7,8 @@ from collections import defaultdict
 from types import ModuleType
 from typing import Any, Dict, Optional
 
+from peagen.errors import InvalidPluginSpecError
+
 # ---------------------------------------------------------------------------
 # Config – group key → (entry-point group string, expected base class)
 # ---------------------------------------------------------------------------
@@ -202,7 +204,12 @@ class PluginManager:
             class_name = "".join(part.capitalize() for part in ref.split("_")) + "Model"
             module = import_module(f"swarmauri.llms.{class_name}")
             return getattr(module, class_name)
-        mod, cls = ref.split(":", 1) if ":" in ref else ref.rsplit(".", 1)
+        if ":" not in ref and "." not in ref:
+            raise InvalidPluginSpecError(ref)
+        try:
+            mod, cls = ref.split(":", 1) if ":" in ref else ref.rsplit(".", 1)
+        except ValueError as exc:  # pragma: no cover - validation just above
+            raise InvalidPluginSpecError(ref) from exc
         module = import_module(mod)
         return getattr(module, cls)
 

--- a/pkgs/standards/peagen/tests/unit/test_plugin_manager.py
+++ b/pkgs/standards/peagen/tests/unit/test_plugin_manager.py
@@ -5,6 +5,8 @@ import pytest
 
 import peagen.plugins as plugins
 from peagen.plugins import PluginManager
+from peagen.errors import InvalidPluginSpecError
+from peagen.plugin_manager import resolve_plugin_spec
 
 from .dummy_plugins import DummyQueue, DummyBackend
 
@@ -88,3 +90,9 @@ def test_ep_paths_use_plugins_namespace():
             assert ep_group == "peagen.template_sets"
         else:
             assert ep_group.startswith("peagen.plugins."), ep_group
+
+
+@pytest.mark.unit
+def test_resolve_plugin_spec_invalid():
+    with pytest.raises(InvalidPluginSpecError):
+        resolve_plugin_spec("evaluators", "invalid")


### PR DESCRIPTION
## Summary
- add `InvalidPluginSpecError` for clear plugin reference failures
- validate plugin specs in plugin manager
- test invalid plugin spec handling

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest`
- `peagen remote -q --gateway-url https://gw.peagen.com/rpc process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml --watch`
- `peagen local -q eval pkgs/standards/peagen/tests/examples/peagen_local_demo/test_workspace` *(fails: InvalidPluginSpecError)*

------
https://chatgpt.com/codex/tasks/task_e_685a8c023edc8326aa79184bafaf8e84