### PR TITLE
Improve Git error messages in peagen

### DIFF
--- a/pkgs/standards/peagen/peagen/errors.py
+++ b/pkgs/standards/peagen/peagen/errors.py
@@ -29,3 +29,29 @@ class GitRemoteMissingError(RuntimeError):
     """Raised when an expected git remote is not configured."""
 
     pass
+
+
+class GitFetchError(GitOperationError):
+    """Raised when fetching from a remote fails."""
+
+    def __init__(self, remote: str, ref: str, url: str, reason: str) -> None:
+        super().__init__(
+            f"Failed to fetch '{ref}' from remote '{remote}' ({url}): {reason}"
+        )
+        self.remote = remote
+        self.ref = ref
+        self.url = url
+        self.reason = reason
+
+
+class GitPushError(GitOperationError):
+    """Raised when pushing to a remote fails."""
+
+    def __init__(self, remote: str, ref: str, url: str, reason: str) -> None:
+        super().__init__(
+            f"Failed to push '{ref}' to remote '{remote}' ({url}): {reason}"
+        )
+        self.remote = remote
+        self.ref = ref
+        self.url = url
+        self.reason = reason


### PR DESCRIPTION
## Summary
- provide detailed GitFetchError and GitPushError exceptions
- surface descriptive errors from GitVCS operations
- test new exceptions

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --directory pkgs/standards/peagen --package peagen pytest`
- `peagen remote -q --gateway-url http://localhost:8000/rpc process projects_payload.yaml --watch`
- `peagen local -q process projects_payload.yaml --watch`

------
https://chatgpt.com/codex/tasks/task_e_685a8ba609d88326a454d4e94873b7a0