### PR TITLE
Add projects_payload schema validation

### DIFF
--- a/pkgs/standards/peagen/peagen/__init__.py
+++ b/pkgs/standards/peagen/peagen/__init__.py
@@ -18,6 +18,7 @@ from .errors import (
     PatchTargetMissingError,
     SpecFileNotFoundError,
     TemplateFileNotFoundError,
+    ProjectsPayloadValidationError,
 )
 from .core.patch_core import apply_patch
 from .plugins.secret_drivers import AutoGpgDriver, SecretDriverBase
@@ -30,6 +31,7 @@ __all__ = [
     "PatchTargetMissingError",
     "SpecFileNotFoundError",
     "TemplateFileNotFoundError",
+    "ProjectsPayloadValidationError",
     "apply_patch",
     "SecretDriverBase",
     "AutoGpgDriver",

--- a/pkgs/standards/peagen/peagen/core/process_core.py
+++ b/pkgs/standards/peagen/peagen/core/process_core.py
@@ -20,6 +20,9 @@ from peagen._utils._search_template_sets import (
     build_ptree_template_search_paths,
     build_file_template_search_paths,
 )
+from peagen.core.validate_core import _collect_errors
+from peagen.schemas import PROJECTS_PAYLOAD_V1_SCHEMA
+from peagen.errors import ProjectsPayloadValidationError
 
 logger = Logger(name=__name__)
 
@@ -61,6 +64,12 @@ def load_projects_payload(
         except (OSError, TypeError, ValueError):
             yaml_text = projects_payload
         doc = yaml.safe_load(yaml_text)
+
+    errors = _collect_errors(doc, PROJECTS_PAYLOAD_V1_SCHEMA)
+    if errors:
+        raise ProjectsPayloadValidationError(
+            errors, str(projects_payload) if isinstance(projects_payload, str) else None
+        )
 
     projects = doc.get("PROJECTS") if isinstance(doc, dict) else doc
     if not isinstance(projects, list):

--- a/pkgs/standards/peagen/peagen/errors.py
+++ b/pkgs/standards/peagen/peagen/errors.py
@@ -79,6 +79,7 @@ class GitPushError(GitOperationError):
             f"Failed to push '{ref}' to remote '{remote}'. Check remote configuration and permissions."
         )
 
+
 class SchedulerError(RuntimeError):
     """Base class for errors raised during task scheduling."""
 
@@ -99,6 +100,7 @@ class NoWorkerAvailableError(SchedulerError):
         self.pool = pool
         self.action = action
 
+
 class InvalidPluginSpecError(ValueError):
     """Raised when a plugin reference cannot be parsed."""
 
@@ -111,3 +113,18 @@ class InvalidPluginSpecError(ValueError):
             f"Invalid plugin specification '{self.spec}'. "
             "Expected 'module.Class' or 'module:Class'."
         )
+
+
+class ProjectsPayloadValidationError(ValueError):
+    """Raised when a projects_payload does not conform to the schema."""
+
+    def __init__(self, errors: list[str], path: str | None = None) -> None:
+        self.errors = errors
+        self.path = path
+        label = f" at '{path}'" if path else ""
+        super().__init__(f"Invalid projects_payload{label}")
+
+    def __str__(self) -> str:  # pragma: no cover - simple
+        details = "; ".join(self.errors)
+        loc = f" in {self.path}" if self.path else ""
+        return f"Invalid projects_payload{loc}: {details}"

--- a/pkgs/standards/peagen/tests/unit/test_load_projects_payload.py
+++ b/pkgs/standards/peagen/tests/unit/test_load_projects_payload.py
@@ -3,15 +3,34 @@ import yaml
 import pytest
 
 from peagen.core.process_core import load_projects_payload
+from peagen.errors import ProjectsPayloadValidationError
 from peagen.plugins.storage_adapters.file_storage_adapter import FileStorageAdapter
 
 
 @pytest.mark.unit
 def test_load_projects_payload_remote(tmp_path):
-    data = {"PROJECTS": [{"NAME": "A"}]}
+    data = {
+        "schemaVersion": "1.0.0",
+        "PROJECTS": [
+            {
+                "NAME": "A",
+                "ROOT": ".",
+                "PACKAGES": [{"NAME": "pkg", "MODULES": [{"NAME": "m", "EXTRAS": {}}]}],
+            }
+        ],
+    }
     yaml_text = yaml.safe_dump(data)
     adapter = FileStorageAdapter(tmp_path)
     uri = adapter.upload("pp.yaml", io.BytesIO(yaml_text.encode()))
 
     projects = load_projects_payload(uri)
     assert projects and projects[0]["NAME"] == "A"
+
+
+@pytest.mark.unit
+def test_load_projects_payload_validation_error(tmp_path):
+    bad = tmp_path / "bad.yaml"
+    bad.write_text("PROJECTS:\n  - NAME: foo\n")
+
+    with pytest.raises(ProjectsPayloadValidationError):
+        load_projects_payload(str(bad))


### PR DESCRIPTION
## Summary
- validate projects_payload.yaml during load
- raise `ProjectsPayloadValidationError` on schema issues
- export new error in package init
- update unit tests for new validation logic

## Testing
- `uv run --directory standards/peagen --package peagen ruff format peagen/core/process_core.py peagen/errors.py peagen/__init__.py`
- `uv run --directory standards/peagen --package peagen ruff check peagen/core/process_core.py peagen/errors.py peagen/__init__.py --fix`
- `uv run --directory standards/peagen --package peagen ruff format tests/unit/test_load_projects_payload.py`
- `uv run --directory standards/peagen --package peagen ruff check tests/unit/test_load_projects_payload.py --fix`
- `uv run --package peagen --directory standards/peagen pytest`
- `peagen remote -q --gateway-url https://gw.peagen.com/rpc process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml >/tmp/remote.log 2>&1 && tail -n 20 /tmp/remote.log`
- `peagen local -q process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml >/tmp/local.log 2>&1 && tail -n 20 /tmp/local.log`


------
https://chatgpt.com/codex/tasks/task_e_685a983c97088326b328bf050d92f5fb