### PR TITLE
Fix DOE spec transmission

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/doe.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/doe.py
@@ -145,6 +145,9 @@ def submit_gen(  # noqa: PLR0913
     }
     if repo:
         args.update({"repo": repo, "ref": ref})
+    else:
+        args["spec_text"] = spec.read_text(encoding="utf-8")
+        args["template_text"] = template.read_text(encoding="utf-8")
     task = _make_task(args, action="doe")
 
     rpc_req = {
@@ -296,6 +299,9 @@ def submit_process(  # noqa: PLR0913
     }
     if repo:
         args.update({"repo": repo, "ref": ref})
+    else:
+        args["spec_text"] = spec.read_text(encoding="utf-8")
+        args["template_text"] = template.read_text(encoding="utf-8")
     task = _make_task(args, action="doe_process")
 
     rpc_req = {


### PR DESCRIPTION
## Summary
- send DOE spec and template content when calling `peagen remote doe`
- handle `spec_text` and `template_text` in remote handlers

## Testing
- `uv run --directory peagen --package peagen ruff format .`
- `uv run --directory peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_685a99e5bd788326a948e6c4f042c8e1