### PR TITLE
Fix plugin specification error message

### DIFF
--- a/pkgs/standards/peagen/peagen/errors.py
+++ b/pkgs/standards/peagen/peagen/errors.py
@@ -79,6 +79,7 @@ class GitPushError(GitOperationError):
             f"Failed to push '{ref}' to remote '{remote}'. Check remote configuration and permissions."
         )
 
+
 class SchedulerError(RuntimeError):
     """Base class for errors raised during task scheduling."""
 
@@ -99,6 +100,7 @@ class NoWorkerAvailableError(SchedulerError):
         self.pool = pool
         self.action = action
 
+
 class InvalidPluginSpecError(ValueError):
     """Raised when a plugin reference cannot be parsed."""
 
@@ -108,6 +110,5 @@ class InvalidPluginSpecError(ValueError):
 
     def __str__(self) -> str:  # pragma: no cover - trivial
         return (
-            f"Invalid plugin specification '{self.spec}'. "
-            "Expected 'module.Class' or 'module:Class'."
+            f"Invalid plugin specification '{self.spec}'. Expected an entry-point name."
         )

--- a/pkgs/standards/peagen/peagen/plugins/__init__.py
+++ b/pkgs/standards/peagen/peagen/plugins/__init__.py
@@ -1,7 +1,6 @@
 # peagen/plugins.py
 """Plugin registry for the Peagen microkernel."""
 
-from importlib import import_module
 from importlib.metadata import entry_points
 from collections import defaultdict
 from types import ModuleType
@@ -198,20 +197,9 @@ class PluginManager:
     # ────────────────────────────── helpers ─────────────────────────────
     def _resolve_spec(self, group: str, ref: str) -> Any:
         obj = registry.get(group, {}).get(ref)
-        if obj is not None:
-            return obj
-        if group == "llms" and "." not in ref:
-            class_name = "".join(part.capitalize() for part in ref.split("_")) + "Model"
-            module = import_module(f"swarmauri.llms.{class_name}")
-            return getattr(module, class_name)
-        if ":" not in ref and "." not in ref:
+        if obj is None:
             raise InvalidPluginSpecError(ref)
-        try:
-            mod, cls = ref.split(":", 1) if ":" in ref else ref.rsplit(".", 1)
-        except ValueError as exc:  # pragma: no cover - validation just above
-            raise InvalidPluginSpecError(ref) from exc
-        module = import_module(mod)
-        return getattr(module, cls)
+        return obj
 
     def _instantiate(self, cls_or_obj: Any, params: Dict[str, Any]) -> Any:
         return cls_or_obj(**params) if isinstance(cls_or_obj, type) else cls_or_obj

--- a/pkgs/standards/peagen/tests/unit/test_plugin_manager.py
+++ b/pkgs/standards/peagen/tests/unit/test_plugin_manager.py
@@ -1,4 +1,3 @@
-import sys
 from importlib import reload
 
 import pytest
@@ -12,21 +11,19 @@ from .dummy_plugins import DummyQueue, DummyBackend
 
 
 @pytest.mark.unit
-def test_plugin_manager_instantiates_defaults(tmp_path):
-    module_path = "tests.unit.dummy_plugins"
-    sys.modules[module_path] = sys.modules[
-        __name__.rsplit(".", 1)[0] + ".dummy_plugins"
-    ]
-
+def test_plugin_manager_instantiates_defaults(tmp_path, monkeypatch):
     cfg = {
-        "queues": {"default_queue": f"{module_path}:DummyQueue"},
-        "result_backends": {
-            "default_backend": f"{module_path}:DummyBackend",
-            "adapters": {},
-        },
+        "queues": {"default_queue": "dummy_queue"},
+        "result_backends": {"default_backend": "dummy_backend", "adapters": {}},
     }
 
+    _reset_plugins(monkeypatch)
+    monkeypatch.setattr(plugins, "entry_points", lambda group: [])
+
     pm = PluginManager(cfg)
+    plugins.registry["queues"]["dummy_queue"] = DummyQueue
+    plugins.registry["result_backends"]["dummy_backend"] = DummyBackend
+
     queue = pm.get("queues")
     backend = pm.get("result_backends")
     assert isinstance(queue, DummyQueue)


### PR DESCRIPTION
## Summary
- tweak wording for plugin specification errors
- restrict plugin lookup to entry-point registry

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format peagen/plugins/__init__.py peagen/errors.py tests/unit/test_plugin_manager.py`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/plugins/__init__.py peagen/errors.py tests/unit/test_plugin_manager.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_685a9d3477488326bb8e476024743dbd