### PR TITLE
Improve Git commit error handling in peagen

### DIFF
--- a/pkgs/standards/peagen/peagen/errors.py
+++ b/pkgs/standards/peagen/peagen/errors.py
@@ -80,6 +80,14 @@ class GitPushError(GitOperationError):
         )
 
 
+class GitCommitError(GitOperationError):
+    """Raised when committing staged changes fails."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(f"Git commit failed: {reason}")
+        self.reason = reason
+
+
 class SchedulerError(RuntimeError):
     """Base class for errors raised during task scheduling."""
 
@@ -113,12 +121,14 @@ class InvalidPluginSpecError(ValueError):
             f"Invalid plugin specification '{self.spec}'. Expected an entry-point name."
         )
 
+
 class PATNotAllowedError(RuntimeError):
     """Raised when a PAT token is passed to a forbidden command."""
 
     def __init__(self) -> None:
         super().__init__("PAT tokens are not allowed for this command")
-        
+
+
 class ProjectsPayloadValidationError(ValueError):
     """Raised when a projects_payload does not conform to the schema."""
 
@@ -133,6 +143,7 @@ class ProjectsPayloadValidationError(ValueError):
         loc = f" in {self.path}" if self.path else ""
         return f"Invalid projects_payload{loc}: {details}"
 
+
 class TaskNotFoundError(RuntimeError):
     """Raised when a task id does not exist in the gateway."""
 
@@ -145,7 +156,8 @@ class TaskNotFoundError(RuntimeError):
             f"Task '{self.task_id}' could not be found. "
             "It may have expired or was never created."
         )
-      
+
+
 class DispatchHTTPError(RuntimeError):
     """Raised when a worker responds with a non-200 HTTP status."""
 


### PR DESCRIPTION
## Summary
- add `GitCommitError` for descriptive commit failures
- raise `GitCommitError` in `GitVCS.commit` and `GitVCS.fan_in`

## Testing
- `uv run --directory . --package peagen ruff format peagen/errors.py peagen/plugins/vcs/git_vcs.py`
- `uv run --directory . --package peagen ruff check peagen/errors.py peagen/plugins/vcs/git_vcs.py --fix`

------
https://chatgpt.com/codex/tasks/task_e_685aa3f7869c8326a24a191e363ebdfa