### PR TITLE
Add Git commit error handling

### DIFF
--- a/pkgs/standards/peagen/peagen/errors.py
+++ b/pkgs/standards/peagen/peagen/errors.py
@@ -3,6 +3,8 @@
 Exception classes used by the Peagen package.
 """
 
+from typing import Iterable
+
 
 class PatchTargetMissingError(ValueError):
     """Patch operation refers to a non-existent path in the template."""
@@ -80,6 +82,16 @@ class GitPushError(GitOperationError):
         )
 
 
+class GitCommitError(GitOperationError):
+    """Raised when committing changes to the repository fails."""
+
+    def __init__(self, paths: Iterable[str]) -> None:
+        joined = ", ".join(paths)
+        super().__init__(
+            f"Failed to commit files [{joined}]. Ensure they exist inside the repository."
+        )
+
+
 class SchedulerError(RuntimeError):
     """Base class for errors raised during task scheduling."""
 
@@ -113,12 +125,14 @@ class InvalidPluginSpecError(ValueError):
             f"Invalid plugin specification '{self.spec}'. Expected an entry-point name."
         )
 
+
 class PATNotAllowedError(RuntimeError):
     """Raised when a PAT token is passed to a forbidden command."""
 
     def __init__(self) -> None:
         super().__init__("PAT tokens are not allowed for this command")
-        
+
+
 class ProjectsPayloadValidationError(ValueError):
     """Raised when a projects_payload does not conform to the schema."""
 
@@ -133,6 +147,7 @@ class ProjectsPayloadValidationError(ValueError):
         loc = f" in {self.path}" if self.path else ""
         return f"Invalid projects_payload{loc}: {details}"
 
+
 class TaskNotFoundError(RuntimeError):
     """Raised when a task id does not exist in the gateway."""
 
@@ -145,7 +160,8 @@ class TaskNotFoundError(RuntimeError):
             f"Task '{self.task_id}' could not be found. "
             "It may have expired or was never created."
         )
-      
+
+
 class DispatchHTTPError(RuntimeError):
     """Raised when a worker responds with a non-200 HTTP status."""
 

--- a/pkgs/standards/peagen/peagen/plugins/vcs/git_vcs.py
+++ b/pkgs/standards/peagen/peagen/plugins/vcs/git_vcs.py
@@ -19,6 +19,7 @@ from peagen.errors import (
     GitCloneError,
     GitFetchError,
     GitPushError,
+    GitCommitError,
 )
 from peagen.plugins.secret_drivers import AutoGpgDriver
 
@@ -202,8 +203,11 @@ class GitVCS:
 
     # ------------------------------------------------------------------ commit/merge/tag
     def commit(self, paths: Iterable[str], message: str) -> str:
-        self.repo.git.add(*paths)
-        self.repo.git.commit("-m", message)
+        try:
+            self.repo.git.add(*paths)
+            self.repo.git.commit("-m", message)
+        except GitCommandError as exc:
+            raise GitCommitError(list(paths)) from exc
         return self.repo.head.commit.hexsha
 
     def fan_in(self, refs: Iterable[str], message: str) -> str:

--- a/pkgs/standards/peagen/tests/unit/test_git_vcs.py
+++ b/pkgs/standards/peagen/tests/unit/test_git_vcs.py
@@ -9,6 +9,7 @@ from peagen.errors import (
     GitRemoteMissingError,
     GitCloneError,
     GitFetchError,
+    GitCommitError,
 )
 from peagen.plugins.secret_drivers import SecretDriverBase
 
@@ -103,3 +104,15 @@ def test_fetch_error(tmp_path: Path) -> None:
     vcs_clone = GitVCS.ensure_repo(repo_clone, remote_url=str(repo_src))
     with pytest.raises(GitFetchError):
         vcs_clone.fetch("refs/heads/missing")
+
+
+def test_commit_error_outside_repo(tmp_path: Path) -> None:
+    repo_dir = tmp_path / "repo"
+    vcs = GitVCS.ensure_repo(repo_dir)
+    (repo_dir / "file.txt").write_text("x")
+    vcs.commit(["file.txt"], "init")
+
+    outside = tmp_path / "outside.txt"
+    outside.write_text("oops")
+    with pytest.raises(GitCommitError):
+        vcs.commit([str(outside)], "fail")


### PR DESCRIPTION
## Summary
- add `GitCommitError` exception with helpful message
- use `GitCommitError` when commits fail in `GitVCS`
- test the new Git commit failure case

## Testing
- `uv run --directory standards --package peagen ruff format peagen`
- `uv run --directory standards --package peagen ruff check peagen --fix`
- `uv run --package peagen --directory standards pytest peagen/tests`

------
https://chatgpt.com/codex/tasks/task_e_685aa40361d483269419380c3b830ca9