### PR TITLE
Update peagen examples and entrypoint

### DIFF
--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -197,6 +197,9 @@ pytest_profiling = "peagen.evaluators.pytest_profiling:PytestProfilingEvaluator"
 benchmark = "peagen.evaluators.benchmark:PytestBenchmarkEvaluator"
 simple_time = "peagen.evaluators.simple_time:SimpleTimeEvaluator"
 
+[project.entry-points."peagen.evaluator_pools"]
+default = "peagen.plugins.evaluator_pools.default:DefaultEvaluatorPool"
+
 [tool.setuptools.package-data]
 "peagen.schemas" = ["*.json", "extras/*.json"]
 "peagen" = [

--- a/pkgs/standards/peagen/tests/examples/evolve_example_2/cfg/remote.toml
+++ b/pkgs/standards/peagen/tests/examples/evolve_example_2/cfg/remote.toml
@@ -20,12 +20,12 @@ secret_key = "${MINIO_SECRET_KEY}"
 secure = false
 
 [evaluation]
-pool = "peagen.plugins.evaluator_pools.default:DefaultEvaluatorPool"
+pool = "default"
 max_workers = 1
 async = false
 strict = true
 
 [evaluation.evaluators]
-default_evaluator = "performance"
+default_evaluator = "simple_time"
 
 [evaluation.evaluators.performance]

--- a/pkgs/standards/peagen/tests/examples/peagen_local_demo/test_workspace/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/peagen_local_demo/test_workspace/.peagen.toml
@@ -14,7 +14,7 @@ default_filter = "file"
 output_dir = "./peagen_artifacts"
 
 [evaluation]
-pool = "peagen.plugins.evaluator_pools.default:DefaultEvaluatorPool"
+pool = "default"
 max_workers = 1
 async = false
 strict = true
@@ -23,9 +23,7 @@ strict = true
 default_mutator = "default_mutator"
 
 [evaluation.evaluators]
-default_evaluator = "performance"
-
-[evaluation.evaluators.performance]
+default_evaluator = "simple_time"
 
 [llm]
 default_provider = "groq"

--- a/pkgs/standards/peagen/tests/examples/simple_evolve_demo/cfg/local.toml
+++ b/pkgs/standards/peagen/tests/examples/simple_evolve_demo/cfg/local.toml
@@ -18,7 +18,7 @@ default_backend = "local_fs"
 root_dir = "./task_runs"
 
 [evaluation]
-pool = "peagen.plugins.evaluator_pools.default:DefaultEvaluatorPool"
+pool = "default"
 max_workers = 1
 async = false
 strict = true

--- a/pkgs/standards/peagen/tests/examples/simple_evolve_demo/cfg/remote.toml
+++ b/pkgs/standards/peagen/tests/examples/simple_evolve_demo/cfg/remote.toml
@@ -20,7 +20,7 @@ secret_key = "${MINIO_SECRET_KEY}"
 secure = false
 
 [evaluation]
-pool = "peagen.plugins.evaluator_pools.default:DefaultEvaluatorPool"
+pool = "default"
 max_workers = 1
 async = false
 strict = true
@@ -31,7 +31,7 @@ provider_params = { path = "." }
 default_vcs = "git"
 
 [evaluation.evaluators]
-default_evaluator = "performance"
+default_evaluator = "simple_time"
 
 [evaluation.evaluators.performance]
 import_path = "sort_alg"

--- a/pkgs/standards/peagen/tests/examples/simple_evolve_demo/workspace/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/simple_evolve_demo/workspace/.peagen.toml
@@ -14,7 +14,7 @@ default_filter = "file"
 output_dir = "./peagen_artifacts"
 
 [evaluation]
-pool = "peagen.plugins.evaluator_pools.default:DefaultEvaluatorPool"
+pool = "default"
 max_workers = 1
 async = false
 strict = true
@@ -23,11 +23,7 @@ strict = true
 default_mutator = "default_mutator"
 
 [evaluation.evaluators]
-default_evaluator = "performance"
-
-[evaluation.evaluators.performance]
-import_path = "sort_alg"
-entry_fn = "bad_sort"
+default_evaluator = "simple_time"
 
 [llm]
 default_provider = "groq"


### PR DESCRIPTION
## Summary
- add `peagen.evaluator_pools` entrypoint in `pyproject.toml`
- switch example workspaces to use `pool = "default"` and `simple_time`
- update evolve demo configs to match new pool naming

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_685aa2eae2a08326abecaee24066875b