### PR TITLE
Verify remote sort command and fix pagination test

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_tui_pagination.py
+++ b/pkgs/standards/peagen/tests/unit/test_tui_pagination.py
@@ -26,6 +26,7 @@ def test_pagination_actions(monkeypatch):
     app.action_jump_page(99)
     assert app.offset == 20
 
+
 @pytest.mark.unit
 def test_perform_filtering_limit_offset():
     app = QueueDashboardApp()
@@ -52,6 +53,15 @@ def test_perform_filtering_limit_offset():
 @pytest.mark.unit
 def test_header_page_info():
     app = QueueDashboardApp()
+
+    class DummyFooter:
+        def __init__(self) -> None:
+            self.page_info = None
+
+        def set_page_info(self, current: int, total: int) -> None:
+            self.page_info = (current, total)
+
+    app.footer = DummyFooter()
     data = {
         "tasks_to_display": [],
         "workers_data": [],
@@ -67,4 +77,3 @@ def test_header_page_info():
     app.offset = 20
     app._update_ui_with_processed_data(data, [])
     assert app.sub_title == "Page 3 of 5"
-


### PR DESCRIPTION
## Summary
- confirm `peagen remote` works against gw.peagen.com
- fix `test_header_page_info` by stubbing the footer

## Testing
- `ruff check .`
- `uv run --package peagen --directory pkgs/standards/peagen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ab2983a9483269cfbe7833c27b987