### PR TITLE
Update peagen evaluator config

### DIFF
--- a/.peagen.toml
+++ b/.peagen.toml
@@ -85,10 +85,7 @@ async = false
 strict = true
 
 [evaluation.evaluators]
-default_evaluator = "performance"
-
-[evaluation.evaluators.performance]
-# parameters for the built-in performance evaluator can go here
+simple_time = "simple_time"
 
 
 [vcs]

--- a/infra/.worker.peagen.toml
+++ b/infra/.worker.peagen.toml
@@ -66,12 +66,7 @@ async = false
 strict = true
 
 [evaluation.evaluators]
-default_evaluator = "ColemanLiauIndexEvaluator"
-
-[evaluation.evaluators.AutomatedReadabilityIndexEvaluator]
-
-[evaluation.evaluators.ColemanLiauIndexEvaluator]
-target_grade_level = 12
+simple_time = "simple_time"
 
 # --- VCS ------------------------------------------------------------
 [vcs]

--- a/pkgs/standards/peagen/docs/pea-ips/ip-0004.md
+++ b/pkgs/standards/peagen/docs/pea-ips/ip-0004.md
@@ -71,10 +71,7 @@ async       = false       # true = asyncio pool.
 strict      = true        # Fail the run if any score == 0.
 
 [evaluation.evaluators]
-default_evaluator = "bleu"
-
-[evaluation.evaluators.bleu]
-ngram = 4                 # Arbitrary kwargs passed to __init__
+simple_time = "simple_time"
 
 [evaluation.evaluators.rouge]
 
@@ -103,7 +100,6 @@ If the same key appears multiple times the **earlier** entry wins, ensuring CLI 
 * Optional keys: `max_workers` (int ≥ 1), `async` (bool), `strict` (bool).
 * **Sub-object** `evaluation.evaluators` with pattern-property `^[A-Za-z0-9_-]+$`.
 
-  * Includes a `default_evaluator` string choosing which evaluator to run by default.
   * Each property value is an object of keyword arguments passed to the evaluator class registered under that key.
 * All strings continue to allow environment-variable interpolation `${FOO}` exactly as other TOML fields do.
 

--- a/pkgs/standards/peagen/peagen/core/eval_core.py
+++ b/pkgs/standards/peagen/peagen/core/eval_core.py
@@ -45,8 +45,6 @@ def _register_evaluators(pool, evaluators_cfg: Dict[str, Any]):
     Support both string and dict forms from .peagen.toml.
     """
     for name, spec in evaluators_cfg.items():
-        if name == "default_evaluator":
-            continue
         # ------------------------------------------------------------------ #
         # 1) Instantiate or locate evaluator
         # ------------------------------------------------------------------ #

--- a/pkgs/standards/peagen/peagen/plugins/__init__.py
+++ b/pkgs/standards/peagen/peagen/plugins/__init__.py
@@ -139,7 +139,6 @@ class PluginManager:
         "evaluators": {
             "section": "evaluation",
             "items": "evaluators",
-            "default": "default_evaluator",
         },
         "evaluator_pools": {
             "section": "evaluation",

--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -196,6 +196,9 @@ memray = "peagen.evaluators.pytest_memray_evaluator:PytestMemrayEvaluator"
 pytest_profiling = "peagen.evaluators.pytest_profiling:PytestProfilingEvaluator"
 benchmark = "peagen.evaluators.benchmark:PytestBenchmarkEvaluator"
 simple_time = "peagen.evaluators.simple_time:SimpleTimeEvaluator"
+pytest = "peagen.plugins.evaluators.pytest_evaluator:PytestEvaluator"
+ruff = "peagen.plugins.evaluators.ruff_evaluator:RuffEvaluator"
+performance = "peagen.plugins.evaluators.performance_evaluator:PerformanceEvaluator"
 
 [project.entry-points."peagen.evaluator_pools"]
 default = "peagen.plugins.evaluator_pools.default:DefaultEvaluatorPool"

--- a/pkgs/standards/peagen/tests/examples/evolve_example_2/cfg/remote.toml
+++ b/pkgs/standards/peagen/tests/examples/evolve_example_2/cfg/remote.toml
@@ -26,6 +26,4 @@ async = false
 strict = true
 
 [evaluation.evaluators]
-default_evaluator = "simple_time"
-
-[evaluation.evaluators.performance]
+simple_time = "simple_time"

--- a/pkgs/standards/peagen/tests/examples/peagen_local_demo/test_workspace/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/peagen_local_demo/test_workspace/.peagen.toml
@@ -23,7 +23,7 @@ strict = true
 default_mutator = "default_mutator"
 
 [evaluation.evaluators]
-default_evaluator = "simple_time"
+simple_time = "simple_time"
 
 [llm]
 default_provider = "groq"

--- a/pkgs/standards/peagen/tests/examples/peagen_tomls/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/peagen_tomls/.peagen.toml
@@ -72,12 +72,7 @@ async = false
 strict = true
 
 [evaluation.evaluators]
-default_evaluator = "ColemanLiauIndexEvaluator"
-
-[evaluation.evaluators.AutomatedReadabilityIndexEvaluator]
-
-[evaluation.evaluators.ColemanLiauIndexEvaluator]
-target_grade_level = 12
+simple_time = "simple_time"
 
 [vcs]
 provider = "git"

--- a/pkgs/standards/peagen/tests/examples/simple_evolve_demo/cfg/local.toml
+++ b/pkgs/standards/peagen/tests/examples/simple_evolve_demo/cfg/local.toml
@@ -29,8 +29,4 @@ provider_params = { path = "." }
 default_vcs = "git"
 
 [evaluation.evaluators]
-default_evaluator = "performance"
-
-[evaluation.evaluators.performance]
-import_path = "sort_alg"
-entry_fn = "bad_sort"
+simple_time = "simple_time"

--- a/pkgs/standards/peagen/tests/examples/simple_evolve_demo/cfg/remote.toml
+++ b/pkgs/standards/peagen/tests/examples/simple_evolve_demo/cfg/remote.toml
@@ -31,8 +31,4 @@ provider_params = { path = "." }
 default_vcs = "git"
 
 [evaluation.evaluators]
-default_evaluator = "simple_time"
-
-[evaluation.evaluators.performance]
-import_path = "sort_alg"
-entry_fn = "bad_sort"
+simple_time = "simple_time"

--- a/pkgs/standards/peagen/tests/examples/simple_evolve_demo/workspace/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/simple_evolve_demo/workspace/.peagen.toml
@@ -23,7 +23,7 @@ strict = true
 default_mutator = "default_mutator"
 
 [evaluation.evaluators]
-default_evaluator = "simple_time"
+simple_time = "simple_time"
 
 [llm]
 default_provider = "groq"


### PR DESCRIPTION
## Summary
- remove unused `default_evaluator` config handling
- simplify example `.peagen.toml` files
- document `simple_time` evaluator
- register additional evaluator entry points

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`

------
https://chatgpt.com/codex/tasks/task_e_685ab37788dc83268f5f979248dd2352