### PR TITLE
Improve git commit error reporting

### DIFF
--- a/pkgs/standards/peagen/peagen/errors.py
+++ b/pkgs/standards/peagen/peagen/errors.py
@@ -85,11 +85,13 @@ class GitPushError(GitOperationError):
 class GitCommitError(GitOperationError):
     """Raised when committing changes to the repository fails."""
 
-    def __init__(self, paths: Iterable[str]) -> None:
+    def __init__(self, paths: Iterable[str], reason: str | None = None) -> None:
         joined = ", ".join(paths)
-        super().__init__(
-            f"Failed to commit files [{joined}]. Ensure they exist inside the repository."
-        )
+        base = f"Failed to commit files [{joined}]. Ensure they exist inside the repository."
+        msg = f"{base} Details: {reason}" if reason else base
+        super().__init__(msg)
+        self.paths = list(paths)
+        self.reason = reason
 
 
 class SchedulerError(RuntimeError):

--- a/pkgs/standards/peagen/peagen/plugins/vcs/git_vcs.py
+++ b/pkgs/standards/peagen/peagen/plugins/vcs/git_vcs.py
@@ -207,7 +207,12 @@ class GitVCS:
             self.repo.git.add(*paths)
             self.repo.git.commit("-m", message)
         except GitCommandError as exc:
-            raise GitCommitError(list(paths)) from exc
+            reason = (
+                exc.stderr.strip()
+                if hasattr(exc, "stderr") and exc.stderr
+                else str(exc)
+            )
+            raise GitCommitError(list(paths), reason) from exc
         return self.repo.head.commit.hexsha
 
     def fan_in(self, refs: Iterable[str], message: str) -> str:

--- a/pkgs/standards/peagen/peagen/tui/app.py
+++ b/pkgs/standards/peagen/peagen/tui/app.py
@@ -712,12 +712,11 @@ class QueueDashboardApp(App):
             self.err_table.scroll_x = min(err_scroll_x, self.err_table.max_scroll_x)
             self.err_table.scroll_y = min(err_scroll_y, self.err_table.max_scroll_y)
 
+        current_page = self.offset // self.limit + 1
+        total_pages = max(1, math.ceil(self.queue_len / self.limit))
         if hasattr(self, "footer"):
-            current_page = self.offset // self.limit + 1
-            total_pages = max(1, math.ceil(self.queue_len / self.limit))
             self.footer.set_page_info(current_page, total_pages)
-            self.sub_title = f"Page {current_page} of {total_pages}"
-
+        self.sub_title = f"Page {current_page} of {total_pages}"
 
     async def on_open_url(self, event: events.OpenURL) -> None:
         if event.url.startswith("file://"):


### PR DESCRIPTION
## Summary
- include underlying Git error details when commit fails
- report page info subtitle even without footer widget

## Testing
- `uv run --directory standards/peagen --package peagen ruff format .`
- `uv run --directory standards/peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest`
- `peagen remote -q --gateway-url http://localhost:8000/rpc process standards/peagen/tests/examples/projects_payloads/projects_payload.yaml --watch` *(fails: ConnectError)*
- `peagen local -q process standards/peagen/tests/examples/projects_payloads/projects_payload.yaml` *(fails: ProjectsPayloadValidationError)*

------
https://chatgpt.com/codex/tasks/task_e_685ab4aa3e008326ae1fdadf4d782a72