### PR TITLE
Update evaluator configuration docs

### DIFF
--- a/.peagen.toml
+++ b/.peagen.toml
@@ -85,7 +85,7 @@ async = false
 strict = true
 
 [evaluation.evaluators]
-simple_time = "simple_time"
+default_evaluator = "simple_time"
 
 
 [vcs]

--- a/infra/.worker.peagen.toml
+++ b/infra/.worker.peagen.toml
@@ -66,7 +66,7 @@ async = false
 strict = true
 
 [evaluation.evaluators]
-simple_time = "simple_time"
+default_evaluator = "simple_time"
 
 # --- VCS ------------------------------------------------------------
 [vcs]

--- a/pkgs/standards/peagen/docs/pea-ips/ip-0004.md
+++ b/pkgs/standards/peagen/docs/pea-ips/ip-0004.md
@@ -71,7 +71,7 @@ async       = false       # true = asyncio pool.
 strict      = true        # Fail the run if any score == 0.
 
 [evaluation.evaluators]
-simple_time = "simple_time"
+default_evaluator = "simple_time"
 
 [evaluation.evaluators.rouge]
 

--- a/pkgs/standards/peagen/tests/examples/evolve_example_2/cfg/remote.toml
+++ b/pkgs/standards/peagen/tests/examples/evolve_example_2/cfg/remote.toml
@@ -26,4 +26,4 @@ async = false
 strict = true
 
 [evaluation.evaluators]
-simple_time = "simple_time"
+default_evaluator = "simple_time"

--- a/pkgs/standards/peagen/tests/examples/peagen_local_demo/test_workspace/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/peagen_local_demo/test_workspace/.peagen.toml
@@ -23,7 +23,7 @@ strict = true
 default_mutator = "default_mutator"
 
 [evaluation.evaluators]
-simple_time = "simple_time"
+default_evaluator = "simple_time"
 
 [llm]
 default_provider = "groq"

--- a/pkgs/standards/peagen/tests/examples/peagen_tomls/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/peagen_tomls/.peagen.toml
@@ -72,7 +72,7 @@ async = false
 strict = true
 
 [evaluation.evaluators]
-simple_time = "simple_time"
+default_evaluator = "simple_time"
 
 [vcs]
 provider = "git"

--- a/pkgs/standards/peagen/tests/examples/simple_evolve_demo/cfg/local.toml
+++ b/pkgs/standards/peagen/tests/examples/simple_evolve_demo/cfg/local.toml
@@ -29,4 +29,4 @@ provider_params = { path = "." }
 default_vcs = "git"
 
 [evaluation.evaluators]
-simple_time = "simple_time"
+default_evaluator = "simple_time"

--- a/pkgs/standards/peagen/tests/examples/simple_evolve_demo/cfg/remote.toml
+++ b/pkgs/standards/peagen/tests/examples/simple_evolve_demo/cfg/remote.toml
@@ -31,4 +31,4 @@ provider_params = { path = "." }
 default_vcs = "git"
 
 [evaluation.evaluators]
-simple_time = "simple_time"
+default_evaluator = "simple_time"

--- a/pkgs/standards/peagen/tests/examples/simple_evolve_demo/workspace/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/simple_evolve_demo/workspace/.peagen.toml
@@ -23,7 +23,7 @@ strict = true
 default_mutator = "default_mutator"
 
 [evaluation.evaluators]
-simple_time = "simple_time"
+default_evaluator = "simple_time"
 
 [llm]
 default_provider = "groq"


### PR DESCRIPTION
## Summary
- adjust evaluator configuration syntax to use `default_evaluator`
- update examples and test configs

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format .`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_685ab8b6f580832680eb90c49c4613f3