### PR TITLE
Add command set batches in demo success config

### DIFF
--- a/pkgs/standards/peagen/peagen/tui/app.py
+++ b/pkgs/standards/peagen/peagen/tui/app.py
@@ -587,6 +587,9 @@ class QueueDashboardApp(App):
         self.fail_len = metrics_data.get("fail_len", 0)
         self.worker_len = metrics_data.get("worker_len", 0)
 
+        current_page = self.offset // self.limit + 1
+        total_pages = max(1, math.ceil(self.queue_len / self.limit))
+
         if hasattr(self, "workers_view"):
             self.workers_view.update_workers(workers_data)
 

--- a/pkgs/standards/peagen/tests/sequence_success/examples/demo_success.yaml
+++ b/pkgs/standards/peagen/tests/sequence_success/examples/demo_success.yaml
@@ -1,2 +1,12 @@
-commands:
-  - ["init", "project", "{tmpdir}/project1"]
+command_sets:
+  - batch:
+      name: "project setup"
+      desc: "initialize a project"
+      commands:
+        - ["init", "project", "{tmpdir}/project1"]
+  - batch:
+      name: "remote sort"
+      desc: "run sort remotely and fetch the result"
+      commands:
+        - ["remote", "--gateway-url", "https://gw.peagen.com", "sort", "tests/examples/projects_payloads/template_two_project.yaml"]
+        - ["remote", "--gateway-url", "https://gw.peagen.com", "task", "get", "{task_id}"]

--- a/pkgs/standards/peagen/tests/sequence_success/test_sequences_success.py
+++ b/pkgs/standards/peagen/tests/sequence_success/test_sequences_success.py
@@ -1,22 +1,58 @@
+import re
 import subprocess
 from pathlib import Path
+
 import yaml
 import pytest
 
 EXAMPLES = Path(__file__).resolve().parent / "examples"
 
 
-def _load_commands(path: Path, tmpdir: Path) -> list[list[str]]:
-    data = yaml.safe_load(path.read_text())
-    cmds = []
-    for cmd in data.get("commands", []):
-        cmds.append([part.replace("{tmpdir}", str(tmpdir)) for part in cmd])
-    return cmds
+def _load_command_batches(path: Path, tmpdir: Path) -> list[list[list[str]]]:
+    """Return a list of command batches from ``path``."""
+    data = yaml.safe_load(path.read_text()) or {}
+    batches: list[list[list[str]]] = []
+
+    if "command_sets" in data:
+        for entry in data["command_sets"]:
+            batch = entry.get("batch", entry)
+            cmds = [
+                [part.replace("{tmpdir}", str(tmpdir)) for part in cmd]
+                for cmd in batch.get("commands", [])
+            ]
+            if cmds:
+                batches.append(cmds)
+
+    elif "batches" in data:
+        for batch in data["batches"]:
+            cmds = [
+                [part.replace("{tmpdir}", str(tmpdir)) for part in cmd] for cmd in batch
+            ]
+            if cmds:
+                batches.append(cmds)
+
+    elif "commands" in data:
+        cmds = [
+            [part.replace("{tmpdir}", str(tmpdir)) for part in cmd]
+            for cmd in data["commands"]
+        ]
+        if cmds:
+            batches.append(cmds)
+
+    return batches
 
 
 @pytest.mark.sequence_success
 @pytest.mark.parametrize("example", sorted(EXAMPLES.glob("*.yaml")))
 def test_sequences_success(example: Path, tmp_path: Path) -> None:
-    for cmd in _load_commands(example, tmp_path):
-        result = subprocess.run(["peagen", *cmd], capture_output=True, text=True)
-        assert result.returncode == 0, result.stdout + result.stderr
+    for batch in _load_command_batches(example, tmp_path):
+        task_id: str | None = None
+        for cmd in batch:
+            parts = [p.replace("{task_id}", task_id or "") for p in cmd]
+            result = subprocess.run(["peagen", *parts], capture_output=True, text=True)
+            assert result.returncode == 0, result.stdout + result.stderr
+
+            if task_id is None:
+                match = re.search(r"taskId=([0-9a-f-]+)", result.stdout)
+                if match:
+                    task_id = match.group(1)


### PR DESCRIPTION
## Summary
- restructure `demo_success.yaml` using `command_sets` with named batches
- update sequence success loader to handle the new format
- compute pagination info earlier to avoid undefined variables in the TUI app

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format .`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_685abb783a6c83269a5851171c1bc1fa