### PR TITLE
Add repo check in worker

### DIFF
--- a/pkgs/standards/peagen/peagen/errors.py
+++ b/pkgs/standards/peagen/peagen/errors.py
@@ -105,6 +105,13 @@ class MissingActionError(SchedulerError):
         super().__init__("Task payload missing 'action' key")
 
 
+class MissingRepoError(SchedulerError):
+    """Raised when a task payload lacks the required 'repo' key."""
+
+    def __init__(self) -> None:
+        super().__init__("Task payload missing 'repo' key")
+
+
 class NoWorkerAvailableError(SchedulerError):
     """Raised when no worker supports the requested action in the pool."""
 

--- a/pkgs/standards/peagen/peagen/tui/app.py
+++ b/pkgs/standards/peagen/peagen/tui/app.py
@@ -587,6 +587,9 @@ class QueueDashboardApp(App):
         self.fail_len = metrics_data.get("fail_len", 0)
         self.worker_len = metrics_data.get("worker_len", 0)
 
+        current_page = self.offset // self.limit + 1
+        total_pages = max(1, math.ceil(self.queue_len / self.limit))
+
         if hasattr(self, "workers_view"):
             self.workers_view.update_workers(workers_data)
 

--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -209,6 +209,12 @@ class WorkerBase:
         task_id = task.get("id")
         payload = task.get("payload", {})
         action = payload.get("action")
+        args = payload.get("args", {})
+
+        if "repo" not in args:
+            from peagen.errors import MissingRepoError
+
+            raise MissingRepoError()
 
         if action not in self._handler_registry:
             await self._notify(


### PR DESCRIPTION
## Summary
- add `MissingRepoError` for tasks without a repo
- raise `MissingRepoError` in `WorkerBase._run_task`
- fix undefined variables in TUI footer logic

## Testing
- `uv run --directory standards/peagen --package peagen ruff format .`
- `uv run --directory standards/peagen --package peagen ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_685abcaacc888326a6cd62675ef75e1e