### PR TITLE
Improve peagen error handling

### DIFF
--- a/pkgs/standards/peagen/peagen/_utils/_jinja.py
+++ b/pkgs/standards/peagen/peagen/_utils/_jinja.py
@@ -50,9 +50,9 @@ def _build_jinja_env(
             seen.add(p)
 
     if not search_paths:
-        raise RuntimeError(
-            "No valid template directories found — check plugin installation and .peagen.toml"
-        )
+        from peagen.errors import TemplateSearchPathError
+
+        raise TemplateSearchPathError()
 
     return Environment(
         loader=FileSystemLoader(search_paths),

--- a/pkgs/standards/peagen/peagen/_utils/_template_sets.py
+++ b/pkgs/standards/peagen/peagen/_utils/_template_sets.py
@@ -59,7 +59,9 @@ def install_template_sets(specs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
             else:
                 raise ValueError(f"unknown template-set type: {typ}")
         except Exception as exc:
-            raise RuntimeError(f"failed to install template-set {name}: {exc}") from exc
+            from peagen.errors import TemplateSetInstallError
+
+            raise TemplateSetInstallError(name, str(exc)) from exc
         # try to resolve installed version
         version = "unknown"
         try:

--- a/pkgs/standards/peagen/peagen/core/process_core.py
+++ b/pkgs/standards/peagen/peagen/core/process_core.py
@@ -77,16 +77,16 @@ def load_projects_payload(
             str(projects_payload) if isinstance(projects_payload, str) else None,
         )
 
-    errors = _collect_errors(doc, PROJECTS_PAYLOAD_V1_SCHEMA)
-    if errors:
-        raise ProjectsPayloadValidationError(
-            errors, str(projects_payload) if isinstance(projects_payload, str) else None
-        )
-
     projects = doc.get("PROJECTS")
     if not isinstance(projects, list):
         raise MissingProjectsListError(
             str(projects_payload) if isinstance(projects_payload, str) else None
+        )
+
+    errors = _collect_errors(doc, PROJECTS_PAYLOAD_V1_SCHEMA)
+    if errors:
+        raise ProjectsPayloadValidationError(
+            errors, str(projects_payload) if isinstance(projects_payload, str) else None
         )
     return projects
 

--- a/pkgs/standards/peagen/peagen/core/sort_core.py
+++ b/pkgs/standards/peagen/peagen/core/sort_core.py
@@ -272,7 +272,9 @@ def sort_file_records(
         else:
             sorted_records = _topological_sort(file_records)
     except Exception as exc:  # noqa: BLE001
-        raise RuntimeError(f"Dependency sort failed: {exc}") from exc
+        from peagen.errors import DependencySortError
+
+        raise DependencySortError(str(exc)) from exc
 
     # -- apply positional skipping ------------------------------------------
     if start_file and not transitive:

--- a/pkgs/standards/peagen/peagen/core/templates_core.py
+++ b/pkgs/standards/peagen/peagen/core/templates_core.py
@@ -129,7 +129,11 @@ def add_template_set(
             stderr=subprocess.STDOUT,
         )
     except subprocess.CalledProcessError as exc:
-        raise RuntimeError(exc.stdout or "installation failed") from exc
+        from peagen.errors import TemplateSetInstallError
+
+        raise TemplateSetInstallError(
+            source, exc.stdout or "installation failed"
+        ) from exc
 
     sets_after = set(discover_template_sets().keys())
     new_sets = sorted(sets_after - sets_before)
@@ -176,7 +180,11 @@ def remove_template_set(
             stderr=subprocess.STDOUT,
         )
     except subprocess.CalledProcessError as exc:
-        raise RuntimeError(exc.stdout or "uninstall failed") from exc
+        from peagen.errors import TemplateSetUninstallError
+
+        raise TemplateSetUninstallError(
+            dists, exc.stdout or "uninstall failed"
+        ) from exc
 
     remaining = discover_template_sets()
     return {"removed": name not in remaining, "dists": dists}

--- a/pkgs/standards/peagen/peagen/errors.py
+++ b/pkgs/standards/peagen/peagen/errors.py
@@ -43,6 +43,42 @@ class TemplateFileNotFoundError(FileNotFoundError):
         return f"Template file not found: {self.template_path}"
 
 
+class TemplateSetInstallError(RuntimeError):
+    """Raise when installing a template set distribution fails."""
+
+    def __init__(self, name: str, reason: str) -> None:
+        super().__init__(f"Failed to install template-set '{name}': {reason}")
+        self.name = name
+        self.reason = reason
+
+
+class TemplateSetUninstallError(RuntimeError):
+    """Raise when uninstalling a template set distribution fails."""
+
+    def __init__(self, names: Iterable[str], reason: str) -> None:
+        joined = ", ".join(names)
+        super().__init__(f"Failed to uninstall template-set(s) [{joined}]: {reason}")
+        self.names = list(names)
+        self.reason = reason
+
+
+class TemplateSearchPathError(RuntimeError):
+    """Raise when no valid template directories can be found."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "No valid template directories found — check plugin installation and .peagen.toml",
+        )
+
+
+class DependencySortError(RuntimeError):
+    """Raise when dependency sorting of file records fails."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(f"Dependency sort failed: {reason}")
+        self.reason = reason
+
+
 class GitOperationError(RuntimeError):
     """Raised when a git command fails."""
 

--- a/pkgs/standards/peagen/peagen/tui/app.py
+++ b/pkgs/standards/peagen/peagen/tui/app.py
@@ -715,6 +715,8 @@ class QueueDashboardApp(App):
         # NOTE: a footer widget is always present in this app; keep this check
         # to avoid future changes that assume otherwise.
         if hasattr(self, "footer"):
+            current_page = self.offset // self.limit + 1
+            total_pages = max(1, math.ceil(self.queue_len / self.limit))
             self.footer.set_page_info(current_page, total_pages)
             self.sub_title = f"Page {current_page} of {total_pages}"
 


### PR DESCRIPTION
## Summary
- define new descriptive exception classes in `peagen.errors`
- surface specific failures when installing/uninstalling template sets
- raise clear error if template search paths are missing
- use custom exception on dependency sorting errors
- fix pagination footer logic
- ensure schema validation runs after checking the project list

## Testing
- `uv run --directory pkgs/standards --package peagen ruff format .`
- `uv run --directory pkgs/standards --package peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_685ac047648c832698a1adcb116b8b7b