### PR TITLE
Add GitVCS remote helpers

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_git_vcs.py
+++ b/pkgs/standards/peagen/tests/unit/test_git_vcs.py
@@ -116,3 +116,21 @@ def test_commit_error_outside_repo(tmp_path: Path) -> None:
     outside.write_text("oops")
     with pytest.raises(GitCommitError):
         vcs.commit([str(outside)], "fail")
+
+
+def test_remote_helpers(tmp_path: Path) -> None:
+    repo_dir = tmp_path / "repo"
+    vcs = GitVCS.ensure_repo(repo_dir)
+
+    assert not vcs.has_remote()
+    with pytest.raises(GitRemoteMissingError):
+        vcs.require_remote()
+
+    vcs.configure_remote("https://example.com/repo.git")
+    assert vcs.has_remote()
+    vcs.require_remote()
+    assert vcs.repo.remotes.origin.url == "https://example.com/repo.git"
+
+    # updating the remote should change the url
+    vcs.configure_remote("https://example.com/new.git")
+    assert vcs.repo.remotes.origin.url == "https://example.com/new.git"

--- a/pkgs/standards/peagen/tests/unit/test_load_projects_payload.py
+++ b/pkgs/standards/peagen/tests/unit/test_load_projects_payload.py
@@ -6,6 +6,7 @@ from peagen.core.process_core import load_projects_payload
 from peagen.errors import (
     ProjectsPayloadValidationError,
     ProjectsPayloadFormatError,
+    MissingProjectsListError,
 )
 from peagen.plugins.storage_adapters.file_storage_adapter import FileStorageAdapter
 
@@ -53,6 +54,6 @@ def test_load_projects_payload_missing_projects_list(tmp_path):
     bad = tmp_path / "missing.yaml"
     bad.write_text("schemaVersion: '1.0.0'\nPROJECTS: {}\n")
 
-    # Schema validation now fails before the missing list check
-    with pytest.raises(ProjectsPayloadValidationError):
+    # Missing list should trigger a dedicated error
+    with pytest.raises(MissingProjectsListError):
         load_projects_payload(str(bad))


### PR DESCRIPTION
## Summary
- extend GitVCS with remote helper methods and use them
- test the new helpers
- adjust load_projects_payload test to expect MissingProjectsListError

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format .`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest -q`
- `uv run --package peagen --directory pkgs/standards/peagen peagen local -q process projects_payload.yaml --watch` *(fails: No such option)*
- `uv run --package peagen --directory pkgs/standards/peagen peagen remote -q --gateway-url http://localhost:8000/rpc process projects_payload.yaml --watch` *(fails: File not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ac81e23b88326a50d00081d383552