### PR TITLE
Add two-user secret exchange i9n test

### DIFF
--- a/pkgs/standards/peagen/tests/i9n/two_user_secret_exchange_i9n_test.py
+++ b/pkgs/standards/peagen/tests/i9n/two_user_secret_exchange_i9n_test.py
@@ -1,0 +1,190 @@
+import json
+import os
+import subprocess
+import pathlib
+import shutil
+
+import httpx
+import pytest
+
+GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
+
+
+def _gateway_available(url: str) -> bool:
+    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}}
+    try:
+        response = httpx.post(url, json=envelope, timeout=5)
+    except Exception:
+        return False
+    return response.status_code == 200
+
+
+@pytest.mark.i9n
+def test_two_user_secret_exchange(tmp_path: pathlib.Path) -> None:
+    if not _gateway_available(GATEWAY):
+        pytest.skip("gateway not reachable")
+
+    user1_home = tmp_path / "user1"
+    user2_home = tmp_path / "user2"
+    user1_key_dir = user1_home / "keys"
+    user2_key_dir = user2_home / "keys"
+
+    # create expected locations for the CLI
+    (user1_home / ".peagen").mkdir(parents=True, exist_ok=True)
+    (user2_home / ".peagen").mkdir(parents=True, exist_ok=True)
+
+    subprocess.run(
+        [
+            "peagen",
+            "keys",
+            "create",
+            "--key-dir",
+            str(user1_key_dir),
+        ],
+        check=True,
+        timeout=60,
+    )
+    # move key pair to HOME/.peagen/keys for CLI use
+    shutil.copytree(user1_key_dir, user1_home / ".peagen" / "keys")
+    subprocess.run(
+        [
+            "peagen",
+            "keys",
+            "create",
+            "--key-dir",
+            str(user2_key_dir),
+        ],
+        check=True,
+        timeout=60,
+    )
+    shutil.copytree(user2_key_dir, user2_home / ".peagen" / "keys")
+
+    subprocess.run(
+        [
+            "peagen",
+            "login",
+            "--gateway-url",
+            GATEWAY,
+            "--key-dir",
+            str(user1_key_dir),
+        ],
+        check=True,
+        timeout=60,
+    )
+    subprocess.run(
+        [
+            "peagen",
+            "login",
+            "--gateway-url",
+            GATEWAY,
+            "--key-dir",
+            str(user2_key_dir),
+        ],
+        check=True,
+        timeout=60,
+    )
+
+    result = subprocess.run(
+        [
+            "peagen",
+            "keys",
+            "list",
+            "--key-dir",
+            str(user1_key_dir),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=60,
+    )
+    data = json.loads(result.stdout)
+    fingerprint = next(iter(data))
+
+    result = subprocess.run(
+        [
+            "peagen",
+            "keys",
+            "show",
+            fingerprint,
+            "--key-dir",
+            str(user1_key_dir),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=60,
+    )
+    pub_path = tmp_path / "user1_pub.asc"
+    pub_path.write_text(result.stdout)
+
+    env2 = os.environ.copy()
+    env2["HOME"] = str(user2_home)
+    subprocess.run(
+        [
+            "peagen",
+            "remote",
+            "--gateway-url",
+            GATEWAY,
+            "secrets",
+            "add",
+            "shared-secret",
+            "the_secret",
+            "--recipient",
+            str(pub_path),
+        ],
+        env=env2,
+        check=True,
+        timeout=60,
+    )
+
+    res2 = subprocess.run(
+        [
+            "peagen",
+            "remote",
+            "--gateway-url",
+            GATEWAY,
+            "secrets",
+            "get",
+            "shared-secret",
+        ],
+        env=env2,
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=60,
+    )
+    assert "the_secret" in res2.stdout
+
+    env1 = os.environ.copy()
+    env1["HOME"] = str(user1_home)
+    res1 = subprocess.run(
+        [
+            "peagen",
+            "remote",
+            "--gateway-url",
+            GATEWAY,
+            "secrets",
+            "get",
+            "shared-secret",
+        ],
+        env=env1,
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=60,
+    )
+    assert "the_secret" in res1.stdout
+
+    subprocess.run(
+        [
+            "peagen",
+            "remote",
+            "--gateway-url",
+            GATEWAY,
+            "secrets",
+            "remove",
+            "shared-secret",
+        ],
+        check=True,
+        timeout=60,
+    )


### PR DESCRIPTION
## Summary
- verify peagen remote secret exchange with two users
- ensure each user can decrypt the other's secret

## Testing
- `uv run --directory standards --package peagen ruff check . --fix`
- `uv run --package peagen --directory standards pytest peagen/tests/i9n/two_user_secret_exchange_i9n_test.py`

------
https://chatgpt.com/codex/tasks/task_e_685ac9e9dd308326bd7e4a66dfe592e3