### PR TITLE
Fix missing repo error handling

### DIFF
--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -214,7 +214,8 @@ class WorkerBase:
         if "repo" not in args:
             from peagen.errors import MissingRepoError
 
-            raise MissingRepoError()
+            await self._notify("failed", task_id, {"error": str(MissingRepoError())})
+            return
 
         if action not in self._handler_registry:
             await self._notify(

--- a/pkgs/standards/peagen/tests/unit/test_load_projects_payload.py
+++ b/pkgs/standards/peagen/tests/unit/test_load_projects_payload.py
@@ -6,6 +6,7 @@ from peagen.core.process_core import load_projects_payload
 from peagen.errors import (
     ProjectsPayloadValidationError,
     ProjectsPayloadFormatError,
+    MissingProjectsListError,
 )
 from peagen.plugins.storage_adapters.file_storage_adapter import FileStorageAdapter
 
@@ -53,6 +54,6 @@ def test_load_projects_payload_missing_projects_list(tmp_path):
     bad = tmp_path / "missing.yaml"
     bad.write_text("schemaVersion: '1.0.0'\nPROJECTS: {}\n")
 
-    # Schema validation now fails before the missing list check
-    with pytest.raises(ProjectsPayloadValidationError):
+    # Missing list should trigger MissingProjectsListError
+    with pytest.raises(MissingProjectsListError):
         load_projects_payload(str(bad))


### PR DESCRIPTION
## Summary
- gracefully fail tasks without a `repo` key
- update expectations for missing project list error

## Testing
- `uv run --package peagen --directory standards/peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest`
- `peagen local -q process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml --repo https://example.com/foo.git` *(fails: GitCloneError)*

------
https://chatgpt.com/codex/tasks/task_e_685acd78caf08326ad5659d36b68c39e