### PR TITLE
Improve projects payload loader PathLike support

### DIFF
--- a/pkgs/standards/peagen/peagen/core/process_core.py
+++ b/pkgs/standards/peagen/peagen/core/process_core.py
@@ -3,6 +3,7 @@
 import os
 import yaml
 from pathlib import Path
+from os import PathLike
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from swarmauri_standard.loggers.Logger import Logger
@@ -32,7 +33,7 @@ logger = Logger(name=__name__)
 
 
 def load_projects_payload(
-    projects_payload: Union[str, List[Dict[str, Any]], Dict[str, Any]],
+    projects_payload: Union[str, PathLike[str], List[Dict[str, Any]], Dict[str, Any]],
 ) -> List[Dict[str, Any]]:
     """Return the list of projects from a payload value.
 
@@ -44,6 +45,8 @@ def load_projects_payload(
         doc = projects_payload
     else:
         try:
+            if isinstance(projects_payload, PathLike):
+                projects_payload = os.fspath(projects_payload)
             maybe_path = Path(projects_payload)
             if maybe_path.is_file():
                 yaml_text = maybe_path.read_text(encoding="utf-8")

--- a/pkgs/standards/peagen/tests/unit/test_load_projects_payload.py
+++ b/pkgs/standards/peagen/tests/unit/test_load_projects_payload.py
@@ -54,7 +54,16 @@ def test_load_projects_payload_missing_projects_list(tmp_path):
     bad = tmp_path / "missing.yaml"
     bad.write_text("schemaVersion: '1.0.0'\nPROJECTS: {}\n")
 
-
     # Missing list should trigger a dedicated error
     with pytest.raises(MissingProjectsListError):
         load_projects_payload(str(bad))
+
+
+@pytest.mark.unit
+def test_load_projects_payload_path_object(tmp_path):
+    bad = tmp_path / "missing.yaml"
+    bad.write_text("schemaVersion: '1.0.0'\nPROJECTS: {}\n")
+
+    # PathLike values should be accepted
+    with pytest.raises(MissingProjectsListError):
+        load_projects_payload(bad)


### PR DESCRIPTION
## Summary
- allow `Path` objects in `load_projects_payload`
- cover new behaviour with a unit test

## Testing
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_load_projects_payload.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685ad05eceac83268329363af22e6736