### PR TITLE
Add remote workflow guide and extend sequence tests

### DIFF
--- a/docs/docs/guide/peagen_remote_workflow.md
+++ b/docs/docs/guide/peagen_remote_workflow.md
@@ -1,0 +1,34 @@
+# Remote DOE Process and Evolve Workflow
+
+This guide explains how to run a DOE process remotely using the public gateway and then launch an evolve job. The gateway URL used throughout is `https://gw.peagen.com`.
+
+1. **Login to the gateway**
+   ```bash
+   peagen login --gateway-url https://gw.peagen.com
+   ```
+2. **Fetch the server key**
+   ```bash
+   peagen keys fetch-server --gateway-url https://gw.peagen.com
+   ```
+3. **Submit a DOE processing task**
+   ```bash
+   peagen remote --gateway-url https://gw.peagen.com \
+     doe process SPEC.yaml TEMPLATE.yaml --watch
+   ```
+   The command prints a `taskId` once submitted and streams status updates while `--watch` is active.
+4. **Run an evolve job**
+   ```bash
+   peagen remote --gateway-url https://gw.peagen.com \
+     evolve EVOLVE_SPEC.yaml --watch
+   ```
+5. **Check task status**
+   ```bash
+   peagen remote --gateway-url https://gw.peagen.com task get <taskId>
+   ```
+6. **Fetch generated artifacts**
+   ```bash
+   peagen fetch WORKSPACE_URI
+   ```
+   Replace `WORKSPACE_URI` with the URI returned by the evolve job.
+
+A successful run will report `"status": "success"` and the fetched workspace should contain the expected artifacts.

--- a/pkgs/standards/peagen/tests/sequence_success/examples/demo_success.yaml
+++ b/pkgs/standards/peagen/tests/sequence_success/examples/demo_success.yaml
@@ -1,4 +1,4 @@
-command_sets:
+batches:
   - batch:
       name: "project setup"
       desc: "initialize a project"
@@ -17,3 +17,12 @@ command_sets:
         - ["login", "--gateway-url", "https://gw.peagen.com"]
         - ["remote", "--gateway-url", "https://gw.peagen.com", "secrets", "add", "test_secret", "secret_value"]
         - ["remote", "--gateway-url", "https://gw.peagen.com", "secrets", "get", "test_secret"]
+  - batch:
+      name: "remote doe and evolve"
+      desc: "process DOE spec then evolve and check status"
+      commands:
+        - ["login", "--gateway-url", "https://gw.peagen.com"]
+        - ["keys", "fetch-server", "--gateway-url", "https://gw.peagen.com"]
+        - ["remote", "--gateway-url", "https://gw.peagen.com", "doe", "process", "tests/examples/gateway_demo/doe_spec.yaml", "tests/examples/gateway_demo/template_project.yaml", "--output", "{tmpdir}/payload.yaml"]
+        - ["remote", "--gateway-url", "https://gw.peagen.com", "evolve", "tests/examples/simple_evolve_demo/evolve_remote_spec.yaml", "--watch"]
+        - ["remote", "--gateway-url", "https://gw.peagen.com", "task", "get", "{task_id}"]


### PR DESCRIPTION
## Summary
- document how to run a DOE process and evolve job via `peagen remote`
- extend `demo_success.yaml` to demonstrate multiple command batches

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest` *(fails: two_user_secret_exchange_i9n_test.py)*

------
https://chatgpt.com/codex/tasks/task_e_685ad50bdd2c8326854a8afeb845acc4