### PR TITLE
Add task relation models

### DIFF
--- a/pkgs/standards/peagen/peagen/models/__init__.py
+++ b/pkgs/standards/peagen/peagen/models/__init__.py
@@ -31,10 +31,14 @@ from .repo.repository_user_association import RepositoryUserAssociation  # noqa:
 # ----------------------------------------------------------------------
 # Task / execution domain
 # ----------------------------------------------------------------------
-from .task.status import Status  # noqa: F401  
+from .task.status import Status  # noqa: F401
 from .task.task_payload import TaskPayload  # noqa: F401
 from .task.raw_blob import RawBlob  # noqa: F401
 from .task.task_run import TaskRun, TaskRunDep  # noqa: F401
+from .task.task_relation import TaskRelation  # noqa: F401
+from .task.task_run_task_relation_association import (
+    TaskRunTaskRelationAssociation,
+)  # noqa: F401
 from .task.project_task_association import ProjectTaskAssociation  # noqa: F401
 
 # ----------------------------------------------------------------------
@@ -86,8 +90,10 @@ __all__: list[str] = [
     # task
     "TaskPayload",
     "RawBlob",
+    "TaskRelation",
     "Status",
     "TaskRun",
+    "TaskRunTaskRelationAssociation",
     "TaskRunDep",
     "ProjectTaskAssociation",
     # evolution

--- a/pkgs/standards/peagen/peagen/models/task/task_relation.py
+++ b/pkgs/standards/peagen/peagen/models/task/task_relation.py
@@ -1,0 +1,25 @@
+"""
+peagen.models.task.task_relation
+================================
+
+Defines a named relationship that can be attached to task runs.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ..base import BaseModel
+
+
+class TaskRelation(BaseModel):
+    """A reusable task relation definition."""
+
+    __tablename__ = "task_relations"
+
+    name: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+    description: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"<TaskRelation name={self.name!r}>"

--- a/pkgs/standards/peagen/peagen/models/task/task_run.py
+++ b/pkgs/standards/peagen/peagen/models/task/task_run.py
@@ -18,7 +18,7 @@ from sqlalchemy import JSON, Enum, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from ..base import BaseModel                               # id, timestamps
+from ..base import BaseModel  # id, timestamps
 from .status import Status
 
 
@@ -61,17 +61,11 @@ class TaskRun(BaseModel):
     )
 
     # ────────────────── Relationships ───────────────────────
-    task_payload: Mapped["TaskPayload"] = relationship(
-        "TaskPayload", lazy="selectin"
-    )
+    task_payload: Mapped["TaskPayload"] = relationship("TaskPayload", lazy="selectin")
 
-    pool: Mapped["Pool | None"] = relationship(
-        "Pool", lazy="selectin"
-    )
+    pool: Mapped["Pool | None"] = relationship("Pool", lazy="selectin")
 
-    worker: Mapped["Worker | None"] = relationship(
-        "Worker", lazy="selectin"
-    )
+    worker: Mapped["Worker | None"] = relationship("Worker", lazy="selectin")
 
     # DAG dependencies
     dependencies: Mapped[list["TaskRun"]] = relationship(
@@ -93,3 +87,23 @@ class TaskRun(BaseModel):
     # ────────────────────── Magic ───────────────────────────
     def __repr__(self) -> str:  # pragma: no cover
         return f"<TaskRun id={self.id} status={self.status}>"
+
+
+class TaskRunDep(BaseModel):
+    """Association table capturing simple task run dependencies."""
+
+    __tablename__ = "task_run_deps"
+
+    task_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("task_runs.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    dep_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("task_runs.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"<TaskRunDep {self.task_id} depends_on {self.dep_id}>"

--- a/pkgs/standards/peagen/peagen/models/task/task_run_task_relation_association.py
+++ b/pkgs/standards/peagen/peagen/models/task/task_run_task_relation_association.py
@@ -1,0 +1,42 @@
+"""
+peagen.models.task.task_run_task_relation_association
+=====================================================
+
+Join table linking a TaskRun with a TaskRelation.
+"""
+
+from __future__ import annotations
+
+import uuid
+from sqlalchemy import ForeignKey, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from ..base import BaseModel
+
+
+class TaskRunTaskRelationAssociation(BaseModel):
+    """Association between a task run and a task relation."""
+
+    __tablename__ = "task_run_task_relation_associations"
+
+    task_run_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("task_runs.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    relation_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("task_relations.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    __table_args__ = (
+        UniqueConstraint("task_run_id", "relation_id", name="uq_taskrun_taskrelation"),
+    )
+
+    task_run: Mapped["TaskRun"] = relationship("TaskRun", lazy="selectin")
+    relation: Mapped["TaskRelation"] = relationship("TaskRelation", lazy="selectin")
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"<TaskRunTaskRelationAssociation run={self.task_run_id} relation={self.relation_id}>"


### PR DESCRIPTION
## Summary
- add new task relation and association tables to ORM
- expose TaskRelation and TaskRunTaskRelationAssociation
- add TaskRunDep association table for task dependencies

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format .`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix` *(fails: F821 undefined names)*
- `uv run --package peagen --directory pkgs/standards/peagen pytest` *(fails: 38 errors during collection)*
- `peagen remote -q process projects_payload.yaml --watch` *(fails: ModuleNotFoundError)*
- `peagen local -q process projects_payload.yaml --watch` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685bcd48ce5083268aed2f13969c88b6