### PR TITLE
Update Peagen models

### DIFF
--- a/pkgs/standards/peagen/peagen/models/__init__.py
+++ b/pkgs/standards/peagen/peagen/models/__init__.py
@@ -26,12 +26,15 @@ from .tenant.tenant_user_association import TenantUserAssociation  # noqa: F401
 from .repo.repository import Repository  # noqa: F401
 from .repo.git_reference import GitReference  # noqa: F401
 from .repo.deploy_key import DeployKey  # noqa: F401
+from .repo.repository_deploy_key_association import (
+    RepositoryDeployKeyAssociation,
+)  # noqa: F401
 from .repo.repository_user_association import RepositoryUserAssociation  # noqa: F401
 
 # ----------------------------------------------------------------------
 # Task / execution domain
 # ----------------------------------------------------------------------
-from .task.status import Status  # noqa: F401  
+from .task.status import Status  # noqa: F401
 from .task.task_payload import TaskPayload  # noqa: F401
 from .task.raw_blob import RawBlob  # noqa: F401
 from .task.task_run import TaskRun, TaskRunDep  # noqa: F401
@@ -82,6 +85,7 @@ __all__: list[str] = [
     "Repository",
     "GitReference",
     "DeployKey",
+    "RepositoryDeployKeyAssociation",
     "RepositoryUserAssociation",
     # task
     "TaskPayload",

--- a/pkgs/standards/peagen/peagen/models/repo/repository.py
+++ b/pkgs/standards/peagen/peagen/models/repo/repository.py
@@ -36,9 +36,13 @@ class Repository(BaseModel):
     tenant_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
     )
-    name: Mapped[str] = mapped_column(String, nullable=False)           # logical repo name
-    url: Mapped[str] = mapped_column(String, nullable=False)            # canonical remote URL (Gitea / GitHub)
-    description: Mapped[str] = mapped_column(String, nullable=True)     # optional human description
+    name: Mapped[str] = mapped_column(String, nullable=False)  # logical repo name
+    url: Mapped[str] = mapped_column(
+        String, nullable=False
+    )  # canonical remote URL (Gitea / GitHub)
+    description: Mapped[str] = mapped_column(
+        String, nullable=True
+    )  # optional human description
     default_branch: Mapped[str] = mapped_column(String, nullable=True)  # e.g. "main"
 
     # Enforce unique repo names *within* each tenant
@@ -58,10 +62,19 @@ class Repository(BaseModel):
         lazy="selectin",
     )
 
+    deploy_key_associations: Mapped[list["RepositoryDeployKeyAssociation"]] = (
+        relationship(
+            "RepositoryDeployKeyAssociation",
+            back_populates="repository",
+            cascade="all, delete-orphan",
+            lazy="selectin",
+        )
+    )
+
     deploy_keys: Mapped[list["DeployKey"]] = relationship(
         "DeployKey",
-        back_populates="repository",
-        cascade="all, delete-orphan",
+        secondary="repository_deploy_key_associations",
+        back_populates="repositories",
         lazy="selectin",
     )
 

--- a/pkgs/standards/peagen/peagen/models/repo/repository_deploy_key_association.py
+++ b/pkgs/standards/peagen/peagen/models/repo/repository_deploy_key_association.py
@@ -1,0 +1,55 @@
+"""
+peagen.models.repo.repository_deploy_key_association
+===================================================
+
+Join table linking DeployKeys to Repositories.
+
+Each deploy key belongs to a user and may be attached to many repositories via
+this association table.
+"""
+
+from __future__ import annotations
+
+import uuid
+from sqlalchemy import UniqueConstraint, ForeignKey
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from ..base import BaseModel
+
+
+class RepositoryDeployKeyAssociation(BaseModel):
+    """Associates a deploy key with a repository."""
+
+    __tablename__ = "repository_deploy_key_associations"
+
+    # ----------------------------- Columns -----------------------------
+    repository_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("repositories.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    deploy_key_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("deploy_keys.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "repository_id",
+            "deploy_key_id",
+            name="uq_repository_deploy_key",
+        ),
+    )
+
+    # --------------------------- Relationships ---------------------------
+    repository: Mapped["Repository"] = relationship(
+        "Repository", back_populates="deploy_key_associations", lazy="selectin"
+    )
+    deploy_key: Mapped["DeployKey"] = relationship(
+        "DeployKey", back_populates="repository_associations", lazy="selectin"
+    )
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"<RepositoryDeployKeyAssociation repo={self.repository_id} key={self.deploy_key_id}>"

--- a/pkgs/standards/peagen/peagen/models/specs/doe_spec.py
+++ b/pkgs/standards/peagen/peagen/models/specs/doe_spec.py
@@ -7,7 +7,7 @@ Design-of-Experiments (DOE) specification.
 Key Features
 ------------
 • Scoped to a Tenant  (multi-workspace isolation).
-• Optional linkage to a ProjectPayload  (many DOE specs per project).
+• Can produce multiple ProjectPayloads.
 • Stores a semantic version tag (`schema_version`) and the raw spec JSON.
 • Uniqueness: DOE spec `name` must be unique **within** its tenant.
 """
@@ -34,12 +34,6 @@ class DoeSpec(BaseModel):
         UUID(as_uuid=True),
         ForeignKey("tenants.id", ondelete="CASCADE"),
         nullable=False,
-    )
-
-    project_payload_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True),
-        ForeignKey("project_payloads.id", ondelete="SET NULL"),
-        nullable=True,
     )
 
     name: Mapped[str] = mapped_column(
@@ -74,9 +68,10 @@ class DoeSpec(BaseModel):
     # ───────────────── Relationships ───────────────────
     tenant: Mapped["Tenant"] = relationship("Tenant", lazy="selectin")
 
-    project_payload: Mapped["ProjectPayload | None"] = relationship(
+    project_payloads: Mapped[list["ProjectPayload"]] = relationship(
         "ProjectPayload",
-        back_populates="doe_specs",
+        back_populates="doe_spec",
+        cascade="all, delete-orphan",
         lazy="selectin",
     )
 

--- a/pkgs/standards/peagen/peagen/models/specs/evolve_spec.py
+++ b/pkgs/standards/peagen/peagen/models/specs/evolve_spec.py
@@ -7,7 +7,6 @@ Genetic / evolutionary optimisation specification.
 Highlights
 ----------
 • Scoped to a Tenant (workspace isolation).
-• Optional link to a ProjectPayload (many evolve specs per project).
 • Stores a semver `schema_version` and raw spec JSON.
 • Enforces unique `name` within each tenant.
 """
@@ -34,12 +33,6 @@ class EvolveSpec(BaseModel):
         UUID(as_uuid=True),
         ForeignKey("tenants.id", ondelete="CASCADE"),
         nullable=False,
-    )
-
-    project_payload_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True),
-        ForeignKey("project_payloads.id", ondelete="SET NULL"),
-        nullable=True,
     )
 
     name: Mapped[str] = mapped_column(
@@ -73,12 +66,6 @@ class EvolveSpec(BaseModel):
 
     # ───────────────── Relationships ───────────────────
     tenant: Mapped["Tenant"] = relationship("Tenant", lazy="selectin")
-
-    project_payload: Mapped["ProjectPayload | None"] = relationship(
-        "ProjectPayload",
-        back_populates="evolve_specs",
-        lazy="selectin",
-    )
 
     # ───────────────────── Magic ───────────────────────
     def __repr__(self) -> str:  # pragma: no cover

--- a/pkgs/standards/peagen/peagen/models/task/task_run.py
+++ b/pkgs/standards/peagen/peagen/models/task/task_run.py
@@ -18,7 +18,7 @@ from sqlalchemy import JSON, Enum, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from ..base import BaseModel                               # id, timestamps
+from ..base import BaseModel  # id, timestamps
 from .status import Status
 
 
@@ -48,6 +48,12 @@ class TaskRun(BaseModel):
         nullable=True,
     )
 
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
     status: Mapped[Status] = mapped_column(
         Enum(Status, name="task_status_enum"),
         nullable=False,
@@ -61,24 +67,22 @@ class TaskRun(BaseModel):
     )
 
     # ────────────────── Relationships ───────────────────────
-    task_payload: Mapped["TaskPayload"] = relationship(
-        "TaskPayload", lazy="selectin"
-    )
+    task_payload: Mapped["TaskPayload"] = relationship("TaskPayload", lazy="selectin")
 
-    pool: Mapped["Pool | None"] = relationship(
-        "Pool", lazy="selectin"
-    )
+    pool: Mapped["Pool | None"] = relationship("Pool", lazy="selectin")
 
-    worker: Mapped["Worker | None"] = relationship(
-        "Worker", lazy="selectin"
-    )
+    worker: Mapped["Worker | None"] = relationship("Worker", lazy="selectin")
+
+    user: Mapped["User | None"] = relationship("User", lazy="selectin")
 
     # join-rows
-    relation_associations: Mapped[list["TaskRunTaskRelationAssociation"]] = relationship(
-        "TaskRunTaskRelationAssociation",
-        back_populates="task_run",
-        cascade="all, delete-orphan",
-        lazy="selectin",
+    relation_associations: Mapped[list["TaskRunTaskRelationAssociation"]] = (
+        relationship(
+            "TaskRunTaskRelationAssociation",
+            back_populates="task_run",
+            cascade="all, delete-orphan",
+            lazy="selectin",
+        )
     )
 
     # convenience list of TaskRelation objects


### PR DESCRIPTION
## Summary
- refactor deploy key model to belong to users via new association table
- update repository to use many-to-many deploy keys
- link project payloads back to DOE specs and drop evolve spec link
- allow tracking task executions by user

## Testing
- `uv run --directory standards --package peagen ruff format .` *(fails: No such file or directory)*
- `uv run --directory standards --package peagen ruff check . --fix` *(fails: F821 errors)*
- `uv run --package peagen --directory standards pytest` *(fails: 95 errors)*
- `peagen local -q process standards/peagen/tests/examples/projects_payloads/projects_payload.yaml --watch` *(failed to run)*
- `peagen remote -q --gateway-url http://localhost:8000/rpc process standards/peagen/tests/examples/projects_payloads/projects_payload.yaml --watch` *(failed to run)*

------
https://chatgpt.com/codex/tasks/task_e_685cfb3dacc083268d9bcc0ab4eb0b2f