### PR TITLE
Add mirror git settings for peagen

### DIFF
--- a/.peagen.toml
+++ b/.peagen.toml
@@ -93,4 +93,10 @@ default_evaluator = "performance"
 
 [vcs]
 provider = "git"
+provider_params = {
+    path = ".",
+    mirror_git_url = "${MIRROR_GIT_URL}",
+    mirror_git_token = "${MIRROR_GIT_TOKEN}",
+    owner = "${OWNER}"
+}
 default_vcs = "git"

--- a/infra/.gw.peagen.toml
+++ b/infra/.gw.peagen.toml
@@ -44,5 +44,11 @@ dsn = "${PG_DSN}"
 # --- VCS ------------------------------------------------------------
 [vcs]
 provider = "git"
+provider_params = {
+    path = ".",
+    mirror_git_url = "${MIRROR_GIT_URL}",
+    mirror_git_token = "${MIRROR_GIT_TOKEN}",
+    owner = "${OWNER}"
+}
 default_vcs = "git"
 

--- a/infra/.worker.peagen.toml
+++ b/infra/.worker.peagen.toml
@@ -76,5 +76,11 @@ target_grade_level = 12
 # --- VCS ------------------------------------------------------------
 [vcs]
 provider = "git"
+provider_params = {
+    path = ".",
+    mirror_git_url = "${MIRROR_GIT_URL}",
+    mirror_git_token = "${MIRROR_GIT_TOKEN}",
+    owner = "${OWNER}"
+}
 default_vcs = "git"
 

--- a/pkgs/standards/peagen/peagen/defaults/__init__.py
+++ b/pkgs/standards/peagen/peagen/defaults/__init__.py
@@ -29,7 +29,15 @@ CONFIG = {
     "mutation": {
         "mutators": {"default_mutator": "DefaultMutator"},
     },
-    "vcs": {"default_vcs": "git"},
+    "vcs": {
+        "default_vcs": "git",
+        "provider_params": {
+            "path": ".",
+            "mirror_git_url": "",
+            "mirror_git_token": "",
+            "owner": "",
+        },
+    },
     "secrets": {"default_secret": "env", "adapters": {"env": {"prefix": ""}}},
 }
 


### PR DESCRIPTION
## Summary
- add provider params defaults for GitVCS
- expose MIRROR_GIT_URL, MIRROR_GIT_TOKEN and OWNER in `.peagen.toml`
- set gateway/worker defaults for the new parameters

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest` *(fails: 38 errors during collection)*
- `peagen local -q process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml --watch` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685d04d35bb48326b9f1231548b45f3f