### PR TITLE
Add mirror git config to peagen

### DIFF
--- a/infra/.gw.peagen.toml
+++ b/infra/.gw.peagen.toml
@@ -46,3 +46,8 @@ dsn = "${PG_DSN}"
 provider = "git"
 default_vcs = "git"
 
+[vcs.provider_params]
+mirror_git_url = "${MIRROR_GIT_URL}"
+mirror_git_token = "${MIRROR_GIT_TOKEN}"
+owner = "${OWNER}"
+

--- a/infra/.worker.peagen.toml
+++ b/infra/.worker.peagen.toml
@@ -78,3 +78,8 @@ target_grade_level = 12
 provider = "git"
 default_vcs = "git"
 
+[vcs.provider_params]
+mirror_git_url = "${MIRROR_GIT_URL}"
+mirror_git_token = "${MIRROR_GIT_TOKEN}"
+owner = "${OWNER}"
+

--- a/pkgs/standards/peagen/docs/git_vcs.md
+++ b/pkgs/standards/peagen/docs/git_vcs.md
@@ -17,6 +17,11 @@ run_ref = pea_ref("run", "exp-a")
 vcs.tag(run_ref)
 ```
 
+Git repositories can also push to a secondary **mirror**. Set
+``mirror_git_url`` and ``mirror_git_token`` under the ``[vcs.provider_params]``
+section in your ``.peagen.toml``.  When configured, :class:`GitVCS` pushes the
+same ref to the ``mirror`` remote after updating ``origin``.
+
 Git references follow the ``refs/pea/<kind>`` convention. Constants are
 exported for common prefixes such as :data:`RUN_REF`, :data:`PROMOTED_REF`,
 and :data:`KEY_AUDIT_REF`.

--- a/pkgs/standards/peagen/peagen/defaults/__init__.py
+++ b/pkgs/standards/peagen/peagen/defaults/__init__.py
@@ -29,7 +29,14 @@ CONFIG = {
     "mutation": {
         "mutators": {"default_mutator": "DefaultMutator"},
     },
-    "vcs": {"default_vcs": "git"},
+    "vcs": {
+        "default_vcs": "git",
+        "provider_params": {
+            "mirror_git_url": "",
+            "mirror_git_token": "",
+            "owner": "",
+        },
+    },
     "secrets": {"default_secret": "env", "adapters": {"env": {"prefix": ""}}},
 }
 


### PR DESCRIPTION
## Summary
- extend peagen GitVCS to support mirroring
- configure default mirror settings
- expose mirror params in gateway/worker configs
- document mirror usage
- add regression test for mirror push

## Testing
- `ruff check pkgs/standards/peagen/peagen/plugins/vcs/git_vcs.py --fix`
- `ruff check pkgs/standards/peagen/peagen/defaults/__init__.py --fix`
- `ruff check pkgs/standards/peagen/tests/unit/test_git_vcs.py --fix`
- `uv run --package peagen --directory standards/peagen pytest` *(fails: 38 errors during collection)*
- `peagen remote -q --gateway-url http://localhost:8000/rpc process projects_payload.yaml --watch` *(failed: ModuleNotFoundError)*
- `peagen local -q process projects_payload.yaml --watch` *(failed: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685d04d35bb48326b9f1231548b45f3f