### PR TITLE
Add MirrorResult model

### DIFF
--- a/pkgs/standards/peagen/peagen/models/__init__.py
+++ b/pkgs/standards/peagen/peagen/models/__init__.py
@@ -69,6 +69,7 @@ from .infra.pool_worker_association import PoolWorkerAssociation  # noqa: F401
 # ----------------------------------------------------------------------
 from .result.eval_result import EvalResult  # noqa: F401
 from .result.analysis_result import AnalysisResult  # noqa: F401
+from .mirror_result import MirrorResult  # noqa: F401
 
 # ----------------------------------------------------------------------
 # Misc / security
@@ -113,6 +114,7 @@ __all__: list[str] = [
     # result
     "EvalResult",
     "AnalysisResult",
+    "MirrorResult",
     # misc
     "AbuseRecord",
 ]

--- a/pkgs/standards/peagen/peagen/models/mirror_result.py
+++ b/pkgs/standards/peagen/peagen/models/mirror_result.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel, HttpUrl
+
+
+class MirrorResult(BaseModel):
+    """Result of :func:`ensure_mirror`."""
+
+    repo_uri: str
+    gitea_repo: HttpUrl
+    created: bool


### PR DESCRIPTION
## Summary
- add new `MirrorResult` model
- expose `MirrorResult` from `peagen.models`

## Testing
- `uv run --package peagen --directory standards/peagen ruff format peagen/models/mirror_result.py`
- `uv run --package peagen --directory standards/peagen ruff check peagen/models/mirror_result.py --fix`
- `uv run --package peagen --directory standards/peagen pytest -q` *(fails: ModuleNotFoundError)*
- `peagen --help` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685d052399708326941fa7944cc8b27d