### PR TITLE
Add preflight core scaffolding to peagen

### DIFF
--- a/pkgs/standards/peagen/peagen/core/preflight_core.py
+++ b/pkgs/standards/peagen/peagen/core/preflight_core.py
@@ -1,0 +1,63 @@
+"""preflight_core
+================
+
+Business logic for preflight environment checks.
+
+This module validates Peagen configuration, ensures a Git mirror
+repository exists and generates/registers an SSH deploy key when needed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from peagen.core.validate_core import validate_config
+from peagen.plugins.vcs import GitVCS
+from peagen.core.keys_core import create_keypair, upload_public_key
+
+DEFAULT_GATEWAY = "http://localhost:8000/rpc"
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def ensure_mirror(path: Path, url: str) -> Dict[str, Any]:
+    """Ensure ``path`` is a Git mirror of ``url``."""
+    vcs = GitVCS.ensure_repo(path, remote_url=url)
+    return {"mirror": str(path), "remote": url, "exists": vcs.has_remote()}
+
+
+def ensure_deploy_key(name: str, gateway_url: str = DEFAULT_GATEWAY) -> Dict[str, Any]:
+    """Generate and register an SSH deploy key."""
+    paths = create_keypair()
+    upload_public_key(gateway_url=gateway_url)
+    return {"key_name": name, "private": paths["private"], "public": paths["public"]}
+
+
+# ---------------------------------------------------------------------------
+# public API
+# ---------------------------------------------------------------------------
+
+
+def preflight(
+    repo_url: str,
+    mirror_path: Path,
+    *,
+    cfg_path: Optional[Path] = None,
+    gateway_url: str = DEFAULT_GATEWAY,
+) -> Dict[str, Any]:
+    """Run all preflight checks."""
+    cfg_result = validate_config(cfg_path)
+    mirror_result = ensure_mirror(mirror_path, repo_url)
+    key_result = ensure_deploy_key("deploy-key", gateway_url)
+    return {
+        "config": cfg_result,
+        "mirror": mirror_result,
+        "deploy_key": key_result,
+    }
+
+
+__all__ = ["preflight", "ensure_mirror", "ensure_deploy_key"]

--- a/pkgs/standards/peagen/tests/unit/test_preflight_core.py
+++ b/pkgs/standards/peagen/tests/unit/test_preflight_core.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+from peagen.core.preflight_core import ensure_mirror
+from peagen.plugins.vcs import GitVCS
+
+
+def test_ensure_mirror_initialises_repo(tmp_path: Path) -> None:
+    origin = tmp_path / "origin.git"
+    vcs_origin = GitVCS.ensure_repo(origin)
+    (origin / "file.txt").write_text("data", encoding="utf-8")
+    vcs_origin.commit(["file.txt"], "init")
+
+    mirror = tmp_path / "mirror"
+    ensure_mirror(mirror, str(origin))
+    assert (mirror / ".git").exists()
+    vcs = GitVCS.open(mirror)
+    assert vcs.has_remote()


### PR DESCRIPTION
## Summary
- add new `preflight_core` helpers under peagen
- test ensuring git mirror initialization

## Testing
- `uv run --package peagen --directory standards ruff check peagen/peagen/core/preflight_core.py --fix`
- `uv run --package peagen --directory standards ruff check peagen/tests/unit/test_preflight_core.py --fix`
- `uv run --package peagen --directory standards pytest peagen/tests/unit/test_preflight_core.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_685d06f832c0832693ec6572e3b335fa