### PR TITLE
Add GitMirror schema

### DIFF
--- a/pkgs/standards/peagen/peagen/models/__init__.py
+++ b/pkgs/standards/peagen/peagen/models/__init__.py
@@ -70,6 +70,7 @@ from .infra.pool_worker_association import PoolWorkerAssociation  # noqa: F401
 from .result.eval_result import EvalResult  # noqa: F401
 from .result.analysis_result import AnalysisResult  # noqa: F401
 from .mirror_result import MirrorResult  # noqa: F401
+from .git_mirror import GitMirror  # noqa: F401
 
 # ----------------------------------------------------------------------
 # Misc / security
@@ -115,6 +116,7 @@ __all__: list[str] = [
     "EvalResult",
     "AnalysisResult",
     "MirrorResult",
+    "GitMirror",
     # misc
     "AbuseRecord",
 ]

--- a/pkgs/standards/peagen/peagen/models/git_mirror.py
+++ b/pkgs/standards/peagen/peagen/models/git_mirror.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, HttpUrl, SecretStr
+
+
+class GitMirror(BaseModel):
+    """Configuration details for a mirrored Git repository."""
+
+    base_url: HttpUrl
+    token: SecretStr | None = None
+    owner: str | None = None


### PR DESCRIPTION
## Summary
- create `GitMirror` pydantic model
- export new schema from `peagen.models`

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix` *(fails: F821 errors)*
- `uv run --package peagen --directory pkgs/standards/peagen pytest -q` *(fails: ModuleNotFoundError)*
- `peagen remote -q --gateway-url http://localhost:8000/rpc process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml --watch` *(fails: ModuleNotFoundError)*
- `peagen local -q process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml --watch` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685d0a3d361c8326aebd089f208b342b