### PR TITLE
Update GitVCS helpers and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,5 +7,7 @@ Follow these high-level steps when updating this repository:
 - **Documentation and Style** – keep code consistent with [STYLE_GUIDE.md](STYLE_GUIDE.md).
 - **Pull Requests** – ensure commits are well described and reference related issues if applicable.
 
-Changes to the **peagen** package require additional validation steps detailed in `pkgs/standards/peagen/AGENTS.md`.
+Changes to the **peagen** package require additional validation steps detailed in
+`pkgs/standards/peagen/AGENTS.md`. When modifying plugin code, ensure all
+plugins are loaded via the ``PluginManager`` rather than direct imports.
 

--- a/pkgs/standards/peagen/AGENTS.md
+++ b/pkgs/standards/peagen/AGENTS.md
@@ -11,6 +11,9 @@ This document explains how to launch the Peagen gateway and worker services and 
 * `uvicorn` available on the PATH
 * Docker (optional) for containerized deployments
 
+All plugins must be instantiated through the :class:`PluginManager`. Avoid
+importing modules from ``peagen.plugins`` directly in application code.
+
 Environment variables control the runtime configuration. A minimal `.peagen.toml` is required in the working directory for both services.
 
 For quick local testing you can rely on the in-memory queue and an in-memory results backend:

--- a/pkgs/standards/peagen/docs/contributing.md
+++ b/pkgs/standards/peagen/docs/contributing.md
@@ -2,6 +2,9 @@
 
 This guide explains how to extend Peagen and how to propose major changes via Peagen Improvement Proposals (PEA-IPs).
 
+All plugin implementations must be accessed via ``PluginManager``. Do not import
+modules from ``peagen.plugins`` directly in production code.
+
 ## Template-Sets
 
 - Place new template files under `peagen/templates/<set_name>`.

--- a/pkgs/standards/peagen/docs/git_vcs.md
+++ b/pkgs/standards/peagen/docs/git_vcs.md
@@ -6,12 +6,17 @@ Peagen can store and manage artifacts inside a Git repository. The
 is created via the ``vcs`` plugin group.
 
 ```python
-from peagen.plugins.vcs import GitVCS, pea_ref, RUN_REF
+from peagen.plugins import PluginManager
+from peagen.core.mirror_core import ensure_repo
+from peagen.plugins.vcs import pea_ref, RUN_REF
+
+pm = PluginManager({})
+GitVCS = pm.get("vcs")
 
 # open or create a repository locally
-vcs = GitVCS.ensure_repo("./repo")
+vcs = ensure_repo("./repo")
 # clone a remote repository if needed
-vcs_remote = GitVCS.ensure_repo("./repo", remote_url="https://github.com/org/repo.git")
+vcs_remote = ensure_repo("./repo", remote_url="https://github.com/org/repo.git")
 vcs.commit(["results.json"], "initial result")
 run_ref = pea_ref("run", "exp-a")
 vcs.tag(run_ref)

--- a/pkgs/standards/peagen/docs/storage_adapters_and_publishers.md
+++ b/pkgs/standards/peagen/docs/storage_adapters_and_publishers.md
@@ -47,7 +47,10 @@ To use a different solution, subclass one of these classes or implement the same
 
 ```python
 from peagen.core import Peagen
-from peagen.plugins.git_filters.minio_filter import MinioFilter
+from peagen.plugins import PluginManager
+
+pm = PluginManager({})
+MinioFilter = pm.get("git_filters", "minio")
 
 pea = Peagen(
     projects_payload_path="projects.yaml",
@@ -63,14 +66,17 @@ The CLI can emit JSON events such as `process.started` and `process.done`. The r
 
 
 ```python
-from peagen.plugins.publishers.redis_publisher import RedisPublisher
+from peagen.plugins import PluginManager
+
+pm = PluginManager({})
+RedisPublisher = pm.get("publishers", "redis")
 
 bus = RedisPublisher("redis://localhost:6379/0")
 bus.publish("peagen.events", {"type": "process.started"})
 ```
 
 ```python
-from peagen.plugins.publishers.webhook_publisher import WebhookPublisher
+WebhookPublisher = pm.get("publishers", "webhook")
 
 bus = WebhookPublisher("https://example.com/peagen")
 bus.publish("peagen.events", {"type": "process.started"})
@@ -79,7 +85,7 @@ bus.publish("peagen.events", {"type": "process.started"})
 You can also publish events to RabbitMQ using `RabbitMQPublisher`:
 
 ```python
-from peagen.plugins.publishers.rabbitmq_publisher import RabbitMQPublisher
+RabbitMQPublisher = pm.get("publishers", "rabbitmq")
 
 bus = RabbitMQPublisher(host="localhost", port=5672, exchange="", routing_key="peagen.events")
 bus.publish("peagen.events", {"type": "process.started"})

--- a/pkgs/standards/peagen/peagen/cli/commands/show.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/show.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 import typer
 
-from peagen.plugins.vcs.git_vcs import GitVCS
+from peagen.core.mirror_core import open_repo
 
 
 show_app = typer.Typer(help="Inspect git objects.")
@@ -16,7 +16,7 @@ def show(
     repo: Path = typer.Option(".", "--repo", help="Repository path"),
 ) -> None:
     """Print type, size and pretty content for *OID*."""
-    vcs = GitVCS.open(repo)
+    vcs = open_repo(repo)
     info = {
         "type": vcs.object_type(oid),
         "size": vcs.object_size(oid),

--- a/pkgs/standards/peagen/peagen/core/fetch_core.py
+++ b/pkgs/standards/peagen/peagen/core/fetch_core.py
@@ -18,7 +18,7 @@ from typing import List, Optional
 
 
 from peagen.plugins.storage_adapters import make_adapter_for_uri  # deprecated
-from peagen.plugins.vcs import GitVCS
+from peagen.core.mirror_core import ensure_repo, open_repo
 from peagen.errors import WorkspaceNotFoundError
 
 
@@ -29,7 +29,7 @@ def _materialise_workspace(uri: str, dest: Path) -> None:
         url_ref = uri[4:]
         url, _, ref = url_ref.partition("@")
         ref = ref or "HEAD"
-        vcs = GitVCS.ensure_repo(dest, remote_url=url)
+        vcs = ensure_repo(dest, remote_url=url)
         try:
             vcs.fetch(ref, checkout=True)
         except Exception:
@@ -72,7 +72,7 @@ def fetch_single(
     old_sha = None
     if (dest_root / ".git").exists():
         try:
-            old_sha = GitVCS.open(dest_root).repo.head.commit.hexsha
+            old_sha = open_repo(dest_root).repo.head.commit.hexsha
         except Exception:  # pragma: no cover - repo may be empty
             pass
 
@@ -82,7 +82,7 @@ def fetch_single(
     updated = True
     if (dest_root / ".git").exists():
         try:
-            vcs = GitVCS.open(dest_root)
+            vcs = open_repo(dest_root)
             new_sha, updated = vcs.repo.head.commit.hexsha, True
             if old_sha is not None:
                 updated = old_sha != new_sha

--- a/pkgs/standards/peagen/peagen/core/init_core.py
+++ b/pkgs/standards/peagen/peagen/core/init_core.py
@@ -101,9 +101,9 @@ def init_project(
 
     _render_scaffold(src_root, path, context, force)
 
-    from peagen.plugins.vcs import GitVCS
+    from peagen.core.mirror_core import ensure_repo
 
-    vcs = GitVCS.ensure_repo(path, remote_url=git_remote)
+    vcs = ensure_repo(path, remote_url=git_remote)
     vcs.commit(["."], "initial commit")
 
     if filter_uri:

--- a/pkgs/standards/peagen/peagen/core/mirror_core.py
+++ b/pkgs/standards/peagen/peagen/core/mirror_core.py
@@ -1,0 +1,45 @@
+"""Helpers for managing git mirrors."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from peagen.plugins.vcs import GitVCS
+
+
+def open_repo(path: str | Path, remote_url: str | None = None, **kwargs: Any) -> GitVCS:
+    """Open a repository at ``path``.
+
+    Parameters
+    ----------
+    path:
+        Filesystem location of the repository.
+    remote_url:
+        Optional remote URL to clone if the repository does not exist.
+    **kwargs:
+        Additional options forwarded to :class:`GitVCS`.
+    """
+    return GitVCS(
+        path,
+        remote_url=remote_url,
+        mirror_git_url=kwargs.get("mirror_git_url"),
+        mirror_git_token=kwargs.get("mirror_git_token"),
+        owner=kwargs.get("owner"),
+    )
+
+
+def ensure_repo(
+    path: str | Path, remote_url: str | None = None, **kwargs: Any
+) -> GitVCS:
+    """Initialise ``path`` if needed and return a :class:`GitVCS`."""
+    return GitVCS(
+        path,
+        remote_url=remote_url,
+        mirror_git_url=kwargs.get("mirror_git_url"),
+        mirror_git_token=kwargs.get("mirror_git_token"),
+        owner=kwargs.get("owner"),
+    )
+
+
+__all__ = ["open_repo", "ensure_repo"]

--- a/pkgs/standards/peagen/peagen/core/preflight_core.py
+++ b/pkgs/standards/peagen/peagen/core/preflight_core.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from peagen.core.validate_core import validate_config
-from peagen.plugins.vcs import GitVCS
+from peagen.core.mirror_core import ensure_repo
 from peagen.core.keys_core import create_keypair, upload_public_key
 
 DEFAULT_GATEWAY = "http://localhost:8000/rpc"
@@ -26,7 +26,7 @@ DEFAULT_GATEWAY = "http://localhost:8000/rpc"
 
 def ensure_mirror(path: Path, url: str) -> Dict[str, Any]:
     """Ensure ``path`` is a Git mirror of ``url``."""
-    vcs = GitVCS.ensure_repo(path, remote_url=url)
+    vcs = ensure_repo(path, remote_url=url)
     return {"mirror": str(path), "remote": url, "exists": vcs.has_remote()}
 
 

--- a/pkgs/standards/peagen/peagen/defaults/__init__.py
+++ b/pkgs/standards/peagen/peagen/defaults/__init__.py
@@ -7,6 +7,8 @@ from .abuse import BAN_THRESHOLD
 from .events import CONTROL_QUEUE, READY_QUEUE, PUBSUB_CHANNEL, TASK_KEY
 from .error_codes import ErrorCode
 
+LOCK_DIR = "~/.cache/peagen/locks"
+
 # Base configuration used when no `.peagen.toml` is present.
 CONFIG = {
     "gateway_url": "http://localhost:8000/rpc",
@@ -47,5 +49,6 @@ __all__ = [
     "READY_QUEUE",
     "PUBSUB_CHANNEL",
     "TASK_KEY",
+    "LOCK_DIR",
     "ErrorCode",
 ]

--- a/pkgs/standards/peagen/peagen/handlers/mutate_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/mutate_handler.py
@@ -53,9 +53,9 @@ async def mutate_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, Any]:
         vcs = pm.get("vcs")
     except Exception:  # pragma: no cover - optional
         if tmp_dir and (tmp_dir / ".git").exists():
-            from peagen.plugins.vcs import GitVCS
+            from peagen.core.mirror_core import open_repo
 
-            vcs = GitVCS.open(tmp_dir)
+            vcs = open_repo(tmp_dir)
         else:
             vcs = None
 

--- a/pkgs/standards/peagen/peagen/plugins/vcs/git_vcs.py
+++ b/pkgs/standards/peagen/peagen/plugins/vcs/git_vcs.py
@@ -76,36 +76,7 @@ class GitVCS:
                 )
 
     # ------------------------------------------------------------------ init/use
-    @classmethod
-    def open(
-        cls,
-        path: str | Path,
-        remote_url: str | None = None,
-        **kwargs: str | None,
-    ) -> "GitVCS":
-        return cls(
-            path,
-            remote_url=remote_url,
-            mirror_git_url=kwargs.get("mirror_git_url"),
-            mirror_git_token=kwargs.get("mirror_git_token"),
-            owner=kwargs.get("owner"),
-        )
-
-    @classmethod
-    def ensure_repo(
-        cls,
-        path: str | Path,
-        remote_url: str | None = None,
-        **kwargs: str | None,
-    ) -> "GitVCS":
-        """Initialise ``path`` if needed and return a :class:`GitVCS`."""
-        return cls(
-            path,
-            remote_url=remote_url,
-            mirror_git_url=kwargs.get("mirror_git_url"),
-            mirror_git_token=kwargs.get("mirror_git_token"),
-            owner=kwargs.get("owner"),
-        )
+    # NOTE: ``open_repo`` and ``ensure_repo`` moved to ``peagen.core.mirror_core``
 
     # ------------------------------------------------------------------ branch mgmt
     def create_branch(
@@ -429,9 +400,9 @@ class GitVCS:
     @contextmanager
     def repo_lock(repo_uri: str):
         """Context manager yielding a file lock for ``repo_uri``."""
-        lock_root = Path(
-            os.getenv("PEAGEN_LOCK_DIR", "~/.cache/peagen/locks")
-        ).expanduser()
+        from peagen.defaults import LOCK_DIR
+
+        lock_root = Path(os.getenv("PEAGEN_LOCK_DIR", LOCK_DIR)).expanduser()
         lock_root.mkdir(parents=True, exist_ok=True)
         lock_path = lock_root / f"{hashlib.sha1(repo_uri.encode()).hexdigest()}.lock"
         with open(lock_path, "w") as fh:

--- a/pkgs/standards/peagen/peagen/tui/app.py
+++ b/pkgs/standards/peagen/peagen/tui/app.py
@@ -1216,9 +1216,9 @@ class QueueDashboardApp(App):
 
     async def open_git_oid(self, oid: str) -> None:
         try:
-            from peagen.plugins.vcs.git_vcs import GitVCS
+            from peagen.core.mirror_core import open_repo
 
-            vcs = GitVCS.open(".")
+            vcs = open_repo(".")
             content = vcs.object_pretty(oid)
         except Exception as exc:
             self.toast(f"Cannot load OID {oid}: {exc}", style="error")

--- a/pkgs/standards/peagen/tests/unit/test_doe_git_branches.py
+++ b/pkgs/standards/peagen/tests/unit/test_doe_git_branches.py
@@ -1,6 +1,7 @@
 import yaml
 from pathlib import Path
-from peagen.plugins.vcs import GitVCS, pea_ref
+from peagen.plugins.vcs import pea_ref
+from peagen.core.mirror_core import ensure_repo
 from peagen.core.doe_core import (
     create_factor_branches,
     create_run_branches,
@@ -13,7 +14,7 @@ import pytest
 @pytest.mark.unit
 def test_factor_and_run_branches(tmp_path: Path, monkeypatch) -> None:
     repo_dir = tmp_path / "repo"
-    vcs = GitVCS.ensure_repo(repo_dir)
+    vcs = ensure_repo(repo_dir)
 
     def safe_switch(branch: str) -> None:
         vcs.repo.git.checkout(branch)

--- a/pkgs/standards/peagen/tests/unit/test_fetch_git_repo.py
+++ b/pkgs/standards/peagen/tests/unit/test_fetch_git_repo.py
@@ -1,12 +1,12 @@
 from pathlib import Path
 
 from peagen.core.fetch_core import fetch_single
-from peagen.plugins.vcs import GitVCS
+from peagen.core.mirror_core import ensure_repo
 
 
 def test_fetch_single_from_repo(tmp_path: Path) -> None:
     repo_dir = tmp_path / "repo"
-    vcs = GitVCS.ensure_repo(repo_dir)
+    vcs = ensure_repo(repo_dir)
     (repo_dir / "file.txt").write_text("data", encoding="utf-8")
     commit_sha = vcs.commit(["file.txt"], "init")
     vcs.create_branch("refs/pea/testbranch", checkout=True)
@@ -28,7 +28,7 @@ def test_fetch_single_from_repo(tmp_path: Path) -> None:
 
 def test_fetch_single_detects_updates(tmp_path: Path) -> None:
     repo_dir = tmp_path / "repo"
-    vcs = GitVCS.ensure_repo(repo_dir)
+    vcs = ensure_repo(repo_dir)
     (repo_dir / "file.txt").write_text("a", encoding="utf-8")
     vcs.commit(["file.txt"], "init")
 

--- a/pkgs/standards/peagen/tests/unit/test_mutate_handler_repo.py
+++ b/pkgs/standards/peagen/tests/unit/test_mutate_handler_repo.py
@@ -1,6 +1,6 @@
 import pytest
 from pathlib import Path
-from peagen.plugins.vcs import GitVCS
+from peagen.core.mirror_core import ensure_repo
 from peagen.handlers import mutate_handler as handler
 
 
@@ -8,11 +8,12 @@ from peagen.handlers import mutate_handler as handler
 @pytest.mark.asyncio
 async def test_mutate_handler_repo(tmp_path: Path, monkeypatch):
     repo_dir = tmp_path / "repo"
-    vcs = GitVCS.ensure_repo(repo_dir)
+    vcs = ensure_repo(repo_dir)
     (repo_dir / "t.py").write_text("x = 1", encoding="utf-8")
     vcs.commit(["t.py"], "init")
 
     # Prevent push errors for the local repo without a remote
+    from peagen.plugins.vcs import GitVCS
     monkeypatch.setattr(GitVCS, "push", lambda self, branch: None)
 
     captured = {}

--- a/pkgs/standards/peagen/tests/unit/test_preflight_core.py
+++ b/pkgs/standards/peagen/tests/unit/test_preflight_core.py
@@ -1,17 +1,17 @@
 from pathlib import Path
 
 from peagen.core.preflight_core import ensure_mirror
-from peagen.plugins.vcs import GitVCS
+from peagen.core.mirror_core import ensure_repo, open_repo
 
 
 def test_ensure_mirror_initialises_repo(tmp_path: Path) -> None:
     origin = tmp_path / "origin.git"
-    vcs_origin = GitVCS.ensure_repo(origin)
+    vcs_origin = ensure_repo(origin)
     (origin / "file.txt").write_text("data", encoding="utf-8")
     vcs_origin.commit(["file.txt"], "init")
 
     mirror = tmp_path / "mirror"
     ensure_mirror(mirror, str(origin))
     assert (mirror / ".git").exists()
-    vcs = GitVCS.open(mirror)
+    vcs = open_repo(mirror)
     assert vcs.has_remote()


### PR DESCRIPTION
## Summary
- move GitVCS helper methods to new `mirror_core` module
- load plugins via `PluginManager` in documentation
- mention plugin loading requirement in AGENTS
- expose `LOCK_DIR` fallback in defaults
- update tests and CLI for new helpers

## Testing
- `uv run --directory peagen --package peagen ruff format .`
- `uv run --directory peagen --package peagen ruff check . --fix` *(fails: F821 Undefined name `RepositoryUserAssociation`)*
- `uv run --package peagen --directory peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_685d11a185a88326bcf0593feb556af3