### PR TITLE
Fix MirrorResult field and add AbuseRecord model

### DIFF
--- a/pkgs/standards/peagen/peagen/models/AbuseRecord.py
+++ b/pkgs/standards/peagen/peagen/models/AbuseRecord.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import datetime as dt
+from sqlalchemy import String, Integer, Boolean, DateTime
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base import Base
+
+
+class AbuseRecord(Base):
+    """Track abuse metrics for a given IP address."""
+
+    __tablename__ = "abuse_records"
+
+    ip: Mapped[str] = mapped_column(String, primary_key=True)
+    count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    first_seen: Mapped[dt.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=dt.datetime.utcnow
+    )
+    banned: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"<AbuseRecord ip={self.ip!r} count={self.count} banned={self.banned}>"

--- a/pkgs/standards/peagen/peagen/models/__init__.py
+++ b/pkgs/standards/peagen/peagen/models/__init__.py
@@ -42,7 +42,6 @@ from .task.task_relation import TaskRelation  # noqa: F401
 from .task.task_run_relation_association import (
     TaskRunTaskRelationAssociation,  # noqa: F401
 )
-from .task.project_task_association import ProjectTaskAssociation  # noqa: F401
 
 # ----------------------------------------------------------------------
 # DOE / Render / Evolution domain
@@ -75,7 +74,7 @@ from .git_mirror import GitMirror  # noqa: F401
 # ----------------------------------------------------------------------
 # Misc / security
 # ----------------------------------------------------------------------
-from .abuse import AbuseRecord  # noqa: F401
+from .AbuseRecord import AbuseRecord  # noqa: F401
 
 # ----------------------------------------------------------------------
 # Public re-exports
@@ -100,7 +99,6 @@ __all__: list[str] = [
     "TaskRun",
     "TaskRelation",
     "TaskRunTaskRelationAssociation",
-    "ProjectTaskAssociation",
     # evolution
     "DoeSpec",
     "EvolveSpec",

--- a/pkgs/standards/peagen/peagen/models/mirror_result.py
+++ b/pkgs/standards/peagen/peagen/models/mirror_result.py
@@ -5,5 +5,5 @@ class MirrorResult(BaseModel):
     """Result of :func:`ensure_mirror`."""
 
     repo_uri: str
-    gitea_repo: HttpUrl
+    git_repo: HttpUrl
     created: bool


### PR DESCRIPTION
## Summary
- rename `gitea_repo` to `git_repo`
- remove stale `ProjectTaskAssociation` import
- add missing `AbuseRecord` model

## Testing
- `uv run --package peagen --directory standards ruff format peagen`
- `uv run --package peagen --directory standards ruff check peagen --fix` *(fails: F821 Undefined name)*
- `uv run --package peagen --directory standards pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685d1214bfb48326a9d0e33e4732af69