### PR TITLE
Move GitVCS helper functions to mirror_core

### DIFF
--- a/pkgs/standards/peagen/peagen/core/mirror_core.py
+++ b/pkgs/standards/peagen/peagen/core/mirror_core.py
@@ -4,6 +4,15 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
+import os
+import hashlib
+import tempfile
+import shutil
+import fcntl
+from contextlib import contextmanager
+import httpx
+
+from git import Repo
 
 from peagen.plugins.vcs import GitVCS
 
@@ -42,4 +51,97 @@ def ensure_repo(
     )
 
 
-__all__ = ["open_repo", "ensure_repo"]
+def add_git_deploy_key(mirror_uri: str, pub_key: str) -> None:
+    """Register ``pub_key`` with the remote ``mirror_uri``."""
+    res = httpx.post(
+        f"{mirror_uri}/deploy_keys",
+        json={"key": pub_key, "read_only": False},
+        timeout=10.0,
+    )
+    res.raise_for_status()
+
+
+def ensure_git_mirror(repo_uri: str) -> Repo:
+    """Clone or open a bare mirror for ``repo_uri``."""
+    mirror_root = Path(
+        os.getenv("PEAGEN_GIT_MIRROR_DIR", "~/.cache/peagen/mirrors")
+    ).expanduser()
+    mirror_root.mkdir(parents=True, exist_ok=True)
+    dest = mirror_root / hashlib.sha1(repo_uri.encode()).hexdigest()
+    if dest.exists():
+        return Repo(str(dest))
+    return Repo.clone_from(repo_uri, dest, mirror=True)
+
+
+def fetch_git_remote(git_repo: Repo) -> None:
+    """Fetch updates for all remotes."""
+    git_repo.git.fetch("--all")
+
+
+def update_git_remote(git_repo: Repo, ssh_cmd: str | None = None) -> None:
+    """Push the mirror back to its origin."""
+    env = os.environ.copy()
+    if ssh_cmd:
+        env["GIT_SSH_COMMAND"] = ssh_cmd
+    git_repo.git.push("--mirror", env=env)
+
+
+@contextmanager
+def repo_lock(repo_uri: str):
+    """Context manager yielding a file lock for ``repo_uri``."""
+    from peagen.defaults import LOCK_DIR
+
+    lock_root = Path(os.getenv("PEAGEN_LOCK_DIR", LOCK_DIR)).expanduser()
+    lock_root.mkdir(parents=True, exist_ok=True)
+    lock_path = lock_root / f"{hashlib.sha1(repo_uri.encode()).hexdigest()}.lock"
+    with open(lock_path, "w") as fh:
+        fcntl.flock(fh, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(fh, fcntl.LOCK_UN)
+
+
+def add_git_worktree(repo: Repo, ref: str) -> Path:
+    """Create a temporary worktree for ``ref`` and return its path."""
+    path = Path(tempfile.mkdtemp())
+    repo.git.worktree("add", str(path), ref)
+    return path
+
+
+def cleanup_git_worktree(worktree: Path) -> None:
+    """Remove a worktree directory."""
+    try:
+        Repo(str(worktree)).git.worktree("prune")
+    except Exception:
+        pass
+    shutil.rmtree(worktree, ignore_errors=True)
+
+
+@contextmanager
+def ssh_identity(priv_key: str):
+    """Yield an SSH command using ``priv_key``."""
+    tmp = tempfile.NamedTemporaryFile("w", delete=False)
+    tmp.write(priv_key)
+    tmp.flush()
+    os.chmod(tmp.name, 0o600)
+    ssh_cmd = f"ssh -i {tmp.name} -o StrictHostKeyChecking=no"
+    try:
+        yield ssh_cmd
+    finally:
+        tmp.close()
+        os.remove(tmp.name)
+
+
+__all__ = [
+    "open_repo",
+    "ensure_repo",
+    "add_git_deploy_key",
+    "ensure_git_mirror",
+    "fetch_git_remote",
+    "update_git_remote",
+    "repo_lock",
+    "add_git_worktree",
+    "cleanup_git_worktree",
+    "ssh_identity",
+]

--- a/pkgs/standards/peagen/peagen/plugins/vcs/git_vcs.py
+++ b/pkgs/standards/peagen/peagen/plugins/vcs/git_vcs.py
@@ -7,10 +7,6 @@ import json
 import tempfile
 import time
 import io
-import hashlib
-import shutil
-import fcntl
-from contextlib import contextmanager
 import httpx
 import paramiko
 import pygit2
@@ -358,89 +354,3 @@ class GitVCS:
     def clean_reset(self) -> None:
         self.repo.git.reset("--hard")
         self.repo.git.clean("-fd")
-
-    # ------------------------------------------------------------------ mirror helpers
-    @staticmethod
-    def add_git_deploy_key(mirror_uri: str, pub_key: str) -> None:
-        """Register ``pub_key`` with the remote ``mirror_uri``."""
-        res = httpx.post(
-            f"{mirror_uri}/deploy_keys",
-            json={"key": pub_key, "read_only": False},
-            timeout=10.0,
-        )
-        res.raise_for_status()
-
-    @staticmethod
-    def ensure_git_mirror(repo_uri: str) -> Repo:
-        """Clone or open a bare mirror for ``repo_uri``."""
-        mirror_root = Path(
-            os.getenv("PEAGEN_GIT_MIRROR_DIR", "~/.cache/peagen/mirrors")
-        ).expanduser()
-        mirror_root.mkdir(parents=True, exist_ok=True)
-        dest = mirror_root / hashlib.sha1(repo_uri.encode()).hexdigest()
-        if dest.exists():
-            return Repo(str(dest))
-        return Repo.clone_from(repo_uri, dest, mirror=True)
-
-    @staticmethod
-    def fetch_git_remote(git_repo: Repo) -> None:
-        """Fetch updates for all remotes."""
-        git_repo.git.fetch("--all")
-
-    @staticmethod
-    def update_git_remote(git_repo: Repo, ssh_cmd: str | None = None) -> None:
-        """Push the mirror back to its origin."""
-        env = os.environ.copy()
-        if ssh_cmd:
-            env["GIT_SSH_COMMAND"] = ssh_cmd
-        git_repo.git.push("--mirror", env=env)
-
-    # ------------------------------------------------------------------ repo locks
-    @staticmethod
-    @contextmanager
-    def repo_lock(repo_uri: str):
-        """Context manager yielding a file lock for ``repo_uri``."""
-        from peagen.defaults import LOCK_DIR
-
-        lock_root = Path(os.getenv("PEAGEN_LOCK_DIR", LOCK_DIR)).expanduser()
-        lock_root.mkdir(parents=True, exist_ok=True)
-        lock_path = lock_root / f"{hashlib.sha1(repo_uri.encode()).hexdigest()}.lock"
-        with open(lock_path, "w") as fh:
-            fcntl.flock(fh, fcntl.LOCK_EX)
-            try:
-                yield
-            finally:
-                fcntl.flock(fh, fcntl.LOCK_UN)
-
-    # ------------------------------------------------------------------ worktree helpers
-    @staticmethod
-    def add_git_worktree(repo: Repo, ref: str) -> Path:
-        """Create a temporary worktree for ``ref`` and return its path."""
-        path = Path(tempfile.mkdtemp())
-        repo.git.worktree("add", str(path), ref)
-        return path
-
-    @staticmethod
-    def cleanup_git_worktree(worktree: Path) -> None:
-        """Remove a worktree directory."""
-        try:
-            Repo(str(worktree)).git.worktree("prune")
-        except Exception:
-            pass
-        shutil.rmtree(worktree, ignore_errors=True)
-
-    # ------------------------------------------------------------------ ssh helpers
-    @staticmethod
-    @contextmanager
-    def ssh_identity(priv_key: str):
-        """Yield an SSH command using ``priv_key``."""
-        tmp = tempfile.NamedTemporaryFile("w", delete=False)
-        tmp.write(priv_key)
-        tmp.flush()
-        os.chmod(tmp.name, 0o600)
-        ssh_cmd = f"ssh -i {tmp.name} -o StrictHostKeyChecking=no"
-        try:
-            yield ssh_cmd
-        finally:
-            tmp.close()
-            os.remove(tmp.name)

--- a/pkgs/standards/peagen/tests/unit/test_git_vcs.py
+++ b/pkgs/standards/peagen/tests/unit/test_git_vcs.py
@@ -5,7 +5,7 @@ import json
 import pytest
 
 from peagen.plugins.vcs import pea_ref
-from peagen.core.mirror_core import ensure_repo, open_repo
+from peagen.core.mirror_core import ensure_repo
 from peagen.errors import (
     GitRemoteMissingError,
     GitCloneError,

--- a/pkgs/standards/peagen/tests/unit/test_mutate_handler_repo.py
+++ b/pkgs/standards/peagen/tests/unit/test_mutate_handler_repo.py
@@ -14,6 +14,7 @@ async def test_mutate_handler_repo(tmp_path: Path, monkeypatch):
 
     # Prevent push errors for the local repo without a remote
     from peagen.plugins.vcs import GitVCS
+
     monkeypatch.setattr(GitVCS, "push", lambda self, branch: None)
 
     captured = {}


### PR DESCRIPTION
## Summary
- move GitVCS helper routines out of the class
- expose helper functions via `mirror_core`
- adjust imports in tests

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format .`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check peagen/plugins/vcs/git_vcs.py peagen/core/mirror_core.py --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685d1ed3ad548326844f1049a7bed742