### PR TITLE
Implement multi-remote support in peagen GitVCS

### DIFF
--- a/.peagen.toml
+++ b/.peagen.toml
@@ -90,7 +90,18 @@ default_evaluator = "performance"
 [evaluation.evaluators.performance]
 # parameters for the built-in performance evaluator can go here
 
-
+# --- VCS ------------------------------------------------------------
 [vcs]
-provider = "git"
+
 default_vcs = "git"
+
+
+[vcs.git]
+mirror_git_url = "${MIRROR_GIT_URL}"
+mirror_git_token = "${MIRROR_GIT_TOKEN}"
+owner = "${OWNER}"
+
+
+[vcs.git.remotes]
+origin = "${GITEA_REMOTE}"
+upstream = "${GITHUB_REMOTE}"

--- a/infra/.gw.peagen.toml
+++ b/infra/.gw.peagen.toml
@@ -43,11 +43,17 @@ dsn = "${PG_DSN}"
 
 # --- VCS ------------------------------------------------------------
 [vcs]
-provider = "git"
+
 default_vcs = "git"
 
-[vcs.provider_params]
+
+[vcs.git]
 mirror_git_url = "${MIRROR_GIT_URL}"
 mirror_git_token = "${MIRROR_GIT_TOKEN}"
 owner = "${OWNER}"
+
+
+[vcs.git.remotes]
+origin = "${GITEA_REMOTE}"
+upstream = "${GITHUB_REMOTE}"
 

--- a/infra/.worker.peagen.toml
+++ b/infra/.worker.peagen.toml
@@ -75,11 +75,17 @@ target_grade_level = 12
 
 # --- VCS ------------------------------------------------------------
 [vcs]
-provider = "git"
+
 default_vcs = "git"
 
-[vcs.provider_params]
+
+[vcs.git]
 mirror_git_url = "${MIRROR_GIT_URL}"
 mirror_git_token = "${MIRROR_GIT_TOKEN}"
 owner = "${OWNER}"
+
+
+[vcs.git.remotes]
+origin = "${GITEA_REMOTE}"
+upstream = "${GITHUB_REMOTE}"
 

--- a/pkgs/standards/peagen/README.md
+++ b/pkgs/standards/peagen/README.md
@@ -137,6 +137,21 @@ default_filter = "file"
 
 [storage.filters.file]
 output_dir = "./peagen_artifacts"
+
+[vcs]
+
+default_vcs = "git"
+
+
+[vcs.git]
+mirror_git_url = "${MIRROR_GIT_URL}"
+mirror_git_token = "${MIRROR_GIT_TOKEN}"
+owner = "${OWNER}"
+
+
+[vcs.git.remotes]
+origin = "${GITEA_REMOTE}"
+upstream = "${GITHUB_REMOTE}"
 ```
 
 With these values in place you can omit `--provider`, `--model-name`, and other

--- a/pkgs/standards/peagen/docs/git_vcs.md
+++ b/pkgs/standards/peagen/docs/git_vcs.md
@@ -23,9 +23,13 @@ vcs.tag(run_ref)
 ```
 
 Git repositories can also push to a secondary **mirror**. Set
-``mirror_git_url`` and ``mirror_git_token`` under the ``[vcs.provider_params]``
-section in your ``.peagen.toml``.  When configured, :class:`GitVCS` pushes the
-same ref to the ``mirror`` remote after updating ``origin``.
+``mirror_git_url`` and ``mirror_git_token`` under the ``[vcs.git]`` section in
+your ``.peagen.toml``. When configured, :class:`GitVCS` pushes the same ref to
+the ``mirror`` remote after updating ``origin``.
+
+Multiple remotes can be declared via ``[vcs.git.remotes]``. The ``origin`` entry
+is used when cloning repositories and additional names such as ``upstream`` are
+configured after creation.
 
 Git references follow the ``refs/pea/<kind>`` convention. Constants are
 exported for common prefixes such as :data:`RUN_REF`, :data:`PROMOTED_REF`,

--- a/pkgs/standards/peagen/peagen/core/mirror_core.py
+++ b/pkgs/standards/peagen/peagen/core/mirror_core.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, TYPE_CHECKING
 import os
 import hashlib
 import tempfile
@@ -14,7 +14,10 @@ import httpx
 
 from git import Repo
 
-from peagen.plugins.vcs import GitVCS
+from peagen.plugins import PluginManager
+
+if TYPE_CHECKING:  # pragma: no cover - import for typing only
+    from peagen.plugins.vcs import GitVCS
 
 
 def open_repo(path: str | Path, remote_url: str | None = None, **kwargs: Any) -> GitVCS:
@@ -29,12 +32,15 @@ def open_repo(path: str | Path, remote_url: str | None = None, **kwargs: Any) ->
     **kwargs:
         Additional options forwarded to :class:`GitVCS`.
     """
+    pm = PluginManager({})
+    GitVCS = pm.get("vcs")
     return GitVCS(
         path,
         remote_url=remote_url,
         mirror_git_url=kwargs.get("mirror_git_url"),
         mirror_git_token=kwargs.get("mirror_git_token"),
         owner=kwargs.get("owner"),
+        remotes=kwargs.get("remotes"),
     )
 
 
@@ -42,12 +48,15 @@ def ensure_repo(
     path: str | Path, remote_url: str | None = None, **kwargs: Any
 ) -> GitVCS:
     """Initialise ``path`` if needed and return a :class:`GitVCS`."""
+    pm = PluginManager({})
+    GitVCS = pm.get("vcs")
     return GitVCS(
         path,
         remote_url=remote_url,
         mirror_git_url=kwargs.get("mirror_git_url"),
         mirror_git_token=kwargs.get("mirror_git_token"),
         owner=kwargs.get("owner"),
+        remotes=kwargs.get("remotes"),
     )
 
 

--- a/pkgs/standards/peagen/peagen/defaults/__init__.py
+++ b/pkgs/standards/peagen/peagen/defaults/__init__.py
@@ -33,10 +33,11 @@ CONFIG = {
     },
     "vcs": {
         "default_vcs": "git",
-        "provider_params": {
+        "git": {
             "mirror_git_url": "",
             "mirror_git_token": "",
             "owner": "",
+            "remotes": {},
         },
     },
     "secrets": {"default_secret": "env", "adapters": {"env": {"prefix": ""}}},

--- a/pkgs/standards/peagen/tests/examples/2x2Grid/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/2x2Grid/.peagen.toml
@@ -12,6 +12,16 @@ default_backend = "local_fs"
 root_dir = "./task_runs"
 
 [vcs]
-provider = "git"
-provider_params = { path = "." }
+
 default_vcs = "git"
+
+
+[vcs.git]
+mirror_git_url = "${MIRROR_GIT_URL}"
+mirror_git_token = "${MIRROR_GIT_TOKEN}"
+owner = "${OWNER}"
+
+
+[vcs.git.remotes]
+origin = "${GITEA_REMOTE}"
+upstream = "${GITHUB_REMOTE}"

--- a/pkgs/standards/peagen/tests/examples/gateway_demo/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/gateway_demo/.peagen.toml
@@ -12,6 +12,16 @@ default_backend = "local_fs"
 root_dir = "./task_runs"
 
 [vcs]
-provider = "git"
-provider_params = { path = "." }
+
 default_vcs = "git"
+
+
+[vcs.git]
+mirror_git_url = "${MIRROR_GIT_URL}"
+mirror_git_token = "${MIRROR_GIT_TOKEN}"
+owner = "${OWNER}"
+
+
+[vcs.git.remotes]
+origin = "${GITEA_REMOTE}"
+upstream = "${GITHUB_REMOTE}"

--- a/pkgs/standards/peagen/tests/examples/peagen_local_demo/test_workspace/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/peagen_local_demo/test_workspace/.peagen.toml
@@ -31,6 +31,16 @@ default_provider = "groq"
 API_KEY = "${GROQ_API_KEY}"
 
 [vcs]
-provider = "git"
-provider_params = { path = "." }
+
 default_vcs = "git"
+
+
+[vcs.git]
+mirror_git_url = "${MIRROR_GIT_URL}"
+mirror_git_token = "${MIRROR_GIT_TOKEN}"
+owner = "${OWNER}"
+
+
+[vcs.git.remotes]
+origin = "${GITEA_REMOTE}"
+upstream = "${GITHUB_REMOTE}"

--- a/pkgs/standards/peagen/tests/examples/peagen_tomls/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/peagen_tomls/.peagen.toml
@@ -80,6 +80,16 @@ default_evaluator = "ColemanLiauIndexEvaluator"
 target_grade_level = 12
 
 [vcs]
-provider = "git"
-provider_params = { path = "." }
+
 default_vcs = "git"
+
+
+[vcs.git]
+mirror_git_url = "${MIRROR_GIT_URL}"
+mirror_git_token = "${MIRROR_GIT_TOKEN}"
+owner = "${OWNER}"
+
+
+[vcs.git.remotes]
+origin = "${GITEA_REMOTE}"
+upstream = "${GITHUB_REMOTE}"

--- a/pkgs/standards/peagen/tests/examples/simple_evolve_demo/cfg/local.toml
+++ b/pkgs/standards/peagen/tests/examples/simple_evolve_demo/cfg/local.toml
@@ -24,9 +24,19 @@ async = false
 strict = true
 
 [vcs]
-provider = "git"
-provider_params = { path = "." }
+
 default_vcs = "git"
+
+
+[vcs.git]
+mirror_git_url = "${MIRROR_GIT_URL}"
+mirror_git_token = "${MIRROR_GIT_TOKEN}"
+owner = "${OWNER}"
+
+
+[vcs.git.remotes]
+origin = "${GITEA_REMOTE}"
+upstream = "${GITHUB_REMOTE}"
 
 [evaluation.evaluators]
 default_evaluator = "performance"

--- a/pkgs/standards/peagen/tests/examples/simple_evolve_demo/cfg/remote.toml
+++ b/pkgs/standards/peagen/tests/examples/simple_evolve_demo/cfg/remote.toml
@@ -26,9 +26,19 @@ async = false
 strict = true
 
 [vcs]
-provider = "git"
-provider_params = { path = "." }
+
 default_vcs = "git"
+
+
+[vcs.git]
+mirror_git_url = "${MIRROR_GIT_URL}"
+mirror_git_token = "${MIRROR_GIT_TOKEN}"
+owner = "${OWNER}"
+
+
+[vcs.git.remotes]
+origin = "${GITEA_REMOTE}"
+upstream = "${GITHUB_REMOTE}"
 
 [evaluation.evaluators]
 default_evaluator = "simple_time"

--- a/pkgs/standards/peagen/tests/examples/simple_evolve_demo/workspace/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/simple_evolve_demo/workspace/.peagen.toml
@@ -31,6 +31,16 @@ default_provider = "groq"
 API_KEY = "${GROQ_API_KEY}"
 
 [vcs]
-provider = "git"
-provider_params = { path = "." }
+
 default_vcs = "git"
+
+
+[vcs.git]
+mirror_git_url = "${MIRROR_GIT_URL}"
+mirror_git_token = "${MIRROR_GIT_TOKEN}"
+owner = "${OWNER}"
+
+
+[vcs.git.remotes]
+origin = "${GITEA_REMOTE}"
+upstream = "${GITHUB_REMOTE}"

--- a/pkgs/standards/peagen/tests/unit/test_git_vcs.py
+++ b/pkgs/standards/peagen/tests/unit/test_git_vcs.py
@@ -137,6 +137,17 @@ def test_remote_helpers(tmp_path: Path) -> None:
     assert vcs.repo.remotes.origin.url == "https://example.com/new.git"
 
 
+def test_multiple_remotes(tmp_path: Path) -> None:
+    repo_dir = tmp_path / "repo_multi"
+    remotes = {
+        "origin": "git@gitea.local:demo/repo.git",
+        "upstream": "git@github.com:demo/repo.git",
+    }
+    vcs = ensure_repo(repo_dir, remotes=remotes)
+    for name, url in remotes.items():
+        assert vcs.repo.remotes[name].url == url
+
+
 def test_mirror_push(tmp_path: Path) -> None:
     origin = tmp_path / "origin"
     mirror = tmp_path / "mirror"


### PR DESCRIPTION
## Summary
- allow specifying additional Git remotes when creating GitVCS
- load GitVCS via PluginManager in mirror helpers
- document remote configuration in README and git_vcs docs
- extend default config and example `.peagen.toml` files with remote entries
- add regression test for multiple remote configuration
- update `.peagen.toml` layouts

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/plugins/vcs/git_vcs.py peagen/core/mirror_core.py peagen/defaults/__init__.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_685d23b34a40832685c21bb887739fba