### PR TITLE
Add multi-remote repo init

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/init.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/init.py
@@ -56,6 +56,9 @@ def local_init_repo(
     pat: str = typer.Option(..., envvar="GITHUB_PAT", help="GitHub PAT"),
     description: str = typer.Option("", help="Repository description"),
     deploy_key: Path = typer.Option(None, "--deploy-key", help="Existing private key"),
+    path: Path = typer.Option(None, "--path", help="Existing repository to configure"),
+    origin: str = typer.Option(None, "--origin", help="Origin remote URL"),
+    upstream: str = typer.Option(None, "--upstream", help="Upstream remote URL"),
 ) -> None:
     """Create a GitHub repository and register a deploy key."""
     self = Logger(name="init_repo")
@@ -67,6 +70,15 @@ def local_init_repo(
         "description": description,
         "deploy_key": str(deploy_key) if deploy_key else None,
     }
+    if path is not None:
+        args["path"] = str(path)
+    if origin or upstream:
+        remotes: Dict[str, str] = {}
+        if origin:
+            remotes["origin"] = origin
+        if upstream:
+            remotes["upstream"] = upstream
+        args["remotes"] = remotes
     result = _call_handler(args)
     _summary(Path("."), result["next"])
     self.logger.info("Exiting local init_repo command")
@@ -352,6 +364,9 @@ def remote_init_repo(
     pat: str = typer.Option(..., envvar="GITHUB_PAT", help="GitHub PAT"),
     description: str = typer.Option("", help="Repository description"),
     deploy_key: Path = typer.Option(None, "--deploy-key", help="Existing private key"),
+    path: Path = typer.Option(None, "--path", help="Existing repository to configure"),
+    origin: str = typer.Option(None, "--origin", help="Origin remote URL"),
+    upstream: str = typer.Option(None, "--upstream", help="Upstream remote URL"),
 ) -> None:
     """Create a GitHub repository via JSON-RPC."""
     args = {
@@ -361,6 +376,15 @@ def remote_init_repo(
         "description": description,
         "deploy_key": str(deploy_key) if deploy_key else None,
     }
+    if path is not None:
+        args["path"] = str(path)
+    if origin or upstream:
+        remotes: Dict[str, str] = {}
+        if origin:
+            remotes["origin"] = origin
+        if upstream:
+            remotes["upstream"] = upstream
+        args["remotes"] = remotes
     try:
         _submit_task(args, ctx.obj.get("gateway_url"), "init repo", allow_pat=True)
     except PATNotAllowedError as exc:

--- a/pkgs/standards/peagen/peagen/core/init_core.py
+++ b/pkgs/standards/peagen/peagen/core/init_core.py
@@ -196,9 +196,15 @@ def init_ci(
 
 
 def init_repo(
-    *, repo: str, pat: str, description: str = "", deploy_key: Path | None = None
+    *,
+    repo: str,
+    pat: str,
+    description: str = "",
+    deploy_key: Path | None = None,
+    path: Path | None = None,
+    remotes: dict[str, str] | None = None,
 ) -> Dict[str, Any]:
-    """Create a GitHub repository and register a deploy key."""
+    """Create a GitHub repository and optionally configure a local repo."""
     from github import Github
     import subprocess
     import tempfile
@@ -239,8 +245,16 @@ def init_repo(
     with pub_key.open() as fh:
         repo_obj.create_key(title="peagen-worker", key=fh.read(), read_only=False)
 
-    return {
+    result = {
         "created": repo,
         "deploy_key": str(deploy_key),
         "next": "configure DEPLOY_KEY_SECRET",
     }
+
+    if path is not None:
+        from peagen.core.mirror_core import ensure_repo
+
+        ensure_repo(path, remotes=remotes or {})
+        result["configured"] = str(path)
+
+    return result

--- a/pkgs/standards/peagen/peagen/handlers/init_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/init_handler.py
@@ -69,6 +69,8 @@ async def init_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, Any]:
             pat=args.get("pat"),
             description=args.get("description", ""),
             deploy_key=Path(args["deploy_key"]) if args.get("deploy_key") else None,
+            path=Path(args["path"]) if args.get("path") else None,
+            remotes=args.get("remotes"),
         )
 
     raise ValueError(f"Unknown init kind '{kind}'")

--- a/pkgs/standards/peagen/tests/unit/test_init_repo.py
+++ b/pkgs/standards/peagen/tests/unit/test_init_repo.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+import pytest
+
+from peagen.core import init_core
+from peagen.core.mirror_core import ensure_repo
+
+
+class DummyRepo:
+    def __init__(self):
+        self.keys = []
+
+    def create_key(self, title: str, key: str, read_only: bool = False):
+        self.keys.append((title, key, read_only))
+
+
+class DummyOwner:
+    def __init__(self):
+        self.repo = DummyRepo()
+
+    def create_repo(self, name, private=True, description=""):
+        return self.repo
+
+
+class DummyGH:
+    def __init__(self, pat):
+        self.owner = DummyOwner()
+
+    def get_organization(self, tenant):
+        return self.owner
+
+    def get_user(self, tenant):
+        return self.owner
+
+    def get_repo(self, repo):
+        return self.owner.repo
+
+
+@pytest.mark.unit
+def test_init_repo_configures_local_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setattr(init_core, "Github", DummyGH)
+    repo_dir = tmp_path / "local"
+    remotes = {
+        "origin": "git@gitea.local:demo/repo.git",
+        "upstream": "git@github.com:demo/repo.git",
+    }
+    result = init_core.init_repo(
+        repo="demo/repo",
+        pat="dummy",
+        path=repo_dir,
+        remotes=remotes,
+    )
+    assert result["configured"] == str(repo_dir)
+    for name, url in remotes.items():
+        assert url == ensure_repo(repo_dir).repo.remotes[name].url


### PR DESCRIPTION
## Summary
- support configuring an existing repo with multiple remotes when running `peagen init repo`
- extend handler and core logic to pass remotes
- add test for new repo configuration helper

## Testing
- `uv run --package peagen --directory . ruff format .`
- `uv run --package peagen --directory . ruff check . --fix` *(fails: F821 undefined names)*
- `uv run --package peagen --directory pkgs/standards/peagen pytest` *(fails: 37 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685d3141f1988326ad32e3a002219262