### PR TITLE
Remove MirrorResult from peagen

### DIFF
--- a/pkgs/standards/peagen/peagen/models/__init__.py
+++ b/pkgs/standards/peagen/peagen/models/__init__.py
@@ -68,7 +68,6 @@ from .infra.pool_worker_association import PoolWorkerAssociation  # noqa: F401
 # ----------------------------------------------------------------------
 from .result.eval_result import EvalResult  # noqa: F401
 from .result.analysis_result import AnalysisResult  # noqa: F401
-from .mirror_result import MirrorResult  # noqa: F401
 from .git_mirror import GitMirror  # noqa: F401
 
 # ----------------------------------------------------------------------
@@ -113,7 +112,6 @@ __all__: list[str] = [
     # result
     "EvalResult",
     "AnalysisResult",
-    "MirrorResult",
     "GitMirror",
     # misc
     "AbuseRecord",

--- a/pkgs/standards/peagen/peagen/models/mirror_result.py
+++ b/pkgs/standards/peagen/peagen/models/mirror_result.py
@@ -1,9 +1,0 @@
-from pydantic import BaseModel, HttpUrl
-
-
-class MirrorResult(BaseModel):
-    """Result of :func:`ensure_mirror`."""
-
-    repo_uri: str
-    git_repo: HttpUrl
-    created: bool


### PR DESCRIPTION
## Summary
- drop `MirrorResult` dataclass
- clean up re-exports

## Testing
- `uv run --directory standards --package peagen ruff check . --fix` *(fails: F821 Undefined name errors)*
- `uv run --package peagen --directory standards pytest` *(fails to collect tests)*
- `peagen remote -q process dummy.yaml --watch` *(fails: cannot import name 'Task')*
- `peagen local -q process dummy.yaml --watch` *(fails: cannot import name 'Task')*

------
https://chatgpt.com/codex/tasks/task_e_685d350d92388326a63a5ddc107eb4fe