### PR TITLE
Add multitenant GitHub repo support to peagen

### DIFF
--- a/pkgs/standards/peagen/docs/git_vcs.md
+++ b/pkgs/standards/peagen/docs/git_vcs.md
@@ -112,7 +112,8 @@ push results back to it.
    can verify your requests.
 
    ```bash
-   peagen login --gateway-url https://gw.peagen.com
+   peagen login --gateway-url https://gw.peagen.com --pool acme-lab \
+     --repo myuser/myrepo
    ```
 
    After logging in you can run remote commands that operate on the GitHub

--- a/pkgs/standards/peagen/peagen/_utils/slug_utils.py
+++ b/pkgs/standards/peagen/peagen/_utils/slug_utils.py
@@ -1,9 +1,25 @@
 """Utilities for generating project slugs."""
 
 import re
+from urllib.parse import urlparse
 
 
 def slugify(name: str) -> str:
     """Return a filesystem-friendly slug version of *name*."""
     slug = re.sub(r"[^0-9A-Za-z_-]+", "-", name).strip("-")
     return slug.lower()
+
+
+def repo_slug(repo: str) -> str:
+    """Return a tenant slug derived from a GitHub reference or repo URL."""
+    if repo.startswith("gh://"):
+        repo = repo[5:]
+    if repo.startswith("git+"):
+        repo = repo[4:].split("@", 1)[0]
+    if repo.startswith("http://") or repo.startswith("https://"):
+        parsed = urlparse(repo)
+        if "github.com" in parsed.netloc:
+            repo = parsed.path.lstrip("/")
+    repo = repo.rstrip(".git")
+    repo = repo.replace("/", "-")
+    return slugify(repo)

--- a/pkgs/standards/peagen/peagen/cli/commands/keys.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/keys.py
@@ -11,6 +11,7 @@ import typer
 
 from peagen.plugins.secret_drivers import AutoGpgDriver
 from peagen.core import keys_core
+from peagen._utils.slug_utils import repo_slug
 
 
 keys_app = typer.Typer(help="Manage local and remote public keys.")
@@ -33,14 +34,18 @@ def upload(
     ctx: typer.Context,
     key_dir: Path = typer.Option(Path.home() / ".peagen" / "keys", "--key-dir"),
     gateway_url: str = typer.Option("http://localhost:8000/rpc", "--gateway-url"),
+    pool: str = typer.Option("default", "--pool"),
+    repo: Optional[str] = typer.Option(None, "--repo"),
 ) -> None:
     """Upload the public key to the gateway."""
     drv = AutoGpgDriver(key_dir=key_dir)
     pubkey = drv.pub_path.read_text()
+    if repo and pool == "default":
+        pool = repo_slug(repo)
     envelope = {
         "jsonrpc": "2.0",
         "method": "Keys.upload",
-        "params": {"public_key": pubkey},
+        "params": {"public_key": pubkey, "tenant_id": pool},
     }
     httpx.post(gateway_url, json=envelope, timeout=10.0)
     typer.echo("Uploaded public key")
@@ -51,12 +56,16 @@ def remove(
     ctx: typer.Context,
     fingerprint: str,
     gateway_url: str = typer.Option("http://localhost:8000/rpc", "--gateway-url"),
+    pool: str = typer.Option("default", "--pool"),
+    repo: Optional[str] = typer.Option(None, "--repo"),
 ) -> None:
     """Remove a public key from the gateway."""
+    if repo and pool == "default":
+        pool = repo_slug(repo)
     envelope = {
         "jsonrpc": "2.0",
         "method": "Keys.delete",
-        "params": {"fingerprint": fingerprint},
+        "params": {"fingerprint": fingerprint, "tenant_id": pool},
     }
     httpx.post(gateway_url, json=envelope, timeout=10.0)
     typer.echo(f"Removed key {fingerprint}")
@@ -66,9 +75,13 @@ def remove(
 def fetch_server(
     ctx: typer.Context,
     gateway_url: str = typer.Option("http://localhost:8000/rpc", "--gateway-url"),
+    pool: str = typer.Option("default", "--pool"),
+    repo: Optional[str] = typer.Option(None, "--repo"),
 ) -> None:
     """Fetch trusted public keys from the gateway."""
-    envelope = {"jsonrpc": "2.0", "method": "Keys.fetch"}
+    if repo and pool == "default":
+        pool = repo_slug(repo)
+    envelope = {"jsonrpc": "2.0", "method": "Keys.fetch", "params": {"tenant_id": pool}}
     res = httpx.post(gateway_url, json=envelope, timeout=10.0)
     typer.echo(json.dumps(res.json().get("result", {}), indent=2))
 

--- a/pkgs/standards/peagen/peagen/cli/commands/login.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/login.py
@@ -9,6 +9,7 @@ import httpx
 import typer
 
 from peagen.plugins.secret_drivers import AutoGpgDriver
+from peagen._utils.slug_utils import repo_slug
 
 
 login_app = typer.Typer(help="Authenticate and upload your public key.")
@@ -24,17 +25,21 @@ def login(
     ),
     key_dir: Path = typer.Option(Path.home() / ".peagen" / "keys", "--key-dir"),
     gateway_url: str = typer.Option("http://localhost:8000/rpc", "--gateway-url"),
+    pool: str = typer.Option("default", "--pool", help="Tenant/workspace name"),
+    repo: Optional[str] = typer.Option(None, "--repo", help="GitHub repo slug"),
 ) -> None:
     """Ensure keys exist and upload the public key."""
     gateway_url = gateway_url.rstrip("/")
     if not gateway_url.endswith("/rpc"):
         gateway_url += "/rpc"
+    if repo and pool == "default":
+        pool = repo_slug(repo)
     drv = AutoGpgDriver(key_dir=key_dir, passphrase=passphrase)
     pubkey = drv.pub_path.read_text()
     payload = {
         "jsonrpc": "2.0",
         "method": "Keys.upload",
-        "params": {"public_key": pubkey},
+        "params": {"public_key": pubkey, "tenant_id": pool},
     }
     try:
         res = httpx.post(gateway_url, json=payload, timeout=10.0)

--- a/pkgs/standards/peagen/peagen/cli/commands/secrets.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/secrets.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 import httpx
 import typer
 
 from peagen.plugins.secret_drivers import AutoGpgDriver
+from peagen._utils.slug_utils import repo_slug
 
 
 local_secrets_app = typer.Typer(help="Manage local secret store.")
@@ -95,12 +96,15 @@ def remote_add(
     version: int = typer.Option(0, "--version"),
     recipient: List[Path] = typer.Option([], "--recipient"),
     pool: str = typer.Option("default", "--pool"),
+    repo: Optional[str] = typer.Option(None, "--repo"),
 ) -> None:
     """Upload an encrypted secret to the gateway."""
     gateway_url = ctx.obj.get("gateway_url", "http://localhost:8000/rpc")
     gateway_url = gateway_url.rstrip("/")
     if not gateway_url.endswith("/rpc"):
         gateway_url += "/rpc"
+    if repo and pool == "default":
+        pool = repo_slug(repo)
     drv = AutoGpgDriver()
     pubs = [p.read_text() for p in recipient]
     pubs.extend(_pool_worker_pubs(pool, gateway_url))
@@ -131,12 +135,15 @@ def remote_get(
     secret_id: str,
     gateway_url: str = typer.Option("http://localhost:8000/rpc", "--gateway-url"),
     pool: str = typer.Option("default", "--pool"),
+    repo: Optional[str] = typer.Option(None, "--repo"),
 ) -> None:
     """Retrieve and decrypt a secret from the gateway."""
     gateway_url = ctx.obj.get("gateway_url", "http://localhost:8000/rpc")
     gateway_url = gateway_url.rstrip("/")
     if not gateway_url.endswith("/rpc"):
         gateway_url += "/rpc"
+    if repo and pool == "default":
+        pool = repo_slug(repo)
     drv = AutoGpgDriver()
     envelope = {
         "jsonrpc": "2.0",
@@ -161,12 +168,15 @@ def remote_remove(
     version: int = typer.Option(None, "--version"),
     gateway_url: str = typer.Option("http://localhost:8000/rpc", "--gateway-url"),
     pool: str = typer.Option("default", "--pool"),
+    repo: Optional[str] = typer.Option(None, "--repo"),
 ) -> None:
     """Delete a secret on the gateway."""
     gateway_url = ctx.obj.get("gateway_url", "http://localhost:8000/rpc")
     gateway_url = gateway_url.rstrip("/")
     if not gateway_url.endswith("/rpc"):
         gateway_url += "/rpc"
+    if repo and pool == "default":
+        pool = repo_slug(repo)
     envelope = {
         "jsonrpc": "2.0",
         "method": "Secrets.delete",

--- a/pkgs/standards/peagen/peagen/core/keys_core.py
+++ b/pkgs/standards/peagen/peagen/core/keys_core.py
@@ -59,6 +59,8 @@ def create_keypair(
 def upload_public_key(
     key_dir: Path | None = None,
     gateway_url: str = DEFAULT_GATEWAY,
+    *,
+    tenant_id: str = "default",
 ) -> dict:
     """Upload the local public key to the gateway."""
     drv = _get_driver(key_dir=key_dir)
@@ -66,28 +68,41 @@ def upload_public_key(
     envelope = {
         "jsonrpc": "2.0",
         "method": "Keys.upload",
-        "params": {"public_key": pubkey},
+        "params": {"public_key": pubkey, "tenant_id": tenant_id},
     }
     res = httpx.post(gateway_url, json=envelope, timeout=10.0)
     res.raise_for_status()
     return res.json()
 
 
-def remove_public_key(fingerprint: str, gateway_url: str = DEFAULT_GATEWAY) -> dict:
+def remove_public_key(
+    fingerprint: str,
+    gateway_url: str = DEFAULT_GATEWAY,
+    *,
+    tenant_id: str = "default",
+) -> dict:
     """Remove a stored public key on the gateway."""
     envelope = {
         "jsonrpc": "2.0",
         "method": "Keys.delete",
-        "params": {"fingerprint": fingerprint},
+        "params": {"fingerprint": fingerprint, "tenant_id": tenant_id},
     }
     res = httpx.post(gateway_url, json=envelope, timeout=10.0)
     res.raise_for_status()
     return res.json()
 
 
-def fetch_server_keys(gateway_url: str = DEFAULT_GATEWAY) -> dict:
+def fetch_server_keys(
+    gateway_url: str = DEFAULT_GATEWAY,
+    *,
+    tenant_id: str = "default",
+) -> dict:
     """Fetch trusted keys from the gateway."""
-    envelope = {"jsonrpc": "2.0", "method": "Keys.fetch"}
+    envelope = {
+        "jsonrpc": "2.0",
+        "method": "Keys.fetch",
+        "params": {"tenant_id": tenant_id},
+    }
     res = httpx.post(gateway_url, json=envelope, timeout=10.0)
     res.raise_for_status()
     return res.json().get("result", {})

--- a/pkgs/standards/peagen/tests/unit/test_cli_login.py
+++ b/pkgs/standards/peagen/tests/unit/test_cli_login.py
@@ -31,13 +31,24 @@ def test_login_success(monkeypatch, tmp_path):
     runner = CliRunner()
     result = runner.invoke(
         app,
-        ["login", "--key-dir", str(tmp_path), "--gateway-url", "http://gw/rpc"],
+        [
+            "login",
+            "--key-dir",
+            str(tmp_path),
+            "--gateway-url",
+            "http://gw/rpc",
+            "--pool",
+            "demo",
+            "--repo",
+            "org/repo",
+        ],
     )
 
     assert result.exit_code == 0
     assert "Logged in and uploaded public key" in result.output
     assert captured["url"] == "http://gw/rpc"
     assert captured["json"]["params"]["public_key"] == "PUB"
+    assert captured["json"]["params"]["tenant_id"] == "demo"
 
 
 @pytest.mark.unit

--- a/pkgs/standards/peagen/tests/unit/test_keys_cli.py
+++ b/pkgs/standards/peagen/tests/unit/test_keys_cli.py
@@ -51,12 +51,19 @@ def test_upload_sends_public_key(monkeypatch, tmp_path, capsys):
 
     monkeypatch.setattr(keys_mod, "httpx", type("X", (), {"post": fake_post}))
 
-    keys_mod.upload(ctx=None, key_dir=tmp_path, gateway_url="http://gw/rpc")
+    keys_mod.upload(
+        ctx=None,
+        key_dir=tmp_path,
+        gateway_url="http://gw/rpc",
+        pool="demo",
+        repo="org/repo",
+    )
     out = capsys.readouterr().out
 
     assert captured["url"] == "http://gw/rpc"
     assert captured["json"]["method"] == "Keys.upload"
     assert captured["json"]["params"]["public_key"] == "PUB"
+    assert captured["json"]["params"]["tenant_id"] == "demo"
     assert "Uploaded public key" in out
 
 
@@ -75,11 +82,18 @@ def test_remove_posts_delete(monkeypatch, capsys):
 
     monkeypatch.setattr(keys_mod, "httpx", type("X", (), {"post": fake_post}))
 
-    keys_mod.remove(ctx=None, fingerprint="abc", gateway_url="http://gw")
+    keys_mod.remove(
+        ctx=None,
+        fingerprint="abc",
+        gateway_url="http://gw",
+        pool="demo",
+        repo="org/repo",
+    )
     out = capsys.readouterr().out
 
     assert captured["json"]["method"] == "Keys.delete"
     assert captured["json"]["params"]["fingerprint"] == "abc"
+    assert captured["json"]["params"]["tenant_id"] == "demo"
     assert "Removed key abc" in out
 
 
@@ -94,7 +108,7 @@ def test_fetch_server_prints_response(monkeypatch, capsys):
 
     monkeypatch.setattr(keys_mod, "httpx", type("X", (), {"post": fake_post}))
 
-    keys_mod.fetch_server(ctx=None, gateway_url="http://gw")
+    keys_mod.fetch_server(ctx=None, gateway_url="http://gw", pool="demo")
     out = capsys.readouterr().out
 
     assert json.loads(out) == {"k": "v"}

--- a/pkgs/standards/peagen/tests/unit/test_keys_core.py
+++ b/pkgs/standards/peagen/tests/unit/test_keys_core.py
@@ -1,5 +1,6 @@
 import tempfile
 from pathlib import Path
+import pytest
 
 
 from peagen.core import keys_core
@@ -64,3 +65,25 @@ def test_export_public_key_delegates(monkeypatch, tmp_path):
     monkeypatch.setattr(keys_core, "PluginManager", PM)
     text = keys_core.export_public_key("FP", key_dir=tmp_path)
     assert text == "KEY"
+
+
+@pytest.mark.unit
+def test_upload_and_remove_key(monkeypatch, tmp_path):
+    monkeypatch.setattr(keys_core, "_get_driver", lambda *a, **k: DummyDriver(tmp_path))
+    posted = {}
+
+    def fake_post(url, json, timeout):
+        posted.update(json=json)
+
+        class R:
+            def json(self):
+                return {}
+
+        return R()
+
+    monkeypatch.setattr(keys_core, "httpx", type("X", (), {"post": fake_post}))
+
+    keys_core.upload_public_key(key_dir=tmp_path, tenant_id="t")
+    assert posted["json"]["params"]["tenant_id"] == "t"
+    keys_core.remove_public_key("FP", tenant_id="t")
+    assert posted["json"]["method"] == "Keys.delete"

--- a/pkgs/standards/peagen/tests/unit/test_secrets_cli.py
+++ b/pkgs/standards/peagen/tests/unit/test_secrets_cli.py
@@ -120,10 +120,12 @@ def test_remote_add_posts(monkeypatch):
         version=1,
         recipient=[],
         pool="p",
+        repo="org/repo",
     )
     assert posted["json"]["params"]["secret"].startswith("enc:")
     assert posted["json"]["params"]["name"] == "ID"
     assert posted["json"]["params"]["version"] == 1
+    assert posted["json"]["params"]["tenant_id"] == "p"
 
 
 def test_remote_get(monkeypatch):
@@ -147,6 +149,7 @@ def test_remote_get(monkeypatch):
         "ID",
         gateway_url="https://gw.peagen.com",
         pool="default",
+        repo=None,
     )
     assert out == ["value"]
     assert posted["json"] == {
@@ -175,6 +178,7 @@ def test_remote_remove(monkeypatch):
         version=2,
         gateway_url="https://gw.peagen.com",
         pool="default",
+        repo=None,
     )
     assert posted["json"] == {
         "jsonrpc": "2.0",

--- a/pkgs/standards/peagen/tests/unit/test_utils_slug.py
+++ b/pkgs/standards/peagen/tests/unit/test_utils_slug.py
@@ -1,5 +1,5 @@
 import pytest
-from peagen._utils.slug_utils import slugify
+from peagen._utils.slug_utils import slugify, repo_slug
 
 
 @pytest.mark.unit
@@ -7,3 +7,9 @@ def test_slugify_simple():
     assert slugify("My Project") == "my-project"
     assert slugify("Hello_World") == "hello_world"
     assert slugify("Some@Project!") == "some-project"
+
+
+@pytest.mark.unit
+def test_repo_slug_parses_refs():
+    assert repo_slug("gh://org/repo") == "org-repo"
+    assert repo_slug("git+https://github.com/org/repo.git@main") == "org-repo"


### PR DESCRIPTION
## Summary
- allow specifying repo to derive tenant slug in `login`, `keys`, and `secrets` commands
- support tenant_id in `keys_core` and gateway RPC methods
- document new `--pool` and `--repo` flags in the GitHub VCS guide
- add `repo_slug` helper and tests

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen --fix` *(fails: F821 Undefined name Tenant)*
- `uv run --package peagen --directory pkgs/standards/peagen pytest` *(fails: ModuleNotFoundError: No module named 'peagen.models.schemas')*
- `peagen gateway --help` *(fails: ImportError: cannot import name 'Task')*
- `peagen local -q process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml --watch` *(fails: ImportError: cannot import name 'Task')*

------
https://chatgpt.com/codex/tasks/task_e_685d3594ba8c83268ff03936d0856fa0