### PR TITLE
Fix .peagen.toml VCS sections

### DIFF
--- a/.peagen.toml
+++ b/.peagen.toml
@@ -96,12 +96,12 @@ default_evaluator = "performance"
 default_vcs = "git"
 
 
-[vcs.git]
+[vcs.adapters.git]
 mirror_git_url = "${MIRROR_GIT_URL}"
 mirror_git_token = "${MIRROR_GIT_TOKEN}"
 owner = "${OWNER}"
 
 
-[vcs.git.remotes]
+[vcs.adapters.git.remotes]
 origin = "${GITEA_REMOTE}"
 upstream = "${GITHUB_REMOTE}"

--- a/infra/.gw.peagen.toml
+++ b/infra/.gw.peagen.toml
@@ -47,13 +47,13 @@ dsn = "${PG_DSN}"
 default_vcs = "git"
 
 
-[vcs.git]
+[vcs.adapters.git]
 mirror_git_url = "${MIRROR_GIT_URL}"
 mirror_git_token = "${MIRROR_GIT_TOKEN}"
 owner = "${OWNER}"
 
 
-[vcs.git.remotes]
+[vcs.adapters.git.remotes]
 origin = "${GITEA_REMOTE}"
 upstream = "${GITHUB_REMOTE}"
 

--- a/infra/.worker.peagen.toml
+++ b/infra/.worker.peagen.toml
@@ -79,13 +79,13 @@ target_grade_level = 12
 default_vcs = "git"
 
 
-[vcs.git]
+[vcs.adapters.git]
 mirror_git_url = "${MIRROR_GIT_URL}"
 mirror_git_token = "${MIRROR_GIT_TOKEN}"
 owner = "${OWNER}"
 
 
-[vcs.git.remotes]
+[vcs.adapters.git.remotes]
 origin = "${GITEA_REMOTE}"
 upstream = "${GITHUB_REMOTE}"
 

--- a/pkgs/standards/peagen/README.md
+++ b/pkgs/standards/peagen/README.md
@@ -143,13 +143,13 @@ output_dir = "./peagen_artifacts"
 default_vcs = "git"
 
 
-[vcs.git]
+[vcs.adapters.git]
 mirror_git_url = "${MIRROR_GIT_URL}"
 mirror_git_token = "${MIRROR_GIT_TOKEN}"
 owner = "${OWNER}"
 
 
-[vcs.git.remotes]
+[vcs.adapters.git.remotes]
 origin = "${GITEA_REMOTE}"
 upstream = "${GITHUB_REMOTE}"
 ```

--- a/pkgs/standards/peagen/docs/git_vcs.md
+++ b/pkgs/standards/peagen/docs/git_vcs.md
@@ -23,11 +23,11 @@ vcs.tag(run_ref)
 ```
 
 Git repositories can also push to a secondary **mirror**. Set
-``mirror_git_url`` and ``mirror_git_token`` under the ``[vcs.git]`` section in
+``mirror_git_url`` and ``mirror_git_token`` under the ``[vcs.adapters.git]`` section in
 your ``.peagen.toml``. When configured, :class:`GitVCS` pushes the same ref to
 the ``mirror`` remote after updating ``origin``.
 
-Multiple remotes can be declared via ``[vcs.git.remotes]``. The ``origin`` entry
+Multiple remotes can be declared via ``[vcs.adapters.git.remotes]``. The ``origin`` entry
 is used when cloning repositories and additional names such as ``upstream`` are
 configured after creation.
 

--- a/pkgs/standards/peagen/tests/examples/2x2Grid/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/2x2Grid/.peagen.toml
@@ -16,12 +16,12 @@ root_dir = "./task_runs"
 default_vcs = "git"
 
 
-[vcs.git]
+[vcs.adapters.git]
 mirror_git_url = "${MIRROR_GIT_URL}"
 mirror_git_token = "${MIRROR_GIT_TOKEN}"
 owner = "${OWNER}"
 
 
-[vcs.git.remotes]
+[vcs.adapters.git.remotes]
 origin = "${GITEA_REMOTE}"
 upstream = "${GITHUB_REMOTE}"

--- a/pkgs/standards/peagen/tests/examples/gateway_demo/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/gateway_demo/.peagen.toml
@@ -16,12 +16,12 @@ root_dir = "./task_runs"
 default_vcs = "git"
 
 
-[vcs.git]
+[vcs.adapters.git]
 mirror_git_url = "${MIRROR_GIT_URL}"
 mirror_git_token = "${MIRROR_GIT_TOKEN}"
 owner = "${OWNER}"
 
 
-[vcs.git.remotes]
+[vcs.adapters.git.remotes]
 origin = "${GITEA_REMOTE}"
 upstream = "${GITHUB_REMOTE}"

--- a/pkgs/standards/peagen/tests/examples/peagen_local_demo/test_workspace/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/peagen_local_demo/test_workspace/.peagen.toml
@@ -35,12 +35,12 @@ API_KEY = "${GROQ_API_KEY}"
 default_vcs = "git"
 
 
-[vcs.git]
+[vcs.adapters.git]
 mirror_git_url = "${MIRROR_GIT_URL}"
 mirror_git_token = "${MIRROR_GIT_TOKEN}"
 owner = "${OWNER}"
 
 
-[vcs.git.remotes]
+[vcs.adapters.git.remotes]
 origin = "${GITEA_REMOTE}"
 upstream = "${GITHUB_REMOTE}"

--- a/pkgs/standards/peagen/tests/examples/peagen_tomls/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/peagen_tomls/.peagen.toml
@@ -84,12 +84,12 @@ target_grade_level = 12
 default_vcs = "git"
 
 
-[vcs.git]
+[vcs.adapters.git]
 mirror_git_url = "${MIRROR_GIT_URL}"
 mirror_git_token = "${MIRROR_GIT_TOKEN}"
 owner = "${OWNER}"
 
 
-[vcs.git.remotes]
+[vcs.adapters.git.remotes]
 origin = "${GITEA_REMOTE}"
 upstream = "${GITHUB_REMOTE}"

--- a/pkgs/standards/peagen/tests/examples/simple_evolve_demo/cfg/local.toml
+++ b/pkgs/standards/peagen/tests/examples/simple_evolve_demo/cfg/local.toml
@@ -28,13 +28,13 @@ strict = true
 default_vcs = "git"
 
 
-[vcs.git]
+[vcs.adapters.git]
 mirror_git_url = "${MIRROR_GIT_URL}"
 mirror_git_token = "${MIRROR_GIT_TOKEN}"
 owner = "${OWNER}"
 
 
-[vcs.git.remotes]
+[vcs.adapters.git.remotes]
 origin = "${GITEA_REMOTE}"
 upstream = "${GITHUB_REMOTE}"
 

--- a/pkgs/standards/peagen/tests/examples/simple_evolve_demo/cfg/remote.toml
+++ b/pkgs/standards/peagen/tests/examples/simple_evolve_demo/cfg/remote.toml
@@ -30,13 +30,13 @@ strict = true
 default_vcs = "git"
 
 
-[vcs.git]
+[vcs.adapters.git]
 mirror_git_url = "${MIRROR_GIT_URL}"
 mirror_git_token = "${MIRROR_GIT_TOKEN}"
 owner = "${OWNER}"
 
 
-[vcs.git.remotes]
+[vcs.adapters.git.remotes]
 origin = "${GITEA_REMOTE}"
 upstream = "${GITHUB_REMOTE}"
 

--- a/pkgs/standards/peagen/tests/examples/simple_evolve_demo/workspace/.peagen.toml
+++ b/pkgs/standards/peagen/tests/examples/simple_evolve_demo/workspace/.peagen.toml
@@ -35,12 +35,12 @@ API_KEY = "${GROQ_API_KEY}"
 default_vcs = "git"
 
 
-[vcs.git]
+[vcs.adapters.git]
 mirror_git_url = "${MIRROR_GIT_URL}"
 mirror_git_token = "${MIRROR_GIT_TOKEN}"
 owner = "${OWNER}"
 
 
-[vcs.git.remotes]
+[vcs.adapters.git.remotes]
 origin = "${GITEA_REMOTE}"
 upstream = "${GITHUB_REMOTE}"


### PR DESCRIPTION
## Summary
- update `[vcs.git]` sections to `[vcs.adapters.git]`
- update README and docs to use new VCS adapter syntax

## Testing
- `uv run --directory . --package peagen ruff format .`
- `uv run --directory . --package peagen ruff check . --fix` *(fails: F821 errors)*
- `uv run --package peagen --directory . pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685d3dfe2cd0832687d31b2e8fc8635b