### PR TITLE
Implement multi-remote git support

### DIFF
--- a/pkgs/standards/peagen/peagen/core/init_core.py
+++ b/pkgs/standards/peagen/peagen/core/init_core.py
@@ -251,6 +251,14 @@ def init_repo(
         "next": "configure DEPLOY_KEY_SECRET",
     }
 
+    if path is not None:
+        from peagen.core.mirror_core import ensure_repo
+
+        ensure_repo(path, remotes=remotes)
+        result.update({"configured": str(path)})
+
+    return result
+
 
 def configure_repo(*, path: Path, remotes: dict[str, str]) -> Dict[str, Any]:
     """Configure an existing repository with additional remotes."""

--- a/pkgs/standards/peagen/peagen/plugins/vcs/git_vcs.py
+++ b/pkgs/standards/peagen/peagen/plugins/vcs/git_vcs.py
@@ -58,7 +58,17 @@ class GitVCS:
         else:
             self.repo = Repo.init(p)
 
+        ordered: list[tuple[str, str]] = []
+        if "origin" in remotes:
+            ordered.append(("origin", remotes["origin"]))
+        if "upstream" in remotes:
+            ordered.append(("upstream", remotes["upstream"]))
         for name, url in remotes.items():
+            if name in {"origin", "upstream"}:
+                continue
+            ordered.append((name, url))
+
+        for name, url in ordered:
             self.configure_remote(url, name=name)
 
         if mirror_git_url:


### PR DESCRIPTION
## Summary
- allow GitVCS to configure `origin` then `upstream`
- let `init_repo` set up local repos with multiple remotes

## Testing
- `uv run --package peagen --directory standards/peagen ruff check peagen/plugins/vcs/git_vcs.py peagen/core/init_core.py --fix`
- `uv run --package peagen --directory standards/peagen pytest` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685e88bda6248326a19722f316425831