### PR TITLE
Rename TaskPayload to Task

### DIFF
--- a/pkgs/standards/peagen/peagen/models/__init__.py
+++ b/pkgs/standards/peagen/peagen/models/__init__.py
@@ -35,7 +35,7 @@ from .repo.repository_user_association import RepositoryUserAssociation  # noqa:
 # Task / execution domain
 # ----------------------------------------------------------------------
 from .task.status import Status  # noqa: F401
-from .task.task_payload import TaskPayload  # noqa: F401
+from .task.task import Task  # noqa: F401
 from .task.raw_blob import RawBlob  # noqa: F401
 from .task.task_run import TaskRun  # noqa: F401
 from .task.task_relation import TaskRelation  # noqa: F401
@@ -92,7 +92,7 @@ __all__: list[str] = [
     "RepositoryDeployKeyAssociation",
     "RepositoryUserAssociation",
     # task
-    "TaskPayload",
+    "Task",
     "RawBlob",
     "Status",
     "TaskRun",

--- a/pkgs/standards/peagen/peagen/models/task/raw_blob.py
+++ b/pkgs/standards/peagen/peagen/models/task/raw_blob.py
@@ -2,12 +2,12 @@
 peagen.models.task.raw_blob
 ===========================
 
-Binary or encoded attachments tied to a TaskPayload.
+Binary or encoded attachments tied to a Task.
 
 Design Highlights
 -----------------
 • Uses the global BaseModel mixin (id, date_created, last_modified).
-• Belongs to exactly one TaskPayload (FK → task_payloads.id).
+• Belongs to exactly one Task (FK → tasks.id).
 • `media_type` records MIME type (e.g. 'image/png', 'text/csv').
 • `encoding` specifies how `data` is represented:
       'base64' | 'utf-8' | 'binary'  (extend as needed).
@@ -19,21 +19,25 @@ import uuid
 from sqlalchemy import String, LargeBinary, ForeignKey, Enum
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imports for type hints
+    from .task import Task
 
 from ..base import BaseModel
 
 
 class RawBlob(BaseModel):
     """
-    Opaque blob packaged with a TaskPayload.
+    Opaque blob packaged with a Task.
     """
 
     __tablename__ = "raw_blobs"
 
     # ──────────────────────── Columns ────────────────────────
-    task_payload_id: Mapped[uuid.UUID] = mapped_column(
+    task_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
-        ForeignKey("task_payloads.id", ondelete="CASCADE"),
+        ForeignKey("tasks.id", ondelete="CASCADE"),
         nullable=False,
     )
 
@@ -56,13 +60,13 @@ class RawBlob(BaseModel):
     )
 
     # ──────────────────── Relationships ──────────────────────
-    task_payload: Mapped["TaskPayload"] = relationship(
-        "TaskPayload", back_populates="raw_blobs", lazy="selectin"
+    task: Mapped["Task"] = relationship(
+        "Task", back_populates="raw_blobs", lazy="selectin"
     )
 
     # ─────────────────────── Magic ───────────────────────────
     def __repr__(self) -> str:  # pragma: no cover
         return (
-            f"<RawBlob id={self.id} payload={self.task_payload_id} "
+            f"<RawBlob id={self.id} payload={self.task_id} "
             f"type={self.media_type!r} enc={self.encoding}>"
         )

--- a/pkgs/standards/peagen/peagen/models/task/task.py
+++ b/pkgs/standards/peagen/peagen/models/task/task.py
@@ -1,8 +1,8 @@
 """
-peagen.models.task.task_payload
-===============================
+peagen.models.task.task
+=======================
 
-Structured payload describing *what* a Task should operate on.
+Structured payload describing *what* a task should operate on.
 
 Key Features
 ------------
@@ -18,11 +18,16 @@ import uuid
 from sqlalchemy import JSON, Text, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imports for type hints
+    from ..repo.git_reference import GitReference
+    from .raw_blob import RawBlob
 
 from ..base import BaseModel
 
 
-class TaskPayload(BaseModel):
+class Task(BaseModel):
     """
     Domain-level description of a Task’s inputs.
 
@@ -34,7 +39,7 @@ class TaskPayload(BaseModel):
     note            : TEXT? – human note / description
     """
 
-    __tablename__ = "task_payloads"
+    __tablename__ = "tasks"
 
     # ──────────────────────── Columns ────────────────────────
     tenant_id: Mapped[uuid.UUID] = mapped_column(
@@ -64,7 +69,7 @@ class TaskPayload(BaseModel):
 
     raw_blobs: Mapped[list["RawBlob"]] = relationship(
         "RawBlob",
-        back_populates="task_payload",
+        back_populates="task",
         cascade="all, delete-orphan",
         lazy="selectin",
     )
@@ -72,6 +77,6 @@ class TaskPayload(BaseModel):
     # ─────────────────────── Magic ───────────────────────────
     def __repr__(self) -> str:  # pragma: no cover
         return (
-            f"<TaskPayload id={self.id} tenant={self.tenant_id} "
+            f"<Task id={self.id} tenant={self.tenant_id} "
             f"git_ref={self.git_reference_id or '∅'}>"
         )

--- a/pkgs/standards/peagen/peagen/models/task/task_run.py
+++ b/pkgs/standards/peagen/peagen/models/task/task_run.py
@@ -2,11 +2,11 @@
 peagen.models.task.task_run
 ===========================
 
-Execution record for a TaskPayload dispatched to the worker pool.
+Execution record for a Task dispatched to the worker pool.
 
 Relationships
 -------------
-TaskPayload 1 ─⟶ 1..n TaskRun
+Task       1 ─⟶ 1..n TaskRun
 TaskRun      n ─⟶ n TaskRunDependencyAssociation (DAG edges)
 TaskRun      1 ─⟶ 0..n EvalResult
 """
@@ -17,6 +17,16 @@ import uuid
 from sqlalchemy import JSON, Enum, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imports for type hints
+    from ..infra.pool import Pool
+    from ..infra.worker import Worker
+    from ..tenant.user import User
+    from .task import Task
+    from .task_relation import TaskRelation
+    from .task_run_relation_association import TaskRunTaskRelationAssociation
+    from ..result.eval_result import EvalResult
 
 from ..base import BaseModel  # id, timestamps
 from .status import Status
@@ -24,15 +34,15 @@ from .status import Status
 
 class TaskRun(BaseModel):
     """
-    One execution attempt of a TaskPayload on a Worker.
+    One execution attempt of a Task on a Worker.
     """
 
     __tablename__ = "task_runs"
 
     # ─────────────────────── Columns ────────────────────────
-    task_payload_id: Mapped[uuid.UUID] = mapped_column(
+    task_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
-        ForeignKey("task_payloads.id", ondelete="CASCADE"),
+        ForeignKey("tasks.id", ondelete="CASCADE"),
         nullable=False,
     )
 
@@ -67,7 +77,7 @@ class TaskRun(BaseModel):
     )
 
     # ────────────────── Relationships ───────────────────────
-    task_payload: Mapped["TaskPayload"] = relationship("TaskPayload", lazy="selectin")
+    task: Mapped["Task"] = relationship("Task", lazy="selectin")
 
     pool: Mapped["Pool | None"] = relationship("Pool", lazy="selectin")
 


### PR DESCRIPTION
## Summary
- rename `TaskPayload` to `Task`
- update references in ORM models
- keep relationships working with forward reference imports for ruff

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format peagen/models/task/task.py peagen/models/task/task_run.py peagen/models/task/raw_blob.py peagen/models/__init__.py`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/models/task/task.py peagen/models/task/task_run.py peagen/models/task/raw_blob.py peagen/models/__init__.py --fix`
- `uv run --directory pkgs/standards --package peagen pytest` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685e9672fbf08326bc9ad232aaed6f58