### PR TITLE
Use FileLock for repo locking

### DIFF
--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -76,7 +76,7 @@ dependencies = [
 
 
     #core
-    "fcntl"
+    "filelock"
 
 
 ]


### PR DESCRIPTION
## Summary
- use `filelock` instead of `fcntl` in `repo_lock`
- add `filelock` dependency

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff check peagen/core/mirror_core.py --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest` *(fails: ModuleNotFoundError: No module named 'peagen.models.task_run')*
- `uv run --package peagen --directory pkgs/standards/peagen peagen remote -q --gateway-url http://localhost:8000/rpc process tests/examples/projects_payloads/projects_payload.yaml --watch` *(fails: ModuleNotFoundError: No module named 'peagen.models.schemas')*
- `uv run --package peagen --directory pkgs/standards/peagen peagen local -q process tests/examples/projects_payloads/projects_payload.yaml --watch` *(fails: ModuleNotFoundError: No module named 'peagen.models.schemas')*

------
https://chatgpt.com/codex/tasks/task_e_685eab43129c832699aaf9f4e14b914c