### PR TITLE
Cross-platform file locking for peagen

### DIFF
--- a/pkgs/standards/peagen/peagen/core/mirror_core.py
+++ b/pkgs/standards/peagen/peagen/core/mirror_core.py
@@ -8,7 +8,7 @@ import os
 import hashlib
 import tempfile
 import shutil
-import fcntl
+from filelock import FileLock
 from contextlib import contextmanager
 import httpx
 
@@ -103,12 +103,9 @@ def repo_lock(repo_uri: str):
     lock_root = Path(os.getenv("PEAGEN_LOCK_DIR", LOCK_DIR)).expanduser()
     lock_root.mkdir(parents=True, exist_ok=True)
     lock_path = lock_root / f"{hashlib.sha1(repo_uri.encode()).hexdigest()}.lock"
-    with open(lock_path, "w") as fh:
-        fcntl.flock(fh, fcntl.LOCK_EX)
-        try:
-            yield
-        finally:
-            fcntl.flock(fh, fcntl.LOCK_UN)
+    file_lock = FileLock(lock_path)
+    with file_lock:
+        yield
 
 
 def add_git_worktree(repo: Repo, ref: str) -> Path:

--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -73,6 +73,7 @@ dependencies = [
     "pygit2",
     "s3fs",
     "pytest-monitor>=1.6.6",
+    "filelock>=3.9",
 
 
 


### PR DESCRIPTION
## Summary
- replace `fcntl` usage with `FileLock` in `mirror_core`
- add `filelock` dependency

## Testing
- `uv run --directory standards --package peagen ruff check peagen/peagen/core/mirror_core.py --fix`
- `uv run --package peagen --directory standards pytest` *(fails: ModuleNotFoundError)*
- `peagen remote -q --gateway-url http://localhost:8000/rpc process standards/peagen/tests/examples/projects_payloads/projects_payload.yaml --watch` *(fails: ModuleNotFoundError)*
- `peagen local -q process standards/peagen/tests/examples/projects_payloads/projects_payload.yaml --watch` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685eabeb20b08326956ab480e44bb991