### PR TITLE
Centralize repo lock directory

### DIFF
--- a/pkgs/standards/peagen/peagen/core/mirror_core.py
+++ b/pkgs/standards/peagen/peagen/core/mirror_core.py
@@ -98,9 +98,9 @@ def update_git_remote(git_repo: Repo, ssh_cmd: str | None = None) -> None:
 @contextmanager
 def repo_lock(repo_uri: str):
     """Context manager yielding a file lock for ``repo_uri``."""
-    from peagen.defaults import LOCK_DIR
+    from peagen.defaults import lock_dir
 
-    lock_root = Path(os.getenv("PEAGEN_LOCK_DIR", LOCK_DIR)).expanduser()
+    lock_root = lock_dir()
     lock_root.mkdir(parents=True, exist_ok=True)
     lock_path = lock_root / f"{hashlib.sha1(repo_uri.encode()).hexdigest()}.lock"
     file_lock = FileLock(lock_path)

--- a/pkgs/standards/peagen/peagen/defaults/__init__.py
+++ b/pkgs/standards/peagen/peagen/defaults/__init__.py
@@ -3,11 +3,22 @@
 Package-level built-in configuration and constants.
 """
 
+import os
+from pathlib import Path
+
 from .abuse import BAN_THRESHOLD
 from .events import CONTROL_QUEUE, READY_QUEUE, PUBSUB_CHANNEL, TASK_KEY
 from .error_codes import ErrorCode
 
+# Default directory for repository lock files.
 LOCK_DIR = "~/.cache/peagen/locks"
+
+
+def lock_dir() -> Path:
+    """Return the directory used for repository locks."""
+    return Path(os.getenv("PEAGEN_LOCK_DIR", LOCK_DIR)).expanduser()
+
+
 # Default worker pool used when none is specified via environment variables.
 DEFAULT_POOL = "default"
 
@@ -55,6 +66,7 @@ __all__ = [
     "PUBSUB_CHANNEL",
     "TASK_KEY",
     "LOCK_DIR",
+    "lock_dir",
     "DEFAULT_POOL",
     "ErrorCode",
 ]


### PR DESCRIPTION
## Summary
- factor out lock directory path logic to `peagen.defaults.lock_dir`
- reference `peagen.defaults.lock_dir` in `repo_lock`

## Testing
- `uv run --directory pkgs/standards --package peagen ruff format .`
- `uv run --directory pkgs/standards --package peagen ruff check . --fix` *(fails: F821 Undefined name `Optional`)*

------
https://chatgpt.com/codex/tasks/task_e_685eb75e09588326a9804020045612da