### PR TITLE
Fix ruff issues in peagen

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/analysis.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/analysis.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 import uuid
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 import httpx
 import typer

--- a/pkgs/standards/peagen/peagen/cli/commands/init.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/init.py
@@ -118,7 +118,7 @@ def local_init_repo_config(
         "path": str(path),
         "remotes": _parse_remotes(git_remote),
     }
-    result = _call_handler(args)
+    _call_handler(args)
     _summary(path, "git remotes configured")
     self.logger.info("Exiting local init_repo_config command")
 

--- a/pkgs/standards/peagen/peagen/cli/commands/validate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/validate.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import uuid
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import typer
 

--- a/pkgs/standards/peagen/peagen/models/__init__.py
+++ b/pkgs/standards/peagen/peagen/models/__init__.py
@@ -37,7 +37,6 @@ from .repo.repository_user_association import RepositoryUserAssociation  # noqa:
 from .task.status import Status  # noqa: F401
 from .task.task import Task  # noqa: F401
 from .task.raw_blob import RawBlob  # noqa: F401
-from .task import Task  # noqa: F401
 from .task.task_run import TaskRun  # noqa: F401
 from .task.task_relation import TaskRelation  # noqa: F401
 from .task.task_run_relation_association import (

--- a/pkgs/standards/peagen/peagen/models/infra/pool.py
+++ b/pkgs/standards/peagen/peagen/models/infra/pool.py
@@ -18,6 +18,12 @@ import uuid
 from sqlalchemy import JSON, String, Text, UniqueConstraint, ForeignKey, Integer
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imports for type hints
+    from ..tenant.tenant import Tenant
+    from .pool_worker_association import PoolWorkerAssociation
+    from .worker import Worker
 
 from ..base import BaseModel
 

--- a/pkgs/standards/peagen/peagen/models/infra/pool_worker_association.py
+++ b/pkgs/standards/peagen/peagen/models/infra/pool_worker_association.py
@@ -17,6 +17,11 @@ import uuid
 from sqlalchemy import Enum, ForeignKey, UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imports for type hints
+    from .pool import Pool
+    from .worker import Worker
 
 from ..base import BaseModel
 

--- a/pkgs/standards/peagen/peagen/models/infra/worker.py
+++ b/pkgs/standards/peagen/peagen/models/infra/worker.py
@@ -26,6 +26,13 @@ from datetime import datetime, timezone
 from sqlalchemy import JSON, Enum, ForeignKey, String, TIMESTAMP, UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imports for type hints
+    from ..tenant.tenant import Tenant
+    from .pool_worker_association import PoolWorkerAssociation
+    from .pool import Pool
+    from ..task.task_run import TaskRun
 
 from ..base import BaseModel
 

--- a/pkgs/standards/peagen/peagen/models/repo/deploy_key.py
+++ b/pkgs/standards/peagen/peagen/models/repo/deploy_key.py
@@ -22,6 +22,13 @@ import uuid
 from sqlalchemy import String, Boolean, Text, UniqueConstraint, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imports for type hints
+    from ..tenant.user import User
+    from ..config.secret import Secret
+    from .repository_deploy_key_association import RepositoryDeployKeyAssociation
+    from .repository import Repository
 
 from ..base import BaseModel
 

--- a/pkgs/standards/peagen/peagen/models/repo/git_reference.py
+++ b/pkgs/standards/peagen/peagen/models/repo/git_reference.py
@@ -17,6 +17,10 @@ import uuid
 from sqlalchemy import String, UniqueConstraint, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imports for type hints
+    from .repository import Repository
 
 from ..base import BaseModel
 

--- a/pkgs/standards/peagen/peagen/models/repo/repository.py
+++ b/pkgs/standards/peagen/peagen/models/repo/repository.py
@@ -21,6 +21,14 @@ import uuid
 from sqlalchemy import String, UniqueConstraint, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imports for type hints
+    from ..tenant.tenant import Tenant
+    from .git_reference import GitReference
+    from .repository_deploy_key_association import RepositoryDeployKeyAssociation
+    from .deploy_key import DeployKey
+    from .repository_user_association import RepositoryUserAssociation
 
 from ..base import BaseModel
 

--- a/pkgs/standards/peagen/peagen/models/repo/repository_deploy_key_association.py
+++ b/pkgs/standards/peagen/peagen/models/repo/repository_deploy_key_association.py
@@ -14,6 +14,11 @@ import uuid
 from sqlalchemy import UniqueConstraint, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imports for type hints
+    from .repository import Repository
+    from .deploy_key import DeployKey
 
 from ..base import BaseModel
 

--- a/pkgs/standards/peagen/peagen/models/repo/repository_user_association.py
+++ b/pkgs/standards/peagen/peagen/models/repo/repository_user_association.py
@@ -17,6 +17,11 @@ import uuid
 from sqlalchemy import String, UniqueConstraint, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imports for type hints
+    from .repository import Repository
+    from ..tenant.user import User
 
 from ..base import BaseModel
 

--- a/pkgs/standards/peagen/peagen/models/result/analysis_result.py
+++ b/pkgs/standards/peagen/peagen/models/result/analysis_result.py
@@ -22,6 +22,10 @@ import uuid
 from sqlalchemy import JSON, Text, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imports for type hints
+    from .eval_result import EvalResult
 
 from ..base import BaseModel
 

--- a/pkgs/standards/peagen/peagen/models/result/eval_result.py
+++ b/pkgs/standards/peagen/peagen/models/result/eval_result.py
@@ -17,6 +17,11 @@ import uuid
 from sqlalchemy import JSON, String, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imports for type hints
+    from ..task.task_run import TaskRun
+    from .analysis_result import AnalysisResult
 
 from ..base import BaseModel
 

--- a/pkgs/standards/peagen/peagen/models/security/public_key.py
+++ b/pkgs/standards/peagen/peagen/models/security/public_key.py
@@ -33,6 +33,10 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imports for type hints
+    from ..tenant.user import User
 
 from ..base import BaseModel
 

--- a/pkgs/standards/peagen/peagen/models/specs/doe_spec.py
+++ b/pkgs/standards/peagen/peagen/models/specs/doe_spec.py
@@ -18,6 +18,11 @@ import uuid
 from sqlalchemy import JSON, String, Text, UniqueConstraint, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imports for type hints
+    from ..tenant.tenant import Tenant
+    from .project_payload import ProjectPayload
 
 from ..base import BaseModel
 

--- a/pkgs/standards/peagen/peagen/models/specs/evolve_spec.py
+++ b/pkgs/standards/peagen/peagen/models/specs/evolve_spec.py
@@ -17,6 +17,10 @@ import uuid
 from sqlalchemy import JSON, String, Text, UniqueConstraint, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imports for type hints
+    from ..tenant.tenant import Tenant
 
 from ..base import BaseModel
 

--- a/pkgs/standards/peagen/peagen/models/specs/project_payload.py
+++ b/pkgs/standards/peagen/peagen/models/specs/project_payload.py
@@ -24,6 +24,11 @@ import uuid
 from sqlalchemy import JSON, String, Text, UniqueConstraint, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imports for type hints
+    from ..tenant.tenant import Tenant
+    from .doe_spec import DoeSpec
 
 from ..base import BaseModel
 

--- a/pkgs/standards/peagen/peagen/models/task/task_relation.py
+++ b/pkgs/standards/peagen/peagen/models/task/task_relation.py
@@ -17,6 +17,12 @@ import uuid
 from sqlalchemy import String, Text, UniqueConstraint, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imports for type hints
+    from ..tenant.tenant import Tenant
+    from .task_run_relation_association import TaskRunTaskRelationAssociation
+    from .task_run import TaskRun
 
 from ..base import BaseModel
 

--- a/pkgs/standards/peagen/peagen/models/task/task_run_relation_association.py
+++ b/pkgs/standards/peagen/peagen/models/task/task_run_relation_association.py
@@ -11,6 +11,11 @@ import uuid
 from sqlalchemy import ForeignKey, UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imports for type hints
+    from .task_run import TaskRun
+    from .task_relation import TaskRelation
 
 from ..base import BaseModel
 

--- a/pkgs/standards/peagen/peagen/models/tenant/tenant.py
+++ b/pkgs/standards/peagen/peagen/models/tenant/tenant.py
@@ -12,6 +12,11 @@ from __future__ import annotations
 
 from sqlalchemy import String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imports for type hints
+    from .tenant_user_association import TenantUserAssociation
+    from .user import User
 
 from ..base import BaseModel  # id, date_created, last_modified mixins
 

--- a/pkgs/standards/peagen/peagen/models/tenant/tenant_user_association.py
+++ b/pkgs/standards/peagen/peagen/models/tenant/tenant_user_association.py
@@ -13,6 +13,11 @@ import uuid
 from sqlalchemy import String, ForeignKey, UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imports for type hints
+    from .tenant import Tenant
+    from .user import User
 
 from ..base import BaseModel
 

--- a/pkgs/standards/peagen/peagen/models/tenant/user.py
+++ b/pkgs/standards/peagen/peagen/models/tenant/user.py
@@ -13,6 +13,13 @@ from __future__ import annotations
 
 from sqlalchemy import String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imports for type hints
+    from .tenant_user_association import TenantUserAssociation
+    from .tenant import Tenant
+    from ..repo.repository_user_association import RepositoryUserAssociation
+    from ..security.public_key import PublicKey
 
 from ..base import BaseModel
 


### PR DESCRIPTION
## Summary
- make linting fixes across peagen CLI and models
- add `TYPE_CHECKING` imports for ORM models
- remove duplicate import in models package

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --directory pkgs/standards/peagen --package peagen pytest` *(fails: Option() got an unexpected keyword argument 'multiple')*
- `peagen local -q process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml --watch` *(fails: TypeError: Option() got an unexpected keyword argument 'multiple')*

------
https://chatgpt.com/codex/tasks/task_e_685eb76e5db08326bdde16b4f2ca62e2