### PR TITLE
Fix imports and CLI option for peagen

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/init.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/init.py
@@ -107,7 +107,6 @@ def local_init_repo_config(
         None,
         "--git-remote",
         help="Git remote in name=url format. Use multiple times for several remotes",
-        multiple=True,
     ),
 ) -> None:
     """Configure Git remotes for an existing repository."""
@@ -147,7 +146,6 @@ def local_init_project(
         None,
         "--git-remote",
         help="Git remote in name=url format. Use multiple times for several remotes",
-        multiple=True,
     ),
     filter_uri: str = typer.Option(
         None, "--filter-uri", help="Configure git filter with this URI"
@@ -204,7 +202,6 @@ def remote_init_project(
         None,
         "--git-remote",
         help="Git remote in name=url format. Use multiple times for several remotes",
-        multiple=True,
     ),
     filter_uri: str = typer.Option(
         None, "--filter-uri", help="Configure git filter with this URI"
@@ -240,7 +237,6 @@ def remote_init_repo_config(
         None,
         "--git-remote",
         help="Git remote in name=url format. Use multiple times for several remotes",
-        multiple=True,
     ),
 ) -> None:
     """Submit a repo configuration task via JSON-RPC."""

--- a/pkgs/standards/peagen/tests/perf/test_backend_benchmarks.py
+++ b/pkgs/standards/peagen/tests/perf/test_backend_benchmarks.py
@@ -2,7 +2,7 @@ import asyncio
 import uuid
 import pytest
 
-from peagen.models.task_run import TaskRun, Status
+from peagen.models import TaskRun, Status
 from peagen.plugins.result_backends.localfs_backend import LocalFsResultBackend
 from peagen.plugins.result_backends.postgres_backend import PostgresResultBackend
 from peagen.plugins.result_backends.in_memory_backend import InMemoryResultBackend

--- a/pkgs/standards/peagen/tests/unit/test_result_backends.py
+++ b/pkgs/standards/peagen/tests/unit/test_result_backends.py
@@ -2,7 +2,7 @@ import json
 import uuid
 import pytest
 
-from peagen.models.task_run import TaskRun, Status
+from peagen.models import TaskRun, Status
 from peagen.plugins.result_backends.localfs_backend import LocalFsResultBackend
 from peagen.plugins.result_backends.postgres_backend import PostgresResultBackend
 from peagen.plugins.result_backends.in_memory_backend import InMemoryResultBackend

--- a/pkgs/standards/peagen/tests/unit/test_selectors.py
+++ b/pkgs/standards/peagen/tests/unit/test_selectors.py
@@ -7,7 +7,7 @@ from peagen.plugins.selectors import (
     InputSelector,
 )
 from peagen.plugins.result_backends.in_memory_backend import InMemoryResultBackend
-from peagen.models.task_run import TaskRun, Status
+from peagen.models import TaskRun, Status
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- fix path for TaskRun/Status imports in tests
- adjust CLI options to work with newer Typer

## Testing
- `uv run --directory standards/peagen --package peagen ruff format .`
- `uv run --directory standards/peagen --package peagen ruff check . --fix`
- `uv run --directory standards/peagen --package peagen pytest -q` *(fails: 51 failed, 176 passed, 31 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_685eba2a28c88326aab04a0ed9f5aaf3