### PR TITLE
Fix peagen migration import

### DIFF
--- a/pkgs/standards/peagen/peagen/migrations/versions/ae1de73e4143_init.py
+++ b/pkgs/standards/peagen/peagen/migrations/versions/ae1de73e4143_init.py
@@ -2,7 +2,11 @@
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy import inspect
-from peagen.models.task_run import status_enum  # ← shared object, create_type=False
+from peagen.models.task.status import Status
+
+status_enum = sa.Enum(
+    Status, name="task_status_enum"
+)  # ← shared object, create_type=False
 
 revision = "ae1de73e4143"
 down_revision = None


### PR DESCRIPTION
## Summary
- fix import path for task_run status enum
- define `status_enum` constant inside the migration for clarity

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format peagen/migrations/versions/ae1de73e4143_init.py`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/migrations/versions/ae1de73e4143_init.py --fix`
- `alembic -c peagen/alembic.ini upgrade head` *(fails: cannot import name 'status_enum')*
- `pytest -k alembic_upgrade_and_current -q` *(fails: 285 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685ec00ad62c83268841f04148f6d3a3