### PR TITLE
Fix peagen model imports

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/evolve.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/evolve.py
@@ -12,7 +12,8 @@ import httpx
 import typer
 
 from peagen.handlers.evolve_handler import evolve_handler
-from peagen.models import Status, Task
+from peagen.models import Status
+from peagen.models.task import Task
 from peagen.core.validate_core import validate_evolve_spec
 
 local_evolve_app = typer.Typer(help="Expand evolve spec and run mutate tasks")

--- a/pkgs/standards/peagen/peagen/migrations/versions/ae1de73e4143_init.py
+++ b/pkgs/standards/peagen/peagen/migrations/versions/ae1de73e4143_init.py
@@ -2,7 +2,9 @@
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy import inspect
-from peagen.models.task_run import status_enum  # ← shared object, create_type=False
+from peagen.models.task.task_run import (
+    status_enum,
+)  # ← shared object, create_type=False
 
 revision = "ae1de73e4143"
 down_revision = None

--- a/pkgs/standards/peagen/peagen/models/__init__.py
+++ b/pkgs/standards/peagen/peagen/models/__init__.py
@@ -74,6 +74,7 @@ from .git_mirror import GitMirror  # noqa: F401
 # Misc / security
 # ----------------------------------------------------------------------
 from .AbuseRecord import AbuseRecord  # noqa: F401
+from .security.public_key import PublicKey  # noqa: F401
 
 # ----------------------------------------------------------------------
 # Public re-exports
@@ -116,4 +117,5 @@ __all__: list[str] = [
     "GitMirror",
     # misc
     "AbuseRecord",
+    "PublicKey",
 ]

--- a/pkgs/standards/peagen/peagen/models/repo/repository.py
+++ b/pkgs/standards/peagen/peagen/models/repo/repository.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:  # pragma: no cover - imports for type hints
     from .repository_deploy_key_association import RepositoryDeployKeyAssociation
     from .deploy_key import DeployKey
     from .repository_user_association import RepositoryUserAssociation
+    from ..config.peagen_toml_spec import PeagenTomlSpec
 
 from ..base import BaseModel
 
@@ -83,6 +84,13 @@ class Repository(BaseModel):
         "DeployKey",
         secondary="repository_deploy_key_associations",
         back_populates="repositories",
+        lazy="selectin",
+    )
+
+    toml_specs: Mapped[list["PeagenTomlSpec"]] = relationship(
+        "PeagenTomlSpec",
+        back_populates="repository",
+        cascade="all, delete-orphan",
         lazy="selectin",
     )
 

--- a/pkgs/standards/peagen/peagen/models/tenant/tenant.py
+++ b/pkgs/standards/peagen/peagen/models/tenant/tenant.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:  # pragma: no cover - imports for type hints
     from .tenant_user_association import TenantUserAssociation
     from .user import User
+    from ..repo.repository import Repository
 
 from ..base import BaseModel  # id, date_created, last_modified mixins
 
@@ -53,6 +54,13 @@ class Tenant(BaseModel):
         "User",
         secondary="tenant_user_associations",
         viewonly=True,
+        lazy="selectin",
+    )
+
+    repositories: Mapped[list["Repository"]] = relationship(
+        "Repository",
+        back_populates="tenant",
+        cascade="all, delete-orphan",
         lazy="selectin",
     )
 


### PR DESCRIPTION
## Summary
- expose PublicKey in models
- add repositories relationship on Tenant
- include toml_specs relationship on Repository
- correct migration import path
- use pydantic Task in evolve CLI

## Testing
- `uv run --directory . --package peagen ruff format .`
- `uv run --directory . --package peagen ruff check . --fix`
- `uv run --package peagen --directory . pytest tests/unit` *(fails: OperationalError)*

------
https://chatgpt.com/codex/tasks/task_e_685ec024484c832683f98b6ca4b25164