### PR TITLE
Fix TaskRun imports in peagen

### DIFF
--- a/pkgs/standards/peagen/peagen/core/task_core.py
+++ b/pkgs/standards/peagen/peagen/core/task_core.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from typing import Dict
 
 from peagen.gateway.db import Session
-from peagen.models import TaskRun
+from peagen.models.task.task_run import TaskRun
 from sqlalchemy.exc import DataError
 from peagen.errors import TaskNotFoundError
 

--- a/pkgs/standards/peagen/peagen/plugins/result_backends/base.py
+++ b/pkgs/standards/peagen/peagen/plugins/result_backends/base.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 from typing import Any, Dict, List
 
-from peagen.models import TaskRun
+from peagen.models.task.task_run import TaskRun
 
 
 class ResultBackendBase:

--- a/pkgs/standards/peagen/peagen/plugins/result_backends/in_memory_backend.py
+++ b/pkgs/standards/peagen/peagen/plugins/result_backends/in_memory_backend.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from peagen.models import TaskRun
+from peagen.models.task.task_run import TaskRun
 from .base import ResultBackendBase
 
 

--- a/pkgs/standards/peagen/peagen/plugins/result_backends/localfs_backend.py
+++ b/pkgs/standards/peagen/peagen/plugins/result_backends/localfs_backend.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from peagen.models import TaskRun
+from peagen.models.task.task_run import TaskRun
 from .base import ResultBackendBase
 
 

--- a/pkgs/standards/peagen/peagen/plugins/result_backends/postgres_backend.py
+++ b/pkgs/standards/peagen/peagen/plugins/result_backends/postgres_backend.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from peagen.models import TaskRun
+from peagen.models.task.task_run import TaskRun
 from .base import ResultBackendBase
 
 Session = None

--- a/pkgs/standards/peagen/tests/perf/test_backend_benchmarks.py
+++ b/pkgs/standards/peagen/tests/perf/test_backend_benchmarks.py
@@ -2,7 +2,8 @@ import asyncio
 import uuid
 import pytest
 
-from peagen.models import TaskRun, Status
+from peagen.models.task.task_run import TaskRun
+from peagen.models.task.status import Status
 from peagen.plugins.result_backends.localfs_backend import LocalFsResultBackend
 from peagen.plugins.result_backends.postgres_backend import PostgresResultBackend
 from peagen.plugins.result_backends.in_memory_backend import InMemoryResultBackend

--- a/pkgs/standards/peagen/tests/unit/test_result_backends.py
+++ b/pkgs/standards/peagen/tests/unit/test_result_backends.py
@@ -2,7 +2,8 @@ import json
 import uuid
 import pytest
 
-from peagen.models import TaskRun, Status
+from peagen.models.task.task_run import TaskRun
+from peagen.models.task.status import Status
 from peagen.plugins.result_backends.localfs_backend import LocalFsResultBackend
 from peagen.plugins.result_backends.postgres_backend import PostgresResultBackend
 from peagen.plugins.result_backends.in_memory_backend import InMemoryResultBackend

--- a/pkgs/standards/peagen/tests/unit/test_selectors.py
+++ b/pkgs/standards/peagen/tests/unit/test_selectors.py
@@ -7,7 +7,8 @@ from peagen.plugins.selectors import (
     InputSelector,
 )
 from peagen.plugins.result_backends.in_memory_backend import InMemoryResultBackend
-from peagen.models import TaskRun, Status
+from peagen.models.task.task_run import TaskRun
+from peagen.models.task.status import Status
 
 
 @pytest.mark.unit

--- a/pkgs/standards/peagen/tests/unit/test_task_metadata.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_metadata.py
@@ -1,6 +1,7 @@
 import pytest
 
-from peagen.models import Task, TaskRun
+from peagen.models.task.task import Task
+from peagen.models.task.task_run import TaskRun
 from peagen.plugins.queues.in_memory_queue import InMemoryQueue
 
 


### PR DESCRIPTION
## Summary
- use explicit `TaskRun` imports from `models/task/task_run`
- update tests to use canonical TaskRun path

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory . pytest` *(fails: 54 failed, 19 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685ec19c40d8832689f359e5b55cef28