### PR TITLE
Fix peagen migration import

### DIFF
--- a/pkgs/standards/peagen/peagen/migrations/versions/ae1de73e4143_init.py
+++ b/pkgs/standards/peagen/peagen/migrations/versions/ae1de73e4143_init.py
@@ -2,7 +2,11 @@
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy import inspect
-from peagen.models.task_run import status_enum  # ← shared object, create_type=False
+from peagen.models.task.status import Status
+
+# Recreate the Status enum used by TaskRun. SQLAlchemy expects a shared Enum
+# object when creating types during migrations.
+status_enum = sa.Enum(Status, name="task_status_enum")
 
 revision = "ae1de73e4143"
 down_revision = None


### PR DESCRIPTION
## Summary
- fix import path for `status_enum` in peagen migration

## Testing
- `uv run --package peagen --directory standards/peagen ruff format .`
- `uv run --package peagen --directory standards/peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest -q` *(fails: 52 failed, 182 passed)*
- `peagen remote -q --gateway-url http://localhost:8000/rpc process projects_payload.yaml --watch` *(fails: file not found)*
- `peagen local -q process projects_payload.yaml --watch` *(fails: unknown option)*

------
https://chatgpt.com/codex/tasks/task_e_685ec1afedc88326a8e0c0bf76b744cd