### PR TITLE
Expose PublicKey model

### DIFF
--- a/pkgs/standards/peagen/peagen/models/__init__.py
+++ b/pkgs/standards/peagen/peagen/models/__init__.py
@@ -74,6 +74,7 @@ from .git_mirror import GitMirror  # noqa: F401
 # Misc / security
 # ----------------------------------------------------------------------
 from .AbuseRecord import AbuseRecord  # noqa: F401
+from .security.public_key import PublicKey  # noqa: F401
 
 # ----------------------------------------------------------------------
 # Public re-exports
@@ -116,4 +117,5 @@ __all__: list[str] = [
     "GitMirror",
     # misc
     "AbuseRecord",
+    "PublicKey",
 ]


### PR DESCRIPTION
## Summary
- export `PublicKey` from peagen.models

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --directory pkgs/standards/peagen --package peagen pytest -q` *(fails: 52 failed, 182 passed, 31 skipped, 19 errors)*
- `peagen remote -q --gateway-url http://localhost:8000/rpc process projects_payload.yaml --watch` *(fails: file not found)*
- `peagen remote -q --gateway-url http://localhost:8000/rpc task get fake-id` *(fails: connection refused)*
- `peagen local -q process projects_payload.yaml --watch` *(fails: unknown option)*

------
https://chatgpt.com/codex/tasks/task_e_685ec1d8775883269d5d3155ae9dea7a