### PR TITLE
Ensure peagen uses canonical models

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/analysis.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/analysis.py
@@ -10,7 +10,8 @@ import httpx
 import typer
 
 from peagen.handlers.analysis_handler import analysis_handler
-from peagen.models import Status, Task
+from peagen.models.task.status import Status
+from peagen.models.task import Task
 
 DEFAULT_GATEWAY = "http://localhost:8000/rpc"
 local_analysis_app = typer.Typer(help="Aggregate run evaluation results.")

--- a/pkgs/standards/peagen/peagen/cli/commands/db.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/db.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import typer
 
 from peagen.handlers.migrate_handler import migrate_handler
-from peagen.models import Task
+from peagen.models.task import Task
 
 # ``alembic.ini`` lives in the package root next to ``migrations``.
 # When running from source the module sits one directory deeper than

--- a/pkgs/standards/peagen/peagen/cli/commands/doe.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/doe.py
@@ -17,7 +17,8 @@ import typer
 
 from peagen.handlers.doe_handler import doe_handler
 from peagen.handlers.doe_process_handler import doe_process_handler
-from peagen.models import Status, Task
+from peagen.models.task.status import Status
+from peagen.models.task import Task
 
 DEFAULT_GATEWAY = "http://localhost:8000/rpc"
 local_doe_app = typer.Typer(help="Generate project-payload bundles from DOE specs.")

--- a/pkgs/standards/peagen/peagen/cli/commands/eval.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/eval.py
@@ -21,7 +21,8 @@ import typer
 from peagen._utils.config_loader import load_peagen_toml
 
 from peagen.handlers.eval_handler import eval_handler
-from peagen.models import Status, Task
+from peagen.models.task.status import Status
+from peagen.models.task import Task
 
 DEFAULT_GATEWAY = "http://localhost:8000/rpc"
 local_eval_app = typer.Typer(

--- a/pkgs/standards/peagen/peagen/cli/commands/evolve.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/evolve.py
@@ -12,7 +12,8 @@ import httpx
 import typer
 
 from peagen.handlers.evolve_handler import evolve_handler
-from peagen.models import Status, Task
+from peagen.models.task.status import Status
+from peagen.models.task import Task
 from peagen.core.validate_core import validate_evolve_spec
 
 local_evolve_app = typer.Typer(help="Expand evolve spec and run mutate tasks")

--- a/pkgs/standards/peagen/peagen/cli/commands/extras.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/extras.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, Optional
 import typer
 
 from peagen.handlers.extras_handler import extras_handler
-from peagen.models import Task
+from peagen.models.task import Task
 from swarmauri_standard.loggers.Logger import Logger
 
 local_extras_app = typer.Typer(help="Manage EXTRAS schemas.")

--- a/pkgs/standards/peagen/peagen/cli/commands/fetch.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/fetch.py
@@ -16,7 +16,8 @@ from typing import List, Optional
 import typer
 
 from peagen.handlers.fetch_handler import fetch_handler
-from peagen.models import Status, Task
+from peagen.models.task.status import Status
+from peagen.models.task import Task
 
 fetch_app = typer.Typer(help="Materialise Peagen workspaces from URIs.")
 

--- a/pkgs/standards/peagen/peagen/cli/commands/mutate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/mutate.py
@@ -13,7 +13,7 @@ import httpx
 import typer
 
 from peagen.handlers.mutate_handler import mutate_handler
-from peagen.models import Task
+from peagen.models.task import Task
 
 DEFAULT_GATEWAY = "http://localhost:8000/rpc"
 local_mutate_app = typer.Typer(help="Run the mutate workflow")

--- a/pkgs/standards/peagen/peagen/cli/commands/process.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/process.py
@@ -22,7 +22,8 @@ import httpx
 import typer
 from peagen._utils.config_loader import _effective_cfg, load_peagen_toml
 from peagen.handlers.process_handler import process_handler
-from peagen.models import Status, Task  # noqa: F401 – only for type hints
+from peagen.models.task.status import Status
+from peagen.models.task import Task  # noqa: F401 – only for type hints
 
 local_process_app = typer.Typer(help="Render / generate project files.")
 remote_process_app = typer.Typer(help="Render / generate project files.")

--- a/pkgs/standards/peagen/peagen/cli/commands/sort.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/sort.py
@@ -9,7 +9,7 @@ import typer
 
 from peagen._utils.config_loader import _effective_cfg, load_peagen_toml
 from peagen.handlers.sort_handler import sort_handler
-from peagen.models import Task
+from peagen.models.task import Task
 
 local_sort_app = typer.Typer(help="Sort generated project files.")
 remote_sort_app = typer.Typer(help="Sort generated project files via JSON-RPC.")

--- a/pkgs/standards/peagen/peagen/cli/commands/task.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/task.py
@@ -11,7 +11,7 @@ import uuid
 import httpx
 import typer
 
-from peagen.models import Status
+from peagen.models.task.status import Status
 
 remote_task_app = typer.Typer(help="Inspect asynchronous tasks.")
 

--- a/pkgs/standards/peagen/peagen/cli/commands/templates.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/templates.py
@@ -9,7 +9,7 @@ import httpx
 import typer
 
 from peagen.handlers.templates_handler import templates_handler
-from peagen.models import Task
+from peagen.models.task import Task
 
 # ──────────────────────────────────────
 DEFAULT_GATEWAY = "http://localhost:8000/rpc"

--- a/pkgs/standards/peagen/peagen/cli/commands/validate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/validate.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Optional
 import typer
 
 from peagen.handlers.validate_handler import validate_handler
-from peagen.models import Task
+from peagen.models.task import Task
 
 local_validate_app = typer.Typer(help="Validate Peagen artifacts.")
 remote_validate_app = typer.Typer(help="Validate Peagen artifacts via JSON-RPC.")

--- a/pkgs/standards/peagen/peagen/core/control_core.py
+++ b/pkgs/standards/peagen/peagen/core/control_core.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import Iterable
 
-from peagen.models import Task, Status
+from peagen.models.task import Task
+from peagen.models.task.status import Status
 
 
 def pause(tasks: Iterable[Task]) -> int:

--- a/pkgs/standards/peagen/peagen/core/task_core.py
+++ b/pkgs/standards/peagen/peagen/core/task_core.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from typing import Dict
 
 from peagen.gateway.db import Session
-from peagen.models import TaskRun
+from peagen.models.task import TaskRun
 from sqlalchemy.exc import DataError
 from peagen.errors import TaskNotFoundError
 

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -26,7 +26,9 @@ from peagen.plugins.queues import QueueBase
 
 from peagen.transport import RPCDispatcher, RPCRequest
 from peagen.transport.jsonrpc import RPCException
-from peagen.models import Task, Status, Base, TaskRun
+from peagen.models.task import Task
+from peagen.models.task.status import Status
+from peagen.models import Base, TaskRun
 
 from peagen.gateway.ws_server import router as ws_router
 

--- a/pkgs/standards/peagen/peagen/gateway/db_helpers.py
+++ b/pkgs/standards/peagen/peagen/gateway/db_helpers.py
@@ -7,8 +7,8 @@ from typing import Dict, Any
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 import sqlalchemy as sa
+from peagen.models.task.status import Status
 from peagen.models import (
-    Status,
     TaskRun,
     TaskRunTaskRelationAssociation,
 )

--- a/pkgs/standards/peagen/peagen/handlers/analysis_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/analysis_handler.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 from peagen._utils import maybe_clone_repo
 
 from peagen.core.analysis_core import analyze_runs
-from peagen.models import Task
+from peagen.models.task import Task
 from peagen._utils.config_loader import resolve_cfg
 from peagen.plugins import PluginManager
 from peagen.plugins.vcs import pea_ref

--- a/pkgs/standards/peagen/peagen/handlers/control_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/control_handler.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Iterable
 
 from peagen.plugins.queues import QueueBase
-from peagen.models import Task
+from peagen.models.task import Task
 from peagen.core import control_core
 from peagen import defaults
 

--- a/pkgs/standards/peagen/peagen/handlers/doe_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/doe_handler.py
@@ -10,7 +10,7 @@ from peagen.core.doe_core import (
     create_factor_branches,
     create_run_branches,
 )
-from peagen.models import Task
+from peagen.models.task import Task
 from peagen._utils.config_loader import resolve_cfg
 from peagen.plugins import PluginManager
 import yaml

--- a/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
@@ -10,7 +10,8 @@ import uuid
 import yaml
 
 from peagen.core.doe_core import generate_payload
-from peagen.models import Task, Status
+from peagen.models.task import Task
+from peagen.models.task.status import Status
 from peagen._utils.config_loader import resolve_cfg
 from peagen.plugins import PluginManager
 from peagen.plugins.storage_adapters.file_storage_adapter import FileStorageAdapter

--- a/pkgs/standards/peagen/peagen/handlers/eval_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/eval_handler.py
@@ -19,7 +19,7 @@ import os
 
 from peagen.core.eval_core import evaluate_workspace
 from peagen._utils.config_loader import resolve_cfg
-from peagen.models import Task  # for typing only
+from peagen.models.task import Task  # for typing only
 
 
 async def eval_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, Any]:

--- a/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
@@ -8,7 +8,8 @@ from typing import Any, Dict, List
 
 import yaml
 
-from peagen.models import Task, Status
+from peagen.models.task import Task
+from peagen.models.task.status import Status
 from .fanout import fan_out
 from peagen._utils.config_loader import resolve_cfg
 from peagen.plugins import PluginManager

--- a/pkgs/standards/peagen/peagen/handlers/extras_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/extras_handler.py
@@ -8,7 +8,7 @@ from typing import Any, Dict
 from peagen._utils import maybe_clone_repo
 
 from peagen.core.extras_core import generate_schemas
-from peagen.models import Task
+from peagen.models.task import Task
 from .repo_utils import fetch_repo, cleanup_repo
 
 

--- a/pkgs/standards/peagen/peagen/handlers/fanout.py
+++ b/pkgs/standards/peagen/peagen/handlers/fanout.py
@@ -6,7 +6,8 @@ from typing import Iterable, List, Dict, Any
 
 import httpx
 
-from peagen.models import Task, Status
+from peagen.models.task import Task
+from peagen.models.task.status import Status
 
 
 async def fan_out(

--- a/pkgs/standards/peagen/peagen/handlers/fetch_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/fetch_handler.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 from peagen.core.fetch_core import fetch_many
-from peagen.models import Task  # for type hints only
+from peagen.models.task import Task  # for type hints only
 
 
 async def fetch_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, Any]:

--- a/pkgs/standards/peagen/peagen/handlers/init_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/init_handler.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 from peagen.core import init_core
-from peagen.models import Task
+from peagen.models.task import Task
 
 
 async def init_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, Any]:

--- a/pkgs/standards/peagen/peagen/handlers/keys_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/keys_handler.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 from peagen.core import keys_core
-from peagen.models import Task
+from peagen.models.task import Task
 
 
 async def keys_handler(task: Dict[str, Any] | Task) -> Dict[str, Any]:

--- a/pkgs/standards/peagen/peagen/handlers/login_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/login_handler.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from peagen.core.login_core import login
-from peagen.models import Task
+from peagen.models.task import Task
 
 
 async def login_handler(task: Dict[str, Any] | Task) -> Dict[str, Any]:

--- a/pkgs/standards/peagen/peagen/handlers/migrate_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/migrate_handler.py
@@ -10,7 +10,7 @@ from peagen.core.migrate_core import (
     alembic_revision,
     alembic_upgrade,
 )
-from peagen.models import Task
+from peagen.models.task import Task
 
 
 async def migrate_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, Any]:

--- a/pkgs/standards/peagen/peagen/handlers/mutate_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/mutate_handler.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 from peagen.core.mutate_core import mutate_workspace
-from peagen.models import Task
+from peagen.models.task import Task
 from peagen._utils.config_loader import resolve_cfg
 from peagen.plugins import PluginManager
 from peagen.plugins.vcs import pea_ref

--- a/pkgs/standards/peagen/peagen/handlers/process_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/process_handler.py
@@ -25,7 +25,8 @@ from peagen.core.process_core import (
     process_single_project,
     process_all_projects,
 )
-from peagen.models import Task, Status  # noqa: F401 – used by type hints
+from peagen.models.task import Task  # noqa: F401 – used by type hints
+from peagen.models.task.status import Status  # noqa: F401 – used by type hints
 
 logger = Logger(name=__name__)
 

--- a/pkgs/standards/peagen/peagen/handlers/secrets_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/secrets_handler.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 from peagen.core import secrets_core
-from peagen.models import Task
+from peagen.models.task import Task
 
 
 async def secrets_handler(task: Dict[str, Any] | Task) -> Dict[str, Any]:

--- a/pkgs/standards/peagen/peagen/handlers/validate_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/validate_handler.py
@@ -7,7 +7,7 @@ from typing import Any, Dict
 from peagen._utils import maybe_clone_repo
 
 from peagen.core.validate_core import validate_artifact
-from peagen.models import Task
+from peagen.models.task import Task
 
 
 async def validate_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, Any]:

--- a/pkgs/standards/peagen/peagen/models/__init__.py
+++ b/pkgs/standards/peagen/peagen/models/__init__.py
@@ -35,7 +35,9 @@ from .repo.repository_user_association import RepositoryUserAssociation  # noqa:
 # Task / execution domain
 # ----------------------------------------------------------------------
 from .task.status import Status  # noqa: F401
-from .task.task import Task  # noqa: F401
+
+# NOTE: Use the lightweight Task envelope rather than the ORM model by default
+from .task import Task  # noqa: F401
 from .task.raw_blob import RawBlob  # noqa: F401
 from .task.task_run import TaskRun  # noqa: F401
 from .task.task_relation import TaskRelation  # noqa: F401
@@ -94,7 +96,6 @@ __all__: list[str] = [
     # task
     "Task",
     "RawBlob",
-    "Task",
     "Status",
     "TaskRun",
     "TaskRelation",

--- a/pkgs/standards/peagen/peagen/plugins/result_backends/base.py
+++ b/pkgs/standards/peagen/peagen/plugins/result_backends/base.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 from typing import Any, Dict, List
 
-from peagen.models import TaskRun
+from peagen.models.task import TaskRun
 
 
 class ResultBackendBase:

--- a/pkgs/standards/peagen/peagen/plugins/result_backends/in_memory_backend.py
+++ b/pkgs/standards/peagen/peagen/plugins/result_backends/in_memory_backend.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from peagen.models import TaskRun
+from peagen.models.task import TaskRun
 from .base import ResultBackendBase
 
 

--- a/pkgs/standards/peagen/peagen/plugins/result_backends/localfs_backend.py
+++ b/pkgs/standards/peagen/peagen/plugins/result_backends/localfs_backend.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from peagen.models import TaskRun
+from peagen.models.task import TaskRun
 from .base import ResultBackendBase
 
 

--- a/pkgs/standards/peagen/peagen/plugins/result_backends/postgres_backend.py
+++ b/pkgs/standards/peagen/peagen/plugins/result_backends/postgres_backend.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from peagen.models import TaskRun
+from peagen.models.task import TaskRun
 from .base import ResultBackendBase
 
 Session = None


### PR DESCRIPTION
## Summary
- use the Task envelope from `peagen.models.task`
- import `Status` from `peagen.models.task.status`
- update imports across peagen to reference the canonical models

## Testing
- `uv run --directory pkgs/standards --package peagen ruff format .`
- `uv run --directory pkgs/standards --package peagen ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_685ec17c08e4832699869816c9c96e86