### PR TITLE
Fix TaskRun import path

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -26,7 +26,8 @@ from peagen.plugins.queues import QueueBase
 
 from peagen.transport import RPCDispatcher, RPCRequest
 from peagen.transport.jsonrpc import RPCException
-from peagen.models import Task, Status, Base, TaskRun
+from peagen.models import Base, Status, Task
+from peagen.models.task.task_run import TaskRun
 
 from peagen.gateway.ws_server import router as ws_router
 


### PR DESCRIPTION
## Summary
- import `TaskRun` directly from `peagen.models.task.task_run`

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --directory pkgs/standards/peagen --package peagen pytest` *(fails: 'pool' is an invalid keyword argument for Task)*
- `uv run --directory pkgs/standards/peagen --package peagen peagen remote -q --gateway-url http://localhost:8000/rpc process projects_payload.yaml --watch` *(fails: file not found / invalid keyword argument)*
- `uv run --directory pkgs/standards/peagen --package peagen peagen local -q process projects_payload.yaml` *(fails: 'pool' is an invalid keyword argument for Task)*

------
https://chatgpt.com/codex/tasks/task_e_685ec8020afc8326b6870e26d8644e5c