### PR TITLE
Fix secret store schema mismatch

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/db_helpers.py
+++ b/pkgs/standards/peagen/peagen/gateway/db_helpers.py
@@ -94,23 +94,18 @@ async def upsert_secret(
     name: str,
     cipher: str,
 ) -> None:
+    """Insert or update a secret for a tenant."""
     data = {
         "tenant_id": tenant_id,
-        "owner_fpr": owner_fpr,
         "name": name,
         "cipher": cipher,
-        "created_at": dt.datetime.utcnow(),
     }
     stmt = (
         pg_insert(Secret)
         .values(**data)
         .on_conflict_do_update(
             index_elements=["tenant_id", "name"],
-            set_={
-                "cipher": cipher,
-                "owner_fpr": owner_fpr,
-                "created_at": data["created_at"],
-            },
+            set_={"cipher": cipher},
         )
     )
     await session.execute(stmt)


### PR DESCRIPTION
## Summary
- align secret upsert with existing ORM model

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --directory pkgs/standards/peagen --package peagen pytest -q` *(fails: `'task_type' is an invalid keyword argument for TaskRun`)*

------
https://chatgpt.com/codex/tasks/task_e_685ec935314c83268c4d03e16bd1e6c8