### PR TITLE
Ensure peagen uses centralized Task model

### DIFF
--- a/pkgs/standards/peagen/peagen/_utils/_init.py
+++ b/pkgs/standards/peagen/peagen/_utils/_init.py
@@ -8,7 +8,7 @@ import re
 import typer
 from peagen.errors import PATNotAllowedError
 from peagen.handlers.init_handler import init_handler
-from peagen.models.task import Task
+from peagen.models.tasks import Task
 from peagen.plugins import discover_and_register_plugins
 
 _PAT_RE = re.compile(r"(gh[pousr]_\w+|github_pat_[0-9A-Za-z]+)", re.IGNORECASE)

--- a/pkgs/standards/peagen/peagen/cli/commands/db.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/db.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import typer
 
 from peagen.handlers.migrate_handler import migrate_handler
-from peagen.models.task import Task
+from peagen.models.tasks import Task
 
 # ``alembic.ini`` lives in the package root next to ``migrations``.
 # When running from source the module sits one directory deeper than

--- a/pkgs/standards/peagen/peagen/cli/commands/extras.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/extras.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, Optional
 import typer
 
 from peagen.handlers.extras_handler import extras_handler
-from peagen.models import Task
+from peagen.models.tasks import Task
 from swarmauri_standard.loggers.Logger import Logger
 
 local_extras_app = typer.Typer(help="Manage EXTRAS schemas.")

--- a/pkgs/standards/peagen/peagen/cli/commands/mutate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/mutate.py
@@ -13,7 +13,7 @@ import httpx
 import typer
 
 from peagen.handlers.mutate_handler import mutate_handler
-from peagen.models import Task
+from peagen.models.tasks import Task
 
 DEFAULT_GATEWAY = "http://localhost:8000/rpc"
 local_mutate_app = typer.Typer(help="Run the mutate workflow")

--- a/pkgs/standards/peagen/peagen/cli/commands/process.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/process.py
@@ -22,7 +22,8 @@ import httpx
 import typer
 from peagen._utils.config_loader import _effective_cfg, load_peagen_toml
 from peagen.handlers.process_handler import process_handler
-from peagen.models import Status, Task  # noqa: F401 – only for type hints
+from peagen.models.tasks import Task
+from peagen.models import Status  # noqa: F401 – only for type hints
 
 local_process_app = typer.Typer(help="Render / generate project files.")
 remote_process_app = typer.Typer(help="Render / generate project files.")

--- a/pkgs/standards/peagen/peagen/cli/commands/sort.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/sort.py
@@ -9,7 +9,7 @@ import typer
 
 from peagen._utils.config_loader import _effective_cfg, load_peagen_toml
 from peagen.handlers.sort_handler import sort_handler
-from peagen.models import Task
+from peagen.models.tasks import Task
 
 local_sort_app = typer.Typer(help="Sort generated project files.")
 remote_sort_app = typer.Typer(help="Sort generated project files via JSON-RPC.")

--- a/pkgs/standards/peagen/peagen/cli/commands/templates.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/templates.py
@@ -9,7 +9,7 @@ import httpx
 import typer
 
 from peagen.handlers.templates_handler import templates_handler
-from peagen.models import Task
+from peagen.models.tasks import Task
 
 # ──────────────────────────────────────
 DEFAULT_GATEWAY = "http://localhost:8000/rpc"

--- a/pkgs/standards/peagen/peagen/cli/commands/validate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/validate.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Optional
 import typer
 
 from peagen.handlers.validate_handler import validate_handler
-from peagen.models import Task
+from peagen.models.tasks import Task
 
 local_validate_app = typer.Typer(help="Validate Peagen artifacts.")
 remote_validate_app = typer.Typer(help="Validate Peagen artifacts via JSON-RPC.")

--- a/pkgs/standards/peagen/peagen/core/control_core.py
+++ b/pkgs/standards/peagen/peagen/core/control_core.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import Iterable
 
-from peagen.models import Task, Status
+from peagen.models.tasks import Task
+from peagen.models import Status
 
 
 def pause(tasks: Iterable[Task]) -> int:

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -26,7 +26,8 @@ from peagen.plugins.queues import QueueBase
 
 from peagen.transport import RPCDispatcher, RPCRequest
 from peagen.transport.jsonrpc import RPCException
-from peagen.models import Task, Status, Base, TaskRun
+from peagen.models.tasks import Task
+from peagen.models import Status, Base, TaskRun
 
 from peagen.gateway.ws_server import router as ws_router
 

--- a/pkgs/standards/peagen/peagen/handlers/analysis_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/analysis_handler.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 from peagen._utils import maybe_clone_repo
 
 from peagen.core.analysis_core import analyze_runs
-from peagen.models import Task
+from peagen.models.tasks import Task
 from peagen._utils.config_loader import resolve_cfg
 from peagen.plugins import PluginManager
 from peagen.plugins.vcs import pea_ref

--- a/pkgs/standards/peagen/peagen/handlers/control_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/control_handler.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Iterable
 
 from peagen.plugins.queues import QueueBase
-from peagen.models import Task
+from peagen.models.tasks import Task
 from peagen.core import control_core
 from peagen import defaults
 

--- a/pkgs/standards/peagen/peagen/handlers/doe_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/doe_handler.py
@@ -10,7 +10,7 @@ from peagen.core.doe_core import (
     create_factor_branches,
     create_run_branches,
 )
-from peagen.models import Task
+from peagen.models.tasks import Task
 from peagen._utils.config_loader import resolve_cfg
 from peagen.plugins import PluginManager
 import yaml

--- a/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
@@ -10,7 +10,8 @@ import uuid
 import yaml
 
 from peagen.core.doe_core import generate_payload
-from peagen.models import Task, Status
+from peagen.models.tasks import Task
+from peagen.models import Status
 from peagen._utils.config_loader import resolve_cfg
 from peagen.plugins import PluginManager
 from peagen.plugins.storage_adapters.file_storage_adapter import FileStorageAdapter

--- a/pkgs/standards/peagen/peagen/handlers/eval_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/eval_handler.py
@@ -19,7 +19,7 @@ import os
 
 from peagen.core.eval_core import evaluate_workspace
 from peagen._utils.config_loader import resolve_cfg
-from peagen.models import Task  # for typing only
+from peagen.models.tasks import Task  # for typing only
 
 
 async def eval_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, Any]:

--- a/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
@@ -8,7 +8,8 @@ from typing import Any, Dict, List
 
 import yaml
 
-from peagen.models import Task, Status
+from peagen.models.tasks import Task
+from peagen.models import Status
 from .fanout import fan_out
 from peagen._utils.config_loader import resolve_cfg
 from peagen.plugins import PluginManager

--- a/pkgs/standards/peagen/peagen/handlers/extras_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/extras_handler.py
@@ -8,7 +8,7 @@ from typing import Any, Dict
 from peagen._utils import maybe_clone_repo
 
 from peagen.core.extras_core import generate_schemas
-from peagen.models import Task
+from peagen.models.tasks import Task
 from .repo_utils import fetch_repo, cleanup_repo
 
 

--- a/pkgs/standards/peagen/peagen/handlers/fanout.py
+++ b/pkgs/standards/peagen/peagen/handlers/fanout.py
@@ -6,7 +6,8 @@ from typing import Iterable, List, Dict, Any
 
 import httpx
 
-from peagen.models import Task, Status
+from peagen.models.tasks import Task
+from peagen.models import Status
 
 
 async def fan_out(

--- a/pkgs/standards/peagen/peagen/handlers/fetch_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/fetch_handler.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 from peagen.core.fetch_core import fetch_many
-from peagen.models import Task  # for type hints only
+from peagen.models.tasks import Task  # for type hints only
 
 
 async def fetch_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, Any]:

--- a/pkgs/standards/peagen/peagen/handlers/init_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/init_handler.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 from peagen.core import init_core
-from peagen.models import Task
+from peagen.models.tasks import Task
 
 
 async def init_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, Any]:

--- a/pkgs/standards/peagen/peagen/handlers/keys_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/keys_handler.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 from peagen.core import keys_core
-from peagen.models import Task
+from peagen.models.tasks import Task
 
 
 async def keys_handler(task: Dict[str, Any] | Task) -> Dict[str, Any]:

--- a/pkgs/standards/peagen/peagen/handlers/login_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/login_handler.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from peagen.core.login_core import login
-from peagen.models import Task
+from peagen.models.tasks import Task
 
 
 async def login_handler(task: Dict[str, Any] | Task) -> Dict[str, Any]:

--- a/pkgs/standards/peagen/peagen/handlers/migrate_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/migrate_handler.py
@@ -10,7 +10,7 @@ from peagen.core.migrate_core import (
     alembic_revision,
     alembic_upgrade,
 )
-from peagen.models import Task
+from peagen.models.tasks import Task
 
 
 async def migrate_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, Any]:

--- a/pkgs/standards/peagen/peagen/handlers/mutate_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/mutate_handler.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 from peagen.core.mutate_core import mutate_workspace
-from peagen.models import Task
+from peagen.models.tasks import Task
 from peagen._utils.config_loader import resolve_cfg
 from peagen.plugins import PluginManager
 from peagen.plugins.vcs import pea_ref

--- a/pkgs/standards/peagen/peagen/handlers/process_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/process_handler.py
@@ -25,7 +25,8 @@ from peagen.core.process_core import (
     process_single_project,
     process_all_projects,
 )
-from peagen.models import Task, Status  # noqa: F401 – used by type hints
+from peagen.models.tasks import Task
+from peagen.models import Status  # noqa: F401 – used by type hints
 
 logger = Logger(name=__name__)
 

--- a/pkgs/standards/peagen/peagen/handlers/secrets_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/secrets_handler.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 from peagen.core import secrets_core
-from peagen.models import Task
+from peagen.models.tasks import Task
 
 
 async def secrets_handler(task: Dict[str, Any] | Task) -> Dict[str, Any]:

--- a/pkgs/standards/peagen/peagen/handlers/templates_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/templates_handler.py
@@ -16,7 +16,7 @@ from peagen.core.templates_core import (
     add_template_set,
     remove_template_set,
 )
-from peagen.models.task import Task  # type: ignore
+from peagen.models.tasks import Task  # type: ignore
 
 
 async def templates_handler(task: Dict[str, Any] | Task) -> Dict[str, Any]:

--- a/pkgs/standards/peagen/peagen/handlers/validate_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/validate_handler.py
@@ -7,7 +7,7 @@ from typing import Any, Dict
 from peagen._utils import maybe_clone_repo
 
 from peagen.core.validate_core import validate_artifact
-from peagen.models import Task
+from peagen.models.tasks import Task
 
 
 async def validate_handler(task_or_dict: Dict[str, Any] | Task) -> Dict[str, Any]:

--- a/pkgs/standards/peagen/peagen/models/tasks/__init__.py
+++ b/pkgs/standards/peagen/peagen/models/tasks/__init__.py
@@ -1,0 +1,3 @@
+from .task import Task
+
+__all__ = ["Task"]

--- a/pkgs/standards/peagen/peagen/models/tasks/task.py
+++ b/pkgs/standards/peagen/peagen/models/tasks/task.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+from ..task.status import Status
+
+
+class Task(BaseModel):
+    """Lightweight task envelope used by the gateway and CLI."""
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    pool: str
+    payload: Dict[str, Any]
+    status: Status = Status.waiting
+    relations: List[str] = Field(default_factory=list)
+    edge_pred: Optional[str] = None
+    labels: List[str] = Field(default_factory=list)
+    in_degree: int = 0
+    config_toml: Optional[str] = None
+    commit_hexsha: Optional[str] = None
+    oids: Optional[List[str]] = None
+    duration: Optional[int] = None
+
+
+__all__ = ["Task"]

--- a/pkgs/standards/peagen/peagen/tui/task_submit.py
+++ b/pkgs/standards/peagen/peagen/tui/task_submit.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import httpx
 from typing import Any
 
-from peagen.models.task import Task
+from peagen.models.tasks import Task
 
 
 def build_task(action: str, args: dict[str, Any], pool: str = "default") -> Task:


### PR DESCRIPTION
## Summary
- add `models.tasks` package with `Task` model
- import Task from `peagen.models.tasks` throughout peagen

## Testing
- `uv run --directory pkgs/standards --package peagen ruff format .`
- `uv run --directory pkgs/standards --package peagen ruff check . --fix`
- `uv run --directory pkgs/standards --package peagen pytest -q` *(fails: ModuleNotFoundError: No module named 'peagen.plugin_registry')*

------
https://chatgpt.com/codex/tasks/task_e_685ec7ef4e2483269513b2d873393381