### PR TITLE
Fix PublicKey import in user model

### DIFF
--- a/pkgs/standards/peagen/peagen/models/tenant/user.py
+++ b/pkgs/standards/peagen/peagen/models/tenant/user.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:  # pragma: no cover - imports for type hints
     from ..security.public_key import PublicKey
 
 # Import at runtime so SQLAlchemy can resolve the relationship target
-from ..security import PublicKey
+from ..security.public_key import PublicKey
 
 from ..base import BaseModel
 


### PR DESCRIPTION
## Summary
- import PublicKey from the correct module

## Testing
- `uv --project pkgs/standards/peagen run ruff format pkgs/standards/peagen/peagen/models/tenant/user.py`
- `uv --project pkgs/standards/peagen run ruff check pkgs/standards/peagen/peagen/models/tenant/user.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_685eca54a19c8326a394d805b530f988