### PR TITLE
Fix Task model default pool

### DIFF
--- a/pkgs/standards/peagen/peagen/models/__init__.py
+++ b/pkgs/standards/peagen/peagen/models/__init__.py
@@ -35,7 +35,7 @@ from .repo.repository_user_association import RepositoryUserAssociation  # noqa:
 # Task / execution domain
 # ----------------------------------------------------------------------
 from .task.status import Status  # noqa: F401
-from .task.task import Task  # noqa: F401
+from .task import Task  # noqa: F401
 from .task.raw_blob import RawBlob  # noqa: F401
 from .task.task_run import TaskRun  # noqa: F401
 from .task.task_relation import TaskRelation  # noqa: F401
@@ -95,7 +95,6 @@ __all__: list[str] = [
     # task
     "Task",
     "RawBlob",
-    "Task",
     "Status",
     "TaskRun",
     "TaskRelation",

--- a/pkgs/standards/peagen/peagen/models/task/__init__.py
+++ b/pkgs/standards/peagen/peagen/models/task/__init__.py
@@ -12,7 +12,7 @@ class Task(BaseModel):
     """Lightweight task envelope used by the gateway and CLI."""
 
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
-    pool: str
+    pool: str = "default"
     payload: Dict[str, Any]
     status: Status = Status.waiting
     relations: List[str] = Field(default_factory=list)


### PR DESCRIPTION
## Summary
- default Task.pool to "default"
- re-export Pydantic Task model

## Testing
- `uv run --package peagen --directory standards/peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest -q` *(fails: Task object has no field 'result')*


------
https://chatgpt.com/codex/tasks/task_e_685ec969be4c83269c2ef941ea5ebb2d