### PR TITLE
Switch to PyGithub for secret push

### DIFF
--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -70,7 +70,6 @@ dependencies = [
     "minio", # this storage adapter needs to be pushed to its own standalone
     "GitPython",
     "paramiko",
-    "pygit2",
     "s3fs",
     "pytest-monitor>=1.6.6",
     "filelock>=3.9",


### PR DESCRIPTION
## Summary
- remove pygit2 from peagen's dependencies
- push via GitPython using a token authenticated with PyGithub

## Testing
- `uv run --directory peagen --package peagen ruff format .`
- `uv run --directory peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_685ecfcbfe88832693192c806c887917