### PR TITLE
Rename ORM classes

### DIFF
--- a/pkgs/standards/peagen/peagen/models/AbuseRecord.py
+++ b/pkgs/standards/peagen/peagen/models/AbuseRecord.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 from .base import Base
 
 
-class AbuseRecord(Base):
+class AbuseRecordModel(Base):
     """Track abuse metrics for a given IP address."""
 
     __tablename__ = "abuse_records"
@@ -21,3 +21,6 @@ class AbuseRecord(Base):
 
     def __repr__(self) -> str:  # pragma: no cover
         return f"<AbuseRecord ip={self.ip!r} count={self.count} banned={self.banned}>"
+
+
+AbuseRecord = AbuseRecordModel

--- a/pkgs/standards/peagen/peagen/models/__init__.py
+++ b/pkgs/standards/peagen/peagen/models/__init__.py
@@ -16,65 +16,76 @@ from .base import Base  # noqa: F401  (re-exported via __all__)
 # ----------------------------------------------------------------------
 # Tenant domain
 # ----------------------------------------------------------------------
-from .tenant.tenant import Tenant  # noqa: F401
-from .tenant.user import User  # noqa: F401
-from .tenant.tenant_user_association import TenantUserAssociation  # noqa: F401
+from .tenant.tenant import TenantModel, Tenant  # noqa: F401
+from .tenant.user import UserModel, User  # noqa: F401
+from .tenant.tenant_user_association import (  # noqa: F401
+    TenantUserAssociationModel,
+    TenantUserAssociation,
+)
 
 # ----------------------------------------------------------------------
 # Repository domain
 # ----------------------------------------------------------------------
-from .repo.repository import Repository  # noqa: F401
-from .repo.git_reference import GitReference  # noqa: F401
-from .repo.deploy_key import DeployKey  # noqa: F401
-from .repo.repository_deploy_key_association import (
+from .repo.repository import RepositoryModel, Repository  # noqa: F401
+from .repo.git_reference import GitReferenceModel, GitReference  # noqa: F401
+from .repo.deploy_key import DeployKeyModel, DeployKey  # noqa: F401
+from .repo.repository_deploy_key_association import (  # noqa: F401
+    RepositoryDeployKeyAssociationModel,
     RepositoryDeployKeyAssociation,
-)  # noqa: F401
-from .repo.repository_user_association import RepositoryUserAssociation  # noqa: F401
+)
+from .repo.repository_user_association import (  # noqa: F401
+    RepositoryUserAssociationModel,
+    RepositoryUserAssociation,
+)
 
 # ----------------------------------------------------------------------
 # Task / execution domain
 # ----------------------------------------------------------------------
 from .task.status import Status  # noqa: F401
-from .task.task import Task  # noqa: F401
-from .task.raw_blob import RawBlob  # noqa: F401
-from .task.task_run import TaskRun  # noqa: F401
-from .task.task_relation import TaskRelation  # noqa: F401
-from .task.task_run_relation_association import (
-    TaskRunTaskRelationAssociation,  # noqa: F401
+from .task.task import TaskModel, Task  # noqa: F401
+from .task.raw_blob import RawBlobModel, RawBlob  # noqa: F401
+from .task.task_run import TaskRunModel, TaskRun  # noqa: F401
+from .task.task_relation import TaskRelationModel, TaskRelation  # noqa: F401
+from .task.task_run_relation_association import (  # noqa: F401
+    TaskRunTaskRelationAssociationModel,
+    TaskRunTaskRelationAssociation,
 )
 
 # ----------------------------------------------------------------------
 # DOE / Render / Evolution domain
 # ----------------------------------------------------------------------
-from .specs.doe_spec import DoeSpec  # noqa: F401
-from .specs.evolve_spec import EvolveSpec  # noqa: F401
-from .specs.project_payload import ProjectPayload  # noqa: F401
+from .specs.doe_spec import DoeSpecModel, DoeSpec  # noqa: F401
+from .specs.evolve_spec import EvolveSpecModel, EvolveSpec  # noqa: F401
+from .specs.project_payload import ProjectPayloadModel, ProjectPayload  # noqa: F401
 
 # ----------------------------------------------------------------------
 # Configuration / secrets
 # ----------------------------------------------------------------------
-from .config.peagen_toml_spec import PeagenTomlSpec  # noqa: F401
-from .config.secret import Secret  # noqa: F401
+from .config.peagen_toml_spec import PeagenTomlSpecModel, PeagenTomlSpec  # noqa: F401
+from .config.secret import SecretModel, Secret  # noqa: F401
 
 # ----------------------------------------------------------------------
 # Infrastructure
 # ----------------------------------------------------------------------
-from .infra.pool import Pool  # noqa: F401
-from .infra.worker import Worker  # noqa: F401
-from .infra.pool_worker_association import PoolWorkerAssociation  # noqa: F401
+from .infra.pool import PoolModel, Pool  # noqa: F401
+from .infra.worker import WorkerModel, Worker  # noqa: F401
+from .infra.pool_worker_association import (  # noqa: F401
+    PoolWorkerAssociationModel,
+    PoolWorkerAssociation,
+)
 
 # ----------------------------------------------------------------------
 # Result domain (evaluation & analysis)
 # ----------------------------------------------------------------------
-from .result.eval_result import EvalResult  # noqa: F401
-from .result.analysis_result import AnalysisResult  # noqa: F401
+from .result.eval_result import EvalResultModel, EvalResult  # noqa: F401
+from .result.analysis_result import AnalysisResultModel, AnalysisResult  # noqa: F401
 from .git_mirror import GitMirror  # noqa: F401
 
 # ----------------------------------------------------------------------
 # Misc / security
 # ----------------------------------------------------------------------
-from .AbuseRecord import AbuseRecord  # noqa: F401
-from .security.public_key import PublicKey  # noqa: F401
+from .AbuseRecord import AbuseRecordModel, AbuseRecord  # noqa: F401
+from .security.public_key import PublicKeyModel, PublicKey  # noqa: F401
 
 # ----------------------------------------------------------------------
 # Public re-exports
@@ -83,39 +94,39 @@ __all__: list[str] = [
     # base
     "Base",
     # tenant
-    "Tenant",
-    "User",
-    "TenantUserAssociation",
+    "TenantModel",
+    "UserModel",
+    "TenantUserAssociationModel",
     # repo
-    "Repository",
-    "GitReference",
-    "DeployKey",
-    "RepositoryDeployKeyAssociation",
-    "RepositoryUserAssociation",
+    "RepositoryModel",
+    "GitReferenceModel",
+    "DeployKeyModel",
+    "RepositoryDeployKeyAssociationModel",
+    "RepositoryUserAssociationModel",
     # task
-    "Task",
-    "RawBlob",
-    "Task",
+    "TaskModel",
+    "RawBlobModel",
+    "TaskModel",
     "Status",
-    "TaskRun",
-    "TaskRelation",
-    "TaskRunTaskRelationAssociation",
+    "TaskRunModel",
+    "TaskRelationModel",
+    "TaskRunTaskRelationAssociationModel",
     # evolution
-    "DoeSpec",
-    "EvolveSpec",
-    "ProjectPayload",
+    "DoeSpecModel",
+    "EvolveSpecModel",
+    "ProjectPayloadModel",
     # config
-    "PeagenTomlSpec",
-    "Secret",
+    "PeagenTomlSpecModel",
+    "SecretModel",
     # infra
-    "Pool",
-    "Worker",
-    "PoolWorkerAssociation",
+    "PoolModel",
+    "WorkerModel",
+    "PoolWorkerAssociationModel",
     # result
-    "EvalResult",
-    "AnalysisResult",
+    "EvalResultModel",
+    "AnalysisResultModel",
     "GitMirror",
     # misc
-    "AbuseRecord",
-    "PublicKey",
+    "AbuseRecordModel",
+    "PublicKeyModel",
 ]

--- a/pkgs/standards/peagen/peagen/models/config/peagen_toml_spec.py
+++ b/pkgs/standards/peagen/peagen/models/config/peagen_toml_spec.py
@@ -26,7 +26,7 @@ from ..tenant.tenant import Tenant
 from ..base import BaseModel
 
 
-class PeagenTomlSpec(BaseModel):
+class PeagenTomlSpecModel(BaseModel):
     """
     Parsed & raw representation of a `.peagen.toml` file.
     """
@@ -89,3 +89,6 @@ class PeagenTomlSpec(BaseModel):
             f"<PeagenTomlSpec id={self.id} tenant={self.tenant_id} "
             f"name={self.name!r} version={self.schema_version}>"
         )
+
+
+PeagenTomlSpec = PeagenTomlSpecModel

--- a/pkgs/standards/peagen/peagen/models/config/secret.py
+++ b/pkgs/standards/peagen/peagen/models/config/secret.py
@@ -26,7 +26,7 @@ from ..tenant.tenant import Tenant
 from ..base import BaseModel
 
 
-class Secret(BaseModel):
+class SecretModel(BaseModel):
     """
     Workspace-level secret (token, password, certificate …).
     """
@@ -80,3 +80,6 @@ class Secret(BaseModel):
             f"<Secret id={self.id} tenant={self.tenant_id} "
             f"name={self.name!r} owner={self.owner_user_id or '∅'}>"
         )
+
+
+Secret = SecretModel

--- a/pkgs/standards/peagen/peagen/models/infra/pool.py
+++ b/pkgs/standards/peagen/peagen/models/infra/pool.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:  # pragma: no cover - imports for type hints
 from ..base import BaseModel
 
 
-class Pool(BaseModel):
+class PoolModel(BaseModel):
     """
     Compute / execution pool definition.
     """
@@ -93,3 +93,6 @@ class Pool(BaseModel):
             f"<Pool id={self.id} tenant={self.tenant_id} "
             f"name={self.name!r} capacity={self.capacity}>"
         )
+
+
+Pool = PoolModel

--- a/pkgs/standards/peagen/peagen/models/infra/pool_worker_association.py
+++ b/pkgs/standards/peagen/peagen/models/infra/pool_worker_association.py
@@ -33,7 +33,7 @@ class PoolWorkerStatus(str, enum.Enum):
 
 
 # ───────────────────────── Association ───────────────────────────
-class PoolWorkerAssociation(BaseModel):
+class PoolWorkerAssociationModel(BaseModel):
     """
     Maps a Worker to a Pool with an optional status.
     """
@@ -80,3 +80,6 @@ class PoolWorkerAssociation(BaseModel):
             f"<PoolWorkerAssociation pool={self.pool_id} "
             f"worker={self.worker_id} status={self.status}>"
         )
+
+
+PoolWorkerAssociation = PoolWorkerAssociationModel

--- a/pkgs/standards/peagen/peagen/models/infra/worker.py
+++ b/pkgs/standards/peagen/peagen/models/infra/worker.py
@@ -46,7 +46,7 @@ class WorkerStatus(str, enum.Enum):
 
 
 # ──────────────────────────── Model ─────────────────────────────
-class Worker(BaseModel):
+class WorkerModel(BaseModel):
     """
     Execution agent capable of processing tasks.
     """
@@ -124,3 +124,6 @@ class Worker(BaseModel):
             f"<Worker id={self.id} tenant={self.tenant_id} "
             f"name={self.name!r} status={self.status}>"
         )
+
+
+Worker = WorkerModel

--- a/pkgs/standards/peagen/peagen/models/repo/deploy_key.py
+++ b/pkgs/standards/peagen/peagen/models/repo/deploy_key.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:  # pragma: no cover - imports for type hints
 from ..base import BaseModel
 
 
-class DeployKey(BaseModel):
+class DeployKeyModel(BaseModel):
     """SSH deploy key bound to a user."""
 
     __tablename__ = "deploy_keys"
@@ -86,3 +86,6 @@ class DeployKey(BaseModel):
     def __repr__(self) -> str:  # pragma: no cover
         scope = "RO" if self.read_only else "RW"
         return f"<DeployKey user={self.user_id} name={self.name!r} {scope}>"
+
+
+DeployKey = DeployKeyModel

--- a/pkgs/standards/peagen/peagen/models/repo/git_reference.py
+++ b/pkgs/standards/peagen/peagen/models/repo/git_reference.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:  # pragma: no cover - imports for type hints
 from ..base import BaseModel
 
 
-class GitReference(BaseModel):
+class GitReferenceModel(BaseModel):
     """
     A named pointer within a Git repository (e.g., `refs/heads/main`).
 
@@ -67,3 +67,6 @@ class GitReference(BaseModel):
             f"<GitReference repo_id={self.repository_id} "
             f"name={self.name!r} sha={self.commit_sha or '…'}>"
         )
+
+
+GitReference = GitReferenceModel

--- a/pkgs/standards/peagen/peagen/models/repo/repository.py
+++ b/pkgs/standards/peagen/peagen/models/repo/repository.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:  # pragma: no cover - imports for type hints
 from ..base import BaseModel
 
 
-class Repository(BaseModel):
+class RepositoryModel(BaseModel):
     """
     Represents a Git repository mirrored or managed by Peagen.
     """
@@ -106,3 +106,6 @@ class Repository(BaseModel):
     # ─────────────────────── Magic ───────────────────────────
     def __repr__(self) -> str:  # pragma: no cover
         return f"<Repository tenant_id={self.tenant_id} name={self.name!r}>"
+
+
+Repository = RepositoryModel

--- a/pkgs/standards/peagen/peagen/models/repo/repository_deploy_key_association.py
+++ b/pkgs/standards/peagen/peagen/models/repo/repository_deploy_key_association.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:  # pragma: no cover - imports for type hints
 from ..base import BaseModel
 
 
-class RepositoryDeployKeyAssociation(BaseModel):
+class RepositoryDeployKeyAssociationModel(BaseModel):
     """Associates a deploy key with a repository."""
 
     __tablename__ = "repository_deploy_key_associations"
@@ -58,3 +58,6 @@ class RepositoryDeployKeyAssociation(BaseModel):
 
     def __repr__(self) -> str:  # pragma: no cover
         return f"<RepositoryDeployKeyAssociation repo={self.repository_id} key={self.deploy_key_id}>"
+
+
+RepositoryDeployKeyAssociation = RepositoryDeployKeyAssociationModel

--- a/pkgs/standards/peagen/peagen/models/repo/repository_user_association.py
+++ b/pkgs/standards/peagen/peagen/models/repo/repository_user_association.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:  # pragma: no cover - imports for type hints
 from ..base import BaseModel
 
 
-class RepositoryUserAssociation(BaseModel):
+class RepositoryUserAssociationModel(BaseModel):
     __tablename__ = "repository_user_associations"
 
     # ──────────────────────── Columns ────────────────────────
@@ -64,3 +64,6 @@ class RepositoryUserAssociation(BaseModel):
             f"<RepositoryUserAssociation repo_id={self.repository_id} "
             f"user_id={self.user_id} role={self.role!r}>"
         )
+
+
+RepositoryUserAssociation = RepositoryUserAssociationModel

--- a/pkgs/standards/peagen/peagen/models/result/analysis_result.py
+++ b/pkgs/standards/peagen/peagen/models/result/analysis_result.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:  # pragma: no cover - imports for type hints
 from ..base import BaseModel
 
 
-class AnalysisResult(BaseModel):
+class AnalysisResultModel(BaseModel):
     """
     Qualitative or extended quantitative analysis of an EvalResult.
     """
@@ -67,3 +67,6 @@ class AnalysisResult(BaseModel):
     # ───────────────────── Magic ───────────────────────
     def __repr__(self) -> str:  # pragma: no cover
         return f"<AnalysisResult id={self.id} eval={self.eval_result_id}>"
+
+
+AnalysisResult = AnalysisResultModel

--- a/pkgs/standards/peagen/peagen/models/result/eval_result.py
+++ b/pkgs/standards/peagen/peagen/models/result/eval_result.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:  # pragma: no cover - imports for type hints
 from ..base import BaseModel
 
 
-class EvalResult(BaseModel):
+class EvalResultModel(BaseModel):
     """
     Numeric or structured evaluation results for a TaskRun.
     """
@@ -72,3 +72,6 @@ class EvalResult(BaseModel):
             f"<EvalResult id={self.id} task_run={self.task_run_id} "
             f"label={self.label or '∅'}>"
         )
+
+
+EvalResult = EvalResultModel

--- a/pkgs/standards/peagen/peagen/models/security/public_key.py
+++ b/pkgs/standards/peagen/peagen/models/security/public_key.py
@@ -50,7 +50,7 @@ class KeyType(str, enum.Enum):
     pgp = "pgp"  # ASCII-armored PGP public key
 
 
-class PublicKey(BaseModel):
+class PublicKeyModel(BaseModel):
     """
     Public key linked to a user identity.
     """
@@ -120,3 +120,6 @@ class PublicKey(BaseModel):
             f"<PublicKey id={self.id} user={self.user_id} "
             f"type={self.key_type} status={status}>"
         )
+
+
+PublicKey = PublicKeyModel

--- a/pkgs/standards/peagen/peagen/models/specs/doe_spec.py
+++ b/pkgs/standards/peagen/peagen/models/specs/doe_spec.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:  # pragma: no cover - imports for type hints
 from ..base import BaseModel
 
 
-class DoeSpec(BaseModel):
+class DoeSpecModel(BaseModel):
     """
     A Design-of-Experiments definition (factor levels, ranges, or sampling plan).
     """
@@ -86,3 +86,6 @@ class DoeSpec(BaseModel):
             f"<DoeSpec id={self.id} tenant={self.tenant_id} "
             f"name={self.name!r} version={self.schema_version}>"
         )
+
+
+DoeSpec = DoeSpecModel

--- a/pkgs/standards/peagen/peagen/models/specs/evolve_spec.py
+++ b/pkgs/standards/peagen/peagen/models/specs/evolve_spec.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:  # pragma: no cover - imports for type hints
 from ..base import BaseModel
 
 
-class EvolveSpec(BaseModel):
+class EvolveSpecModel(BaseModel):
     """
     Evolutionary strategy definition (population config, operators, etc.).
     """
@@ -77,3 +77,6 @@ class EvolveSpec(BaseModel):
             f"<EvolveSpec id={self.id} tenant={self.tenant_id} "
             f"name={self.name!r} version={self.schema_version}>"
         )
+
+
+EvolveSpec = EvolveSpecModel

--- a/pkgs/standards/peagen/peagen/models/specs/project_payload.py
+++ b/pkgs/standards/peagen/peagen/models/specs/project_payload.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:  # pragma: no cover - imports for type hints
 from ..base import BaseModel
 
 
-class ProjectPayload(BaseModel):
+class ProjectPayloadModel(BaseModel):
     """
     A workspace-level project definition (packages, datasets, resources …).
     """
@@ -97,3 +97,6 @@ class ProjectPayload(BaseModel):
             f"<ProjectPayload id={self.id} tenant={self.tenant_id} "
             f"name={self.name!r} version={self.schema_version}>"
         )
+
+
+ProjectPayload = ProjectPayloadModel

--- a/pkgs/standards/peagen/peagen/models/task/raw_blob.py
+++ b/pkgs/standards/peagen/peagen/models/task/raw_blob.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:  # pragma: no cover - imports for type hints
 from ..base import BaseModel
 
 
-class RawBlob(BaseModel):
+class RawBlobModel(BaseModel):
     """
     Opaque blob packaged with a Task.
     """
@@ -70,3 +70,6 @@ class RawBlob(BaseModel):
             f"<RawBlob id={self.id} payload={self.task_id} "
             f"type={self.media_type!r} enc={self.encoding}>"
         )
+
+
+RawBlob = RawBlobModel

--- a/pkgs/standards/peagen/peagen/models/task/task.py
+++ b/pkgs/standards/peagen/peagen/models/task/task.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:  # pragma: no cover - imports for type hints
 from ..base import BaseModel
 
 
-class Task(BaseModel):
+class TaskModel(BaseModel):
     """
     Domain-level description of a Task’s inputs.
 
@@ -80,3 +80,6 @@ class Task(BaseModel):
             f"<Task id={self.id} tenant={self.tenant_id} "
             f"git_ref={self.git_reference_id or '∅'}>"
         )
+
+
+Task = TaskModel

--- a/pkgs/standards/peagen/peagen/models/task/task_relation.py
+++ b/pkgs/standards/peagen/peagen/models/task/task_relation.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:  # pragma: no cover - imports for type hints
 from ..base import BaseModel
 
 
-class TaskRelation(BaseModel):
+class TaskRelationModel(BaseModel):
     """
     A named relation / tag that can be attached to many TaskRuns.
     """
@@ -73,3 +73,6 @@ class TaskRelation(BaseModel):
     # ─────────────────── Magic ───────────────────
     def __repr__(self) -> str:  # pragma: no cover
         return f"<TaskRelation id={self.id} tenant={self.tenant_id} name={self.name!r}>"
+
+
+TaskRelation = TaskRelationModel

--- a/pkgs/standards/peagen/peagen/models/task/task_run.py
+++ b/pkgs/standards/peagen/peagen/models/task/task_run.py
@@ -34,7 +34,7 @@ from .status import Status
 from ..task import Task
 
 
-class TaskRun(BaseModel):
+class TaskRunModel(BaseModel):
     """
     One execution attempt of a Task on a Worker.
     """
@@ -138,3 +138,6 @@ class TaskRun(BaseModel):
         tr.commit_hexsha = task.commit_hexsha
         tr.oids = task.oids
         return tr
+
+
+TaskRun = TaskRunModel

--- a/pkgs/standards/peagen/peagen/models/task/task_run_relation_association.py
+++ b/pkgs/standards/peagen/peagen/models/task/task_run_relation_association.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:  # pragma: no cover - imports for type hints
 from ..base import BaseModel
 
 
-class TaskRunTaskRelationAssociation(BaseModel):
+class TaskRunTaskRelationAssociationModel(BaseModel):
     __tablename__ = "task_run_task_relation_associations"
 
     # ─────────────────── Columns ──────────────────
@@ -51,3 +51,6 @@ class TaskRunTaskRelationAssociation(BaseModel):
     # ─────────────────── Magic ───────────────────
     def __repr__(self) -> str:  # pragma: no cover
         return f"<TaskRunTaskRelationAssociation run={self.task_run_id} rel={self.relation_id}>"
+
+
+TaskRunTaskRelationAssociation = TaskRunTaskRelationAssociationModel

--- a/pkgs/standards/peagen/peagen/models/tenant/tenant.py
+++ b/pkgs/standards/peagen/peagen/models/tenant/tenant.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:  # pragma: no cover - imports for type hints
 from ..base import BaseModel  # id, date_created, last_modified mixins
 
 
-class Tenant(BaseModel):
+class TenantModel(BaseModel):
     """
     Represents an organizational boundary (company, team, project-space).
 
@@ -69,3 +69,6 @@ class Tenant(BaseModel):
     # ─────────────────────── Magic ───────────────────────────
     def __repr__(self) -> str:  # pragma: no cover
         return f"<Tenant slug={self.slug!r} name={self.name!r}>"
+
+
+Tenant = TenantModel

--- a/pkgs/standards/peagen/peagen/models/tenant/tenant_user_association.py
+++ b/pkgs/standards/peagen/peagen/models/tenant/tenant_user_association.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:  # pragma: no cover - imports for type hints
 from ..base import BaseModel
 
 
-class TenantUserAssociation(BaseModel):
+class TenantUserAssociationModel(BaseModel):
     """
     Association row defining a user's membership (and role) within a Tenant.
 
@@ -66,3 +66,6 @@ class TenantUserAssociation(BaseModel):
             f"<TenantUserAssociation tenant_id={self.tenant_id} "
             f"user_id={self.user_id} role={self.role!r}>"
         )
+
+
+TenantUserAssociation = TenantUserAssociationModel

--- a/pkgs/standards/peagen/peagen/models/tenant/user.py
+++ b/pkgs/standards/peagen/peagen/models/tenant/user.py
@@ -27,7 +27,7 @@ from ..security.public_key import PublicKey
 from ..base import BaseModel
 
 
-class User(BaseModel):
+class UserModel(BaseModel):
     """
     A globally unique user who may join any number of tenant workspaces.
     """
@@ -73,3 +73,6 @@ class User(BaseModel):
     # ─────────────────────── Magic ───────────────────────────
     def __repr__(self) -> str:  # pragma: no cover
         return f"<User username={self.username!r} email={self.email!r}>"
+
+
+User = UserModel


### PR DESCRIPTION
## Summary
- rename ORM models with `Model` suffix, keep old names as aliases
- export renamed models via `__all__`
- update imports in the `peagen` model aggregator

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest` *(fails: 72 failed, 162 passed, 31 skipped, 19 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685ed172f7048326a1d3aa4c8d204f5e