### PR TITLE
Fix Task schema generation and handler task validation

### DIFF
--- a/pkgs/standards/peagen/peagen/handlers/__init__.py
+++ b/pkgs/standards/peagen/peagen/handlers/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, Dict
 
 from peagen.models import Task
+from peagen.models.schemas import TaskRead
 
 
 def ensure_task(task: Task | Dict[str, Any]) -> Task:
@@ -12,7 +13,7 @@ def ensure_task(task: Task | Dict[str, Any]) -> Task:
 
     if isinstance(task, Task):
         return task
-    return Task.model_validate(task)
+    return TaskRead.model_validate(task)
 
 
 __all__ = ["ensure_task"]

--- a/pkgs/standards/peagen/peagen/models/schemas.py
+++ b/pkgs/standards/peagen/peagen/models/schemas.py
@@ -21,6 +21,7 @@ def _python_type(column: Any) -> type:
 
 for _name in model_names:
     model_cls = getattr(base_module, _name, None)
+    base_name = _name[:-5] if _name.endswith("Model") else _name
     if model_cls is None:
         try:
             mod = __import__("peagen.models", fromlist=[_name])
@@ -45,7 +46,7 @@ for _name in model_names:
         for c_name, c in columns.items()
         if c_name not in ["last_modified", "date_created"]
     }
-    create_cls = create_model(f"{_name}Create", **create_fields)
+    create_cls = create_model(f"{base_name}Create", **create_fields)
 
     # UPDATE: all optional fields except 'date_created'
     update_fields = {
@@ -53,7 +54,7 @@ for _name in model_names:
         for c_name, c in columns.items()
         if c_name not in ["date_created", "last_modified"]
     }
-    update_cls = create_model(f"{_name}Update", **update_fields)
+    update_cls = create_model(f"{base_name}Update", **update_fields)
 
     # READ: all required, including id and date_created
     read_fields = {"id": (id_type, ...)}
@@ -61,10 +62,10 @@ for _name in model_names:
         read_fields[c_name] = (_python_type(c), ...)
     if "date_created" not in read_fields and "date_created" in columns:
         read_fields["date_created"] = (datetime, ...)
-    read_cls = create_model(f"{_name}Read", **read_fields)
+    read_cls = create_model(f"{base_name}Read", **read_fields)
 
     # CHILD: id only
-    child_cls = create_model(f"{_name}Child", id=(id_type, ...))
+    child_cls = create_model(f"{base_name}Child", id=(id_type, ...))
 
     # Register in global scope and __all__
     globals()[create_cls.__name__] = create_cls

--- a/pkgs/standards/peagen/peagen/models/task/__init__.py
+++ b/pkgs/standards/peagen/peagen/models/task/__init__.py
@@ -1,1 +1,5 @@
+"""Task subpackage exports."""
 
+from .task import TaskModel, Task
+
+__all__ = ["TaskModel", "Task"]


### PR DESCRIPTION
## Summary
- generate CRUD Pydantic schemas without the `Model` suffix
- ensure task validation uses `TaskRead`
- export `Task` from `peagen.models.task`

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format .`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest -q` *(fails: 63 failed, 171 passed, 31 skipped, 19 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685ed7e34fe48326918d37712f1eb8fb