### PR TITLE
Fix Peagen model references

### DIFF
--- a/pkgs/standards/peagen/peagen/models/config/peagen_toml_spec.py
+++ b/pkgs/standards/peagen/peagen/models/config/peagen_toml_spec.py
@@ -20,8 +20,8 @@ from sqlalchemy import JSON, String, Text, UniqueConstraint, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from ..repo.repository import Repository
-from ..tenant.tenant import Tenant
+from ..repo.repository import RepositoryModel
+from ..tenant.tenant import TenantModel
 
 from ..base import BaseModel
 
@@ -75,10 +75,10 @@ class PeagenTomlSpecModel(BaseModel):
     __table_args__ = (UniqueConstraint("tenant_id", "name", name="uq_toml_per_tenant"),)
 
     # ───────────────── Relationships ───────────────────
-    tenant: Mapped[Tenant] = relationship("Tenant", lazy="selectin")
+    tenant: Mapped["TenantModel"] = relationship("TenantModel", lazy="selectin")
 
-    repository: Mapped[Repository | None] = relationship(
-        "Repository",
+    repository: Mapped[RepositoryModel | None] = relationship(
+        "RepositoryModel",
         lazy="selectin",
         back_populates="toml_specs",
     )

--- a/pkgs/standards/peagen/peagen/models/config/secret.py
+++ b/pkgs/standards/peagen/peagen/models/config/secret.py
@@ -20,8 +20,8 @@ from sqlalchemy import String, Text, UniqueConstraint, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from ..tenant.user import User
-from ..tenant.tenant import Tenant
+from ..tenant.user import UserModel
+from ..tenant.tenant import TenantModel
 
 from ..base import BaseModel
 
@@ -70,9 +70,9 @@ class SecretModel(BaseModel):
     )
 
     # ───────────────── Relationships ───────────────────
-    tenant: Mapped[Tenant] = relationship("Tenant", lazy="selectin")
+    tenant: Mapped["TenantModel"] = relationship("TenantModel", lazy="selectin")
 
-    owner: Mapped[User | None] = relationship("User", lazy="selectin")
+    owner: Mapped[UserModel | None] = relationship("UserModel", lazy="selectin")
 
     # ───────────────────── Magic ───────────────────────
     def __repr__(self) -> str:  # pragma: no cover

--- a/pkgs/standards/peagen/peagen/models/infra/pool.py
+++ b/pkgs/standards/peagen/peagen/models/infra/pool.py
@@ -21,9 +21,9 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - imports for type hints
-    from ..tenant.tenant import Tenant
-    from .pool_worker_association import PoolWorkerAssociation
-    from .worker import Worker
+    from ..tenant.tenant import TenantModel
+    from .pool_worker_association import PoolWorkerAssociationModel
+    from .worker import WorkerModel
 
 from ..base import BaseModel
 
@@ -71,17 +71,17 @@ class PoolModel(BaseModel):
     __table_args__ = (UniqueConstraint("tenant_id", "name", name="uq_pool_per_tenant"),)
 
     # ───────────────── Relationships ───────────────────
-    tenant: Mapped["Tenant"] = relationship("Tenant", lazy="selectin")
+    tenant: Mapped["TenantModel"] = relationship("TenantModel", lazy="selectin")
 
-    worker_associations: Mapped[list["PoolWorkerAssociation"]] = relationship(
-        "PoolWorkerAssociation",
+    worker_associations: Mapped[list["PoolWorkerAssociationModel"]] = relationship(
+        "PoolWorkerAssociationModel",
         back_populates="pool",
         cascade="all, delete-orphan",
         lazy="selectin",
     )
 
-    workers: Mapped[list["Worker"]] = relationship(
-        "Worker",
+    workers: Mapped[list["WorkerModel"]] = relationship(
+        "WorkerModel",
         secondary="pool_worker_associations",
         viewonly=True,
         lazy="selectin",

--- a/pkgs/standards/peagen/peagen/models/infra/pool_worker_association.py
+++ b/pkgs/standards/peagen/peagen/models/infra/pool_worker_association.py
@@ -20,8 +20,8 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - imports for type hints
-    from .pool import Pool
-    from .worker import Worker
+    from .pool import PoolModel
+    from .worker import WorkerModel
 
 from ..base import BaseModel
 
@@ -62,14 +62,14 @@ class PoolWorkerAssociationModel(BaseModel):
     __table_args__ = (UniqueConstraint("pool_id", "worker_id", name="uq_pool_worker"),)
 
     # ───────────── Relationships ────────────────
-    pool: Mapped["Pool"] = relationship(
-        "Pool",
+    pool: Mapped["PoolModel"] = relationship(
+        "PoolModel",
         back_populates="worker_associations",
         lazy="selectin",
     )
 
-    worker: Mapped["Worker"] = relationship(
-        "Worker",
+    worker: Mapped["WorkerModel"] = relationship(
+        "WorkerModel",
         back_populates="pool_associations",
         lazy="selectin",
     )

--- a/pkgs/standards/peagen/peagen/models/infra/worker.py
+++ b/pkgs/standards/peagen/peagen/models/infra/worker.py
@@ -29,10 +29,10 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - imports for type hints
-    from ..tenant.tenant import Tenant
-    from .pool_worker_association import PoolWorkerAssociation
-    from .pool import Pool
-    from ..task.task_run import TaskRun
+    from ..tenant.tenant import TenantModel
+    from .pool_worker_association import PoolWorkerAssociationModel
+    from .pool import PoolModel
+    from ..task.task_run import TaskRunModel
 
 from ..base import BaseModel
 
@@ -96,24 +96,24 @@ class WorkerModel(BaseModel):
     )
 
     # ─────────────── Relationships ────────────────
-    tenant: Mapped["Tenant"] = relationship("Tenant", lazy="selectin")
+    tenant: Mapped["TenantModel"] = relationship("TenantModel", lazy="selectin")
 
-    pool_associations: Mapped[list["PoolWorkerAssociation"]] = relationship(
-        "PoolWorkerAssociation",
+    pool_associations: Mapped[list["PoolWorkerAssociationModel"]] = relationship(
+        "PoolWorkerAssociationModel",
         back_populates="worker",
         cascade="all, delete-orphan",
         lazy="selectin",
     )
 
-    pools: Mapped[list["Pool"]] = relationship(
-        "Pool",
+    pools: Mapped[list["PoolModel"]] = relationship(
+        "PoolModel",
         secondary="pool_worker_associations",
         viewonly=True,
         lazy="selectin",
     )
 
-    task_runs: Mapped[list["TaskRun"]] = relationship(
-        "TaskRun",
+    task_runs: Mapped[list["TaskRunModel"]] = relationship(
+        "TaskRunModel",
         back_populates="worker",
         lazy="selectin",
     )

--- a/pkgs/standards/peagen/peagen/models/repo/deploy_key.py
+++ b/pkgs/standards/peagen/peagen/models/repo/deploy_key.py
@@ -25,10 +25,10 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - imports for type hints
-    from ..tenant.user import User
-    from ..config.secret import Secret
-    from .repository_deploy_key_association import RepositoryDeployKeyAssociation
-    from .repository import Repository
+    from ..tenant.user import UserModel
+    from ..config.secret import SecretModel
+    from .repository_deploy_key_association import RepositoryDeployKeyAssociationModel
+    from .repository import RepositoryModel
 
 from ..base import BaseModel
 
@@ -63,10 +63,10 @@ class DeployKeyModel(BaseModel):
     )
 
     # ──────────────────── Relationships ──────────────────────
-    user: Mapped["User"] = relationship("User", lazy="selectin")
-    secret: Mapped["Secret"] = relationship("Secret", lazy="selectin")
+    user: Mapped["UserModel"] = relationship("UserModel", lazy="selectin")
+    secret: Mapped["SecretModel"] = relationship("SecretModel", lazy="selectin")
 
-    repository_associations: Mapped[list["RepositoryDeployKeyAssociation"]] = (
+    repository_associations: Mapped[list["RepositoryDeployKeyAssociationModel"]] = (
         relationship(
             "RepositoryDeployKeyAssociation",
             back_populates="deploy_key",
@@ -75,8 +75,8 @@ class DeployKeyModel(BaseModel):
         )
     )
 
-    repositories: Mapped[list["Repository"]] = relationship(
-        "Repository",
+    repositories: Mapped[list["RepositoryModel"]] = relationship(
+        "RepositoryModel",
         secondary="repository_deploy_key_associations",
         back_populates="deploy_keys",
         lazy="selectin",

--- a/pkgs/standards/peagen/peagen/models/repo/git_reference.py
+++ b/pkgs/standards/peagen/peagen/models/repo/git_reference.py
@@ -20,7 +20,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - imports for type hints
-    from .repository import Repository
+    from .repository import RepositoryModel
 
 from ..base import BaseModel
 
@@ -55,8 +55,8 @@ class GitReferenceModel(BaseModel):
     )
 
     # ──────────────────── Relationships ──────────────────────
-    repository: Mapped["Repository"] = relationship(
-        "Repository",
+    repository: Mapped["RepositoryModel"] = relationship(
+        "RepositoryModel",
         back_populates="git_references",
         lazy="selectin",
     )

--- a/pkgs/standards/peagen/peagen/models/repo/repository.py
+++ b/pkgs/standards/peagen/peagen/models/repo/repository.py
@@ -24,12 +24,12 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - imports for type hints
-    from ..tenant.tenant import Tenant
-    from .git_reference import GitReference
-    from .repository_deploy_key_association import RepositoryDeployKeyAssociation
-    from .deploy_key import DeployKey
-    from .repository_user_association import RepositoryUserAssociation
-    from ..config.peagen_toml_spec import PeagenTomlSpec
+    from ..tenant.tenant import TenantModel
+    from .git_reference import GitReferenceModel
+    from .repository_deploy_key_association import RepositoryDeployKeyAssociationModel
+    from .deploy_key import DeployKeyModel
+    from .repository_user_association import RepositoryUserAssociationModel
+    from ..config.peagen_toml_spec import PeagenTomlSpecModel
 
 # Import at runtime so SQLAlchemy can resolve relationship targets
 
@@ -62,42 +62,42 @@ class RepositoryModel(BaseModel):
     )
 
     # ──────────────────── Relationships ──────────────────────
-    tenant: Mapped["Tenant"] = relationship(
-        "Tenant", lazy="selectin", back_populates="repositories"
+    tenant: Mapped["TenantModel"] = relationship(
+        "TenantModel", lazy="selectin", back_populates="repositories"
     )
 
-    git_references: Mapped[list["GitReference"]] = relationship(
-        "GitReference",
+    git_references: Mapped[list["GitReferenceModel"]] = relationship(
+        "GitReferenceModel",
         back_populates="repository",
         cascade="all, delete-orphan",
         lazy="selectin",
     )
 
-    deploy_key_associations: Mapped[list["RepositoryDeployKeyAssociation"]] = (
+    deploy_key_associations: Mapped[list["RepositoryDeployKeyAssociationModel"]] = (
         relationship(
-            "RepositoryDeployKeyAssociation",
+            "RepositoryDeployKeyAssociationModel",
             back_populates="repository",
             cascade="all, delete-orphan",
             lazy="selectin",
         )
     )
 
-    toml_specs: Mapped[list["PeagenTomlSpec"]] = relationship(
-        "PeagenTomlSpec",
+    toml_specs: Mapped[list["PeagenTomlSpecModel"]] = relationship(
+        "PeagenTomlSpecModel",
         back_populates="repository",
         cascade="all, delete-orphan",
         lazy="selectin",
     )
 
-    deploy_keys: Mapped[list["DeployKey"]] = relationship(
-        "DeployKey",
+    deploy_keys: Mapped[list["DeployKeyModel"]] = relationship(
+        "DeployKeyModel",
         secondary="repository_deploy_key_associations",
         back_populates="repositories",
         lazy="selectin",
     )
 
-    user_associations: Mapped[list["RepositoryUserAssociation"]] = relationship(
-        "RepositoryUserAssociation",
+    user_associations: Mapped[list["RepositoryUserAssociationModel"]] = relationship(
+        "RepositoryUserAssociationModel",
         back_populates="repository",
         cascade="all, delete-orphan",
         lazy="selectin",

--- a/pkgs/standards/peagen/peagen/models/repo/repository_deploy_key_association.py
+++ b/pkgs/standards/peagen/peagen/models/repo/repository_deploy_key_association.py
@@ -17,8 +17,8 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - imports for type hints
-    from .repository import Repository
-    from .deploy_key import DeployKey
+    from .repository import RepositoryModel
+    from .deploy_key import DeployKeyModel
 
 from ..base import BaseModel
 
@@ -49,11 +49,11 @@ class RepositoryDeployKeyAssociationModel(BaseModel):
     )
 
     # --------------------------- Relationships ---------------------------
-    repository: Mapped["Repository"] = relationship(
-        "Repository", back_populates="deploy_key_associations", lazy="selectin"
+    repository: Mapped["RepositoryModel"] = relationship(
+        "RepositoryModel", back_populates="deploy_key_associations", lazy="selectin"
     )
-    deploy_key: Mapped["DeployKey"] = relationship(
-        "DeployKey", back_populates="repository_associations", lazy="selectin"
+    deploy_key: Mapped["DeployKeyModel"] = relationship(
+        "DeployKeyModel", back_populates="repository_associations", lazy="selectin"
     )
 
     def __repr__(self) -> str:  # pragma: no cover

--- a/pkgs/standards/peagen/peagen/models/repo/repository_user_association.py
+++ b/pkgs/standards/peagen/peagen/models/repo/repository_user_association.py
@@ -20,8 +20,8 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - imports for type hints
-    from .repository import Repository
-    from ..tenant.user import User
+    from .repository import RepositoryModel
+    from ..tenant.user import UserModel
 
 from ..base import BaseModel
 
@@ -51,11 +51,11 @@ class RepositoryUserAssociationModel(BaseModel):
     )
 
     # ──────────────────── Relationships ──────────────────────
-    repository: Mapped["Repository"] = relationship(
-        "Repository", back_populates="user_associations", lazy="selectin"
+    repository: Mapped["RepositoryModel"] = relationship(
+        "RepositoryModel", back_populates="user_associations", lazy="selectin"
     )
-    user: Mapped["User"] = relationship(
-        "User", back_populates="repository_associations", lazy="selectin"
+    user: Mapped["UserModel"] = relationship(
+        "UserModel", back_populates="repository_associations", lazy="selectin"
     )
 
     # ─────────────────────── Magic ───────────────────────────

--- a/pkgs/standards/peagen/peagen/models/result/analysis_result.py
+++ b/pkgs/standards/peagen/peagen/models/result/analysis_result.py
@@ -25,7 +25,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - imports for type hints
-    from .eval_result import EvalResult
+    from .eval_result import EvalResultModel
 
 from ..base import BaseModel
 
@@ -58,8 +58,8 @@ class AnalysisResultModel(BaseModel):
     )
 
     # ───────────────── Relationships ───────────────────
-    eval_result: Mapped["EvalResult"] = relationship(
-        "EvalResult",
+    eval_result: Mapped["EvalResultModel"] = relationship(
+        "EvalResultModel",
         back_populates="analyses",
         lazy="selectin",
     )

--- a/pkgs/standards/peagen/peagen/models/result/eval_result.py
+++ b/pkgs/standards/peagen/peagen/models/result/eval_result.py
@@ -20,8 +20,8 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - imports for type hints
-    from ..task.task_run import TaskRun
-    from .analysis_result import AnalysisResult
+    from ..task.task_run import TaskRunModel
+    from .analysis_result import AnalysisResultModel
 
 from ..base import BaseModel
 
@@ -53,14 +53,14 @@ class EvalResultModel(BaseModel):
     )
 
     # ───────────────── Relationships ───────────────────
-    task_run: Mapped["TaskRun"] = relationship(
-        "TaskRun",
+    task_run: Mapped["TaskRunModel"] = relationship(
+        "TaskRunModel",
         back_populates="eval_results",
         lazy="selectin",
     )
 
-    analyses: Mapped[list["AnalysisResult"]] = relationship(
-        "AnalysisResult",
+    analyses: Mapped[list["AnalysisResultModel"]] = relationship(
+        "AnalysisResultModel",
         back_populates="eval_result",
         cascade="all, delete-orphan",
         lazy="selectin",

--- a/pkgs/standards/peagen/peagen/models/security/public_key.py
+++ b/pkgs/standards/peagen/peagen/models/security/public_key.py
@@ -36,7 +36,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - imports for type hints
-    from ..tenant.user import User
+    from ..tenant.user import UserModel
 
 from ..base import BaseModel
 
@@ -107,8 +107,8 @@ class PublicKeyModel(BaseModel):
     )
 
     # ───────────────── Relationships ───────────────────
-    user: Mapped["User"] = relationship(
-        "User",
+    user: Mapped["UserModel"] = relationship(
+        "UserModel",
         back_populates="public_keys",
         lazy="selectin",
     )

--- a/pkgs/standards/peagen/peagen/models/specs/doe_spec.py
+++ b/pkgs/standards/peagen/peagen/models/specs/doe_spec.py
@@ -21,8 +21,8 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - imports for type hints
-    from ..tenant.tenant import Tenant
-    from .project_payload import ProjectPayload
+    from ..tenant.tenant import TenantModel
+    from .project_payload import ProjectPayloadModel
 
 from ..base import BaseModel
 
@@ -71,10 +71,10 @@ class DoeSpecModel(BaseModel):
     )
 
     # ───────────────── Relationships ───────────────────
-    tenant: Mapped["Tenant"] = relationship("Tenant", lazy="selectin")
+    tenant: Mapped["TenantModel"] = relationship("TenantModel", lazy="selectin")
 
-    project_payloads: Mapped[list["ProjectPayload"]] = relationship(
-        "ProjectPayload",
+    project_payloads: Mapped[list["ProjectPayloadModel"]] = relationship(
+        "ProjectPayloadModel",
         back_populates="doe_spec",
         cascade="all, delete-orphan",
         lazy="selectin",

--- a/pkgs/standards/peagen/peagen/models/specs/evolve_spec.py
+++ b/pkgs/standards/peagen/peagen/models/specs/evolve_spec.py
@@ -20,7 +20,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - imports for type hints
-    from ..tenant.tenant import Tenant
+    from ..tenant.tenant import TenantModel
 
 from ..base import BaseModel
 
@@ -69,7 +69,7 @@ class EvolveSpecModel(BaseModel):
     )
 
     # ───────────────── Relationships ───────────────────
-    tenant: Mapped["Tenant"] = relationship("Tenant", lazy="selectin")
+    tenant: Mapped["TenantModel"] = relationship("TenantModel", lazy="selectin")
 
     # ───────────────────── Magic ───────────────────────
     def __repr__(self) -> str:  # pragma: no cover

--- a/pkgs/standards/peagen/peagen/models/specs/project_payload.py
+++ b/pkgs/standards/peagen/peagen/models/specs/project_payload.py
@@ -27,8 +27,8 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - imports for type hints
-    from ..tenant.tenant import Tenant
-    from .doe_spec import DoeSpec
+    from ..tenant.tenant import TenantModel
+    from .doe_spec import DoeSpecModel
 
 from ..base import BaseModel
 
@@ -83,10 +83,10 @@ class ProjectPayloadModel(BaseModel):
     )
 
     # ───────────────── Relationships ───────────────────
-    tenant: Mapped["Tenant"] = relationship("Tenant", lazy="selectin")
+    tenant: Mapped["TenantModel"] = relationship("TenantModel", lazy="selectin")
 
-    doe_spec: Mapped["DoeSpec | None"] = relationship(
-        "DoeSpec",
+    doe_spec: Mapped[DoeSpecModel | None] = relationship(
+        "DoeSpecModel",
         back_populates="project_payloads",
         lazy="selectin",
     )

--- a/pkgs/standards/peagen/peagen/models/task/raw_blob.py
+++ b/pkgs/standards/peagen/peagen/models/task/raw_blob.py
@@ -22,7 +22,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - imports for type hints
-    from .task import Task
+    from .task import TaskModel
 
 from ..base import BaseModel
 
@@ -60,8 +60,8 @@ class RawBlobModel(BaseModel):
     )
 
     # ──────────────────── Relationships ──────────────────────
-    task: Mapped["Task"] = relationship(
-        "Task", back_populates="raw_blobs", lazy="selectin"
+    task: Mapped["TaskModel"] = relationship(
+        "TaskModel", back_populates="raw_blobs", lazy="selectin"
     )
 
     # ─────────────────────── Magic ───────────────────────────

--- a/pkgs/standards/peagen/peagen/models/task/task.py
+++ b/pkgs/standards/peagen/peagen/models/task/task.py
@@ -21,9 +21,10 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - imports for type hints
-    from ..repo.git_reference import GitReference
-    from .raw_blob import RawBlob
+    from ..repo.git_reference import GitReferenceModel
+    from .raw_blob import RawBlobModel
 
+from ..repo.git_reference import GitReferenceModel
 from ..base import BaseModel
 
 
@@ -63,12 +64,12 @@ class TaskModel(BaseModel):
     )
 
     # ──────────────────── Relationships ──────────────────────
-    git_reference: Mapped["GitReference | None"] = relationship(
-        "GitReference", lazy="selectin"
+    git_reference: Mapped[GitReferenceModel | None] = relationship(
+        "GitReferenceModel", lazy="selectin"
     )
 
-    raw_blobs: Mapped[list["RawBlob"]] = relationship(
-        "RawBlob",
+    raw_blobs: Mapped[list["RawBlobModel"]] = relationship(
+        "RawBlobModel",
         back_populates="task",
         cascade="all, delete-orphan",
         lazy="selectin",

--- a/pkgs/standards/peagen/peagen/models/task/task_relation.py
+++ b/pkgs/standards/peagen/peagen/models/task/task_relation.py
@@ -20,9 +20,9 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - imports for type hints
-    from ..tenant.tenant import Tenant
-    from .task_run_relation_association import TaskRunTaskRelationAssociation
-    from .task_run import TaskRun
+    from ..tenant.tenant import TenantModel
+    from .task_run_relation_association import TaskRunTaskRelationAssociationModel
+    from .task_run import TaskRunModel
 
 from ..base import BaseModel
 
@@ -54,17 +54,19 @@ class TaskRelationModel(BaseModel):
     )
 
     # ───────────── Relationships ────────────────
-    tenant: Mapped["Tenant"] = relationship("Tenant", lazy="selectin")
+    tenant: Mapped["TenantModel"] = relationship("TenantModel", lazy="selectin")
 
-    task_associations: Mapped[list["TaskRunTaskRelationAssociation"]] = relationship(
-        "TaskRunTaskRelationAssociation",
-        back_populates="relation",
-        cascade="all, delete-orphan",
-        lazy="selectin",
+    task_associations: Mapped[list["TaskRunTaskRelationAssociationModel"]] = (
+        relationship(
+            "TaskRunTaskRelationAssociationModel",
+            back_populates="relation",
+            cascade="all, delete-orphan",
+            lazy="selectin",
+        )
     )
 
-    task_runs: Mapped[list["TaskRun"]] = relationship(
-        "TaskRun",
+    task_runs: Mapped[list["TaskRunModel"]] = relationship(
+        "TaskRunModel",
         secondary="task_run_task_relation_associations",
         viewonly=True,
         lazy="selectin",

--- a/pkgs/standards/peagen/peagen/models/task/task_run.py
+++ b/pkgs/standards/peagen/peagen/models/task/task_run.py
@@ -21,17 +21,20 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - imports for type hints
-    from ..infra.pool import Pool
-    from ..infra.worker import Worker
-    from ..tenant.user import User
-    from .task import Task
-    from .task_relation import TaskRelation
-    from .task_run_relation_association import TaskRunTaskRelationAssociation
-    from ..result.eval_result import EvalResult
+    from ..infra.pool import PoolModel
+    from ..infra.worker import WorkerModel
+    from ..tenant.user import UserModel
+    from .task import TaskModel
+    from .task_relation import TaskRelationModel
+    from .task_run_relation_association import TaskRunTaskRelationAssociationModel
+    from ..result.eval_result import EvalResultModel
 
 from ..base import BaseModel  # id, timestamps
 from .status import Status
-from ..task import Task
+from ..task.task import TaskModel
+from ..infra.pool import PoolModel
+from ..infra.worker import WorkerModel
+from ..tenant.user import UserModel
 
 
 class TaskRunModel(BaseModel):
@@ -79,18 +82,18 @@ class TaskRunModel(BaseModel):
     )
 
     # ────────────────── Relationships ───────────────────────
-    task: Mapped["Task"] = relationship("Task", lazy="selectin")
+    task: Mapped["TaskModel"] = relationship("TaskModel", lazy="selectin")
 
-    pool: Mapped["Pool | None"] = relationship("Pool", lazy="selectin")  # noqa: F821
+    pool: Mapped[PoolModel | None] = relationship("PoolModel", lazy="selectin")  # noqa: F821
 
-    worker: Mapped["Worker | None"] = relationship("Worker", lazy="selectin")  # noqa: F821
+    worker: Mapped[WorkerModel | None] = relationship("WorkerModel", lazy="selectin")  # noqa: F821
 
-    user: Mapped["User | None"] = relationship("User", lazy="selectin")  # noqa: F821
+    user: Mapped[UserModel | None] = relationship("UserModel", lazy="selectin")  # noqa: F821
 
     # join-rows
-    relation_associations: Mapped[list["TaskRunTaskRelationAssociation"]] = (
+    relation_associations: Mapped[list["TaskRunTaskRelationAssociationModel"]] = (
         relationship(
-            "TaskRunTaskRelationAssociation",
+            "TaskRunTaskRelationAssociationModel",
             back_populates="task_run",
             cascade="all, delete-orphan",
             lazy="selectin",
@@ -98,16 +101,16 @@ class TaskRunModel(BaseModel):
     )  # noqa: F821
 
     # convenience list of TaskRelation objects
-    relations: Mapped[list["TaskRelation"]] = relationship(
-        "TaskRelation",
+    relations: Mapped[list["TaskRelationModel"]] = relationship(
+        "TaskRelationModel",
         secondary="task_run_task_relation_associations",
         viewonly=True,
         lazy="selectin",
     )  # noqa: F821
 
     # Evaluation pipeline
-    eval_results: Mapped[list["EvalResult"]] = relationship(
-        "EvalResult",
+    eval_results: Mapped[list["EvalResultModel"]] = relationship(
+        "EvalResultModel",
         back_populates="task_run",
         cascade="all, delete-orphan",
         lazy="selectin",
@@ -119,7 +122,7 @@ class TaskRunModel(BaseModel):
 
     # ------------------------------------------------------------------
     @classmethod
-    def from_task(cls, task: "Task") -> "TaskRun":
+    def from_task(cls, task: "TaskModel") -> "TaskRunModel":
         """Create a minimal TaskRun instance from a :class:`Task`."""
 
         tr = cls(

--- a/pkgs/standards/peagen/peagen/models/task/task_run_relation_association.py
+++ b/pkgs/standards/peagen/peagen/models/task/task_run_relation_association.py
@@ -14,8 +14,8 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - imports for type hints
-    from .task_run import TaskRun
-    from .task_relation import TaskRelation
+    from .task_run import TaskRunModel
+    from .task_relation import TaskRelationModel
 
 from ..base import BaseModel
 
@@ -41,11 +41,11 @@ class TaskRunTaskRelationAssociationModel(BaseModel):
     )
 
     # ───────────── Relationships ────────────────
-    task_run: Mapped["TaskRun"] = relationship(
-        "TaskRun", back_populates="relation_associations", lazy="selectin"
+    task_run: Mapped["TaskRunModel"] = relationship(
+        "TaskRunModel", back_populates="relation_associations", lazy="selectin"
     )
-    relation: Mapped["TaskRelation"] = relationship(
-        "TaskRelation", back_populates="task_associations", lazy="selectin"
+    relation: Mapped["TaskRelationModel"] = relationship(
+        "TaskRelationModel", back_populates="task_associations", lazy="selectin"
     )
 
     # ─────────────────── Magic ───────────────────

--- a/pkgs/standards/peagen/peagen/models/tenant/tenant.py
+++ b/pkgs/standards/peagen/peagen/models/tenant/tenant.py
@@ -15,9 +15,9 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - imports for type hints
-    from .tenant_user_association import TenantUserAssociation
-    from .user import User
-    from ..repo.repository import Repository
+    from .tenant_user_association import TenantUserAssociationModel
+    from .user import UserModel
+    from ..repo.repository import RepositoryModel
 
 # Import at runtime so SQLAlchemy can resolve the relationship target
 
@@ -44,23 +44,23 @@ class TenantModel(BaseModel):
 
     # ──────────────────── Relationships ──────────────────────
     # full association rows (contains role etc.)
-    user_associations: Mapped[list["TenantUserAssociation"]] = relationship(
-        "TenantUserAssociation",
+    user_associations: Mapped[list["TenantUserAssociationModel"]] = relationship(
+        "TenantUserAssociationModel",
         back_populates="tenant",
         cascade="all, delete-orphan",
         lazy="selectin",
     )
 
     # convenience: direct list of members via the association table
-    members: Mapped[list["User"]] = relationship(
-        "User",
+    members: Mapped[list["UserModel"]] = relationship(
+        "UserModel",
         secondary="tenant_user_associations",
         viewonly=True,
         lazy="selectin",
     )
 
-    repositories: Mapped[list["Repository"]] = relationship(
-        "Repository",
+    repositories: Mapped[list["RepositoryModel"]] = relationship(
+        "RepositoryModel",
         back_populates="tenant",
         cascade="all, delete-orphan",
         lazy="selectin",

--- a/pkgs/standards/peagen/peagen/models/tenant/tenant_user_association.py
+++ b/pkgs/standards/peagen/peagen/models/tenant/tenant_user_association.py
@@ -16,8 +16,8 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - imports for type hints
-    from .tenant import Tenant
-    from .user import User
+    from .tenant import TenantModel
+    from .user import UserModel
 
 from ..base import BaseModel
 
@@ -53,11 +53,11 @@ class TenantUserAssociationModel(BaseModel):
     )
 
     # ──────────────────── Relationships ──────────────────────
-    tenant: Mapped["Tenant"] = relationship(
-        "Tenant", back_populates="user_associations", lazy="selectin"
+    tenant: Mapped["TenantModel"] = relationship(
+        "TenantModel", back_populates="user_associations", lazy="selectin"
     )
-    user: Mapped["User"] = relationship(
-        "User", back_populates="tenant_associations", lazy="selectin"
+    user: Mapped["UserModel"] = relationship(
+        "UserModel", back_populates="tenant_associations", lazy="selectin"
     )
 
     # ─────────────────────── Magic ───────────────────────────

--- a/pkgs/standards/peagen/peagen/models/tenant/user.py
+++ b/pkgs/standards/peagen/peagen/models/tenant/user.py
@@ -16,13 +16,12 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - imports for type hints
-    from .tenant_user_association import TenantUserAssociation
-    from .tenant import Tenant
-    from ..repo.repository_user_association import RepositoryUserAssociation
-    from ..security.public_key import PublicKey
+    from .tenant_user_association import TenantUserAssociationModel
+    from .tenant import TenantModel
+    from ..repo.repository_user_association import RepositoryUserAssociationModel
+    from ..security.public_key import PublicKeyModel
 
 # Import at runtime so SQLAlchemy can resolve the relationship target
-from ..security.public_key import PublicKey
 
 from ..base import BaseModel
 
@@ -40,31 +39,33 @@ class UserModel(BaseModel):
     role: Mapped[str] = mapped_column(String, nullable=False, default="member")
 
     # ──────────────────── Relationships ──────────────────────
-    tenant_associations: Mapped[list["TenantUserAssociation"]] = relationship(
-        "TenantUserAssociation",
+    tenant_associations: Mapped[list["TenantUserAssociationModel"]] = relationship(
+        "TenantUserAssociationModel",
         back_populates="user",
         cascade="all, delete-orphan",
         lazy="selectin",
     )
 
     # Convenience relationship to fetch all tenants a user belongs to
-    tenants: Mapped[list["Tenant"]] = relationship(
-        "Tenant",
+    tenants: Mapped[list["TenantModel"]] = relationship(
+        "TenantModel",
         secondary="tenant_user_associations",
         viewonly=True,
         lazy="selectin",
     )
 
     # user.py  (add this block)
-    repository_associations: Mapped[list["RepositoryUserAssociation"]] = relationship(
-        "RepositoryUserAssociation",
-        back_populates="user",
-        cascade="all, delete-orphan",
-        lazy="selectin",
+    repository_associations: Mapped[list["RepositoryUserAssociationModel"]] = (
+        relationship(
+            "RepositoryUserAssociationModel",
+            back_populates="user",
+            cascade="all, delete-orphan",
+            lazy="selectin",
+        )
     )
 
-    public_keys: Mapped[list["PublicKey"]] = relationship(
-        "PublicKey",
+    public_keys: Mapped[list["PublicKeyModel"]] = relationship(
+        "PublicKeyModel",
         back_populates="user",
         cascade="all, delete-orphan",
         lazy="selectin",


### PR DESCRIPTION
## Summary
- update peagen ORM model imports and relationship targets
- keep all model names consistent with `Model` suffix

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --directory pkgs/standards/peagen --package peagen pytest -q` *(fails: sqlalchemy.orm.exc.MappedAnnotationError)*

------
https://chatgpt.com/codex/tasks/task_e_685ee62ddd408326a54985e5213b7c92