### PR TITLE
Switch to swarmauri_base.ComponentBase

### DIFF
--- a/docs/docs/home/contribute.md
+++ b/docs/docs/home/contribute.md
@@ -68,7 +68,7 @@ We welcome contributions from the community to help improve Swarmauri SDK. This 
 1. **Define the Plugin**: Create a new Python file for your plugin and define the necessary classes and functions.
 2. **Register the Plugin**: Use the `ComponentBase.register_type` decorator to register your plugin with the Swarmauri SDK.
    ```python
-   from swarmauri_core.ComponentBase import ComponentBase
+   from swarmauri_base.ComponentBase import ComponentBase
 
    @ComponentBase.register_type(ToolBase, "MyCustomPlugin")
    class MyCustomPlugin(ToolBase):

--- a/docs/docstring_tasks.md
+++ b/docs/docstring_tasks.md
@@ -343,7 +343,7 @@ For each file listed below, add missing spaCy-style docstrings for the module, a
 - [ ] ./pkgs/community/swarmauri_vectorstore_redis/tests/unit/RedisVectorStore_test.py
 - [ ] ./pkgs/community/swm_example_community_package/swm_example_community_package/ExampleCommunityAgent.py
 - [ ] ./pkgs/community/swm_example_community_package/swm_example_community_package/__init__.py
-- [ ] ./pkgs/core/swarmauri_core/ComponentBase.py
+- [ ] ./pkgs/base/swarmauri_base/ComponentBase.py
 - [ ] ./pkgs/core/swarmauri_core/__init__.py
 - [ ] ./pkgs/core/swarmauri_core/agent_apis/IAgentCommands.py
 - [ ] ./pkgs/core/swarmauri_core/agent_apis/IAgentRouterCRUD.py

--- a/docs/missing_docstrings.md
+++ b/docs/missing_docstrings.md
@@ -341,7 +341,7 @@
 - ./pkgs/community/swarmauri_vectorstore_redis/tests/unit/RedisVectorStore_test.py
 - ./pkgs/community/swm_example_community_package/swm_example_community_package/ExampleCommunityAgent.py
 - ./pkgs/community/swm_example_community_package/swm_example_community_package/__init__.py
-- ./pkgs/core/swarmauri_core/ComponentBase.py
+- ./pkgs/base/swarmauri_base/ComponentBase.py
 - ./pkgs/core/swarmauri_core/__init__.py
 - ./pkgs/core/swarmauri_core/agent_apis/IAgentCommands.py
 - ./pkgs/core/swarmauri_core/agent_apis/IAgentRouterCRUD.py

--- a/docs/scripts/generate_content.py
+++ b/docs/scripts/generate_content.py
@@ -139,7 +139,7 @@ def build_nav(
     for module_name in sorted_modules:
         class_names = sorted(module_classes_map[module_name])
         for cls_name in class_names:
-            # E.g. "src/swarmauri_core/ComponentBase/ComponentBase.md"
+            # E.g. "src/swarmauri_base/ComponentBase/ComponentBase.md"
             if len(module_name.split(".")) > 2:
                 print(module_name)
                 module_name = "/".join(module_name.split(".")[:2])

--- a/pkgs/community/swarmauri_tool_jupyterclearoutput/README.md
+++ b/pkgs/community/swarmauri_tool_jupyterclearoutput/README.md
@@ -100,7 +100,7 @@ from typing import List, Dict, Any, Literal
 from pydantic import Field
 from swarmauri_standard.tools.Parameter import Parameter
 from swarmauri_base.tools.ToolBase import ToolBase
-from swarmauri_core.ComponentBase import ComponentBase
+from swarmauri_base.ComponentBase import ComponentBase
 
 logger = logging.getLogger(__name__)
 

--- a/pkgs/community/swarmauri_tool_jupyterexportlatex/README.md
+++ b/pkgs/community/swarmauri_tool_jupyterexportlatex/README.md
@@ -116,7 +116,7 @@ import tempfile
 
 from swarmauri_standard.tools.Parameter import Parameter
 from swarmauri_base.tools.ToolBase import ToolBase
-from swarmauri_core.ComponentBase import ComponentBase
+from swarmauri_base.ComponentBase import ComponentBase
 
 
 @ComponentBase.register_type(ToolBase, 'JupyterExportLatexTool')

--- a/pkgs/community/swarmauri_tool_jupyterfromdict/README.md
+++ b/pkgs/community/swarmauri_tool_jupyterfromdict/README.md
@@ -96,7 +96,7 @@ from nbformat import from_dict, validate, NotebookNode, ValidationError
 
 from swarmauri_standard.tools.Parameter import Parameter
 from swarmauri_base.tools.ToolBase import ToolBase
-from swarmauri_core.ComponentBase import ComponentBase
+from swarmauri_base.ComponentBase import ComponentBase
 
 logger = logging.getLogger(__name__)
 

--- a/pkgs/experimental/ptree_dag_extension_example/ptree_dag/templates/example_template_set/{{ PROJECT_ROOT }}/{{ PKG.NAME }}/{{ PKG.NAME }}/{{ MOD.NAME }}.py.j2
+++ b/pkgs/experimental/ptree_dag_extension_example/ptree_dag/templates/example_template_set/{{ PROJECT_ROOT }}/{{ PKG.NAME }}/{{ PKG.NAME }}/{{ MOD.NAME }}.py.j2
@@ -1,4 +1,4 @@
-from swarmauri_core.ComponentBase import ComponentBase
+from swarmauri_base.ComponentBase import ComponentBase
 
 
 @ComponentBase.register_type({{ MOD.BASE_NAME }}, "{{ MOD.NAME }}")

--- a/pkgs/experimental/swarmauri_experimental/swarmauri_experimental/agents/IterativeMemoryAgent.py
+++ b/pkgs/experimental/swarmauri_experimental/swarmauri_experimental/agents/IterativeMemoryAgent.py
@@ -27,7 +27,7 @@ from swarmauri_base.agents.AgentConversationMixin import AgentConversationMixin
 from swarmauri_base.agents.AgentVectorStoreMixin import AgentVectorStoreMixin
 from swarmauri_base.agents.AgentSystemContextMixin import AgentSystemContextMixin
 
-from swarmauri_core.ComponentBase import SubclassUnion, ComponentBase
+from swarmauri_base.ComponentBase import SubclassUnion, ComponentBase
 from swarmauri_core.messages.IMessage import IMessage
 
 @ComponentBase.register_type(AgentBase, 'IterativeMemoryAgent')

--- a/pkgs/standards/peagen/peagen/plugins/evaluators/performance_evaluator.py
+++ b/pkgs/standards/peagen/peagen/plugins/evaluators/performance_evaluator.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, Tuple, Literal
 
 import tracemalloc
 from swarmauri_base.evaluators.EvaluatorBase import EvaluatorBase
-from swarmauri_core.ComponentBase import ComponentBase
+from swarmauri_base.ComponentBase import ComponentBase
 from swarmauri_core.programs.IProgram import IProgram as Program
 
 

--- a/pkgs/standards/peagen/peagen/plugins/evaluators/pytest_memray_evaluator.py
+++ b/pkgs/standards/peagen/peagen/plugins/evaluators/pytest_memray_evaluator.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Any, Dict, Tuple, Literal
 
 from swarmauri_base.evaluators.EvaluatorBase import EvaluatorBase
-from swarmauri_core.ComponentBase import ComponentBase
+from swarmauri_base.ComponentBase import ComponentBase
 from swarmauri_core.programs.IProgram import IProgram as Program
 
 

--- a/pkgs/standards/peagen/peagen/plugins/evaluators/ruff_evaluator.py
+++ b/pkgs/standards/peagen/peagen/plugins/evaluators/ruff_evaluator.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any, Dict, Tuple, Literal
 
 from swarmauri_base.evaluators.EvaluatorBase import EvaluatorBase
-from swarmauri_core.ComponentBase import ComponentBase
+from swarmauri_base.ComponentBase import ComponentBase
 from swarmauri_core.programs.IProgram import IProgram as Program
 
 

--- a/pkgs/standards/peagen/peagen/template_sets/no_requirements/{{ PROJECT_ROOT }}/{{ PKG.NAME }}/{{ PKG.NAME }}/{{ MOD.NAME }}.py.j2
+++ b/pkgs/standards/peagen/peagen/template_sets/no_requirements/{{ PROJECT_ROOT }}/{{ PKG.NAME }}/{{ PKG.NAME }}/{{ MOD.NAME }}.py.j2
@@ -1,4 +1,4 @@
-from swarmauri_core.ComponentBase import ComponentBase
+from swarmauri_base.ComponentBase import ComponentBase
 
 
 @ComponentBase.register_type({{ MOD.BASE_NAME }}, "{{ MOD.NAME }}")

--- a/pkgs/standards/peagen/peagen/template_sets/swarmauri_community/{{ PROJ.ROOT }}/community/{{ PKG.NAME }}/{{ PKG.NAME }}/{{ MOD.NAME }}.py.j2
+++ b/pkgs/standards/peagen/peagen/template_sets/swarmauri_community/{{ PROJ.ROOT }}/community/{{ PKG.NAME }}/{{ PKG.NAME }}/{{ MOD.NAME }}.py.j2
@@ -1,4 +1,4 @@
-from swarmauri_core.ComponentBase import ComponentBase
+from swarmauri_base.ComponentBase import ComponentBase
 
 
 @ComponentBase.register_type({{ MOD.EXTRAS.BASE_NAME }}, "{{ MOD.NAME }}")

--- a/pkgs/standards/peagen/peagen/template_sets/swarmauri_standard_standalone/{{ PROJ.ROOT }}/standards/{{ PKG.NAME }}/{{ PKG.NAME }}/{{ MOD.NAME }}.py.j2
+++ b/pkgs/standards/peagen/peagen/template_sets/swarmauri_standard_standalone/{{ PROJ.ROOT }}/standards/{{ PKG.NAME }}/{{ PKG.NAME }}/{{ MOD.NAME }}.py.j2
@@ -1,4 +1,4 @@
-from swarmauri_core.ComponentBase import ComponentBase
+from swarmauri_base.ComponentBase import ComponentBase
 
 
 @ComponentBase.register_type({{ MOD.EXTRAS.BASE_NAME }}, "{{ MOD.NAME }}")

--- a/pkgs/standards/peagen/peagen/template_sets/test3/{{ PROJECT_ROOT }}/{{ PKG.NAME }}/{{ PKG.NAME }}/{{ MOD.NAME }}.py.j2
+++ b/pkgs/standards/peagen/peagen/template_sets/test3/{{ PROJECT_ROOT }}/{{ PKG.NAME }}/{{ PKG.NAME }}/{{ MOD.NAME }}.py.j2
@@ -1,4 +1,4 @@
-from swarmauri_core.ComponentBase import ComponentBase
+from swarmauri_base.ComponentBase import ComponentBase
 
 
 @ComponentBase.register_type({{ MOD.BASE_NAME }}, "{{ MOD.NAME }}")

--- a/pkgs/standards/peagen/peagen/template_sets/test5/{{ PROJECT_ROOT }}/{{ PKG.NAME }}/{{ PKG.NAME }}/{{ MOD.NAME }}.py.j2
+++ b/pkgs/standards/peagen/peagen/template_sets/test5/{{ PROJECT_ROOT }}/{{ PKG.NAME }}/{{ PKG.NAME }}/{{ MOD.NAME }}.py.j2
@@ -1,4 +1,4 @@
-from swarmauri_core.ComponentBase import ComponentBase
+from swarmauri_base.ComponentBase import ComponentBase
 
 
 @ComponentBase.register_type({{ MOD.BASE_NAME }}, "{{ MOD.NAME }}")

--- a/pkgs/standards/swarmauri_evaluator_externalimports/swarmauri_evaluator_externalimports/ExternalImportsEvaluator.py
+++ b/pkgs/standards/swarmauri_evaluator_externalimports/swarmauri_evaluator_externalimports/ExternalImportsEvaluator.py
@@ -6,7 +6,7 @@ import sys
 from typing import Any, Dict, List, Literal, Set, Tuple
 
 from swarmauri_base.evaluators.EvaluatorBase import EvaluatorBase
-from swarmauri_core.ComponentBase import ComponentBase
+from swarmauri_base.ComponentBase import ComponentBase
 from swarmauri_core.programs.IProgram import IProgram as Program
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- migrate all ComponentBase imports to swarmauri_base
- adjust peagen templates and docs for new base package

## Testing
- `uv run --package swarmauri_tool_jupyterexportlatex --directory pkgs/community/swarmauri_tool_jupyterexportlatex ruff format .`
- `uv run --package swarmauri_tool_jupyterexportlatex --directory pkgs/community/swarmauri_tool_jupyterexportlatex ruff check . --fix`
- `uv run --package swarmauri_tool_jupyterfromdict --directory pkgs/community/swarmauri_tool_jupyterfromdict ruff format .`
- `uv run --package swarmauri_tool_jupyterfromdict --directory pkgs/community/swarmauri_tool_jupyterfromdict ruff check . --fix`
- `uv run --package swarmauri_tool_jupyterclearoutput --directory pkgs/community/swarmauri_tool_jupyterclearoutput ruff format .`
- `uv run --package swarmauri_tool_jupyterclearoutput --directory pkgs/community/swarmauri_tool_jupyterclearoutput ruff check . --fix`
- `uv run --package ptree-dag-extension-example --directory pkgs/experimental/ptree_dag_extension_example ruff format .` *(fails: build backend error)*
- `uv run --package ptree-dag-extension-example --directory pkgs/experimental/ptree_dag_extension_example ruff check . --fix` *(fails: build backend error)*
- `uv run --package swarmauri-experimental --directory pkgs/experimental/swarmauri_experimental ruff format .` *(fails: no project table)*
- `uv run --package swarmauri-experimental --directory pkgs/experimental/swarmauri_experimental ruff check . --fix` *(fails: no project table)*
- `uv run --package swarmauri-evaluator-externalimports --directory pkgs/standards/swarmauri_evaluator_externalimports ruff format .`
- `uv run --package swarmauri-evaluator-externalimports --directory pkgs/standards/swarmauri_evaluator_externalimports ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen ruff format .`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`
- `uv run --package swarmauri_tool_jupyterexportlatex --directory pkgs/community/swarmauri_tool_jupyterexportlatex pytest`
- `uv run --package swarmauri_tool_jupyterfromdict --directory pkgs/community/swarmauri_tool_jupyterfromdict pytest` *(fails: AssertionError)*
- `uv run --package swarmauri_tool_jupyterclearoutput --directory pkgs/community/swarmauri_tool_jupyterclearoutput pytest`
- `uv run --package swarmauri-evaluator-externalimports --directory pkgs/standards/swarmauri_evaluator_externalimports pytest`
- `uv run --package peagen --directory pkgs/standards/peagen pytest` *(fails: multiple errors)*
- `uv run --package swarmauri-experimental --directory pkgs/experimental/swarmauri_experimental pytest` *(fails: no project table)*
- `uv run --package ptree-dag-extension-example --directory pkgs/experimental/ptree_dag_extension_example pytest` *(fails: build backend error)*

------
https://chatgpt.com/codex/tasks/task_e_685ef5142638832685a501b69b588ef2