### PR TITLE
Fix relationship target name

### DIFF
--- a/pkgs/standards/peagen/peagen/models/repo/deploy_key.py
+++ b/pkgs/standards/peagen/peagen/models/repo/deploy_key.py
@@ -68,7 +68,7 @@ class DeployKeyModel(BaseModel):
 
     repository_associations: Mapped[list["RepositoryDeployKeyAssociationModel"]] = (
         relationship(
-            "RepositoryDeployKeyAssociation",
+            "RepositoryDeployKeyAssociationModel",
             back_populates="deploy_key",
             cascade="all, delete-orphan",
             lazy="selectin",


### PR DESCRIPTION
## Summary
- adjust `DeployKeyModel` to reference `RepositoryDeployKeyAssociationModel`

## Testing
- `uv run --package peagen --directory . ruff check . --fix`
- `uv run --package peagen --directory . pytest tests/unit/test_task_metadata.py::test_task_model_roundtrip -q` *(fails: 'pool' is an invalid keyword argument for TaskModel)*

------
https://chatgpt.com/codex/tasks/task_e_685ef7503ad083268e11bb90611e5869