### PR TITLE
Fix duplicate TaskModel export

### DIFF
--- a/pkgs/standards/peagen/peagen/models/__init__.py
+++ b/pkgs/standards/peagen/peagen/models/__init__.py
@@ -106,7 +106,6 @@ __all__: list[str] = [
     # task
     "TaskModel",
     "RawBlobModel",
-    "TaskModel",
     "Status",
     "TaskRunModel",
     "TaskRelationModel",


### PR DESCRIPTION
## Summary
- clean up `peagen` models exports

## Testing
- `uv run --directory standards --package peagen ruff format .`
- `uv run --directory standards --package peagen ruff check . --fix`
- `uv run --directory standards --package peagen pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685efad44fa483268a1f2974a611557b