### PR TITLE
Fix Task schema imports

### DIFF
--- a/pkgs/standards/peagen/README.md
+++ b/pkgs/standards/peagen/README.md
@@ -401,6 +401,21 @@ projects = pea.load_projects()
 result, idx = pea.process_single_project(projects[0], start_idx=0)
 ```
 
+### Transport Models
+
+Runtime RPC payloads should be validated using the Pydantic schemas generated
+in `peagen.models.schemas`. For example, use
+`TaskRead.model_validate_json()` when decoding a task received over the network:
+
+```python
+from peagen.models.schemas import TaskRead
+
+task = TaskRead.model_validate_json(raw_json)
+```
+
+The gateway and worker components rely on these schema classes rather than the
+ORM models under `peagen.models`.
+
 ### Git Filters & Publishers
 
 Peagen's artifact output and event publishing are pluggable. Use the `git_filter` argument to control where files are saved and optionally provide a publisher for notifications. Built‑ins live under the `peagen.plugins` namespace. Available filters include `S3FSFilter` and `MinioFilter`, while publisher options cover `RedisPublisher`, `RabbitMQPublisher`, and `WebhookPublisher`. See [docs/storage_adapters_and_publishers.md](docs/storage_adapters_and_publishers.md) for details.

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -27,6 +27,7 @@ from peagen.plugins.queues import QueueBase
 from peagen.transport import RPCDispatcher, RPCRequest
 from peagen.transport.jsonrpc import RPCException
 from peagen.models import Base, Status, Task
+from peagen.models.schemas import TaskRead
 from peagen.models.task.task_run import TaskRun
 
 from peagen.gateway.ws_server import router as ws_router
@@ -278,12 +279,12 @@ async def _save_task(task: Task) -> None:
     await queue.expire(key, TASK_TTL)
 
 
-async def _load_task(tid: str) -> Task | None:
+async def _load_task(tid: str) -> TaskRead | None:
     data = await queue.hget(_task_key(tid), "blob")
-    return Task.model_validate_json(data) if data else None
+    return TaskRead.model_validate_json(data) if data else None
 
 
-async def _select_tasks(selector: str) -> list[Task]:
+async def _select_tasks(selector: str) -> list[TaskRead]:
     """Return tasks matching *selector*.
 
     A selector may be a task-id or ``label:<name>``.
@@ -295,7 +296,7 @@ async def _select_tasks(selector: str) -> list[Task]:
             data = await queue.hget(key, "blob")
             if not data:
                 continue
-            t = Task.model_validate_json(data)
+            t = TaskRead.model_validate_json(data)
             if label in t.labels:
                 tasks.append(t)
         return tasks
@@ -337,7 +338,7 @@ async def _flush_state() -> None:
         data = await queue.hget(key, "blob")
         if not data:
             continue
-        task = Task.model_validate_json(data)
+        task = TaskRead.model_validate_json(data)
         if result_backend:
             await result_backend.store(TaskRun.from_task(task))
     if hasattr(queue, "client"):
@@ -358,7 +359,7 @@ async def _finalize_parent_tasks(child_id: str) -> None:
         data = await queue.hget(key, "blob")
         if not data:
             continue
-        parent = Task.model_validate_json(data)
+        parent = TaskRead.model_validate_json(data)
         children = []
         if parent.result and isinstance(parent.result, dict):
             children = parent.result.get("children") or []
@@ -387,7 +388,7 @@ async def _backlog_scanner(interval: float = 5.0) -> None:
             data = await queue.hget(key, "blob")
             if not data:
                 continue
-            t = Task.model_validate_json(data)
+            t = TaskRead.model_validate_json(data)
             children = []
             if t.result and isinstance(t.result, dict):
                 children = t.result.get("children") or []
@@ -755,7 +756,7 @@ async def pool_list(poolName: str, limit: int | None = None, offset: int = 0):
     ids = await queue.lrange(f"{READY_QUEUE}:{poolName}", start, end)
     tasks = []
     for r in ids:
-        t = Task.model_validate_json(r)
+        t = TaskRead.model_validate_json(r)
         data = t.model_dump()
         if t.duration is not None:
             data["duration"] = t.duration
@@ -905,7 +906,7 @@ async def scheduler():
             queue_key, task_raw = res  # guaranteed 2-tuple here
             pool = queue_key.split(":", 1)[1]  # remove prefix '<READY_QUEUE>:'
             await _publish_queue_length(pool)
-            task = Task.model_validate_json(task_raw)
+            task = TaskRead.model_validate_json(task_raw)
 
             # pick a worker that supports the task's action
             worker_list = await _live_workers_by_pool(pool)

--- a/pkgs/standards/peagen/peagen/handlers/__init__.py
+++ b/pkgs/standards/peagen/peagen/handlers/__init__.py
@@ -5,15 +5,15 @@ from __future__ import annotations
 from typing import Any, Dict
 
 from peagen.models import Task
-from peagen.models import schemas
+from peagen.models.schemas import TaskRead
 
 
-def ensure_task(task: Task | Dict[str, Any]) -> schemas.TaskRead | Task:
+def ensure_task(task: Task | Dict[str, Any]) -> TaskRead | Task:
     """Return ``task`` as a :class:`~peagen.models.schemas.TaskRead` instance."""
 
     if isinstance(task, Task):
         return task
-    return schemas.TaskRead.model_validate(task)
+    return TaskRead.model_validate(task)
 
 
 __all__ = ["ensure_task"]

--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -18,8 +18,8 @@ from peagen.transport import RPCDispatcher, RPCRequest, RPCResponse
 from peagen._utils.config_loader import resolve_cfg
 from peagen.plugins import PluginManager
 from peagen.errors import HTTPClientNotInitializedError
-from peagen.models import Task
 from peagen.handlers import ensure_task
+from peagen.models.schemas import TaskRead
 
 
 # ──────────────────────────── utils  ────────────────────────────
@@ -199,7 +199,7 @@ class WorkerBase:
         return list(self._handler_registry.keys())
 
     # ───────────────────────── Dispatch & Task Execution ─────────────────────────
-    async def _run_task(self, task: Task | Dict[str, Any]) -> None:
+    async def _run_task(self, task: TaskRead | Dict[str, Any]) -> None:
         """Execute *task* by dispatching to a registered handler."""
         canonical = ensure_task(task)
         task_id = canonical.id


### PR DESCRIPTION
## Summary
- update gateway to use `TaskRead` for JSON validation
- adjust handler utilities and worker annotations for schema models
- document transport model usage in README

## Testing
- `uv run --package peagen --directory peagen ruff format .`
- `uv run --package peagen --directory peagen ruff check . --fix`
- `uv run --package peagen --directory peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_685efa297c4c8326bbe3d708c1c048ce