### PR TITLE
Refactor schema handling

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/validate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/validate.py
@@ -1,13 +1,12 @@
 # peagen/commands/validate.py
 
 import asyncio
-import uuid
 from typing import Any, Dict, Optional
 
 import typer
 
 from peagen.handlers.validate_handler import validate_handler
-from peagen.models import Task
+from peagen.models.schemas import TaskCreate
 
 local_validate_app = typer.Typer(help="Validate Peagen artifacts.")
 remote_validate_app = typer.Typer(help="Validate Peagen artifacts via JSON-RPC.")
@@ -33,15 +32,13 @@ def run_validate(
     and invoking the same handler that a worker would use.
     """
     # 1) Create a Task instance with default status/result
-    task_id = str(uuid.uuid4())
     args: Dict[str, Any] = {
         "kind": kind,
         "path": path,
     }
     if repo:
         args.update({"repo": repo, "ref": ref})
-    task = Task(
-        id=task_id,
+    task = TaskCreate(
         pool="default",
         payload={"action": "validate", "args": args},
     )
@@ -80,15 +77,13 @@ def submit_validate(
     Submit this validation as a background task. Returns immediately with a taskId.
     """
     # 1) Create a Task instance
-    task_id = str(uuid.uuid4())
     args: Dict[str, Any] = {
         "kind": kind,
         "path": path,
     }
     if repo:
         args.update({"repo": repo, "ref": ref})
-    task = Task(
-        id=task_id,
+    task = TaskCreate(
         pool="default",
         payload={"action": "validate", "args": args},
     )

--- a/pkgs/standards/peagen/peagen/handlers/__init__.py
+++ b/pkgs/standards/peagen/peagen/handlers/__init__.py
@@ -4,16 +4,15 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-from peagen.models import Task
-from peagen.models import schemas
+from peagen.models.schemas import TaskRead
 
 
-def ensure_task(task: Task | Dict[str, Any]) -> schemas.TaskRead | Task:
-    """Return ``task`` as a :class:`~peagen.models.schemas.TaskRead` instance."""
+def ensure_task(task: TaskRead | Dict[str, Any]) -> TaskRead:
+    """Return ``task`` as a :class:`~peagen.schemas.TaskRead` instance."""
 
-    if isinstance(task, Task):
+    if isinstance(task, TaskRead):
         return task
-    return schemas.TaskRead.model_validate(task)
+    return TaskRead.model_validate(task)
 
 
 __all__ = ["ensure_task"]

--- a/pkgs/standards/peagen/peagen/models/__init__.py
+++ b/pkgs/standards/peagen/peagen/models/__init__.py
@@ -42,7 +42,7 @@ from .repo.repository_user_association import (  # noqa: F401
 # Task / execution domain
 # ----------------------------------------------------------------------
 from .task.status import Status  # noqa: F401
-from .task.task import TaskModel, Task  # noqa: F401
+from .task.task import TaskModel  # noqa: F401
 from .task.raw_blob import RawBlobModel, RawBlob  # noqa: F401
 from .task.task_run import TaskRunModel, TaskRun  # noqa: F401
 from .task.task_relation import TaskRelationModel, TaskRelation  # noqa: F401
@@ -106,7 +106,6 @@ __all__: list[str] = [
     # task
     "TaskModel",
     "RawBlobModel",
-    "TaskModel",
     "Status",
     "TaskRunModel",
     "TaskRelationModel",

--- a/pkgs/standards/peagen/peagen/models/schemas.py
+++ b/pkgs/standards/peagen/peagen/models/schemas.py
@@ -72,11 +72,9 @@ for _name in model_names:
     globals()[update_cls.__name__] = update_cls
     globals()[read_cls.__name__] = read_cls
     globals()[child_cls.__name__] = child_cls
-    globals()[root_name] = read_cls
     __all__ += [
         create_cls.__name__,
         update_cls.__name__,
         read_cls.__name__,
         child_cls.__name__,
-        root_name,
     ]

--- a/pkgs/standards/peagen/peagen/models/task/__init__.py
+++ b/pkgs/standards/peagen/peagen/models/task/__init__.py
@@ -1,4 +1,4 @@
-from .task import TaskModel, Task
+from .task import TaskModel
 from .task_run import TaskRunModel, TaskRun
 from .task_relation import TaskRelationModel, TaskRelation
 from .task_run_relation_association import (
@@ -9,7 +9,6 @@ from .raw_blob import RawBlobModel, RawBlob
 
 __all__ = [
     "TaskModel",
-    "Task",
     "TaskRunModel",
     "TaskRun",
     "TaskRelationModel",

--- a/pkgs/standards/peagen/peagen/models/task/task.py
+++ b/pkgs/standards/peagen/peagen/models/task/task.py
@@ -81,6 +81,3 @@ class TaskModel(BaseModel):
             f"<Task id={self.id} tenant={self.tenant_id} "
             f"git_ref={self.git_reference_id or '∅'}>"
         )
-
-
-Task = TaskModel

--- a/pkgs/standards/peagen/peagen/orm/__init__.py
+++ b/pkgs/standards/peagen/peagen/orm/__init__.py
@@ -1,0 +1,6 @@
+"""SQLAlchemy ORM models re-exported from :mod:`peagen.models`."""
+
+from peagen.models import *  # noqa: F401, F403
+from peagen.models import __all__ as _all
+
+__all__ = list(_all)


### PR DESCRIPTION
## Summary
- create `orm` package as stable import path for all models
- generate Pydantic schemas without `Task` alias
- update gateway helpers to use `TaskRead`
- validate CLI input using `TaskCreate`

## Testing
- `ruff format .`
- `ruff check . --fix`
- `uv run --package peagen --directory standards pytest` *(fails: 88 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685efbd29a7c83269361a8a020cf1f7f