### PR TITLE
Update plugin imports to new orm alias

### DIFF
--- a/pkgs/standards/peagen/README.md
+++ b/pkgs/standards/peagen/README.md
@@ -404,17 +404,17 @@ result, idx = pea.process_single_project(projects[0], start_idx=0)
 ### Transport Models
 
 Runtime RPC payloads should be validated using the Pydantic schemas generated
-in `peagen.models.schemas`. For example, use
+in `peagen.schemas`. For example, use
 `TaskRead.model_validate_json()` when decoding a task received over the network:
 
 ```python
-from peagen.models.schemas import TaskRead
+from peagen.schemas import TaskRead
 
 task = TaskRead.model_validate_json(raw_json)
 ```
 
 The gateway and worker components rely on these schema classes rather than the
-ORM models under `peagen.models`.
+ORM models under `peagen.orm`.
 
 ### Git Filters & Publishers
 

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -26,9 +26,9 @@ from peagen.plugins.queues import QueueBase
 
 from peagen.transport import RPCDispatcher, RPCRequest
 from peagen.transport.jsonrpc import RPCException
-from peagen.models import Base, Status, Task
-from peagen.models.schemas import TaskRead
-from peagen.models.task.task_run import TaskRun
+from peagen.orm import Base, Status, Task
+from peagen.schemas import TaskRead
+from peagen.orm.task.task_run import TaskRun
 
 from peagen.gateway.ws_server import router as ws_router
 

--- a/pkgs/standards/peagen/peagen/handlers/__init__.py
+++ b/pkgs/standards/peagen/peagen/handlers/__init__.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-from peagen.models import Task
-from peagen.models.schemas import TaskRead
+from peagen.orm import Task
+from peagen.schemas import TaskRead
 
 
 def ensure_task(task: Task | Dict[str, Any]) -> TaskRead | Task:
-    """Return ``task`` as a :class:`~peagen.models.schemas.TaskRead` instance."""
+    """Return ``task`` as a :class:`~peagen.schemas.TaskRead` instance."""
 
     if isinstance(task, Task):
         return task

--- a/pkgs/standards/peagen/peagen/orm/__init__.py
+++ b/pkgs/standards/peagen/peagen/orm/__init__.py
@@ -1,0 +1,23 @@
+"""ORM model re-exports.
+
+This module provides a backward compatibility layer for the old
+``peagen.models`` package. All ORM classes are imported from
+:mod:`peagen.models` and re-exported under :mod:`peagen.orm`.
+"""
+
+from .. import models as _models
+import pkgutil
+import importlib
+import sys
+
+for _name in dir(_models):
+    if not _name.startswith("_"):
+        globals()[_name] = getattr(_models, _name)
+
+# Map submodules of peagen.models to peagen.orm
+for _info in pkgutil.walk_packages(_models.__path__, _models.__name__ + "."):
+    _mod = importlib.import_module(_info.name)
+    _alias = _info.name.replace("peagen.models", __name__)
+    sys.modules[_alias] = _mod
+
+__all__ = [n for n in dir(_models) if not n.startswith("_")]

--- a/pkgs/standards/peagen/peagen/plugins/result_backends/base.py
+++ b/pkgs/standards/peagen/peagen/plugins/result_backends/base.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 from typing import Any, Dict, List
 
-from peagen.models.task.task_run import TaskRun
+from peagen.orm.task.task_run import TaskRun
 
 
 class ResultBackendBase:

--- a/pkgs/standards/peagen/peagen/plugins/result_backends/in_memory_backend.py
+++ b/pkgs/standards/peagen/peagen/plugins/result_backends/in_memory_backend.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from peagen.models.task.task_run import TaskRun
+from peagen.orm.task.task_run import TaskRun
 from .base import ResultBackendBase
 
 

--- a/pkgs/standards/peagen/peagen/plugins/result_backends/localfs_backend.py
+++ b/pkgs/standards/peagen/peagen/plugins/result_backends/localfs_backend.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from peagen.models.task.task_run import TaskRun
+from peagen.orm.task.task_run import TaskRun
 from .base import ResultBackendBase
 
 

--- a/pkgs/standards/peagen/peagen/plugins/result_backends/postgres_backend.py
+++ b/pkgs/standards/peagen/peagen/plugins/result_backends/postgres_backend.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from peagen.models.task.task_run import TaskRun
+from peagen.orm.task.task_run import TaskRun
 from .base import ResultBackendBase
 
 Session = None

--- a/pkgs/standards/peagen/peagen/plugins/selectors/selector_base.py
+++ b/pkgs/standards/peagen/peagen/plugins/selectors/selector_base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
-from peagen.models.task.status import Status
+from peagen.orm.task.status import Status
 from peagen.plugins.result_backends import ResultBackendBase
 
 

--- a/pkgs/standards/peagen/peagen/schemas/__init__.py
+++ b/pkgs/standards/peagen/peagen/schemas/__init__.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 import json
 import importlib.resources as res
+from ..models import schemas as _pyd_schemas
 
 
 PEAGEN_TOML_V1_SCHEMA = json.loads(
@@ -96,3 +97,11 @@ __all__ = [
     "LLM_PATCH_V1_SCHEMA",
     "EXTRAS_SCHEMAS",
 ]
+
+# ---------------------------------------------------------------------------
+# Pydantic models previously in ``peagen.models.schemas``
+# ---------------------------------------------------------------------------
+for _name in getattr(_pyd_schemas, "__all__", []):
+    globals()[_name] = getattr(_pyd_schemas, _name)
+
+__all__ += list(getattr(_pyd_schemas, "__all__", []))

--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -19,7 +19,7 @@ from peagen._utils.config_loader import resolve_cfg
 from peagen.plugins import PluginManager
 from peagen.errors import HTTPClientNotInitializedError
 from peagen.handlers import ensure_task
-from peagen.models.schemas import TaskRead
+from peagen.schemas import TaskRead
 
 
 # ──────────────────────────── utils  ────────────────────────────


### PR DESCRIPTION
## Summary
- alias `peagen.orm` to `peagen.models`
- expose pydantic schema classes from `peagen.schemas`
- update plugins to import from the new locations
- document new packages in the Peagen README

## Testing
- `uv run --directory standards/peagen --package peagen ruff format .`
- `uv run --directory standards/peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest` *(fails: ModuleNotFoundError and multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_685f027878908326b0ddbfd4fe5bbc2b