### PR TITLE
Update Task schemas import path

### DIFF
--- a/pkgs/standards/peagen/README.md
+++ b/pkgs/standards/peagen/README.md
@@ -404,11 +404,11 @@ result, idx = pea.process_single_project(projects[0], start_idx=0)
 ### Transport Models
 
 Runtime RPC payloads should be validated using the Pydantic schemas generated
-in `peagen.models.schemas`. For example, use
+in `peagen.schemas`. For example, use
 `TaskRead.model_validate_json()` when decoding a task received over the network:
 
 ```python
-from peagen.models.schemas import TaskRead
+from peagen.schemas import TaskRead
 
 task = TaskRead.model_validate_json(raw_json)
 ```

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -27,7 +27,7 @@ from peagen.plugins.queues import QueueBase
 from peagen.transport import RPCDispatcher, RPCRequest
 from peagen.transport.jsonrpc import RPCException
 from peagen.orm import Base, Status, Task
-from peagen.models.schemas import TaskRead
+from peagen.schemas import TaskRead
 from peagen.orm.task.task_run import TaskRun
 
 from peagen.gateway.ws_server import router as ws_router

--- a/pkgs/standards/peagen/peagen/handlers/__init__.py
+++ b/pkgs/standards/peagen/peagen/handlers/__init__.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 from typing import Any, Dict
 
 from peagen.orm import Task
-from peagen.models.schemas import TaskRead
+from peagen.schemas import TaskRead
 
 
 def ensure_task(task: Task | Dict[str, Any]) -> TaskRead | Task:
-    """Return ``task`` as a :class:`~peagen.models.schemas.TaskRead` instance."""
+    """Return ``task`` as a :class:`~peagen.schemas.TaskRead` instance."""
 
     if isinstance(task, Task):
         return task

--- a/pkgs/standards/peagen/peagen/schemas/__init__.py
+++ b/pkgs/standards/peagen/peagen/schemas/__init__.py
@@ -2,8 +2,15 @@
 """Expose Peagen JSON Schemas as Python dicts."""
 
 from __future__ import annotations
+
 import json
 import importlib.resources as res
+
+# Dynamic Pydantic models generated from ORM
+from peagen.models import schemas as model_schemas
+
+# Re-export ORM-based Pydantic models
+globals().update({name: getattr(model_schemas, name) for name in model_schemas.__all__})
 
 
 PEAGEN_TOML_V1_SCHEMA = json.loads(
@@ -83,6 +90,7 @@ EXTRAS_SCHEMAS = {
 
 
 __all__ = [
+    *model_schemas.__all__,
     "PEAGEN_TOML_V1_SCHEMA",
     "PEAGEN_TOML_V1_1_SCHEMA",
     "DOE_SPEC_V1_SCHEMA",

--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -19,7 +19,7 @@ from peagen._utils.config_loader import resolve_cfg
 from peagen.plugins import PluginManager
 from peagen.errors import HTTPClientNotInitializedError
 from peagen.handlers import ensure_task
-from peagen.models.schemas import TaskRead
+from peagen.schemas import TaskRead
 
 
 # ──────────────────────────── utils  ────────────────────────────


### PR DESCRIPTION
## Summary
- reference TaskRead from `peagen.schemas`
- re-export ORM schema models via `peagen.schemas`

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_utils_graph.py::test_immediate_dependencies -q`


------
https://chatgpt.com/codex/tasks/task_e_685f0425fd288326810af8eadd3cb29a