### PR TITLE
Create unified status module

### DIFF
--- a/pkgs/standards/peagen/peagen/migrations/versions/ae1de73e4143_init.py
+++ b/pkgs/standards/peagen/peagen/migrations/versions/ae1de73e4143_init.py
@@ -2,7 +2,7 @@
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy import inspect
-from peagen.orm.task.status import Status
+from peagen.orm.status import Status
 
 status_enum = sa.Enum(
     Status, name="task_status_enum"

--- a/pkgs/standards/peagen/peagen/orm/__init__.py
+++ b/pkgs/standards/peagen/peagen/orm/__init__.py
@@ -41,7 +41,7 @@ from .repo.repository_user_association import (  # noqa: F401
 # ----------------------------------------------------------------------
 # Task / execution domain
 # ----------------------------------------------------------------------
-from .task.status import Status  # noqa: F401
+from .status import Status  # noqa: F401
 from .task.task import TaskModel, Task  # noqa: F401
 from .task.raw_blob import RawBlobModel, RawBlob  # noqa: F401
 from .task.task_run import TaskRunModel, TaskRun  # noqa: F401

--- a/pkgs/standards/peagen/peagen/orm/status.py
+++ b/pkgs/standards/peagen/peagen/orm/status.py
@@ -1,0 +1,9 @@
+"""Status enumeration re-export.
+
+This module exposes :class:`Status` from
+``peagen.orm.task.status`` under a unified path.
+"""
+
+from .task.status import Status
+
+__all__ = ["Status"]

--- a/pkgs/standards/peagen/peagen/orm/task/task_run.py
+++ b/pkgs/standards/peagen/peagen/orm/task/task_run.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:  # pragma: no cover - imports for type hints
     from ..result.eval_result import EvalResultModel
 
 from ..base import BaseModel  # id, timestamps
-from .status import Status
+from ..status import Status
 from ..task.task import TaskModel
 from ..infra.pool import PoolModel
 from ..infra.worker import WorkerModel

--- a/pkgs/standards/peagen/peagen/plugins/selectors/selector_base.py
+++ b/pkgs/standards/peagen/peagen/plugins/selectors/selector_base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
-from peagen.orm.task.status import Status
+from peagen.orm.status import Status
 from peagen.plugins.result_backends import ResultBackendBase
 
 

--- a/pkgs/standards/peagen/peagen/tui/app.py
+++ b/pkgs/standards/peagen/peagen/tui/app.py
@@ -508,7 +508,7 @@ class QueueDashboardApp(App):
                         task_item.get("started_at") or task_item.get("finished_at") or 0
                     )
                 if sort_key == "status":
-                    from peagen.orm.task.status import Status
+                    from peagen.orm.status import Status
 
                     status_value = task_item.get("status")
                     try:

--- a/pkgs/standards/peagen/peagen/tui/components/filter_bar.py
+++ b/pkgs/standards/peagen/peagen/tui/components/filter_bar.py
@@ -6,7 +6,7 @@ from textual.app import ComposeResult
 from textual.containers import Horizontal
 from textual.widgets import Input, Select
 
-from peagen.orm.task.status import Status
+from peagen.orm.status import Status
 
 
 class FilterBar(Horizontal):

--- a/pkgs/standards/peagen/tests/unit/test_result_backends.py
+++ b/pkgs/standards/peagen/tests/unit/test_result_backends.py
@@ -3,7 +3,7 @@ import uuid
 import pytest
 
 from peagen.orm.task.task_run import TaskRun
-from peagen.orm.task.status import Status
+from peagen.orm.status import Status
 from peagen.plugins.result_backends.localfs_backend import LocalFsResultBackend
 from peagen.plugins.result_backends.postgres_backend import PostgresResultBackend
 from peagen.plugins.result_backends.in_memory_backend import InMemoryResultBackend

--- a/pkgs/standards/peagen/tests/unit/test_selectors.py
+++ b/pkgs/standards/peagen/tests/unit/test_selectors.py
@@ -8,7 +8,7 @@ from peagen.plugins.selectors import (
 )
 from peagen.plugins.result_backends.in_memory_backend import InMemoryResultBackend
 from peagen.orm.task.task_run import TaskRun
-from peagen.orm.task.status import Status
+from peagen.orm.status import Status
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- create `peagen.orm.status` that re-exports `Status`
- update imports to use the new path

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format .`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix` *(fails: SyntaxError in peagen/jsonschemas/__init__.py)*
- `uv run --package peagen --directory pkgs/standards/peagen pytest` *(fails: SyntaxError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685f060b440c8326ba5e353425edd0fd