### PR TITLE
Add tests for task roundtrip and CLI submission

### DIFF
--- a/pkgs/standards/peagen/tests/smoke/test_cli_task_submit.py
+++ b/pkgs/standards/peagen/tests/smoke/test_cli_task_submit.py
@@ -1,0 +1,20 @@
+import json
+import subprocess
+import uuid
+
+import pytest
+
+pytestmark = pytest.mark.smoke
+
+
+def test_cli_task_submit_returns_id(tmp_path):
+    """peagen task submit should output a valid taskId using local queue."""
+    result = subprocess.run(
+        ["peagen", "task", "submit", "--queue", "in_memory", "--payload", "{}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    data = json.loads(result.stdout.strip().splitlines()[-1])
+    assert uuid.UUID(data["taskId"])

--- a/pkgs/standards/peagen/tests/unit/test_task_model_roundtrip.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_model_roundtrip.py
@@ -1,0 +1,24 @@
+import uuid
+import pytest
+
+import peagen.gateway as gw
+from peagen.models.schemas import TaskCreate, TaskRead
+from peagen.orm.task.task import TaskModel
+
+
+@pytest.mark.unit
+def test_task_model_roundtrip() -> None:
+    """Ensure TaskCreate → TaskModel → TaskRead → json → TaskRead works."""
+    create = TaskCreate(
+        id=str(uuid.uuid4()),
+        tenant_id=uuid.uuid4(),
+        git_reference_id=None,
+        parameters={"x": 1},
+        note="demo",
+    )
+    orm = gw.to_orm(create)
+    assert isinstance(orm, TaskModel)
+    read = gw.to_schema(orm)
+    blob = read.model_dump_json()
+    again = TaskRead.model_validate_json(blob)
+    assert again == read


### PR DESCRIPTION
## Summary
- add unit test for TaskCreate/TaskModel/TaskRead round-trip
- add smoke test for `peagen task submit`

## Testing
- `uv run --directory pkgs --package peagen ruff format standards/peagen/tests/unit/test_task_model_roundtrip.py standards/peagen/tests/smoke/test_cli_task_submit.py`
- `uv run --directory pkgs --package peagen ruff check standards/peagen/tests/unit/test_task_model_roundtrip.py standards/peagen/tests/smoke/test_cli_task_submit.py --fix`
- `uv run --directory pkgs --package peagen pytest standards/peagen/tests/unit/test_task_model_roundtrip.py standards/peagen/tests/smoke/test_cli_task_submit.py -q` *(fails: SyntaxError in peagen package)*

------
https://chatgpt.com/codex/tasks/task_e_685f0681f6488326b4ee42c30d782e74