### PR TITLE
Move schemas module and update imports

### DIFF
--- a/pkgs/standards/peagen/README.md
+++ b/pkgs/standards/peagen/README.md
@@ -404,11 +404,11 @@ result, idx = pea.process_single_project(projects[0], start_idx=0)
 ### Transport Models
 
 Runtime RPC payloads should be validated using the Pydantic schemas generated
-in `peagen.models.schemas`. For example, use
+in `peagen.schemas`. For example, use
 `TaskRead.model_validate_json()` when decoding a task received over the network:
 
 ```python
-from peagen.models.schemas import TaskRead
+from peagen.schemas import TaskRead
 
 task = TaskRead.model_validate_json(raw_json)
 ```

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -26,10 +26,10 @@ from peagen.plugins.queues import QueueBase
 
 from peagen.transport import RPCDispatcher, RPCRequest
 from peagen.transport.jsonrpc import RPCException
-from peagen.models import Base, Status, Task
-from peagen.models.schemas import TaskRead, TaskCreate, TaskUpdate
-from peagen.models.task.task import TaskModel
-from peagen.models.task.task_run import TaskRun
+from peagen.orm import Base, Status, Task
+from peagen.schemas import TaskRead, TaskCreate, TaskUpdate
+from peagen.orm.task.task import TaskModel
+from peagen.orm.task.task_run import TaskRun
 
 from peagen.gateway.ws_server import router as ws_router
 

--- a/pkgs/standards/peagen/peagen/handlers/__init__.py
+++ b/pkgs/standards/peagen/peagen/handlers/__init__.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 from typing import Any, Dict
 
 from peagen.orm import Task
-from peagen.models.schemas import TaskRead
+from peagen.schemas import TaskRead
 
 
 def ensure_task(task: Task | Dict[str, Any]) -> TaskRead | Task:
-    """Return ``task`` as a :class:`~peagen.models.schemas.TaskRead` instance."""
+    """Return ``task`` as a :class:`~peagen.schemas.TaskRead` instance."""
 
     if isinstance(task, Task):
         return task

--- a/pkgs/standards/peagen/peagen/handlers/eval_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/eval_handler.py
@@ -3,7 +3,7 @@
 Async task-handler for “eval” jobs.
 
 The worker runtime (or a local CLI run) calls this coroutine with
-either a plain dict (decoded JSON-RPC) or a peagen.models.Task object.
+either a plain dict (decoded JSON-RPC) or a peagen.orm.Task object.
 
 Returns a JSON-serialisable mapping:
   { "report": {…}, "strict_failed": bool }

--- a/pkgs/standards/peagen/peagen/handlers/fetch_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/fetch_handler.py
@@ -2,7 +2,7 @@
 """
 Async entry-point for the *fetch* pipeline.
 
-• Accepts either a plain dict (decoded JSON-RPC) or a peagen.models.Task.
+• Accepts either a plain dict (decoded JSON-RPC) or a peagen.orm.Task.
 • Delegates all heavy-lifting to core.fetch_core.fetch_many().
 • Returns a lightweight JSON-serialisable summary.
 """

--- a/pkgs/standards/peagen/peagen/handlers/init_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/init_handler.py
@@ -3,7 +3,7 @@
 
 Asynchronous entry-point for initialisation tasks.
 
-The handler accepts either a plain dictionary or a :class:`peagen.models.Task`
+The handler accepts either a plain dictionary or a :class:`peagen.orm.Task`
 and delegates to :mod:`peagen.core.init_core`.
 """
 

--- a/pkgs/standards/peagen/peagen/handlers/process_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/process_handler.py
@@ -4,7 +4,7 @@ Unified entry-point for “process” tasks.
 
 A worker (or a local CLI run) will pass in either:
   • a plain ``dict`` decoded from JSON-RPC, or
-  • a ``peagen.models.Task`` instance.
+  • a ``peagen.orm.Task`` instance.
 
 The handler merges CLI-style overrides with ``.peagen.toml``,
 invokes the appropriate functions in **process_core**, and

--- a/pkgs/standards/peagen/peagen/jsonschemas/__init__.py
+++ b/pkgs/standards/peagen/peagen/jsonschemas/__init__.py
@@ -1,20 +1,98 @@
-<<<<<<<< HEAD:pkgs/standards/peagen/peagen/jsonschemas/__init__.py
 # peagen/jsonschemas/__init__.py
 """Expose Peagen JSON Schemas as Python dicts."""
-========
-"""Deprecated access point for JSON Schemas."""
->>>>>>>> coby/peagenv2-add_schemas_06_25_25:pkgs/standards/peagen/peagen/schemas/__init__.py
 
 from __future__ import annotations
+import json
+import importlib.resources as res
 
-import warnings
 
-from peagen.jsonschemas import *  # noqa: F401,F403
-
-warnings.warn(
-    "peagen.schemas is deprecated; use peagen.jsonschemas instead",
-    DeprecationWarning,
-    stacklevel=2,
+PEAGEN_TOML_V1_SCHEMA = json.loads(
+    res.files(__package__)
+    .joinpath("peagen.toml.schema.v1.json")
+    .read_text(encoding="utf-8")
 )
 
-__all__ = [name for name in globals() if name.isupper()]
+PEAGEN_TOML_V1_1_SCHEMA = json.loads(
+    res.files(__package__)
+    .joinpath("peagen.toml.schema.v1.1.0.json")
+    .read_text(encoding="utf-8")
+)
+
+DOE_SPEC_V1_SCHEMA = json.loads(
+    res.files(__package__)
+    .joinpath("doe_spec.schema.v1.json")
+    .read_text(encoding="utf-8")
+)
+
+DOE_SPEC_V1_1_SCHEMA = json.loads(
+    res.files(__package__)
+    .joinpath("doe_spec.schema.v1.1.json")
+    .read_text(encoding="utf-8")
+)
+
+DOE_SPEC_V2_SCHEMA = json.loads(
+    res.files(__package__)
+    .joinpath("doe_spec.schema.v2.json")
+    .read_text(encoding="utf-8")
+)
+
+PTREE_V1_SCHEMA = json.loads(
+    res.files(__package__).joinpath("ptree.schema.v1.json").read_text(encoding="utf-8")
+)
+
+PROJECTS_PAYLOAD_V1_SCHEMA = json.loads(
+    res.files(__package__)
+    .joinpath("projects_payload.schema.v1.json")
+    .read_text(encoding="utf-8")
+)
+
+
+EVENT_V1_SCHEMA = json.loads(
+    res.files(__package__).joinpath("event.schema.v1.json").read_text(encoding="utf-8")
+)
+
+EVOLVE_SPEC_V1_SCHEMA = json.loads(
+    res.files(__package__)
+    .joinpath("evolve_spec.schema.v1.json")
+    .read_text(encoding="utf-8")
+)
+
+try:
+    EVOLVE_SPEC_V2_SCHEMA = json.loads(
+        res.files(__package__)
+        .joinpath("evolve_spec.schema.v2.0.0.json")
+        .read_text(encoding="utf-8")
+    )
+except Exception:
+    EVOLVE_SPEC_V2_SCHEMA = {}
+
+LLM_PATCH_V1_SCHEMA = json.loads(
+    res.files(__package__)
+    .joinpath("llm_patch.schema.v1.json")
+    .read_text(encoding="utf-8")
+)
+
+
+# ── EXTRAS schemas ─────────────────────────────────────────────
+_extras_pkg = res.files(__package__).joinpath("extras")
+EXTRAS_SCHEMAS = {
+    fp.name.replace(".schema.v1.json", ""): json.loads(fp.read_text(encoding="utf-8"))
+    for fp in _extras_pkg.iterdir()
+    if fp.name.endswith(".schema.v1.json")
+}
+
+
+__all__ = [
+    "PEAGEN_TOML_V1_SCHEMA",
+    "PEAGEN_TOML_V1_1_SCHEMA",
+    "DOE_SPEC_V1_SCHEMA",
+    "DOE_SPEC_V1_1_SCHEMA",
+    "DOE_SPEC_V2_SCHEMA",
+    "PTREE_V1_SCHEMA",
+    "PROJECTS_PAYLOAD_V1_SCHEMA",
+    "EVENT_V1_SCHEMA",
+    "EVOLVE_SPEC_V1_SCHEMA",
+    "EVOLVE_SPEC_V2_SCHEMA",
+    "LLM_PATCH_V1_SCHEMA",
+    "EXTRAS_SCHEMAS",
+]

--- a/pkgs/standards/peagen/peagen/schemas/__init__.py
+++ b/pkgs/standards/peagen/peagen/schemas/__init__.py
@@ -72,11 +72,13 @@ for _name in model_names:
     globals()[update_cls.__name__] = update_cls
     globals()[read_cls.__name__] = read_cls
     globals()[child_cls.__name__] = child_cls
-    globals()[root_name] = read_cls
     __all__ += [
         create_cls.__name__,
         update_cls.__name__,
         read_cls.__name__,
         child_cls.__name__,
-        root_name,
     ]
+
+# Explicit exports for common task schemas
+if "TaskRead" in globals():
+    __all__.extend(["TaskRead", "TaskCreate", "TaskUpdate"])

--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -19,7 +19,7 @@ from peagen._utils.config_loader import resolve_cfg
 from peagen.plugins import PluginManager
 from peagen.errors import HTTPClientNotInitializedError
 from peagen.handlers import ensure_task
-from peagen.models.schemas import TaskRead
+from peagen.schemas import TaskRead
 
 
 # ──────────────────────────── utils  ────────────────────────────


### PR DESCRIPTION
## Summary
- relocate `schemas.py` into new `peagen.schemas` package
- adjust gateway, worker and handler imports to use `peagen.schemas`
- fix README and docs to reference `peagen.schemas`
- remove deprecated alias generation and explicitly export common task schemas
- restore missing jsonschemas module

## Testing
- `uv run --directory standards/peagen --package peagen ruff format peagen/schemas/__init__.py peagen/worker/base.py peagen/handlers/__init__.py peagen/handlers/eval_handler.py peagen/handlers/fetch_handler.py peagen/handlers/init_handler.py peagen/handlers/process_handler.py peagen/gateway/__init__.py`
- `uv run --directory standards/peagen --package peagen ruff check peagen/schemas/__init__.py peagen/worker/base.py peagen/handlers/__init__.py peagen/handlers/eval_handler.py peagen/handlers/fetch_handler.py peagen/handlers/init_handler.py peagen/handlers/process_handler.py peagen/gateway/__init__.py --fix`
- `uv run --package peagen --directory standards/peagen pytest` *(fails: 62 failed, 172 passed, 31 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_685f060969b883269c4989042bdb1e02