### PR TITLE
Add schemas compatibility shim

### DIFF
--- a/pkgs/standards/peagen/peagen/models/schemas.py
+++ b/pkgs/standards/peagen/peagen/models/schemas.py
@@ -1,0 +1,13 @@
+"""Backwards compatibility shim for :mod:`peagen.schemas`."""
+
+from __future__ import annotations
+
+from warnings import warn
+
+from peagen.schemas import *  # noqa: F401,F403
+
+warn(
+    "peagen.models.schemas is deprecated; use peagen.schemas instead",
+    DeprecationWarning,
+    stacklevel=2,
+)


### PR DESCRIPTION
## Summary
- provide backward compat shim `peagen.models.schemas`
- keep generated schemas in `peagen.schemas` importing from orm

## Testing
- `uv run --directory standards --package peagen ruff format peagen`
- `uv run --directory standards --package peagen ruff check peagen --fix`
- `uv run --package peagen --directory standards pytest` *(fails: 95 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685f0aa623b483268eb49d8e2b4001c8