### PR TITLE
Update peagen package metadata and imports

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/__init__.py
+++ b/pkgs/standards/peagen/peagen/cli/__init__.py
@@ -13,10 +13,10 @@ from peagen import defaults
 import typer
 
 # ─── Banner helper (printed unless –quiet) ────────────────────────────────
-from ._banner import _print_banner
+from peagen.cli._banner import _print_banner
 
 # ─── Sub-command apps ──────────────────────────────────────────────────────
-from .commands import (
+from peagen.cli.commands import (
     local_doe_app,
     local_eval_app,
     local_extras_app,

--- a/pkgs/standards/peagen/peagen/cli/commands/__init__.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/__init__.py
@@ -1,24 +1,27 @@
 """Expose all Typer sub-applications for the CLI."""
 
-from .doe import local_doe_app, remote_doe_app
-from .eval import local_eval_app, remote_eval_app
-from .extras import local_extras_app, remote_extras_app
-from .fetch import fetch_app
-from .db import local_db_app, remote_db_app
-from .init import local_init_app, remote_init_app
-from .process import local_process_app, remote_process_app
-from .mutate import local_mutate_app, remote_mutate_app
-from .evolve import local_evolve_app, remote_evolve_app
-from .sort import local_sort_app, remote_sort_app
-from .task import remote_task_app
-from .analysis import local_analysis_app, remote_analysis_app
-from .templates import local_template_sets_app, remote_template_sets_app
-from .tui import dashboard_app
-from .validate import local_validate_app, remote_validate_app
-from .login import login_app
-from .keys import keys_app
-from .secrets import local_secrets_app, remote_secrets_app
-from .show import show_app
+from peagen.cli.commands.doe import local_doe_app, remote_doe_app
+from peagen.cli.commands.eval import local_eval_app, remote_eval_app
+from peagen.cli.commands.extras import local_extras_app, remote_extras_app
+from peagen.cli.commands.fetch import fetch_app
+from peagen.cli.commands.db import local_db_app, remote_db_app
+from peagen.cli.commands.init import local_init_app, remote_init_app
+from peagen.cli.commands.process import local_process_app, remote_process_app
+from peagen.cli.commands.mutate import local_mutate_app, remote_mutate_app
+from peagen.cli.commands.evolve import local_evolve_app, remote_evolve_app
+from peagen.cli.commands.sort import local_sort_app, remote_sort_app
+from peagen.cli.commands.task import remote_task_app
+from peagen.cli.commands.analysis import local_analysis_app, remote_analysis_app
+from peagen.cli.commands.templates import (
+    local_template_sets_app,
+    remote_template_sets_app,
+)
+from peagen.cli.commands.tui import dashboard_app
+from peagen.cli.commands.validate import local_validate_app, remote_validate_app
+from peagen.cli.commands.login import login_app
+from peagen.cli.commands.keys import keys_app
+from peagen.cli.commands.secrets import local_secrets_app, remote_secrets_app
+from peagen.cli.commands.show import show_app
 
 __all__ = [
     "local_doe_app",

--- a/pkgs/standards/peagen/peagen/plugins/__init__.py
+++ b/pkgs/standards/peagen/peagen/plugins/__init__.py
@@ -229,7 +229,7 @@ class PluginManager:
             model_name = cfg.get("default_model_name")
             temperature = cfg.get("default_temperature")
             max_tokens = cfg.get("default_max_tokens")
-            from ..core._llm import GenericLLM
+            from peagen.core._llm import GenericLLM
 
             llm_mgr = GenericLLM()
             kwargs: Dict[str, Any] = {}

--- a/pkgs/standards/peagen/peagen/transport/__init__.py
+++ b/pkgs/standards/peagen/peagen/transport/__init__.py
@@ -1,4 +1,9 @@
-from .jsonrpc import RPCDispatcher
-from .schemas import RPCRequest, RPCResponse, RPCError, RPCErrorData
+from peagen.transport.jsonrpc import RPCDispatcher
+from peagen.transport.schemas import (
+    RPCRequest,
+    RPCResponse,
+    RPCError,
+    RPCErrorData,
+)
 
 __all__ = ["RPCDispatcher", "RPCRequest", "RPCResponse", "RPCError", "RPCErrorData"]

--- a/pkgs/standards/peagen/peagen/transport/jsonrpc.py
+++ b/pkgs/standards/peagen/peagen/transport/jsonrpc.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import inspect
 from typing import Callable, Dict
 
-from .schemas import RPCError
+from peagen.transport.schemas import RPCError
 
 
 class RPCException(Exception):

--- a/pkgs/standards/peagen/peagen/tui/__init__.py
+++ b/pkgs/standards/peagen/peagen/tui/__init__.py
@@ -10,26 +10,26 @@ __all__ = [
 ]
 
 if TYPE_CHECKING:  # pragma: no cover - used only for type checkers
-    from .app import QueueDashboardApp
-    from .ws_client import TaskStreamClient
-    from .fileops import download_remote, upload_remote
+    from peagen.tui.app import QueueDashboardApp
+    from peagen.tui.ws_client import TaskStreamClient
+    from peagen.tui.fileops import download_remote, upload_remote
 
 
 def __getattr__(name: str):
     if name == "QueueDashboardApp":
-        from .app import QueueDashboardApp as _QueueDashboardApp
+        from peagen.tui.app import QueueDashboardApp as _QueueDashboardApp
 
         return _QueueDashboardApp
     if name == "TaskStreamClient":
-        from .ws_client import TaskStreamClient as _TaskStreamClient
+        from peagen.tui.ws_client import TaskStreamClient as _TaskStreamClient
 
         return _TaskStreamClient
     if name == "download_remote":
-        from .fileops import download_remote as _download_remote
+        from peagen.tui.fileops import download_remote as _download_remote
 
         return _download_remote
     if name == "upload_remote":
-        from .fileops import upload_remote as _upload_remote
+        from peagen.tui.fileops import upload_remote as _upload_remote
 
         return _upload_remote
     raise AttributeError(name)

--- a/pkgs/standards/peagen/peagen/tui/components/__init__.py
+++ b/pkgs/standards/peagen/peagen/tui/components/__init__.py
@@ -1,16 +1,16 @@
 """Reusable TUI widgets for Peagen."""
 
-from .footer import DashboardFooter
-from .tree_view import FileTree
-from .log_view import LogView
-from .metrics_tab import MetricsTab
-from .workers_view import WorkersView
-from .templates_view import TemplatesView
-from .reconnect_screen import ReconnectScreen
-from .task_detail_screen import TaskDetailScreen
-from .number_input_screen import NumberInputScreen
-from .task_table import TaskTable
-from .filter_bar import FilterBar
+from peagen.tui.components.footer import DashboardFooter
+from peagen.tui.components.tree_view import FileTree
+from peagen.tui.components.log_view import LogView
+from peagen.tui.components.metrics_tab import MetricsTab
+from peagen.tui.components.workers_view import WorkersView
+from peagen.tui.components.templates_view import TemplatesView
+from peagen.tui.components.reconnect_screen import ReconnectScreen
+from peagen.tui.components.task_detail_screen import TaskDetailScreen
+from peagen.tui.components.number_input_screen import NumberInputScreen
+from peagen.tui.components.task_table import TaskTable
+from peagen.tui.components.filter_bar import FilterBar
 
 __all__ = [
     "DashboardFooter",

--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -214,3 +214,6 @@ default = "peagen.plugins.evaluator_pools.default:DefaultEvaluatorPool"
   "alembic.ini",
   "migrations/**",
 ]
+
+[tool.setuptools.packages.find]
+include = ["peagen", "peagen.*"]


### PR DESCRIPTION
## Summary
- include all `peagen.*` subpackages in distribution
- update CLI and transport imports to use absolute paths
- switch TUI modules to absolute imports

## Testing
- `uv run --package peagen --directory standards/peagen ruff format .`
- `uv run --package peagen --directory standards/peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest -q` *(fails: ImportError due to circular import)*
- `peagen remote -q --gateway-url http://localhost:8000/rpc process projects_payload.yaml --watch` *(fails: ImportError)*
- `peagen local -q process projects_payload.yaml --watch` *(fails: ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_685f0a5a303c8326ab425c02a28982dc