### PR TITLE
Synchronize ORM docs

### DIFF
--- a/pkgs/standards/peagen/peagen/orm/__init__.py
+++ b/pkgs/standards/peagen/peagen/orm/__init__.py
@@ -4,6 +4,8 @@ peagen.orm
 
 • Aggregates **all** SQLAlchemy ORM classes.
 • No engine/session helpers—those live elsewhere.
+
+`peagen.models` is deprecated and now forwards to this package.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- add docstring note in `peagen.orm` about the deprecated models wrapper
- run `ruff format` and `ruff check` for `peagen`

## Testing
- `uv run --directory pkgs/standards --package peagen ruff format .`
- `uv run --directory pkgs/standards --package peagen ruff check . --fix`
- `peagen -q --help` *(fails: ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_685f0b5a274c8326bd097a2da83599f1