### PR TITLE
Fix README snippet and import

### DIFF
--- a/pkgs/standards/peagen/README.md
+++ b/pkgs/standards/peagen/README.md
@@ -101,7 +101,7 @@ cd pkgs/standards/peagen
 pip install .
 
 peagen --help
-````
+```
 
 ### Executing `peagen --help`
 

--- a/pkgs/standards/peagen/peagen/orm/task/task_run.py
+++ b/pkgs/standards/peagen/peagen/orm/task/task_run.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:  # pragma: no cover - imports for type hints
     from ..result.eval_result import EvalResultModel
 
 from ..base import BaseModel  # id, timestamps
-from ..status import Status
+from .status import Status
 from ..task.task import TaskModel
 from ..infra.pool import PoolModel
 from ..infra.worker import WorkerModel


### PR DESCRIPTION
## Summary
- fix code block in peagen README
- fix import path for `Status` in `TaskRun`

## Testing
- `uv run --package peagen --directory standards/peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest` *(fails: 62 failed, 172 passed)*
- `peagen local -q process standards/peagen/tests/examples/projects_payloads/projects_payload.yaml` *(fails: TypeError)*
- `peagen remote -q --gateway-url http://localhost:8000/rpc process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml` *(fails: TypeError)*

------
https://chatgpt.com/codex/tasks/task_e_685f0b61fbe08326bc6b8ef30fc33029