### PR TITLE
Fix packaging for new peagen modules

### DIFF
--- a/pkgs/standards/peagen/peagen/transport/__init__.py
+++ b/pkgs/standards/peagen/peagen/transport/__init__.py
@@ -1,4 +1,4 @@
-from .jsonrpc import RPCDispatcher
-from .schemas import RPCRequest, RPCResponse, RPCError, RPCErrorData
+from peagen.transport.jsonrpc import RPCDispatcher
+from peagen.transport.schemas import RPCRequest, RPCResponse, RPCError, RPCErrorData
 
 __all__ = ["RPCDispatcher", "RPCRequest", "RPCResponse", "RPCError", "RPCErrorData"]

--- a/pkgs/standards/peagen/peagen/transport/jsonrpc.py
+++ b/pkgs/standards/peagen/peagen/transport/jsonrpc.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import inspect
 from typing import Callable, Dict
 
-from .schemas import RPCError
+from peagen.transport.schemas import RPCError
 
 
 class RPCException(Exception):

--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -214,3 +214,11 @@ default = "peagen.plugins.evaluator_pools.default:DefaultEvaluatorPool"
   "alembic.ini",
   "migrations/**",
 ]
+
+[tool.setuptools.packages.find]
+include = [
+    "peagen",
+    "peagen.orm",
+    "peagen.jsonschemas",
+    "peagen.schemas",
+]


### PR DESCRIPTION
## Summary
- include `peagen.orm`, `peagen.jsonschemas`, and `peagen.schemas` in setup config
- switch to absolute imports in `peagen.transport`

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format . --diff`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest` *(fails: 38 errors)*
- `peagen remote -q --gateway-url http://localhost:8000/rpc process standards/peagen/tests/examples/projects_payloads/projects_payload.yaml --watch` *(fails: ImportError due to circular import)*
- `peagen local -q process standards/peagen/tests/examples/projects_payloads/projects_payload.yaml --watch` *(fails: ImportError due to circular import)*

------
https://chatgpt.com/codex/tasks/task_e_685f0a4fc2288326a9ce301fa87f5ca1