### PR TITLE
Remove task_type usage from peagen

### DIFF
--- a/pkgs/standards/peagen/peagen/migrations/versions/97a9f54587b2_automated_revision.py
+++ b/pkgs/standards/peagen/peagen/migrations/versions/97a9f54587b2_automated_revision.py
@@ -464,7 +464,6 @@ def upgrade() -> None:
     op.create_foreign_key(
         None, "task_runs", "tasks", ["task_id"], ["id"], ondelete="CASCADE"
     )
-    op.drop_column("task_runs", "task_type")
     op.drop_column("task_runs", "oids")
     op.drop_column("task_runs", "in_degree")
     op.drop_column("task_runs", "finished_at")
@@ -648,7 +647,6 @@ def downgrade() -> None:
         ),
     )
     op.add_column("task_runs", sa.Column("oids", sqlite.JSON(), nullable=True))
-    op.add_column("task_runs", sa.Column("task_type", sa.VARCHAR(), nullable=True))
     op.drop_constraint(None, "task_runs", type_="foreignkey")
     op.drop_constraint(None, "task_runs", type_="foreignkey")
     op.drop_constraint(None, "task_runs", type_="foreignkey")

--- a/pkgs/standards/peagen/peagen/migrations/versions/ae1de73e4143_init.py
+++ b/pkgs/standards/peagen/peagen/migrations/versions/ae1de73e4143_init.py
@@ -30,7 +30,6 @@ def upgrade() -> None:
                 "id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True
             ),
             sa.Column("pool", sa.String()),
-            sa.Column("task_type", sa.String()),
             sa.Column("status", status_enum, nullable=False),
             sa.Column("payload", sa.JSON()),
             sa.Column("result", sa.JSON()),

--- a/pkgs/standards/peagen/tests/unit/test_result_backends.py
+++ b/pkgs/standards/peagen/tests/unit/test_result_backends.py
@@ -16,7 +16,6 @@ async def test_localfs_backend_writes_file(tmp_path):
     tr = TaskRun(
         id=uuid.uuid4(),
         pool="p",
-        task_type="t",
         status=Status.success,
         payload={},
         result=None,
@@ -59,7 +58,6 @@ async def test_postgres_backend_invokes_helpers(monkeypatch):
     tr = TaskRun(
         id=uuid.uuid4(),
         pool="p",
-        task_type="t",
         status=Status.success,
         payload={},
         result=None,
@@ -77,7 +75,6 @@ async def test_in_memory_backend_stores_in_dict():
     tr = TaskRun(
         id=uuid.uuid4(),
         pool="p",
-        task_type="t",
         status=Status.success,
         payload={},
         result=None,

--- a/pkgs/standards/peagen/tests/unit/test_selectors.py
+++ b/pkgs/standards/peagen/tests/unit/test_selectors.py
@@ -18,7 +18,6 @@ async def test_result_backend_selector_picks_leader_and_running_candidates():
     tr1 = TaskRun(
         id=uuid.uuid4(),
         pool="p",
-        task_type="t",
         status=Status.running,
         payload={},
         result=None,
@@ -26,7 +25,6 @@ async def test_result_backend_selector_picks_leader_and_running_candidates():
     tr2 = TaskRun(
         id=uuid.uuid4(),
         pool="p",
-        task_type="t",
         status=Status.success,
         payload={},
         result={"score": 1},
@@ -34,7 +32,6 @@ async def test_result_backend_selector_picks_leader_and_running_candidates():
     tr3 = TaskRun(
         id=uuid.uuid4(),
         pool="p",
-        task_type="t",
         status=Status.running,
         payload={},
         result=None,
@@ -58,7 +55,6 @@ async def test_bootstrap_selector_switches_after_first_call():
     tr = TaskRun(
         id=uuid.uuid4(),
         pool="p",
-        task_type="t",
         status=Status.running,
         payload={},
         result=None,
@@ -80,7 +76,6 @@ async def test_input_selector_uses_initial_candidate_once():
     tr = TaskRun(
         id=uuid.uuid4(),
         pool="p",
-        task_type="t",
         status=Status.running,
         payload={},
         result=None,


### PR DESCRIPTION
## Summary
- drop references to deprecated `task_type` field in migrations
- remove `task_type` argument from tests

## Testing
- `N/A`

------
https://chatgpt.com/codex/tasks/task_e_685f1071ca5c832692062b49f79b2826