### PR TITLE
Add basic task service and persist via gateway

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -58,6 +58,7 @@ from peagen.defaults import BAN_THRESHOLD
 from peagen.defaults.error_codes import ErrorCode
 from peagen.core import migrate_core
 from peagen.core.task_core import get_task_result
+from peagen.services import create_task
 
 _db = reload(_db)
 engine = _db.engine
@@ -328,7 +329,19 @@ async def _persist(task: TaskModel | TaskCreate | TaskUpdate) -> None:
     try:
         log.info("persisting task %s", task.id)
         orm_task = task if isinstance(task, TaskModel) else to_orm(task)
-        await result_backend.store(TaskRun.from_task(orm_task))
+        if result_backend:
+            await result_backend.store(TaskRun.from_task(orm_task))
+        async with Session() as session:
+            await create_task(
+                session,
+                TaskCreate(
+                    id=orm_task.id,
+                    tenant_id=orm_task.tenant_id,
+                    git_reference_id=orm_task.git_reference_id,
+                    parameters=orm_task.parameters,
+                    note=orm_task.note or "",
+                ),
+            )
     except Exception as e:
         log.warning(f"_persist error '{e}'")
 

--- a/pkgs/standards/peagen/peagen/services/__init__.py
+++ b/pkgs/standards/peagen/peagen/services/__init__.py
@@ -1,0 +1,5 @@
+"""Service layer for database-backed operations."""
+
+from .tasks import create_task, get_task, update_task
+
+__all__ = ["create_task", "get_task", "update_task"]

--- a/pkgs/standards/peagen/peagen/services/tasks.py
+++ b/pkgs/standards/peagen/peagen/services/tasks.py
@@ -1,0 +1,51 @@
+"""Database operations for ``Task`` objects."""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from peagen.orm.task.task import TaskModel
+from peagen.schemas import TaskCreate, TaskRead, TaskUpdate
+
+
+def _to_orm(data: TaskCreate | TaskUpdate) -> TaskModel:
+    return TaskModel(**data.model_dump())
+
+
+def _to_schema(row: TaskModel) -> TaskRead:
+    return TaskRead.from_orm(row)
+
+
+async def create_task(db: AsyncSession, data: TaskCreate) -> TaskRead:
+    """Persist a new ``Task`` and return the created row."""
+
+    obj = _to_orm(data)
+    db.add(obj)
+    await db.commit()
+    await db.refresh(obj)
+    return _to_schema(obj)
+
+
+async def get_task(db: AsyncSession, task_id: str) -> TaskRead | None:
+    """Return a task by its ID."""
+
+    result = await db.execute(select(TaskModel).where(TaskModel.id == task_id))
+    row = result.scalar_one_or_none()
+    return _to_schema(row) if row else None
+
+
+async def update_task(
+    db: AsyncSession, task_id: str, data: TaskUpdate
+) -> TaskRead | None:
+    """Update a task with ``data`` and return the updated row."""
+
+    result = await db.execute(select(TaskModel).where(TaskModel.id == task_id))
+    obj = result.scalar_one_or_none()
+    if obj is None:
+        return None
+    for field, value in data.model_dump(exclude_unset=True).items():
+        setattr(obj, field, value)
+    await db.commit()
+    await db.refresh(obj)
+    return _to_schema(obj)


### PR DESCRIPTION
## Summary
- implement a new `peagen.services.tasks` module
- call the service from the gateway `_persist` helper

## Testing
- `uv run --package peagen --directory peagen ruff format .`
- `uv run --package peagen --directory peagen ruff check . --fix`
- `uv run --package peagen --directory peagen pytest -q`
- `peagen local -q process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml` *(fails: "'pool' is an invalid keyword argument for TaskModel")*

------
https://chatgpt.com/codex/tasks/task_e_685f0e8d46b883268123470f0498dcba