### PR TITLE
Add pydantic Task schema and update TaskRun

### DIFF
--- a/pkgs/standards/peagen/peagen/orm/task/task.py
+++ b/pkgs/standards/peagen/peagen/orm/task/task.py
@@ -26,6 +26,8 @@ if TYPE_CHECKING:  # pragma: no cover - imports for type hints
 
 from ..repo.git_reference import GitReferenceModel
 from ..base import BaseModel
+from pydantic import BaseModel as PydanticModel, Field
+from .status import Status
 
 
 class TaskModel(BaseModel):
@@ -83,4 +85,19 @@ class TaskModel(BaseModel):
         )
 
 
-Task = TaskModel
+class Task(PydanticModel):
+    """Lightweight task schema used by CLI and gateway."""
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    pool: str = "default"
+    payload: dict = Field(default_factory=dict)
+    relations: list[str] = Field(default_factory=list)
+    deps: list[str] = Field(default_factory=list)
+    edge_pred: str | None = None
+    labels: list[str] = Field(default_factory=list)
+    in_degree: int = 0
+    config_toml: str | None = None
+    status: Status = Status.waiting
+    result: dict | None = None
+    commit_hexsha: str | None = None
+    oids: list[str] = Field(default_factory=list)

--- a/pkgs/standards/peagen/peagen/orm/task/task_run.py
+++ b/pkgs/standards/peagen/peagen/orm/task/task_run.py
@@ -127,7 +127,6 @@ class TaskRunModel(BaseModel):
 
         tr = cls(
             id=uuid.UUID(task.id),
-            task_payload_id=uuid.uuid4(),
             status=task.status,
             result=None,
         )


### PR DESCRIPTION
## Summary
- introduce a light-weight pydantic Task used by the CLI and gateway
- drop obsolete `task_payload_id` from `TaskRun.from_task`

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format .`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_task_metadata.py::test_task_model_roundtrip tests/unit/test_task_metadata.py::test_taskrun_from_task -q`


------
https://chatgpt.com/codex/tasks/task_e_685f1010d08883269ab053668fe56d1e