### PR TITLE
Add task model roundtrip and CLI smoke tests

### DIFF
--- a/pkgs/standards/peagen/tests/smoke/test_cli_task_submit.py
+++ b/pkgs/standards/peagen/tests/smoke/test_cli_task_submit.py
@@ -1,0 +1,69 @@
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from peagen.cli import app
+from peagen.cli.commands import process as process_mod
+
+
+@pytest.mark.smoke
+def test_cli_task_submit_local(monkeypatch, tmp_path: Path) -> None:
+    def fake_post(url: str, json: dict, timeout: float):
+        assert json["method"] == "Task.submit"
+        data = {"result": {"taskId": "123"}}
+
+        class Resp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return data
+
+        return Resp()
+
+    class DummyClient:
+        def __init__(self, *a, **k):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def post(self, url: str, json: dict):
+            return fake_post(url, json, 30.0)
+
+    import httpx
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+    monkeypatch.setattr(httpx, "Client", DummyClient)
+
+    class DummyTask:
+        def __init__(self, pool: str, payload: dict):
+            self.id = "abc"
+            self.pool = pool
+            self.payload = payload
+
+    monkeypatch.setattr(
+        process_mod,
+        "_build_task",
+        lambda args, pool: DummyTask(pool, {"action": "process", "args": args}),
+    )
+
+    payload = tmp_path / "payload.yaml"
+    payload.write_text("PROJECTS: []", encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["remote", "-q", "--gateway-url", "http://gw/rpc", "process", str(payload)],
+    )
+
+    assert result.exit_code == 0
+    output = result.stdout.strip().splitlines()
+    assert any("Submitted task" in line for line in output)
+    last = json.loads("\n".join(output[-3:]))
+    assert "taskId" in last

--- a/pkgs/standards/peagen/tests/unit/test_task_roundtrip.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_roundtrip.py
@@ -1,0 +1,41 @@
+import uuid
+import datetime
+
+import pytest
+
+from peagen.schemas import TaskCreate, TaskRead
+
+
+@pytest.mark.unit
+def test_task_roundtrip_json(monkeypatch):
+    class StubPM:
+        def __init__(self, cfg):
+            pass
+
+        def get(self, group):
+            return None
+
+    import peagen.plugins
+
+    monkeypatch.setattr(peagen.plugins, "PluginManager", StubPM)
+    import importlib
+    import peagen.gateway as gw
+
+    importlib.reload(gw)
+
+    from peagen.gateway import to_orm
+
+    create = TaskCreate(
+        id=uuid.uuid4(),
+        tenant_id=uuid.uuid4(),
+        git_reference_id=uuid.uuid4(),
+        parameters={"foo": "bar"},
+        note="demo",
+    )
+    model = to_orm(create)
+    model.date_created = datetime.datetime.now(datetime.timezone.utc)
+    model.last_modified = model.date_created
+    read = TaskRead.model_validate(model, from_attributes=True)
+    dumped = read.model_dump_json()
+    restored = TaskRead.model_validate_json(dumped)
+    assert restored == read


### PR DESCRIPTION
## Summary
- add test showing TaskCreate → TaskModel → TaskRead → JSON → TaskRead conversion
- add CLI smoke test for submitting a task

## Testing
- `uv run --package peagen --directory pkgs pytest standards/peagen/tests/unit/test_task_roundtrip.py standards/peagen/tests/smoke/test_cli_task_submit.py -m "smoke or not smoke" -q`

------
https://chatgpt.com/codex/tasks/task_e_685f0e8d70688326ad8a8eaf382f32c9