### PR TITLE
Centralize Status import path

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/analysis.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/analysis.py
@@ -10,7 +10,8 @@ import httpx
 import typer
 
 from peagen.handlers.analysis_handler import analysis_handler
-from peagen.orm import Status, Task
+from peagen.orm import Task
+from peagen.orm.status import Status
 
 DEFAULT_GATEWAY = "http://localhost:8000/rpc"
 local_analysis_app = typer.Typer(help="Aggregate run evaluation results.")

--- a/pkgs/standards/peagen/peagen/cli/commands/doe.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/doe.py
@@ -17,7 +17,8 @@ import typer
 
 from peagen.handlers.doe_handler import doe_handler
 from peagen.handlers.doe_process_handler import doe_process_handler
-from peagen.orm import Status, Task
+from peagen.orm import Task
+from peagen.orm.status import Status
 
 DEFAULT_GATEWAY = "http://localhost:8000/rpc"
 local_doe_app = typer.Typer(help="Generate project-payload bundles from DOE specs.")

--- a/pkgs/standards/peagen/peagen/cli/commands/eval.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/eval.py
@@ -21,7 +21,8 @@ import typer
 from peagen._utils.config_loader import load_peagen_toml
 
 from peagen.handlers.eval_handler import eval_handler
-from peagen.orm import Status, Task
+from peagen.orm import Task
+from peagen.orm.status import Status
 
 DEFAULT_GATEWAY = "http://localhost:8000/rpc"
 local_eval_app = typer.Typer(

--- a/pkgs/standards/peagen/peagen/cli/commands/evolve.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/evolve.py
@@ -12,7 +12,8 @@ import httpx
 import typer
 
 from peagen.handlers.evolve_handler import evolve_handler
-from peagen.orm import Status, Task
+from peagen.orm import Task
+from peagen.orm.status import Status
 from peagen.core.validate_core import validate_evolve_spec
 
 local_evolve_app = typer.Typer(help="Expand evolve spec and run mutate tasks")

--- a/pkgs/standards/peagen/peagen/cli/commands/fetch.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/fetch.py
@@ -16,7 +16,8 @@ from typing import List, Optional
 import typer
 
 from peagen.handlers.fetch_handler import fetch_handler
-from peagen.orm import Status, Task
+from peagen.orm import Task
+from peagen.orm.status import Status
 
 fetch_app = typer.Typer(help="Materialise Peagen workspaces from URIs.")
 

--- a/pkgs/standards/peagen/peagen/cli/commands/process.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/process.py
@@ -22,7 +22,8 @@ import httpx
 import typer
 from peagen._utils.config_loader import _effective_cfg, load_peagen_toml
 from peagen.handlers.process_handler import process_handler
-from peagen.orm import Status, Task  # noqa: F401 – only for type hints
+from peagen.orm import Task  # noqa: F401 – only for type hints
+from peagen.orm.status import Status
 
 local_process_app = typer.Typer(help="Render / generate project files.")
 remote_process_app = typer.Typer(help="Render / generate project files.")

--- a/pkgs/standards/peagen/peagen/cli/commands/task.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/task.py
@@ -11,7 +11,7 @@ import uuid
 import httpx
 import typer
 
-from peagen.orm import Status
+from peagen.orm.status import Status
 
 remote_task_app = typer.Typer(help="Inspect asynchronous tasks.")
 

--- a/pkgs/standards/peagen/peagen/core/control_core.py
+++ b/pkgs/standards/peagen/peagen/core/control_core.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import Iterable
 
-from peagen.orm import Task, Status
+from peagen.orm import Task
+from peagen.orm.status import Status
 
 
 def pause(tasks: Iterable[Task]) -> int:

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -26,7 +26,8 @@ from peagen.plugins.queues import QueueBase
 
 from peagen.transport import RPCDispatcher, RPCRequest
 from peagen.transport.jsonrpc import RPCException
-from peagen.orm import Base, Status, Task
+from peagen.orm import Base, Task
+from peagen.orm.status import Status
 from peagen.schemas import TaskRead, TaskCreate, TaskUpdate
 from peagen.orm.task.task import TaskModel
 from peagen.orm.task.task_run import TaskRun

--- a/pkgs/standards/peagen/peagen/gateway/db_helpers.py
+++ b/pkgs/standards/peagen/peagen/gateway/db_helpers.py
@@ -8,10 +8,10 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 import sqlalchemy as sa
 from peagen.orm import (
-    Status,
     TaskRun,
     TaskRunTaskRelationAssociation,
 )
+from peagen.orm.status import Status
 from peagen.orm.config.secret import Secret
 from peagen.orm.AbuseRecord import AbuseRecord
 

--- a/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
@@ -10,7 +10,8 @@ import uuid
 import yaml
 
 from peagen.core.doe_core import generate_payload
-from peagen.orm import Task, Status
+from peagen.orm import Task
+from peagen.orm.status import Status
 from peagen._utils.config_loader import resolve_cfg
 from peagen.plugins import PluginManager
 from peagen.plugins.storage_adapters.file_storage_adapter import FileStorageAdapter

--- a/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
@@ -8,7 +8,8 @@ from typing import Any, Dict, List
 
 import yaml
 
-from peagen.orm import Task, Status
+from peagen.orm import Task
+from peagen.orm.status import Status
 from .fanout import fan_out
 from . import ensure_task
 from peagen._utils.config_loader import resolve_cfg

--- a/pkgs/standards/peagen/peagen/handlers/fanout.py
+++ b/pkgs/standards/peagen/peagen/handlers/fanout.py
@@ -6,7 +6,8 @@ from typing import Iterable, List, Dict, Any
 
 import httpx
 
-from peagen.orm import Task, Status
+from peagen.orm import Task
+from peagen.orm.status import Status
 from . import ensure_task
 
 

--- a/pkgs/standards/peagen/peagen/handlers/process_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/process_handler.py
@@ -25,7 +25,7 @@ from peagen.core.process_core import (
     process_single_project,
     process_all_projects,
 )
-from peagen.orm import Task, Status  # noqa: F401 – used by type hints
+from peagen.orm import Task  # noqa: F401 – used by type hints
 from . import ensure_task
 
 logger = Logger(name=__name__)

--- a/pkgs/standards/peagen/tests/unit/test_fetch_cli.py
+++ b/pkgs/standards/peagen/tests/unit/test_fetch_cli.py
@@ -5,7 +5,7 @@ import pytest
 import typer
 
 from peagen.cli.commands import fetch
-from peagen.orm import Status
+from peagen.orm.status import Status
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- standardize imports to use `peagen.orm.status`
- run formatters and tests

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest -q --maxfail=1` *(fails: test_sequences_failure[example0])*

------
https://chatgpt.com/codex/tasks/task_e_685f0e8d402c8326bf1b156c9a5d9e5a