### PR TITLE
Fix ensure_task to parse minimal task data

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/analysis.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/analysis.py
@@ -17,7 +17,7 @@ local_analysis_app = typer.Typer(help="Aggregate run evaluation results.")
 remote_analysis_app = typer.Typer(help="Aggregate run evaluation results.")
 
 
-def _build_task(args: dict, pool: str) -> Task:
+def _build_task(args: dict, pool: str = "default") -> Task:
     return Task(
         id=str(uuid.uuid4()),
         pool=pool,

--- a/pkgs/standards/peagen/peagen/cli/commands/eval.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/eval.py
@@ -33,7 +33,7 @@ remote_eval_app = typer.Typer(
 
 
 # ───────────────────────── helpers ─────────────────────────────────────────
-def _build_task(args: dict, pool: str) -> Task:
+def _build_task(args: dict, pool: str = "default") -> Task:
     return Task(
         id=str(uuid.uuid4()),
         pool=pool,

--- a/pkgs/standards/peagen/peagen/cli/commands/evolve.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/evolve.py
@@ -19,7 +19,7 @@ local_evolve_app = typer.Typer(help="Expand evolve spec and run mutate tasks")
 remote_evolve_app = typer.Typer(help="Expand evolve spec and run mutate tasks")
 
 
-def _build_task(args: dict, pool: str) -> Task:
+def _build_task(args: dict, pool: str = "default") -> Task:
     return Task(
         id=str(uuid.uuid4()),
         pool=pool,

--- a/pkgs/standards/peagen/peagen/cli/commands/extras.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/extras.py
@@ -17,7 +17,7 @@ local_extras_app = typer.Typer(help="Manage EXTRAS schemas.")
 remote_extras_app = typer.Typer(help="Manage EXTRAS schemas remotely.")
 
 
-def _build_task(args: Dict[str, Any], pool: str) -> Task:
+def _build_task(args: Dict[str, Any], pool: str = "default") -> Task:
     return Task(
         id=str(uuid.uuid4()), pool=pool, payload={"action": "extras", "args": args}
     )

--- a/pkgs/standards/peagen/peagen/cli/commands/fetch.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/fetch.py
@@ -22,7 +22,7 @@ fetch_app = typer.Typer(help="Materialise Peagen workspaces from URIs.")
 
 
 # ───────────────────────── helpers ─────────────────────────
-def _build_task(args: dict, pool: str) -> Task:
+def _build_task(args: dict, pool: str = "default") -> Task:
     """Construct a Task with the fetch action embedded in the payload."""
     return Task(
         id=str(uuid.uuid4()),

--- a/pkgs/standards/peagen/peagen/cli/commands/mutate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/mutate.py
@@ -20,7 +20,7 @@ local_mutate_app = typer.Typer(help="Run the mutate workflow")
 remote_mutate_app = typer.Typer(help="Run the mutate workflow")
 
 
-def _build_task(args: dict, pool: str) -> Task:
+def _build_task(args: dict, pool: str = "default") -> Task:
     return Task(
         id=str(uuid.uuid4()),
         pool=pool,

--- a/pkgs/standards/peagen/peagen/cli/commands/process.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/process.py
@@ -60,7 +60,7 @@ def _collect_args(  # noqa: C901 – straight-through mapper
     return args
 
 
-def _build_task(args: Dict[str, Any], pool: str) -> Task:
+def _build_task(args: Dict[str, Any], pool: str = "default") -> Task:
     """Fabricate a Task model so the CLI uses the same payload shape as workers."""
     return Task(
         pool=pool,

--- a/pkgs/standards/peagen/peagen/handlers/__init__.py
+++ b/pkgs/standards/peagen/peagen/handlers/__init__.py
@@ -5,15 +5,14 @@ from __future__ import annotations
 from typing import Any, Dict
 
 from peagen.orm import Task
-from peagen.schemas import TaskRead
 
 
-def ensure_task(task: Task | Dict[str, Any]) -> TaskRead | Task:
-    """Return ``task`` as a :class:`~peagen.schemas.TaskRead` instance."""
+def ensure_task(task: Task | Dict[str, Any]) -> Task:
+    """Return ``task`` as a :class:`~peagen.orm.Task` instance."""
 
     if isinstance(task, Task):
         return task
-    return TaskRead.model_validate(task)
+    return Task.model_validate(task)
 
 
 __all__ = ["ensure_task"]


### PR DESCRIPTION
## Summary
- accept `Task` dicts via `Task.model_validate` in `ensure_task`
- default `_build_task` pool parameter across CLI modules

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest -q` *(fails: 26 failed, 208 passed)*
- `peagen remote -q --gateway-url http://localhost:8000/rpc process projects_payload.yaml --watch` *(fails: file not found)*
- `peagen local -q process projects_payload.yaml --watch` *(fails: unrecognized option)*

------
https://chatgpt.com/codex/tasks/task_e_685f13fb31508326a4b5173517b7b1da