### PR TITLE
Update Peagen schemas for create/update/read

### DIFF
--- a/pkgs/standards/peagen/peagen/schemas/__init__.py
+++ b/pkgs/standards/peagen/peagen/schemas/__init__.py
@@ -39,20 +39,20 @@ for _name in model_names:
         continue
     id_type = _python_type(id_col)
 
-    # CREATE: all required fields except 'id' and 'date_created'
+    # CREATE: all required fields except 'date_created'
     create_fields = {
         c_name: (_python_type(c), ...)
         for c_name, c in columns.items()
-        if c_name not in ["last_modified", "date_created"]
+        if c_name != "date_created"
     }
     root_name = _name[:-5] if _name.endswith("Model") else _name
     create_cls = create_model(f"{root_name}Create", **create_fields)
 
-    # UPDATE: all optional fields except 'date_created'
+    # UPDATE: all optional fields except 'id' and 'date_created'
     update_fields = {
         c_name: (Optional[_python_type(c)], None)
         for c_name, c in columns.items()
-        if c_name not in ["date_created", "last_modified"]
+        if c_name not in ["id", "date_created"]
     }
     update_cls = create_model(f"{root_name}Update", **update_fields)
 

--- a/pkgs/standards/peagen/tests/unit/test_task_roundtrip.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_roundtrip.py
@@ -3,7 +3,7 @@ import datetime
 
 import pytest
 
-from peagen.schemas import TaskCreate, TaskRead
+from peagen.schemas import TaskCreate, TaskRead, TaskUpdate
 
 
 @pytest.mark.unit
@@ -29,6 +29,7 @@ def test_task_roundtrip_json(monkeypatch):
         id=uuid.uuid4(),
         tenant_id=uuid.uuid4(),
         git_reference_id=uuid.uuid4(),
+        last_modified=datetime.datetime.now(datetime.timezone.utc),
         parameters={"foo": "bar"},
         note="demo",
     )
@@ -39,3 +40,18 @@ def test_task_roundtrip_json(monkeypatch):
     dumped = read.model_dump_json()
     restored = TaskRead.model_validate_json(dumped)
     assert restored == read
+
+
+@pytest.mark.unit
+def test_task_schema_fields():
+    # TaskCreate includes id and last_modified but not date_created
+    assert "id" in TaskCreate.model_fields
+    assert "last_modified" in TaskCreate.model_fields
+    assert "date_created" not in TaskCreate.model_fields
+
+    # TaskUpdate excludes id and date_created
+    assert "id" not in TaskUpdate.model_fields
+    assert "date_created" not in TaskUpdate.model_fields
+
+    # TaskRead includes date_created
+    assert "date_created" in TaskRead.model_fields


### PR DESCRIPTION
## Summary
- update schema generator to include `id` in create, exclude `date_created`
- exclude `id` from update schemas
- adjust `TaskCreate` usage in tests and add schema field checks

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --directory pkgs/standards/peagen --package peagen pytest` *(fails: ProjectsPayloadValidationError and other errors)*
- `peagen local process pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml` *(fails: ProjectsPayloadValidationError)*

------
https://chatgpt.com/codex/tasks/task_e_685f1799566483268bf6b488568e0c1e