### PR TITLE
Remove dead GitMirror import

### DIFF
--- a/pkgs/standards/peagen/peagen/orm/__init__.py
+++ b/pkgs/standards/peagen/peagen/orm/__init__.py
@@ -76,7 +76,6 @@ from .infra.pool_worker_association import (  # noqa: F401
 # ----------------------------------------------------------------------
 from .result.eval_result import EvalResultModel  # noqa: F401
 from .result.analysis_result import AnalysisResultModel  # noqa: F401
-from .git_mirror import GitMirror  # noqa: F401
 
 # ----------------------------------------------------------------------
 # Misc / security


### PR DESCRIPTION
## Summary
- remove unused GitMirror import from `peagen.orm`

## Testing
- `uv run --directory peagen --package peagen ruff format .`
- `uv run --directory peagen --package peagen ruff check . --fix`
- `uv run --directory peagen --package peagen pytest` *(fails: cannot import name 'Task' from 'peagen.orm')*
- `peagen remote -q --gateway-url http://localhost:8000/rpc process ./projects_payloads/projects_payload.yaml --watch` *(fails: cannot import name 'Task' from 'peagen.orm')*
- `peagen local -q process ../../projects_payloads/projects_payload.yaml --watch` *(fails: cannot import name 'Task' from 'peagen.orm')*

------
https://chatgpt.com/codex/tasks/task_e_685f19f1cd808326982a779c7c76af43