### PR TITLE
Move peagen schema generator

### DIFF
--- a/pkgs/standards/peagen/peagen/schemas/__init__.py
+++ b/pkgs/standards/peagen/peagen/schemas/__init__.py
@@ -1,84 +1,15 @@
+"""Pydantic schemas generated from ORM models.
+
+The :mod:`._generator` module inspects ``peagen.orm`` and creates
+Pydantic models for each SQLAlchemy model.  Common schemas such as
+``TaskCreate``, ``TaskUpdate``, ``TaskRead``, ``TaskRunCreate``,
+``TaskRunUpdate``, and ``TaskRunRead`` are all produced by this
+generator.
+"""
+
 from __future__ import annotations
 
-import inspect
-from datetime import datetime
-from typing import Any, Optional
+from ._generator import __all__ as _generated_all
+from ._generator import *  # noqa: F401,F403
 
-from pydantic import create_model
-
-from peagen.orm import __all__ as model_names
-from peagen.orm import base as base_module
-
-__all__ = []
-
-
-def _python_type(column: Any) -> type:
-    try:
-        return column.type.python_type
-    except Exception:  # fallback for custom/complex types
-        return Any
-
-
-for _name in model_names:
-    model_cls = getattr(base_module, _name, None)
-    if model_cls is None:
-        try:
-            mod = __import__("peagen.orm", fromlist=[_name])
-            model_cls = getattr(mod, _name)
-        except Exception:
-            continue
-
-    if not inspect.isclass(model_cls) or not issubclass(
-        model_cls, base_module.BaseModel
-    ):
-        continue
-
-    columns = {c.name: c for c in model_cls.__table__.columns}
-    id_col = columns.get("id", None)
-    if id_col is None:
-        continue
-    id_type = _python_type(id_col)
-
-    # CREATE: all required fields except 'date_created'
-    create_fields = {
-        c_name: (_python_type(c), ...)
-        for c_name, c in columns.items()
-        if c_name != "date_created"
-    }
-    root_name = _name[:-5] if _name.endswith("Model") else _name
-    create_cls = create_model(f"{root_name}Create", **create_fields)
-
-    # UPDATE: all optional fields except 'id' and 'date_created'
-    update_fields = {
-        c_name: (Optional[_python_type(c)], None)
-        for c_name, c in columns.items()
-        if c_name not in ["id", "date_created"]
-    }
-    update_cls = create_model(f"{root_name}Update", **update_fields)
-
-    # READ: all required, including id and date_created
-    read_fields = {"id": (id_type, ...)}
-    for c_name, c in columns.items():
-        read_fields[c_name] = (_python_type(c), ...)
-    if "date_created" not in read_fields and "date_created" in columns:
-        read_fields["date_created"] = (datetime, ...)
-    read_cls = create_model(f"{root_name}Read", **read_fields)
-
-    # CHILD: id only
-    child_cls = create_model(f"{root_name}Child", id=(id_type, ...))
-
-    # Register in global scope and __all__
-    globals()[create_cls.__name__] = create_cls
-    globals()[update_cls.__name__] = update_cls
-    globals()[read_cls.__name__] = read_cls
-    globals()[child_cls.__name__] = child_cls
-    __all__ += [
-        create_cls.__name__,
-        update_cls.__name__,
-        read_cls.__name__,
-        child_cls.__name__,
-    ]
-
-# Explicit exports for common task schemas
-if "TaskRead" in globals():
-    __all__.extend(["TaskRead", "TaskCreate", "TaskUpdate"])
+__all__: list[str] = list(_generated_all)

--- a/pkgs/standards/peagen/peagen/schemas/_generator.py
+++ b/pkgs/standards/peagen/peagen/schemas/_generator.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import inspect
+from datetime import datetime
+from typing import Any, Optional
+
+from pydantic import create_model
+
+from peagen.orm import __all__ as model_names
+from peagen.orm import base as base_module
+
+__all__ = []
+
+
+def _python_type(column: Any) -> type:
+    try:
+        return column.type.python_type
+    except Exception:  # fallback for custom/complex types
+        return Any
+
+
+for _name in model_names:
+    model_cls = getattr(base_module, _name, None)
+    if model_cls is None:
+        try:
+            mod = __import__("peagen.orm", fromlist=[_name])
+            model_cls = getattr(mod, _name)
+        except Exception:
+            continue
+
+    if not inspect.isclass(model_cls) or not issubclass(
+        model_cls, base_module.BaseModel
+    ):
+        continue
+
+    columns = {c.name: c for c in model_cls.__table__.columns}
+    id_col = columns.get("id", None)
+    if id_col is None:
+        continue
+    id_type = _python_type(id_col)
+
+    # CREATE: all required fields except 'date_created'
+    create_fields = {
+        c_name: (_python_type(c), ...)
+        for c_name, c in columns.items()
+        if c_name != "date_created"
+    }
+    root_name = _name[:-5] if _name.endswith("Model") else _name
+    create_cls = create_model(f"{root_name}Create", **create_fields)
+
+    # UPDATE: all optional fields except 'id' and 'date_created'
+    update_fields = {
+        c_name: (Optional[_python_type(c)], None)
+        for c_name, c in columns.items()
+        if c_name not in ["id", "date_created"]
+    }
+    update_cls = create_model(f"{root_name}Update", **update_fields)
+
+    # READ: all required, including id and date_created
+    read_fields = {"id": (id_type, ...)}
+    for c_name, c in columns.items():
+        read_fields[c_name] = (_python_type(c), ...)
+    if "date_created" not in read_fields and "date_created" in columns:
+        read_fields["date_created"] = (datetime, ...)
+    read_cls = create_model(f"{root_name}Read", **read_fields)
+
+    # CHILD: id only
+    child_cls = create_model(f"{root_name}Child", id=(id_type, ...))
+
+    # Register in global scope and __all__
+    globals()[create_cls.__name__] = create_cls
+    globals()[update_cls.__name__] = update_cls
+    globals()[read_cls.__name__] = read_cls
+    globals()[child_cls.__name__] = child_cls
+    __all__ += [
+        create_cls.__name__,
+        update_cls.__name__,
+        read_cls.__name__,
+        child_cls.__name__,
+    ]
+
+# Explicit exports for common task schemas
+if "TaskRead" in globals():
+    __all__.extend(["TaskRead", "TaskCreate", "TaskUpdate"])


### PR DESCRIPTION
## Summary
- move schema generator into `_generator.py`
- re-export generated schema classes from `peagen.schemas`
- document the generated `Task` and `TaskRun` schemas

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_685f376408a483268c12793a65699590