### PR TITLE
Add Delete schemas

### DIFF
--- a/pkgs/standards/peagen/peagen/schemas/_generator.py
+++ b/pkgs/standards/peagen/peagen/schemas/_generator.py
@@ -67,16 +67,21 @@ for _name in model_names:
     # CHILD: id only
     child_cls = create_model(f"{root_name}Child", id=(id_type, ...))
 
+    # DELETE: id only
+    delete_cls = create_model(f"{root_name}Delete", id=(id_type, ...))
+
     # Register in global scope and __all__
     globals()[create_cls.__name__] = create_cls
     globals()[update_cls.__name__] = update_cls
     globals()[read_cls.__name__] = read_cls
     globals()[child_cls.__name__] = child_cls
+    globals()[delete_cls.__name__] = delete_cls
     __all__ += [
         create_cls.__name__,
         update_cls.__name__,
         read_cls.__name__,
         child_cls.__name__,
+        delete_cls.__name__,
     ]
 
 # Explicit exports for common task schemas

--- a/pkgs/standards/peagen/tests/unit/test_task_roundtrip.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_roundtrip.py
@@ -3,7 +3,7 @@ import datetime
 
 import pytest
 
-from peagen.schemas import TaskCreate, TaskRead, TaskUpdate
+from peagen.schemas import TaskCreate, TaskDelete, TaskRead, TaskUpdate
 
 
 @pytest.mark.unit
@@ -55,3 +55,6 @@ def test_task_schema_fields():
 
     # TaskRead includes date_created
     assert "date_created" in TaskRead.model_fields
+
+    # TaskDelete requires only id
+    assert set(TaskDelete.model_fields) == {"id"}


### PR DESCRIPTION
## Summary
- extend schema generator to produce `<Resource>Delete` models
- test that `TaskDelete` only has an `id` field

## Testing
- `uv run --package peagen --directory standards/peagen ruff format .`
- `uv run --package peagen --directory standards/peagen ruff check . --fix` *(fails: Undefined name `TaskRunModel`)*
- `uv run --package peagen --directory standards/peagen pytest` *(fails: 6 errors during collection)*
- `peagen local process pkgs/standards/peagen/peagen/template_sets/python_orm/example.payload.yaml` *(fails: `TypeError: 'pool' is an invalid keyword argument for TaskModel`)*
- `peagen remote process pkgs/standards/peagen/peagen/template_sets/python_orm/example.payload.yaml` *(fails: `TypeError: 'pool' is an invalid keyword argument for TaskModel`)*

------
https://chatgpt.com/codex/tasks/task_e_685f4e93b7a08326935c493cbbf2ad8d