### PR TITLE
Refactor peagen CLI to validate with TaskCreate

### DIFF
--- a/pkgs/standards/peagen/peagen/_utils/_init.py
+++ b/pkgs/standards/peagen/peagen/_utils/_init.py
@@ -1,6 +1,5 @@
 import asyncio
 import textwrap
-import uuid
 from pathlib import Path
 from typing import Any, Dict
 import re
@@ -8,8 +7,8 @@ import re
 import typer
 from peagen.errors import PATNotAllowedError
 from peagen.handlers.init_handler import init_handler
-from peagen.orm.task import TaskModel
 from peagen.plugins import discover_and_register_plugins
+from peagen.schemas import TaskCreate
 
 _PAT_RE = re.compile(r"(gh[pousr]_\w+|github_pat_[0-9A-Za-z]+)", re.IGNORECASE)
 
@@ -28,8 +27,7 @@ def _call_handler(args: Dict[str, Any]) -> Dict[str, Any]:
     """Invoke ``init_handler`` synchronously."""
     # Ensure plugin templates are registered before invoking handlers
     discover_and_register_plugins()
-    task = Task(
-        id=str(uuid.uuid4()),
+    task = TaskCreate(
         pool="default",
         payload={"action": "init", "args": args},
     )
@@ -42,16 +40,12 @@ def _submit_task(
     """Send *args* to a JSON-RPC worker."""
     if not allow_pat and ("pat" in args or _contains_pat(args)):
         raise PATNotAllowedError()
-    task = Task(
-        id=str(uuid.uuid4()), pool="default", payload={"action": "init", "args": args}
-    )
+    task = TaskCreate(pool="default", payload={"action": "init", "args": args})
     envelope = {
         "jsonrpc": "2.0",
         "method": "Task.submit",
         "params": {
-            "pool": task.pool,
-            "payload": task.payload,
-            "taskId": task.id,
+            **task.model_dump(mode="json"),
         },
     }
 

--- a/pkgs/standards/peagen/peagen/cli/commands/doe.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/doe.py
@@ -17,7 +17,7 @@ import typer
 
 from peagen.handlers.doe_handler import doe_handler
 from peagen.handlers.doe_process_handler import doe_process_handler
-from peagen.orm import Task
+from peagen.schemas import TaskCreate
 from peagen.defaults import TASK_SUBMIT, TASK_GET
 from peagen.orm.status import Status
 
@@ -26,12 +26,9 @@ local_doe_app = typer.Typer(help="Generate project-payload bundles from DOE spec
 remote_doe_app = typer.Typer(help="Generate project-payload bundles from DOE specs.")
 
 
-def _make_task(args: dict, action: str = "doe") -> Task:
-    return Task(
-        id=str(uuid.uuid4()),
+def _make_task(args: dict, action: str = "doe") -> TaskCreate:
+    return TaskCreate(
         pool="default",
-        action=action,
-        status=Status.waiting,
         payload={"action": action, "args": args},
     )
 
@@ -155,7 +152,7 @@ def submit_gen(  # noqa: PLR0913
     rpc_req = {
         "jsonrpc": "2.0",
         "method": TASK_SUBMIT,
-        "params": {"taskId": task.id, "pool": task.pool, "payload": task.payload},
+        "params": task.model_dump(mode="json"),
     }
 
     with httpx.Client(timeout=30.0) as client:
@@ -309,7 +306,7 @@ def submit_process(  # noqa: PLR0913
     rpc_req = {
         "jsonrpc": "2.0",
         "method": TASK_SUBMIT,
-        "params": {"taskId": task.id, "pool": task.pool, "payload": task.payload},
+        "params": task.model_dump(mode="json"),
     }
 
     with httpx.Client(timeout=30.0) as client:

--- a/pkgs/standards/peagen/peagen/cli/commands/eval.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/eval.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import uuid
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -21,9 +20,8 @@ import typer
 from peagen._utils.config_loader import load_peagen_toml
 
 from peagen.handlers.eval_handler import eval_handler
-from peagen.orm import Task
+from peagen.schemas import TaskCreate
 from peagen.defaults import TASK_SUBMIT
-from peagen.orm.status import Status
 
 DEFAULT_GATEWAY = "http://localhost:8000/rpc"
 local_eval_app = typer.Typer(
@@ -35,11 +33,9 @@ remote_eval_app = typer.Typer(
 
 
 # ───────────────────────── helpers ─────────────────────────────────────────
-def _build_task(args: dict, pool: str = "default") -> Task:
-    return Task(
-        id=str(uuid.uuid4()),
+def _build_task(args: dict, pool: str = "default") -> TaskCreate:
+    return TaskCreate(
         pool=pool,
-        status=Status.waiting,
         payload={"action": "eval", "args": args},
     )
 
@@ -135,7 +131,7 @@ def submit(  # noqa: PLR0913
         "jsonrpc": "2.0",
         "id": task.id,
         "method": TASK_SUBMIT,
-        "params": {"taskId": task.id, "pool": task.pool, "payload": task.payload},
+        "params": task.model_dump(mode="json"),
     }
 
     with httpx.Client(timeout=30.0) as client:

--- a/pkgs/standards/peagen/peagen/cli/commands/extras.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/extras.py
@@ -3,14 +3,13 @@
 from __future__ import annotations
 
 import asyncio
-import uuid
 from pathlib import Path
 from typing import Any, Dict, Optional
 
 import typer
 
 from peagen.handlers.extras_handler import extras_handler
-from peagen.orm import Task
+from peagen.schemas import TaskCreate
 from swarmauri_standard.loggers.Logger import Logger
 from peagen.defaults import TASK_SUBMIT
 
@@ -18,10 +17,8 @@ local_extras_app = typer.Typer(help="Manage EXTRAS schemas.")
 remote_extras_app = typer.Typer(help="Manage EXTRAS schemas remotely.")
 
 
-def _build_task(args: Dict[str, Any], pool: str = "default") -> Task:
-    return Task(
-        id=str(uuid.uuid4()), pool=pool, payload={"action": "extras", "args": args}
-    )
+def _build_task(args: Dict[str, Any], pool: str = "default") -> TaskCreate:
+    return TaskCreate(pool=pool, payload={"action": "extras", "args": args})
 
 
 @local_extras_app.command("extras")
@@ -87,10 +84,7 @@ def submit_extras(
     envelope = {
         "jsonrpc": "2.0",
         "method": TASK_SUBMIT,
-        "params": {
-            "pool": task.pool,
-            "payload": task.payload,
-        },
+        "params": task.model_dump(mode="json"),
     }
 
     try:

--- a/pkgs/standards/peagen/peagen/cli/commands/fetch.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/fetch.py
@@ -9,26 +9,22 @@ from __future__ import annotations
 
 import asyncio
 import json
-import uuid
 from pathlib import Path
 from typing import List, Optional
 
 import typer
 
 from peagen.handlers.fetch_handler import fetch_handler
-from peagen.orm import Task
-from peagen.orm.status import Status
+from peagen.schemas import TaskCreate
 
 fetch_app = typer.Typer(help="Materialise Peagen workspaces from URIs.")
 
 
 # ───────────────────────── helpers ─────────────────────────
-def _build_task(args: dict, pool: str = "default") -> Task:
-    """Construct a Task with the fetch action embedded in the payload."""
-    return Task(
-        id=str(uuid.uuid4()),
+def _build_task(args: dict, pool: str = "default") -> TaskCreate:
+    """Construct a ``TaskCreate`` with the fetch action embedded in the payload."""
+    return TaskCreate(
         pool=pool,
-        status=Status.waiting,
         payload={"action": "fetch", "args": args},
     )
 

--- a/pkgs/standards/peagen/peagen/cli/commands/mutate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/mutate.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import uuid
 from pathlib import Path
 from typing import Optional
 
@@ -13,7 +12,7 @@ import httpx
 import typer
 
 from peagen.handlers.mutate_handler import mutate_handler
-from peagen.orm import Task
+from peagen.schemas import TaskCreate
 from peagen.defaults import TASK_SUBMIT
 
 DEFAULT_GATEWAY = "http://localhost:8000/rpc"
@@ -21,9 +20,8 @@ local_mutate_app = typer.Typer(help="Run the mutate workflow")
 remote_mutate_app = typer.Typer(help="Run the mutate workflow")
 
 
-def _build_task(args: dict, pool: str = "default") -> Task:
-    return Task(
-        id=str(uuid.uuid4()),
+def _build_task(args: dict, pool: str = "default") -> TaskCreate:
+    return TaskCreate(
         pool=pool,
         payload={"action": "mutate", "args": args},
     )
@@ -117,11 +115,7 @@ def submit(
     rpc_req = {
         "jsonrpc": "2.0",
         "method": TASK_SUBMIT,
-        "params": {
-            "pool": task.pool,
-            "payload": task.payload,
-            "taskId": task.id,
-        },
+        "params": task.model_dump(mode="json"),
     }
 
     with httpx.Client(timeout=30.0) as client:

--- a/pkgs/standards/peagen/peagen/cli/commands/sort.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/sort.py
@@ -9,7 +9,7 @@ import typer
 
 from peagen._utils.config_loader import _effective_cfg, load_peagen_toml
 from peagen.handlers.sort_handler import sort_handler
-from peagen.orm import Task
+from peagen.schemas import TaskCreate
 from peagen.defaults import TASK_SUBMIT
 
 local_sort_app = typer.Typer(help="Sort generated project files.")
@@ -51,7 +51,7 @@ def run_sort(  # ← now receives the Typer context
     }
     if repo:
         args.update({"repo": repo, "ref": ref})
-    task = Task(
+    task = TaskCreate(
         pool="default",
         payload={
             "action": "sort",
@@ -126,17 +126,16 @@ def submit_sort(
     }
     if repo:
         args.update({"repo": repo, "ref": ref})
-    task = Task(
+    task = TaskCreate(
         pool="default",
         payload={"action": "sort", "args": args},
-        # status and result left as defaults
     )
 
     # 2) Build Task.submit envelope using Task fields
     envelope = {
         "jsonrpc": "2.0",
         "method": TASK_SUBMIT,
-        "params": {"taskId": task.id, "pool": task.pool, "payload": task.payload},
+        "params": task.model_dump(mode="json"),
     }
 
     # 3) POST to gateway

--- a/pkgs/standards/peagen/peagen/orm/task/__init__.py
+++ b/pkgs/standards/peagen/peagen/orm/task/__init__.py
@@ -9,5 +9,5 @@ __all__ = [
     "TaskRunModel",
     "TaskRelationModel",
     "TaskRunTaskRelationAssociationModel",
-    "RawBlobModel"
+    "RawBlobModel",
 ]

--- a/pkgs/standards/peagen/peagen/tui/task_submit.py
+++ b/pkgs/standards/peagen/peagen/tui/task_submit.py
@@ -8,6 +8,7 @@ from typing import Any
 from peagen.schemas import TaskCreate
 from peagen.defaults import TASK_SUBMIT
 
+
 def build_task(action: str, args: dict[str, Any], pool: str = "default") -> TaskCreate:
     """Construct a :class:`TaskCreate` from CLI-style arguments."""
 


### PR DESCRIPTION
## Summary
- refactor CLI commands to use `TaskCreate` models
- update util helpers and schema imports
- fix db helper imports
- run ruff and format on peagen package

## Testing
- `uv run --directory peagen --package peagen ruff format .`
- `uv run --directory peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_685f4efd34088326abaf6cdc1ebbd474