### PR TITLE
Fix ruff issues in peagen package

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/db_helpers.py
+++ b/pkgs/standards/peagen/peagen/gateway/db_helpers.py
@@ -73,9 +73,7 @@ async def upsert_task(session: AsyncSession, row: TaskRunModel) -> None:
     )
     values = [{"task_run_id": row.id, "relation_id": uuid.UUID(d)} for d in row.deps]
     if values:
-        await session.execute(
-            sa.insert(TaskRunTaskRelationAssociationModel), values
-        )
+        await session.execute(sa.insert(TaskRunTaskRelationAssociationModel), values)
     log.info("upsert rowcount=%s id=%s status=%s", result.rowcount, row.id, row.status)
 
 


### PR DESCRIPTION
## Summary
- address lint in gateway helpers
- clean up task submission RPC
- run isolated ruff check on peagen package

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff check .`
- `uv run --package peagen --directory pkgs/standards/peagen pytest -q` *(fails: SyntaxError in gateway module)*

------
https://chatgpt.com/codex/tasks/task_e_685f5afc5b48832697431a0747fd524e