### PR TITLE
Fix peagen unit tests

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/db_helpers.py
+++ b/pkgs/standards/peagen/peagen/gateway/db_helpers.py
@@ -73,9 +73,7 @@ async def upsert_task(session: AsyncSession, row: TaskRunModel) -> None:
     )
     values = [{"task_run_id": row.id, "relation_id": uuid.UUID(d)} for d in row.deps]
     if values:
-        await session.execute(
-            sa.insert(TaskRunTaskRelationAssociationModel), values
-        )
+        await session.execute(sa.insert(TaskRunTaskRelationAssociationModel), values)
     log.info("upsert rowcount=%s id=%s status=%s", result.rowcount, row.id, row.status)
 
 

--- a/pkgs/standards/peagen/peagen/gateway/rpc/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/__init__.py
@@ -1,0 +1,9 @@
+"""RPC method decorator shim for gateway submodules."""
+
+from .. import _rpc_dispatcher
+
+
+def method(name: str):
+    """Delegate to the gateway's dispatcher."""
+
+    return _rpc_dispatcher.method(name)

--- a/pkgs/standards/peagen/peagen/gateway/rpc/secrets.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/secrets.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from .. import log, rpc, Session
+from .. import log, rpc
 from peagen.defaults import SECRETS_ADD, SECRETS_GET, SECRETS_DELETE
 from ..db_helpers import delete_secret, fetch_secret, upsert_secret
 from peagen.defaults.error_codes import ErrorCode
@@ -16,7 +16,9 @@ async def secrets_add(
     version: int | None = None,
 ) -> dict:
     """Store an encrypted secret."""
-    async with Session() as session:
+    from peagen.gateway import db
+
+    async with db.Session() as session:
         await upsert_secret(session, tenant_id, owner_fpr, name, secret)
         await session.commit()
     log.info("secret stored: %s", name)
@@ -26,7 +28,9 @@ async def secrets_add(
 @rpc.method(SECRETS_GET)
 async def secrets_get(name: str, tenant_id: str = "default") -> dict:
     """Retrieve an encrypted secret."""
-    async with Session() as session:
+    from peagen.gateway import db
+
+    async with db.Session() as session:
         row = await fetch_secret(session, tenant_id, name)
     if not row:
         raise RPCException(
@@ -43,7 +47,9 @@ async def secrets_delete(
     version: int | None = None,
 ) -> dict:
     """Remove a secret by name."""
-    async with Session() as session:
+    from peagen.gateway import db
+
+    async with db.Session() as session:
         await delete_secret(session, tenant_id, name)
         await session.commit()
     log.info("secret removed: %s", name)

--- a/pkgs/standards/peagen/peagen/gateway/rpc/workers.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/workers.py
@@ -4,20 +4,8 @@ import time
 
 import httpx
 
-from .. import (
-    _upsert_worker,
-    WORKER_KEY,
-    WORKER_TTL,
-    log,
-    queue,
-    rpc,
-    _load_task,
-    _persist,
-    _publish_task,
-    _save_task,
-    _finalize_parent_tasks,
-)
-from ..orm.status import Status
+from .. import WORKER_KEY, WORKER_TTL, log, queue, rpc
+from peagen.orm.status import Status
 from peagen.transport.jsonrpc import RPCException
 from peagen.defaults import (
     WORKER_REGISTER,
@@ -36,6 +24,8 @@ async def worker_register(
     handlers: list[str] | None = None,
 ) -> dict:
     """Register a worker and persist its advertised handlers."""
+
+    from .. import _upsert_worker
 
     handler_list: list[str] = handlers or []
     if not handler_list:
@@ -110,6 +100,14 @@ async def worker_list(pool: str | None = None) -> list[dict]:
 
 @rpc.method(WORK_FINISHED)
 async def work_finished(taskId: str, status: str, result: dict | None = None) -> dict:
+    from .. import (
+        _finalize_parent_tasks,
+        _load_task,
+        _persist,
+        _publish_task,
+        _save_task,
+    )
+
     t = await _load_task(taskId)
     if not t:
         log.warning("Work.finished for unknown task %s", taskId)

--- a/pkgs/standards/peagen/peagen/orm/__init__.py
+++ b/pkgs/standards/peagen/peagen/orm/__init__.py
@@ -84,6 +84,9 @@ from .result.analysis_result import AnalysisResultModel  # noqa: F401
 from .abuse_record import AbuseRecordModel  # noqa: F401
 from .security.public_key import PublicKeyModel  # noqa: F401
 
+# Backwards compatibility alias
+TaskRun = TaskRunModel
+
 # ----------------------------------------------------------------------
 # Public re-exports
 # ----------------------------------------------------------------------
@@ -105,6 +108,7 @@ __all__: list[str] = [
     "RawBlobModel",
     "Status",
     "TaskRunModel",
+    "TaskRun",
     "TaskRelationModel",
     "TaskRunTaskRelationAssociationModel",
     # evolution


### PR DESCRIPTION
## Summary
- resolve circular imports in gateway module
- add RPC decorator shim and re-export secret functions
- refresh db session lookups
- expose TaskRun alias

## Testing
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_abuse_records.py -q`
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_gateway_client_ip.py -q`
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_scheduler_worker_selection.py -q`
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_secret_store.py -q`
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_secret_store_versioning.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685f70b1c33883268320f00ff7d397bd