### PR TITLE
Fix Peagen unit tests

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/rpc/keys.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/keys.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from pgpy import PGPKey
 
-from .. import log, rpc, TRUSTED_USERS
+from .. import dispatcher, log, TRUSTED_USERS
 from peagen.defaults import KEYS_UPLOAD, KEYS_FETCH, KEYS_DELETE
 
 
-@rpc.method(KEYS_UPLOAD)
+@dispatcher.method(KEYS_UPLOAD)
 async def keys_upload(public_key: str) -> dict:
     """Store a trusted public key."""
     key = PGPKey()
@@ -16,13 +16,13 @@ async def keys_upload(public_key: str) -> dict:
     return {"fingerprint": key.fingerprint}
 
 
-@rpc.method(KEYS_FETCH)
+@dispatcher.method(KEYS_FETCH)
 async def keys_fetch() -> dict:
     """Return all trusted keys indexed by fingerprint."""
     return TRUSTED_USERS
 
 
-@rpc.method(KEYS_DELETE)
+@dispatcher.method(KEYS_DELETE)
 async def keys_delete(fingerprint: str) -> dict:
     """Remove a public key by its fingerprint."""
     TRUSTED_USERS.pop(fingerprint, None)

--- a/pkgs/standards/peagen/peagen/gateway/rpc/pool.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/pool.py
@@ -2,18 +2,18 @@ from __future__ import annotations
 
 import uuid
 
-from .. import log, queue, rpc, READY_QUEUE
+from .. import READY_QUEUE, dispatcher, log, queue
 from peagen.defaults import POOL_CREATE, POOL_JOIN, POOL_LIST_TASKS
 
 
-@rpc.method(POOL_CREATE)
+@dispatcher.method(POOL_CREATE)
 async def pool_create(name: str) -> dict:
     await queue.sadd("pools", name)
     log.info("pool created: %s", name)
     return {"name": name}
 
 
-@rpc.method(POOL_JOIN)
+@dispatcher.method(POOL_JOIN)
 async def pool_join(name: str) -> dict:
     member = str(uuid.uuid4())[:8]
     await queue.sadd(f"pool:{name}:members", member)
@@ -21,7 +21,7 @@ async def pool_join(name: str) -> dict:
     return {"memberId": member}
 
 
-@rpc.method(POOL_LIST_TASKS)
+@dispatcher.method(POOL_LIST_TASKS)
 async def pool_list(
     poolName: str, limit: int | None = None, offset: int = 0
 ) -> list[dict]:

--- a/pkgs/standards/peagen/peagen/gateway/rpc/secrets.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/secrets.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-from .. import log, rpc, Session
+from .. import Session, dispatcher, log
 from peagen.defaults import SECRETS_ADD, SECRETS_GET, SECRETS_DELETE
 from ..db_helpers import delete_secret, fetch_secret, upsert_secret
 from peagen.defaults.error_codes import ErrorCode
 from peagen.transport.jsonrpc import RPCException
 
 
-@rpc.method(SECRETS_ADD)
+@dispatcher.method(SECRETS_ADD)
 async def secrets_add(
     name: str,
     secret: str,
@@ -23,7 +23,7 @@ async def secrets_add(
     return {"ok": True}
 
 
-@rpc.method(SECRETS_GET)
+@dispatcher.method(SECRETS_GET)
 async def secrets_get(name: str, tenant_id: str = "default") -> dict:
     """Retrieve an encrypted secret."""
     async with Session() as session:
@@ -36,7 +36,7 @@ async def secrets_get(name: str, tenant_id: str = "default") -> dict:
     return {"secret": row.cipher}
 
 
-@rpc.method(SECRETS_DELETE)
+@dispatcher.method(SECRETS_DELETE)
 async def secrets_delete(
     name: str,
     tenant_id: str = "default",

--- a/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
@@ -28,9 +28,9 @@ from .. import (
     _publish_task,
     _save_task,
     _select_tasks,
+    dispatcher,
     log,
     queue,
-    rpc,
 )
 from peagen.errors import TaskNotFoundError
 from peagen.schemas import TaskCreate, TaskRead, TaskUpdate
@@ -40,7 +40,7 @@ from peagen.orm.status import Status
 from sqlalchemy.ext.asyncio import AsyncSession as Session
 
 
-@rpc.method(TASK_SUBMIT)
+@dispatcher.method(TASK_SUBMIT)
 async def task_submit(dto: TaskCreate) -> dict:
     """Persist *dto* and enqueue the task."""
 
@@ -92,7 +92,7 @@ async def task_submit(dto: TaskCreate) -> dict:
     return {"taskId": str(task_rd.id)}
 
 
-@rpc.method(TASK_CANCEL)
+@dispatcher.method(TASK_CANCEL)
 async def task_cancel(selector: str) -> dict:
     targets = await _select_tasks(selector)
     from peagen.handlers import control_handler
@@ -102,7 +102,7 @@ async def task_cancel(selector: str) -> dict:
     return {"count": count}
 
 
-@rpc.method(TASK_PAUSE)
+@dispatcher.method(TASK_PAUSE)
 async def task_pause(selector: str) -> dict:
     targets = await _select_tasks(selector)
     from peagen.handlers import control_handler
@@ -112,7 +112,7 @@ async def task_pause(selector: str) -> dict:
     return {"count": count}
 
 
-@rpc.method(TASK_RESUME)
+@dispatcher.method(TASK_RESUME)
 async def task_resume(selector: str) -> dict:
     targets = await _select_tasks(selector)
     from peagen.handlers import control_handler
@@ -122,7 +122,7 @@ async def task_resume(selector: str) -> dict:
     return {"count": count}
 
 
-@rpc.method(TASK_RETRY)
+@dispatcher.method(TASK_RETRY)
 async def task_retry(selector: str) -> dict:
     targets = await _select_tasks(selector)
     from peagen.handlers import control_handler
@@ -132,7 +132,7 @@ async def task_retry(selector: str) -> dict:
     return {"count": count}
 
 
-@rpc.method(TASK_RETRY_FROM)
+@dispatcher.method(TASK_RETRY_FROM)
 async def task_retry_from(selector: str) -> dict:
     targets = await _select_tasks(selector)
     from peagen.handlers import control_handler
@@ -144,14 +144,14 @@ async def task_retry_from(selector: str) -> dict:
     return {"count": count}
 
 
-@rpc.method(GUARD_SET)
+@dispatcher.method(GUARD_SET)
 async def guard_set(label: str, spec: dict) -> dict:
     await queue.hset(f"guard:{label}", mapping=spec)
     log.info("guard set %s", label)
     return {"ok": True}
 
 
-@rpc.method(TASK_PATCH)
+@dispatcher.method(TASK_PATCH)
 async def task_patch(taskId: str, changes: dict) -> dict:
     """Update persisted metadata for an existing task."""
     task = await _load_task(taskId)
@@ -177,7 +177,7 @@ async def task_patch(taskId: str, changes: dict) -> dict:
     return task.model_dump()
 
 
-@rpc.method(TASK_GET)
+@dispatcher.method(TASK_GET)
 async def task_get(taskId: str) -> dict:
     try:
         uuid.UUID(taskId)

--- a/pkgs/standards/peagen/peagen/gateway/rpc/workers.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/workers.py
@@ -5,17 +5,17 @@ import time
 import httpx
 
 from .. import (
-    _upsert_worker,
     WORKER_KEY,
     WORKER_TTL,
-    log,
-    queue,
-    rpc,
+    _finalize_parent_tasks,
     _load_task,
     _persist,
     _publish_task,
     _save_task,
-    _finalize_parent_tasks,
+    _upsert_worker,
+    dispatcher,
+    log,
+    queue,
 )
 from ..orm.status import Status
 from peagen.transport.jsonrpc import RPCException
@@ -27,7 +27,7 @@ from peagen.defaults import (
 )
 
 
-@rpc.method(WORKER_REGISTER)
+@dispatcher.method(WORKER_REGISTER)
 async def worker_register(
     workerId: str,
     pool: str,
@@ -64,7 +64,7 @@ async def worker_register(
     return {"ok": True}
 
 
-@rpc.method(WORKER_HEARTBEAT)
+@dispatcher.method(WORKER_HEARTBEAT)
 async def worker_heartbeat(
     workerId: str,
     metrics: dict,
@@ -89,7 +89,7 @@ async def worker_heartbeat(
     return {"ok": True}
 
 
-@rpc.method(WORKER_LIST)
+@dispatcher.method(WORKER_LIST)
 async def worker_list(pool: str | None = None) -> list[dict]:
     """Return active workers, optionally filtered by *pool*."""
 
@@ -108,7 +108,7 @@ async def worker_list(pool: str | None = None) -> list[dict]:
     return workers
 
 
-@rpc.method(WORK_FINISHED)
+@dispatcher.method(WORK_FINISHED)
 async def work_finished(taskId: str, status: str, result: dict | None = None) -> dict:
     t = await _load_task(taskId)
     if not t:

--- a/pkgs/standards/peagen/peagen/plugins/result_backends/base.py
+++ b/pkgs/standards/peagen/peagen/plugins/result_backends/base.py
@@ -4,13 +4,15 @@ import json
 from pathlib import Path
 from typing import Any, Dict, List
 
-from peagen.orm import TaskRun
+from peagen.orm import TaskRunModel
 
 
 class ResultBackendBase:
     """Default functionality shared by result backend implementations."""
 
-    async def store(self, task_run: TaskRun) -> None:  # pragma: no cover - interface
+    async def store(
+        self, task_run: TaskRunModel
+    ) -> None:  # pragma: no cover - interface
         raise NotImplementedError
 
     async def list_tasks(self) -> List[Dict[str, Any]]:

--- a/pkgs/standards/peagen/peagen/plugins/result_backends/in_memory_backend.py
+++ b/pkgs/standards/peagen/peagen/plugins/result_backends/in_memory_backend.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from peagen.orm import TaskRun
+from peagen.orm import TaskRunModel
 from .base import ResultBackendBase
 
 
@@ -8,7 +8,7 @@ class InMemoryResultBackend(ResultBackendBase):
     """Store TaskRun objects in memory for testing."""
 
     def __init__(self, **_: object) -> None:
-        self.tasks: dict[str, TaskRun] = {}
+        self.tasks: dict[str, TaskRunModel] = {}
 
-    async def store(self, task_run: TaskRun) -> None:
+    async def store(self, task_run: TaskRunModel) -> None:
         self.tasks[str(task_run.id)] = task_run

--- a/pkgs/standards/peagen/peagen/plugins/result_backends/localfs_backend.py
+++ b/pkgs/standards/peagen/peagen/plugins/result_backends/localfs_backend.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from peagen.orm import TaskRun
+from peagen.orm import TaskRunModel
 from .base import ResultBackendBase
 
 
@@ -13,7 +13,7 @@ class LocalFsResultBackend(ResultBackendBase):
         self.root = Path(root_dir)
         self.root.mkdir(parents=True, exist_ok=True)
 
-    async def store(self, task_run: TaskRun) -> None:
+    async def store(self, task_run: TaskRunModel) -> None:
         path = self.root / f"{task_run.id}.json"
         with path.open("w", encoding="utf-8") as fh:
             json.dump(task_run.to_dict(), fh, default=str)

--- a/pkgs/standards/peagen/peagen/plugins/result_backends/postgres_backend.py
+++ b/pkgs/standards/peagen/peagen/plugins/result_backends/postgres_backend.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from peagen.orm import TaskRun
+from peagen.orm import TaskRunModel
 from .base import ResultBackendBase
 
 Session = None
@@ -23,7 +23,7 @@ class PostgresResultBackend(ResultBackendBase):
     def __init__(self, dsn: str | None = None, **_: object) -> None:
         self.dsn = dsn  # unused but kept for future extension
 
-    async def store(self, task_run: TaskRun) -> None:
+    async def store(self, task_run: TaskRunModel) -> None:
         _ensure_deps()
         async with Session() as session:
             await upsert_task(session, task_run)


### PR DESCRIPTION
## Summary
- resolve circular imports in gateway module
- expose secret RPC handlers for tests
- fix TaskRun result backend imports
- handle missing SQLite tables in secret store helper

## Testing
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_abuse_records.py tests/unit/test_gateway_client_ip.py tests/unit/test_scheduler_worker_selection.py tests/unit/test_secret_store.py tests/unit/test_secret_store_versioning.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685f70b1005c832683cd364da0b7b8ce