### PR TITLE
Expose RPC handlers in gateway

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -667,6 +667,26 @@ async def delete_secret_route(name: str, tenant_id: str = "default") -> dict:
     return {"removed": name}
 
 
+# expose RPC handler functions for unit tests
+from .rpc.workers import (  # noqa: F401,E402
+    work_finished,
+    worker_heartbeat,
+    worker_list,
+    worker_register,
+)
+from .rpc.tasks import (  # noqa: F401,E402
+    guard_set,
+    task_cancel,
+    task_get,
+    task_patch,
+    task_pause,
+    task_resume,
+    task_retry,
+    task_retry_from,
+    task_submit,
+)
+
+
 # ─────────────────────────────── Healthcheck ───────────────────────────────
 @app.get("/healthz", tags=["health"])
 async def health() -> dict:

--- a/pkgs/standards/peagen/peagen/gateway/rpc/workers.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/workers.py
@@ -17,7 +17,7 @@ from .. import (
     log,
     queue,
 )
-from ..orm.status import Status
+from peagen.orm.status import Status
 from peagen.transport.jsonrpc import RPCException
 from peagen.defaults import (
     WORKER_REGISTER,


### PR DESCRIPTION
## Summary
- expose worker and task RPC helpers from `peagen.gateway`
- fix incorrect import path in worker RPC module

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_worker_list.py::test_worker_list tests/unit/test_worker_register_handlers.py::test_worker_register_records_handlers tests/unit/test_worker_register_reject_empty.py::test_worker_register_rejects_no_handlers tests/unit/test_worker_register_well_known.py::test_worker_register_fetches_well_known -q`


------
https://chatgpt.com/codex/tasks/task_e_685f8109479483269b1560012e4cb94e