### PR TITLE
Fix worker RPC handler exports

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -721,3 +721,28 @@ async def _on_shutdown() -> None:
     log.info("state flushed to persistent storage")
     await engine.dispose()
     log.info("database connections closed")
+
+
+# expose RPC handlers for test modules
+from .rpc.workers import (  # noqa: F401,E402
+    worker_register,
+    worker_heartbeat,
+    worker_list,
+    work_finished,
+)
+from .rpc.tasks import (  # noqa: F401,E402
+    task_submit,
+    task_cancel,
+    task_pause,
+    task_resume,
+    task_retry,
+    task_retry_from,
+    guard_set,
+    task_patch,
+    task_get,
+)
+from .rpc.pool import (  # noqa: F401,E402
+    pool_create,
+    pool_join,
+    pool_list,
+)

--- a/pkgs/standards/peagen/peagen/gateway/rpc/workers.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/workers.py
@@ -17,7 +17,7 @@ from .. import (
     log,
     queue,
 )
-from ..orm.status import Status
+from ...orm.status import Status
 from peagen.transport.jsonrpc import RPCException
 from peagen.defaults import (
     WORKER_REGISTER,


### PR DESCRIPTION
## Summary
- expose worker/task/pool RPC handlers at gateway module init
- correct relative import for Status in workers module

## Testing
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_worker_register_handlers.py tests/unit/test_worker_register_reject_empty.py tests/unit/test_worker_register_well_known.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685f836df7248326aeab32bf60544a1a