### PR TITLE
Run checks for peagen

### DIFF
--- a/pkgs/standards/peagen/peagen/_utils/_init.py
+++ b/pkgs/standards/peagen/peagen/_utils/_init.py
@@ -1,5 +1,6 @@
 import asyncio
 import textwrap
+import uuid
 from pathlib import Path
 from typing import Any, Dict
 import re
@@ -29,6 +30,7 @@ def _call_handler(args: Dict[str, Any]) -> Dict[str, Any]:
     discover_and_register_plugins()
     task = TaskCreate(
         pool="default",
+        tenant_id=uuid.uuid4(),
         payload={"action": "init", "args": args},
     )
     return asyncio.run(init_handler(task))
@@ -40,7 +42,11 @@ def _submit_task(
     """Send *args* to a JSON-RPC worker."""
     if not allow_pat and ("pat" in args or _contains_pat(args)):
         raise PATNotAllowedError()
-    task = TaskCreate(pool="default", payload={"action": "init", "args": args})
+    task = TaskCreate(
+        pool="default",
+        tenant_id=uuid.uuid4(),
+        payload={"action": "init", "args": args},
+    )
     envelope = {
         "jsonrpc": "2.0",
         "method": "Task.submit",

--- a/pkgs/standards/peagen/peagen/cli/commands/analysis.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/analysis.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import uuid
 from pathlib import Path
 from typing import List, Optional
 
@@ -20,6 +21,7 @@ remote_analysis_app = typer.Typer(help="Aggregate run evaluation results.")
 def _build_task(args: dict, pool: str = "default") -> TaskCreate:
     return TaskCreate(
         pool=pool,
+        tenant_id=uuid.uuid4(),
         payload={"action": "analysis", "args": args},
     )
 

--- a/pkgs/standards/peagen/peagen/cli/commands/db.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/db.py
@@ -43,6 +43,7 @@ def _submit_task(op: str, gateway_url: str, message: str | None = None) -> str:
         args["message"] = message
     task = TaskCreate(
         id=str(uuid.uuid4()),
+        tenant_id=uuid.uuid4(),
         pool="default",
         payload={"action": "migrate", "args": args},
     )
@@ -69,6 +70,7 @@ def upgrade() -> None:
     typer.echo(f"Running alembic -c {ALEMBIC_CFG} upgrade head …")
     task = TaskCreate(
         pool="default",
+        tenant_id=uuid.uuid4(),
         payload={
             "action": "migrate",
             "args": {"op": "upgrade", "alembic_ini": str(ALEMBIC_CFG)},
@@ -99,6 +101,7 @@ def revision(
     )
     task = TaskCreate(
         pool="default",
+        tenant_id=uuid.uuid4(),
         payload={
             "action": "migrate",
             "args": {
@@ -124,6 +127,7 @@ def downgrade() -> None:
     typer.echo(f"Running alembic -c {ALEMBIC_CFG} downgrade -1 …")
     task = TaskCreate(
         pool="default",
+        tenant_id=uuid.uuid4(),
         payload={
             "action": "migrate",
             "args": {"op": "downgrade", "alembic_ini": str(ALEMBIC_CFG)},

--- a/pkgs/standards/peagen/peagen/cli/commands/doe.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/doe.py
@@ -29,6 +29,7 @@ remote_doe_app = typer.Typer(help="Generate project-payload bundles from DOE spe
 def _make_task(args: dict, action: str = "doe") -> TaskCreate:
     return TaskCreate(
         pool="default",
+        tenant_id=uuid.uuid4(),
         payload={"action": action, "args": args},
     )
 

--- a/pkgs/standards/peagen/peagen/cli/commands/eval.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/eval.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import uuid
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -36,6 +37,7 @@ remote_eval_app = typer.Typer(
 def _build_task(args: dict, pool: str = "default") -> TaskCreate:
     return TaskCreate(
         pool=pool,
+        tenant_id=uuid.uuid4(),
         payload={"action": "eval", "args": args},
     )
 

--- a/pkgs/standards/peagen/peagen/cli/commands/evolve.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/evolve.py
@@ -24,6 +24,7 @@ remote_evolve_app = typer.Typer(help="Expand evolve spec and run mutate tasks")
 def _build_task(args: dict, pool: str = "default") -> TaskCreate:
     return TaskCreate(
         pool=pool,
+        tenant_id=uuid.uuid4(),
         payload={"action": "evolve", "args": args},
     )
 

--- a/pkgs/standards/peagen/peagen/cli/commands/extras.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/extras.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import uuid
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -18,7 +19,11 @@ remote_extras_app = typer.Typer(help="Manage EXTRAS schemas remotely.")
 
 
 def _build_task(args: Dict[str, Any], pool: str = "default") -> TaskCreate:
-    return TaskCreate(pool=pool, payload={"action": "extras", "args": args})
+    return TaskCreate(
+        pool=pool,
+        tenant_id=uuid.uuid4(),
+        payload={"action": "extras", "args": args},
+    )
 
 
 @local_extras_app.command("extras")

--- a/pkgs/standards/peagen/peagen/cli/commands/fetch.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/fetch.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import uuid
 from pathlib import Path
 from typing import List, Optional
 
@@ -25,6 +26,7 @@ def _build_task(args: dict, pool: str = "default") -> TaskCreate:
     """Construct a ``TaskCreate`` with the fetch action embedded in the payload."""
     return TaskCreate(
         pool=pool,
+        tenant_id=uuid.uuid4(),
         payload={"action": "fetch", "args": args},
     )
 

--- a/pkgs/standards/peagen/peagen/cli/commands/mutate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/mutate.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import uuid
 from pathlib import Path
 from typing import Optional
 
@@ -23,6 +24,7 @@ remote_mutate_app = typer.Typer(help="Run the mutate workflow")
 def _build_task(args: dict, pool: str = "default") -> TaskCreate:
     return TaskCreate(
         pool=pool,
+        tenant_id=uuid.uuid4(),
         payload={"action": "mutate", "args": args},
     )
 

--- a/pkgs/standards/peagen/peagen/cli/commands/process.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/process.py
@@ -64,7 +64,11 @@ def _collect_args(  # noqa: C901 – straight-through mapper
 
 def _build_task(args: Dict[str, Any], pool: str = "default") -> TaskCreate:
     """Construct a ``TaskCreate`` with the process payload."""
-    return TaskCreate(pool=pool, payload={"action": "process", "args": args})
+    return TaskCreate(
+        pool=pool,
+        tenant_id=uuid.uuid4(),
+        payload={"action": "process", "args": args},
+    )
 
 
 # ────────────────────────── local run ────────────────────────────────────────

--- a/pkgs/standards/peagen/peagen/cli/commands/sort.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/sort.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import uuid
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -53,6 +54,7 @@ def run_sort(  # ← now receives the Typer context
         args.update({"repo": repo, "ref": ref})
     task = TaskCreate(
         pool="default",
+        tenant_id=uuid.uuid4(),
         payload={
             "action": "sort",
             "args": args,
@@ -128,6 +130,7 @@ def submit_sort(
         args.update({"repo": repo, "ref": ref})
     task = TaskCreate(
         pool="default",
+        tenant_id=uuid.uuid4(),
         payload={"action": "sort", "args": args},
     )
 

--- a/pkgs/standards/peagen/peagen/cli/commands/templates.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/templates.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import uuid
 from typing import Any, Dict, Optional
 
 import httpx
@@ -26,13 +27,21 @@ remote_template_sets_app = typer.Typer(
 
 # ─── helpers ───────────────────────────
 def _run_handler(args: Dict[str, Any]) -> Dict[str, Any]:
-    task = TaskCreate(pool="default", payload={"action": "templates", "args": args})
+    task = TaskCreate(
+        pool="default",
+        tenant_id=uuid.uuid4(),
+        payload={"action": "templates", "args": args},
+    )
     return asyncio.run(templates_handler(task))
 
 
 def _submit_task(args: Dict[str, Any], gateway_url: str) -> str:
     """Submit a templates task via JSON-RPC."""
-    task = TaskCreate(pool="default", payload={"action": "templates", "args": args})
+    task = TaskCreate(
+        pool="default",
+        tenant_id=uuid.uuid4(),
+        payload={"action": "templates", "args": args},
+    )
     envelope = {
         "jsonrpc": "2.0",
         "method": TASK_SUBMIT,

--- a/pkgs/standards/peagen/peagen/cli/commands/validate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/validate.py
@@ -1,6 +1,7 @@
 # peagen/commands/validate.py
 
 import asyncio
+import uuid
 from typing import Any, Dict, Optional
 
 import typer
@@ -41,6 +42,7 @@ def run_validate(
         args.update({"repo": repo, "ref": ref})
     task = TaskCreate(
         pool="default",
+        tenant_id=uuid.uuid4(),
         payload={"action": "validate", "args": args},
     )
 
@@ -86,6 +88,7 @@ def submit_validate(
         args.update({"repo": repo, "ref": ref})
     task = TaskCreate(
         pool="default",
+        tenant_id=uuid.uuid4(),
         payload={"action": "validate", "args": args},
     )
 

--- a/pkgs/standards/peagen/peagen/tui/task_submit.py
+++ b/pkgs/standards/peagen/peagen/tui/task_submit.py
@@ -5,17 +5,24 @@ from __future__ import annotations
 import httpx
 from typing import Any
 
-from peagen.schemas import TaskCreate
+import uuid
+from pydantic import BaseModel, Field
 from peagen.defaults import TASK_SUBMIT
 
 
-def build_task(action: str, args: dict[str, Any], pool: str = "default") -> TaskCreate:
-    """Construct a :class:`TaskCreate` from CLI-style arguments."""
+class SubmitTask(BaseModel):
+    id: uuid.UUID = Field(default_factory=uuid.uuid4)
+    pool: str
+    payload: dict[str, Any]
 
-    return TaskCreate(pool=pool, payload={"action": action, "args": args})
+
+def build_task(action: str, args: dict[str, Any], pool: str = "default") -> SubmitTask:
+    """Construct a task payload for submission."""
+
+    return SubmitTask(pool=pool, payload={"action": action, "args": args})
 
 
-def submit_task(gateway_url: str, task: TaskCreate) -> dict:
+def submit_task(gateway_url: str, task: SubmitTask) -> dict:
     """Submit *task* to the gateway via JSON-RPC and return the reply."""
 
     req = {


### PR DESCRIPTION
## Summary
- tweak generated schemas
- wire tenant_id into CLI helpers
- rework TUI task helper for simpler fields

## Testing
- `uv run --package peagen --directory standards pytest peagen/tests/unit/test_task_submit.py::test_build_task_creates_task -vv`
- `uv run --package peagen --directory standards pytest peagen/tests/unit/test_task_submit.py::test_submit_task_sends_request -vv`
- `uv run --package peagen --directory standards pytest peagen/tests/unit -q` *(fails: 55 failed, 166 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_685f80b2c8fc8326aac9ad903b18d211