### PR TITLE
Fix TaskCreate submission tests

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
@@ -5,6 +5,8 @@ import uuid
 
 from peagen.transport.jsonrpc import RPCException
 from peagen.defaults.error_codes import ErrorCode
+import peagen.defaults as defaults
+import hashlib
 from peagen.defaults import (
     TASK_SUBMIT,
     TASK_CANCEL,
@@ -40,15 +42,22 @@ from peagen.orm.status import Status
 from sqlalchemy.ext.asyncio import AsyncSession as Session
 
 
+def _spec_hash(payload: dict) -> str:
+    blob = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(blob.encode()).hexdigest()
+
+
 @dispatcher.method(TASK_SUBMIT)
 async def task_submit(dto: TaskCreate) -> dict:
     """Persist *dto* and enqueue the task."""
 
-    await queue.sadd("pools", dto.pool)
+    pool = dto.parameters.get("pool", defaults.DEFAULT_POOL)
 
-    action = (dto.payload or {}).get("action")
+    await queue.sadd("pools", pool)
+
+    action = dto.parameters.get("action")
     handlers: set[str] = set()
-    for w in await _live_workers_by_pool(dto.pool):
+    for w in await _live_workers_by_pool(pool):
         raw = w.get("handlers", [])
         if isinstance(raw, str):
             try:
@@ -67,6 +76,9 @@ async def task_submit(dto: TaskCreate) -> dict:
         log.warning("task id collision: %s → %s", task_id, new_id)
         task_id = new_id
 
+    if not getattr(dto, "spec_hash", None):
+        dto.spec_hash = _spec_hash(dto.parameters)
+
     async with Session() as ses:
         # 1. create definition-of-task row
         payload = dto.model_dump()
@@ -84,11 +96,11 @@ async def task_submit(dto: TaskCreate) -> dict:
     # 3. make the object that will travel over Redis / websockets
     task_rd = TaskRead.model_validate(task_db.__dict__)
 
-    await queue.rpush(f"{READY_QUEUE}:{task_rd.pool}", task_rd.model_dump_json())
-    await _publish_queue_length(task_rd.pool)
+    await queue.rpush(f"{READY_QUEUE}:{pool}", task_rd.model_dump_json())
+    await _publish_queue_length(pool)
     await _save_task(task_rd)
     await _publish_task(task_rd)
-    log.info("task %s queued in %s (ttl=%ss)", task_rd.id, task_rd.pool, TASK_TTL)
+    log.info("task %s queued in %s (ttl=%s)", task_rd.id, pool, TASK_TTL)
     return {"taskId": str(task_rd.id)}
 
 

--- a/pkgs/standards/peagen/peagen/tui/task_submit.py
+++ b/pkgs/standards/peagen/peagen/tui/task_submit.py
@@ -5,14 +5,33 @@ from __future__ import annotations
 import httpx
 from typing import Any
 
+import hashlib
+import json
+from datetime import datetime, timezone
+from uuid import uuid4
+
 from peagen.schemas import TaskCreate
 from peagen.defaults import TASK_SUBMIT
+
+
+def _spec_hash(obj: dict[str, Any]) -> str:
+    blob = json.dumps(obj, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(blob.encode()).hexdigest()
 
 
 def build_task(action: str, args: dict[str, Any], pool: str = "default") -> TaskCreate:
     """Construct a :class:`TaskCreate` from CLI-style arguments."""
 
-    return TaskCreate(pool=pool, payload={"action": action, "args": args})
+    payload = {"action": action, "args": args, "pool": pool}
+    return TaskCreate(
+        id=uuid4(),
+        tenant_id=uuid4(),
+        git_reference_id=uuid4(),
+        parameters=payload,
+        note="",
+        spec_hash=_spec_hash(payload),
+        last_modified=datetime.now(timezone.utc),
+    )
 
 
 def submit_task(gateway_url: str, task: TaskCreate) -> dict:
@@ -21,7 +40,7 @@ def submit_task(gateway_url: str, task: TaskCreate) -> dict:
     req = {
         "jsonrpc": "2.0",
         "method": TASK_SUBMIT,
-        "params": {"taskId": task.id, "pool": task.pool, "payload": task.payload},
+        "params": json.loads(task.model_dump_json()),
     }
     resp = httpx.post(gateway_url, json=req, timeout=30.0)
     resp.raise_for_status()

--- a/pkgs/standards/peagen/tests/unit/test_task_roundtrip.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_roundtrip.py
@@ -25,13 +25,17 @@ def test_task_roundtrip_json(monkeypatch):
 
     from peagen.gateway import to_orm
 
+    params = {"foo": "bar"}
     create = TaskCreate(
         id=uuid.uuid4(),
         tenant_id=uuid.uuid4(),
         git_reference_id=uuid.uuid4(),
         last_modified=datetime.datetime.now(datetime.timezone.utc),
-        parameters={"foo": "bar"},
+        parameters=params,
         note="demo",
+        spec_hash=gw.rpc.tasks._spec_hash(params)
+        if hasattr(gw.rpc.tasks, "_spec_hash")
+        else "",
     )
     model = to_orm(create)
     model.date_created = datetime.datetime.now(datetime.timezone.utc)

--- a/pkgs/standards/peagen/tests/unit/test_task_submit.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_submit.py
@@ -7,8 +7,8 @@ from peagen.tui.task_submit import build_task, submit_task
 @pytest.mark.unit
 def test_build_task_creates_task():
     task = build_task("demo", {"x": 1})
-    assert task.payload["action"] == "demo"
-    assert task.payload["args"] == {"x": 1}
+    assert task.parameters["action"] == "demo"
+    assert task.parameters["args"] == {"x": 1}
 
 
 @pytest.mark.unit
@@ -31,5 +31,5 @@ def test_submit_task_sends_request(monkeypatch):
     monkeypatch.setattr(httpx, "post", fake_post)
     task = build_task("demo", {})
     reply = submit_task("http://gw/rpc", task)
-    assert captured["json"]["params"]["taskId"] == task.id
+    assert captured["json"]["params"]["id"] == str(task.id)
     assert reply == {"ok": True}


### PR DESCRIPTION
## Summary
- update task submission helpers to match new TaskCreate schema
- revise RPC task_submit implementation
- update unit tests for TaskCreate changes

## Testing
- `ruff format .`
- `ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_task_roundtrip.py tests/unit/test_task_submit.py tests/unit/test_task_submit_unknown.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685f8505010483269f88272926dcbd55