### PR TITLE
Fix init_repo Github patching

### DIFF
--- a/pkgs/standards/peagen/peagen/core/init_core.py
+++ b/pkgs/standards/peagen/peagen/core/init_core.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape, Template
+from github import Github
 
 from peagen.plugins import registry, discover_and_register_plugins
 from peagen.core.doe_core import _sha256
@@ -205,7 +206,6 @@ def init_repo(
     remotes: dict[str, str] | None = None,
 ) -> Dict[str, Any]:
     """Create a GitHub repository and optionally configure a local repo."""
-    from github import Github
     import subprocess
     import tempfile
 


### PR DESCRIPTION
## Summary
- expose Github import at module level so tests can monkeypatch it

## Testing
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_init_repo.py`
- `peagen remote -q --gateway-url http://localhost:8000/rpc process standards/peagen/tests/examples/projects_payloads/projects_payload.yaml --watch` *(fails: File not found)*
- `peagen local -q process standards/peagen/tests/examples/projects_payloads/projects_payload.yaml` *(fails: ValidationError)*


------
https://chatgpt.com/codex/tasks/task_e_685f91deb378832680b483bc3a4467ca