### PR TITLE
Fix repo argument handling in fetch_single

### DIFF
--- a/pkgs/standards/peagen/peagen/core/fetch_core.py
+++ b/pkgs/standards/peagen/peagen/core/fetch_core.py
@@ -75,12 +75,16 @@ def fetch_single(
     Returns a dictionary containing the workspace path, the fetched commit SHA
     when applicable, and whether the repository was updated during the fetch.
     """
-    if repo:
-        if "://" not in repo:
-            workspace_uri = f"gh://{repo}"
-        else:
+    if repo is not None:
+        if "://" in repo:
             workspace_uri = f"git+{repo}@{ref}"
-    if workspace_uri and workspace_uri.startswith("gh://") and "@" not in workspace_uri:
+        elif Path(repo).exists():
+            workspace_uri = repo
+        else:
+            workspace_uri = f"gh://{repo}"
+    elif (
+        workspace_uri and workspace_uri.startswith("gh://") and "@" not in workspace_uri
+    ):
         workspace_uri += f"@{ref}"
     if workspace_uri is None:
         raise ValueError("workspace_uri or repo required")


### PR DESCRIPTION
## Summary
- handle local repo paths correctly in `fetch_single`
- avoid appending ref to GitHub shorthand repos

## Testing
- `uv run --package peagen --directory standards ruff check . --fix`
- `uv run --package peagen --directory standards pytest peagen/tests/unit/test_fetch_git_repo.py peagen/tests/unit/test_fetch_handler.py peagen/tests/unit/test_fetch_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685f935962a88326a255c694cf0e766d