### PR TITLE
Fix evolve_handler child task validation

### DIFF
--- a/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
@@ -103,11 +103,13 @@ async def evolve_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, A
                 mut["uri"] = _resolve_path(uri)
 
         children.append(
-            TaskRead(
-                id=str(uuid.uuid4()),
-                pool=pool,
-                status=Status.waiting,
-                payload={"action": "mutate", "args": job},
+            ensure_task(
+                {
+                    "id": str(uuid.uuid4()),
+                    "pool": pool,
+                    "status": Status.waiting,
+                    "payload": {"action": "mutate", "args": job},
+                }
             )
         )
 


### PR DESCRIPTION
## Summary
- construct child tasks in evolve handler using `ensure_task`
- run ruff format and ruff check
- ensure evolve handler unit test passes

## Testing
- `uv run --package peagen --directory standards/peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_evolve_handler.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685f9565a6608326a23b8e8852936c7f