### PR TITLE
Fix Peagen handlers' child task creation

### DIFF
--- a/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
@@ -126,18 +126,19 @@ async def doe_process_handler(
     children: List[TaskRead] = []
     for path, proj in projects:
         children.append(
-            TaskRead(
-                id=str(uuid.uuid4()),
-                pool=pool,
-                action="process",
-                status=Status.waiting,
-                payload={
-                    "action": "process",
-                    "args": {
-                        "projects_payload": path,
-                        "project_name": proj.get("NAME"),
+            ensure_task(
+                {
+                    "id": str(uuid.uuid4()),
+                    "pool": pool,
+                    "status": Status.waiting,
+                    "payload": {
+                        "action": "process",
+                        "args": {
+                            "projects_payload": path,
+                            "project_name": proj.get("NAME"),
+                        },
                     },
-                },
+                }
             )
         )
 

--- a/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
@@ -103,11 +103,13 @@ async def evolve_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, A
                 mut["uri"] = _resolve_path(uri)
 
         children.append(
-            TaskRead(
-                id=str(uuid.uuid4()),
-                pool=pool,
-                status=Status.waiting,
-                payload={"action": "mutate", "args": job},
+            ensure_task(
+                {
+                    "id": str(uuid.uuid4()),
+                    "pool": pool,
+                    "status": Status.waiting,
+                    "payload": {"action": "mutate", "args": job},
+                }
             )
         )
 


### PR DESCRIPTION
## Summary
- use `ensure_task` when spawning new tasks in evolve and DOE handlers

## Testing
- `uv run --package peagen --directory standards ruff check . --fix`
- `uv run --package peagen --directory standards pytest peagen/tests/unit/test_evolve_handler.py::test_evolve_handler_fanout peagen/tests/unit/test_doe_process_handler.py::test_doe_process_handler_dispatches peagen/tests/unit/test_doe_process_handler.py::test_doe_process_handler_dry_run -q`

------
https://chatgpt.com/codex/tasks/task_e_685f964a611083268d39755d7ec67321