### PR TITLE
Fix style in peagen handlers

### DIFF
--- a/pkgs/standards/peagen/peagen/handlers/__init__.py
+++ b/pkgs/standards/peagen/peagen/handlers/__init__.py
@@ -4,14 +4,11 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from typing import Any, Dict
-from datetime import datetime, timezone
 import uuid
 
 from peagen.orm.status import Status
 
-import uuid
 
-from peagen.orm.status import Status
 from peagen.schemas import TaskRead
 
 


### PR DESCRIPTION
## Summary
- clean up imports in `peagen.handlers`

## Testing
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_extras_handler.py`
- `uv run --directory standards/peagen --package peagen ruff check peagen/handlers/__init__.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_685f968144888326b44c2178e629a482