### PR TITLE
Restrict ensure_task to TaskRead

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -805,4 +805,3 @@ def __getattr__(name: str):
         module = modules[name]
         return getattr(module, name)
     raise AttributeError(name)
-

--- a/pkgs/standards/peagen/peagen/handlers/__init__.py
+++ b/pkgs/standards/peagen/peagen/handlers/__init__.py
@@ -2,39 +2,15 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any, Dict
-
-import uuid
-
-from peagen.orm.status import Status
 from peagen.schemas import TaskRead
 
 
-def ensure_task(task: TaskRead | Dict[str, Any]) -> TaskRead:
-    """Return ``task`` as a :class:`~peagen.schemas.TaskRead` instance."""
+def ensure_task(task: TaskRead) -> TaskRead:
+    """Return ``task`` if it's a :class:`~peagen.schemas.TaskRead` instance."""
 
-    if isinstance(task, TaskRead):
-        return task
-    if not isinstance(task, dict):
-        raise TypeError("task must be a mapping or TaskRead instance")
-
-    try:
-        return TaskRead.model_validate(task)
-    except Exception:
-        now = datetime.now(timezone.utc)
-        return TaskRead.model_construct(
-            id=uuid.uuid4(),
-            tenant_id=uuid.uuid4(),
-            git_reference_id=None,
-            pool=task.get("pool", "default"),
-            payload=task.get("payload", {}),
-            status=task.get("status", Status.queued),
-            note=task.get("note"),
-            spec_hash=task.get("spec_hash", ""),
-            date_created=now,
-            last_modified=now,
-        )
+    if not isinstance(task, TaskRead):
+        raise TypeError("task must be a TaskRead instance")
+    return task
 
 
 __all__ = ["ensure_task"]

--- a/pkgs/standards/peagen/peagen/handlers/analysis_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/analysis_handler.py
@@ -14,8 +14,8 @@ from peagen.plugins.vcs import pea_ref
 from .repo_utils import fetch_repo, cleanup_repo
 
 
-async def analysis_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
-    task = ensure_task(task_or_dict)
+async def analysis_handler(task: TaskRead) -> Dict[str, Any]:
+    task = ensure_task(task)
     payload = task.payload
     args: Dict[str, Any] = payload.get("args", {})
     repo = args.get("repo")

--- a/pkgs/standards/peagen/peagen/handlers/doe_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/doe_handler.py
@@ -17,8 +17,8 @@ from peagen.plugins import PluginManager
 import yaml
 
 
-async def doe_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
-    task = ensure_task(task_or_dict)
+async def doe_handler(task: TaskRead) -> Dict[str, Any]:
+    task = ensure_task(task)
     payload = task.payload
     args: Dict[str, Any] = payload.get("args", {})
 

--- a/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
@@ -20,10 +20,10 @@ from . import ensure_task
 
 
 async def doe_process_handler(
-    task_or_dict: Dict[str, Any] | TaskRead,
+    task: TaskRead,
 ) -> Dict[str, Any]:
     """Expand the DOE spec and spawn a process task for each project."""
-    task = ensure_task(task_or_dict)
+    task = ensure_task(task)
     payload = task.payload
     args: Dict[str, Any] = payload.get("args", {})
     repo = args.get("repo")

--- a/pkgs/standards/peagen/peagen/handlers/eval_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/eval_handler.py
@@ -23,8 +23,8 @@ from peagen.schemas import TaskRead
 from . import ensure_task
 
 
-async def eval_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
-    task = ensure_task(task_or_dict)
+async def eval_handler(task: TaskRead) -> Dict[str, Any]:
+    task = ensure_task(task)
     payload = task.payload
     args: Dict[str, Any] = payload.get("args", {})
     cfg_override: Dict[str, Any] = payload.get("cfg_override", {})

--- a/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
@@ -34,8 +34,8 @@ def _load_spec(path_or_text: str) -> tuple[Path | None, dict]:
     return None, yaml.safe_load(path_or_text)
 
 
-async def evolve_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
-    task = ensure_task(task_or_dict)
+async def evolve_handler(task: TaskRead) -> Dict[str, Any]:
+    task = ensure_task(task)
     payload = task.payload
     args: Dict[str, Any] = payload.get("args", {})
 

--- a/pkgs/standards/peagen/peagen/handlers/extras_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/extras_handler.py
@@ -14,9 +14,9 @@ from peagen.schemas import TaskRead
 from .repo_utils import fetch_repo, cleanup_repo
 
 
-async def extras_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
+async def extras_handler(task: TaskRead) -> Dict[str, Any]:
     """Generate EXTRAS schemas based on template-set ``EXTRAS.md`` files."""
-    task = ensure_task(task_or_dict)
+    task = ensure_task(task)
     payload = task.payload
     args: Dict[str, Any] = payload.get("args", {})
     repo = args.get("repo")

--- a/pkgs/standards/peagen/peagen/handlers/fanout.py
+++ b/pkgs/standards/peagen/peagen/handlers/fanout.py
@@ -12,7 +12,7 @@ from . import ensure_task
 
 
 async def fan_out(
-    parent: TaskRead | Dict[str, Any],
+    parent: TaskRead,
     children: Iterable[TaskRead],
     *,
     result: Dict[str, Any] | None = None,

--- a/pkgs/standards/peagen/peagen/handlers/fetch_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/fetch_handler.py
@@ -18,7 +18,7 @@ from peagen.core.fetch_core import fetch_many
 from peagen.schemas import TaskRead
 
 
-async def fetch_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
+async def fetch_handler(task: TaskRead) -> Dict[str, Any]:
     """
     Parameters (in task.payload.args)
     ---------------------------------
@@ -28,7 +28,7 @@ async def fetch_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, An
     install_template_sets: bool – ignored
     """
     # normalise ---------------------------------------------
-    task = ensure_task(task_or_dict)
+    task = ensure_task(task)
     payload = task.payload
     args: Dict[str, Any] = payload.get("args", {})
     uris: List[str] = args.get("workspaces", [])

--- a/pkgs/standards/peagen/peagen/handlers/init_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/init_handler.py
@@ -17,9 +17,9 @@ from peagen.schemas import TaskRead
 from . import ensure_task
 
 
-async def init_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
+async def init_handler(task: TaskRead) -> Dict[str, Any]:
     """Dispatch to the correct init function based on ``kind``."""
-    task = ensure_task(task_or_dict)
+    task = ensure_task(task)
     payload = task.payload
     args: Dict[str, Any] = payload.get("args", {})
     kind = args.get("kind")

--- a/pkgs/standards/peagen/peagen/handlers/keys_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/keys_handler.py
@@ -10,7 +10,7 @@ from peagen.schemas import TaskRead
 from . import ensure_task
 
 
-async def keys_handler(task: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
+async def keys_handler(task: TaskRead) -> Dict[str, Any]:
     """Handle key management actions."""
     task = ensure_task(task)
     payload = task.payload

--- a/pkgs/standards/peagen/peagen/handlers/login_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/login_handler.py
@@ -10,7 +10,7 @@ from peagen.schemas import TaskRead
 from . import ensure_task
 
 
-async def login_handler(task: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
+async def login_handler(task: TaskRead) -> Dict[str, Any]:
     """Handle a login task."""
     task = ensure_task(task)
     payload = task.payload

--- a/pkgs/standards/peagen/peagen/handlers/migrate_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/migrate_handler.py
@@ -13,8 +13,8 @@ from peagen.schemas import TaskRead
 from . import ensure_task
 
 
-async def migrate_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
-    task = ensure_task(task_or_dict)
+async def migrate_handler(task: TaskRead) -> Dict[str, Any]:
+    task = ensure_task(task)
     args: Dict[str, Any] = task.payload["args"]
     op: str = args["op"]
     cfg_path_str: str | None = args.get("alembic_ini")

--- a/pkgs/standards/peagen/peagen/handlers/mutate_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/mutate_handler.py
@@ -15,8 +15,8 @@ from peagen.plugins import PluginManager
 from peagen.plugins.vcs import pea_ref
 
 
-async def mutate_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
-    task = ensure_task(task_or_dict)
+async def mutate_handler(task: TaskRead) -> Dict[str, Any]:
+    task = ensure_task(task)
     payload = task.payload
     args: Dict[str, Any] = payload.get("args", {})
     repo = args.get("repo")

--- a/pkgs/standards/peagen/peagen/handlers/process_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/process_handler.py
@@ -31,10 +31,10 @@ from . import ensure_task
 logger = Logger(name=__name__)
 
 
-async def process_handler(task: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
+async def process_handler(task: TaskRead) -> Dict[str, Any]:
     """Main coroutine invoked by workers and synchronous CLI runs."""
     # ------------------------------------------------------------------ #
-    # 0) Normalise input – accept TaskRead *or* plain dict
+    # 0) Normalise input
     # ------------------------------------------------------------------ #
     canonical = ensure_task(task)
     payload: Dict[str, Any] = canonical.payload

--- a/pkgs/standards/peagen/peagen/handlers/secrets_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/secrets_handler.py
@@ -10,7 +10,7 @@ from peagen.schemas import TaskRead
 from . import ensure_task
 
 
-async def secrets_handler(task: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
+async def secrets_handler(task: TaskRead) -> Dict[str, Any]:
     """Dispatch secret management actions."""
     task = ensure_task(task)
     payload = task.payload

--- a/pkgs/standards/peagen/peagen/handlers/sort_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/sort_handler.py
@@ -31,7 +31,7 @@ from peagen.core.sort_core import sort_single_project, sort_all_projects
 from peagen._utils.config_loader import resolve_cfg
 
 
-async def sort_handler(task: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
+async def sort_handler(task: TaskRead) -> Dict[str, Any]:
     """
     Async handler registered under JSON-RPC method ``Task.sort`` (or similar).
 

--- a/pkgs/standards/peagen/peagen/handlers/templates_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/templates_handler.py
@@ -20,7 +20,7 @@ from peagen.schemas import TaskRead
 from . import ensure_task
 
 
-async def templates_handler(task: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
+async def templates_handler(task: TaskRead) -> Dict[str, Any]:
     """Dispatch template-set operations based on ``args.operation``."""
     task = ensure_task(task)
     payload = task.payload

--- a/pkgs/standards/peagen/peagen/handlers/validate_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/validate_handler.py
@@ -11,8 +11,8 @@ from peagen.core.validate_core import validate_artifact
 from peagen.schemas import TaskRead
 
 
-async def validate_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
-    task = ensure_task(task_or_dict)
+async def validate_handler(task: TaskRead) -> Dict[str, Any]:
+    task = ensure_task(task)
     args: Dict[str, Any] = task.payload["args"]
     repo = args.get("repo")
     ref = args.get("ref", "HEAD")

--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -118,7 +118,7 @@ class WorkerBase:
         # ─── REGISTER built‐in RPC methods ──────────────────────────
         # 1) Work.start  →  on_work_start (async)
         @self.rpc.method(WORK_START)
-        async def on_work_start(task: Dict[str, Any]) -> Dict[str, Any]:
+        async def on_work_start(task: TaskRead) -> Dict[str, Any]:
             canonical = ensure_task(task)
             self.log.info(
                 "Work.start received    task=%s pool=%s", canonical.id, self.POOL
@@ -206,7 +206,7 @@ class WorkerBase:
         return list(self._handler_registry.keys())
 
     # ───────────────────────── Dispatch & Task Execution ─────────────────────────
-    async def _run_task(self, task: TaskRead | Dict[str, Any]) -> None:
+    async def _run_task(self, task: TaskRead) -> None:
         """Execute *task* by dispatching to a registered handler."""
         canonical = ensure_task(task)
         task_id = canonical.id

--- a/pkgs/standards/peagen/tests/unit/test_doe_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_doe_handler.py
@@ -2,6 +2,10 @@ import pytest
 from pathlib import Path
 
 from peagen.handlers import doe_handler as handler
+from peagen.schemas import TaskRead
+from peagen.orm.status import Status
+import uuid
+from datetime import datetime, timezone
 
 
 @pytest.mark.unit
@@ -26,7 +30,19 @@ async def test_doe_handler_calls_generate_payload(monkeypatch):
         "skip_validate": True,
     }
 
-    result = await handler.doe_handler({"payload": {"args": args}})
+    task = TaskRead.model_construct(
+        id=str(uuid.uuid4()),
+        tenant_id=uuid.uuid4(),
+        git_reference_id=None,
+        pool="default",
+        payload={"args": args},
+        status=Status.queued,
+        note=None,
+        spec_hash="",
+        date_created=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
+    )
+    result = await handler.doe_handler(task)
 
     assert result == {"done": True}
     assert captured["spec_path"] == Path("spec.yml")

--- a/pkgs/standards/peagen/tests/unit/test_doe_process_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_doe_process_handler.py
@@ -1,6 +1,10 @@
 import pytest
 
 from peagen.handlers import doe_process_handler as handler
+from peagen.schemas import TaskRead
+from peagen.orm.status import Status
+import uuid
+from datetime import datetime, timezone
 
 
 @pytest.mark.unit
@@ -57,13 +61,20 @@ async def test_doe_process_handler_dispatches(monkeypatch, tmp_path):
 
     monkeypatch.setattr(handler, "generate_payload", fake_generate_payload)
 
-    task = {
-        "id": "T0",
-        "pool": "default",
-        "payload": {
+    task = TaskRead.model_construct(
+        id="T0",
+        tenant_id=uuid.uuid4(),
+        git_reference_id=None,
+        pool="default",
+        payload={
             "args": {"spec": "s", "template": "t", "output": str(tmp_path / "out.yaml")}
         },
-    }
+        status=Status.queued,
+        note=None,
+        spec_hash="",
+        date_created=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
+    )
     result = await handler.doe_process_handler(task)
 
     assert len(sent) == 4
@@ -133,10 +144,12 @@ async def test_doe_process_handler_dry_run(monkeypatch, tmp_path):
 
     monkeypatch.setattr(handler, "generate_payload", fake_generate_payload)
 
-    task = {
-        "id": "T0",
-        "pool": "default",
-        "payload": {
+    task = TaskRead.model_construct(
+        id="T0",
+        tenant_id=uuid.uuid4(),
+        git_reference_id=None,
+        pool="default",
+        payload={
             "args": {
                 "spec": "s",
                 "template": "t",
@@ -144,7 +157,12 @@ async def test_doe_process_handler_dry_run(monkeypatch, tmp_path):
                 "dry_run": True,
             }
         },
-    }
+        status=Status.queued,
+        note=None,
+        spec_hash="",
+        date_created=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
+    )
     result = await handler.doe_process_handler(task)
 
     assert sent == []

--- a/pkgs/standards/peagen/tests/unit/test_eval_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_eval_handler.py
@@ -1,6 +1,10 @@
 import pytest
 
 from peagen.handlers import eval_handler as handler
+from peagen.schemas import TaskRead
+from peagen.orm.status import Status
+import uuid
+from datetime import datetime, timezone
 
 
 @pytest.mark.unit
@@ -13,7 +17,19 @@ async def test_eval_handler(monkeypatch, strict):
     monkeypatch.setattr(handler, "evaluate_workspace", fake_evaluate_workspace)
 
     args = {"workspace_uri": "ws", "strict": strict}
-    result = await handler.eval_handler({"payload": {"args": args}})
+    task = TaskRead.model_construct(
+        id=str(uuid.uuid4()),
+        tenant_id=uuid.uuid4(),
+        git_reference_id=None,
+        pool="default",
+        payload={"args": args},
+        status=Status.queued,
+        note=None,
+        spec_hash="",
+        date_created=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
+    )
+    result = await handler.eval_handler(task)
 
     assert result["report"]["results"][0]["score"] == 0
     assert result["strict_failed"] == (strict and True)

--- a/pkgs/standards/peagen/tests/unit/test_extras_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_extras_handler.py
@@ -2,6 +2,10 @@ import pytest
 from pathlib import Path
 
 from peagen.handlers import extras_handler as handler
+from peagen.schemas import TaskRead
+from peagen.orm.status import Status
+import uuid
+from datetime import datetime, timezone
 
 
 @pytest.mark.unit
@@ -28,7 +32,19 @@ async def test_extras_handler_calls_generate_schemas(
     if schemas_dir:
         args["schemas_dir"] = schemas_dir
 
-    result = await handler.extras_handler({"payload": {"args": args}})
+    task = TaskRead.model_construct(
+        id=str(uuid.uuid4()),
+        tenant_id=uuid.uuid4(),
+        git_reference_id=None,
+        pool="default",
+        payload={"args": args},
+        status=Status.queued,
+        note=None,
+        spec_hash="",
+        date_created=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
+    )
+    result = await handler.extras_handler(task)
 
     base = Path(handler.__file__).resolve().parents[1]
     expected_templates = (

--- a/pkgs/standards/peagen/tests/unit/test_fetch_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_fetch_handler.py
@@ -2,6 +2,10 @@ import pytest
 from pathlib import Path
 
 from peagen.handlers import fetch_handler as handler
+from peagen.schemas import TaskRead
+from peagen.orm.status import Status
+import uuid
+from datetime import datetime, timezone
 
 
 @pytest.mark.unit
@@ -22,7 +26,19 @@ async def test_fetch_handler_passes_args(monkeypatch):
         "install_template_sets": False,
     }
 
-    result = await handler.fetch_handler({"payload": {"args": args}})
+    task = TaskRead.model_construct(
+        id=str(uuid.uuid4()),
+        tenant_id=uuid.uuid4(),
+        git_reference_id=None,
+        pool="default",
+        payload={"args": args},
+        status=Status.queued,
+        note=None,
+        spec_hash="",
+        date_created=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
+    )
+    result = await handler.fetch_handler(task)
 
     assert result == {"count": 2}
     assert captured["workspace_uris"] == ["w1", "w2"]

--- a/pkgs/standards/peagen/tests/unit/test_init_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_init_handler.py
@@ -2,6 +2,10 @@ import pytest
 from pathlib import Path
 
 from peagen.handlers import init_handler as handler
+from peagen.schemas import TaskRead
+from peagen.orm.status import Status
+import uuid
+from datetime import datetime, timezone
 from peagen.core import init_core
 
 
@@ -25,7 +29,19 @@ async def test_init_handler_dispatch(monkeypatch, kind, func):
 
     monkeypatch.setattr(init_core, func, fake)
     args = {"kind": kind, "path": "~/p"}
-    result = await handler.init_handler({"payload": {"args": args}})
+    task = TaskRead.model_construct(
+        id=str(uuid.uuid4()),
+        tenant_id=uuid.uuid4(),
+        git_reference_id=None,
+        pool="default",
+        payload={"args": args},
+        status=Status.queued,
+        note=None,
+        spec_hash="",
+        date_created=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
+    )
+    result = await handler.init_handler(task)
 
     assert result == {"kind": kind}
     assert called.get("path") == Path("~/p").expanduser()
@@ -35,7 +51,31 @@ async def test_init_handler_dispatch(monkeypatch, kind, func):
 @pytest.mark.asyncio
 async def test_init_handler_errors(monkeypatch):
     with pytest.raises(ValueError):
-        await handler.init_handler({"payload": {"args": {}}})
+        task = TaskRead.model_construct(
+            id=str(uuid.uuid4()),
+            tenant_id=uuid.uuid4(),
+            git_reference_id=None,
+            pool="default",
+            payload={"args": {}},
+            status=Status.queued,
+            note=None,
+            spec_hash="",
+            date_created=datetime.now(timezone.utc),
+            last_modified=datetime.now(timezone.utc),
+        )
+        await handler.init_handler(task)
 
     with pytest.raises(ValueError):
-        await handler.init_handler({"payload": {"args": {"kind": "unknown"}}})
+        task = TaskRead.model_construct(
+            id=str(uuid.uuid4()),
+            tenant_id=uuid.uuid4(),
+            git_reference_id=None,
+            pool="default",
+            payload={"args": {"kind": "unknown"}},
+            status=Status.queued,
+            note=None,
+            spec_hash="",
+            date_created=datetime.now(timezone.utc),
+            last_modified=datetime.now(timezone.utc),
+        )
+        await handler.init_handler(task)

--- a/pkgs/standards/peagen/tests/unit/test_mutate_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_mutate_handler.py
@@ -1,6 +1,10 @@
 import pytest
 
 from peagen.handlers import mutate_handler as handler
+from peagen.schemas import TaskRead
+from peagen.orm.status import Status
+import uuid
+from datetime import datetime, timezone
 
 
 @pytest.mark.unit
@@ -26,7 +30,19 @@ async def test_mutate_handler_invokes_core(monkeypatch):
         "evaluator_ref": "ev",
     }
 
-    result = await handler.mutate_handler({"payload": {"args": args}})
+    task = TaskRead.model_construct(
+        id=str(uuid.uuid4()),
+        tenant_id=uuid.uuid4(),
+        git_reference_id=None,
+        pool="default",
+        payload={"args": args},
+        status=Status.queued,
+        note=None,
+        spec_hash="",
+        date_created=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
+    )
+    result = await handler.mutate_handler(task)
 
     assert result == {"winner": "w.py", "score": "1", "meta": {"ok": True}}
     assert captured["workspace_uri"] == "ws"

--- a/pkgs/standards/peagen/tests/unit/test_mutate_handler_repo.py
+++ b/pkgs/standards/peagen/tests/unit/test_mutate_handler_repo.py
@@ -2,6 +2,10 @@ import pytest
 from pathlib import Path
 from peagen.core.mirror_core import ensure_repo
 from peagen.handlers import mutate_handler as handler
+from peagen.schemas import TaskRead
+from peagen.orm.status import Status
+import uuid
+from datetime import datetime, timezone
 
 
 @pytest.mark.unit
@@ -40,7 +44,19 @@ async def test_mutate_handler_repo(tmp_path: Path, monkeypatch):
         "evaluator_ref": "ev",
     }
 
-    result = await handler.mutate_handler({"payload": {"args": args}})
+    task = TaskRead.model_construct(
+        id=str(uuid.uuid4()),
+        tenant_id=uuid.uuid4(),
+        git_reference_id=None,
+        pool="default",
+        payload={"args": args},
+        status=Status.queued,
+        note=None,
+        spec_hash="",
+        date_created=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
+    )
+    result = await handler.mutate_handler(task)
 
     assert not Path(captured["workspace_uri"]).exists()
     assert result["score"] == "0"

--- a/pkgs/standards/peagen/tests/unit/test_process_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_process_handler.py
@@ -1,6 +1,10 @@
 import pytest
 
 from peagen.handlers import process_handler as handler
+from peagen.schemas import TaskRead
+from peagen.orm.status import Status
+import uuid
+from datetime import datetime, timezone
 
 
 class DummyPM:
@@ -46,7 +50,19 @@ async def test_process_handler_dispatch(monkeypatch, project_name):
     if project_name:
         args["project_name"] = project_name
 
-    result = await handler.process_handler({"payload": {"args": args}})
+    task = TaskRead.model_construct(
+        id=str(uuid.uuid4()),
+        tenant_id=uuid.uuid4(),
+        git_reference_id=None,
+        pool="default",
+        payload={"args": args},
+        status=Status.queued,
+        note=None,
+        spec_hash="",
+        date_created=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
+    )
+    result = await handler.process_handler(task)
 
     if project_name:
         assert calls["single"] == {"NAME": project_name}

--- a/pkgs/standards/peagen/tests/unit/test_sort_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_sort_handler.py
@@ -1,6 +1,10 @@
 import pytest
 
 from peagen.handlers import sort_handler as handler
+from peagen.schemas import TaskRead
+from peagen.orm.status import Status
+import uuid
+from datetime import datetime, timezone
 
 
 @pytest.mark.unit
@@ -28,7 +32,19 @@ async def test_sort_handler_delegates(monkeypatch, project_name):
     if project_name:
         args["project_name"] = project_name
 
-    result = await handler.sort_handler({"payload": {"args": args}})
+    task = TaskRead.model_construct(
+        id=str(uuid.uuid4()),
+        tenant_id=uuid.uuid4(),
+        git_reference_id=None,
+        pool="default",
+        payload={"args": args},
+        status=Status.queued,
+        note=None,
+        spec_hash="",
+        date_created=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
+    )
+    result = await handler.sort_handler(task)
 
     if project_name:
         assert "single" in calls

--- a/pkgs/standards/peagen/tests/unit/test_templates_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_templates_handler.py
@@ -1,6 +1,10 @@
 import pytest
 
 from peagen.handlers import templates_handler as handler
+from peagen.schemas import TaskRead
+from peagen.orm.status import Status
+import uuid
+from datetime import datetime, timezone
 
 
 @pytest.mark.unit
@@ -28,9 +32,19 @@ async def test_templates_handler_dispatch(monkeypatch, op, func, args):
 
     monkeypatch.setattr(handler, func, fake)
 
-    result = await handler.templates_handler(
-        {"payload": {"args": {"operation": op, **args}}}
+    task = TaskRead.model_construct(
+        id=str(uuid.uuid4()),
+        tenant_id=uuid.uuid4(),
+        git_reference_id=None,
+        pool="default",
+        payload={"args": {"operation": op, **args}},
+        status=Status.queued,
+        note=None,
+        spec_hash="",
+        date_created=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
     )
+    result = await handler.templates_handler(task)
 
     assert result == {"op": op}
     assert called


### PR DESCRIPTION
## Summary
- enforce that `ensure_task` only accepts `TaskRead`
- update handlers and worker code to use the stricter interface
- adjust unit tests to create `TaskRead` instances
- run formatting and lint checks
- execute test suite (fails)
- attempt peagen remote/local commands

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format .`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest` *(fails)*
- `peagen remote -q --gateway-url http://localhost:8000/rpc process projects_payload.yaml --watch` *(fails: file not found)*
- `peagen local -q process projects_payload.yaml --watch` *(fails: no such option)*

------
https://chatgpt.com/codex/tasks/task_e_685f953b0b888326b55f1e485807d406