### PR TITLE
Fix local repo fetching in peagen

### DIFF
--- a/pkgs/standards/peagen/peagen/core/fetch_core.py
+++ b/pkgs/standards/peagen/peagen/core/fetch_core.py
@@ -76,11 +76,15 @@ def fetch_single(
     when applicable, and whether the repository was updated during the fetch.
     """
     if repo:
-        if "://" not in repo:
-            workspace_uri = f"gh://{repo}"
-        else:
+        if "://" in repo:
             workspace_uri = f"git+{repo}@{ref}"
-    if workspace_uri and workspace_uri.startswith("gh://") and "@" not in workspace_uri:
+        elif Path(repo).exists():
+            workspace_uri = repo
+        else:
+            workspace_uri = f"gh://{repo}"
+    elif (
+        workspace_uri and workspace_uri.startswith("gh://") and "@" not in workspace_uri
+    ):
         workspace_uri += f"@{ref}"
     if workspace_uri is None:
         raise ValueError("workspace_uri or repo required")

--- a/pkgs/standards/peagen/peagen/handlers/__init__.py
+++ b/pkgs/standards/peagen/peagen/handlers/__init__.py
@@ -4,14 +4,11 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from typing import Any, Dict
-from datetime import datetime, timezone
 import uuid
 
 from peagen.orm.status import Status
 
-import uuid
 
-from peagen.orm.status import Status
 from peagen.schemas import TaskRead
 
 


### PR DESCRIPTION
## Summary
- handle local repository paths correctly in `fetch_single`
- clean up duplicate imports in handlers

## Testing
- `uv run --package peagen --directory standards pytest peagen/tests/unit/test_fetch_git_repo.py -q`
- `peagen remote -q --gateway-url http://localhost:8000/rpc process projects_payload.yaml --watch` *(fails: File not found)*
- `peagen remote -q --gateway-url http://localhost:8000/rpc task get dummy` *(fails: Connection refused)*
- `peagen local -q process projects_payload.yaml --watch` *(fails: No such option --watch)*

------
https://chatgpt.com/codex/tasks/task_e_685f96f9dc0c8326931b0dcf69b75ed4