### PR TITLE
Fix evolve handler tests

### DIFF
--- a/pkgs/standards/peagen/peagen/handlers/__init__.py
+++ b/pkgs/standards/peagen/peagen/handlers/__init__.py
@@ -4,11 +4,6 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from typing import Any, Dict
-from datetime import datetime, timezone
-import uuid
-
-from peagen.orm.status import Status
-
 import uuid
 
 from peagen.orm.status import Status
@@ -41,7 +36,11 @@ def ensure_task(task: TaskRead | Dict[str, Any]) -> TaskRead:
     }
 
     merged = {**defaults, **task}
-    return TaskRead.model_validate(merged)
+    try:
+        return TaskRead.model_validate(merged)
+    except Exception:  # pragma: no cover - fallback for invalid input
+        merged["id"] = uuid.uuid4()
+        return TaskRead.model_validate(merged)
 
 
 __all__ = ["ensure_task"]

--- a/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
-import uuid
 
 import yaml
 
@@ -126,18 +125,18 @@ async def doe_process_handler(
     children: List[TaskRead] = []
     for path, proj in projects:
         children.append(
-            TaskRead(
-                id=str(uuid.uuid4()),
-                pool=pool,
-                action="process",
-                status=Status.waiting,
-                payload={
-                    "action": "process",
-                    "args": {
-                        "projects_payload": path,
-                        "project_name": proj.get("NAME"),
+            ensure_task(
+                {
+                    "pool": pool,
+                    "status": Status.waiting,
+                    "payload": {
+                        "action": "process",
+                        "args": {
+                            "projects_payload": path,
+                            "project_name": proj.get("NAME"),
+                        },
                     },
-                },
+                }
             )
         )
 

--- a/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import uuid
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -103,11 +102,12 @@ async def evolve_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, A
                 mut["uri"] = _resolve_path(uri)
 
         children.append(
-            TaskRead(
-                id=str(uuid.uuid4()),
-                pool=pool,
-                status=Status.waiting,
-                payload={"action": "mutate", "args": job},
+            ensure_task(
+                {
+                    "pool": pool,
+                    "status": Status.waiting,
+                    "payload": {"action": "mutate", "args": job},
+                }
             )
         )
 


### PR DESCRIPTION
## Summary
- adjust `ensure_task` to tolerate invalid IDs
- use `ensure_task` for child task creation in evolve and DOE handlers
- run formatting and fix lint

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_evolve_handler.py -q`
- `peagen local -q process /tmp/projects_payload.yaml` *(fails: ValidationError)*
- `peagen remote -q --gateway-url http://localhost:8000/rpc process /tmp/projects_payload.yaml --watch` *(fails: ValidationError)*

------
https://chatgpt.com/codex/tasks/task_e_685f975422a08326834bf3c78578b47d