### PR TITLE
Fix dry-run skip in doe handler

### DIFF
--- a/pkgs/standards/peagen/peagen/handlers/doe_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/doe_handler.py
@@ -54,7 +54,7 @@ async def doe_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, Any]
         evaluate_runs=args.get("evaluate_runs", False),
     )
 
-    if vcs and not result.get("dry_run"):
+    if vcs and not args.get("dry_run", False):
         repo_root = Path(vcs.repo.working_tree_dir)
         rel_paths: List[str] = [
             os.path.relpath(p, repo_root) for p in result.get("outputs", [])


### PR DESCRIPTION
## Summary
- ensure `doe_handler` skips VCS operations when dry-run is enabled
- ruff format and tests

## Testing
- `uv run --package peagen --directory standards/peagen ruff format .`
- `uv run --package peagen --directory standards/peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_doe_handler.py tests/unit/test_doe_process_handler.py tests/unit/test_eval_handler.py tests/unit/test_evolve_handler.py tests/unit/test_extras_handler.py tests/unit/test_fetch_handler.py tests/unit/test_init_handler.py tests/unit/test_mutate_handler.py tests/unit/test_process_handler.py tests/unit/test_sort_handler.py`
- `peagen remote -q --gateway-url http://localhost:8000/rpc process projects_payload.yaml --watch` *(fails: File not found)*
- `peagen remote -q --gateway-url http://localhost:8000/rpc task get dummy-id` *(fails: Connection refused)*
- `peagen local -q process projects_payload.yaml --watch` *(fails: unrecognized option)*
- `peagen local -q task get dummy-id` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_685f9c6356f8832690e036efbb0637bc