### PR TITLE
Fix task submit tests

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/analysis.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/analysis.py
@@ -37,7 +37,7 @@ def run(
     if repo:
         args.update({"repo": repo, "ref": ref})
     task = _build_task(args, ctx.obj.get("pool", "default"))
-    result = asyncio.run(analysis_handler(task))
+    result = asyncio.run(analysis_handler(task.model_dump(exclude_none=True)))
     typer.echo(
         json.dumps(result, indent=2) if json_out else json.dumps(result, indent=2)
     )

--- a/pkgs/standards/peagen/peagen/cli/commands/doe.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/doe.py
@@ -89,7 +89,7 @@ def run_gen(  # noqa: PLR0913
         args.update({"repo": repo, "ref": ref})
 
     task = _make_task(args, action="doe")
-    result = asyncio.run(doe_handler(task))
+    result = asyncio.run(doe_handler(task.model_dump(exclude_none=True)))
 
     if json_out:
         typer.echo(json.dumps(result, indent=2))
@@ -225,7 +225,7 @@ def run_process(  # noqa: PLR0913
         args.update({"repo": repo, "ref": ref})
 
     task = _make_task(args, action="doe_process")
-    result = asyncio.run(doe_process_handler(task))
+    result = asyncio.run(doe_process_handler(task.model_dump(exclude_none=True)))
 
     typer.echo(
         json.dumps(result, indent=2) if json_out else json.dumps(result, indent=2)

--- a/pkgs/standards/peagen/peagen/cli/commands/eval.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/eval.py
@@ -67,7 +67,7 @@ def run(  # noqa: PLR0913 – CLI needs many options
     if repo:
         args.update({"repo": repo, "ref": ref})
     task = _build_task(args, ctx.obj.get("pool", "default"))
-    result = asyncio.run(eval_handler(task))
+    result = asyncio.run(eval_handler(task.model_dump(exclude_none=True)))
     report = result["report"]
 
     # ----- output ----------------------------------------------------------

--- a/pkgs/standards/peagen/peagen/cli/commands/evolve.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/evolve.py
@@ -69,7 +69,7 @@ def run(
     if repo:
         args.update({"repo": repo, "ref": ref})
     task = _build_task(args, ctx.obj.get("pool", "default"))
-    result = asyncio.run(evolve_handler(task))
+    result = asyncio.run(evolve_handler(task.model_dump()))
     if json_out:
         typer.echo(json.dumps(result, indent=2))
     else:

--- a/pkgs/standards/peagen/peagen/cli/commands/extras.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/extras.py
@@ -46,7 +46,9 @@ def run_extras(
     task = _build_task(args, ctx.obj.get("pool", "default"))
 
     try:
-        result: Dict[str, Any] = asyncio.run(extras_handler(task))
+        result: Dict[str, Any] = asyncio.run(
+            extras_handler(task.model_dump(exclude_none=True))
+        )
     except Exception as exc:
         typer.echo(f"[ERROR] Exception inside extras_handler: {exc}")
         raise typer.Exit(1)

--- a/pkgs/standards/peagen/peagen/cli/commands/fetch.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/fetch.py
@@ -88,5 +88,5 @@ def run(
         pool = ctx.obj.get("pool", "default")
     task = _build_task(args, pool)
 
-    result = asyncio.run(fetch_handler(task))
+    result = asyncio.run(fetch_handler(task.model_dump(exclude_none=True)))
     typer.echo(json.dumps(result, indent=2))

--- a/pkgs/standards/peagen/peagen/cli/commands/mutate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/mutate.py
@@ -67,7 +67,7 @@ def run(
         "mutations": [{"kind": mutator}],
     }
     task = _build_task(args, ctx.obj.get("pool", "default"))
-    result = asyncio.run(mutate_handler(task))
+    result = asyncio.run(mutate_handler(task.model_dump(exclude_none=True)))
 
     if json_out:
         typer.echo(json.dumps(result, indent=2))

--- a/pkgs/standards/peagen/peagen/cli/commands/process.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/process.py
@@ -119,7 +119,7 @@ def run(  # noqa: PLR0913 – CLI signature needs many options
     task = _build_task(args, ctx.obj.get("pool", "default"))
     task.payload["cfg_override"] = cfg_override
 
-    result = asyncio.run(process_handler(task))
+    result = asyncio.run(process_handler(task.model_dump(exclude_none=True)))
     typer.echo(json.dumps(result, indent=2))
 
 

--- a/pkgs/standards/peagen/peagen/cli/commands/sort.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/sort.py
@@ -62,7 +62,9 @@ def run_sort(  # ← now receives the Typer context
 
     # ─────────────────────── 3) call handler ────────────────────────────
     try:
-        result: Dict[str, Any] = asyncio.run(sort_handler(task))
+        result: Dict[str, Any] = asyncio.run(
+            sort_handler(task.model_dump(exclude_none=True))
+        )
     except Exception as exc:
         typer.echo(f"[ERROR] Exception inside sort_handler: {exc}")
         raise typer.Exit(1)

--- a/pkgs/standards/peagen/peagen/cli/commands/templates.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/templates.py
@@ -27,7 +27,7 @@ remote_template_sets_app = typer.Typer(
 # ─── helpers ───────────────────────────
 def _run_handler(args: Dict[str, Any]) -> Dict[str, Any]:
     task = TaskCreate(pool="default", payload={"action": "templates", "args": args})
-    return asyncio.run(templates_handler(task))
+    return asyncio.run(templates_handler(task.model_dump(exclude_none=True)))
 
 
 def _submit_task(args: Dict[str, Any], gateway_url: str) -> str:

--- a/pkgs/standards/peagen/peagen/cli/commands/validate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/validate.py
@@ -46,7 +46,9 @@ def run_validate(
 
     # 2) Call validate_handler(task) via asyncio.run
     try:
-        result: Dict[str, Any] = asyncio.run(validate_handler(task))
+        result: Dict[str, Any] = asyncio.run(
+            validate_handler(task.model_dump(exclude_none=True))
+        )
     except Exception as exc:
         typer.echo(f"[ERROR] Exception inside validate_handler: {exc}")
         raise typer.Exit(1)


### PR DESCRIPTION
## Summary
- generate optional defaults in schema generator
- allow CLI commands to pass task dictionaries to handlers
- fix process CLI and friends to use exclude_none

## Testing
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_task_submit.py -q`
- `peagen remote -q --gateway-url http://localhost:8000/rpc process standards/peagen/tests/examples/projects_payloads/project_payloads.yaml --watch` *(fails: Connection refused)*
- `peagen local -q process tests/examples/projects_payloads/project_payloads.yaml --start-idx 0` *(fails: ProjectsPayloadFormatError)*

------
https://chatgpt.com/codex/tasks/task_e_685f9d002fc88326815a204dd954df37