### PR TITLE
Refactor handlers to require TaskRead

### DIFF
--- a/pkgs/standards/peagen/peagen/_utils/_init.py
+++ b/pkgs/standards/peagen/peagen/_utils/_init.py
@@ -7,6 +7,7 @@ import re
 import typer
 from peagen.errors import PATNotAllowedError
 from peagen.handlers.init_handler import init_handler
+from peagen.handlers import ensure_task
 from peagen.plugins import discover_and_register_plugins
 from peagen.schemas import TaskCreate
 
@@ -31,7 +32,8 @@ def _call_handler(args: Dict[str, Any]) -> Dict[str, Any]:
         pool="default",
         payload={"action": "init", "args": args},
     )
-    return asyncio.run(init_handler(task))
+    canonical = ensure_task(task)
+    return asyncio.run(init_handler(canonical))
 
 
 def _submit_task(

--- a/pkgs/standards/peagen/peagen/cli/commands/analysis.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/analysis.py
@@ -9,6 +9,7 @@ import httpx
 import typer
 
 from peagen.handlers.analysis_handler import analysis_handler
+from peagen.handlers import ensure_task
 from peagen.schemas import TaskCreate
 from peagen.defaults import TASK_SUBMIT
 
@@ -37,7 +38,7 @@ def run(
     if repo:
         args.update({"repo": repo, "ref": ref})
     task = _build_task(args, ctx.obj.get("pool", "default"))
-    result = asyncio.run(analysis_handler(task))
+    result = asyncio.run(analysis_handler(ensure_task(task)))
     typer.echo(
         json.dumps(result, indent=2) if json_out else json.dumps(result, indent=2)
     )

--- a/pkgs/standards/peagen/peagen/cli/commands/db.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/db.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import typer
 
 from peagen.handlers.migrate_handler import migrate_handler
+from peagen.handlers import ensure_task
 
 from peagen.schemas import TaskCreate
 from peagen.defaults import TASK_SUBMIT
@@ -74,7 +75,7 @@ def upgrade() -> None:
             "args": {"op": "upgrade", "alembic_ini": str(ALEMBIC_CFG)},
         },
     }
-    result = asyncio.run(migrate_handler(task))
+    result = asyncio.run(migrate_handler(ensure_task(task)))
     if stdout := result.get("stdout"):
         typer.echo(stdout)
     if stderr := result.get("stderr"):
@@ -108,7 +109,7 @@ def revision(
             },
         },
     }
-    result = asyncio.run(migrate_handler(task))
+    result = asyncio.run(migrate_handler(ensure_task(task)))
     if stdout := result.get("stdout"):
         typer.echo(stdout)
     if stderr := result.get("stderr"):
@@ -129,7 +130,7 @@ def downgrade() -> None:
             "args": {"op": "downgrade", "alembic_ini": str(ALEMBIC_CFG)},
         },
     }
-    result = asyncio.run(migrate_handler(task))
+    result = asyncio.run(migrate_handler(ensure_task(task)))
     if stdout := result.get("stdout"):
         typer.echo(stdout)
     if stderr := result.get("stderr"):

--- a/pkgs/standards/peagen/peagen/cli/commands/doe.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/doe.py
@@ -17,6 +17,7 @@ import typer
 
 from peagen.handlers.doe_handler import doe_handler
 from peagen.handlers.doe_process_handler import doe_process_handler
+from peagen.handlers import ensure_task
 from peagen.schemas import TaskCreate
 from peagen.defaults import TASK_SUBMIT, TASK_GET
 from peagen.orm.status import Status
@@ -89,7 +90,7 @@ def run_gen(  # noqa: PLR0913
         args.update({"repo": repo, "ref": ref})
 
     task = _make_task(args, action="doe")
-    result = asyncio.run(doe_handler(task))
+    result = asyncio.run(doe_handler(ensure_task(task)))
 
     if json_out:
         typer.echo(json.dumps(result, indent=2))
@@ -225,7 +226,7 @@ def run_process(  # noqa: PLR0913
         args.update({"repo": repo, "ref": ref})
 
     task = _make_task(args, action="doe_process")
-    result = asyncio.run(doe_process_handler(task))
+    result = asyncio.run(doe_process_handler(ensure_task(task)))
 
     typer.echo(
         json.dumps(result, indent=2) if json_out else json.dumps(result, indent=2)

--- a/pkgs/standards/peagen/peagen/cli/commands/extras.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/extras.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, Optional
 import typer
 
 from peagen.handlers.extras_handler import extras_handler
+from peagen.handlers import ensure_task
 from peagen.schemas import TaskCreate
 from swarmauri_standard.loggers.Logger import Logger
 from peagen.defaults import TASK_SUBMIT
@@ -46,7 +47,7 @@ def run_extras(
     task = _build_task(args, ctx.obj.get("pool", "default"))
 
     try:
-        result: Dict[str, Any] = asyncio.run(extras_handler(task))
+        result: Dict[str, Any] = asyncio.run(extras_handler(ensure_task(task)))
     except Exception as exc:
         typer.echo(f"[ERROR] Exception inside extras_handler: {exc}")
         raise typer.Exit(1)

--- a/pkgs/standards/peagen/peagen/cli/commands/fetch.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/fetch.py
@@ -17,6 +17,7 @@ from typing import List, Optional
 import typer
 
 from peagen.handlers.fetch_handler import fetch_handler
+from peagen.handlers import ensure_task
 from peagen.orm.status import Status
 from peagen.schemas import TaskCreate
 
@@ -88,5 +89,5 @@ def run(
         pool = ctx.obj.get("pool", "default")
     task = _build_task(args, pool)
 
-    result = asyncio.run(fetch_handler(task))
+    result = asyncio.run(fetch_handler(ensure_task(task)))
     typer.echo(json.dumps(result, indent=2))

--- a/pkgs/standards/peagen/peagen/cli/commands/mutate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/mutate.py
@@ -12,6 +12,7 @@ import httpx
 import typer
 
 from peagen.handlers.mutate_handler import mutate_handler
+from peagen.handlers import ensure_task
 from peagen.schemas import TaskCreate
 from peagen.defaults import TASK_SUBMIT
 
@@ -67,7 +68,7 @@ def run(
         "mutations": [{"kind": mutator}],
     }
     task = _build_task(args, ctx.obj.get("pool", "default"))
-    result = asyncio.run(mutate_handler(task))
+    result = asyncio.run(mutate_handler(ensure_task(task)))
 
     if json_out:
         typer.echo(json.dumps(result, indent=2))

--- a/pkgs/standards/peagen/peagen/cli/commands/process.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/process.py
@@ -22,6 +22,7 @@ import httpx
 import typer
 from peagen._utils.config_loader import _effective_cfg, load_peagen_toml
 from peagen.handlers.process_handler import process_handler
+from peagen.handlers import ensure_task
 from peagen.defaults import TASK_SUBMIT, TASK_GET
 from peagen.schemas import TaskCreate
 from peagen.orm.status import Status
@@ -119,7 +120,7 @@ def run(  # noqa: PLR0913 – CLI signature needs many options
     task = _build_task(args, ctx.obj.get("pool", "default"))
     task.payload["cfg_override"] = cfg_override
 
-    result = asyncio.run(process_handler(task))
+    result = asyncio.run(process_handler(ensure_task(task)))
     typer.echo(json.dumps(result, indent=2))
 
 

--- a/pkgs/standards/peagen/peagen/cli/commands/templates.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/templates.py
@@ -8,6 +8,7 @@ import httpx
 import typer
 
 from peagen.handlers.templates_handler import templates_handler
+from peagen.handlers import ensure_task
 from peagen.schemas import TaskCreate
 from peagen.defaults import TASK_SUBMIT
 
@@ -27,7 +28,7 @@ remote_template_sets_app = typer.Typer(
 # ─── helpers ───────────────────────────
 def _run_handler(args: Dict[str, Any]) -> Dict[str, Any]:
     task = TaskCreate(pool="default", payload={"action": "templates", "args": args})
-    return asyncio.run(templates_handler(task))
+    return asyncio.run(templates_handler(ensure_task(task)))
 
 
 def _submit_task(args: Dict[str, Any], gateway_url: str) -> str:

--- a/pkgs/standards/peagen/peagen/cli/commands/validate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/validate.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Optional
 import typer
 
 from peagen.handlers.validate_handler import validate_handler
+from peagen.handlers import ensure_task
 from peagen.schemas import TaskCreate
 from peagen.defaults import TASK_SUBMIT
 
@@ -46,7 +47,7 @@ def run_validate(
 
     # 2) Call validate_handler(task) via asyncio.run
     try:
-        result: Dict[str, Any] = asyncio.run(validate_handler(task))
+        result: Dict[str, Any] = asyncio.run(validate_handler(ensure_task(task)))
     except Exception as exc:
         typer.echo(f"[ERROR] Exception inside validate_handler: {exc}")
         raise typer.Exit(1)

--- a/pkgs/standards/peagen/peagen/handlers/analysis_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/analysis_handler.py
@@ -7,15 +7,13 @@ from peagen._utils import maybe_clone_repo
 
 from peagen.core.analysis_core import analyze_runs
 from peagen.schemas import TaskRead
-from . import ensure_task
 from peagen._utils.config_loader import resolve_cfg
 from peagen.plugins import PluginManager
 from peagen.plugins.vcs import pea_ref
 from .repo_utils import fetch_repo, cleanup_repo
 
 
-async def analysis_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
-    task = ensure_task(task_or_dict)
+async def analysis_handler(task: TaskRead) -> Dict[str, Any]:
     payload = task.payload
     args: Dict[str, Any] = payload.get("args", {})
     repo = args.get("repo")

--- a/pkgs/standards/peagen/peagen/handlers/doe_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/doe_handler.py
@@ -11,14 +11,12 @@ from peagen.core.doe_core import (
     create_run_branches,
 )
 from peagen.schemas import TaskRead
-from . import ensure_task
 from peagen._utils.config_loader import resolve_cfg
 from peagen.plugins import PluginManager
 import yaml
 
 
-async def doe_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
-    task = ensure_task(task_or_dict)
+async def doe_handler(task: TaskRead) -> Dict[str, Any]:
     payload = task.payload
     args: Dict[str, Any] = payload.get("args", {})
 

--- a/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
@@ -18,11 +18,8 @@ from .fanout import fan_out
 from . import ensure_task
 
 
-async def doe_process_handler(
-    task_or_dict: Dict[str, Any] | TaskRead,
-) -> Dict[str, Any]:
+async def doe_process_handler(task: TaskRead) -> Dict[str, Any]:
     """Expand the DOE spec and spawn a process task for each project."""
-    task = ensure_task(task_or_dict)
     payload = task.payload
     args: Dict[str, Any] = payload.get("args", {})
     repo = args.get("repo")

--- a/pkgs/standards/peagen/peagen/handlers/eval_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/eval_handler.py
@@ -20,11 +20,9 @@ import os
 from peagen.core.eval_core import evaluate_workspace
 from peagen._utils.config_loader import resolve_cfg
 from peagen.schemas import TaskRead
-from . import ensure_task
 
 
-async def eval_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
-    task = ensure_task(task_or_dict)
+async def eval_handler(task: TaskRead) -> Dict[str, Any]:
     payload = task.payload
     args: Dict[str, Any] = payload.get("args", {})
     cfg_override: Dict[str, Any] = payload.get("cfg_override", {})

--- a/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
@@ -33,8 +33,7 @@ def _load_spec(path_or_text: str) -> tuple[Path | None, dict]:
     return None, yaml.safe_load(path_or_text)
 
 
-async def evolve_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
-    task = ensure_task(task_or_dict)
+async def evolve_handler(task: TaskRead) -> Dict[str, Any]:
     payload = task.payload
     args: Dict[str, Any] = payload.get("args", {})
 

--- a/pkgs/standards/peagen/peagen/handlers/extras_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/extras_handler.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict
 
-from . import ensure_task
-
 from peagen._utils import maybe_clone_repo
 
 from peagen.core.extras_core import generate_schemas
@@ -14,9 +12,8 @@ from peagen.schemas import TaskRead
 from .repo_utils import fetch_repo, cleanup_repo
 
 
-async def extras_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
+async def extras_handler(task: TaskRead) -> Dict[str, Any]:
     """Generate EXTRAS schemas based on template-set ``EXTRAS.md`` files."""
-    task = ensure_task(task_or_dict)
     payload = task.payload
     args: Dict[str, Any] = payload.get("args", {})
     repo = args.get("repo")

--- a/pkgs/standards/peagen/peagen/handlers/fetch_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/fetch_handler.py
@@ -12,13 +12,11 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, List
 
-from . import ensure_task
-
 from peagen.core.fetch_core import fetch_many
 from peagen.schemas import TaskRead
 
 
-async def fetch_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
+async def fetch_handler(task: TaskRead) -> Dict[str, Any]:
     """
     Parameters (in task.payload.args)
     ---------------------------------
@@ -28,7 +26,6 @@ async def fetch_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, An
     install_template_sets: bool – ignored
     """
     # normalise ---------------------------------------------
-    task = ensure_task(task_or_dict)
     payload = task.payload
     args: Dict[str, Any] = payload.get("args", {})
     uris: List[str] = args.get("workspaces", [])

--- a/pkgs/standards/peagen/peagen/handlers/init_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/init_handler.py
@@ -14,12 +14,10 @@ from typing import Any, Dict
 
 from peagen.core import init_core
 from peagen.schemas import TaskRead
-from . import ensure_task
 
 
-async def init_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
+async def init_handler(task: TaskRead) -> Dict[str, Any]:
     """Dispatch to the correct init function based on ``kind``."""
-    task = ensure_task(task_or_dict)
     payload = task.payload
     args: Dict[str, Any] = payload.get("args", {})
     kind = args.get("kind")

--- a/pkgs/standards/peagen/peagen/handlers/keys_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/keys_handler.py
@@ -7,12 +7,10 @@ from typing import Any, Dict
 
 from peagen.core import keys_core
 from peagen.schemas import TaskRead
-from . import ensure_task
 
 
-async def keys_handler(task: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
+async def keys_handler(task: TaskRead) -> Dict[str, Any]:
     """Handle key management actions."""
-    task = ensure_task(task)
     payload = task.payload
     action = payload.get("action")
     args: Dict[str, Any] = payload.get("args", {})

--- a/pkgs/standards/peagen/peagen/handlers/login_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/login_handler.py
@@ -7,12 +7,10 @@ from typing import Any, Dict, Optional
 
 from peagen.core.login_core import login
 from peagen.schemas import TaskRead
-from . import ensure_task
 
 
-async def login_handler(task: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
+async def login_handler(task: TaskRead) -> Dict[str, Any]:
     """Handle a login task."""
-    task = ensure_task(task)
     payload = task.payload
     args: Dict[str, Any] = payload.get("args", {})
     key_dir = args.get("key_dir")

--- a/pkgs/standards/peagen/peagen/handlers/migrate_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/migrate_handler.py
@@ -10,11 +10,9 @@ from peagen.core.migrate_core import (
     alembic_upgrade,
 )
 from peagen.schemas import TaskRead
-from . import ensure_task
 
 
-async def migrate_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
-    task = ensure_task(task_or_dict)
+async def migrate_handler(task: TaskRead) -> Dict[str, Any]:
     args: Dict[str, Any] = task.payload["args"]
     op: str = args["op"]
     cfg_path_str: str | None = args.get("alembic_ini")

--- a/pkgs/standards/peagen/peagen/handlers/mutate_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/mutate_handler.py
@@ -6,7 +6,6 @@ import os
 from pathlib import Path
 from typing import Any, Dict
 
-from . import ensure_task
 
 from peagen.core.mutate_core import mutate_workspace
 from peagen.schemas import TaskRead
@@ -15,8 +14,7 @@ from peagen.plugins import PluginManager
 from peagen.plugins.vcs import pea_ref
 
 
-async def mutate_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
-    task = ensure_task(task_or_dict)
+async def mutate_handler(task: TaskRead) -> Dict[str, Any]:
     payload = task.payload
     args: Dict[str, Any] = payload.get("args", {})
     repo = args.get("repo")

--- a/pkgs/standards/peagen/peagen/handlers/process_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/process_handler.py
@@ -26,18 +26,16 @@ from peagen.core.process_core import (
     process_all_projects,
 )
 from peagen.schemas import TaskRead
-from . import ensure_task
 
 logger = Logger(name=__name__)
 
 
-async def process_handler(task: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
+async def process_handler(task: TaskRead) -> Dict[str, Any]:
     """Main coroutine invoked by workers and synchronous CLI runs."""
     # ------------------------------------------------------------------ #
-    # 0) Normalise input – accept TaskRead *or* plain dict
+    # 0) Extract payload and arguments
     # ------------------------------------------------------------------ #
-    canonical = ensure_task(task)
-    payload: Dict[str, Any] = canonical.payload
+    payload: Dict[str, Any] = task.payload
     args: Dict[str, Any] = payload.get("args", {})
     cfg_override = payload.get("cfg_override", {})
     # Mandatory flag

--- a/pkgs/standards/peagen/peagen/handlers/secrets_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/secrets_handler.py
@@ -7,12 +7,10 @@ from typing import Any, Dict
 
 from peagen.core import secrets_core
 from peagen.schemas import TaskRead
-from . import ensure_task
 
 
-async def secrets_handler(task: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
+async def secrets_handler(task: TaskRead) -> Dict[str, Any]:
     """Dispatch secret management actions."""
-    task = ensure_task(task)
     payload = task.payload
     action = payload.get("action")
     args: Dict[str, Any] = payload.get("args", {})

--- a/pkgs/standards/peagen/peagen/handlers/sort_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/sort_handler.py
@@ -23,22 +23,19 @@ from typing import Any, Dict
 
 from peagen.schemas import TaskRead
 
-from . import ensure_task
-
 from peagen._utils import maybe_clone_repo
 
 from peagen.core.sort_core import sort_single_project, sort_all_projects
 from peagen._utils.config_loader import resolve_cfg
 
 
-async def sort_handler(task: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
+async def sort_handler(task: TaskRead) -> Dict[str, Any]:
     """
     Async handler registered under JSON-RPC method ``Task.sort`` (or similar).
 
     • Delegates to sort_core.
     • Returns whatever the core returns (sorted list or error dict).
     """
-    task = ensure_task(task)
     payload = task.payload
     args = payload.get("args", {})
     repo = args.get("repo")

--- a/pkgs/standards/peagen/peagen/handlers/templates_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/templates_handler.py
@@ -17,12 +17,10 @@ from peagen.core.templates_core import (
     remove_template_set,
 )
 from peagen.schemas import TaskRead
-from . import ensure_task
 
 
-async def templates_handler(task: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
+async def templates_handler(task: TaskRead) -> Dict[str, Any]:
     """Dispatch template-set operations based on ``args.operation``."""
-    task = ensure_task(task)
     payload = task.payload
     args: Dict[str, Any] = payload.get("args", {})
     repo = args.get("repo")

--- a/pkgs/standards/peagen/peagen/handlers/validate_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/validate_handler.py
@@ -3,16 +3,13 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict
 
-from . import ensure_task
-
 from peagen._utils import maybe_clone_repo
 
 from peagen.core.validate_core import validate_artifact
 from peagen.schemas import TaskRead
 
 
-async def validate_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
-    task = ensure_task(task_or_dict)
+async def validate_handler(task: TaskRead) -> Dict[str, Any]:
     args: Dict[str, Any] = task.payload["args"]
     repo = args.get("repo")
     ref = args.get("ref", "HEAD")

--- a/pkgs/standards/peagen/tests/unit/test_doe_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_doe_handler.py
@@ -1,7 +1,7 @@
 import pytest
 from pathlib import Path
 
-from peagen.handlers import doe_handler as handler
+from peagen.handlers import doe_handler as handler, ensure_task
 
 
 @pytest.mark.unit
@@ -26,7 +26,7 @@ async def test_doe_handler_calls_generate_payload(monkeypatch):
         "skip_validate": True,
     }
 
-    result = await handler.doe_handler({"payload": {"args": args}})
+    result = await handler.doe_handler(ensure_task({"payload": {"args": args}}))
 
     assert result == {"done": True}
     assert captured["spec_path"] == Path("spec.yml")

--- a/pkgs/standards/peagen/tests/unit/test_eval_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_eval_handler.py
@@ -1,6 +1,6 @@
 import pytest
 
-from peagen.handlers import eval_handler as handler
+from peagen.handlers import eval_handler as handler, ensure_task
 
 
 @pytest.mark.unit
@@ -13,7 +13,7 @@ async def test_eval_handler(monkeypatch, strict):
     monkeypatch.setattr(handler, "evaluate_workspace", fake_evaluate_workspace)
 
     args = {"workspace_uri": "ws", "strict": strict}
-    result = await handler.eval_handler({"payload": {"args": args}})
+    result = await handler.eval_handler(ensure_task({"payload": {"args": args}}))
 
     assert result["report"]["results"][0]["score"] == 0
     assert result["strict_failed"] == (strict and True)

--- a/pkgs/standards/peagen/tests/unit/test_evolve_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_evolve_handler.py
@@ -1,6 +1,6 @@
 import pytest
 
-from peagen.handlers import evolve_handler as handler
+from peagen.handlers import evolve_handler as handler, ensure_task
 
 
 @pytest.mark.unit
@@ -41,7 +41,7 @@ async def test_evolve_handler_fanout(monkeypatch, tmp_path):
         "pool": "default",
         "payload": {"args": {"evolve_spec": str(spec)}},
     }
-    result = await handler.evolve_handler(task)
+    result = await handler.evolve_handler(ensure_task(task))
 
     assert result["jobs"] == 1
     assert sent and sent[-1]["method"] == "Work.finished"

--- a/pkgs/standards/peagen/tests/unit/test_extras_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_extras_handler.py
@@ -1,7 +1,7 @@
 import pytest
 from pathlib import Path
 
-from peagen.handlers import extras_handler as handler
+from peagen.handlers import extras_handler as handler, ensure_task
 
 
 @pytest.mark.unit
@@ -28,7 +28,7 @@ async def test_extras_handler_calls_generate_schemas(
     if schemas_dir:
         args["schemas_dir"] = schemas_dir
 
-    result = await handler.extras_handler({"payload": {"args": args}})
+    result = await handler.extras_handler(ensure_task({"payload": {"args": args}}))
 
     base = Path(handler.__file__).resolve().parents[1]
     expected_templates = (

--- a/pkgs/standards/peagen/tests/unit/test_fetch_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_fetch_handler.py
@@ -1,7 +1,7 @@
 import pytest
 from pathlib import Path
 
-from peagen.handlers import fetch_handler as handler
+from peagen.handlers import fetch_handler as handler, ensure_task
 
 
 @pytest.mark.unit
@@ -22,7 +22,7 @@ async def test_fetch_handler_passes_args(monkeypatch):
         "install_template_sets": False,
     }
 
-    result = await handler.fetch_handler({"payload": {"args": args}})
+    result = await handler.fetch_handler(ensure_task({"payload": {"args": args}}))
 
     assert result == {"count": 2}
     assert captured["workspace_uris"] == ["w1", "w2"]

--- a/pkgs/standards/peagen/tests/unit/test_init_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_init_handler.py
@@ -1,7 +1,7 @@
 import pytest
 from pathlib import Path
 
-from peagen.handlers import init_handler as handler
+from peagen.handlers import init_handler as handler, ensure_task
 from peagen.core import init_core
 
 
@@ -25,7 +25,7 @@ async def test_init_handler_dispatch(monkeypatch, kind, func):
 
     monkeypatch.setattr(init_core, func, fake)
     args = {"kind": kind, "path": "~/p"}
-    result = await handler.init_handler({"payload": {"args": args}})
+    result = await handler.init_handler(ensure_task({"payload": {"args": args}}))
 
     assert result == {"kind": kind}
     assert called.get("path") == Path("~/p").expanduser()
@@ -35,7 +35,9 @@ async def test_init_handler_dispatch(monkeypatch, kind, func):
 @pytest.mark.asyncio
 async def test_init_handler_errors(monkeypatch):
     with pytest.raises(ValueError):
-        await handler.init_handler({"payload": {"args": {}}})
+        await handler.init_handler(ensure_task({"payload": {"args": {}}}))
 
     with pytest.raises(ValueError):
-        await handler.init_handler({"payload": {"args": {"kind": "unknown"}}})
+        await handler.init_handler(
+            ensure_task({"payload": {"args": {"kind": "unknown"}}})
+        )

--- a/pkgs/standards/peagen/tests/unit/test_mutate_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_mutate_handler.py
@@ -1,6 +1,6 @@
 import pytest
 
-from peagen.handlers import mutate_handler as handler
+from peagen.handlers import mutate_handler as handler, ensure_task
 
 
 @pytest.mark.unit
@@ -26,7 +26,7 @@ async def test_mutate_handler_invokes_core(monkeypatch):
         "evaluator_ref": "ev",
     }
 
-    result = await handler.mutate_handler({"payload": {"args": args}})
+    result = await handler.mutate_handler(ensure_task({"payload": {"args": args}}))
 
     assert result == {"winner": "w.py", "score": "1", "meta": {"ok": True}}
     assert captured["workspace_uri"] == "ws"

--- a/pkgs/standards/peagen/tests/unit/test_mutate_handler_repo.py
+++ b/pkgs/standards/peagen/tests/unit/test_mutate_handler_repo.py
@@ -1,7 +1,7 @@
 import pytest
 from pathlib import Path
 from peagen.core.mirror_core import ensure_repo
-from peagen.handlers import mutate_handler as handler
+from peagen.handlers import mutate_handler as handler, ensure_task
 
 
 @pytest.mark.unit
@@ -40,7 +40,7 @@ async def test_mutate_handler_repo(tmp_path: Path, monkeypatch):
         "evaluator_ref": "ev",
     }
 
-    result = await handler.mutate_handler({"payload": {"args": args}})
+    result = await handler.mutate_handler(ensure_task({"payload": {"args": args}}))
 
     assert not Path(captured["workspace_uri"]).exists()
     assert result["score"] == "0"

--- a/pkgs/standards/peagen/tests/unit/test_process_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_process_handler.py
@@ -1,6 +1,6 @@
 import pytest
 
-from peagen.handlers import process_handler as handler
+from peagen.handlers import process_handler as handler, ensure_task
 
 
 class DummyPM:
@@ -46,7 +46,7 @@ async def test_process_handler_dispatch(monkeypatch, project_name):
     if project_name:
         args["project_name"] = project_name
 
-    result = await handler.process_handler({"payload": {"args": args}})
+    result = await handler.process_handler(ensure_task({"payload": {"args": args}}))
 
     if project_name:
         assert calls["single"] == {"NAME": project_name}

--- a/pkgs/standards/peagen/tests/unit/test_sort_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_sort_handler.py
@@ -1,6 +1,6 @@
 import pytest
 
-from peagen.handlers import sort_handler as handler
+from peagen.handlers import sort_handler as handler, ensure_task
 
 
 @pytest.mark.unit
@@ -28,7 +28,7 @@ async def test_sort_handler_delegates(monkeypatch, project_name):
     if project_name:
         args["project_name"] = project_name
 
-    result = await handler.sort_handler({"payload": {"args": args}})
+    result = await handler.sort_handler(ensure_task({"payload": {"args": args}}))
 
     if project_name:
         assert "single" in calls


### PR DESCRIPTION
## Summary
- update all peagen handlers to accept `task: TaskRead`
- adjust CLI commands and helper functions for TaskRead inputs
- update unit tests for the new handler signatures
- apply formatting and lint fixes

## Testing
- `uv run --package peagen --directory standards ruff format .`
- `uv run --package peagen --directory standards ruff check . --fix`
- `uv run --package peagen --directory standards pytest` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685f9dcf6d7c832690d78013e5dbd24f