### PR TITLE
Fix warnings in peagen worker tests

### DIFF
--- a/pkgs/standards/peagen/peagen/core/fetch_core.py
+++ b/pkgs/standards/peagen/peagen/core/fetch_core.py
@@ -19,7 +19,7 @@ from typing import List, Optional
 
 import os
 
-from peagen.plugins.storage_adapters import make_adapter_for_uri  # deprecated
+from peagen.plugins.git_filters import make_filter_for_uri
 from peagen.core.mirror_core import ensure_repo, open_repo
 from peagen.errors import WorkspaceNotFoundError
 
@@ -48,9 +48,9 @@ def _materialise_workspace(uri: str, dest: Path) -> None:
         return
 
     if "://" in uri:
-        adapter = make_adapter_for_uri(uri)
-        prefix = getattr(adapter, "_prefix", "")
-        adapter.download_prefix(prefix, dest)  # type: ignore[attr-defined]
+        git_filter = make_filter_for_uri(uri)
+        prefix = getattr(git_filter, "_prefix", "")
+        git_filter.download_prefix(prefix, dest)  # type: ignore[attr-defined]
         return
 
     path = Path(uri)

--- a/pkgs/standards/peagen/peagen/core/process_core.py
+++ b/pkgs/standards/peagen/peagen/core/process_core.py
@@ -55,7 +55,7 @@ def load_projects_payload(
                 from peagen.plugins import discover_and_register_plugins
 
                 discover_and_register_plugins()
-                from peagen.plugins.storage_adapters import make_adapter_for_uri
+                from peagen.plugins.git_filters import make_filter_for_uri
 
                 parsed = urlparse(projects_payload)
                 if not parsed.scheme:
@@ -63,8 +63,8 @@ def load_projects_payload(
 
                 dir_path, key = parsed.path.rsplit("/", 1)
                 root = urlunparse((parsed.scheme, parsed.netloc, dir_path, "", "", ""))
-                adapter = make_adapter_for_uri(root)
-                with adapter.download(key) as fh:  # type: ignore[attr-defined]
+                git_filter = make_filter_for_uri(root)
+                with git_filter.download(key) as fh:  # type: ignore[attr-defined]
                     yaml_text = fh.read().decode("utf-8")
             else:
                 yaml_text = projects_payload

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -709,8 +709,7 @@ async def health() -> dict:
 
 
 # ───────────────────────────────    Startup  ───────────────────────────────
-@app.on_event("startup")
-async def _on_start():
+async def _on_start() -> None:
     log.info("gateway startup initiated")
     result = migrate_core.alembic_upgrade()
     if not result.get("ok", False):
@@ -743,13 +742,16 @@ async def _on_start():
     log.info("gateway startup complete")
 
 
-@app.on_event("shutdown")
 async def _on_shutdown() -> None:
     log.info("gateway shutdown initiated")
     await _flush_state()
     log.info("state flushed to persistent storage")
     await engine.dispose()
     log.info("database connections closed")
+
+
+app.add_event_handler("startup", _on_start)
+app.add_event_handler("shutdown", _on_shutdown)
 
 
 # expose RPC handlers for test modules

--- a/pkgs/standards/peagen/peagen/gateway/runtime_cfg.py
+++ b/pkgs/standards/peagen/peagen/gateway/runtime_cfg.py
@@ -2,7 +2,7 @@
 
 import os
 from dotenv import load_dotenv
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import Field
 from typing import Optional
 
@@ -47,9 +47,7 @@ class Settings(BaseSettings):
     jwt_secret: str = Field(os.environ.get("JWT_SECRET", "insecure-dev-secret"))
     log_level: str = Field(os.environ.get("LOG_LEVEL", "INFO"))
 
-    class Config:
-        # No env_file needed since we already called load_dotenv().
-        pass
+    model_config = SettingsConfigDict(env_file=None)
 
 
 settings = Settings()

--- a/pkgs/standards/peagen/peagen/orm/base.py
+++ b/pkgs/standards/peagen/peagen/orm/base.py
@@ -1,8 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, declarative_base
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy import DateTime, func
 

--- a/pkgs/standards/peagen/peagen/transport/schemas.py
+++ b/pkgs/standards/peagen/peagen/transport/schemas.py
@@ -5,9 +5,11 @@ from pydantic import BaseModel, Field
 
 
 class RPCErrorData(BaseModel):
-    code: int = Field(..., example=-32601)
-    message: str = Field(..., example="Method not found")
-    data: Optional[Any] = Field(None, example={"detail": "extra info"})
+    code: int = Field(..., json_schema_extra={"example": -32601})
+    message: str = Field(..., json_schema_extra={"example": "Method not found"})
+    data: Optional[Any] = Field(
+        None, json_schema_extra={"example": {"detail": "extra info"}}
+    )
 
 
 class RPCError(Exception):
@@ -22,19 +24,21 @@ class RPCError(Exception):
 
 
 class RPCRequest(BaseModel):
-    jsonrpc: Literal["2.0"] = Field("2.0", example="2.0")
+    jsonrpc: Literal["2.0"] = Field("2.0", json_schema_extra={"example": "2.0"})
     id: Optional[Union[int, str]] = Field(
         None,
         description="Client request-id (optional). If omitted, gateway will supply one.",
         examples=[1, "abc123"],
     )
-    method: str = Field(..., example="Task.submit")
+    method: str = Field(..., json_schema_extra={"example": "Task.submit"})
     params: Optional[Dict[str, Any]] = Field(default_factory=dict)
 
 
 class RPCResponse(BaseModel):
-    jsonrpc: Literal["2.0"] = Field("2.0", example="2.0")
-    id: Union[int, str, None] = Field(..., example=1)
+    jsonrpc: Literal["2.0"] = Field("2.0", json_schema_extra={"example": "2.0"})
+    id: Union[int, str, None] = Field(..., json_schema_extra={"example": 1})
     # exactly one of result / error is present
-    result: Optional[Any] = Field(None, example={"taskId": "01HX..."})
+    result: Optional[Any] = Field(
+        None, json_schema_extra={"example": {"taskId": "01HX..."}}
+    )
     error: Optional[RPCErrorData] = None

--- a/pkgs/standards/peagen/peagen/tui/fileops.py
+++ b/pkgs/standards/peagen/peagen/tui/fileops.py
@@ -5,7 +5,7 @@ import tempfile
 from pathlib import Path
 from urllib.parse import urlparse
 
-from peagen.plugins.storage_adapters import make_adapter_for_uri
+from peagen.plugins.git_filters import make_filter_for_uri
 
 
 def download_remote(uri: str) -> tuple[Path, object, str]:
@@ -13,7 +13,7 @@ def download_remote(uri: str) -> tuple[Path, object, str]:
 
     root = uri.rsplit("/", 1)[0] + "/"
     key = uri.rsplit("/", 1)[1]
-    adapter = make_adapter_for_uri(root)
+    adapter = make_filter_for_uri(root)
     data = adapter.download(key)
     tmp = Path(tempfile.mkdtemp()) / Path(urlparse(uri).path).name
     with open(tmp, "wb") as fh:


### PR DESCRIPTION
## Summary
- silence DeprecationWarnings in peagen by switching to the new `git_filters`
- update ORM and settings to modern APIs
- register FastAPI event handlers without the deprecated `on_event`
- adjust Pydantic schema fields for v2 compatibility

## Testing
- `uv run --package peagen --directory standards ruff format .`
- `uv run --package peagen --directory . ruff check . --fix`
- `uv run --package peagen --directory standards pytest peagen/tests/unit/test_worker_list.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685f9cb33dec8326a5d38ee23ceba442