### PR TITLE
Fix peagen task_submit wrapper

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -699,29 +699,43 @@ from .rpc.tasks import (  # noqa: F401,E402
 
 
 async def task_submit(
-    *, pool: str, payload: dict, taskId: str | None = None, **extras: Any
+    task: TaskCreate | None = None,
+    *,
+    pool: str | None = None,
+    payload: dict | None = None,
+    taskId: str | None = None,
+    **extras: Any,
 ) -> dict:
-    """Compatibility wrapper for :func:`_task_submit_rpc`."""
+    """Compatibility wrapper for :func:`_task_submit_rpc`.
 
-    task = TaskCreate(
-        id=uuid.uuid4(),
-        tenant_id=uuid.uuid4(),
-        git_reference_id=uuid.uuid4(),
-        pool=pool,
-        payload=payload,
-        status=Status.queued,
-        note="",
-        spec_hash="dummy",
-        last_modified=datetime.utcnow(),
-    )
-    if taskId is not None:
-        task.id = taskId
+    Accepts either a preconstructed :class:`TaskCreate` instance as the first
+    positional argument or keyword arguments to build one.
+    """
 
-    for field, value in extras.items():
-        if field in TaskCreate.model_fields:
-            setattr(task, field, value)
+    if task is None:
+        if pool is None or payload is None:
+            raise TypeError("task or pool/payload required")
 
-    task.id = str(task.id)
+        task = TaskCreate(
+            id=uuid.uuid4(),
+            tenant_id=uuid.uuid4(),
+            git_reference_id=uuid.uuid4(),
+            pool=pool,
+            payload=payload,
+            status=Status.queued,
+            note="",
+            spec_hash="dummy",
+            last_modified=datetime.utcnow(),
+        )
+        if taskId is not None:
+            task.id = taskId
+
+        for field, value in extras.items():
+            if field in TaskCreate.model_fields:
+                setattr(task, field, value)
+
+        task.id = str(task.id)
+
     return await _task_submit_rpc(task)
 
 


### PR DESCRIPTION
## Summary
- update `task_submit` wrapper in peagen gateway to accept a `TaskCreate`
- add fallback to construct a task from keyword args

## Testing
- `uv run --package peagen --directory standards ruff format .`
- `uv run --package peagen --directory standards ruff check . --fix`
- `uv run --package peagen --directory standards pytest peagen/tests/unit/test_task_submit.py peagen/tests/unit/test_task_submit_unknown.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685fa0e5c48483269764518875481e2c