### PR TITLE
Fix task type handling

### DIFF
--- a/pkgs/standards/peagen/peagen/handlers/__init__.py
+++ b/pkgs/standards/peagen/peagen/handlers/__init__.py
@@ -7,14 +7,17 @@ from typing import Any, Dict
 import uuid
 
 from peagen.orm.status import Status
-from peagen.schemas import TaskRead
+from peagen.schemas import TaskCreate, TaskRead
 
 
-def ensure_task(task: TaskRead | Dict[str, Any]) -> TaskRead:
+def ensure_task(task: TaskRead | TaskCreate | Dict[str, Any]) -> TaskRead:
     """Return ``task`` as a :class:`~peagen.schemas.TaskRead` instance."""
 
     if isinstance(task, TaskRead):
         return task
+
+    if isinstance(task, TaskCreate):
+        task = task.model_dump()
 
     if not isinstance(task, dict):  # pragma: no cover - defensive
         raise TypeError(f"Expected dict or TaskRead, got {type(task)!r}")


### PR DESCRIPTION
## Summary
- handle `TaskCreate` in `ensure_task`

## Testing
- `ruff format standards/peagen/peagen/handlers/__init__.py`
- `ruff check standards/peagen/peagen/handlers/__init__.py --fix`
- `uv run --package peagen --directory standards/peagen pytest tests/sequence_failure/test_sequences_failure.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685fa2d0b26c8326b1053e9f2d71bb79