### PR TITLE
Fix mutate handler commit addition

### DIFF
--- a/pkgs/standards/peagen/peagen/handlers/mutate_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/mutate_handler.py
@@ -74,7 +74,8 @@ async def mutate_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, A
             branch = pea_ref("run", winner_path.stem)
             vcs.create_branch(branch, checkout=False)
             vcs.push(branch)
-        result["commit"] = commit_sha
+        if commit_sha is not None:
+            result["commit"] = commit_sha
         if branch:
             result["branch"] = branch
     if tmp_dir:


### PR DESCRIPTION
## Summary
- avoid adding `commit` field when mutate workspace didn't create a commit
- keep ruff and pytest clean for peagen

## Testing
- `uv run --package peagen --directory standards/peagen ruff format .`
- `uv run --package peagen --directory standards/peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_mutate_handler.py::test_mutate_handler_invokes_core -q`


------
https://chatgpt.com/codex/tasks/task_e_685fa2ef067083268454195a65186ff7