### PR TITLE
Fix peagen task submit test

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_task_submit_unknown.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_submit_unknown.py
@@ -67,7 +67,7 @@ async def test_task_submit_unknown_action(monkeypatch):
     )
 
     with pytest.raises(gw.RPCException) as exc:
-        await gw.task_submit(task)
+        await gw.task_submit(pool="p", payload=task.payload)
     assert exc.value.code == -32601
     items = await q.lrange("ready:p", 0, -1)
     assert items == []


### PR DESCRIPTION
## Summary
- update `test_task_submit_unknown_action` to use keyword args with gateway
- confirm tests pass

## Testing
- `uv run --package peagen --directory standards ruff check peagen/tests/unit/test_task_submit_unknown.py --fix`
- `uv run --package peagen --directory standards pytest peagen/tests/unit/test_task_submit.py peagen/tests/unit/test_task_submit_unknown.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685fa34ff4048326aeb372f2b22ac53e