### PR TITLE
Fix peagen sequence success tests

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/sort.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/sort.py
@@ -9,7 +9,6 @@ import typer
 
 from peagen._utils.config_loader import _effective_cfg, load_peagen_toml
 from peagen.handlers.sort_handler import sort_handler
-from peagen.schemas import TaskCreate
 from peagen.defaults import TASK_SUBMIT
 
 local_sort_app = typer.Typer(help="Sort generated project files.")
@@ -51,14 +50,14 @@ def run_sort(  # ← now receives the Typer context
     }
     if repo:
         args.update({"repo": repo, "ref": ref})
-    task = TaskCreate(
-        pool="default",
-        payload={
+    task = {
+        "pool": "default",
+        "payload": {
             "action": "sort",
             "args": args,
             "cfg_override": cfg_override,
         },
-    )
+    }
 
     # ─────────────────────── 3) call handler ────────────────────────────
     try:
@@ -126,16 +125,13 @@ def submit_sort(
     }
     if repo:
         args.update({"repo": repo, "ref": ref})
-    task = TaskCreate(
-        pool="default",
-        payload={"action": "sort", "args": args},
-    )
+    task = {"pool": "default", "payload": {"action": "sort", "args": args}}
 
     # 2) Build Task.submit envelope using Task fields
     envelope = {
         "jsonrpc": "2.0",
         "method": TASK_SUBMIT,
-        "params": task.model_dump(mode="json"),
+        "params": task,
     }
 
     # 3) POST to gateway

--- a/pkgs/standards/peagen/peagen/handlers/__init__.py
+++ b/pkgs/standards/peagen/peagen/handlers/__init__.py
@@ -7,17 +7,20 @@ from typing import Any, Dict
 import uuid
 
 from peagen.orm.status import Status
-from peagen.schemas import TaskRead
+from peagen.schemas import TaskCreate, TaskRead
 
 
-def ensure_task(task: TaskRead | Dict[str, Any]) -> TaskRead:
+def ensure_task(task: TaskRead | TaskCreate | Dict[str, Any]) -> TaskRead:
     """Return ``task`` as a :class:`~peagen.schemas.TaskRead` instance."""
 
     if isinstance(task, TaskRead):
         return task
 
+    if isinstance(task, TaskCreate):
+        task = task.model_dump()
+
     if not isinstance(task, dict):  # pragma: no cover - defensive
-        raise TypeError(f"Expected dict or TaskRead, got {type(task)!r}")
+        raise TypeError(f"Expected dict or TaskRead or TaskCreate, got {type(task)!r}")
 
     # If the incoming mapping is missing required fields, assume it comes from
     # a local CLI invocation and populate sane defaults so handler logic can

--- a/pkgs/standards/peagen/tests/sequence_success/examples/demo_success.yaml
+++ b/pkgs/standards/peagen/tests/sequence_success/examples/demo_success.yaml
@@ -8,7 +8,7 @@ command_sets:
       name: "remote sort"
       desc: "run sort remotely and fetch the result"
       commands:
-        - ["remote", "--gateway-url", "https://gw.peagen.com", "sort", "tests/examples/projects_payloads/template_two_project.yaml"]
+        - ["remote", "--gateway-url", "https://gw.peagen.com", "sort", "peagen/tests/examples/projects_payloads/template_two_project.yaml"]
         - ["remote", "--gateway-url", "https://gw.peagen.com", "task", "get", "{task_id}"]
   - batch:
       name: "remote secrets"


### PR DESCRIPTION
## Summary
- support TaskCreate input for `ensure_task`
- use dicts in CLI sort command
- update test example path for sort
- ensure CLI submits correct payload to gateway

## Testing
- `uv run --package peagen --directory standards ruff format .`
- `uv run --package peagen --directory standards ruff check . --fix`
- `uv run --package peagen --directory standards pytest peagen/tests/sequence_success/test_sequences_success.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685fa2d4ba8483269c7fb48a55b2739c