### PR TITLE
Fix worker_list test isolation

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_worker_list.py
+++ b/pkgs/standards/peagen/tests/unit/test_worker_list.py
@@ -28,11 +28,14 @@ async def test_worker_list(monkeypatch):
 
     monkeypatch.setattr(peagen.plugins, "PluginManager", StubPM)
     import peagen.gateway as gw
+    import peagen.gateway.rpc.workers as workers
 
     importlib.reload(gw)
+    importlib.reload(workers)
 
     monkeypatch.setattr(gw, "queue", q)
     monkeypatch.setattr(gw, "result_backend", DummyBackend())
+    monkeypatch.setattr(workers, "queue", q)
 
     async def noop(*_args, **_kw):
         return None


### PR DESCRIPTION
## Summary
- isolate worker queue in `test_worker_list`

## Testing
- `uv run --package peagen --directory standards/peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest -k worker_list -q`


------
https://chatgpt.com/codex/tasks/task_e_685fa2c327108326b1e2b1a5a2b7a3c0