### PR TITLE
Fix mutate handler repo test expectation

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_mutate_handler_repo.py
+++ b/pkgs/standards/peagen/tests/unit/test_mutate_handler_repo.py
@@ -45,5 +45,5 @@ async def test_mutate_handler_repo(tmp_path: Path, monkeypatch):
     assert not Path(captured["workspace_uri"]).exists()
     assert result["score"] == "0"
     assert result["meta"] == {"ok": True}
-    assert result["commit"] is None
+    assert "commit" not in result
     assert "winner_oid" not in result


### PR DESCRIPTION
## Summary
- update expectation for mutate handler repo test

## Testing
- `uv run --package peagen --directory standards/peagen ruff format tests/unit/test_mutate_handler_repo.py`
- `uv run --package peagen --directory standards/peagen ruff check tests/unit/test_mutate_handler_repo.py --fix`
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_mutate_handler_repo.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685fa899b3408326a4753935d6fd31f8