### PR TITLE
Fix load_projects_payload with file:// URIs

### DIFF
--- a/pkgs/standards/peagen/peagen/core/process_core.py
+++ b/pkgs/standards/peagen/peagen/core/process_core.py
@@ -61,11 +61,17 @@ def load_projects_payload(
                 if not parsed.scheme:
                     raise ValueError(f"Invalid URI: {projects_payload}")
 
-                dir_path, key = parsed.path.rsplit("/", 1)
-                root = urlunparse((parsed.scheme, parsed.netloc, dir_path, "", "", ""))
-                git_filter = make_filter_for_uri(root)
-                with git_filter.download(key) as fh:  # type: ignore[attr-defined]
-                    yaml_text = fh.read().decode("utf-8")
+                if parsed.scheme == "file":
+                    path = Path(parsed.path)
+                    yaml_text = path.read_text(encoding="utf-8")
+                else:
+                    dir_path, key = parsed.path.rsplit("/", 1)
+                    root = urlunparse(
+                        (parsed.scheme, parsed.netloc, dir_path, "", "", "")
+                    )
+                    git_filter = make_filter_for_uri(root)
+                    with git_filter.download(key) as fh:  # type: ignore[attr-defined]
+                        yaml_text = fh.read().decode("utf-8")
             else:
                 yaml_text = projects_payload
         except (OSError, TypeError, ValueError):


### PR DESCRIPTION
## Summary
- handle `file://` URIs in `load_projects_payload`
- format with ruff

## Testing
- `uv run --package peagen --directory standards/peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_load_projects_payload.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_685fa8a95db08326b597e1043754f2b2