### PR TITLE
Fix peagen sequence success path

### DIFF
--- a/pkgs/standards/peagen/tests/sequence_success/examples/demo_success.yaml
+++ b/pkgs/standards/peagen/tests/sequence_success/examples/demo_success.yaml
@@ -8,7 +8,7 @@ command_sets:
       name: "remote sort"
       desc: "run sort remotely and fetch the result"
       commands:
-        - ["remote", "--gateway-url", "https://gw.peagen.com", "sort", "peagen/tests/examples/projects_payloads/template_two_project.yaml"]
+        - ["remote", "--gateway-url", "https://gw.peagen.com", "sort", "tests/examples/projects_payloads/template_two_project.yaml"]
         - ["remote", "--gateway-url", "https://gw.peagen.com", "task", "get", "{task_id}"]
   - batch:
       name: "remote secrets"


### PR DESCRIPTION
## Summary
- fix invalid template path in `demo_success.yaml`
- run ruff format/check
- ensure sequence tests pass

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen pytest -k sequences_success -q`
- `uv run --package peagen --directory pkgs/standards/peagen pytest -k sequences_failure -q`

------
https://chatgpt.com/codex/tasks/task_e_685fa82b48cc8326ae92e7f23cb46378