### PR TITLE
Fix FileOps tests via new FileFilter

### DIFF
--- a/pkgs/standards/peagen/peagen/plugins/git_filters/__init__.py
+++ b/pkgs/standards/peagen/peagen/plugins/git_filters/__init__.py
@@ -5,6 +5,7 @@ from urllib.parse import urlparse
 from .minio_filter import MinioFilter
 from .gh_release_filter import GithubReleaseFilter
 from .s3fs_filter import S3FSFilter
+from .file_filter import FileFilter
 from peagen.plugins import PluginManager
 from peagen._utils.config_loader import resolve_cfg
 
@@ -23,6 +24,7 @@ def make_filter_for_uri(uri: str):
 
 
 __all__ = [
+    "FileFilter",
     "MinioFilter",
     "GithubReleaseFilter",
     "S3FSFilter",

--- a/pkgs/standards/peagen/peagen/plugins/git_filters/file_filter.py
+++ b/pkgs/standards/peagen/peagen/plugins/git_filters/file_filter.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import io
+import hashlib
+from pathlib import Path
+
+from peagen.plugins.storage_adapters.file_storage_adapter import FileStorageAdapter
+
+
+class FileFilter(FileStorageAdapter):
+    """Git filter that stores files on the local filesystem."""
+
+    @classmethod
+    def from_uri(cls, uri: str) -> "FileFilter":
+        if not uri.startswith("file://"):
+            raise ValueError("URI must start with file://")
+        path = Path(uri[7:]).resolve()
+        return cls(output_dir=path)
+
+    def clean(self, data: bytes) -> str:
+        """Store *data* under its SHA256 and return the OID."""
+        oid = "sha256:" + hashlib.sha256(data).hexdigest()
+        try:
+            self.download(oid)
+        except FileNotFoundError:
+            self.upload(oid, io.BytesIO(data))
+        return oid
+
+    def smudge(self, oid: str) -> bytes:
+        """Retrieve the bytes for *oid*."""
+        with self.download(oid) as fh:
+            return fh.read()

--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -157,6 +157,7 @@ gh_release    = "peagen.plugins.storage_adapters.gh_release_storage_adapter:Gith
 minio   = "peagen.plugins.git_filters.minio_filter:MinioFilter"
 gh_release    = "peagen.plugins.git_filters.gh_release_filter:GithubReleaseFilter"
 s3fs    = "peagen.plugins.git_filters.s3fs_filter:S3FSFilter"
+file    = "peagen.plugins.git_filters.file_filter:FileFilter"
 
 [project.entry-points."peagen.plugins.vcs"]
 git = "peagen.plugins.vcs.git_vcs:GitVCS"


### PR DESCRIPTION
## Summary
- implement `FileFilter` git filter for local `file://` scheme
- register new filter in plugin init and entry points
- provide ruff and test fixes

## Testing
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_fileops.py -q`
- `uv run --directory standards/peagen --package peagen peagen remote -q process tests/examples/projects_payloads/projects_payload.yaml --watch` *(fails: ValidationError)*
- `uv run --directory standards/peagen --package peagen peagen local -q process tests/examples/projects_payloads/projects_payload.yaml --watch` *(fails: No such option: --watch)*

------
https://chatgpt.com/codex/tasks/task_e_685fa8905f2c8326a0b7f60cddb3cf7a