### PR TITLE
Fix fetch_single copy overwrite

### DIFF
--- a/pkgs/standards/peagen/peagen/core/fetch_core.py
+++ b/pkgs/standards/peagen/peagen/core/fetch_core.py
@@ -57,7 +57,9 @@ def _materialise_workspace(uri: str, dest: Path) -> None:
     if not path.exists():
         raise WorkspaceNotFoundError(uri)
     if path.is_dir():
-        shutil.copytree(path, dest, dirs_exist_ok=True)
+        if dest.exists():
+            shutil.rmtree(dest)
+        shutil.copytree(path, dest)
     else:
         raise ValueError(f"Unsupported workspace URI: {uri}")
 


### PR DESCRIPTION
## Summary
- clean up _materialise_workspace overwrites
- ensure `fetch_single` removes existing workspace before copy

## Testing
- `uv run --package peagen --directory standards ruff format .`
- `uv run --package peagen --directory standards ruff check . --fix`
- `uv run --package peagen --directory standards pytest peagen/tests/unit/test_fetch_git_repo.py::test_fetch_single_detects_updates -q`


------
https://chatgpt.com/codex/tasks/task_e_685fac8c064083268bc4263d6533bf3f