### PR TITLE
Fix fetch_single repo updates

### DIFF
--- a/pkgs/standards/peagen/peagen/core/fetch_core.py
+++ b/pkgs/standards/peagen/peagen/core/fetch_core.py
@@ -57,7 +57,9 @@ def _materialise_workspace(uri: str, dest: Path) -> None:
     if not path.exists():
         raise WorkspaceNotFoundError(uri)
     if path.is_dir():
-        shutil.copytree(path, dest, dirs_exist_ok=True)
+        if dest.exists():
+            shutil.rmtree(dest)
+        shutil.copytree(path, dest)
     else:
         raise ValueError(f"Unsupported workspace URI: {uri}")
 


### PR DESCRIPTION
## Summary
- fix workspace copy when destination already exists
- keep ruff checks green
- ensure fetch_single update detection works

## Testing
- `uv run --package peagen --directory . pytest -k test_fetch_git_repo -q`

------
https://chatgpt.com/codex/tasks/task_e_685fae9e17908326a59dfcb9122b7e44