### PR TITLE
Fix Alembic head conflict

### DIFF
--- a/pkgs/standards/peagen/peagen/migrations/versions/0b9f60f12a3f_merge_heads.py
+++ b/pkgs/standards/peagen/peagen/migrations/versions/0b9f60f12a3f_merge_heads.py
@@ -1,0 +1,16 @@
+"""merge spec_hash and automated revision heads"""
+
+from typing import Sequence, Union
+
+revision = "0b9f60f12a3f"
+down_revision: Union[str, Sequence[str], None] = ("abcd1234efgh", "97a9f54587b2")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary
- add merge revision to unify alembic heads

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest` *(fails: tests/sequence_success/test_sequences_success.py::test_sequences_success[example0])*

------
https://chatgpt.com/codex/tasks/task_e_685fb3abf4448326af86bf0d62397087