### PR TITLE
Fix gateway migration command

### DIFF
--- a/pkgs/standards/peagen/peagen/core/migrate_core.py
+++ b/pkgs/standards/peagen/peagen/core/migrate_core.py
@@ -80,14 +80,14 @@ def _run_alembic(cmd: List[str], stream: bool) -> Dict[str, Any]:
 
 
 def alembic_upgrade(cfg: Path = ALEMBIC_CFG, *, stream: bool = False) -> Dict[str, Any]:
-    """Apply migrations up to HEAD using *cfg*."""
+    """Apply all outstanding migrations using *cfg*."""
     return _run_alembic(
         [
             "alembic",
             "-c",
             str(cfg),
             "upgrade",
-            "head",
+            "heads",
         ],
         stream,
     )

--- a/pkgs/standards/peagen/tests/unit/test_migrate_core.py
+++ b/pkgs/standards/peagen/tests/unit/test_migrate_core.py
@@ -23,7 +23,7 @@ def test_alembic_upgrade_invokes_subprocess(monkeypatch, tmp_path: Path):
     result = migrate_core.alembic_upgrade(cfg)
 
     assert result == {"ok": True, "stdout": "stdout", "stderr": ""}
-    assert calls["cmd"] == ["alembic", "-c", str(cfg), "upgrade", "head"]
+    assert calls["cmd"] == ["alembic", "-c", str(cfg), "upgrade", "heads"]
 
 
 @pytest.mark.unit
@@ -92,4 +92,4 @@ def test_alembic_upgrade_stream(monkeypatch, tmp_path: Path):
     result = migrate_core.alembic_upgrade(cfg, stream=True)
 
     assert result == {"ok": True, "stdout": "out\n", "stderr": "err\n"}
-    assert calls["cmd"] == ["alembic", "-c", str(cfg), "upgrade", "head"]
+    assert calls["cmd"] == ["alembic", "-c", str(cfg), "upgrade", "heads"]


### PR DESCRIPTION
## Summary
- run `alembic upgrade heads` when migrating the gateway
- update migrate_core unit tests to expect `upgrade heads`

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format peagen/core/migrate_core.py tests/unit/test_migrate_core.py`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/core/migrate_core.py tests/unit/test_migrate_core.py --fix`
- `uv run --directory pkgs/standards/peagen --package peagen pytest -m "not sequence_success"`


------
https://chatgpt.com/codex/tasks/task_e_685fb40af6dc832692fbc14ada0fa667