### PR TITLE
Fix peagen migration enum creation

### DIFF
--- a/pkgs/standards/peagen/peagen/migrations/versions/ae1de73e4143_init.py
+++ b/pkgs/standards/peagen/peagen/migrations/versions/ae1de73e4143_init.py
@@ -5,7 +5,9 @@ from sqlalchemy import inspect
 from peagen.orm.status import Status
 
 status_enum = sa.Enum(
-    Status, name="task_status_enum"
+    Status,
+    name="status",
+    _create_events=False,
 )  # ← shared object, create_type=False
 
 revision = "ae1de73e4143"


### PR DESCRIPTION
## Summary
- ensure `status` enum doesn't auto-create during migrations by adding `_create_events=False`

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff check .`
- `uv run --package peagen --directory pkgs/standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_685fbdc4bd088326b562a6469a3a13e2