### PR TITLE
Fix PG_DSN support for Peagen

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/db.py
+++ b/pkgs/standards/peagen/peagen/gateway/db.py
@@ -2,7 +2,7 @@ from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
 from sqlalchemy.orm import sessionmaker
 from .runtime_cfg import settings
 
-if settings.pg_host and settings.pg_db and settings.pg_user:
+if settings.pg_dsn_env or (settings.pg_host and settings.pg_db and settings.pg_user):
     dsn = settings.apg_dsn
 else:
     # Fallback to a local SQLite database when Postgres settings are missing

--- a/pkgs/standards/peagen/peagen/migrations/env.py
+++ b/pkgs/standards/peagen/peagen/migrations/env.py
@@ -8,13 +8,19 @@ from sqlalchemy.ext.asyncio import create_async_engine
 import os
 from peagen.orm import Base
 
+pg_dsn = os.environ.get("PG_DSN")
 pg_host = os.environ.get("PG_HOST")
 pg_port = os.environ.get("PG_PORT", "5432")
 pg_db = os.environ.get("PG_DB")
 pg_user = os.environ.get("PG_USER")
 pg_pass = os.environ.get("PG_PASS")
 
-if pg_host and pg_db and pg_user:
+if pg_dsn:
+    if pg_dsn.startswith("postgresql://"):
+        dsn = pg_dsn.replace("postgresql://", "postgresql+asyncpg://", 1)
+    else:
+        dsn = pg_dsn
+elif pg_host and pg_db and pg_user:
     dsn = f"postgresql+asyncpg://{pg_user}:{pg_pass}@{pg_host}:{pg_port}/{pg_db}"
 else:
     dsn = "sqlite+aiosqlite:///./gateway.db"


### PR DESCRIPTION
## Summary
- allow `PG_DSN` environment variable in gateway runtime config
- detect `PG_DSN` in database migration env file
- fall back to Postgres when `PG_DSN` is set in gateway DB helper

## Testing
- `uv run --directory . --package peagen ruff check . --fix`
- `uv run --directory . --package peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_685fc42a367883268fa036c7a9958814