### PR TITLE
Improve migration error logging

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -777,7 +777,14 @@ async def _on_start() -> None:
         result = migrate_core.alembic_upgrade()
         if not result.get("ok", False):
             error_msg = result.get("error")
-            log.error("migration failed: %s", error_msg)
+            stdout = result.get("stdout", "").strip()
+            stderr = result.get("stderr", "").strip()
+            log.error(
+                "migration failed: %s\nstdout:\n%s\nstderr:\n%s",
+                error_msg,
+                stdout,
+                stderr,
+            )
             raise MigrationFailureError(str(error_msg))
         log.info("migrations applied; verifying database schema")
         await db_helpers.ensure_status_enum(engine)


### PR DESCRIPTION
## Summary
- log alembic stdout/stderr when migrations fail

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_685fc5b0d6c483269bb687378d50b328