### PR TITLE
Fix missing abuse_records table

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -788,6 +788,9 @@ async def _on_start() -> None:
             raise MigrationFailureError(str(error_msg))
         log.info("migrations applied; verifying database schema")
         await db_helpers.ensure_status_enum(engine)
+        async with engine.begin() as conn:
+            # create missing tables if migrations provided none
+            await conn.run_sync(Base.metadata.create_all)
     else:
         async with engine.begin() as conn:
             # run once – creates task_runs if it doesn't exist


### PR DESCRIPTION
## Summary
- create missing tables after migrations during startup
- update Alembic integration test to reflect empty migration set

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --directory pkgs/standards/peagen --package peagen pytest`
- `uv run --directory pkgs/standards/peagen --package peagen peagen -q --help` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685fd3cf5b30832699d02dc3efd6a0d8