### PR TITLE
Run peagen services, ruff, and tests

### DIFF
--- a/pkgs/base/swarmauri_base/secrets/__init__.py
+++ b/pkgs/base/swarmauri_base/secrets/__init__.py
@@ -1,4 +1,5 @@
 """Simple secret resolution utilities."""
+
 from __future__ import annotations
 
 import os
@@ -23,5 +24,6 @@ def resolve_secret_ref(secret_ref: str) -> str:
     pm = PluginManager(cfg)
     secret_plugin = pm.get("secrets", provider or None)
     return secret_plugin.get(name)
+
 
 __all__ = ["resolve_secret_ref"]

--- a/pkgs/swarmauri_standard/tests/unit/utils/retry_decorator_test.py
+++ b/pkgs/swarmauri_standard/tests/unit/utils/retry_decorator_test.py
@@ -14,7 +14,9 @@ async def test_retry_async_exhausts_retries():
         call_count += 1
         request = httpx.Request("GET", "http://test")
         response = httpx.Response(status_code=429, request=request)
-        raise httpx.HTTPStatusError("Too Many Requests", request=request, response=response)
+        raise httpx.HTTPStatusError(
+            "Too Many Requests", request=request, response=response
+        )
 
     with pytest.raises(Exception) as exc_info:
         await failing()
@@ -34,7 +36,9 @@ def test_retry_sync_eventual_success():
         if call_count < 3:
             request = httpx.Request("GET", "http://test")
             response = httpx.Response(status_code=429, request=request)
-            raise httpx.HTTPStatusError("Too Many Requests", request=request, response=response)
+            raise httpx.HTTPStatusError(
+                "Too Many Requests", request=request, response=response
+            )
         return "ok"
 
     assert sometimes_fails() == "ok"


### PR DESCRIPTION
## Summary
- run ruff formatting which updated two files
- run pytests for `swarmauri-base` and `swarmauri-standard`
- start the peagen gateway and worker per docs

## Testing
- `uv run ruff check .`
- `uv run --package swarmauri-base --directory pkgs/base pytest -q`
- `uv run --package swarmauri-standard --directory pkgs/swarmauri_standard pytest tests/unit -q` *(fails: ValidationError)*

------
https://chatgpt.com/codex/tasks/task_e_685fd37ecdc083269c3ea9cfa87c7b5c