### PR TITLE
Fix remote sort CLI repo requirement

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/sort.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/sort.py
@@ -114,6 +114,9 @@ def submit_sort(
         )
 
     # ─────────────────────── 2) build Task model ────────────────────────
+    if repo is None:
+        raise typer.BadParameter("--repo is required for remote sorting")
+
     args = {
         "projects_payload": yaml_text,  # ← inline text
         "project_name": project_name,
@@ -121,11 +124,17 @@ def submit_sort(
         "start_file": start_file,
         "transitive": transitive,
         "show_dependencies": show_dependencies,
-        "cfg_override": cfg_override,
+        "repo": repo,
+        "ref": ref,
     }
-    if repo:
-        args.update({"repo": repo, "ref": ref})
-    task = {"pool": "default", "payload": {"action": "sort", "args": args}}
+    task = {
+        "pool": "default",
+        "payload": {
+            "action": "sort",
+            "args": args,
+            "cfg_override": cfg_override,
+        },
+    }
 
     # 2) Build Task.submit envelope using Task fields
     envelope = {

--- a/pkgs/standards/peagen/peagen/orm/repo/repository.py
+++ b/pkgs/standards/peagen/peagen/orm/repo/repository.py
@@ -93,8 +93,8 @@ class RepositoryModel(BaseModel):
         "DeployKeyModel",
         secondary="repository_deploy_key_associations",
         back_populates="repositories",
-        viewonly=True,                      # 🔑 read-only
-        overlaps="deploy_key_associations", # silence SAWarning
+        viewonly=True,  # 🔑 read-only
+        overlaps="deploy_key_associations",  # silence SAWarning
     )
 
     user_associations: Mapped[list["RepositoryUserAssociationModel"]] = relationship(

--- a/pkgs/standards/peagen/tests/sequence_success/examples/demo_success.yaml
+++ b/pkgs/standards/peagen/tests/sequence_success/examples/demo_success.yaml
@@ -8,7 +8,7 @@ command_sets:
       name: "remote sort"
       desc: "run sort remotely and fetch the result"
       commands:
-        - ["remote", "--gateway-url", "https://gw.peagen.com", "sort", "tests/examples/projects_payloads/template_two_project.yaml"]
+        - ["remote", "--gateway-url", "https://gw.peagen.com", "sort", "tests/examples/projects_payloads/template_two_project.yaml", "--repo", "{tmpdir}/project1"]
         - ["remote", "--gateway-url", "https://gw.peagen.com", "task", "get", "{task_id}"]
   - batch:
       name: "remote secrets"


### PR DESCRIPTION
## Summary
- require `--repo` when submitting `peagen remote sort`
- carry cfg overrides at payload level in `remote sort`
- update demo success sequence
- clean up minor ruff formatting

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `PEAGEN_TEST_GATEWAY=http://localhost:9 uv run --package peagen --directory pkgs/standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_685fed4c049c8326a493724a682f2522