### PR TITLE
Fix secret upsert and accept TaskSubmit object

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/db_helpers.py
+++ b/pkgs/standards/peagen/peagen/gateway/db_helpers.py
@@ -118,7 +118,7 @@ async def upsert_secret(
         "name": name,
         "cipher": cipher,
     }
-    stmt = sa.insert(SecretModel).values(**data)
+    stmt = pg_insert(SecretModel).values(**data)
     if session.bind.dialect.name == "sqlite":
         stmt = stmt.prefix_with("OR REPLACE")
     else:

--- a/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import uuid
+import typing as t
 
 from peagen.transport.jsonrpc import RPCException
 from peagen.defaults.error_codes import ErrorCode
@@ -45,6 +46,7 @@ from .. import Session, engine, Base
 
 # -----------------Helper---------------------------------------
 
+
 def _parse_task_create(raw: dict) -> TaskCreate:
     # Legacy support
     if "dto" in raw and isinstance(raw["dto"], dict):
@@ -55,10 +57,12 @@ def _parse_task_create(raw: dict) -> TaskCreate:
 
 # --------------Basic Task Methods ---------------------------------
 
+
 @dispatcher.method(TASK_SUBMIT)
-async def task_submit(**raw: t.Any) -> dict:
+async def task_submit(dto: TaskCreate | None = None, **raw: t.Any) -> dict:
     """Persist *dto* and enqueue the task."""
-    dto: TaskCreate = _parse_task_create(raw)
+    if dto is None:
+        dto = _parse_task_create(raw)
     await queue.sadd("pools", dto.pool)
 
     action = (dto.payload or {}).get("action")


### PR DESCRIPTION
## Summary
- fix Postgres upsert for secrets using dialect insert
- allow `Task.submit` RPC endpoint to accept positional `TaskCreate`

## Testing
- `uv run --package peagen --directory standards/peagen ruff check . --fix`
- `PEAGEN_TEST_GATEWAY=http://localhost:8000/rpc uv run --package peagen --directory standards/peagen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ff77bc4148326b26303c9f8d9fb1a