### PR TITLE
Fix secret upsert and task submission logic

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/db_helpers.py
+++ b/pkgs/standards/peagen/peagen/gateway/db_helpers.py
@@ -118,13 +118,17 @@ async def upsert_secret(
         "name": name,
         "cipher": cipher,
     }
-    stmt = sa.insert(SecretModel).values(**data)
     if session.bind.dialect.name == "sqlite":
+        stmt = sa.insert(SecretModel).values(**data)
         stmt = stmt.prefix_with("OR REPLACE")
     else:
-        stmt = stmt.on_conflict_do_update(
-            index_elements=["tenant_id", "name"],
-            set_={"cipher": cipher},
+        stmt = (
+            pg_insert(SecretModel)
+            .values(**data)
+            .on_conflict_do_update(
+                index_elements=["tenant_id", "name"],
+                set_={"cipher": cipher},
+            )
         )
     try:
         await session.execute(stmt)

--- a/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import uuid
+import typing as t
 
 from peagen.transport.jsonrpc import RPCException
 from peagen.defaults.error_codes import ErrorCode
@@ -45,6 +46,7 @@ from .. import Session, engine, Base
 
 # -----------------Helper---------------------------------------
 
+
 def _parse_task_create(raw: dict) -> TaskCreate:
     # Legacy support
     if "dto" in raw and isinstance(raw["dto"], dict):
@@ -55,10 +57,11 @@ def _parse_task_create(raw: dict) -> TaskCreate:
 
 # --------------Basic Task Methods ---------------------------------
 
+
 @dispatcher.method(TASK_SUBMIT)
-async def task_submit(**raw: t.Any) -> dict:
+async def task_submit(task: TaskCreate | None = None, **raw: t.Any) -> dict:
     """Persist *dto* and enqueue the task."""
-    dto: TaskCreate = _parse_task_create(raw)
+    dto: TaskCreate = task if task is not None else _parse_task_create(raw)
     await queue.sadd("pools", dto.pool)
 
     action = (dto.payload or {}).get("action")


### PR DESCRIPTION
## Summary
- use Postgres upsert when storing secrets
- allow `task_submit` RPC handler to accept `TaskCreate` object
- adjust gateway wrapper accordingly
- ensure ruff and pytest pass for `peagen` package

## Testing
- `uv run --directory standards/peagen --package peagen ruff format .`
- `uv run --directory standards/peagen --package peagen ruff check . --fix`
- `PEAGEN_TEST_GATEWAY=http://localhost:65500 uv run --package peagen --directory standards/peagen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ff905ccbc8326a63501e87f0502bf