### PR TITLE
Fix import path for TaskRead

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/rpc/pool.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/pool.py
@@ -30,7 +30,7 @@ async def pool_list(
     end = -1 if limit is None else start + limit - 1
     ids = await queue.lrange(f"{READY_QUEUE}:{poolName}", start, end)
     tasks = []
-    from ..schemas import TaskRead  # dynamic import to avoid circular
+    from peagen.schemas import TaskRead  # dynamic import to avoid circular
 
     for r in ids:
         t = TaskRead.model_validate_json(r)


### PR DESCRIPTION
## Summary
- fix `Pool.listTasks` to load TaskRead from `peagen.schemas`

## Testing
- `uv run --directory peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_6860026d598083269fb2194ddfd61133