### PR TITLE
Fix RPC parsing and clarify docs

### DIFF
--- a/pkgs/standards/peagen/AGENTS.md
+++ b/pkgs/standards/peagen/AGENTS.md
@@ -23,6 +23,11 @@ and return ``TaskRead``, ``TaskCreate``, or ``TaskUpdate`` instances
 exclusively. This ensures interoperability across services and avoids subtle
 validation issues.
 
+RPC handlers strictly expect parameters matching these schemas. **Never** wrap a
+task under a ``dto`` key or send unvalidated dictionaries. When invoking the
+Python API, always construct a :class:`TaskCreate` object first and pass it
+directly.
+
 Environment variables control the runtime configuration. A minimal `.peagen.toml` is required in the working directory for both services.
 
 For quick local testing you can rely on the in-memory queue and an in-memory results backend:

--- a/pkgs/standards/peagen/README.md
+++ b/pkgs/standards/peagen/README.md
@@ -416,6 +416,11 @@ task = TaskRead.model_validate_json(raw_json)
 The gateway and worker components rely on these schema classes rather than the
 ORM models under `peagen.orm`.
 
+RPC methods accept these models directly. Do **not** wrap a task inside a
+``dto`` field or send arbitrary dictionaries; always build a valid
+``TaskCreate`` instance and serialize it with ``model_dump()`` when calling the
+API over the network.
+
 > **Note**
 > Earlier versions exposed these models under ``peagen.models`` and the
 > transport schemas under ``peagen.models.schemas``. Update any imports to use

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -755,6 +755,8 @@ async def task_submit(
 
         # keep the UUID instance so the ORM receives the correct type
 
+    # keep the UUID instance so the ORM receives the correct type
+
     return await _task_submit_rpc(task)
 
 

--- a/pkgs/standards/peagen/peagen/gateway/rpc/pool.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/pool.py
@@ -30,7 +30,7 @@ async def pool_list(
     end = -1 if limit is None else start + limit - 1
     ids = await queue.lrange(f"{READY_QUEUE}:{poolName}", start, end)
     tasks = []
-    from ..schemas import TaskRead  # dynamic import to avoid circular
+    from peagen.schemas import TaskRead  # dynamic import to avoid circular
 
     for r in ids:
         t = TaskRead.model_validate_json(r)

--- a/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
@@ -48,10 +48,7 @@ from .. import Session, engine, Base
 
 
 def _parse_task_create(raw: dict) -> TaskCreate:
-    # Legacy support
-    if "dto" in raw and isinstance(raw["dto"], dict):
-        return TaskCreate.model_validate(raw["dto"])
-    # Preferred: flattened KV pairs
+    """Normalize *raw* into a :class:`TaskCreate` instance."""
     return TaskCreate.model_validate(raw)
 
 


### PR DESCRIPTION
## Summary
- enforce strict TaskCreate parsing in RPC helper
- drop legacy dto routing in gateway
- document that RPC handlers only accept validated schema objects

## Testing
- `uv run --directory peagen --package peagen ruff format .`
- `uv run --directory peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory peagen pytest -q`
- `peagen remote -q --gateway-url https://gw.peagen.com/rpc task get dummy_id` *(fails: 503 Service Unavailable)*
- `peagen local -q process projects_payload.yaml --watch` *(fails: No such option)*

------
https://chatgpt.com/codex/tasks/task_e_6860026cb9f8832689e3299d9e70c26f