### PR TITLE
Introduce JSON-RPC typed models for keys

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/rpc/keys.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/keys.py
@@ -4,27 +4,39 @@ from pgpy import PGPKey
 
 from .. import dispatcher, log, TRUSTED_USERS
 from peagen.defaults import KEYS_UPLOAD, KEYS_FETCH, KEYS_DELETE
+from peagen.rpc_models import (
+    KeysUploadParams,
+    KeysUploadResult,
+    KeysFetchResult,
+    KeysDeleteParams,
+    KeysDeleteResult,
+)
 
 
 @dispatcher.method(KEYS_UPLOAD)
 async def keys_upload(public_key: str) -> dict:
     """Store a trusted public key."""
+    params = KeysUploadParams(public_key=public_key)
     key = PGPKey()
-    key.parse(public_key)
-    TRUSTED_USERS[key.fingerprint] = public_key
+    key.parse(params.public_key)
+    TRUSTED_USERS[key.fingerprint] = params.public_key
     log.info("key uploaded: %s", key.fingerprint)
-    return {"fingerprint": key.fingerprint}
+    result = KeysUploadResult(fingerprint=key.fingerprint)
+    return result.model_dump()
 
 
 @dispatcher.method(KEYS_FETCH)
 async def keys_fetch() -> dict:
     """Return all trusted keys indexed by fingerprint."""
-    return TRUSTED_USERS
+    result = KeysFetchResult(keys=TRUSTED_USERS)
+    return result.model_dump()
 
 
 @dispatcher.method(KEYS_DELETE)
 async def keys_delete(fingerprint: str) -> dict:
     """Remove a public key by its fingerprint."""
-    TRUSTED_USERS.pop(fingerprint, None)
-    log.info("key removed: %s", fingerprint)
-    return {"ok": True}
+    params = KeysDeleteParams(fingerprint=fingerprint)
+    TRUSTED_USERS.pop(params.fingerprint, None)
+    log.info("key removed: %s", params.fingerprint)
+    result = KeysDeleteResult(ok=True)
+    return result.model_dump()

--- a/pkgs/standards/peagen/peagen/rpc_models/__init__.py
+++ b/pkgs/standards/peagen/peagen/rpc_models/__init__.py
@@ -1,0 +1,75 @@
+"""Typed JSON-RPC request/response models."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from peagen.transport import RPCRequest, RPCResponse
+from peagen.defaults import KEYS_UPLOAD, KEYS_FETCH, KEYS_DELETE
+
+
+class KeysUploadParams(BaseModel):
+    public_key: str
+
+
+class KeysUploadResult(BaseModel):
+    fingerprint: str
+
+
+class KeysUploadRequest(RPCRequest):
+    method: str = Field(default=KEYS_UPLOAD, const=True)
+    params: KeysUploadParams
+
+
+class KeysUploadResponse(RPCResponse):
+    result: KeysUploadResult | None
+
+
+class KeysFetchParams(BaseModel):
+    pass
+
+
+class KeysFetchResult(BaseModel):
+    keys: dict[str, str]
+
+
+class KeysFetchRequest(RPCRequest):
+    method: str = Field(default=KEYS_FETCH, const=True)
+    params: KeysFetchParams | None = None
+
+
+class KeysFetchResponse(RPCResponse):
+    result: KeysFetchResult | None
+
+
+class KeysDeleteParams(BaseModel):
+    fingerprint: str
+
+
+class KeysDeleteResult(BaseModel):
+    ok: bool
+
+
+class KeysDeleteRequest(RPCRequest):
+    method: str = Field(default=KEYS_DELETE, const=True)
+    params: KeysDeleteParams
+
+
+class KeysDeleteResponse(RPCResponse):
+    result: KeysDeleteResult | None
+
+
+__all__ = [
+    "KeysUploadParams",
+    "KeysUploadResult",
+    "KeysUploadRequest",
+    "KeysUploadResponse",
+    "KeysFetchParams",
+    "KeysFetchResult",
+    "KeysFetchRequest",
+    "KeysFetchResponse",
+    "KeysDeleteParams",
+    "KeysDeleteResult",
+    "KeysDeleteRequest",
+    "KeysDeleteResponse",
+]


### PR DESCRIPTION
## Summary
- add typed request/response models under `rpc_models`
- use the new models inside gateway key RPC handlers
- update key client helpers to build and parse these models

## Testing
- `uv run --directory peagen --package peagen ruff format .`
- `uv run --directory peagen --package peagen ruff check . --fix`

------
https://chatgpt.com/codex/tasks/task_e_6860111f9ecc8326994cb9a0d4b4de95