### PR TITLE
Refactor error codes and RPC wrappers

### DIFF
--- a/pkgs/standards/peagen/peagen/defaults/__init__.py
+++ b/pkgs/standards/peagen/peagen/defaults/__init__.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from .abuse import BAN_THRESHOLD
 from .events import CONTROL_QUEUE, READY_QUEUE, PUBSUB_CHANNEL, TASK_KEY
 from .methods import *  # noqa: F401,F403 re-export rpc method names
-from .error_codes import ErrorCode
+from peagen.protocols.error_codes import Code as ErrorCode
 
 # Default directory for repository lock files.
 LOCK_DIR = "~/.cache/peagen/locks"

--- a/pkgs/standards/peagen/peagen/defaults/error_codes.py
+++ b/pkgs/standards/peagen/peagen/defaults/error_codes.py
@@ -1,19 +1,5 @@
-"""peagen.defaults.error_codes
-----------------------------
-Application-specific JSON-RPC error codes.
-"""
+"""Backward compatible re-export of the canonical error codes."""
 
-from enum import IntEnum
-
-
-class ErrorCode(IntEnum):
-    """Enumerates Peagen-specific JSON-RPC error codes."""
-
-    SECRET_NOT_FOUND = -32004
-    TASK_NOT_FOUND = -32001
-    INVALID_REQUEST = -32600
-    METHOD_NOT_FOUND = -32601
-    INVALID_PARAMS = -32602
-
+from peagen.protocols.error_codes import Code as ErrorCode
 
 __all__ = ["ErrorCode"]

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -50,7 +50,7 @@ from peagen.errors import (
 )
 import peagen.defaults as defaults
 from peagen.defaults import BAN_THRESHOLD
-from peagen.defaults.error_codes import ErrorCode
+from peagen.protocols.error_codes import Code as ErrorCode
 from peagen.core import migrate_core
 from peagen.services import create_task, get_task, update_task
 

--- a/pkgs/standards/peagen/peagen/gateway/rpc/secrets.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/secrets.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from .. import Session, dispatcher, log
 from peagen.defaults import SECRETS_ADD, SECRETS_GET, SECRETS_DELETE
 from ..db_helpers import delete_secret, fetch_secret, upsert_secret
-from peagen.defaults.error_codes import ErrorCode
+from peagen.protocols.error_codes import Code as ErrorCode
 from peagen.transport.jsonrpc import RPCException
 
 

--- a/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
@@ -4,7 +4,7 @@ import json
 import uuid
 import typing as t
 from peagen.transport.jsonrpc import RPCException
-from peagen.defaults.error_codes import ErrorCode
+from peagen.protocols.error_codes import Code as ErrorCode
 from peagen.defaults import (
     TASK_SUBMIT,
     TASK_CANCEL,
@@ -52,6 +52,7 @@ def _parse_task_create(task: t.Any) -> TaskCreate:
     if not isinstance(task, TaskCreate):
         raise TypeError("TaskCreate required")
     return task
+
 
 # --------------Basic Task Methods ---------------------------------
 

--- a/pkgs/standards/peagen/peagen/transport/__init__.py
+++ b/pkgs/standards/peagen/peagen/transport/__init__.py
@@ -4,12 +4,12 @@ from peagen.protocols import (
     Response as RPCResponse,
     Error as RPCErrorData,
 )
-from peagen.transport.schemas import RPCError
+from peagen.transport.schemas import RPCException
 
 __all__ = [
     "RPCDispatcher",
     "RPCRequest",
     "RPCResponse",
-    "RPCError",
+    "RPCException",
     "RPCErrorData",
 ]

--- a/pkgs/standards/peagen/peagen/transport/schemas.py
+++ b/pkgs/standards/peagen/peagen/transport/schemas.py
@@ -9,7 +9,7 @@ from peagen.protocols import (
 )
 
 
-class RPCError(Exception):
+class RPCException(Exception):
     """Exception carrying JSON-RPC error details."""
 
     def __init__(self, *, code: int, message: str, data: dict | None = None) -> None:
@@ -20,4 +20,4 @@ class RPCError(Exception):
         return self.error.model_dump()
 
 
-__all__ = ["RPCRequest", "RPCResponse", "RPCError", "RPCErrorData"]
+__all__ = ["RPCRequest", "RPCResponse", "RPCException", "RPCErrorData"]


### PR DESCRIPTION
## Summary
- unify error codes by referencing `peagen.protocols.error_codes.Code`
- rename RPC error wrapper class to `RPCException`
- adjust transport re-exports
- update gateway imports to the new error code module

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format .`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest` *(fails: AttributeError and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_686017d384b48326b3f4fcd8eba63a3c