### PR TITLE
Add protocols package

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/analysis.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/analysis.py
@@ -12,6 +12,7 @@ from functools import partial
 from peagen.handlers.analysis_handler import analysis_handler
 from peagen.defaults import TASK_SUBMIT
 from peagen.cli.task_builder import _build_task as _generic_build_task
+from peagen.protocols import Request, Response
 
 DEFAULT_GATEWAY = "http://localhost:8000/rpc"
 local_analysis_app = typer.Typer(help="Aggregate run evaluation results.")
@@ -52,20 +53,22 @@ def submit(
     if repo:
         args.update({"repo": repo, "ref": ref})
     task = _build_task(args, ctx.obj.get("pool", "default"))
-    rpc_req = {
-        "jsonrpc": "2.0",
-        "id": task.id,
-        "method": TASK_SUBMIT,
-        "params": task.model_dump(mode="json"),
-    }
+    rpc_req = Request(
+        id=task.id,
+        method=TASK_SUBMIT,
+        params=task.model_dump(mode="json"),
+    )
     with httpx.Client(timeout=30.0) as client:
-        reply = client.post(ctx.obj.get("gateway_url"), json=rpc_req).json()
-    if "error" in reply:
+        reply = client.post(
+            ctx.obj.get("gateway_url"), json=rpc_req.model_dump(mode="json")
+        ).json()
+    response = Response[dict].model_validate(reply)
+    if response.error:
         typer.secho(
-            f"Remote error {reply['error']['code']}: {reply['error']['message']}",
+            f"Remote error {response.error.code}: {response.error.message}",
             fg=typer.colors.RED,
             err=True,
         )
         raise typer.Exit(1)
     typer.secho(f"Submitted task {task.id}", fg=typer.colors.GREEN)
-    typer.echo(json.dumps(reply.get("result", {}), indent=2))
+    typer.echo(json.dumps(response.result or {}, indent=2))

--- a/pkgs/standards/peagen/peagen/cli/commands/eval.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/eval.py
@@ -23,6 +23,7 @@ from peagen._utils.config_loader import load_peagen_toml
 from peagen.handlers.eval_handler import eval_handler
 from peagen.defaults import TASK_SUBMIT
 from peagen.cli.task_builder import _build_task as _generic_build_task
+from peagen.protocols import Request, Response
 
 DEFAULT_GATEWAY = "http://localhost:8000/rpc"
 local_eval_app = typer.Typer(
@@ -124,26 +125,28 @@ def submit(  # noqa: PLR0913
         cfg_override.update(load_peagen_toml(Path(file_), required=True))
     task.payload["cfg_override"] = cfg_override
 
-    rpc_req = {
-        "jsonrpc": "2.0",
-        "id": task.id,
-        "method": TASK_SUBMIT,
-        "params": task.model_dump(mode="json"),
-    }
+    rpc_req = Request(
+        id=task.id,
+        method=TASK_SUBMIT,
+        params=task.model_dump(mode="json"),
+    )
 
     with httpx.Client(timeout=30.0) as client:
-        resp = client.post(ctx.obj.get("gateway_url"), json=rpc_req)
+        resp = client.post(
+            ctx.obj.get("gateway_url"), json=rpc_req.model_dump(mode="json")
+        )
         resp.raise_for_status()
         reply = resp.json()
 
-    if "error" in reply:
+    response = Response[dict].model_validate(reply)
+    if response.error:
         typer.secho(
-            f"Remote error {reply['error']['code']}: {reply['error']['message']}",
+            f"Remote error {response.error.code}: {response.error.message}",
             fg=typer.colors.RED,
             err=True,
         )
         raise typer.Exit(1)
 
     typer.secho(f"Submitted task {task.id}", fg=typer.colors.GREEN)
-    if reply.get("result"):
-        typer.echo(json.dumps(reply["result"], indent=2))
+    if response.result:
+        typer.echo(json.dumps(response.result, indent=2))

--- a/pkgs/standards/peagen/peagen/cli/commands/evolve.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/evolve.py
@@ -17,6 +17,7 @@ from peagen.orm.status import Status
 from peagen.core.validate_core import validate_evolve_spec
 from peagen.defaults import TASK_SUBMIT
 from peagen.cli.task_builder import _build_task as _generic_build_task
+from peagen.protocols import Request, Response
 
 local_evolve_app = typer.Typer(help="Expand evolve spec and run mutate tasks")
 remote_evolve_app = typer.Typer(help="Expand evolve spec and run mutate tasks")
@@ -102,34 +103,39 @@ def submit(
     if repo:
         args.update({"repo": repo, "ref": ref})
     task = _build_task(args, ctx.obj.get("pool", "default"))
-    rpc_req = {
-        "jsonrpc": "2.0",
-        "method": TASK_SUBMIT,
-        "params": task.model_dump(mode="json"),
-    }
+    rpc_req = Request(
+        method=TASK_SUBMIT,
+        params=task.model_dump(mode="json"),
+    )
     with httpx.Client(timeout=30.0) as client:
-        reply = client.post(ctx.obj.get("gateway_url"), json=rpc_req).json()
-    if "error" in reply:
+        reply = client.post(
+            ctx.obj.get("gateway_url"), json=rpc_req.model_dump(mode="json")
+        ).json()
+    response = Response[dict].model_validate(reply)
+    if response.error:
         typer.secho(
-            f"Remote error {reply['error']['code']}: {reply['error']['message']}",
+            f"Remote error {response.error.code}: {response.error.message}",
             fg=typer.colors.RED,
             err=True,
         )
         raise typer.Exit(1)
     typer.secho(f"Submitted task {task.id}", fg=typer.colors.GREEN)
-    if reply.get("result"):
-        typer.echo(json.dumps(reply["result"], indent=2))
+    if response.result:
+        typer.echo(json.dumps(response.result, indent=2))
     if watch:
 
         def _rpc_call() -> dict:
-            req = {
-                "jsonrpc": "2.0",
-                "id": str(uuid.uuid4()),
-                "method": "Task.get",
-                "params": {"taskId": task.id},
-            }
-            res = httpx.post(ctx.obj.get("gateway_url"), json=req, timeout=30.0).json()
-            return res["result"]
+            req = Request(
+                id=str(uuid.uuid4()),
+                method="Task.get",
+                params={"taskId": task.id},
+            )
+            res = httpx.post(
+                ctx.obj.get("gateway_url"),
+                json=req.model_dump(mode="json"),
+                timeout=30.0,
+            ).json()
+            return Response[dict].model_validate(res).result or {}
 
         import time
 

--- a/pkgs/standards/peagen/peagen/cli/commands/login.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/login.py
@@ -9,6 +9,7 @@ import httpx
 import typer
 
 from peagen.plugins.secret_drivers import AutoGpgDriver
+from peagen.protocols import Request
 
 
 login_app = typer.Typer(help="Authenticate and upload your public key.")
@@ -31,13 +32,11 @@ def login(
         gateway_url += "/rpc"
     drv = AutoGpgDriver(key_dir=key_dir, passphrase=passphrase)
     pubkey = drv.pub_path.read_text()
-    payload = {
-        "jsonrpc": "2.0",
-        "method": "Keys.upload",
-        "params": {"public_key": pubkey},
-    }
+    payload = Request(method="Keys.upload", params={"public_key": pubkey})
     try:
-        res = httpx.post(gateway_url, json=payload, timeout=10.0)
+        res = httpx.post(
+            gateway_url, json=payload.model_dump(mode="json"), timeout=10.0
+        )
     except httpx.RequestError as e:  # pragma: no cover - network errors
         typer.echo(f"HTTP error: {e}", err=True)
         raise typer.Exit(1)

--- a/pkgs/standards/peagen/peagen/cli/commands/process.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/process.py
@@ -26,6 +26,7 @@ from peagen.handlers.process_handler import process_handler
 from peagen.defaults import TASK_SUBMIT, TASK_GET
 from peagen.orm.status import Status
 from peagen.cli.task_builder import _build_task as _generic_build_task
+from peagen.protocols import Request, Response
 
 local_process_app = typer.Typer(help="Render / generate project files.")
 remote_process_app = typer.Typer(help="Render / generate project files.")
@@ -187,38 +188,43 @@ def submit(  # noqa: PLR0913 – CLI signature needs many options
         cfg_override.update(load_peagen_toml(Path(file_), required=True))
     task.payload["cfg_override"] = cfg_override
 
-    rpc_req = {
-        "jsonrpc": "2.0",
-        "method": TASK_SUBMIT,
-        "params": task.model_dump(mode="json"),
-    }
+    rpc_req = Request(
+        method=TASK_SUBMIT,
+        params=task.model_dump(mode="json"),
+    )
     with httpx.Client(timeout=30.0) as client:
-        resp = client.post(ctx.obj.get("gateway_url"), json=rpc_req)
+        resp = client.post(
+            ctx.obj.get("gateway_url"), json=rpc_req.model_dump(mode="json")
+        )
         resp.raise_for_status()
         reply = resp.json()
 
-    if "error" in reply:
+    response = Response[dict].model_validate(reply)
+    if response.error:
         typer.secho(
-            f"Remote error {reply['error']['code']}: {reply['error']['message']}",
+            f"Remote error {response.error.code}: {response.error.message}",
             fg=typer.colors.RED,
             err=True,
         )
         raise typer.Exit(code=1)
 
     typer.secho(f"Submitted task {task.id}", fg=typer.colors.GREEN)
-    if reply.get("result"):
-        typer.echo(json.dumps(reply["result"], indent=2))
+    if response.result:
+        typer.echo(json.dumps(response.result, indent=2))
     if watch:
 
         def _rpc_call() -> dict:
-            req = {
-                "jsonrpc": "2.0",
-                "id": str(uuid.uuid4()),
-                "method": TASK_GET,
-                "params": {"taskId": task.id},
-            }
-            res = httpx.post(ctx.obj.get("gateway_url"), json=req, timeout=30.0).json()
-            return res["result"]
+            req = Request(
+                id=str(uuid.uuid4()),
+                method=TASK_GET,
+                params={"taskId": task.id},
+            )
+            res = httpx.post(
+                ctx.obj.get("gateway_url"),
+                json=req.model_dump(mode="json"),
+                timeout=30.0,
+            ).json()
+            return Response[dict].model_validate(res).result or {}
 
         while True:
             task_reply = _rpc_call()

--- a/pkgs/standards/peagen/peagen/cli/commands/sort.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/sort.py
@@ -10,6 +10,7 @@ import typer
 from peagen._utils.config_loader import _effective_cfg, load_peagen_toml
 from peagen.handlers.sort_handler import sort_handler
 from peagen.defaults import TASK_SUBMIT
+from peagen.protocols import Request, Response
 
 local_sort_app = typer.Typer(help="Sort generated project files.")
 remote_sort_app = typer.Typer(help="Sort generated project files via JSON-RPC.")
@@ -137,23 +138,26 @@ def submit_sort(
     }
 
     # 2) Build Task.submit envelope using Task fields
-    envelope = {
-        "jsonrpc": "2.0",
-        "method": TASK_SUBMIT,
-        "params": task,
-    }
+    envelope = Request(
+        method=TASK_SUBMIT,
+        params=task,
+    )
 
     # 3) POST to gateway
     try:
         import httpx
 
-        resp = httpx.post(ctx.obj.get("gateway_url"), json=envelope, timeout=10.0)
+        resp = httpx.post(
+            ctx.obj.get("gateway_url"),
+            json=envelope.model_dump(mode="json"),
+            timeout=10.0,
+        )
         resp.raise_for_status()
-        data = resp.json()
-        if data.get("error"):
-            typer.echo(f"[ERROR] {data['error']}")
+        data = Response[dict].model_validate(resp.json())
+        if data.error:
+            typer.echo(f"[ERROR] {data.error}")
             raise typer.Exit(1)
-        typer.echo(f"Submitted sort → taskId={data['result']['taskId']}")
+        typer.echo(f"Submitted sort → taskId={(data.result or {}).get('taskId')}")
     except Exception as exc:
         typer.echo(
             f"[ERROR] Could not reach gateway at {ctx.obj.get('gateway_url')}: {exc}"

--- a/pkgs/standards/peagen/peagen/cli/commands/validate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/validate.py
@@ -8,6 +8,7 @@ import typer
 from peagen.handlers.validate_handler import validate_handler
 from peagen.schemas import TaskCreate
 from peagen.defaults import TASK_SUBMIT
+from peagen.protocols import Request, Response
 
 local_validate_app = typer.Typer(help="Validate Peagen artifacts.")
 remote_validate_app = typer.Typer(help="Validate Peagen artifacts via JSON-RPC.")
@@ -90,21 +91,24 @@ def submit_validate(
     )
 
     # 2) Build Task.submit envelope using Task fields
-    envelope = {
-        "jsonrpc": "2.0",
-        "method": TASK_SUBMIT,
-        "params": task.model_dump(mode="json"),
-    }
+    envelope = Request(
+        method=TASK_SUBMIT,
+        params=task.model_dump(mode="json"),
+    )
 
     # 3) POST to gateway
     try:
         import httpx
 
-        resp = httpx.post(ctx.obj.get("gateway_url"), json=envelope, timeout=10.0)
+        resp = httpx.post(
+            ctx.obj.get("gateway_url"),
+            json=envelope.model_dump(mode="json"),
+            timeout=10.0,
+        )
         resp.raise_for_status()
-        data = resp.json()
-        if data.get("error"):
-            typer.echo(f"[ERROR] {data['error']}")
+        data = Response[dict].model_validate(resp.json())
+        if data.error:
+            typer.echo(f"[ERROR] {data.error}")
             raise typer.Exit(1)
         typer.echo(f"Submitted validation → taskId={task.id}")
     except Exception as exc:

--- a/pkgs/standards/peagen/peagen/defaults/__init__.py
+++ b/pkgs/standards/peagen/peagen/defaults/__init__.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from .abuse import BAN_THRESHOLD
 from .events import CONTROL_QUEUE, READY_QUEUE, PUBSUB_CHANNEL, TASK_KEY
 from .methods import *  # noqa: F401,F403 re-export rpc method names
-from .error_codes import ErrorCode
+from peagen.protocols.error_codes import Code as ErrorCode
 
 # Default directory for repository lock files.
 LOCK_DIR = "~/.cache/peagen/locks"

--- a/pkgs/standards/peagen/peagen/defaults/error_codes.py
+++ b/pkgs/standards/peagen/peagen/defaults/error_codes.py
@@ -1,19 +1,5 @@
-"""peagen.defaults.error_codes
-----------------------------
-Application-specific JSON-RPC error codes.
-"""
+"""Deprecated: use :mod:`peagen.protocols.error_codes` instead."""
 
-from enum import IntEnum
-
-
-class ErrorCode(IntEnum):
-    """Enumerates Peagen-specific JSON-RPC error codes."""
-
-    SECRET_NOT_FOUND = -32004
-    TASK_NOT_FOUND = -32001
-    INVALID_REQUEST = -32600
-    METHOD_NOT_FOUND = -32601
-    INVALID_PARAMS = -32602
-
+from peagen.protocols.error_codes import Code as ErrorCode
 
 __all__ = ["ErrorCode"]

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -50,7 +50,7 @@ from peagen.errors import (
 )
 import peagen.defaults as defaults
 from peagen.defaults import BAN_THRESHOLD
-from peagen.defaults.error_codes import ErrorCode
+from peagen.protocols.error_codes import Code as ErrorCode
 from peagen.core import migrate_core
 from peagen.services import create_task, get_task, update_task
 

--- a/pkgs/standards/peagen/peagen/gateway/rpc/secrets.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/secrets.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from .. import Session, dispatcher, log
 from peagen.defaults import SECRETS_ADD, SECRETS_GET, SECRETS_DELETE
 from ..db_helpers import delete_secret, fetch_secret, upsert_secret
-from peagen.defaults.error_codes import ErrorCode
+from peagen.protocols.error_codes import Code as ErrorCode
 from peagen.transport.jsonrpc import RPCException
 
 

--- a/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
@@ -4,7 +4,7 @@ import json
 import uuid
 import typing as t
 from peagen.transport.jsonrpc import RPCException
-from peagen.defaults.error_codes import ErrorCode
+from peagen.protocols.error_codes import Code as ErrorCode
 from peagen.defaults import (
     TASK_SUBMIT,
     TASK_CANCEL,
@@ -52,6 +52,7 @@ def _parse_task_create(task: t.Any) -> TaskCreate:
     if not isinstance(task, TaskCreate):
         raise TypeError("TaskCreate required")
     return task
+
 
 # --------------Basic Task Methods ---------------------------------
 

--- a/pkgs/standards/peagen/peagen/protocols/__init__.py
+++ b/pkgs/standards/peagen/peagen/protocols/__init__.py
@@ -1,0 +1,16 @@
+from .envelope import Request, Response, Error, parse_request
+from ._registry import register, params_model, result_model
+from . import methods  # re-export via __all__
+from .methods import *  # noqa: F401,F403 re-export method constants
+from .error_codes import Code
+
+__all__ = [
+    "Request",
+    "Response",
+    "Error",
+    "parse_request",
+    "register",
+    "params_model",
+    "result_model",
+    "Code",
+] + methods.__all__

--- a/pkgs/standards/peagen/peagen/protocols/_registry.py
+++ b/pkgs/standards/peagen/peagen/protocols/_registry.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from collections import namedtuple
+from typing import Dict, Type
+
+from pydantic import BaseModel
+
+_MethodSpec = namedtuple("_MethodSpec", "params result")
+
+_registry: Dict[str, _MethodSpec] = {}
+
+
+def register(
+    *, method: str, params_model: Type[BaseModel], result_model: Type[BaseModel]
+):
+    if method in _registry:
+        raise RuntimeError(f"Duplicate JSON-RPC method name: {method}")
+    _registry[method] = _MethodSpec(params_model, result_model)
+    return method
+
+
+def params_model(method: str) -> Type[BaseModel] | None:
+    spec = _registry.get(method)
+    return None if spec is None else spec.params
+
+
+def result_model(method: str) -> Type[BaseModel] | None:
+    spec = _registry.get(method)
+    return None if spec is None else spec.result

--- a/pkgs/standards/peagen/peagen/protocols/envelope.py
+++ b/pkgs/standards/peagen/peagen/protocols/envelope.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Generic, Literal, Optional, TypeVar
+
+from pydantic import BaseModel, TypeAdapter
+
+P = TypeVar("P")
+R = TypeVar("R")
+
+
+class Error(BaseModel):
+    code: int
+    message: str
+    data: Optional[dict] = None
+
+
+class Request(BaseModel, Generic[P]):
+    jsonrpc: Literal["2.0"] = "2.0"
+    id: int | str
+    method: str
+    params: P
+
+
+class Response(BaseModel, Generic[R]):
+    jsonrpc: Literal["2.0"] = "2.0"
+    id: int | str | None
+    result: Optional[R] = None
+    error: Optional[Error] = None
+
+    @classmethod
+    def ok(cls, *, id: int | str | None, result: R) -> "Response[R]":
+        return cls(id=id, result=result)
+
+    @classmethod
+    def fail(cls, *, id: int | str | None, err: Error) -> "Response[None]":
+        return cls(id=id, error=err)
+
+
+# ---------- helpers for wiring into the dispatcher ----------
+
+
+def parse_request(raw: dict) -> Request:
+    """Runtime validation entry point used by the gateway."""
+    structural = TypeAdapter(Request[dict]).validate_python(raw)
+    return structural

--- a/pkgs/standards/peagen/peagen/protocols/error_codes.py
+++ b/pkgs/standards/peagen/peagen/protocols/error_codes.py
@@ -1,0 +1,20 @@
+from enum import IntEnum
+
+
+class Code(IntEnum):
+    # Standard JSON-RPC codes
+    PARSE_ERROR = -32700
+    INVALID_REQUEST = -32600
+    METHOD_NOT_FOUND = -32601
+    INVALID_PARAMS = -32602
+    INTERNAL_ERROR = -32603
+
+    # Peagen-specific domain errors, never re-use numbers
+    TEMPLATE_SET_MISSING = -32010
+    WORKER_OFFLINE = -32020
+    DATABASE_FAILURE = -32030
+    SECRET_NOT_FOUND = -32004
+    TASK_NOT_FOUND = -32001
+
+
+__all__ = ["Code"]

--- a/pkgs/standards/peagen/peagen/protocols/methods/__init__.py
+++ b/pkgs/standards/peagen/peagen/protocols/methods/__init__.py
@@ -1,0 +1,7 @@
+from peagen.protocols.methods.task import TASK_SUBMIT, SubmitParams, SubmitResult
+
+__all__ = [
+    "TASK_SUBMIT",
+    "SubmitParams",
+    "SubmitResult",
+]

--- a/pkgs/standards/peagen/peagen/protocols/methods/task.py
+++ b/pkgs/standards/peagen/peagen/protocols/methods/task.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from pydantic import BaseModel, Field
+
+from peagen.protocols._registry import register
+
+
+class SubmitParams(BaseModel):
+    template_set: str = Field(
+        ..., description="Name of the template set to instantiate"
+    )
+    inputs: dict[str, str] = Field(
+        ..., description="Template input variables (raw strings only)"
+    )
+    priority: int | None = Field(0, ge=0, le=9, description="Lower is higher priority")
+
+
+class SubmitResult(BaseModel):
+    task_id: Annotated[str, Field(pattern=r"^[A-Z0-9]{12}$")]
+
+
+TASK_SUBMIT = register(
+    method="Task.submit.v1",
+    params_model=SubmitParams,
+    result_model=SubmitResult,
+)
+
+__all__ = ["TASK_SUBMIT", "SubmitParams", "SubmitResult"]

--- a/pkgs/standards/peagen/tests/test_protocols_envelope.py
+++ b/pkgs/standards/peagen/tests/test_protocols_envelope.py
@@ -1,0 +1,19 @@
+from peagen.protocols import (
+    Request,
+    parse_request,
+    TASK_SUBMIT,
+    params_model,
+    result_model,
+)
+
+
+def test_parse_request_structural() -> None:
+    raw = {"jsonrpc": "2.0", "id": 1, "method": "Task.submit.v1", "params": {}}
+    req = parse_request(raw)
+    assert isinstance(req, Request)
+    assert req.method == "Task.submit.v1"
+
+
+def test_registry_models() -> None:
+    assert params_model(TASK_SUBMIT).__name__ == "SubmitParams"
+    assert result_model(TASK_SUBMIT).__name__ == "SubmitResult"


### PR DESCRIPTION
## Summary
- refactor CLI commands to use Request/Response wrappers from `peagen.protocols`

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --directory pkgs/standards/peagen --package peagen pytest` *(fails: 19 failed, 209 passed)*
- `peagen --help`
- `peagen local process run pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml` *(fails: Missing option '--repo')*
- `peagen remote process submit pkgs/standards/peagen/tests/examples/projects_payloads/projects_payload.yaml --repo example_repo` *(fails: CLI argument error)*

------
https://chatgpt.com/codex/tasks/task_e_686014b3daa88326b85ba5bf07814515