### PR TITLE
Switch CLI to protocol-based RPC

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/db.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/db.py
@@ -15,7 +15,7 @@ import typer
 from peagen.handlers.migrate_handler import migrate_handler
 
 from peagen.schemas import TaskCreate
-from peagen.defaults import TASK_SUBMIT
+from peagen.protocols import Request, Response, TASK_SUBMIT
 
 
 # ``alembic.ini`` lives in the package root next to ``migrations``.
@@ -46,21 +46,21 @@ def _submit_task(op: str, gateway_url: str, message: str | None = None) -> str:
         pool="default",
         payload={"action": "migrate", "args": args},
     )
-    envelope = {
-        "jsonrpc": "2.0",
-        "method": TASK_SUBMIT,
-        "params": {
+    req = Request(
+        id=task.id,
+        method=TASK_SUBMIT,
+        params={
             "pool": task.pool,
             "payload": task.payload,
             "taskId": task.id,
         },
-    }
-    resp = httpx.post(gateway_url, json=envelope, timeout=10.0)
+    )
+    resp = httpx.post(gateway_url, json=req.model_dump(mode="json"), timeout=10.0)
     resp.raise_for_status()
-    data = resp.json()
-    if data.get("error"):
-        raise RuntimeError(data["error"])
-    return str(data.get("result", {}).get("taskId", task.id))
+    data = Response.model_validate(resp.json())
+    if data.error:
+        raise RuntimeError(data.error)
+    return str(data.result.get("taskId", task.id))
 
 
 @local_db_app.command("upgrade")

--- a/pkgs/standards/peagen/peagen/cli/commands/evolve.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/evolve.py
@@ -15,7 +15,7 @@ from functools import partial
 from peagen.handlers.evolve_handler import evolve_handler
 from peagen.orm.status import Status
 from peagen.core.validate_core import validate_evolve_spec
-from peagen.defaults import TASK_SUBMIT
+from peagen.protocols import Request, Response, TASK_SUBMIT
 from peagen.cli.task_builder import _build_task as _generic_build_task
 
 local_evolve_app = typer.Typer(help="Expand evolve spec and run mutate tasks")
@@ -102,34 +102,34 @@ def submit(
     if repo:
         args.update({"repo": repo, "ref": ref})
     task = _build_task(args, ctx.obj.get("pool", "default"))
-    rpc_req = {
-        "jsonrpc": "2.0",
-        "method": TASK_SUBMIT,
-        "params": task.model_dump(mode="json"),
-    }
+    req = Request(id=task.id, method=TASK_SUBMIT, params=task.model_dump(mode="json"))
     with httpx.Client(timeout=30.0) as client:
-        reply = client.post(ctx.obj.get("gateway_url"), json=rpc_req).json()
-    if "error" in reply:
+        reply = client.post(
+            ctx.obj.get("gateway_url"), json=req.model_dump(mode="json")
+        ).json()
+        reply = Response.model_validate(reply)
+    if reply.error:
         typer.secho(
-            f"Remote error {reply['error']['code']}: {reply['error']['message']}",
+            f"Remote error {reply.error.code}: {reply.error.message}",
             fg=typer.colors.RED,
             err=True,
         )
         raise typer.Exit(1)
     typer.secho(f"Submitted task {task.id}", fg=typer.colors.GREEN)
-    if reply.get("result"):
-        typer.echo(json.dumps(reply["result"], indent=2))
+    if reply.result:
+        typer.echo(json.dumps(reply.result, indent=2))
     if watch:
 
         def _rpc_call() -> dict:
-            req = {
-                "jsonrpc": "2.0",
-                "id": str(uuid.uuid4()),
-                "method": "Task.get",
-                "params": {"taskId": task.id},
-            }
-            res = httpx.post(ctx.obj.get("gateway_url"), json=req, timeout=30.0).json()
-            return res["result"]
+            req = Request(
+                id=str(uuid.uuid4()), method="Task.get", params={"taskId": task.id}
+            )
+            res = httpx.post(
+                ctx.obj.get("gateway_url"),
+                json=req.model_dump(mode="json"),
+                timeout=30.0,
+            ).json()
+            return Response.model_validate(res).result
 
         import time
 

--- a/pkgs/standards/peagen/peagen/cli/commands/extras.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/extras.py
@@ -11,7 +11,7 @@ from functools import partial
 
 from peagen.handlers.extras_handler import extras_handler
 from swarmauri_standard.loggers.Logger import Logger
-from peagen.defaults import TASK_SUBMIT
+from peagen.protocols import Request, Response, TASK_SUBMIT
 from peagen.cli.task_builder import _build_task as _generic_build_task
 
 local_extras_app = typer.Typer(help="Manage EXTRAS schemas.")
@@ -81,22 +81,18 @@ def submit_extras(
         args.update({"repo": repo, "ref": ref})
     task = _build_task(args, ctx.obj.get("pool", "default"))
 
-    envelope = {
-        "jsonrpc": "2.0",
-        "method": TASK_SUBMIT,
-        "params": task.model_dump(mode="json"),
-    }
+    req = Request(id=task.id, method=TASK_SUBMIT, params=task.model_dump(mode="json"))
 
     try:
         import httpx
 
-        resp = httpx.post(gateway_url, json=envelope, timeout=10.0)
+        resp = httpx.post(gateway_url, json=req.model_dump(mode="json"), timeout=10.0)
         resp.raise_for_status()
-        data = resp.json()
-        if data.get("error"):
-            typer.echo(f"[ERROR] {data['error']}")
+        data = Response.model_validate(resp.json())
+        if data.error:
+            typer.echo(f"[ERROR] {data.error}")
             raise typer.Exit(1)
-        typer.echo(f"Submitted extras generation → taskId={data['id']}")
+        typer.echo(f"Submitted extras generation → taskId={data.result['taskId']}")
     except Exception as exc:
         typer.echo(f"[ERROR] Could not reach gateway at {gateway_url}: {exc}")
         raise typer.Exit(1)

--- a/pkgs/standards/peagen/peagen/cli/commands/keys.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/keys.py
@@ -11,6 +11,7 @@ import typer
 
 from peagen.plugins.secret_drivers import AutoGpgDriver
 from peagen.core import keys_core
+from peagen.protocols import Request, KEYS_UPLOAD, KEYS_DELETE, KEYS_FETCH
 
 
 keys_app = typer.Typer(help="Manage local and remote public keys.")
@@ -37,12 +38,8 @@ def upload(
     """Upload the public key to the gateway."""
     drv = AutoGpgDriver(key_dir=key_dir)
     pubkey = drv.pub_path.read_text()
-    envelope = {
-        "jsonrpc": "2.0",
-        "method": "Keys.upload",
-        "params": {"public_key": pubkey},
-    }
-    httpx.post(gateway_url, json=envelope, timeout=10.0)
+    req = Request(id="1", method=KEYS_UPLOAD, params={"public_key": pubkey})
+    httpx.post(gateway_url, json=req.model_dump(mode="json"), timeout=10.0)
     typer.echo("Uploaded public key")
 
 
@@ -53,12 +50,8 @@ def remove(
     gateway_url: str = typer.Option("http://localhost:8000/rpc", "--gateway-url"),
 ) -> None:
     """Remove a public key from the gateway."""
-    envelope = {
-        "jsonrpc": "2.0",
-        "method": "Keys.delete",
-        "params": {"fingerprint": fingerprint},
-    }
-    httpx.post(gateway_url, json=envelope, timeout=10.0)
+    req = Request(id="1", method=KEYS_DELETE, params={"fingerprint": fingerprint})
+    httpx.post(gateway_url, json=req.model_dump(mode="json"), timeout=10.0)
     typer.echo(f"Removed key {fingerprint}")
 
 
@@ -68,8 +61,8 @@ def fetch_server(
     gateway_url: str = typer.Option("http://localhost:8000/rpc", "--gateway-url"),
 ) -> None:
     """Fetch trusted public keys from the gateway."""
-    envelope = {"jsonrpc": "2.0", "method": "Keys.fetch"}
-    res = httpx.post(gateway_url, json=envelope, timeout=10.0)
+    req = Request(id="1", method=KEYS_FETCH, params={})
+    res = httpx.post(gateway_url, json=req.model_dump(mode="json"), timeout=10.0)
     typer.echo(json.dumps(res.json().get("result", {}), indent=2))
 
 

--- a/pkgs/standards/peagen/peagen/cli/commands/login.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/login.py
@@ -9,6 +9,7 @@ import httpx
 import typer
 
 from peagen.plugins.secret_drivers import AutoGpgDriver
+from peagen.protocols import Request, KEYS_UPLOAD
 
 
 login_app = typer.Typer(help="Authenticate and upload your public key.")
@@ -31,13 +32,11 @@ def login(
         gateway_url += "/rpc"
     drv = AutoGpgDriver(key_dir=key_dir, passphrase=passphrase)
     pubkey = drv.pub_path.read_text()
-    payload = {
-        "jsonrpc": "2.0",
-        "method": "Keys.upload",
-        "params": {"public_key": pubkey},
-    }
+    payload = Request(id="1", method=KEYS_UPLOAD, params={"public_key": pubkey})
     try:
-        res = httpx.post(gateway_url, json=payload, timeout=10.0)
+        res = httpx.post(
+            gateway_url, json=payload.model_dump(mode="json"), timeout=10.0
+        )
     except httpx.RequestError as e:  # pragma: no cover - network errors
         typer.echo(f"HTTP error: {e}", err=True)
         raise typer.Exit(1)

--- a/pkgs/standards/peagen/peagen/cli/commands/task.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/task.py
@@ -10,6 +10,7 @@ import uuid
 
 import httpx
 import typer
+from peagen.protocols import Request, Response
 from peagen.defaults import (
     TASK_GET,
     TASK_PATCH,
@@ -37,14 +38,11 @@ def get(  # noqa: D401
     """Fetch status / result for *TASK_ID* (optionally watch until done)."""
 
     def _rpc_call() -> dict:
-        req = {
-            "jsonrpc": "2.0",
-            "id": str(uuid.uuid4()),
-            "method": TASK_GET,
-            "params": {"taskId": task_id},
-        }
-        res = httpx.post(ctx.obj.get("gateway_url"), json=req, timeout=30.0).json()
-        return res["result"]
+        req = Request(id=str(uuid.uuid4()), method=TASK_GET, params={"taskId": task_id})
+        res = httpx.post(
+            ctx.obj.get("gateway_url"), json=req.model_dump(mode="json"), timeout=30.0
+        ).json()
+        return Response.model_validate(res).result
 
     while True:
         reply = _rpc_call()
@@ -64,25 +62,27 @@ def patch_task(
     """Send a Task.patch RPC call."""
 
     payload = json.loads(changes)
-    req = {
-        "jsonrpc": "2.0",
-        "id": str(uuid.uuid4()),
-        "method": TASK_PATCH,
-        "params": {"taskId": task_id, "changes": payload},
-    }
-    res = httpx.post(ctx.obj.get("gateway_url"), json=req, timeout=30.0).json()
-    typer.echo(json.dumps(res["result"], indent=2))
+    req = Request(
+        id=str(uuid.uuid4()),
+        method=TASK_PATCH,
+        params={"taskId": task_id, "changes": payload},
+    )
+    res = httpx.post(
+        ctx.obj.get("gateway_url"), json=req.model_dump(mode="json"), timeout=30.0
+    ).json()
+    typer.echo(json.dumps(Response.model_validate(res).result, indent=2))
 
 
 def _simple_call(ctx: typer.Context, method: str, selector: str) -> None:
-    req = {
-        "jsonrpc": "2.0",
-        "id": str(uuid.uuid4()),
-        "method": method,
-        "params": {"selector": selector},
-    }
-    res = httpx.post(ctx.obj.get("gateway_url"), json=req, timeout=30.0).json()
-    typer.echo(json.dumps(res["result"], indent=2))
+    req = Request(
+        id=str(uuid.uuid4()),
+        method=method,
+        params={"selector": selector},
+    )
+    res = httpx.post(
+        ctx.obj.get("gateway_url"), json=req.model_dump(mode="json"), timeout=30.0
+    ).json()
+    typer.echo(json.dumps(Response.model_validate(res).result, indent=2))
 
 
 @remote_task_app.command("pause")

--- a/pkgs/standards/peagen/peagen/cli/commands/templates.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/templates.py
@@ -9,7 +9,7 @@ import typer
 
 from peagen.handlers.templates_handler import templates_handler
 from peagen.schemas import TaskCreate
-from peagen.defaults import TASK_SUBMIT
+from peagen.protocols import Request, Response, TASK_SUBMIT
 
 # ──────────────────────────────────────
 DEFAULT_GATEWAY = "http://localhost:8000/rpc"
@@ -33,17 +33,13 @@ def _run_handler(args: Dict[str, Any]) -> Dict[str, Any]:
 def _submit_task(args: Dict[str, Any], gateway_url: str) -> str:
     """Submit a templates task via JSON-RPC."""
     task = TaskCreate(pool="default", payload={"action": "templates", "args": args})
-    envelope = {
-        "jsonrpc": "2.0",
-        "method": TASK_SUBMIT,
-        "params": task.model_dump(mode="json"),
-    }
-    resp = httpx.post(gateway_url, json=envelope, timeout=10.0)
+    req = Request(id=task.id, method=TASK_SUBMIT, params=task.model_dump(mode="json"))
+    resp = httpx.post(gateway_url, json=req.model_dump(mode="json"), timeout=10.0)
     resp.raise_for_status()
-    data = resp.json()
-    if data.get("error"):
-        raise RuntimeError(data["error"])
-    return str(data.get("result", {}).get("taskId", task.id))
+    data = Response.model_validate(resp.json())
+    if data.error:
+        raise RuntimeError(data.error)
+    return str(data.result.get("taskId", task.id))
 
 
 # ─── list ──────────────────────────────

--- a/pkgs/standards/peagen/peagen/cli/commands/validate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/validate.py
@@ -7,7 +7,7 @@ import typer
 
 from peagen.handlers.validate_handler import validate_handler
 from peagen.schemas import TaskCreate
-from peagen.defaults import TASK_SUBMIT
+from peagen.protocols import Request, Response, TASK_SUBMIT
 
 local_validate_app = typer.Typer(help="Validate Peagen artifacts.")
 remote_validate_app = typer.Typer(help="Validate Peagen artifacts via JSON-RPC.")
@@ -90,21 +90,23 @@ def submit_validate(
     )
 
     # 2) Build Task.submit envelope using Task fields
-    envelope = {
-        "jsonrpc": "2.0",
-        "method": TASK_SUBMIT,
-        "params": task.model_dump(mode="json"),
-    }
+    envelope = Request(
+        id=task.id, method=TASK_SUBMIT, params=task.model_dump(mode="json")
+    )
 
     # 3) POST to gateway
     try:
         import httpx
 
-        resp = httpx.post(ctx.obj.get("gateway_url"), json=envelope, timeout=10.0)
+        resp = httpx.post(
+            ctx.obj.get("gateway_url"),
+            json=envelope.model_dump(mode="json"),
+            timeout=10.0,
+        )
         resp.raise_for_status()
-        data = resp.json()
-        if data.get("error"):
-            typer.echo(f"[ERROR] {data['error']}")
+        data = Response.model_validate(resp.json())
+        if data.error:
+            typer.echo(f"[ERROR] {data.error}")
             raise typer.Exit(1)
         typer.echo(f"Submitted validation → taskId={task.id}")
     except Exception as exc:


### PR DESCRIPTION
## Summary
- refactor CLI commands to build JSON-RPC envelopes via `peagen.protocols`
- use `Request`/`Response` models across remote subcommands

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --directory pkgs/standards/peagen --package peagen pytest` *(fails: 11 failed, 216 passed, 34 skipped)*
- `peagen remote -q process projects_payload.yaml --watch` *(fails: Connection refused)*
- `peagen local -q process projects_payload.yaml` *(fails: Missing option '--repo')*

------
https://chatgpt.com/codex/tasks/task_e_68601902a5b08326bce51edbd253034e