### PR TITLE
Refactor CLI commands to use typed RPC envelopes

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/doe.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/doe.py
@@ -18,7 +18,7 @@ import typer
 from peagen.handlers.doe_handler import doe_handler
 from peagen.handlers.doe_process_handler import doe_process_handler
 from peagen.schemas import TaskCreate
-from peagen.defaults import TASK_SUBMIT, TASK_GET
+from peagen.protocols import Request
 from peagen.orm.status import Status
 
 DEFAULT_GATEWAY = "http://localhost:8000/rpc"
@@ -145,14 +145,16 @@ def submit_gen(  # noqa: PLR0913
     args.update({"repo": repo, "ref": ref})
     task = _make_task(args, action="doe")
 
-    rpc_req = {
-        "jsonrpc": "2.0",
-        "method": TASK_SUBMIT,
-        "params": task.model_dump(mode="json"),
-    }
+    rpc_req = Request(
+        id=task.id,
+        method="Task.submit",
+        params=task.model_dump(mode="json"),
+    )
 
     with httpx.Client(timeout=30.0) as client:
-        reply = client.post(ctx.obj.get("gateway_url"), json=rpc_req).json()
+        reply = client.post(
+            ctx.obj.get("gateway_url"), json=rpc_req.model_dump()
+        ).json()
 
     if "error" in reply:
         typer.secho(
@@ -295,14 +297,16 @@ def submit_process(  # noqa: PLR0913
     args.update({"repo": repo, "ref": ref})
     task = _make_task(args, action="doe_process")
 
-    rpc_req = {
-        "jsonrpc": "2.0",
-        "method": TASK_SUBMIT,
-        "params": task.model_dump(mode="json"),
-    }
+    rpc_req = Request(
+        id=task.id,
+        method="Task.submit",
+        params=task.model_dump(mode="json"),
+    )
 
     with httpx.Client(timeout=30.0) as client:
-        reply = client.post(ctx.obj.get("gateway_url"), json=rpc_req).json()
+        reply = client.post(
+            ctx.obj.get("gateway_url"), json=rpc_req.model_dump()
+        ).json()
 
     if "error" in reply:
         typer.secho(
@@ -316,13 +320,14 @@ def submit_process(  # noqa: PLR0913
     if watch:
 
         def _rpc_call(tid: str) -> dict:
-            req = {
-                "jsonrpc": "2.0",
-                "id": str(uuid.uuid4()),
-                "method": TASK_GET,
-                "params": {"taskId": tid},
-            }
-            res = httpx.post(ctx.obj.get("gateway_url"), json=req, timeout=30.0).json()
+            req = Request(
+                id=str(uuid.uuid4()),
+                method="Task.get",
+                params={"taskId": tid},
+            )
+            res = httpx.post(
+                ctx.obj.get("gateway_url"), json=req.model_dump(), timeout=30.0
+            ).json()
             return res["result"]
 
         while True:

--- a/pkgs/standards/peagen/peagen/cli/commands/keys.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/keys.py
@@ -11,6 +11,7 @@ import typer
 
 from peagen.plugins.secret_drivers import AutoGpgDriver
 from peagen.core import keys_core
+from peagen.protocols import Request
 
 
 keys_app = typer.Typer(help="Manage local and remote public keys.")
@@ -37,12 +38,12 @@ def upload(
     """Upload the public key to the gateway."""
     drv = AutoGpgDriver(key_dir=key_dir)
     pubkey = drv.pub_path.read_text()
-    envelope = {
-        "jsonrpc": "2.0",
-        "method": "Keys.upload",
-        "params": {"public_key": pubkey},
-    }
-    httpx.post(gateway_url, json=envelope, timeout=10.0)
+    envelope = Request(
+        id="upload-key",
+        method="Keys.upload",
+        params={"public_key": pubkey},
+    )
+    httpx.post(gateway_url, json=envelope.model_dump(), timeout=10.0)
     typer.echo("Uploaded public key")
 
 
@@ -53,12 +54,12 @@ def remove(
     gateway_url: str = typer.Option("http://localhost:8000/rpc", "--gateway-url"),
 ) -> None:
     """Remove a public key from the gateway."""
-    envelope = {
-        "jsonrpc": "2.0",
-        "method": "Keys.delete",
-        "params": {"fingerprint": fingerprint},
-    }
-    httpx.post(gateway_url, json=envelope, timeout=10.0)
+    envelope = Request(
+        id="delete-key",
+        method="Keys.delete",
+        params={"fingerprint": fingerprint},
+    )
+    httpx.post(gateway_url, json=envelope.model_dump(), timeout=10.0)
     typer.echo(f"Removed key {fingerprint}")
 
 
@@ -68,8 +69,8 @@ def fetch_server(
     gateway_url: str = typer.Option("http://localhost:8000/rpc", "--gateway-url"),
 ) -> None:
     """Fetch trusted public keys from the gateway."""
-    envelope = {"jsonrpc": "2.0", "method": "Keys.fetch"}
-    res = httpx.post(gateway_url, json=envelope, timeout=10.0)
+    envelope = Request(id="fetch-keys", method="Keys.fetch", params={})
+    res = httpx.post(gateway_url, json=envelope.model_dump(), timeout=10.0)
     typer.echo(json.dumps(res.json().get("result", {}), indent=2))
 
 

--- a/pkgs/standards/peagen/peagen/cli/commands/login.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/login.py
@@ -9,6 +9,7 @@ import httpx
 import typer
 
 from peagen.plugins.secret_drivers import AutoGpgDriver
+from peagen.protocols import Request
 
 
 login_app = typer.Typer(help="Authenticate and upload your public key.")
@@ -31,13 +32,13 @@ def login(
         gateway_url += "/rpc"
     drv = AutoGpgDriver(key_dir=key_dir, passphrase=passphrase)
     pubkey = drv.pub_path.read_text()
-    payload = {
-        "jsonrpc": "2.0",
-        "method": "Keys.upload",
-        "params": {"public_key": pubkey},
-    }
+    payload = Request(
+        id="login",
+        method="Keys.upload",
+        params={"public_key": pubkey},
+    )
     try:
-        res = httpx.post(gateway_url, json=payload, timeout=10.0)
+        res = httpx.post(gateway_url, json=payload.model_dump(), timeout=10.0)
     except httpx.RequestError as e:  # pragma: no cover - network errors
         typer.echo(f"HTTP error: {e}", err=True)
         raise typer.Exit(1)

--- a/pkgs/standards/peagen/peagen/cli/commands/mutate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/mutate.py
@@ -13,7 +13,7 @@ import typer
 from functools import partial
 
 from peagen.handlers.mutate_handler import mutate_handler
-from peagen.defaults import TASK_SUBMIT
+from peagen.protocols import Request
 from peagen.cli.task_builder import _build_task as _generic_build_task
 
 DEFAULT_GATEWAY = "http://localhost:8000/rpc"
@@ -109,14 +109,14 @@ def submit(
     }
     task = _build_task(args, ctx.obj.get("pool", "default"))
 
-    rpc_req = {
-        "jsonrpc": "2.0",
-        "method": TASK_SUBMIT,
-        "params": task.model_dump(mode="json"),
-    }
+    rpc_req = Request(
+        id=task.id,
+        method="Task.submit",
+        params=task.model_dump(mode="json"),
+    )
 
     with httpx.Client(timeout=30.0) as client:
-        resp = client.post(ctx.obj.get("gateway_url"), json=rpc_req)
+        resp = client.post(ctx.obj.get("gateway_url"), json=rpc_req.model_dump())
         resp.raise_for_status()
         reply = resp.json()
 

--- a/pkgs/standards/peagen/peagen/cli/commands/process.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/process.py
@@ -23,7 +23,7 @@ import typer
 from functools import partial
 from peagen._utils.config_loader import _effective_cfg, load_peagen_toml
 from peagen.handlers.process_handler import process_handler
-from peagen.defaults import TASK_SUBMIT, TASK_GET
+from peagen.protocols import Request
 from peagen.orm.status import Status
 from peagen.cli.task_builder import _build_task as _generic_build_task
 
@@ -187,13 +187,13 @@ def submit(  # noqa: PLR0913 – CLI signature needs many options
         cfg_override.update(load_peagen_toml(Path(file_), required=True))
     task.payload["cfg_override"] = cfg_override
 
-    rpc_req = {
-        "jsonrpc": "2.0",
-        "method": TASK_SUBMIT,
-        "params": task.model_dump(mode="json"),
-    }
+    rpc_req = Request(
+        id=task.id,
+        method="Task.submit",
+        params=task.model_dump(mode="json"),
+    )
     with httpx.Client(timeout=30.0) as client:
-        resp = client.post(ctx.obj.get("gateway_url"), json=rpc_req)
+        resp = client.post(ctx.obj.get("gateway_url"), json=rpc_req.model_dump())
         resp.raise_for_status()
         reply = resp.json()
 
@@ -211,13 +211,14 @@ def submit(  # noqa: PLR0913 – CLI signature needs many options
     if watch:
 
         def _rpc_call() -> dict:
-            req = {
-                "jsonrpc": "2.0",
-                "id": str(uuid.uuid4()),
-                "method": TASK_GET,
-                "params": {"taskId": task.id},
-            }
-            res = httpx.post(ctx.obj.get("gateway_url"), json=req, timeout=30.0).json()
+            req = Request(
+                id=str(uuid.uuid4()),
+                method="Task.get",
+                params={"taskId": task.id},
+            )
+            res = httpx.post(
+                ctx.obj.get("gateway_url"), json=req.model_dump(), timeout=30.0
+            ).json()
             return res["result"]
 
         while True:

--- a/pkgs/standards/peagen/peagen/cli/commands/secrets.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/secrets.py
@@ -10,6 +10,7 @@ import httpx
 import typer
 
 from peagen.plugins.secret_drivers import AutoGpgDriver
+from peagen.protocols import Request
 
 
 local_secrets_app = typer.Typer(help="Manage local secret store.")
@@ -19,13 +20,13 @@ STORE_FILE = Path.home() / ".peagen" / "secret_store.json"
 
 def _pool_worker_pubs(pool: str, gateway_url: str) -> list[str]:
     """Return public keys advertised by workers in ``pool``."""
-    envelope = {
-        "jsonrpc": "2.0",
-        "method": "Worker.list",
-        "params": {"pool": pool},
-    }
+    envelope = Request(
+        id="worker-list",
+        method="Worker.list",
+        params={"pool": pool},
+    )
     try:
-        res = httpx.post(gateway_url, json=envelope, timeout=10.0)
+        res = httpx.post(gateway_url, json=envelope.model_dump(), timeout=10.0)
         res.raise_for_status()
     except Exception:
         return []
@@ -105,17 +106,17 @@ def remote_add(
     pubs = [p.read_text() for p in recipient]
     pubs.extend(_pool_worker_pubs(pool, gateway_url))
     cipher = drv.encrypt(value.encode(), pubs).decode()
-    envelope = {
-        "jsonrpc": "2.0",
-        "method": "Secrets.add",
-        "params": {
+    envelope = Request(
+        id="secrets-add",
+        method="Secrets.add",
+        params={
             "name": secret_id,
             "cipher": cipher,
             "version": version,
             "tenant_id": pool,
         },
-    }
-    res = httpx.post(gateway_url, json=envelope, timeout=10.0)
+    )
+    res = httpx.post(gateway_url, json=envelope.model_dump(), timeout=10.0)
     if getattr(res, "status_code", 200) >= 400:
         typer.echo(
             f"Error {getattr(res, 'status_code', 'unknown')}: {getattr(res, 'text', '')}",
@@ -138,12 +139,12 @@ def remote_get(
     if not gateway_url.endswith("/rpc"):
         gateway_url += "/rpc"
     drv = AutoGpgDriver()
-    envelope = {
-        "jsonrpc": "2.0",
-        "method": "Secrets.get",
-        "params": {"name": secret_id, "tenant_id": pool},
-    }
-    res = httpx.post(gateway_url, json=envelope, timeout=10.0)
+    envelope = Request(
+        id="secrets-get",
+        method="Secrets.get",
+        params={"name": secret_id, "tenant_id": pool},
+    )
+    res = httpx.post(gateway_url, json=envelope.model_dump(), timeout=10.0)
     if getattr(res, "status_code", 200) >= 400:
         typer.echo(
             f"Error {getattr(res, 'status_code', 'unknown')}: {getattr(res, 'text', '')}",
@@ -167,13 +168,13 @@ def remote_remove(
     gateway_url = gateway_url.rstrip("/")
     if not gateway_url.endswith("/rpc"):
         gateway_url += "/rpc"
-    envelope = {
-        "jsonrpc": "2.0",
-        "method": "Secrets.delete",
-        "params": {"name": secret_id, "version": version, "tenant_id": pool},
-    }
+    envelope = Request(
+        id="secrets-delete",
+        method="Secrets.delete",
+        params={"name": secret_id, "version": version, "tenant_id": pool},
+    )
 
-    res = httpx.post(gateway_url, json=envelope, timeout=10.0)
+    res = httpx.post(gateway_url, json=envelope.model_dump(), timeout=10.0)
     if getattr(res, "status_code", 200) >= 400:
         typer.echo(
             f"Error {getattr(res, 'status_code', 'unknown')}: {getattr(res, 'text', '')}",

--- a/pkgs/standards/peagen/peagen/cli/commands/sort.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/sort.py
@@ -9,7 +9,7 @@ import typer
 
 from peagen._utils.config_loader import _effective_cfg, load_peagen_toml
 from peagen.handlers.sort_handler import sort_handler
-from peagen.defaults import TASK_SUBMIT
+from peagen.protocols import Request
 
 local_sort_app = typer.Typer(help="Sort generated project files.")
 remote_sort_app = typer.Typer(help="Sort generated project files via JSON-RPC.")
@@ -137,17 +137,15 @@ def submit_sort(
     }
 
     # 2) Build Task.submit envelope using Task fields
-    envelope = {
-        "jsonrpc": "2.0",
-        "method": TASK_SUBMIT,
-        "params": task,
-    }
+    envelope = Request(id="sort", method="Task.submit", params=task)
 
     # 3) POST to gateway
     try:
         import httpx
 
-        resp = httpx.post(ctx.obj.get("gateway_url"), json=envelope, timeout=10.0)
+        resp = httpx.post(
+            ctx.obj.get("gateway_url"), json=envelope.model_dump(), timeout=10.0
+        )
         resp.raise_for_status()
         data = resp.json()
         if data.get("error"):

--- a/pkgs/standards/peagen/peagen/cli/commands/templates.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/templates.py
@@ -9,7 +9,7 @@ import typer
 
 from peagen.handlers.templates_handler import templates_handler
 from peagen.schemas import TaskCreate
-from peagen.defaults import TASK_SUBMIT
+from peagen.protocols import Request
 
 # ──────────────────────────────────────
 DEFAULT_GATEWAY = "http://localhost:8000/rpc"
@@ -33,12 +33,12 @@ def _run_handler(args: Dict[str, Any]) -> Dict[str, Any]:
 def _submit_task(args: Dict[str, Any], gateway_url: str) -> str:
     """Submit a templates task via JSON-RPC."""
     task = TaskCreate(pool="default", payload={"action": "templates", "args": args})
-    envelope = {
-        "jsonrpc": "2.0",
-        "method": TASK_SUBMIT,
-        "params": task.model_dump(mode="json"),
-    }
-    resp = httpx.post(gateway_url, json=envelope, timeout=10.0)
+    envelope = Request(
+        id=task.id,
+        method="Task.submit",
+        params=task.model_dump(mode="json"),
+    )
+    resp = httpx.post(gateway_url, json=envelope.model_dump(), timeout=10.0)
     resp.raise_for_status()
     data = resp.json()
     if data.get("error"):

--- a/pkgs/standards/peagen/tests/unit/test_secrets_cli.py
+++ b/pkgs/standards/peagen/tests/unit/test_secrets_cli.py
@@ -151,6 +151,7 @@ def test_remote_get(monkeypatch):
     assert out == ["value"]
     assert posted["json"] == {
         "jsonrpc": "2.0",
+        "id": "secrets-get",
         "method": "Secrets.get",
         "params": {"name": "ID", "tenant_id": "default"},
     }
@@ -178,6 +179,7 @@ def test_remote_remove(monkeypatch):
     )
     assert posted["json"] == {
         "jsonrpc": "2.0",
+        "id": "secrets-delete",
         "method": "Secrets.delete",
         "params": {"name": "ID", "version": 2, "tenant_id": "default"},
     }


### PR DESCRIPTION
## Summary
- update CLI modules to construct `Request` objects from `peagen.protocols`
- keep existing RPC method names for compatibility
- adjust secrets CLI unit test for new envelope structure

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format .`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest` *(fails: AssertionError in secrets_cli and TypeError in task_submit related tests)*

------
https://chatgpt.com/codex/tasks/task_e_686018c1409483268f49b62b53fe2f89