### PR TITLE
Use protocol constants everywhere

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/secrets.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/secrets.py
@@ -10,7 +10,12 @@ from peagen.cli.rpc_utils import rpc_post
 import typer
 
 from peagen.plugins.secret_drivers import AutoGpgDriver
-from peagen.protocols import SECRETS_ADD, SECRETS_GET, SECRETS_DELETE
+from peagen.protocols import (
+    SECRETS_ADD,
+    SECRETS_GET,
+    SECRETS_DELETE,
+    WORKER_LIST,
+)
 
 
 local_secrets_app = typer.Typer(help="Manage local secret store.")
@@ -22,7 +27,7 @@ def _pool_worker_pubs(pool: str, gateway_url: str) -> list[str]:
     """Return public keys advertised by workers in ``pool``."""
     envelope = {"pool": pool}
     try:
-        res = rpc_post(gateway_url, "Worker.list", envelope, timeout=10.0)
+        res = rpc_post(gateway_url, WORKER_LIST, envelope, timeout=10.0)
     except Exception:
         return []
     workers = res.get("result", [])

--- a/pkgs/standards/peagen/peagen/core/keys_core.py
+++ b/pkgs/standards/peagen/peagen/core/keys_core.py
@@ -9,6 +9,7 @@ import httpx
 
 from peagen._utils.config_loader import load_peagen_toml
 from peagen.plugins import PluginManager
+from peagen.protocols import Request, KEYS_UPLOAD, KEYS_DELETE, KEYS_FETCH
 
 DEFAULT_GATEWAY = "http://localhost:8000/rpc"
 
@@ -63,11 +64,11 @@ def upload_public_key(
     """Upload the local public key to the gateway."""
     drv = _get_driver(key_dir=key_dir)
     pubkey = drv.pub_path.read_text()
-    envelope = {
-        "jsonrpc": "2.0",
-        "method": "Keys.upload",
-        "params": {"public_key": pubkey},
-    }
+    envelope = Request(
+        id="0",
+        method=KEYS_UPLOAD,
+        params={"public_key": pubkey},
+    ).model_dump()
     res = httpx.post(gateway_url, json=envelope, timeout=10.0)
     res.raise_for_status()
     return res.json()
@@ -75,11 +76,11 @@ def upload_public_key(
 
 def remove_public_key(fingerprint: str, gateway_url: str = DEFAULT_GATEWAY) -> dict:
     """Remove a stored public key on the gateway."""
-    envelope = {
-        "jsonrpc": "2.0",
-        "method": "Keys.delete",
-        "params": {"fingerprint": fingerprint},
-    }
+    envelope = Request(
+        id="0",
+        method=KEYS_DELETE,
+        params={"fingerprint": fingerprint},
+    ).model_dump()
     res = httpx.post(gateway_url, json=envelope, timeout=10.0)
     res.raise_for_status()
     return res.json()
@@ -87,7 +88,7 @@ def remove_public_key(fingerprint: str, gateway_url: str = DEFAULT_GATEWAY) -> d
 
 def fetch_server_keys(gateway_url: str = DEFAULT_GATEWAY) -> dict:
     """Fetch trusted keys from the gateway."""
-    envelope = {"jsonrpc": "2.0", "method": "Keys.fetch"}
+    envelope = Request(id="0", method=KEYS_FETCH, params={}).model_dump()
     res = httpx.post(gateway_url, json=envelope, timeout=10.0)
     res.raise_for_status()
     return res.json().get("result", {})

--- a/pkgs/standards/peagen/peagen/core/login_core.py
+++ b/pkgs/standards/peagen/peagen/core/login_core.py
@@ -8,6 +8,7 @@ from typing import Optional
 import httpx
 
 from peagen.plugins.secret_drivers import AutoGpgDriver
+from peagen.protocols import Request, KEYS_UPLOAD
 
 DEFAULT_GATEWAY = "http://localhost:8000/rpc"
 
@@ -29,11 +30,11 @@ def login(
     """
     drv = AutoGpgDriver(key_dir=key_dir, passphrase=passphrase)
     pubkey = drv.pub_path.read_text()
-    payload = {
-        "jsonrpc": "2.0",
-        "method": "Keys.upload",
-        "params": {"public_key": pubkey},
-    }
-    res = httpx.post(gateway_url, json=payload, timeout=10.0)
+    envelope = Request(
+        id="0",
+        method=KEYS_UPLOAD,
+        params={"public_key": pubkey},
+    ).model_dump()
+    res = httpx.post(gateway_url, json=envelope, timeout=10.0)
     res.raise_for_status()
     return res.json()

--- a/pkgs/standards/peagen/peagen/core/secrets_core.py
+++ b/pkgs/standards/peagen/peagen/core/secrets_core.py
@@ -9,17 +9,24 @@ from typing import List, Optional
 import httpx
 
 from peagen.plugins.secret_drivers import AutoGpgDriver
+from peagen.protocols import (
+    Request,
+    WORKER_LIST,
+    SECRETS_ADD,
+    SECRETS_GET,
+    SECRETS_DELETE,
+)
 
 DEFAULT_GATEWAY = "http://localhost:8000/rpc"
 STORE_FILE = Path.home() / ".peagen" / "secret_store.json"
 
 
 def _pool_worker_pubs(pool: str, gateway_url: str) -> list[str]:
-    envelope = {
-        "jsonrpc": "2.0",
-        "method": "Worker.list",
-        "params": {"pool": pool},
-    }
+    envelope = Request(
+        id="0",
+        method=WORKER_LIST,
+        params={"pool": pool},
+    ).model_dump()
     try:
         res = httpx.post(gateway_url, json=envelope, timeout=10.0)
         res.raise_for_status()
@@ -88,16 +95,16 @@ def add_remote_secret(
     pubs = [p.read_text() for p in recipients or []]
     pubs.extend(_pool_worker_pubs(pool, gateway_url))
     cipher = drv.encrypt(value.encode(), pubs).decode()
-    envelope = {
-        "jsonrpc": "2.0",
-        "method": "Secrets.add",
-        "params": {
+    envelope = Request(
+        id="0",
+        method=SECRETS_ADD,
+        params={
             "name": secret_id,
-            "secret": cipher,
+            "cipher": cipher,
             "version": version,
             "tenant_id": pool,
         },
-    }
+    ).model_dump()
     res = httpx.post(gateway_url, json=envelope, timeout=10.0)
     res.raise_for_status()
     return res.json()
@@ -111,11 +118,11 @@ def get_remote_secret(
 ) -> str:
     """Retrieve and decrypt a secret from the gateway."""
     drv = AutoGpgDriver()
-    envelope = {
-        "jsonrpc": "2.0",
-        "method": "Secrets.get",
-        "params": {"name": secret_id, "tenant_id": pool},
-    }
+    envelope = Request(
+        id="0",
+        method=SECRETS_GET,
+        params={"name": secret_id, "tenant_id": pool},
+    ).model_dump()
     res = httpx.post(gateway_url, json=envelope, timeout=10.0)
     res.raise_for_status()
     cipher = res.json()["result"]["secret"].encode()
@@ -130,11 +137,11 @@ def remove_remote_secret(
     pool: str = "default",
 ) -> dict:
     """Delete a secret stored on the gateway."""
-    envelope = {
-        "jsonrpc": "2.0",
-        "method": "Secrets.delete",
-        "params": {"name": secret_id, "version": version, "tenant_id": pool},
-    }
+    envelope = Request(
+        id="0",
+        method=SECRETS_DELETE,
+        params={"name": secret_id, "version": version, "tenant_id": pool},
+    ).model_dump()
     res = httpx.post(gateway_url, json=envelope, timeout=10.0)
     res.raise_for_status()
     return res.json()

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -33,6 +33,7 @@ from peagen.orm import Base
 from peagen.orm.status import Status
 from pydantic import ValidationError
 from peagen.protocols.methods.task import SubmitResult
+from peagen.protocols.methods import WORK_START
 from peagen.schemas import TaskRead, TaskCreate, TaskUpdate
 from peagen.orm import TaskModel, TaskRunModel
 
@@ -627,7 +628,7 @@ async def scheduler():
                 continue
             rpc_req = RPCEnvelope(
                 id=str(uuid.uuid4()),
-                method="Work.start",
+                method=WORK_START,
                 params={"task": task.model_dump()},
             ).model_dump()
 

--- a/pkgs/standards/peagen/peagen/gateway/rpc/workers.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/workers.py
@@ -20,7 +20,7 @@ from .. import (
 
 from peagen.orm.status import Status
 from peagen.transport.jsonrpc import RPCException
-from peagen.defaults import (
+from peagen.protocols.methods import (
     WORKER_REGISTER,
     WORKER_HEARTBEAT,
     WORKER_LIST,

--- a/pkgs/standards/peagen/peagen/handlers/fanout.py
+++ b/pkgs/standards/peagen/peagen/handlers/fanout.py
@@ -8,7 +8,11 @@ import httpx
 
 from peagen.schemas import TaskRead
 from peagen.orm.status import Status
-from peagen.protocols.methods import TASK_SUBMIT, TASK_PATCH
+from peagen.protocols.methods import (
+    TASK_SUBMIT,
+    TASK_PATCH,
+    WORK_FINISHED,
+)
 from . import ensure_task
 
 
@@ -53,7 +57,7 @@ async def fan_out(
         finish = {
             "jsonrpc": "2.0",
             "id": str(uuid.uuid4()),
-            "method": "Work.finished",
+            "method": WORK_FINISHED,
             "params": {
                 "taskId": parent_id,
                 "status": final_status.value,

--- a/pkgs/standards/peagen/peagen/protocols/__init__.py
+++ b/pkgs/standards/peagen/peagen/protocols/__init__.py
@@ -18,6 +18,13 @@ from .methods import (
     SECRETS_ADD,
     SECRETS_GET,
     SECRETS_DELETE,
+    WORKER_REGISTER,
+    WORKER_HEARTBEAT,
+    WORKER_LIST,
+    WORK_START,
+    WORK_CANCEL,
+    WORK_FINISHED,
+    GUARD_SET,
 )
 
 __all__ = [
@@ -41,4 +48,11 @@ __all__ = [
     "SECRETS_ADD",
     "SECRETS_GET",
     "SECRETS_DELETE",
+    "WORKER_REGISTER",
+    "WORKER_HEARTBEAT",
+    "WORKER_LIST",
+    "WORK_START",
+    "WORK_CANCEL",
+    "WORK_FINISHED",
+    "GUARD_SET",
 ]

--- a/pkgs/standards/peagen/peagen/protocols/methods/__init__.py
+++ b/pkgs/standards/peagen/peagen/protocols/methods/__init__.py
@@ -10,6 +10,15 @@ from .task import (
 )
 from .keys import KEYS_UPLOAD, KEYS_FETCH, KEYS_DELETE
 from .secrets import SECRETS_ADD, SECRETS_GET, SECRETS_DELETE
+from .workers import (
+    WORKER_REGISTER,
+    WORKER_HEARTBEAT,
+    WORKER_LIST,
+    WORK_START,
+    WORK_CANCEL,
+    WORK_FINISHED,
+    GUARD_SET,
+)
 
 __all__ = [
     "TASK_SUBMIT",
@@ -26,4 +35,11 @@ __all__ = [
     "SECRETS_ADD",
     "SECRETS_GET",
     "SECRETS_DELETE",
+    "WORKER_REGISTER",
+    "WORKER_HEARTBEAT",
+    "WORKER_LIST",
+    "WORK_START",
+    "WORK_CANCEL",
+    "WORK_FINISHED",
+    "GUARD_SET",
 ]

--- a/pkgs/standards/peagen/peagen/protocols/methods/task.py
+++ b/pkgs/standards/peagen/peagen/protocols/methods/task.py
@@ -80,7 +80,6 @@ class GetResult(PatchResult):
     """Result returned by ``Task.get`` -- identical to :class:`PatchResult`."""
 
 
-
 TASK_SUBMIT = register(
     method="Task.submit",
     params_model=SubmitParams,

--- a/pkgs/standards/peagen/peagen/protocols/methods/workers.py
+++ b/pkgs/standards/peagen/peagen/protocols/methods/workers.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, RootModel
+
+from peagen.protocols._registry import register
+
+
+class RegisterParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    workerId: str
+    pool: str
+    url: str
+    advertises: dict
+    handlers: list[str] | None = None
+
+
+class RegisterResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    ok: bool
+
+
+WORKER_REGISTER = register(
+    method="Worker.register",
+    params_model=RegisterParams,
+    result_model=RegisterResult,
+)
+
+
+class HeartbeatParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    workerId: str
+    metrics: dict
+    pool: str | None = None
+    url: str | None = None
+
+
+class HeartbeatResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    ok: bool
+
+
+WORKER_HEARTBEAT = register(
+    method="Worker.heartbeat",
+    params_model=HeartbeatParams,
+    result_model=HeartbeatResult,
+)
+
+
+class ListParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    pool: str | None = None
+
+
+class WorkerInfo(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    pool: str | None = None
+    url: str | None = None
+    advertises: dict | None = None
+    handlers: list[str] | None = None
+    last_seen: int | None = None
+
+
+class ListResult(RootModel[list[WorkerInfo]]):
+    model_config = ConfigDict(extra="forbid")
+
+
+WORKER_LIST = register(
+    method="Worker.list",
+    params_model=ListParams,
+    result_model=ListResult,
+)
+
+
+class WorkStartParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    task: dict
+
+
+class WorkStartResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    accepted: bool
+
+
+WORK_START = register(
+    method="Work.start",
+    params_model=WorkStartParams,
+    result_model=WorkStartResult,
+)
+
+
+class WorkCancelParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    taskId: str
+
+
+class WorkCancelResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    ok: bool
+
+
+WORK_CANCEL = register(
+    method="Work.cancel",
+    params_model=WorkCancelParams,
+    result_model=WorkCancelResult,
+)
+
+
+class WorkFinishedParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    taskId: str
+    status: str
+    result: dict | None = None
+
+
+class WorkFinishedResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    ok: bool
+
+
+WORK_FINISHED = register(
+    method="Work.finished",
+    params_model=WorkFinishedParams,
+    result_model=WorkFinishedResult,
+)
+
+
+class GuardSetParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    label: str
+    spec: dict
+
+
+class GuardSetResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    ok: bool
+
+
+GUARD_SET = register(
+    method="Guard.set",
+    params_model=GuardSetParams,
+    result_model=GuardSetResult,
+)

--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -15,8 +15,8 @@ from fastapi import Body, FastAPI, Request, HTTPException
 from json.decoder import JSONDecodeError
 
 from peagen.transport import RPCDispatcher, RPCRequest, RPCResponse
-from peagen.protocols import Request as RPCEnvelope
-from peagen.defaults import (
+from peagen.protocols import (
+    Request as RPCEnvelope,
     WORK_START,
     WORK_CANCEL,
     WORK_FINISHED,


### PR DESCRIPTION
## Summary
- introduce typed protocol models for worker, work and guard
- replace hard-coded method names with protocol constants in CLI handlers
- update gateway dispatcher imports to use protocol constants
- use protocol constants throughout core helpers
- register protocol usage inside worker base

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_6860253b13a88326a02dcadefdc793c3