### PR TITLE
Fix CLI httpx attribute errors

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/keys.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/keys.py
@@ -6,12 +6,12 @@ import json
 from pathlib import Path
 from typing import Optional
 
-from peagen.cli.rpc_utils import rpc_post
+from peagen.cli.rpc_utils import httpx
 import typer
 
 from peagen.plugins.secret_drivers import AutoGpgDriver
 from peagen.core import keys_core
-from peagen.protocols import KEYS_UPLOAD, KEYS_DELETE, KEYS_FETCH
+from peagen.protocols import KEYS_UPLOAD, KEYS_DELETE, KEYS_FETCH, Request
 
 
 keys_app = typer.Typer(help="Manage local and remote public keys.")
@@ -38,7 +38,8 @@ def upload(
     """Upload the public key to the gateway."""
     drv = AutoGpgDriver(key_dir=key_dir)
     pubkey = drv.pub_path.read_text()
-    rpc_post(gateway_url, KEYS_UPLOAD, {"public_key": pubkey}, timeout=10.0)
+    envelope = Request(id="0", method=KEYS_UPLOAD, params={"public_key": pubkey})
+    httpx.post(gateway_url, json=envelope.model_dump(), timeout=10.0)
     typer.echo("Uploaded public key")
 
 
@@ -49,12 +50,8 @@ def remove(
     gateway_url: str = typer.Option("http://localhost:8000/rpc", "--gateway-url"),
 ) -> None:
     """Remove a public key from the gateway."""
-    rpc_post(
-        gateway_url,
-        KEYS_DELETE,
-        {"fingerprint": fingerprint},
-        timeout=10.0,
-    )
+    envelope = Request(id="0", method=KEYS_DELETE, params={"fingerprint": fingerprint})
+    httpx.post(gateway_url, json=envelope.model_dump(), timeout=10.0)
     typer.echo(f"Removed key {fingerprint}")
 
 
@@ -64,8 +61,10 @@ def fetch_server(
     gateway_url: str = typer.Option("http://localhost:8000/rpc", "--gateway-url"),
 ) -> None:
     """Fetch trusted public keys from the gateway."""
-    res = rpc_post(gateway_url, KEYS_FETCH, {}, timeout=10.0)
-    typer.echo(json.dumps(res.get("result", {}), indent=2))
+    envelope = Request(id="0", method=KEYS_FETCH, params={})
+    res = httpx.post(gateway_url, json=envelope.model_dump(), timeout=10.0)
+    data = res.json().get("result", {})
+    typer.echo(json.dumps(data, indent=2))
 
 
 @keys_app.command("list")


### PR DESCRIPTION
## Summary
- expose `httpx` objects and simplify JSON-RPC calls in CLI modules
- ensure keys, login and secrets commands work with patched `httpx`

## Testing
- `uv run --package peagen --directory . ruff format .`
- `uv run --package peagen --directory . ruff check . --fix`
- `PEAGEN_TEST_GATEWAY=http://localhost:65500 uv run --package peagen --directory . pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686024dd7edc832699c62ed5e09230b4