### PR TITLE
Update CLI RPC params

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/login.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/login.py
@@ -10,6 +10,7 @@ import typer
 
 from peagen.plugins.secret_drivers import AutoGpgDriver
 from peagen.protocols import KEYS_UPLOAD
+from peagen.protocols.methods.keys import UploadParams
 
 
 login_app = typer.Typer(help="Authenticate and upload your public key.")
@@ -33,10 +34,11 @@ def login(
     drv = AutoGpgDriver(key_dir=key_dir, passphrase=passphrase)
     pubkey = drv.pub_path.read_text()
     try:
+        params = UploadParams(public_key=pubkey).model_dump()
         reply = rpc_post(
             gateway_url,
             KEYS_UPLOAD,
-            {"public_key": pubkey},
+            params,
             timeout=10.0,
         )
     except Exception as e:  # pragma: no cover - network errors


### PR DESCRIPTION
## Summary
- integrate protocol param models into login, keys, and secrets CLI commands

## Testing
- `uv run --directory peagen --package peagen ruff format .`
- `uv run --directory peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory peagen pytest` *(fails: tests/i9n/two_user_secret_exchange_i9n_test.py::test_two_user_secret_exchange, tests/sequence_success/test_sequences_success.py::test_sequences_success[example0])*

------
https://chatgpt.com/codex/tasks/task_e_686028a6d7448326a472e0ca052c49e1