### PR TITLE
Fix CLI tests for rpc_post usage

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_cli_login.py
+++ b/pkgs/standards/peagen/tests/unit/test_cli_login.py
@@ -1,4 +1,4 @@
-import httpx
+from httpx import RequestError
 from typer.testing import CliRunner
 import pytest
 
@@ -55,7 +55,7 @@ def test_login_http_error(monkeypatch, tmp_path):
 @pytest.mark.unit
 def test_login_request_error(monkeypatch, tmp_path):
     def fake_rpc_post(*_a, **_k):
-        raise httpx.RequestError("oops")
+        raise RequestError("oops")
 
     monkeypatch.setattr(login_mod, "AutoGpgDriver", DummyDriver)
     monkeypatch.setattr(login_mod, "rpc_post", fake_rpc_post)


### PR DESCRIPTION
## Summary
- update login CLI tests to import `RequestError`
- adapt exception raising to new import

## Testing
- `uv run --package peagen --directory standards/peagen pytest -q tests/unit/test_cli_login.py tests/unit/test_keys_cli.py tests/unit/test_secrets_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_6860294dea4c8326afc0e3cb46bf1b1d