### PR TITLE
Update gateway tests to use protocol constants

### DIFF
--- a/pkgs/standards/peagen/tests/smoke/test_remote_process_rpc.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_process_rpc.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import httpx
 import pytest
 from peagen.tui.task_submit import build_task, submit_task
+from peagen.protocols.methods import TASK_GET
 
 pytestmark = pytest.mark.smoke
 
@@ -65,7 +66,7 @@ def test_rpc_watch_remote_process(tmp_path: Path) -> None:
 
     envelope = {
         "jsonrpc": "2.0",
-        "method": "Task.get",
+        "method": TASK_GET,
         "params": {"taskId": tid},
         "id": 1,
     }

--- a/pkgs/standards/peagen/tests/unit/test_secrets_cli.py
+++ b/pkgs/standards/peagen/tests/unit/test_secrets_cli.py
@@ -1,6 +1,7 @@
 import json
 import pytest
 import typer
+from peagen.protocols import SECRETS_ADD, SECRETS_GET, SECRETS_DELETE
 
 from peagen.cli.commands import secrets as secrets_cli
 
@@ -111,6 +112,7 @@ def test_remote_add_posts(monkeypatch):
         recipient=[],
         pool="p",
     )
+    assert posted["method"] == SECRETS_ADD
     assert posted["params"]["cipher"].startswith("enc:")
     assert posted["params"]["name"] == "ID"
     assert posted["params"]["version"] == 1
@@ -135,7 +137,7 @@ def test_remote_get(monkeypatch):
         pool="default",
     )
     assert out == ["value"]
-    assert posted["method"] == "Secrets.get"
+    assert posted["method"] == SECRETS_GET
     assert posted["params"] == {"name": "ID", "tenant_id": "default"}
 
 
@@ -156,5 +158,5 @@ def test_remote_remove(monkeypatch):
         gateway_url="https://gw.peagen.com",
         pool="default",
     )
-    assert posted["method"] == "Secrets.delete"
+    assert posted["method"] == SECRETS_DELETE
     assert posted["params"] == {"name": "ID", "version": 2, "tenant_id": "default"}


### PR DESCRIPTION
## Summary
- ensure secret CLI tests use protocol method constants
- update remote RPC smoke test to use `TASK_GET`

## Testing
- `PEAGEN_TEST_GATEWAY=http://127.0.0.1:9999/rpc uv run --package peagen --directory pkgs/standards/peagen pytest -q`
- `uv run --package peagen --directory pkgs/standards/peagen peagen local -q evolve tests/examples/simple_evolve_demo/evolve_spec_local.yaml --repo tests/examples/simple_evolve_demo/workspace --out /tmp/out.json` *(fails: AttributeError: 'str' object has no attribute 'get')*

------
https://chatgpt.com/codex/tasks/task_e_686029ee22508326b514b3dd99ab6f52