### PR TITLE
Update handler tests to use protocol constants

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_doe_process_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_doe_process_handler.py
@@ -1,6 +1,8 @@
 import pytest
 
 from peagen.handlers import doe_process_handler as handler
+from peagen.protocols.methods import TASK_SUBMIT, TASK_PATCH
+from peagen.defaults import WORK_FINISHED
 
 
 @pytest.mark.unit
@@ -67,7 +69,10 @@ async def test_doe_process_handler_dispatches(monkeypatch, tmp_path):
     result = await handler.doe_process_handler(task)
 
     assert len(sent) == 4
-    assert sent[-1]["method"] == "Work.finished"
+    assert sent[0]["method"] == TASK_SUBMIT
+    assert sent[1]["method"] == TASK_SUBMIT
+    assert sent[2]["method"] == TASK_PATCH
+    assert sent[-1]["method"] == WORK_FINISHED
     assert sent[-1]["params"]["status"] == "waiting"
     assert result["children"] and len(result["children"]) == 2
     assert result["outputs"][0].startswith("PROJECTS:")


### PR DESCRIPTION
## Summary
- use `TASK_SUBMIT` and `TASK_PATCH` from `peagen.protocols` in `doe_process_handler` tests

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest -m unit`

------
https://chatgpt.com/codex/tasks/task_e_686029eb34f08326b3fec5116e03400e