### PR TITLE
Use protocol constants for worker RPC tests

### DIFF
--- a/pkgs/standards/peagen/peagen/protocols/__init__.py
+++ b/pkgs/standards/peagen/peagen/protocols/__init__.py
@@ -18,6 +18,9 @@ from .methods import (
     SECRETS_ADD,
     SECRETS_GET,
     SECRETS_DELETE,
+    WORKER_REGISTER,
+    WORKER_HEARTBEAT,
+    WORKER_LIST,
 )
 
 __all__ = [
@@ -41,4 +44,7 @@ __all__ = [
     "SECRETS_ADD",
     "SECRETS_GET",
     "SECRETS_DELETE",
+    "WORKER_REGISTER",
+    "WORKER_HEARTBEAT",
+    "WORKER_LIST",
 ]

--- a/pkgs/standards/peagen/peagen/protocols/methods/__init__.py
+++ b/pkgs/standards/peagen/peagen/protocols/methods/__init__.py
@@ -10,6 +10,7 @@ from .task import (
 )
 from .keys import KEYS_UPLOAD, KEYS_FETCH, KEYS_DELETE
 from .secrets import SECRETS_ADD, SECRETS_GET, SECRETS_DELETE
+from .worker import WORKER_REGISTER, WORKER_HEARTBEAT, WORKER_LIST
 
 __all__ = [
     "TASK_SUBMIT",
@@ -26,4 +27,7 @@ __all__ = [
     "SECRETS_ADD",
     "SECRETS_GET",
     "SECRETS_DELETE",
+    "WORKER_REGISTER",
+    "WORKER_HEARTBEAT",
+    "WORKER_LIST",
 ]

--- a/pkgs/standards/peagen/peagen/protocols/methods/worker.py
+++ b/pkgs/standards/peagen/peagen/protocols/methods/worker.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, RootModel
+
+from .._registry import register
+
+
+class RegisterParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    workerId: str
+    pool: str
+    url: str
+    advertises: dict
+    handlers: list[str] | None = None
+
+
+class RegisterResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    ok: bool
+
+
+class HeartbeatParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    workerId: str
+    metrics: dict
+    pool: str | None = None
+    url: str | None = None
+
+
+class HeartbeatResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    ok: bool
+
+
+class ListParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    pool: str | None = None
+
+
+class WorkerInfo(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    pool: str
+    url: str | None = None
+    advertises: dict | None = None
+    handlers: list[str] | None = None
+    last_seen: int | None = None
+
+
+class ListResult(RootModel[list[WorkerInfo]]):
+    pass
+
+
+WORKER_REGISTER = register(
+    method="Worker.register",
+    params_model=RegisterParams,
+    result_model=RegisterResult,
+)
+
+WORKER_HEARTBEAT = register(
+    method="Worker.heartbeat",
+    params_model=HeartbeatParams,
+    result_model=HeartbeatResult,
+)
+
+WORKER_LIST = register(
+    method="Worker.list",
+    params_model=ListParams,
+    result_model=ListResult,
+)

--- a/pkgs/standards/peagen/tests/e2e/test_local_evolve.py
+++ b/pkgs/standards/peagen/tests/e2e/test_local_evolve.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import httpx
 import pytest
+from peagen.protocols.methods.worker import WORKER_LIST
 
 pytestmark = pytest.mark.e2e
 
@@ -14,7 +15,7 @@ GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "http://localhost:8000/rpc")
 
 
 def _gateway_available(url: str) -> bool:
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = {"jsonrpc": "2.0", "method": WORKER_LIST, "params": {}, "id": 0}
     try:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/i9n/two_user_secret_exchange_i9n_test.py
+++ b/pkgs/standards/peagen/tests/i9n/two_user_secret_exchange_i9n_test.py
@@ -6,12 +6,13 @@ import shutil
 
 import httpx
 import pytest
+from peagen.protocols.methods.worker import WORKER_LIST
 
 GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
 
 
 def _gateway_available(url: str) -> bool:
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}}
+    envelope = {"jsonrpc": "2.0", "method": WORKER_LIST, "params": {}}
     try:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/sequence_success/test_sequences_success.py
+++ b/pkgs/standards/peagen/tests/sequence_success/test_sequences_success.py
@@ -6,13 +6,14 @@ import os
 import yaml
 import pytest
 import httpx
+from peagen.protocols.methods.worker import WORKER_LIST
 
 EXAMPLES = Path(__file__).resolve().parent / "examples"
 GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
 
 
 def _gateway_available(url: str) -> bool:
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}}
+    envelope = {"jsonrpc": "2.0", "method": WORKER_LIST, "params": {}}
     try:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/smoke/test_gateway_login_keys_secrets_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_gateway_login_keys_secrets_cli.py
@@ -4,6 +4,7 @@ import subprocess
 
 import httpx
 import pytest
+from peagen.protocols.methods.worker import WORKER_LIST
 
 pytestmark = pytest.mark.smoke
 GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
@@ -11,7 +12,7 @@ GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
 
 def _gateway_available(url: str) -> bool:
     """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = {"jsonrpc": "2.0", "method": WORKER_LIST, "params": {}, "id": 0}
     try:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/smoke/test_gateway_remote_doe.py
+++ b/pkgs/standards/peagen/tests/smoke/test_gateway_remote_doe.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import httpx
 import pytest
+from peagen.protocols.methods.worker import WORKER_LIST
 
 pytestmark = pytest.mark.smoke
 
@@ -14,7 +15,7 @@ REPO = "testproject"
 
 def _gateway_available(url: str) -> bool:
     """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = {"jsonrpc": "2.0", "method": WORKER_LIST, "params": {}, "id": 0}
     try:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/smoke/test_remote_doe_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_doe_cli.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import httpx
 import pytest
+from peagen.protocols.methods.worker import WORKER_LIST
 
 pytestmark = pytest.mark.smoke
 
@@ -13,7 +14,7 @@ REPO = "testproject"
 
 def _gateway_available(url: str) -> bool:
     """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = {"jsonrpc": "2.0", "method": WORKER_LIST, "params": {}, "id": 0}
     try:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/smoke/test_remote_doe_process_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_doe_process_cli.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import httpx
 import pytest
+from peagen.protocols.methods.worker import WORKER_LIST
 
 pytestmark = pytest.mark.smoke
 
@@ -17,7 +18,7 @@ REPO = "testproject"
 
 def _gateway_available(url: str) -> bool:
     """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = {"jsonrpc": "2.0", "method": WORKER_LIST, "params": {}, "id": 0}
     try:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/smoke/test_remote_eval_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_eval_cli.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import httpx
 import pytest
+from peagen.protocols.methods.worker import WORKER_LIST
 
 pytestmark = pytest.mark.smoke
 
@@ -15,7 +16,7 @@ REPO = "testproject"
 
 def _gateway_available(url: str) -> bool:
     """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = {"jsonrpc": "2.0", "method": WORKER_LIST, "params": {}, "id": 0}
     try:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/smoke/test_remote_eval_rpc.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_eval_rpc.py
@@ -2,6 +2,7 @@ import os
 import uuid
 import httpx
 import pytest
+from peagen.protocols.methods.worker import WORKER_LIST
 
 pytestmark = pytest.mark.smoke
 
@@ -10,7 +11,7 @@ GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
 
 def _gateway_available(url: str) -> bool:
     """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = {"jsonrpc": "2.0", "method": WORKER_LIST, "params": {}, "id": 0}
     try:
         resp = httpx.post(url, json=envelope, timeout=5)
     except Exception:
@@ -25,7 +26,7 @@ def test_worker_list_returns_workers() -> None:
 
     resp = httpx.post(
         GATEWAY,
-        json={"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 1},
+        json={"jsonrpc": "2.0", "method": WORKER_LIST, "params": {}, "id": 1},
         timeout=5,
     )
     assert resp.status_code == 200

--- a/pkgs/standards/peagen/tests/smoke/test_remote_evolve.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_evolve.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import httpx
 import pytest
+from peagen.protocols.methods.worker import WORKER_LIST
 
 pytestmark = pytest.mark.smoke
 
@@ -22,7 +23,7 @@ SPEC_PATH = (
 
 def _gateway_available(url: str) -> bool:
     """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = {"jsonrpc": "2.0", "method": WORKER_LIST, "params": {}, "id": 0}
     try:
         resp = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/smoke/test_remote_full_flow.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_full_flow.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import httpx
 import pytest
+from peagen.protocols.methods.worker import WORKER_LIST
 
 pytestmark = pytest.mark.smoke
 
@@ -18,7 +19,7 @@ REPO = "testproject"
 
 def _gateway_available(url: str) -> bool:
     """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = {"jsonrpc": "2.0", "method": WORKER_LIST, "params": {}, "id": 0}
     try:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/smoke/test_remote_mutate_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_mutate_cli.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import httpx
 import pytest
+from peagen.protocols.methods.worker import WORKER_LIST
 
 pytestmark = pytest.mark.smoke
 
@@ -12,7 +13,7 @@ GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
 
 def _gateway_available(url: str) -> bool:
     """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = {"jsonrpc": "2.0", "method": WORKER_LIST, "params": {}, "id": 0}
     try:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/smoke/test_remote_process_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_process_cli.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import httpx
 import pytest
+from peagen.protocols.methods.worker import WORKER_LIST
 
 pytestmark = pytest.mark.smoke
 
@@ -19,7 +20,7 @@ REPO = "testproject"
 
 def _gateway_available(url: str) -> bool:
     """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = {"jsonrpc": "2.0", "method": WORKER_LIST, "params": {}, "id": 0}
     try:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/smoke/test_remote_process_rpc.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_process_rpc.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import httpx
 import pytest
+from peagen.protocols.methods.worker import WORKER_LIST
 from peagen.tui.task_submit import build_task, submit_task
 
 pytestmark = pytest.mark.smoke
@@ -22,7 +23,7 @@ REPO = "testproject"
 
 def _gateway_available(url: str) -> bool:
     """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = {"jsonrpc": "2.0", "method": WORKER_LIST, "params": {}, "id": 0}
     try:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/smoke/test_remote_sort_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_sort_cli.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import httpx
 import pytest
+from peagen.protocols.methods.worker import WORKER_LIST
 
 pytestmark = pytest.mark.smoke
 
@@ -15,7 +16,7 @@ REPO = "testproject"
 
 def _gateway_available(url: str) -> bool:
     """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = {"jsonrpc": "2.0", "method": WORKER_LIST, "params": {}, "id": 0}
     try:
         resp = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/unit/test_secrets_cli.py
+++ b/pkgs/standards/peagen/tests/unit/test_secrets_cli.py
@@ -1,8 +1,8 @@
 import json
 import pytest
 import typer
-
 from peagen.cli.commands import secrets as secrets_cli
+from peagen.protocols.methods.worker import WORKER_LIST
 
 
 class DummyDriver:
@@ -44,7 +44,7 @@ def test_pool_worker_pubs_collects_keys(monkeypatch):
     monkeypatch.setattr(secrets_cli, "rpc_post", fake_rpc_post)
     keys = secrets_cli._pool_worker_pubs("p", "http://gw")
     assert keys == ["A", "B"]
-    assert captured["method"] == "Worker.list"
+    assert captured["method"] == WORKER_LIST
 
 
 def test_pool_worker_pubs_handles_error(monkeypatch):


### PR DESCRIPTION
## Summary
- add worker method constants to `peagen.protocols`
- update tests to use `WORKER_LIST`

## Testing
- `ruff format peagen/protocols/methods/worker.py`
- `ruff check peagen/protocols/methods/worker.py --fix`
- `pytest tests/unit/test_worker_list.py::test_worker_list -q`

------
https://chatgpt.com/codex/tasks/task_e_686029eed8b88326a85097f88a3593de