### PR TITLE
Use protocol constants in peagen tests

### DIFF
--- a/pkgs/standards/peagen/tests/e2e/test_local_evolve.py
+++ b/pkgs/standards/peagen/tests/e2e/test_local_evolve.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import httpx
 import pytest
+from peagen.defaults import WORKER_LIST
 
 pytestmark = pytest.mark.e2e
 
@@ -14,7 +15,7 @@ GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "http://localhost:8000/rpc")
 
 
 def _gateway_available(url: str) -> bool:
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = {"jsonrpc": "2.0", "method": WORKER_LIST, "params": {}, "id": 0}
     try:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/i9n/two_user_secret_exchange_i9n_test.py
+++ b/pkgs/standards/peagen/tests/i9n/two_user_secret_exchange_i9n_test.py
@@ -6,12 +6,13 @@ import shutil
 
 import httpx
 import pytest
+from peagen.defaults import WORKER_LIST
 
 GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
 
 
 def _gateway_available(url: str) -> bool:
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}}
+    envelope = {"jsonrpc": "2.0", "method": WORKER_LIST, "params": {}}
     try:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/sequence_success/test_sequences_success.py
+++ b/pkgs/standards/peagen/tests/sequence_success/test_sequences_success.py
@@ -6,13 +6,14 @@ import os
 import yaml
 import pytest
 import httpx
+from peagen.defaults import WORKER_LIST
 
 EXAMPLES = Path(__file__).resolve().parent / "examples"
 GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
 
 
 def _gateway_available(url: str) -> bool:
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}}
+    envelope = {"jsonrpc": "2.0", "method": WORKER_LIST, "params": {}}
     try:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/smoke/test_gateway_login_keys_secrets_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_gateway_login_keys_secrets_cli.py
@@ -4,6 +4,7 @@ import subprocess
 
 import httpx
 import pytest
+from peagen.defaults import WORKER_LIST
 
 pytestmark = pytest.mark.smoke
 GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
@@ -11,7 +12,7 @@ GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
 
 def _gateway_available(url: str) -> bool:
     """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = {"jsonrpc": "2.0", "method": WORKER_LIST, "params": {}, "id": 0}
     try:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/smoke/test_gateway_remote_doe.py
+++ b/pkgs/standards/peagen/tests/smoke/test_gateway_remote_doe.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import httpx
 import pytest
+from peagen.defaults import WORKER_LIST
 
 pytestmark = pytest.mark.smoke
 
@@ -14,7 +15,7 @@ REPO = "testproject"
 
 def _gateway_available(url: str) -> bool:
     """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = {"jsonrpc": "2.0", "method": WORKER_LIST, "params": {}, "id": 0}
     try:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/smoke/test_remote_doe_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_doe_cli.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import httpx
 import pytest
+from peagen.defaults import WORKER_LIST
 
 pytestmark = pytest.mark.smoke
 
@@ -13,7 +14,7 @@ REPO = "testproject"
 
 def _gateway_available(url: str) -> bool:
     """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = {"jsonrpc": "2.0", "method": WORKER_LIST, "params": {}, "id": 0}
     try:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/smoke/test_remote_doe_process_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_doe_process_cli.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import httpx
 import pytest
+from peagen.defaults import WORKER_LIST
 
 pytestmark = pytest.mark.smoke
 
@@ -17,7 +18,7 @@ REPO = "testproject"
 
 def _gateway_available(url: str) -> bool:
     """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = {"jsonrpc": "2.0", "method": WORKER_LIST, "params": {}, "id": 0}
     try:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/smoke/test_remote_eval_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_eval_cli.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import httpx
 import pytest
+from peagen.defaults import WORKER_LIST
 
 pytestmark = pytest.mark.smoke
 
@@ -15,7 +16,7 @@ REPO = "testproject"
 
 def _gateway_available(url: str) -> bool:
     """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = {"jsonrpc": "2.0", "method": WORKER_LIST, "params": {}, "id": 0}
     try:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/smoke/test_remote_eval_rpc.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_eval_rpc.py
@@ -2,6 +2,7 @@ import os
 import uuid
 import httpx
 import pytest
+from peagen.defaults import WORKER_LIST
 
 pytestmark = pytest.mark.smoke
 
@@ -10,7 +11,7 @@ GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
 
 def _gateway_available(url: str) -> bool:
     """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = {"jsonrpc": "2.0", "method": WORKER_LIST, "params": {}, "id": 0}
     try:
         resp = httpx.post(url, json=envelope, timeout=5)
     except Exception:
@@ -25,7 +26,7 @@ def test_worker_list_returns_workers() -> None:
 
     resp = httpx.post(
         GATEWAY,
-        json={"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 1},
+        json={"jsonrpc": "2.0", "method": WORKER_LIST, "params": {}, "id": 1},
         timeout=5,
     )
     assert resp.status_code == 200

--- a/pkgs/standards/peagen/tests/smoke/test_remote_evolve.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_evolve.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import httpx
 import pytest
+from peagen.defaults import WORKER_LIST
 
 pytestmark = pytest.mark.smoke
 
@@ -22,7 +23,7 @@ SPEC_PATH = (
 
 def _gateway_available(url: str) -> bool:
     """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = {"jsonrpc": "2.0", "method": WORKER_LIST, "params": {}, "id": 0}
     try:
         resp = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/smoke/test_remote_full_flow.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_full_flow.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import httpx
 import pytest
+from peagen.defaults import WORKER_LIST
 
 pytestmark = pytest.mark.smoke
 
@@ -18,7 +19,7 @@ REPO = "testproject"
 
 def _gateway_available(url: str) -> bool:
     """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = {"jsonrpc": "2.0", "method": WORKER_LIST, "params": {}, "id": 0}
     try:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/smoke/test_remote_mutate_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_mutate_cli.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import httpx
 import pytest
+from peagen.defaults import WORKER_LIST
 
 pytestmark = pytest.mark.smoke
 
@@ -12,7 +13,7 @@ GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
 
 def _gateway_available(url: str) -> bool:
     """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = {"jsonrpc": "2.0", "method": WORKER_LIST, "params": {}, "id": 0}
     try:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/smoke/test_remote_process_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_process_cli.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import httpx
 import pytest
+from peagen.defaults import WORKER_LIST
 
 pytestmark = pytest.mark.smoke
 
@@ -19,7 +20,7 @@ REPO = "testproject"
 
 def _gateway_available(url: str) -> bool:
     """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = {"jsonrpc": "2.0", "method": WORKER_LIST, "params": {}, "id": 0}
     try:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/smoke/test_remote_process_rpc.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_process_rpc.py
@@ -4,7 +4,9 @@ from pathlib import Path
 
 import httpx
 import pytest
+from peagen.defaults import WORKER_LIST
 from peagen.tui.task_submit import build_task, submit_task
+from peagen.protocols.methods import TASK_GET
 
 pytestmark = pytest.mark.smoke
 
@@ -22,7 +24,7 @@ REPO = "testproject"
 
 def _gateway_available(url: str) -> bool:
     """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = {"jsonrpc": "2.0", "method": WORKER_LIST, "params": {}, "id": 0}
     try:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:
@@ -65,7 +67,7 @@ def test_rpc_watch_remote_process(tmp_path: Path) -> None:
 
     envelope = {
         "jsonrpc": "2.0",
-        "method": "Task.get",
+        "method": TASK_GET,
         "params": {"taskId": tid},
         "id": 1,
     }

--- a/pkgs/standards/peagen/tests/smoke/test_remote_sort_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_sort_cli.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import httpx
 import pytest
+from peagen.defaults import WORKER_LIST
 
 pytestmark = pytest.mark.smoke
 
@@ -15,7 +16,7 @@ REPO = "testproject"
 
 def _gateway_available(url: str) -> bool:
     """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = {"jsonrpc": "2.0", "method": WORKER_LIST, "params": {}, "id": 0}
     try:
         resp = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/unit/test_cli_login.py
+++ b/pkgs/standards/peagen/tests/unit/test_cli_login.py
@@ -1,6 +1,7 @@
 import httpx
 from typer.testing import CliRunner
 import pytest
+from peagen.protocols import KEYS_UPLOAD
 
 from peagen.cli import app
 import peagen.cli.commands.login as login_mod
@@ -33,6 +34,7 @@ def test_login_success(monkeypatch, tmp_path):
     assert result.exit_code == 0
     assert "Logged in and uploaded public key" in result.output
     assert captured["url"] == "http://gw/rpc"
+    assert captured["method"] == KEYS_UPLOAD
     assert captured["params"]["public_key"] == "PUB"
 
 

--- a/pkgs/standards/peagen/tests/unit/test_doe_process_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_doe_process_handler.py
@@ -1,6 +1,7 @@
 import pytest
 
 from peagen.handlers import doe_process_handler as handler
+from peagen.defaults import WORK_FINISHED
 
 
 @pytest.mark.unit
@@ -67,7 +68,7 @@ async def test_doe_process_handler_dispatches(monkeypatch, tmp_path):
     result = await handler.doe_process_handler(task)
 
     assert len(sent) == 4
-    assert sent[-1]["method"] == "Work.finished"
+    assert sent[-1]["method"] == WORK_FINISHED
     assert sent[-1]["params"]["status"] == "waiting"
     assert result["children"] and len(result["children"]) == 2
     assert result["outputs"][0].startswith("PROJECTS:")

--- a/pkgs/standards/peagen/tests/unit/test_evolve_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_evolve_handler.py
@@ -1,6 +1,7 @@
 import pytest
 
 from peagen.handlers import evolve_handler as handler
+from peagen.defaults import WORK_FINISHED
 
 
 @pytest.mark.unit
@@ -44,7 +45,7 @@ async def test_evolve_handler_fanout(monkeypatch, tmp_path):
     result = await handler.evolve_handler(task)
 
     assert result["jobs"] == 1
-    assert sent and sent[-1]["method"] == "Work.finished"
+    assert sent and sent[-1]["method"] == WORK_FINISHED
     submit = sent[0]
     from peagen.protocols.methods import TASK_SUBMIT
 

--- a/pkgs/standards/peagen/tests/unit/test_secrets_cli.py
+++ b/pkgs/standards/peagen/tests/unit/test_secrets_cli.py
@@ -1,6 +1,8 @@
 import json
 import pytest
 import typer
+from peagen.defaults import WORKER_LIST
+from peagen.protocols import SECRETS_GET, SECRETS_DELETE
 
 from peagen.cli.commands import secrets as secrets_cli
 
@@ -44,7 +46,7 @@ def test_pool_worker_pubs_collects_keys(monkeypatch):
     monkeypatch.setattr(secrets_cli, "rpc_post", fake_rpc_post)
     keys = secrets_cli._pool_worker_pubs("p", "http://gw")
     assert keys == ["A", "B"]
-    assert captured["method"] == "Worker.list"
+    assert captured["method"] == WORKER_LIST
 
 
 def test_pool_worker_pubs_handles_error(monkeypatch):
@@ -135,7 +137,7 @@ def test_remote_get(monkeypatch):
         pool="default",
     )
     assert out == ["value"]
-    assert posted["method"] == "Secrets.get"
+    assert posted["method"] == SECRETS_GET
     assert posted["params"] == {"name": "ID", "tenant_id": "default"}
 
 
@@ -156,5 +158,5 @@ def test_remote_remove(monkeypatch):
         gateway_url="https://gw.peagen.com",
         pool="default",
     )
-    assert posted["method"] == "Secrets.delete"
+    assert posted["method"] == SECRETS_DELETE
     assert posted["params"] == {"name": "ID", "version": 2, "tenant_id": "default"}


### PR DESCRIPTION
## Summary
- update peagen tests to rely on protocol constants
- keep worker method checks using defaults

## Testing
- `uv run --directory standards --package peagen ruff format .`
- `uv run --directory standards --package peagen ruff check . --fix`
- `uv run --package peagen --directory standards pytest peagen/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_686029e4f5a483268e4b1e7b3a758330