### PR TITLE
Update CLI tests to use Peagen protocols

### DIFF
--- a/pkgs/standards/peagen/tests/e2e/test_local_evolve.py
+++ b/pkgs/standards/peagen/tests/e2e/test_local_evolve.py
@@ -5,6 +5,7 @@ import subprocess
 from pathlib import Path
 
 import httpx
+from peagen.protocols import Request
 import pytest
 
 pytestmark = pytest.mark.e2e
@@ -14,7 +15,7 @@ GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "http://localhost:8000/rpc")
 
 
 def _gateway_available(url: str) -> bool:
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = Request(id=0, method="Worker.list", params={}).model_dump()
     try:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/i9n/two_user_secret_exchange_i9n_test.py
+++ b/pkgs/standards/peagen/tests/i9n/two_user_secret_exchange_i9n_test.py
@@ -6,12 +6,13 @@ import shutil
 
 import httpx
 import pytest
+from peagen.protocols import Request
 
 GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
 
 
 def _gateway_available(url: str) -> bool:
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}}
+    envelope = Request(id=0, method="Worker.list", params={}).model_dump()
     try:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/sequence_success/test_sequences_success.py
+++ b/pkgs/standards/peagen/tests/sequence_success/test_sequences_success.py
@@ -6,13 +6,14 @@ import os
 import yaml
 import pytest
 import httpx
+from peagen.protocols import Request
 
 EXAMPLES = Path(__file__).resolve().parent / "examples"
 GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
 
 
 def _gateway_available(url: str) -> bool:
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}}
+    envelope = Request(id=0, method="Worker.list", params={}).model_dump()
     try:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/smoke/test_gateway_login_keys_secrets_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_gateway_login_keys_secrets_cli.py
@@ -4,6 +4,7 @@ import subprocess
 
 import httpx
 import pytest
+from peagen.protocols import Request
 
 pytestmark = pytest.mark.smoke
 GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
@@ -11,7 +12,7 @@ GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
 
 def _gateway_available(url: str) -> bool:
     """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = Request(id=0, method="Worker.list", params={}).model_dump()
     try:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/smoke/test_gateway_remote_doe.py
+++ b/pkgs/standards/peagen/tests/smoke/test_gateway_remote_doe.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import httpx
 import pytest
+from peagen.protocols import Request
 
 pytestmark = pytest.mark.smoke
 
@@ -14,7 +15,7 @@ REPO = "testproject"
 
 def _gateway_available(url: str) -> bool:
     """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = Request(id=0, method="Worker.list", params={}).model_dump()
     try:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/smoke/test_remote_doe_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_doe_cli.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import httpx
 import pytest
+from peagen.protocols import Request
 
 pytestmark = pytest.mark.smoke
 
@@ -13,7 +14,7 @@ REPO = "testproject"
 
 def _gateway_available(url: str) -> bool:
     """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = Request(id=0, method="Worker.list", params={}).model_dump()
     try:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/smoke/test_remote_doe_process_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_doe_process_cli.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import httpx
 import pytest
+from peagen.protocols import Request
 
 pytestmark = pytest.mark.smoke
 
@@ -17,7 +18,7 @@ REPO = "testproject"
 
 def _gateway_available(url: str) -> bool:
     """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = Request(id=0, method="Worker.list", params={}).model_dump()
     try:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/smoke/test_remote_eval_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_eval_cli.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import httpx
 import pytest
+from peagen.protocols import Request
 
 pytestmark = pytest.mark.smoke
 
@@ -15,7 +16,7 @@ REPO = "testproject"
 
 def _gateway_available(url: str) -> bool:
     """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = Request(id=0, method="Worker.list", params={}).model_dump()
     try:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/smoke/test_remote_evolve.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_evolve.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import httpx
 import pytest
+from peagen.protocols import Request
 
 pytestmark = pytest.mark.smoke
 
@@ -22,7 +23,7 @@ SPEC_PATH = (
 
 def _gateway_available(url: str) -> bool:
     """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = Request(id=0, method="Worker.list", params={}).model_dump()
     try:
         resp = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/smoke/test_remote_full_flow.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_full_flow.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import httpx
 import pytest
+from peagen.protocols import Request
 
 pytestmark = pytest.mark.smoke
 
@@ -18,7 +19,7 @@ REPO = "testproject"
 
 def _gateway_available(url: str) -> bool:
     """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = Request(id=0, method="Worker.list", params={}).model_dump()
     try:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/smoke/test_remote_mutate_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_mutate_cli.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import httpx
 import pytest
+from peagen.protocols import Request
 
 pytestmark = pytest.mark.smoke
 
@@ -12,7 +13,7 @@ GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
 
 def _gateway_available(url: str) -> bool:
     """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = Request(id=0, method="Worker.list", params={}).model_dump()
     try:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/smoke/test_remote_process_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_process_cli.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import httpx
 import pytest
+from peagen.protocols import Request
 
 pytestmark = pytest.mark.smoke
 
@@ -19,7 +20,7 @@ REPO = "testproject"
 
 def _gateway_available(url: str) -> bool:
     """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = Request(id=0, method="Worker.list", params={}).model_dump()
     try:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/smoke/test_remote_process_rpc.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_process_rpc.py
@@ -5,6 +5,8 @@ from pathlib import Path
 import httpx
 import pytest
 from peagen.tui.task_submit import build_task, submit_task
+from peagen.protocols import Request
+from peagen.protocols.methods import TASK_GET
 
 pytestmark = pytest.mark.smoke
 
@@ -22,7 +24,7 @@ REPO = "testproject"
 
 def _gateway_available(url: str) -> bool:
     """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = Request(id=0, method="Worker.list", params={}).model_dump()
     try:
         response = httpx.post(url, json=envelope, timeout=5)
     except Exception:
@@ -63,12 +65,7 @@ def test_rpc_watch_remote_process(tmp_path: Path) -> None:
     tid = reply.get("result", {}).get("taskId")
     assert tid
 
-    envelope = {
-        "jsonrpc": "2.0",
-        "method": "Task.get",
-        "params": {"taskId": tid},
-        "id": 1,
-    }
+    envelope = Request(id=1, method=TASK_GET, params={"taskId": tid}).model_dump()
     status = None
     for _ in range(30):
         result = httpx.post(GATEWAY, json=envelope, timeout=30).json()["result"]

--- a/pkgs/standards/peagen/tests/smoke/test_remote_sort_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_sort_cli.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import httpx
 import pytest
+from peagen.protocols import Request
 
 pytestmark = pytest.mark.smoke
 
@@ -15,7 +16,7 @@ REPO = "testproject"
 
 def _gateway_available(url: str) -> bool:
     """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
-    envelope = {"jsonrpc": "2.0", "method": "Worker.list", "params": {}, "id": 0}
+    envelope = Request(id=0, method="Worker.list", params={}).model_dump()
     try:
         resp = httpx.post(url, json=envelope, timeout=5)
     except Exception:

--- a/pkgs/standards/peagen/tests/unit/test_cli_login.py
+++ b/pkgs/standards/peagen/tests/unit/test_cli_login.py
@@ -1,6 +1,7 @@
 import httpx
 from typer.testing import CliRunner
 import pytest
+from peagen.protocols.methods import KEYS_UPLOAD
 
 from peagen.cli import app
 import peagen.cli.commands.login as login_mod
@@ -33,6 +34,7 @@ def test_login_success(monkeypatch, tmp_path):
     assert result.exit_code == 0
     assert "Logged in and uploaded public key" in result.output
     assert captured["url"] == "http://gw/rpc"
+    assert captured["method"] == KEYS_UPLOAD
     assert captured["params"]["public_key"] == "PUB"
 
 

--- a/pkgs/standards/peagen/tests/unit/test_secrets_cli.py
+++ b/pkgs/standards/peagen/tests/unit/test_secrets_cli.py
@@ -1,6 +1,7 @@
 import json
 import pytest
 import typer
+from peagen.protocols.methods import SECRETS_GET, SECRETS_DELETE
 
 from peagen.cli.commands import secrets as secrets_cli
 
@@ -135,7 +136,7 @@ def test_remote_get(monkeypatch):
         pool="default",
     )
     assert out == ["value"]
-    assert posted["method"] == "Secrets.get"
+    assert posted["method"] == SECRETS_GET
     assert posted["params"] == {"name": "ID", "tenant_id": "default"}
 
 
@@ -156,5 +157,5 @@ def test_remote_remove(monkeypatch):
         gateway_url="https://gw.peagen.com",
         pool="default",
     )
-    assert posted["method"] == "Secrets.delete"
+    assert posted["method"] == SECRETS_DELETE
     assert posted["params"] == {"name": "ID", "version": 2, "tenant_id": "default"}


### PR DESCRIPTION
## Summary
- refactor CLI-related tests to build JSON-RPC requests via `peagen.protocols`
- reference protocol constants in unit tests

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest` *(fails: two tests)*

------
https://chatgpt.com/codex/tasks/task_e_686029e941ac8326b7c616edd5966b0e