### PR TITLE
Use protocol models for worker RPC

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_scheduler_remove_bad_worker.py
+++ b/pkgs/standards/peagen/tests/unit/test_scheduler_remove_bad_worker.py
@@ -43,8 +43,16 @@ async def test_scheduler_removes_bad_worker(monkeypatch):
     monkeypatch.setattr(gw, "_persist", noop)
     monkeypatch.setattr(gw, "_publish_task", noop)
 
+    from peagen.protocols.methods.worker import RegisterParams
+
     await gw.worker_register(
-        workerId="w1", pool="p", url="http://w1/rpc", advertises={}, handlers=["demo"]
+        RegisterParams(
+            workerId="w1",
+            pool="p",
+            url="http://w1/rpc",
+            advertises={},
+            handlers=["demo"],
+        )
     )
 
     await q.sadd("pools", "p")

--- a/pkgs/standards/peagen/tests/unit/test_task_submit_unknown.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_submit_unknown.py
@@ -46,12 +46,16 @@ async def test_task_submit_unknown_action(monkeypatch):
     monkeypatch.setattr(gw, "_persist", noop)
     monkeypatch.setattr(gw, "_publish_event", noop)
 
+    from peagen.protocols.methods.worker import RegisterParams
+
     await gw.worker_register(
-        workerId="w1",
-        pool="p",
-        url="http://w1/rpc",
-        advertises={},
-        handlers=["foo"],
+        RegisterParams(
+            workerId="w1",
+            pool="p",
+            url="http://w1/rpc",
+            advertises={},
+            handlers=["foo"],
+        )
     )
 
     task = TaskCreate(

--- a/pkgs/standards/peagen/tests/unit/test_worker_list.py
+++ b/pkgs/standards/peagen/tests/unit/test_worker_list.py
@@ -43,9 +43,13 @@ async def test_worker_list(monkeypatch):
     monkeypatch.setattr(gw, "_persist", noop)
     monkeypatch.setattr(gw, "_publish_event", noop)
 
+    from peagen.protocols.methods.worker import RegisterParams, ListParams
+
     await gw.worker_register(
-        workerId="w1", pool="p", url="http://w1", advertises={}, handlers=["demo"]
+        RegisterParams(
+            workerId="w1", pool="p", url="http://w1", advertises={}, handlers=["demo"]
+        )
     )
-    workers = await gw.worker_list()
-    assert workers[0]["id"] == "w1"
-    assert workers[0]["pool"] == "p"
+    workers = await gw.worker_list(ListParams())
+    assert workers.root[0].id == "w1"
+    assert workers.root[0].pool == "p"

--- a/pkgs/standards/peagen/tests/unit/test_worker_register_handlers.py
+++ b/pkgs/standards/peagen/tests/unit/test_worker_register_handlers.py
@@ -41,12 +41,16 @@ async def test_worker_register_records_handlers(monkeypatch):
     monkeypatch.setattr(gw, "_persist", noop)
     monkeypatch.setattr(gw, "_publish_event", noop)
 
+    from peagen.protocols.methods.worker import RegisterParams
+
     await gw.worker_register(
-        workerId="w1",
-        pool="p",
-        url="http://w1/rpc",
-        advertises={},
-        handlers=["demo"],
+        RegisterParams(
+            workerId="w1",
+            pool="p",
+            url="http://w1/rpc",
+            advertises={},
+            handlers=["demo"],
+        )
     )
     data = await q.hgetall("worker:w1")
     assert json.loads(data["handlers"]) == ["demo"]

--- a/pkgs/standards/peagen/tests/unit/test_worker_register_reject_empty.py
+++ b/pkgs/standards/peagen/tests/unit/test_worker_register_reject_empty.py
@@ -40,13 +40,17 @@ async def test_worker_register_rejects_no_handlers(monkeypatch):
     monkeypatch.setattr(gw, "_persist", noop)
     monkeypatch.setattr(gw, "_publish_event", noop)
 
+    from peagen.protocols.methods.worker import RegisterParams
+
     with pytest.raises(gw.RPCException) as exc:
         await gw.worker_register(
-            workerId="w1",
-            pool="p",
-            url="http://w1/rpc",
-            advertises={},
-            handlers=[],
+            RegisterParams(
+                workerId="w1",
+                pool="p",
+                url="http://w1/rpc",
+                advertises={},
+                handlers=[],
+            )
         )
     assert exc.value.code == -32602
     data = await q.hgetall("worker:w1")

--- a/pkgs/standards/peagen/tests/unit/test_worker_register_well_known.py
+++ b/pkgs/standards/peagen/tests/unit/test_worker_register_well_known.py
@@ -65,8 +65,10 @@ async def test_worker_register_fetches_well_known(monkeypatch):
     monkeypatch.setattr(gw, "_persist", noop)
     monkeypatch.setattr(gw, "_publish_event", noop)
 
+    from peagen.protocols.methods.worker import RegisterParams
+
     await gw.worker_register(
-        workerId="w1", pool="p", url="http://w1/rpc", advertises={}
+        RegisterParams(workerId="w1", pool="p", url="http://w1/rpc", advertises={})
     )
     data = await q.hgetall("worker:w1")
     handlers = json.loads(data["handlers"])


### PR DESCRIPTION
## Summary
- refactor worker RPC functions to use params/result models from peagen protocols
- update tests for new worker RPC signatures

## Testing
- `uv run --directory standards/peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest` *(fails: tests/i9n/two_user_secret_exchange_i9n_test.py::test_two_user_secret_exchange)*
- `peagen local -q process non_existent.yaml --watch` *(fails: No such option: --watch)*

------
https://chatgpt.com/codex/tasks/task_e_68602e3024c88326b07dd894c38e183d