### PR TITLE
Use typed RPC protocols for worker API

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/rpc/workers.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/workers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import time
+import json
 
 import httpx
 
@@ -20,80 +21,82 @@ from .. import (
 
 from peagen.orm.status import Status
 from peagen.transport.jsonrpc import RPCException
-from peagen.defaults import (
+from peagen.protocols.methods.worker import (
     WORKER_REGISTER,
     WORKER_HEARTBEAT,
     WORKER_LIST,
-    WORK_FINISHED,
+    RegisterParams,
+    RegisterResult,
+    HeartbeatParams,
+    HeartbeatResult,
+    ListParams,
+    ListResult,
+    WorkerInfo,
 )
+from peagen.defaults import WORK_FINISHED
 
 
 @dispatcher.method(WORKER_REGISTER)
-async def worker_register(
-    workerId: str,
-    pool: str,
-    url: str,
-    advertises: dict,
-    handlers: list[str] | None = None,
-) -> dict:
+async def worker_register(params: RegisterParams) -> dict:
     """Register a worker and persist its advertised handlers."""
 
-    handler_list: list[str] = handlers or []
+    handler_list: list[str] = params.handlers or []
     if not handler_list:
-        well_known_url = url.replace("/rpc", "/well-known")
+        well_known_url = params.url.replace("/rpc", "/well-known")
         try:
             async with httpx.AsyncClient(timeout=5) as client:
                 resp = await client.get(well_known_url)
                 if resp.status_code == 200:
                     handler_list = resp.json().get("handlers", [])
         except Exception as exc:  # noqa: BLE001
-            log.warning("/well-known fetch failed for %s: %s", workerId, exc)
+            log.warning("/well-known fetch failed for %s: %s", params.workerId, exc)
 
     if not handler_list:
         raise RPCException(code=-32602, message="worker supports no handlers")
 
     await _upsert_worker(
-        workerId,
+        params.workerId,
         {
-            "pool": pool,
-            "url": url,
-            "advertises": advertises,
+            "pool": params.pool,
+            "url": params.url,
+            "advertises": params.advertises,
             "handlers": handler_list,
         },
     )
-    log.info("worker %s registered (%s) handlers=%s", workerId, pool, handler_list)
-    return {"ok": True}
+    log.info(
+        "worker %s registered (%s) handlers=%s",
+        params.workerId,
+        params.pool,
+        handler_list,
+    )
+    return RegisterResult(ok=True).model_dump()
 
 
 @dispatcher.method(WORKER_HEARTBEAT)
-async def worker_heartbeat(
-    workerId: str,
-    metrics: dict,
-    pool: str | None = None,
-    url: str | None = None,
-) -> dict:
-    known = await queue.exists(WORKER_KEY.format(workerId))
-    if not known and not (pool and url):
+async def worker_heartbeat(params: HeartbeatParams) -> dict:
+    known = await queue.exists(WORKER_KEY.format(params.workerId))
+    if not known and not (params.pool and params.url):
         log.warning(
             "heartbeat from %s ignored: gateway lacks metadata; send pool+url or re-register",
-            workerId,
+            params.workerId,
         )
         return {"ok": False}
 
     mapping = {"last_seen": int(time.time())}
-    if pool:
-        mapping["pool"] = pool
-    if url:
-        mapping["url"] = url
-    await queue.hset(WORKER_KEY.format(workerId), mapping=mapping)
-    await queue.expire(WORKER_KEY.format(workerId), WORKER_TTL)
-    return {"ok": True}
+    if params.pool:
+        mapping["pool"] = params.pool
+    if params.url:
+        mapping["url"] = params.url
+    await queue.hset(WORKER_KEY.format(params.workerId), mapping=mapping)
+    await queue.expire(WORKER_KEY.format(params.workerId), WORKER_TTL)
+    return HeartbeatResult(ok=True).model_dump()
 
 
 @dispatcher.method(WORKER_LIST)
-async def worker_list(pool: str | None = None) -> list[dict]:
+async def worker_list(params: ListParams | None = None) -> list[dict]:
     """Return active workers, optionally filtered by *pool*."""
 
+    pool = params.pool if params else None
     keys = await queue.keys("worker:*")
     workers = []
     now = int(time.time())
@@ -105,8 +108,18 @@ async def worker_list(pool: str | None = None) -> list[dict]:
             continue
         if pool and w.get("pool") != pool:
             continue
+        if "advertises" in w and isinstance(w["advertises"], str):
+            try:
+                w["advertises"] = json.loads(w["advertises"])
+            except Exception:  # noqa: BLE001
+                pass
+        if "handlers" in w and isinstance(w["handlers"], str):
+            try:
+                w["handlers"] = json.loads(w["handlers"])
+            except Exception:  # noqa: BLE001
+                pass
         workers.append({"id": key.split(":", 1)[1], **{k: v for k, v in w.items()}})
-    return workers
+    return ListResult([WorkerInfo.model_validate(w) for w in workers]).model_dump()
 
 
 @dispatcher.method(WORK_FINISHED)

--- a/pkgs/standards/peagen/tests/unit/test_scheduler_remove_bad_worker.py
+++ b/pkgs/standards/peagen/tests/unit/test_scheduler_remove_bad_worker.py
@@ -5,6 +5,7 @@ import datetime
 import httpx
 import pytest
 from peagen.plugins.queues.in_memory_queue import InMemoryQueue
+from peagen.protocols.methods.worker import RegisterParams
 
 
 @pytest.mark.unit
@@ -43,9 +44,10 @@ async def test_scheduler_removes_bad_worker(monkeypatch):
     monkeypatch.setattr(gw, "_persist", noop)
     monkeypatch.setattr(gw, "_publish_task", noop)
 
-    await gw.worker_register(
+    params = RegisterParams(
         workerId="w1", pool="p", url="http://w1/rpc", advertises={}, handlers=["demo"]
     )
+    await gw.worker_register(params)
 
     await q.sadd("pools", "p")
     task = gw.TaskRead(

--- a/pkgs/standards/peagen/tests/unit/test_task_submit_unknown.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_submit_unknown.py
@@ -5,6 +5,7 @@ import uuid
 from datetime import datetime, timezone
 
 from peagen.plugins.queues.in_memory_queue import InMemoryQueue
+from peagen.protocols.methods.worker import RegisterParams
 from peagen.schemas import TaskCreate
 from peagen.orm.status import Status
 
@@ -47,11 +48,13 @@ async def test_task_submit_unknown_action(monkeypatch):
     monkeypatch.setattr(gw, "_publish_event", noop)
 
     await gw.worker_register(
-        workerId="w1",
-        pool="p",
-        url="http://w1/rpc",
-        advertises={},
-        handlers=["foo"],
+        RegisterParams(
+            workerId="w1",
+            pool="p",
+            url="http://w1/rpc",
+            advertises={},
+            handlers=["foo"],
+        )
     )
 
     task = TaskCreate(

--- a/pkgs/standards/peagen/tests/unit/test_worker_list.py
+++ b/pkgs/standards/peagen/tests/unit/test_worker_list.py
@@ -1,6 +1,7 @@
 import pytest
 
 from peagen.plugins.queues.in_memory_queue import InMemoryQueue
+from peagen.protocols.methods.worker import RegisterParams, ListParams, WorkerInfo
 
 
 @pytest.mark.unit
@@ -43,9 +44,11 @@ async def test_worker_list(monkeypatch):
     monkeypatch.setattr(gw, "_persist", noop)
     monkeypatch.setattr(gw, "_publish_event", noop)
 
-    await gw.worker_register(
+    params = RegisterParams(
         workerId="w1", pool="p", url="http://w1", advertises={}, handlers=["demo"]
     )
-    workers = await gw.worker_list()
-    assert workers[0]["id"] == "w1"
-    assert workers[0]["pool"] == "p"
+    await gw.worker_register(params)
+    result = await gw.worker_list(ListParams(pool=None))
+    info = WorkerInfo.model_validate(result[0])
+    assert info.id == "w1"
+    assert info.pool == "p"

--- a/pkgs/standards/peagen/tests/unit/test_worker_register_handlers.py
+++ b/pkgs/standards/peagen/tests/unit/test_worker_register_handlers.py
@@ -3,6 +3,7 @@ import importlib
 import pytest
 
 from peagen.plugins.queues.in_memory_queue import InMemoryQueue
+from peagen.protocols.methods.worker import RegisterParams
 
 
 @pytest.mark.unit
@@ -41,12 +42,13 @@ async def test_worker_register_records_handlers(monkeypatch):
     monkeypatch.setattr(gw, "_persist", noop)
     monkeypatch.setattr(gw, "_publish_event", noop)
 
-    await gw.worker_register(
+    params = RegisterParams(
         workerId="w1",
         pool="p",
         url="http://w1/rpc",
         advertises={},
         handlers=["demo"],
     )
+    await gw.worker_register(params)
     data = await q.hgetall("worker:w1")
     assert json.loads(data["handlers"]) == ["demo"]

--- a/pkgs/standards/peagen/tests/unit/test_worker_register_reject_empty.py
+++ b/pkgs/standards/peagen/tests/unit/test_worker_register_reject_empty.py
@@ -2,6 +2,7 @@ import importlib
 import pytest
 
 from peagen.plugins.queues.in_memory_queue import InMemoryQueue
+from peagen.protocols.methods.worker import RegisterParams
 
 
 @pytest.mark.unit
@@ -41,13 +42,14 @@ async def test_worker_register_rejects_no_handlers(monkeypatch):
     monkeypatch.setattr(gw, "_publish_event", noop)
 
     with pytest.raises(gw.RPCException) as exc:
-        await gw.worker_register(
+        params = RegisterParams(
             workerId="w1",
             pool="p",
             url="http://w1/rpc",
             advertises={},
             handlers=[],
         )
+        await gw.worker_register(params)
     assert exc.value.code == -32602
     data = await q.hgetall("worker:w1")
     assert data == {}

--- a/pkgs/standards/peagen/tests/unit/test_worker_register_well_known.py
+++ b/pkgs/standards/peagen/tests/unit/test_worker_register_well_known.py
@@ -3,6 +3,7 @@ import importlib
 import pytest
 
 from peagen.plugins.queues.in_memory_queue import InMemoryQueue
+from peagen.protocols.methods.worker import RegisterParams
 
 
 @pytest.mark.unit
@@ -65,9 +66,8 @@ async def test_worker_register_fetches_well_known(monkeypatch):
     monkeypatch.setattr(gw, "_persist", noop)
     monkeypatch.setattr(gw, "_publish_event", noop)
 
-    await gw.worker_register(
-        workerId="w1", pool="p", url="http://w1/rpc", advertises={}
-    )
+    params = RegisterParams(workerId="w1", pool="p", url="http://w1/rpc", advertises={})
+    await gw.worker_register(params)
     data = await q.hgetall("worker:w1")
     handlers = json.loads(data["handlers"])
     assert handlers == ["a", "b"]


### PR DESCRIPTION
## Summary
- refactor worker RPC methods to accept protocol params and emit protocol results
- update tests for new worker protocol usage

## Testing
- `uv run --directory standards/peagen --package peagen pytest tests/unit/test_worker_list.py tests/unit/test_worker_register_handlers.py tests/unit/test_worker_register_reject_empty.py tests/unit/test_worker_register_well_known.py tests/unit/test_scheduler_remove_bad_worker.py tests/unit/test_task_submit_unknown.py -q`
- `uv run --directory standards/peagen --package peagen pytest -q` *(fails: two_user_secret_exchange_i9n_test.py, test_sequences_success[example0])*

------
https://chatgpt.com/codex/tasks/task_e_68602e2ba6008326ae5869753f163b71