### PR TITLE
Refactor peagen CLI to use protocol models

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/analysis.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/analysis.py
@@ -57,12 +57,12 @@ def submit(
         TASK_SUBMIT,
         task.model_dump(mode="json"),
     )
-    if "error" in reply:
+    if reply.error:
         typer.secho(
-            f"Remote error {reply['error']['code']}: {reply['error']['message']}",
+            f"Remote error {reply.error.code}: {reply.error.message}",
             fg=typer.colors.RED,
             err=True,
         )
         raise typer.Exit(1)
     typer.secho(f"Submitted task {task.id}", fg=typer.colors.GREEN)
-    typer.echo(json.dumps(reply.get("result", {}), indent=2))
+    typer.echo(json.dumps(reply.result or {}, indent=2))

--- a/pkgs/standards/peagen/peagen/cli/commands/db.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/db.py
@@ -52,9 +52,9 @@ def _submit_task(op: str, gateway_url: str, message: str | None = None) -> str:
         {"pool": task.pool, "payload": task.payload, "taskId": task.id},
         timeout=10.0,
     )
-    if data.get("error"):
-        raise RuntimeError(data["error"])
-    return str(data.get("result", {}).get("taskId", task.id))
+    if data.error:
+        raise RuntimeError(data.error)
+    return str(data.result.get("taskId", task.id))
 
 
 @local_db_app.command("upgrade")

--- a/pkgs/standards/peagen/peagen/cli/commands/eval.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/eval.py
@@ -130,9 +130,9 @@ def submit(  # noqa: PLR0913
         task.model_dump(mode="json"),
     )
 
-    if "error" in reply:
+    if reply.error:
         typer.secho(
-            f"Remote error {reply['error']['code']}: {reply['error']['message']}",
+            f"Remote error {reply.error.code}: {reply.error.message}",
             fg=typer.colors.RED,
             err=True,
         )

--- a/pkgs/standards/peagen/peagen/cli/commands/evolve.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/evolve.py
@@ -14,7 +14,8 @@ from functools import partial
 from peagen.handlers.evolve_handler import evolve_handler
 from peagen.orm.status import Status
 from peagen.core.validate_core import validate_evolve_spec
-from peagen.protocols import TASK_SUBMIT
+from peagen.protocols import TASK_SUBMIT, TASK_GET
+from peagen.protocols.methods.task import GetParams
 from peagen.cli.task_builder import _build_task as _generic_build_task
 
 local_evolve_app = typer.Typer(help="Expand evolve spec and run mutate tasks")
@@ -119,12 +120,13 @@ def submit(
     if watch:
 
         def _rpc_call() -> dict:
+            params = GetParams(taskId=task.id)
             res = rpc_post(
                 ctx.obj.get("gateway_url"),
-                "Task.get",
-                {"taskId": task.id},
+                TASK_GET,
+                params,
             )
-            return res["result"]
+            return res.result
 
         import time
 

--- a/pkgs/standards/peagen/peagen/cli/commands/extras.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/extras.py
@@ -89,10 +89,10 @@ def submit_extras(
             task.model_dump(mode="json"),
             timeout=10.0,
         )
-        if reply.get("error"):
-            typer.echo(f"[ERROR] {reply['error']}")
+        if reply.error:
+            typer.echo(f"[ERROR] {reply.error}")
             raise typer.Exit(1)
-        typer.echo(f"Submitted extras generation → taskId={reply['id']}")
+        typer.echo(f"Submitted extras generation → taskId={reply.id}")
     except Exception as exc:
         typer.echo(f"[ERROR] Could not reach gateway at {gateway_url}: {exc}")
         raise typer.Exit(1)

--- a/pkgs/standards/peagen/peagen/cli/commands/keys.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/keys.py
@@ -43,7 +43,7 @@ def upload(
     """Upload the public key to the gateway."""
     drv = AutoGpgDriver(key_dir=key_dir)
     pubkey = drv.pub_path.read_text()
-    params = UploadParams(public_key=pubkey).model_dump()
+    params = UploadParams(public_key=pubkey)
     rpc_post(gateway_url, KEYS_UPLOAD, params, timeout=10.0)
     typer.echo("Uploaded public key")
 
@@ -55,7 +55,7 @@ def remove(
     gateway_url: str = typer.Option("http://localhost:8000/rpc", "--gateway-url"),
 ) -> None:
     """Remove a public key from the gateway."""
-    params = DeleteParams(fingerprint=fingerprint).model_dump()
+    params = DeleteParams(fingerprint=fingerprint)
     rpc_post(gateway_url, KEYS_DELETE, params, timeout=10.0)
     typer.echo(f"Removed key {fingerprint}")
 
@@ -66,9 +66,9 @@ def fetch_server(
     gateway_url: str = typer.Option("http://localhost:8000/rpc", "--gateway-url"),
 ) -> None:
     """Fetch trusted public keys from the gateway."""
-    params = FetchParams().model_dump()
+    params = FetchParams()
     res = rpc_post(gateway_url, KEYS_FETCH, params, timeout=10.0)
-    typer.echo(json.dumps(res.get("result", {}), indent=2))
+    typer.echo(json.dumps(res.result or {}, indent=2))
 
 
 @keys_app.command("list")

--- a/pkgs/standards/peagen/peagen/cli/commands/login.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/login.py
@@ -34,7 +34,7 @@ def login(
     drv = AutoGpgDriver(key_dir=key_dir, passphrase=passphrase)
     pubkey = drv.pub_path.read_text()
     try:
-        params = UploadParams(public_key=pubkey).model_dump()
+        params = UploadParams(public_key=pubkey)
         reply = rpc_post(
             gateway_url,
             KEYS_UPLOAD,
@@ -44,7 +44,7 @@ def login(
     except Exception as e:  # pragma: no cover - network errors
         typer.echo(f"HTTP error: {e}", err=True)
         raise typer.Exit(1)
-    if reply.get("error"):
-        typer.echo(f"Failed to upload key: {reply['error']}", err=True)
+    if reply.error:
+        typer.echo(f"Failed to upload key: {reply.error}", err=True)
         raise typer.Exit(1)
     typer.echo("Logged in and uploaded public key")

--- a/pkgs/standards/peagen/peagen/cli/commands/mutate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/mutate.py
@@ -115,14 +115,14 @@ def submit(
         task.model_dump(mode="json"),
     )
 
-    if "error" in reply:
+    if reply.error:
         typer.secho(
-            f"Remote error {reply['error']['code']}: {reply['error']['message']}",
+            f"Remote error {reply.error.code}: {reply.error.message}",
             fg=typer.colors.RED,
             err=True,
         )
         raise typer.Exit(1)
 
     typer.secho(f"Submitted task {task.id}", fg=typer.colors.GREEN)
-    if reply.get("result"):
-        typer.echo(json.dumps(reply["result"], indent=2))
+    if reply.result:
+        typer.echo(json.dumps(reply.result, indent=2))

--- a/pkgs/standards/peagen/peagen/cli/commands/process.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/process.py
@@ -22,6 +22,7 @@ from functools import partial
 from peagen._utils.config_loader import _effective_cfg, load_peagen_toml
 from peagen.handlers.process_handler import process_handler
 from peagen.protocols import TASK_SUBMIT, TASK_GET
+from peagen.protocols.methods.task import GetParams
 from peagen.cli.rpc_utils import rpc_post
 from peagen.orm.status import Status
 from peagen.cli.task_builder import _build_task as _generic_build_task
@@ -206,12 +207,13 @@ def submit(  # noqa: PLR0913 – CLI signature needs many options
     if watch:
 
         def _rpc_call() -> dict:
+            params = GetParams(taskId=task.id)
             res = rpc_post(
                 ctx.obj.get("gateway_url"),
                 TASK_GET,
-                {"taskId": task.id},
+                params,
             )
-            return res["result"]
+            return res.result
 
         while True:
             task_reply = _rpc_call()

--- a/pkgs/standards/peagen/peagen/cli/commands/sort.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/sort.py
@@ -145,10 +145,10 @@ def submit_sort(
             task,
             timeout=10.0,
         )
-        if data.get("error"):
-            typer.echo(f"[ERROR] {data['error']}")
+        if data.error:
+            typer.echo(f"[ERROR] {data.error}")
             raise typer.Exit(1)
-        typer.echo(f"Submitted sort → taskId={data['result']['taskId']}")
+        typer.echo(f"Submitted sort → taskId={data.result['taskId']}")
     except Exception as exc:
         typer.echo(
             f"[ERROR] Could not reach gateway at {ctx.obj.get('gateway_url')}: {exc}"

--- a/pkgs/standards/peagen/peagen/cli/commands/task.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/task.py
@@ -18,6 +18,11 @@ from peagen.protocols import (
     TASK_RETRY,
     TASK_RETRY_FROM,
 )
+from peagen.protocols.methods.task import (
+    GetParams,
+    PatchParams,
+    SimpleSelectorParams,
+)
 from peagen.cli.rpc_utils import rpc_post
 
 from peagen.orm.status import Status
@@ -37,12 +42,13 @@ def get(  # noqa: D401
     """Fetch status / result for *TASK_ID* (optionally watch until done)."""
 
     def _rpc_call() -> dict:
+        params = GetParams(taskId=task_id)
         res = rpc_post(
             ctx.obj.get("gateway_url"),
             TASK_GET,
-            {"taskId": task_id},
+            params,
         )
-        return res["result"]
+        return res.result
 
     while True:
         reply = _rpc_call()
@@ -62,21 +68,23 @@ def patch_task(
     """Send a Task.patch RPC call."""
 
     payload = json.loads(changes)
+    params = PatchParams(taskId=task_id, changes=payload)
     res = rpc_post(
         ctx.obj.get("gateway_url"),
         TASK_PATCH,
-        {"taskId": task_id, "changes": payload},
+        params,
     )
-    typer.echo(json.dumps(res["result"], indent=2))
+    typer.echo(json.dumps(res.result, indent=2))
 
 
 def _simple_call(ctx: typer.Context, method: str, selector: str) -> None:
+    params = SimpleSelectorParams(selector=selector)
     res = rpc_post(
         ctx.obj.get("gateway_url"),
         method,
-        {"selector": selector},
+        params,
     )
-    typer.echo(json.dumps(res["result"], indent=2))
+    typer.echo(json.dumps(res.result, indent=2))
 
 
 @remote_task_app.command("pause")

--- a/pkgs/standards/peagen/peagen/cli/commands/templates.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/templates.py
@@ -39,9 +39,9 @@ def _submit_task(args: Dict[str, Any], gateway_url: str) -> str:
         task.model_dump(mode="json"),
         timeout=10.0,
     )
-    if data.get("error"):
-        raise RuntimeError(data["error"])
-    return str(data.get("result", {}).get("taskId", task.id))
+    if data.error:
+        raise RuntimeError(data.error)
+    return str(data.result.get("taskId", task.id))
 
 
 # ─── list ──────────────────────────────

--- a/pkgs/standards/peagen/peagen/cli/commands/validate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/validate.py
@@ -98,8 +98,8 @@ def submit_validate(
             task.model_dump(mode="json"),
             timeout=10.0,
         )
-        if reply.get("error"):
-            typer.echo(f"[ERROR] {reply['error']}")
+        if reply.error:
+            typer.echo(f"[ERROR] {reply.error}")
             raise typer.Exit(1)
         typer.echo(f"Submitted validation → taskId={task.id}")
     except Exception as exc:

--- a/pkgs/standards/peagen/peagen/cli/rpc_utils.py
+++ b/pkgs/standards/peagen/peagen/cli/rpc_utils.py
@@ -1,23 +1,34 @@
 from __future__ import annotations
 
 import uuid
-from typing import Any, Dict
+from typing import Any, Dict, Type
 
 import httpx
+from pydantic import BaseModel
 
-from peagen.protocols import Request
+from peagen.protocols import Request, Response, _registry
 
 
 def rpc_post(
     url: str,
     method: str,
-    params: Dict[str, Any],
+    params: BaseModel | Dict[str, Any],
     *,
     id: str | None = None,
     timeout: float = 30.0,
-) -> Dict[str, Any]:
-    """Send a JSON-RPC request using :class:`peagen.protocols.Request`."""
-    envelope = Request(id=id or str(uuid.uuid4()), method=method, params=params)
+) -> Response:
+    """Send a typed JSON-RPC request and return a :class:`Response`."""
+
+    payload = (
+        params.model_dump(mode="python") if isinstance(params, BaseModel) else params
+    )
+    envelope: Request = Request(
+        id=id or str(uuid.uuid4()), method=method, params=payload
+    )
     resp = httpx.post(url, json=envelope.model_dump(), timeout=timeout)
     resp.raise_for_status()
-    return resp.json()
+
+    data = resp.json()
+    result_model: Type[BaseModel] | None = _registry.result_model(method)
+    response_cls = Response[result_model] if result_model else Response
+    return response_cls.model_validate(data)


### PR DESCRIPTION
## Summary
- refactor peagen CLI commands to use protocol params and result models
- update rpc utils to return typed Response objects

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest -q` *(fails: tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68602e2079e88326afa552fd6bed7566