### PR TITLE
Fix secrets RPC handling

### DIFF
--- a/pkgs/standards/peagen/peagen/core/secrets_core.py
+++ b/pkgs/standards/peagen/peagen/core/secrets_core.py
@@ -93,7 +93,7 @@ def add_remote_secret(
         "method": "Secrets.add",
         "params": {
             "name": secret_id,
-            "secret": cipher,
+            "cipher": cipher,
             "version": version,
             "tenant_id": pool,
         },


### PR DESCRIPTION
## Summary
- ensure `peagen` RPC dispatcher passes correct parameters for secrets
- adjust secrets core to send `cipher` instead of `secret`
- update gateway secret RPC endpoints to accept keyword arguments

## Testing
- `PEAGEN_TEST_GATEWAY=http://127.0.0.1:8000/rpc uv run --package peagen --directory pkgs/standards/peagen pytest tests/smoke/test_gateway_login_keys_secrets_cli.py::test_secret_roundtrip -m smoke -vv`


------
https://chatgpt.com/codex/tasks/task_e_68602fa966348326b651c9aa639b0f40