### PR TITLE
Fix RPC param model mismatch

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/rpc_utils.py
+++ b/pkgs/standards/peagen/peagen/cli/rpc_utils.py
@@ -5,7 +5,7 @@ from typing import Any, Dict
 
 import httpx
 
-from peagen.protocols import Request
+from peagen.protocols import Request, TASK_SUBMIT
 
 
 def rpc_post(
@@ -17,6 +17,8 @@ def rpc_post(
     timeout: float = 30.0,
 ) -> Dict[str, Any]:
     """Send a JSON-RPC request using :class:`peagen.protocols.Request`."""
+    if method == TASK_SUBMIT and "task" not in params:
+        params = {"task": params}
     envelope = Request(id=id or str(uuid.uuid4()), method=method, params=params)
     resp = httpx.post(url, json=envelope.model_dump(), timeout=timeout)
     resp.raise_for_status()

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -391,7 +391,7 @@ async def _publish_event(event_type: str, data: dict) -> None:
         "time": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         "data": data,
     }
-    await queue.publish(PUBSUB_TOPIC, json.dumps(event))
+    await queue.publish(PUBSUB_TOPIC, json.dumps(event, default=str))
 
 
 async def _flush_state() -> None:
@@ -561,7 +561,9 @@ async def rpc_endpoint(request: Request):
                     status = 404
     log.debug("RPC out -> %s", resp)
     return Response(
-        content=json.dumps(resp), status_code=status, media_type="application/json"
+        content=json.dumps(resp, default=str),
+        status_code=status,
+        media_type="application/json",
     )
 
 

--- a/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
@@ -50,9 +50,11 @@ from .. import Session, engine, Base
 def _parse_task_create(task: t.Any) -> TaskCreate:
     """Return ``task`` if it is a :class:`TaskCreate` instance."""
 
-    if not isinstance(task, TaskCreate):
-        raise TypeError("TaskCreate required")
-    return task
+    if isinstance(task, TaskCreate):
+        return task
+    if isinstance(task, dict):
+        return TaskCreate.model_validate(task)
+    raise TypeError("TaskCreate required")
 
 
 # --------------Basic Task Methods ---------------------------------

--- a/pkgs/standards/peagen/peagen/protocols/methods/task.py
+++ b/pkgs/standards/peagen/peagen/protocols/methods/task.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 
 from pydantic import BaseModel, ConfigDict
+from peagen.schemas import TaskCreate
 
 from peagen.protocols._registry import register
 
@@ -9,11 +10,9 @@ from peagen.protocols._registry import register
 class SubmitParams(BaseModel):
     """Parameters for the ``Task.submit`` RPC method."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="allow")
 
-    template_set: str
-    inputs: dict
-    priority: int | None = None
+    task: TaskCreate
 
 
 class SubmitResult(BaseModel):

--- a/pkgs/standards/peagen/tests/test_protocols_basic.py
+++ b/pkgs/standards/peagen/tests/test_protocols_basic.py
@@ -14,15 +14,23 @@ def test_parse_and_registry() -> None:
         "id": 1,
         "method": TASK_SUBMIT,
         "params": {
-            "template_set": "foo",
-            "inputs": {"x": "y"},
-            "priority": 1,
+            "task": {
+                "tenant_id": "01234567-89ab-cdef-0123-456789abcdef",
+                "git_reference_id": "fedcba98-7654-3210-fedc-ba9876543210",
+                "pool": "default",
+                "payload": {"action": "demo"},
+                "status": "queued",
+                "note": "",
+                "spec_hash": "dummy",
+                "id": "11111111-2222-3333-4444-555555555555",
+                "last_modified": "2024-01-01T00:00:00Z",
+            }
         },
     }
     req = parse_request(raw)
     PModel = _registry.params_model(req.method)
     params = PModel.model_validate(req.params)
-    assert params.template_set == "foo"
+    assert params.task.pool == "default"
     res = Response.ok(id=req.id, result={"task_id": "ABCDEFGHIJKL"})
     assert res.jsonrpc == "2.0"
 


### PR DESCRIPTION
## Summary
- update CLI rpc_post helper to wrap Task.submit payloads
- allow gateway RPC handler to parse dicts into TaskCreate
- adjust SubmitParams model to expect a `task` field
- serialize UUID values in gateway responses/events
- update protocol tests for new SubmitParams shape

## Testing
- `uv run --package peagen --directory standards/peagen ruff format .`
- `uv run --package peagen --directory standards/peagen ruff check . --fix`
- `PEAGEN_TEST_GATEWAY=http://127.0.0.1:8000/rpc uv run --package peagen --directory standards/peagen pytest -m smoke` *(fails: 16 failed, 4 passed, 3 skipped, 2 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68602f86ddc48326985c200a45be21e1