### PR TITLE
Fix JSON-RPC dispatch for typed params

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/doe.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/doe.py
@@ -14,9 +14,11 @@ from typing import Optional
 
 import typer
 
+from functools import partial
+
 from peagen.handlers.doe_handler import doe_handler
 from peagen.handlers.doe_process_handler import doe_process_handler
-from peagen.schemas import TaskCreate
+from peagen.cli.task_builder import _build_task as _generic_build_task
 from peagen.protocols import TASK_SUBMIT, TASK_GET
 from peagen.orm.status import Status
 
@@ -25,11 +27,7 @@ local_doe_app = typer.Typer(help="Generate project-payload bundles from DOE spec
 remote_doe_app = typer.Typer(help="Generate project-payload bundles from DOE specs.")
 
 
-def _make_task(args: dict, action: str = "doe") -> TaskCreate:
-    return TaskCreate(
-        pool="default",
-        payload={"action": action, "args": args},
-    )
+_build_task = partial(_generic_build_task, "doe")
 
 
 # ───────────────────────────── local run ───────────────────────────────────
@@ -87,7 +85,7 @@ def run_gen(  # noqa: PLR0913
     if repo:
         args.update({"repo": repo, "ref": ref})
 
-    task = _make_task(args, action="doe")
+    task = _build_task(args, ctx.obj.get("pool", "default"))
     result = asyncio.run(doe_handler(task))
 
     if json_out:
@@ -142,7 +140,7 @@ def submit_gen(  # noqa: PLR0913
         "evaluate_runs": evaluate_runs,
     }
     args.update({"repo": repo, "ref": ref})
-    task = _make_task(args, action="doe")
+    task = _build_task(args, ctx.obj.get("pool", "default"))
 
     reply = rpc_post(
         ctx.obj.get("gateway_url"),
@@ -216,7 +214,7 @@ def run_process(  # noqa: PLR0913
     if repo:
         args.update({"repo": repo, "ref": ref})
 
-    task = _make_task(args, action="doe_process")
+    task = _build_task(args, ctx.obj.get("pool", "default"))
     result = asyncio.run(doe_process_handler(task))
 
     typer.echo(
@@ -289,7 +287,7 @@ def submit_process(  # noqa: PLR0913
         "evaluate_runs": evaluate_runs,
     }
     args.update({"repo": repo, "ref": ref})
-    task = _make_task(args, action="doe_process")
+    task = _build_task(args, ctx.obj.get("pool", "default"))
 
     reply = rpc_post(
         ctx.obj.get("gateway_url"),


### PR DESCRIPTION
## Summary
- support dataclass parameters in RPC dispatcher
- build DOE tasks using generic helper

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`
- `PEAGEN_TEST_GATEWAY=http://localhost:8000/rpc uv run --package peagen --directory pkgs/standards/peagen pytest -k keys_upload -vv`
- `PEAGEN_TEST_GATEWAY=http://localhost:8000/rpc uv run --package peagen --directory pkgs/standards/peagen pytest -m smoke` *(fails: subprocess.CalledProcessError)*

------
https://chatgpt.com/codex/tasks/task_e_68602fdd8610832697a16c46ae74f7cd