### PR TITLE
Update CLI to use typed protocols

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/keys.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/keys.py
@@ -16,6 +16,9 @@ from peagen.protocols.methods.keys import (
     UploadParams,
     DeleteParams,
     FetchParams,
+    UploadResult,
+    DeleteResult,
+    FetchResult,
 )
 
 
@@ -44,7 +47,13 @@ def upload(
     drv = AutoGpgDriver(key_dir=key_dir)
     pubkey = drv.pub_path.read_text()
     params = UploadParams(public_key=pubkey).model_dump()
-    rpc_post(gateway_url, KEYS_UPLOAD, params, timeout=10.0)
+    rpc_post(
+        gateway_url,
+        KEYS_UPLOAD,
+        params,
+        timeout=10.0,
+        result_model=UploadResult,
+    )
     typer.echo("Uploaded public key")
 
 
@@ -56,7 +65,13 @@ def remove(
 ) -> None:
     """Remove a public key from the gateway."""
     params = DeleteParams(fingerprint=fingerprint).model_dump()
-    rpc_post(gateway_url, KEYS_DELETE, params, timeout=10.0)
+    rpc_post(
+        gateway_url,
+        KEYS_DELETE,
+        params,
+        timeout=10.0,
+        result_model=DeleteResult,
+    )
     typer.echo(f"Removed key {fingerprint}")
 
 
@@ -67,8 +82,14 @@ def fetch_server(
 ) -> None:
     """Fetch trusted public keys from the gateway."""
     params = FetchParams().model_dump()
-    res = rpc_post(gateway_url, KEYS_FETCH, params, timeout=10.0)
-    typer.echo(json.dumps(res.get("result", {}), indent=2))
+    res = rpc_post(
+        gateway_url,
+        KEYS_FETCH,
+        params,
+        timeout=10.0,
+        result_model=FetchResult,
+    )
+    typer.echo(json.dumps(res.result.model_dump() if res.result else {}, indent=2))
 
 
 @keys_app.command("list")

--- a/pkgs/standards/peagen/peagen/cli/commands/login.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/login.py
@@ -10,7 +10,7 @@ import typer
 
 from peagen.plugins.secret_drivers import AutoGpgDriver
 from peagen.protocols import KEYS_UPLOAD
-from peagen.protocols.methods.keys import UploadParams
+from peagen.protocols.methods.keys import UploadParams, UploadResult
 
 
 login_app = typer.Typer(help="Authenticate and upload your public key.")
@@ -40,11 +40,12 @@ def login(
             KEYS_UPLOAD,
             params,
             timeout=10.0,
+            result_model=UploadResult,
         )
     except Exception as e:  # pragma: no cover - network errors
         typer.echo(f"HTTP error: {e}", err=True)
         raise typer.Exit(1)
-    if reply.get("error"):
-        typer.echo(f"Failed to upload key: {reply['error']}", err=True)
+    if reply.error:
+        typer.echo(f"Failed to upload key: {reply.error}", err=True)
         raise typer.Exit(1)
     typer.echo("Logged in and uploaded public key")

--- a/pkgs/standards/peagen/peagen/cli/rpc_utils.py
+++ b/pkgs/standards/peagen/peagen/cli/rpc_utils.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import uuid
-from typing import Any, Dict
+from typing import Any, Dict, Type, TypeVar
 
 import httpx
 
-from peagen.protocols import Request
+from pydantic import TypeAdapter
+
+from peagen.protocols import Request, Response
+
+R = TypeVar("R")
 
 
 def rpc_post(
@@ -15,9 +19,14 @@ def rpc_post(
     *,
     id: str | None = None,
     timeout: float = 30.0,
-) -> Dict[str, Any]:
-    """Send a JSON-RPC request using :class:`peagen.protocols.Request`."""
+    result_model: Type[R] | None = None,
+) -> Response[R | Dict[str, Any]]:
+    """Send a JSON-RPC request and return a typed :class:`Response`."""
     envelope = Request(id=id or str(uuid.uuid4()), method=method, params=params)
     resp = httpx.post(url, json=envelope.model_dump(), timeout=timeout)
     resp.raise_for_status()
-    return resp.json()
+    if result_model is not None:
+        adapter = TypeAdapter(Response[result_model])  # type: ignore[index]
+    else:
+        adapter = TypeAdapter(Response[Dict[str, Any]])
+    return adapter.validate_python(resp.json())


### PR DESCRIPTION
## Summary
- adopt `Request` and `Response` wrappers for JSON-RPC calls
- use typed param/result models across CLI commands
- update tests for new protocol usage

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest -k 'not two_user_secret_exchange and not sequences_success' -q`

------
https://chatgpt.com/codex/tasks/task_e_6860328a22788326a0036e88072bc51f