### PR TITLE
Align label RPC methods with protocol models

### DIFF
--- a/pkgs/standards/peagen/peagen/tui/app.py
+++ b/pkgs/standards/peagen/peagen/tui/app.py
@@ -11,6 +11,8 @@ import math
 from urllib.parse import urlparse
 
 import httpx
+from peagen.protocols import Request
+from peagen.protocols.methods.worker import WORKER_LIST
 from textual import events
 from textual.app import App, ComposeResult
 from textual.containers import Vertical
@@ -157,24 +159,14 @@ class RemoteBackend:
             params["limit"] = int(limit)
         if offset:
             params["offset"] = int(offset)
-        payload = {
-            "jsonrpc": "2.0",
-            "id": "1",
-            "method": "Pool.listTasks",
-            "params": params,
-        }
-        resp = await self.http.post(self.rpc_url, json=payload)
+        req = Request(id="1", method="Pool.listTasks", params=params)
+        resp = await self.http.post(self.rpc_url, json=req.model_dump())
         resp.raise_for_status()
         self.tasks = resp.json().get("result", [])
 
     async def fetch_workers(self) -> None:
-        payload = {
-            "jsonrpc": "2.0",
-            "id": "2",
-            "method": "Worker.list",
-            "params": {},
-        }
-        resp = await self.http.post(self.rpc_url, json=payload)
+        req = Request(id="2", method=WORKER_LIST, params={})
+        resp = await self.http.post(self.rpc_url, json=req.model_dump())
         resp.raise_for_status()
         raw_workers = resp.json().get("result", [])
         workers: Dict[str, dict] = {}

--- a/pkgs/standards/peagen/peagen/tui/task_submit.py
+++ b/pkgs/standards/peagen/peagen/tui/task_submit.py
@@ -6,7 +6,7 @@ import httpx
 from typing import Any
 
 from peagen.schemas import TaskCreate
-from peagen.protocols import TASK_SUBMIT
+from peagen.protocols import TASK_SUBMIT, Request
 from peagen.cli.task_builder import _build_task
 
 
@@ -19,11 +19,7 @@ def build_task(action: str, args: dict[str, Any], pool: str = "default") -> Task
 def submit_task(gateway_url: str, task: TaskCreate) -> dict:
     """Submit *task* to the gateway via JSON-RPC and return the reply."""
 
-    req = {
-        "jsonrpc": "2.0",
-        "method": TASK_SUBMIT,
-        "params": task.model_dump(mode="json"),
-    }
-    resp = httpx.post(gateway_url, json=req, timeout=30.0)
+    req = Request(id="1", method=TASK_SUBMIT, params={"task": task})
+    resp = httpx.post(gateway_url, json=req.model_dump(mode="json"), timeout=30.0)
     resp.raise_for_status()
     return resp.json()

--- a/pkgs/standards/peagen/tests/unit/test_task_patch_labels.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_patch_labels.py
@@ -1,6 +1,7 @@
 import pytest
 
 from peagen.plugins.queues.in_memory_queue import InMemoryQueue
+from peagen.protocols.methods.task import PatchParams
 
 
 @pytest.mark.unit
@@ -79,6 +80,6 @@ async def test_task_patch_updates_labels(monkeypatch):
     result = await task_submit(dto)
     tid = result["task_id"]
 
-    await task_patch(taskId=tid, changes={"labels": ["patched"]})
+    await task_patch(PatchParams(taskId=tid, changes={"labels": ["patched"]}))
     patched = await task_get(tid)
-    assert patched["labels"] == ["patched"]
+    assert patched.labels == ["patched"]


### PR DESCRIPTION
## Summary
- use typed request/response models in task label operations
- send canonical envelopes in TUI
- update tests for new parameter style

## Testing
- `uv run --package peagen --directory peagen pytest ../tests/unit/test_task_patch_labels.py ../tests/test_protocols_basic.py -q`
- `peagen remote -q --gateway-url https://gw.peagen.com task get dummy` *(fails: Invalid task id)*
- `peagen local -q process tests/examples/gateway_demo/doe_spec.yaml --repo /tmp/dummyrepo` *(fails: ProjectsPayloadFormatError)*

------
https://chatgpt.com/codex/tasks/task_e_686035bc120883268a834d4323cb25ae