### PR TITLE
Update worker RPC helpers to use protocols

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/secrets.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/secrets.py
@@ -25,9 +25,11 @@ STORE_FILE = Path.home() / ".peagen" / "secret_store.json"
 
 def _pool_worker_pubs(pool: str, gateway_url: str) -> list[str]:
     """Return public keys advertised by workers in ``pool``."""
-    envelope = {"pool": pool}
+    from peagen.protocols.methods.worker import WORKER_LIST, ListParams
+
+    params = ListParams(pool=pool).model_dump()
     try:
-        res = rpc_post(gateway_url, "Worker.list", envelope, timeout=10.0)
+        res = rpc_post(gateway_url, WORKER_LIST, params, timeout=10.0)
     except Exception:
         return []
     workers = res.get("result", [])

--- a/pkgs/standards/peagen/peagen/gateway/rpc/secrets.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/secrets.py
@@ -5,8 +5,11 @@ from peagen.protocols.methods.secrets import (
     SECRETS_ADD,
     SECRETS_GET,
     SECRETS_DELETE,
+    AddParams,
     AddResult,
+    GetParams,
     GetResult,
+    DeleteParams,
     DeleteResult,
 )
 from ..db_helpers import delete_secret, fetch_secret, upsert_secret
@@ -15,33 +18,26 @@ from peagen.transport.jsonrpc import RPCException
 
 
 @dispatcher.method(SECRETS_ADD)
-async def secrets_add(
-    *,
-    name: str,
-    cipher: str,
-    tenant_id: str = "default",
-    owner_user_id: str | None = None,
-    version: int | None = None,
-) -> dict:
+async def secrets_add(params: AddParams) -> dict:
     """Store an encrypted secret."""
     async with Session() as session:
         await upsert_secret(
             session,
-            tenant_id,
+            params.tenant_id,
             "unknown",
-            name,
-            cipher,
+            params.name,
+            params.cipher,
         )
         await session.commit()
-    log.info("secret stored: %s", name)
+    log.info("secret stored: %s", params.name)
     return AddResult(ok=True).model_dump()
 
 
 @dispatcher.method(SECRETS_GET)
-async def secrets_get(*, name: str, tenant_id: str = "default") -> dict:
+async def secrets_get(params: GetParams) -> dict:
     """Retrieve an encrypted secret."""
     async with Session() as session:
-        row = await fetch_secret(session, tenant_id, name)
+        row = await fetch_secret(session, params.tenant_id, params.name)
     if not row:
         raise RPCException(
             code=ErrorCode.SECRET_NOT_FOUND,
@@ -51,12 +47,10 @@ async def secrets_get(*, name: str, tenant_id: str = "default") -> dict:
 
 
 @dispatcher.method(SECRETS_DELETE)
-async def secrets_delete(
-    *, name: str, tenant_id: str = "default", version: int | None = None
-) -> dict:
+async def secrets_delete(params: DeleteParams) -> dict:
     """Remove a secret by name."""
     async with Session() as session:
-        await delete_secret(session, tenant_id, name)
+        await delete_secret(session, params.tenant_id, params.name)
         await session.commit()
-    log.info("secret removed: %s", name)
+    log.info("secret removed: %s", params.name)
     return DeleteResult(ok=True).model_dump()

--- a/pkgs/standards/peagen/peagen/tui/app.py
+++ b/pkgs/standards/peagen/peagen/tui/app.py
@@ -168,12 +168,10 @@ class RemoteBackend:
         self.tasks = resp.json().get("result", [])
 
     async def fetch_workers(self) -> None:
-        payload = {
-            "jsonrpc": "2.0",
-            "id": "2",
-            "method": "Worker.list",
-            "params": {},
-        }
+        from peagen.protocols import Request
+        from peagen.protocols.methods.worker import WORKER_LIST, ListParams
+
+        payload = Request(id="2", method=WORKER_LIST, params=ListParams()).model_dump()
         resp = await self.http.post(self.rpc_url, json=payload)
         resp.raise_for_status()
         raw_workers = resp.json().get("result", [])


### PR DESCRIPTION
## Summary
- use ListParams when requesting Worker.list
- swap worker helpers to construct Request envelopes with params models
- revert gateway secret RPCs to param-model API

## Testing
- `uv run --directory standards/peagen --package peagen ruff check . --fix`
- `PEAGEN_TEST_GATEWAY=http://localhost:9 uv run --directory standards/peagen --package peagen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686036b1cbe88326a0b92324fe9dfb25