### PR TITLE
Refactor gateway RPC to use typed protocols

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -32,7 +32,12 @@ from peagen.transport.jsonrpc import RPCException as RPCException
 from peagen.orm import Base
 from peagen.orm.status import Status
 from pydantic import ValidationError
-from peagen.protocols.methods.task import SubmitResult
+from peagen.protocols.methods.task import (
+    SubmitParams,
+    PatchParams,
+    GetParams,
+    SimpleSelectorParams,
+)
 from peagen.schemas import TaskRead, TaskCreate, TaskUpdate
 from peagen.orm import TaskModel, TaskRunModel
 
@@ -713,13 +718,13 @@ from .rpc.workers import (  # noqa: F401,E402
 )
 from .rpc.tasks import (  # noqa: F401,E402
     guard_set,
-    task_cancel,
-    task_get,
-    task_patch,
-    task_pause,
-    task_resume,
-    task_retry,
-    task_retry_from,
+    task_cancel as _task_cancel_rpc,
+    task_get as _task_get_rpc,
+    task_patch as _task_patch_rpc,
+    task_pause as _task_pause_rpc,
+    task_resume as _task_resume_rpc,
+    task_retry as _task_retry_rpc,
+    task_retry_from as _task_retry_from_rpc,
     task_submit as _task_submit_rpc,
 )
 
@@ -763,7 +768,8 @@ async def task_submit(
         # keep the UUID instance so the ORM receives the correct type
 
     try:
-        return await _task_submit_rpc(task)
+        res = await _task_submit_rpc(SubmitParams(task=task))
+        return {"task_id": res["taskId"]}
     except ValidationError:
         task_id = str(task.id)
         if await _load_task(task_id):
@@ -776,7 +782,35 @@ async def task_submit(
         await _save_task(task_rd)
         await _publish_task(task_rd)
         log.info("task %s queued in %s (ttl=%ss)", task_rd.id, task_rd.pool, TASK_TTL)
-        return SubmitResult.model_construct(task_id=str(task_rd.id)).model_dump()
+        return {"task_id": str(task_rd.id)}
+
+
+async def task_patch(*, taskId: str, changes: dict) -> dict:
+    return await _task_patch_rpc(PatchParams(taskId=taskId, changes=changes))
+
+
+async def task_get(taskId: str) -> dict:
+    return await _task_get_rpc(GetParams(taskId=taskId))
+
+
+async def task_cancel(selector: str) -> dict:
+    return await _task_cancel_rpc(SimpleSelectorParams(selector=selector))
+
+
+async def task_pause(selector: str) -> dict:
+    return await _task_pause_rpc(SimpleSelectorParams(selector=selector))
+
+
+async def task_resume(selector: str) -> dict:
+    return await _task_resume_rpc(SimpleSelectorParams(selector=selector))
+
+
+async def task_retry(selector: str) -> dict:
+    return await _task_retry_rpc(SimpleSelectorParams(selector=selector))
+
+
+async def task_retry_from(selector: str) -> dict:
+    return await _task_retry_from_rpc(SimpleSelectorParams(selector=selector))
 
 
 # ─────────────────────────────── Healthcheck ───────────────────────────────

--- a/pkgs/standards/peagen/peagen/gateway/rpc/secrets.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/secrets.py
@@ -5,8 +5,11 @@ from peagen.protocols.methods.secrets import (
     SECRETS_ADD,
     SECRETS_GET,
     SECRETS_DELETE,
+    AddParams,
     AddResult,
+    GetParams,
     GetResult,
+    DeleteParams,
     DeleteResult,
 )
 from ..db_helpers import delete_secret, fetch_secret, upsert_secret
@@ -15,15 +18,11 @@ from peagen.transport.jsonrpc import RPCException
 
 
 @dispatcher.method(SECRETS_ADD)
-async def secrets_add(
-    *,
-    name: str,
-    cipher: str,
-    tenant_id: str = "default",
-    owner_user_id: str | None = None,
-    version: int | None = None,
-) -> dict:
+async def secrets_add(params: AddParams) -> dict:
     """Store an encrypted secret."""
+    name = params.name
+    cipher = params.cipher
+    tenant_id = params.tenant_id
     async with Session() as session:
         await upsert_secret(
             session,
@@ -38,8 +37,10 @@ async def secrets_add(
 
 
 @dispatcher.method(SECRETS_GET)
-async def secrets_get(*, name: str, tenant_id: str = "default") -> dict:
+async def secrets_get(params: GetParams) -> dict:
     """Retrieve an encrypted secret."""
+    name = params.name
+    tenant_id = params.tenant_id
     async with Session() as session:
         row = await fetch_secret(session, tenant_id, name)
     if not row:
@@ -51,10 +52,10 @@ async def secrets_get(*, name: str, tenant_id: str = "default") -> dict:
 
 
 @dispatcher.method(SECRETS_DELETE)
-async def secrets_delete(
-    *, name: str, tenant_id: str = "default", version: int | None = None
-) -> dict:
+async def secrets_delete(params: DeleteParams) -> dict:
     """Remove a secret by name."""
+    name = params.name
+    tenant_id = params.tenant_id
     async with Session() as session:
         await delete_secret(session, tenant_id, name)
         await session.commit()

--- a/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
@@ -16,6 +16,16 @@ from peagen.protocols import (
     TASK_PATCH,
     TASK_GET,
 )
+from peagen.protocols.methods.task import (
+    SubmitParams,
+    SubmitResult,
+    PatchParams,
+    PatchResult,
+    SimpleSelectorParams,
+    CountResult,
+    GetParams,
+    GetResult,
+)
 from peagen.defaults import GUARD_SET
 
 from .. import (
@@ -61,9 +71,9 @@ def _parse_task_create(task: t.Any) -> TaskCreate:
 
 
 @dispatcher.method(TASK_SUBMIT)
-async def task_submit(task: TaskCreate) -> dict:
+async def task_submit(params: SubmitParams) -> dict:
     """Persist *task* and enqueue it."""
-    dto = _parse_task_create(task)
+    dto = _parse_task_create(params.task)
     await queue.sadd("pools", dto.pool)
 
     action = (dto.payload or {}).get("action")
@@ -133,12 +143,14 @@ async def task_submit(task: TaskCreate) -> dict:
     await _save_task(task_rd)
     await _publish_task(task_rd)
     log.info("task %s queued in %s (ttl=%ss)", task_rd.id, task_rd.pool, TASK_TTL)
-    return {"task_id": str(task_rd.id)}
+    return SubmitResult(taskId=str(task_rd.id)).model_dump()
 
 
 @dispatcher.method(TASK_PATCH)
-async def task_patch(taskId: str, changes: dict) -> dict:
+async def task_patch(params: PatchParams) -> dict:
     """Update persisted metadata for an existing task."""
+    taskId = params.taskId
+    changes = params.changes
     task = await _load_task(taskId)
     if not task:
         raise TaskNotFoundError(taskId)
@@ -159,21 +171,23 @@ async def task_patch(taskId: str, changes: dict) -> dict:
             for cid in children:
                 await _finalize_parent_tasks(cid)
     log.info("task %s patched with %s", taskId, ",".join(changes.keys()))
-    return task.model_dump()
+    return PatchResult(**task.model_dump(mode="json")).model_dump()
 
 
 @dispatcher.method(TASK_GET)
-async def task_get(taskId: str) -> dict:
+async def task_get(params: GetParams) -> dict:
+    taskId = params.taskId
     try:
         uuid.UUID(taskId)
     except ValueError:
         raise RPCException(code=-32602, message="Invalid task id")
     if t := await _load_task(taskId):
-        data = t.model_dump()
+        data = t.model_dump(mode="json")
         duration = getattr(t, "duration", None)
         if duration is not None:
             data["duration"] = duration
-        return data
+        filtered = {k: v for k, v in data.items() if k in GetResult.model_fields}
+        return GetResult(**filtered).model_dump()
     try:
         from ..core.task_core import get_task_result
 
@@ -186,47 +200,52 @@ async def task_get(taskId: str) -> dict:
 
 
 @dispatcher.method(TASK_CANCEL)
-async def task_cancel(selector: str) -> dict:
+async def task_cancel(params: SimpleSelectorParams) -> dict:
+    selector = params.selector
     targets = await _select_tasks(selector)
     from peagen.handlers import control_handler
 
     count = await control_handler.apply("cancel", queue, targets, READY_QUEUE, TASK_TTL)
     log.info("cancel %s -> %d tasks", selector, count)
-    return {"count": count}
+    return CountResult(count=count).model_dump()
 
 
 @dispatcher.method(TASK_PAUSE)
-async def task_pause(selector: str) -> dict:
+async def task_pause(params: SimpleSelectorParams) -> dict:
+    selector = params.selector
     targets = await _select_tasks(selector)
     from peagen.handlers import control_handler
 
     count = await control_handler.apply("pause", queue, targets, READY_QUEUE, TASK_TTL)
     log.info("pause %s -> %d tasks", selector, count)
-    return {"count": count}
+    return CountResult(count=count).model_dump()
 
 
 @dispatcher.method(TASK_RESUME)
-async def task_resume(selector: str) -> dict:
+async def task_resume(params: SimpleSelectorParams) -> dict:
+    selector = params.selector
     targets = await _select_tasks(selector)
     from peagen.handlers import control_handler
 
     count = await control_handler.apply("resume", queue, targets, READY_QUEUE, TASK_TTL)
     log.info("resume %s -> %d tasks", selector, count)
-    return {"count": count}
+    return CountResult(count=count).model_dump()
 
 
 @dispatcher.method(TASK_RETRY)
-async def task_retry(selector: str) -> dict:
+async def task_retry(params: SimpleSelectorParams) -> dict:
+    selector = params.selector
     targets = await _select_tasks(selector)
     from peagen.handlers import control_handler
 
     count = await control_handler.apply("retry", queue, targets, READY_QUEUE, TASK_TTL)
     log.info("retry %s -> %d tasks", selector, count)
-    return {"count": count}
+    return CountResult(count=count).model_dump()
 
 
 @dispatcher.method(TASK_RETRY_FROM)
-async def task_retry_from(selector: str) -> dict:
+async def task_retry_from(params: SimpleSelectorParams) -> dict:
+    selector = params.selector
     targets = await _select_tasks(selector)
     from peagen.handlers import control_handler
 
@@ -234,7 +253,7 @@ async def task_retry_from(selector: str) -> dict:
         "retry_from", queue, targets, READY_QUEUE, TASK_TTL
     )
     log.info("retry_from %s -> %d tasks", selector, count)
-    return {"count": count}
+    return CountResult(count=count).model_dump()
 
 
 # --------Guard Rail Support --------------------------------------


### PR DESCRIPTION
## Summary
- switch task RPC handlers to typed protocols
- wrap gateway RPC functions for compatibility
- update secrets RPC handlers to accept typed params

## Testing
- `uv run --directory standards/peagen --package peagen ruff format peagen/gateway/__init__.py peagen/gateway/rpc/tasks.py peagen/gateway/rpc/secrets.py`
- `uv run --directory standards/peagen --package peagen ruff check peagen/gateway/__init__.py peagen/gateway/rpc/tasks.py peagen/gateway/rpc/secrets.py --fix`
- `uv run --package peagen --directory standards/peagen pytest -q` *(fails: tests/i9n/two_user_secret_exchange_i9n_test.py::test_two_user_secret_exchange, tests/sequence_success/test_sequences_success.py::test_sequences_success[example0])*

------
https://chatgpt.com/codex/tasks/task_e_686037afe1608326866d15b1bc68d47d