### PR TITLE
Align label RPC responses with canonical schema

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -776,7 +776,7 @@ async def task_submit(
         await _save_task(task_rd)
         await _publish_task(task_rd)
         log.info("task %s queued in %s (ttl=%ss)", task_rd.id, task_rd.pool, TASK_TTL)
-        return SubmitResult.model_construct(task_id=str(task_rd.id)).model_dump()
+        return SubmitResult.model_construct(taskId=str(task_rd.id)).model_dump()
 
 
 # ─────────────────────────────── Healthcheck ───────────────────────────────

--- a/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
@@ -133,7 +133,7 @@ async def task_submit(task: TaskCreate) -> dict:
     await _save_task(task_rd)
     await _publish_task(task_rd)
     log.info("task %s queued in %s (ttl=%ss)", task_rd.id, task_rd.pool, TASK_TTL)
-    return {"task_id": str(task_rd.id)}
+    return {"taskId": str(task_rd.id)}
 
 
 @dispatcher.method(TASK_PATCH)

--- a/pkgs/standards/peagen/tests/smoke/test_cli_task_submit.py
+++ b/pkgs/standards/peagen/tests/smoke/test_cli_task_submit.py
@@ -13,7 +13,7 @@ from peagen.protocols.methods import TASK_SUBMIT
 def test_cli_task_submit_local(monkeypatch, tmp_path: Path) -> None:
     def fake_post(url: str, json: dict, timeout: float):
         assert json["method"] == TASK_SUBMIT
-        data = {"result": {"task_id": "123"}}
+        data = {"result": {"taskId": "123"}}
 
         class Resp:
             def raise_for_status(self):
@@ -70,4 +70,4 @@ def test_cli_task_submit_local(monkeypatch, tmp_path: Path) -> None:
     output = result.stdout.strip().splitlines()
     assert any("Submitted task" in line for line in output)
     last = json.loads("\n".join(output[-3:]))
-    assert "task_id" in last
+    assert "taskId" in last

--- a/pkgs/standards/peagen/tests/smoke/test_remote_eval_rpc.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_eval_rpc.py
@@ -58,4 +58,4 @@ def test_eval_submit_returns_task_id() -> None:
     assert resp.status_code == 200
     data = resp.json()
 
-    assert "result" in data and "task_id" in data["result"]
+    assert "result" in data and "taskId" in data["result"]

--- a/pkgs/standards/peagen/tests/test_protocols_basic.py
+++ b/pkgs/standards/peagen/tests/test_protocols_basic.py
@@ -31,7 +31,7 @@ def test_parse_and_registry() -> None:
     PModel = _registry.params_model(req.method)
     params = PModel.model_validate(req.params)
     assert params.task.pool == "default"
-    res = Response.ok(id=req.id, result={"task_id": "ABCDEFGHIJKL"})
+    res = Response.ok(id=req.id, result={"taskId": "ABCDEFGHIJKL"})
     assert res.jsonrpc == "2.0"
 
 

--- a/pkgs/standards/peagen/tests/unit/test_task_id_collision.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_id_collision.py
@@ -44,5 +44,5 @@ async def test_task_submit_id_collision(monkeypatch):
 
     r1 = await task_submit(pool="p", payload={}, taskId="dup")
     r2 = await task_submit(pool="p", payload={}, taskId="dup")
-    assert r1["task_id"] == "dup"
-    assert r2["task_id"] != "dup"
+    assert r1["taskId"] == "dup"
+    assert r2["taskId"] != "dup"

--- a/pkgs/standards/peagen/tests/unit/test_task_metadata.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_metadata.py
@@ -110,7 +110,7 @@ async def test_task_submit_roundtrip(monkeypatch):
     )
 
     result = await task_submit(dto)
-    tid = result["task_id"]
+    tid = result["taskId"]
     stored = await task_get(tid)
     assert stored["pool"] == "p"
     assert stored["payload"] == {}

--- a/pkgs/standards/peagen/tests/unit/test_task_patch_finalize.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_patch_finalize.py
@@ -74,7 +74,7 @@ async def test_task_patch_triggers_finalize(monkeypatch):
         spec_hash=uuid.uuid4().hex,
         last_modified=datetime.datetime.now(timezone.utc),
     )
-    parent_id = (await task_submit(parent_dto))["task_id"]
+    parent_id = (await task_submit(parent_dto))["taskId"]
 
     child_dto = TaskCreate(
         id=uuid.uuid4(),
@@ -87,7 +87,7 @@ async def test_task_patch_triggers_finalize(monkeypatch):
         spec_hash=uuid.uuid4().hex,
         last_modified=datetime.datetime.now(timezone.utc),
     )
-    child_id = (await task_submit(child_dto))["task_id"]
+    child_id = (await task_submit(child_dto))["taskId"]
     await work_finished(taskId=child_id, status="success", result=None)
 
     await task_patch(taskId=parent_id, changes={"result": {"children": [child_id]}})
@@ -167,7 +167,7 @@ async def test_task_patch_triggers_finalize_rejected(monkeypatch):
         spec_hash=uuid.uuid4().hex,
         last_modified=datetime.datetime.now(timezone.utc),
     )
-    parent_id = (await task_submit(parent_dto))["task_id"]
+    parent_id = (await task_submit(parent_dto))["taskId"]
 
     child_dto = TaskCreate(
         id=uuid.uuid4(),
@@ -180,7 +180,7 @@ async def test_task_patch_triggers_finalize_rejected(monkeypatch):
         spec_hash=uuid.uuid4().hex,
         last_modified=datetime.datetime.now(timezone.utc),
     )
-    child_id = (await task_submit(child_dto))["task_id"]
+    child_id = (await task_submit(child_dto))["taskId"]
     await work_finished(taskId=child_id, status="rejected", result=None)
 
     await task_patch(taskId=parent_id, changes={"result": {"children": [child_id]}})

--- a/pkgs/standards/peagen/tests/unit/test_task_patch_labels.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_patch_labels.py
@@ -77,7 +77,7 @@ async def test_task_patch_updates_labels(monkeypatch):
     )
 
     result = await task_submit(dto)
-    tid = result["task_id"]
+    tid = result["taskId"]
 
     await task_patch(taskId=tid, changes={"labels": ["patched"]})
     patched = await task_get(tid)

--- a/pkgs/standards/peagen/tests/unit/test_task_patch_status.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_patch_status.py
@@ -77,7 +77,7 @@ async def test_task_patch_updates_status(monkeypatch):
     )
 
     result = await task_submit(dto)
-    tid = result["task_id"]
+    tid = result["taskId"]
 
     await task_patch(taskId=tid, changes={"status": "success"})
     patched = await task_get(tid)


### PR DESCRIPTION
## Summary
- return `taskId` from `task_submit`
- fix wrapper `task_submit` return value
- adjust tests for the canonical `taskId` key

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest` *(fails: two_user_secret_exchange_i9n_test, sequence_success, secret_store)*

------
https://chatgpt.com/codex/tasks/task_e_686038e0b64c8326b10a1c23e792dbaa