### PR TITLE
Update task RPC usage

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/eval.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/eval.py
@@ -22,6 +22,7 @@ from peagen._utils.config_loader import load_peagen_toml
 
 from peagen.handlers.eval_handler import eval_handler
 from peagen.protocols import TASK_SUBMIT
+from peagen.protocols.methods.task import SubmitParams, SubmitResult
 from peagen.cli.task_builder import _build_task as _generic_build_task
 
 DEFAULT_GATEWAY = "http://localhost:8000/rpc"
@@ -127,12 +128,13 @@ def submit(  # noqa: PLR0913
     reply = rpc_post(
         ctx.obj.get("gateway_url"),
         TASK_SUBMIT,
-        task.model_dump(mode="json"),
+        SubmitParams(task=task).model_dump(),
+        result_model=SubmitResult,
     )
 
-    if "error" in reply:
+    if reply.error:
         typer.secho(
-            f"Remote error {reply['error']['code']}: {reply['error']['message']}",
+            f"Remote error {reply.error.code}: {reply.error.message}",
             fg=typer.colors.RED,
             err=True,
         )

--- a/pkgs/standards/peagen/peagen/cli/commands/extras.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/extras.py
@@ -12,6 +12,7 @@ from functools import partial
 from peagen.handlers.extras_handler import extras_handler
 from swarmauri_standard.loggers.Logger import Logger
 from peagen.protocols import TASK_SUBMIT
+from peagen.protocols.methods.task import SubmitParams, SubmitResult
 from peagen.cli.rpc_utils import rpc_post
 from peagen.cli.task_builder import _build_task as _generic_build_task
 
@@ -86,13 +87,14 @@ def submit_extras(
         reply = rpc_post(
             gateway_url,
             TASK_SUBMIT,
-            task.model_dump(mode="json"),
+            SubmitParams(task=task).model_dump(),
             timeout=10.0,
+            result_model=SubmitResult,
         )
-        if reply.get("error"):
-            typer.echo(f"[ERROR] {reply['error']}")
+        if reply.error:
+            typer.echo(f"[ERROR] {reply.error.message}")
             raise typer.Exit(1)
-        typer.echo(f"Submitted extras generation → taskId={reply['id']}")
+        typer.echo(f"Submitted extras generation → taskId={reply.result.taskId}")
     except Exception as exc:
         typer.echo(f"[ERROR] Could not reach gateway at {gateway_url}: {exc}")
         raise typer.Exit(1)

--- a/pkgs/standards/peagen/peagen/cli/commands/mutate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/mutate.py
@@ -14,6 +14,7 @@ from functools import partial
 
 from peagen.handlers.mutate_handler import mutate_handler
 from peagen.protocols import TASK_SUBMIT
+from peagen.protocols.methods.task import SubmitParams, SubmitResult
 from peagen.cli.task_builder import _build_task as _generic_build_task
 
 DEFAULT_GATEWAY = "http://localhost:8000/rpc"
@@ -112,7 +113,8 @@ def submit(
     reply = rpc_post(
         ctx.obj.get("gateway_url"),
         TASK_SUBMIT,
-        task.model_dump(mode="json"),
+        SubmitParams(task=task).model_dump(),
+        result_model=SubmitResult,
     )
 
     if "error" in reply:

--- a/pkgs/standards/peagen/peagen/cli/commands/process.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/process.py
@@ -22,7 +22,12 @@ from functools import partial
 from peagen._utils.config_loader import _effective_cfg, load_peagen_toml
 from peagen.handlers.process_handler import process_handler
 from peagen.protocols import TASK_SUBMIT, TASK_GET
-from peagen.protocols.methods.task import GetParams, GetResult, SubmitResult
+from peagen.protocols.methods.task import (
+    GetParams,
+    GetResult,
+    SubmitParams,
+    SubmitResult,
+)
 from peagen.cli.rpc_utils import rpc_post
 from peagen.orm.status import Status
 from peagen.cli.task_builder import _build_task as _generic_build_task
@@ -190,7 +195,7 @@ def submit(  # noqa: PLR0913 – CLI signature needs many options
     reply = rpc_post(
         ctx.obj.get("gateway_url"),
         TASK_SUBMIT,
-        task.model_dump(mode="json"),
+        SubmitParams(task=task).model_dump(),
         result_model=SubmitResult,
     )
 

--- a/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
@@ -35,6 +35,7 @@ from .. import (
 )
 from peagen.errors import TaskNotFoundError
 from peagen.schemas import TaskCreate, TaskUpdate, TaskRead
+from peagen.protocols.methods.task import SubmitResult
 from peagen.services.tasks import _to_schema
 from peagen.orm.task.task import TaskModel
 from peagen.orm.task.task_run import TaskRunModel
@@ -133,7 +134,7 @@ async def task_submit(task: TaskCreate) -> dict:
     await _save_task(task_rd)
     await _publish_task(task_rd)
     log.info("task %s queued in %s (ttl=%ss)", task_rd.id, task_rd.pool, TASK_TTL)
-    return {"task_id": str(task_rd.id)}
+    return SubmitResult(taskId=str(task_rd.id)).model_dump()
 
 
 @dispatcher.method(TASK_PATCH)


### PR DESCRIPTION
## Summary
- update remote CLI commands to use SubmitParams and SubmitResult
- align RPC handler return value with SubmitResult

## Testing
- `uv run --package peagen --directory pkgs ruff format .`
- `uv run --package peagen --directory pkgs ruff check . --fix`
- `uv run --package peagen --directory pkgs pytest` *(fails: 220 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686038d13c5c8326970b6a303e6b8174