### PR TITLE
Update guard CLI/gateway for canonical RPC

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/secrets.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/secrets.py
@@ -38,12 +38,20 @@ def _pool_worker_pubs(pool: str, gateway_url: str) -> list[str]:
             timeout=10.0,
             result_model=ListResult,
         )
-        workers = res.result or []
+        if res.result is None:
+            workers = []
+        elif hasattr(res.result, "root"):
+            workers = res.result.root
+        else:
+            workers = res.result
     except Exception:
         return []
     keys = []
     for w in workers:
-        advert = w.get("advertises") or {}
+        if isinstance(w, dict):
+            advert = w.get("advertises") or {}
+        else:
+            advert = w.advertises or {}
         if isinstance(advert, str):  # gateway may return JSON string
             try:
                 advert = json.loads(advert)

--- a/pkgs/standards/peagen/peagen/gateway/rpc/secrets.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/secrets.py
@@ -5,8 +5,11 @@ from peagen.protocols.methods.secrets import (
     SECRETS_ADD,
     SECRETS_GET,
     SECRETS_DELETE,
+    AddParams,
     AddResult,
+    GetParams,
     GetResult,
+    DeleteParams,
     DeleteResult,
 )
 from ..db_helpers import delete_secret, fetch_secret, upsert_secret
@@ -15,33 +18,26 @@ from peagen.transport.jsonrpc import RPCException
 
 
 @dispatcher.method(SECRETS_ADD)
-async def secrets_add(
-    *,
-    name: str,
-    cipher: str,
-    tenant_id: str = "default",
-    owner_user_id: str | None = None,
-    version: int | None = None,
-) -> dict:
+async def secrets_add(params: AddParams) -> dict:
     """Store an encrypted secret."""
     async with Session() as session:
         await upsert_secret(
             session,
-            tenant_id,
-            "unknown",
-            name,
-            cipher,
+            params.tenant_id,
+            params.owner_user_id or "unknown",
+            params.name,
+            params.cipher,
         )
         await session.commit()
-    log.info("secret stored: %s", name)
+    log.info("secret stored: %s", params.name)
     return AddResult(ok=True).model_dump()
 
 
 @dispatcher.method(SECRETS_GET)
-async def secrets_get(*, name: str, tenant_id: str = "default") -> dict:
+async def secrets_get(params: GetParams) -> dict:
     """Retrieve an encrypted secret."""
     async with Session() as session:
-        row = await fetch_secret(session, tenant_id, name)
+        row = await fetch_secret(session, params.tenant_id, params.name)
     if not row:
         raise RPCException(
             code=ErrorCode.SECRET_NOT_FOUND,
@@ -51,12 +47,10 @@ async def secrets_get(*, name: str, tenant_id: str = "default") -> dict:
 
 
 @dispatcher.method(SECRETS_DELETE)
-async def secrets_delete(
-    *, name: str, tenant_id: str = "default", version: int | None = None
-) -> dict:
+async def secrets_delete(params: DeleteParams) -> dict:
     """Remove a secret by name."""
     async with Session() as session:
-        await delete_secret(session, tenant_id, name)
+        await delete_secret(session, params.tenant_id, params.name)
         await session.commit()
-    log.info("secret removed: %s", name)
+    log.info("secret removed: %s", params.name)
     return DeleteResult(ok=True).model_dump()


### PR DESCRIPTION
## Summary
- use canonical schema objects in secrets gateway
- wire keys/secrets core functions through canonical RPC helper
- handle typed worker info in CLI

## Testing
- `uv run --directory standards/peagen --package peagen ruff format peagen/core/secrets_core.py peagen/core/keys_core.py peagen/gateway/rpc/secrets.py peagen/cli/commands/secrets.py`
- `uv run --directory standards/peagen --package peagen ruff check peagen/core/secrets_core.py peagen/core/keys_core.py peagen/gateway/rpc/secrets.py peagen/cli/commands/secrets.py --fix`
- `uv run --package peagen --directory standards/peagen pytest` *(fails: tests/i9n/two_user_secret_exchange_i9n_test.py::test_two_user_secret_exchange)*

------
https://chatgpt.com/codex/tasks/task_e_686038d7a3b08326859590fdaa364e8d