### PR TITLE
Refactor secrets RPC methods to use protocols

### DIFF
--- a/pkgs/standards/peagen/peagen/core/secrets_core.py
+++ b/pkgs/standards/peagen/peagen/core/secrets_core.py
@@ -6,7 +6,22 @@ import json
 from pathlib import Path
 from typing import List, Optional
 
+import uuid
 import httpx
+from pydantic import TypeAdapter
+from peagen.protocols import Request, Response
+from peagen.protocols.methods.worker import WORKER_LIST, ListParams, ListResult
+from peagen.protocols.methods.secrets import (
+    AddParams,
+    AddResult,
+    GetParams,
+    GetResult,
+    DeleteParams,
+    DeleteResult,
+    SECRETS_ADD,
+    SECRETS_GET,
+    SECRETS_DELETE,
+)
 
 from peagen.plugins.secret_drivers import AutoGpgDriver
 
@@ -14,21 +29,41 @@ DEFAULT_GATEWAY = "http://localhost:8000/rpc"
 STORE_FILE = Path.home() / ".peagen" / "secret_store.json"
 
 
+def _rpc_post(
+    url: str, method: str, params: dict, *, timeout: float = 10.0, result_model=None
+):
+    """Send a JSON-RPC request and return a typed ``Response``."""
+    envelope = Request(id=str(uuid.uuid4()), method=method, params=params)
+    resp = httpx.post(url, json=envelope.model_dump(), timeout=timeout)
+    resp.raise_for_status()
+    if result_model is not None:
+        adapter = TypeAdapter(Response[result_model])  # type: ignore[index]
+    else:
+        adapter = TypeAdapter(Response[dict])
+    return adapter.validate_python(resp.json())
+
+
 def _pool_worker_pubs(pool: str, gateway_url: str) -> list[str]:
-    envelope = {
-        "jsonrpc": "2.0",
-        "method": "Worker.list",
-        "params": {"pool": pool},
-    }
+    envelope = ListParams(pool=pool).model_dump()
     try:
-        res = httpx.post(gateway_url, json=envelope, timeout=10.0)
-        res.raise_for_status()
+        res = _rpc_post(
+            gateway_url,
+            WORKER_LIST,
+            envelope,
+            timeout=10.0,
+            result_model=ListResult,
+        )
+        workers = res.result or []
     except Exception:
         return []
-    workers = res.json().get("result", [])
     keys = []
     for w in workers:
         advert = w.get("advertises") or {}
+        if isinstance(advert, str):  # gateway may return JSON string
+            try:
+                advert = json.loads(advert)
+            except Exception:  # pragma: no cover - invalid JSON
+                advert = {}
         key = advert.get("public_key") or advert.get("pubkey")
         if key:
             keys.append(key)
@@ -88,19 +123,20 @@ def add_remote_secret(
     pubs = [p.read_text() for p in recipients or []]
     pubs.extend(_pool_worker_pubs(pool, gateway_url))
     cipher = drv.encrypt(value.encode(), pubs).decode()
-    envelope = {
-        "jsonrpc": "2.0",
-        "method": "Secrets.add",
-        "params": {
-            "name": secret_id,
-            "cipher": cipher,
-            "version": version,
-            "tenant_id": pool,
-        },
-    }
-    res = httpx.post(gateway_url, json=envelope, timeout=10.0)
-    res.raise_for_status()
-    return res.json()
+    params = AddParams(
+        name=secret_id,
+        cipher=cipher,
+        tenant_id=pool,
+        version=version,
+    ).model_dump()
+    res = _rpc_post(
+        gateway_url,
+        SECRETS_ADD,
+        params,
+        timeout=10.0,
+        result_model=AddResult,
+    )
+    return res.model_dump()
 
 
 def get_remote_secret(
@@ -111,14 +147,15 @@ def get_remote_secret(
 ) -> str:
     """Retrieve and decrypt a secret from the gateway."""
     drv = AutoGpgDriver()
-    envelope = {
-        "jsonrpc": "2.0",
-        "method": "Secrets.get",
-        "params": {"name": secret_id, "tenant_id": pool},
-    }
-    res = httpx.post(gateway_url, json=envelope, timeout=10.0)
-    res.raise_for_status()
-    cipher = res.json()["result"]["secret"].encode()
+    params = GetParams(name=secret_id, tenant_id=pool).model_dump()
+    res = _rpc_post(
+        gateway_url,
+        SECRETS_GET,
+        params,
+        timeout=10.0,
+        result_model=GetResult,
+    )
+    cipher = res.result.secret.encode()
     return drv.decrypt(cipher).decode()
 
 
@@ -130,11 +167,16 @@ def remove_remote_secret(
     pool: str = "default",
 ) -> dict:
     """Delete a secret stored on the gateway."""
-    envelope = {
-        "jsonrpc": "2.0",
-        "method": "Secrets.delete",
-        "params": {"name": secret_id, "version": version, "tenant_id": pool},
-    }
-    res = httpx.post(gateway_url, json=envelope, timeout=10.0)
-    res.raise_for_status()
-    return res.json()
+    params = DeleteParams(
+        name=secret_id,
+        tenant_id=pool,
+        version=version,
+    ).model_dump()
+    res = _rpc_post(
+        gateway_url,
+        SECRETS_DELETE,
+        params,
+        timeout=10.0,
+        result_model=DeleteResult,
+    )
+    return res.model_dump()

--- a/pkgs/standards/peagen/peagen/gateway/rpc/secrets.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/secrets.py
@@ -5,8 +5,11 @@ from peagen.protocols.methods.secrets import (
     SECRETS_ADD,
     SECRETS_GET,
     SECRETS_DELETE,
+    AddParams,
     AddResult,
+    GetParams,
     GetResult,
+    DeleteParams,
     DeleteResult,
 )
 from ..db_helpers import delete_secret, fetch_secret, upsert_secret
@@ -15,33 +18,26 @@ from peagen.transport.jsonrpc import RPCException
 
 
 @dispatcher.method(SECRETS_ADD)
-async def secrets_add(
-    *,
-    name: str,
-    cipher: str,
-    tenant_id: str = "default",
-    owner_user_id: str | None = None,
-    version: int | None = None,
-) -> dict:
+async def secrets_add(params: AddParams) -> dict:
     """Store an encrypted secret."""
     async with Session() as session:
         await upsert_secret(
             session,
-            tenant_id,
+            params.tenant_id,
             "unknown",
-            name,
-            cipher,
+            params.name,
+            params.cipher,
         )
         await session.commit()
-    log.info("secret stored: %s", name)
+    log.info("secret stored: %s", params.name)
     return AddResult(ok=True).model_dump()
 
 
 @dispatcher.method(SECRETS_GET)
-async def secrets_get(*, name: str, tenant_id: str = "default") -> dict:
+async def secrets_get(params: GetParams) -> dict:
     """Retrieve an encrypted secret."""
     async with Session() as session:
-        row = await fetch_secret(session, tenant_id, name)
+        row = await fetch_secret(session, params.tenant_id, params.name)
     if not row:
         raise RPCException(
             code=ErrorCode.SECRET_NOT_FOUND,
@@ -51,12 +47,10 @@ async def secrets_get(*, name: str, tenant_id: str = "default") -> dict:
 
 
 @dispatcher.method(SECRETS_DELETE)
-async def secrets_delete(
-    *, name: str, tenant_id: str = "default", version: int | None = None
-) -> dict:
+async def secrets_delete(params: DeleteParams) -> dict:
     """Remove a secret by name."""
     async with Session() as session:
-        await delete_secret(session, tenant_id, name)
+        await delete_secret(session, params.tenant_id, params.name)
         await session.commit()
-    log.info("secret removed: %s", name)
+    log.info("secret removed: %s", params.name)
     return DeleteResult(ok=True).model_dump()


### PR DESCRIPTION
## Summary
- use AddParams/GetParams/DeleteParams in the gateway
- implement typed rpc client in `secrets_core`
- update `git_vcs.push_with_secret` to fetch secrets via JSON-RPC

## Testing
- `uv run --package peagen --directory standards/peagen ruff check peagen/plugins/vcs/git_vcs.py peagen/core/secrets_core.py peagen/gateway/rpc/secrets.py --fix`
- `PEAGEN_TEST_GATEWAY=http://127.0.0.1:9999 uv run --package peagen --directory standards/peagen pytest -q`
- `peagen local -q process tests/examples/projects_payloads/template_two_project.yaml --repo testrepo` *(fails: GitCloneError)*

------
https://chatgpt.com/codex/tasks/task_e_68603aebb5e08326befe149bbc08dcff