### PR TITLE
Fix CLI usage of protocol responses

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/doe.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/doe.py
@@ -157,9 +157,9 @@ def submit_gen(  # noqa: PLR0913
         result_model=SubmitResult,
     )
 
-    if "error" in reply:
+    if reply.error:
         typer.secho(
-            f"Remote error {reply['error']['code']}: {reply['error']['message']}",
+            f"Remote error {reply.error.code}: {reply.error.message}",
             fg=typer.colors.RED,
             err=True,
         )

--- a/pkgs/standards/peagen/peagen/cli/commands/eval.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/eval.py
@@ -141,5 +141,5 @@ def submit(  # noqa: PLR0913
         raise typer.Exit(1)
 
     typer.secho(f"Submitted task {task.id}", fg=typer.colors.GREEN)
-    if reply.get("result"):
-        typer.echo(json.dumps(reply["result"], indent=2))
+    if reply.result:
+        typer.echo(json.dumps(reply.result.model_dump(), indent=2))

--- a/pkgs/standards/peagen/peagen/cli/commands/mutate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/mutate.py
@@ -117,14 +117,14 @@ def submit(
         result_model=SubmitResult,
     )
 
-    if "error" in reply:
+    if reply.error:
         typer.secho(
-            f"Remote error {reply['error']['code']}: {reply['error']['message']}",
+            f"Remote error {reply.error.code}: {reply.error.message}",
             fg=typer.colors.RED,
             err=True,
         )
         raise typer.Exit(1)
 
     typer.secho(f"Submitted task {task.id}", fg=typer.colors.GREEN)
-    if reply.get("result"):
-        typer.echo(json.dumps(reply["result"], indent=2))
+    if reply.result:
+        typer.echo(json.dumps(reply.result.model_dump(), indent=2))


### PR DESCRIPTION
## Summary
- use `reply.error` and `reply.result` objects from peagen protocols
- apply ruff formatting

## Testing
- `uv run --directory peagen --package peagen ruff check cli/commands/mutate.py cli/commands/doe.py cli/commands/eval.py --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_cli_login.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68603e45c4fc8326811d022003003a2c