### PR TITLE
Align peagen gateway/worker with new protocols

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -26,18 +26,18 @@ import pgpy
 from fastapi import FastAPI, Request, Response, HTTPException
 from peagen.plugins.queues import QueueBase
 
-from peagen.transport import RPCDispatcher, RPCRequest
-from peagen.protocols import Request as RPCEnvelope, parse_request, _registry
+from peagen.transport import RPCDispatcher
+from peagen.protocols import (
+    Request as RPCRequest,
+    Request as RPCEnvelope,
+    parse_request,
+    _registry,
+)
 from peagen.transport.jsonrpc import RPCException as RPCException
 from peagen.orm import Base
 from peagen.orm.status import Status
 from pydantic import ValidationError
-from peagen.protocols.methods.task import (
-    SubmitParams,
-    PatchParams,
-    GetParams,
-    SimpleSelectorParams,
-)
+from peagen.protocols.methods.task import SubmitParams, SubmitResult
 from peagen.schemas import TaskRead, TaskCreate, TaskUpdate
 from peagen.orm import TaskModel, TaskRunModel
 
@@ -121,7 +121,7 @@ from .rpc.secrets import (  # noqa: E402
 from peagen.protocols.methods.secrets import (  # noqa: E402
     AddParams,
     DeleteParams,
-    GetParams,
+    GetParams as SecretGetParams,
 )
 
 # ─────────────────────────── Key/Secret store ───────────────────
@@ -150,7 +150,7 @@ async def secrets_add(
 
 
 async def secrets_get(
-    params: GetParams | None = None,
+    params: SecretGetParams | None = None,
     **kwargs,
 ) -> dict:
     if params is not None:
@@ -824,7 +824,6 @@ async def task_submit(
         await _publish_task(task_rd)
         log.info("task %s queued in %s (ttl=%ss)", task_rd.id, task_rd.pool, TASK_TTL)
         return SubmitResult.model_construct(taskId=str(task_rd.id)).model_dump()
-
 
 
 # ─────────────────────────────── Healthcheck ───────────────────────────────

--- a/pkgs/standards/peagen/peagen/gateway/rpc/secrets.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/secrets.py
@@ -20,9 +20,6 @@ from peagen.transport.jsonrpc import RPCException
 @dispatcher.method(SECRETS_ADD)
 async def secrets_add(params: AddParams) -> dict:
     """Store an encrypted secret."""
-    name = params.name
-    cipher = params.cipher
-    tenant_id = params.tenant_id
     async with Session() as session:
         await upsert_secret(
             session,
@@ -39,8 +36,6 @@ async def secrets_add(params: AddParams) -> dict:
 @dispatcher.method(SECRETS_GET)
 async def secrets_get(params: GetParams) -> dict:
     """Retrieve an encrypted secret."""
-    name = params.name
-    tenant_id = params.tenant_id
     async with Session() as session:
         row = await fetch_secret(session, params.tenant_id, params.name)
     if not row:
@@ -54,8 +49,6 @@ async def secrets_get(params: GetParams) -> dict:
 @dispatcher.method(SECRETS_DELETE)
 async def secrets_delete(params: DeleteParams) -> dict:
     """Remove a secret by name."""
-    name = params.name
-    tenant_id = params.tenant_id
     async with Session() as session:
         await delete_secret(session, params.tenant_id, params.name)
         await session.commit()

--- a/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
@@ -27,7 +27,6 @@ from peagen.protocols.methods.task import (
     GetResult,
 )
 from peagen.defaults import GUARD_SET
-from peagen.protocols.methods.task import CountResult
 
 from .. import (
     READY_QUEUE,
@@ -46,7 +45,6 @@ from .. import (
 )
 from peagen.errors import TaskNotFoundError
 from peagen.schemas import TaskCreate, TaskUpdate, TaskRead
-from peagen.protocols.methods.task import SubmitResult
 from peagen.services.tasks import _to_schema
 from peagen.orm.task.task import TaskModel
 from peagen.orm.task.task_run import TaskRunModel
@@ -146,7 +144,6 @@ async def task_submit(params: SubmitParams) -> dict:
     await _publish_task(task_rd)
     log.info("task %s queued in %s (ttl=%ss)", task_rd.id, task_rd.pool, TASK_TTL)
     return SubmitResult(taskId=str(task_rd.id)).model_dump()
-
 
 
 @dispatcher.method(TASK_PATCH)

--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -16,11 +16,11 @@ import httpx
 from fastapi import Body, FastAPI, Request, HTTPException
 from json.decoder import JSONDecodeError
 
-from peagen.transport import RPCDispatcher, RPCRequest, RPCResponse
+from peagen.transport import RPCDispatcher
+from peagen.protocols import Request as RPCRequest, Response as RPCResponse
 from peagen.protocols import Request as RPCEnvelope
 from peagen.defaults import WORK_CANCEL, WORK_FINISHED, WORK_START
 from peagen.protocols.methods.worker import (
-
     WORKER_HEARTBEAT,
     WORKER_REGISTER,
     HeartbeatParams,
@@ -279,9 +279,9 @@ class WorkerBase:
         ).model_dump()
         try:
             await self._client.post(self.DQ_GATEWAY, json=body)
-            self.log.debug("sent %s → %s", request.method, request.params)
+            self.log.debug("sent %s → %s", method, payload)
         except Exception as exc:
-            self.log.warning("Failed sending %s to gateway: %s", request.method, exc)
+            self.log.warning("Failed sending %s to gateway: %s", method, exc)
 
     async def _on_startup(self) -> None:
         """


### PR DESCRIPTION
## Summary
- update gateway and worker imports to use peagen.protocols
- streamline secret RPC handlers
- adjust internal logging for RPC sends
- drop unused imports in tasks RPC module

## Testing
- `uv run --directory . --package peagen ruff check . --fix`
- `PEAGEN_TEST_GATEWAY=http://localhost:9999 uv run --package peagen --directory standards/peagen pytest -k protocols_basic -q`


------
https://chatgpt.com/codex/tasks/task_e_68603ea11a78832693468daca0903b60