### PR TITLE
Fix undefined variable in worker _send_rpc

### DIFF
--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -20,7 +20,6 @@ from peagen.transport import RPCDispatcher, RPCRequest, RPCResponse
 from peagen.protocols import Request as RPCEnvelope
 from peagen.defaults import WORK_CANCEL, WORK_FINISHED, WORK_START
 from peagen.protocols.methods.worker import (
-
     WORKER_HEARTBEAT,
     WORKER_REGISTER,
     HeartbeatParams,
@@ -279,9 +278,9 @@ class WorkerBase:
         ).model_dump()
         try:
             await self._client.post(self.DQ_GATEWAY, json=body)
-            self.log.debug("sent %s → %s", request.method, request.params)
+            self.log.debug("sent %s → %s", method, payload)
         except Exception as exc:
-            self.log.warning("Failed sending %s to gateway: %s", request.method, exc)
+            self.log.warning("Failed sending %s to gateway: %s", method, exc)
 
     async def _on_startup(self) -> None:
         """


### PR DESCRIPTION
## Summary
- fix debug logging in `_send_rpc`

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff check peagen/worker/base.py --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest` *(fails: two_user_secret_exchange_i9n_test.py::test_two_user_secret_exchange, test_sequences_success[example0], test_secret_roundtrip, test_secret_roundtrip, test_task_submit_id_collision, test_task_submit_roundtrip, test_task_patch_triggers_finalize, test_task_patch_triggers_finalize_rejected, test_task_patch_updates_labels, test_task_patch_missing, test_task_patch_updates_status)*

------
https://chatgpt.com/codex/tasks/task_e_68603f3bc4b08326b5c58eea15566922