### PR TITLE
Align gateway RPC wrappers with protocol models

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -34,9 +34,9 @@ from peagen.orm.status import Status
 from pydantic import ValidationError
 from peagen.protocols.methods.task import (
     SubmitParams,
+    SubmitResult,
     PatchParams,
     GetParams,
-    SimpleSelectorParams,
 )
 from peagen.schemas import TaskRead, TaskCreate, TaskUpdate
 from peagen.orm import TaskModel, TaskRunModel
@@ -121,7 +121,7 @@ from .rpc.secrets import (  # noqa: E402
 from peagen.protocols.methods.secrets import (  # noqa: E402
     AddParams,
     DeleteParams,
-    GetParams,
+    GetParams as SecretGetParams,
 )
 
 # ─────────────────────────── Key/Secret store ───────────────────
@@ -146,18 +146,18 @@ async def secrets_add(
         if kwargs:
             raise TypeError("params or kwargs expected, not both")
         kwargs = params.model_dump()
-    return await _secrets_add_rpc(**kwargs)
+    return await _secrets_add_rpc(AddParams(**kwargs))
 
 
 async def secrets_get(
-    params: GetParams | None = None,
+    params: SecretGetParams | None = None,
     **kwargs,
 ) -> dict:
     if params is not None:
         if kwargs:
             raise TypeError("params or kwargs expected, not both")
         kwargs = params.model_dump()
-    return await _secrets_get_rpc(**kwargs)
+    return await _secrets_get_rpc(SecretGetParams(**kwargs))
 
 
 async def secrets_delete(
@@ -168,7 +168,7 @@ async def secrets_delete(
         if kwargs:
             raise TypeError("params or kwargs expected, not both")
         kwargs = params.model_dump()
-    return await _secrets_delete_rpc(**kwargs)
+    return await _secrets_delete_rpc(DeleteParams(**kwargs))
 
 
 # ─────────────────────────── IP tracking ─────────────────────────
@@ -810,7 +810,7 @@ async def task_submit(
 
     try:
         res = await _task_submit_rpc(SubmitParams(task=task))
-        return {"task_id": res["taskId"]}
+        return res
     except ValidationError:
         task_id = str(task.id)
         if await _load_task(task_id):
@@ -825,6 +825,15 @@ async def task_submit(
         log.info("task %s queued in %s (ttl=%ss)", task_rd.id, task_rd.pool, TASK_TTL)
         return SubmitResult.model_construct(taskId=str(task_rd.id)).model_dump()
 
+
+async def task_get(taskId: str) -> dict:
+    """Compatibility wrapper for :func:`_task_get_rpc`."""
+    return await _task_get_rpc(GetParams(taskId=taskId))
+
+
+async def task_patch(*, taskId: str, changes: dict) -> dict:
+    """Compatibility wrapper for :func:`_task_patch_rpc`."""
+    return await _task_patch_rpc(PatchParams(taskId=taskId, changes=changes))
 
 
 # ─────────────────────────────── Healthcheck ───────────────────────────────

--- a/pkgs/standards/peagen/peagen/gateway/rpc/workers.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/workers.py
@@ -37,7 +37,7 @@ from peagen.protocols.methods.worker import (
 
 
 @dispatcher.method(WORKER_REGISTER)
-async def worker_register(params: RegisterParams) -> RegisterResult:
+async def worker_register(params: RegisterParams) -> dict:
     """Register a worker and persist its advertised handlers."""
 
     workerId = params.workerId
@@ -70,11 +70,11 @@ async def worker_register(params: RegisterParams) -> RegisterResult:
         },
     )
     log.info("worker %s registered (%s) handlers=%s", workerId, pool, handler_list)
-    return RegisterResult(ok=True)
+    return RegisterResult(ok=True).model_dump()
 
 
 @dispatcher.method(WORKER_HEARTBEAT)
-async def worker_heartbeat(params: HeartbeatParams) -> HeartbeatResult:
+async def worker_heartbeat(params: HeartbeatParams) -> dict:
     workerId = params.workerId
     # metrics are currently ignored
     pool = params.pool
@@ -95,11 +95,11 @@ async def worker_heartbeat(params: HeartbeatParams) -> HeartbeatResult:
         mapping["url"] = url
     await queue.hset(WORKER_KEY.format(workerId), mapping=mapping)
     await queue.expire(WORKER_KEY.format(workerId), WORKER_TTL)
-    return HeartbeatResult(ok=True)
+    return HeartbeatResult(ok=True).model_dump()
 
 
 @dispatcher.method(WORKER_LIST)
-async def worker_list(params: ListParams) -> ListResult:
+async def worker_list(params: ListParams) -> dict:
     """Return active workers, optionally filtered by *pool*."""
 
     pool = params.pool
@@ -135,7 +135,7 @@ async def worker_list(params: ListParams) -> ListResult:
             "handlers": handlers,
         }
         workers.append(worker_info)
-    return ListResult([WorkerInfo(**w) for w in workers])
+    return ListResult([WorkerInfo(**w) for w in workers]).model_dump()
 
 
 @dispatcher.method(WORK_FINISHED)

--- a/pkgs/standards/peagen/tests/unit/test_worker_list.py
+++ b/pkgs/standards/peagen/tests/unit/test_worker_list.py
@@ -51,5 +51,5 @@ async def test_worker_list(monkeypatch):
         )
     )
     workers = await gw.worker_list(ListParams())
-    assert workers.root[0].id == "w1"
-    assert workers.root[0].pool == "p"
+    assert workers[0]["id"] == "w1"
+    assert workers[0]["pool"] == "p"


### PR DESCRIPTION
## Summary
- ensure gateway RPC helpers construct protocol models before invocation
- return JSON-friendly dicts from worker RPC methods
- adjust worker list test for new return type

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68603eb4181883269235c6ae07d00f0f