### PR TITLE
Refactor clients to use protocol wrappers

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/rpc/secrets.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/secrets.py
@@ -20,9 +20,6 @@ from peagen.transport.jsonrpc import RPCException
 @dispatcher.method(SECRETS_ADD)
 async def secrets_add(params: AddParams) -> dict:
     """Store an encrypted secret."""
-    name = params.name
-    cipher = params.cipher
-    tenant_id = params.tenant_id
     async with Session() as session:
         await upsert_secret(
             session,
@@ -39,8 +36,6 @@ async def secrets_add(params: AddParams) -> dict:
 @dispatcher.method(SECRETS_GET)
 async def secrets_get(params: GetParams) -> dict:
     """Retrieve an encrypted secret."""
-    name = params.name
-    tenant_id = params.tenant_id
     async with Session() as session:
         row = await fetch_secret(session, params.tenant_id, params.name)
     if not row:
@@ -54,8 +49,6 @@ async def secrets_get(params: GetParams) -> dict:
 @dispatcher.method(SECRETS_DELETE)
 async def secrets_delete(params: DeleteParams) -> dict:
     """Remove a secret by name."""
-    name = params.name
-    tenant_id = params.tenant_id
     async with Session() as session:
         await delete_secret(session, params.tenant_id, params.name)
         await session.commit()

--- a/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
@@ -27,7 +27,6 @@ from peagen.protocols.methods.task import (
     GetResult,
 )
 from peagen.defaults import GUARD_SET
-from peagen.protocols.methods.task import CountResult
 
 from .. import (
     READY_QUEUE,
@@ -46,7 +45,6 @@ from .. import (
 )
 from peagen.errors import TaskNotFoundError
 from peagen.schemas import TaskCreate, TaskUpdate, TaskRead
-from peagen.protocols.methods.task import SubmitResult
 from peagen.services.tasks import _to_schema
 from peagen.orm.task.task import TaskModel
 from peagen.orm.task.task_run import TaskRunModel
@@ -146,7 +144,6 @@ async def task_submit(params: SubmitParams) -> dict:
     await _publish_task(task_rd)
     log.info("task %s queued in %s (ttl=%ss)", task_rd.id, task_rd.pool, TASK_TTL)
     return SubmitResult(taskId=str(task_rd.id)).model_dump()
-
 
 
 @dispatcher.method(TASK_PATCH)

--- a/pkgs/standards/peagen/peagen/tui/task_submit.py
+++ b/pkgs/standards/peagen/peagen/tui/task_submit.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import httpx
 from typing import Any
+from pydantic import TypeAdapter
 
 from peagen.schemas import TaskCreate
-from peagen.protocols import TASK_SUBMIT
+from peagen.protocols import Request, Response, TASK_SUBMIT
+from peagen.protocols.methods.task import SubmitParams, SubmitResult
 from peagen.cli.task_builder import _build_task
 
 
@@ -19,11 +21,9 @@ def build_task(action: str, args: dict[str, Any], pool: str = "default") -> Task
 def submit_task(gateway_url: str, task: TaskCreate) -> dict:
     """Submit *task* to the gateway via JSON-RPC and return the reply."""
 
-    req = {
-        "jsonrpc": "2.0",
-        "method": TASK_SUBMIT,
-        "params": task.model_dump(mode="json"),
-    }
+    params = SubmitParams(task=task).model_dump()
+    req = Request(id="1", method=TASK_SUBMIT, params=params).model_dump()
     resp = httpx.post(gateway_url, json=req, timeout=30.0)
     resp.raise_for_status()
-    return resp.json()
+    adapter = TypeAdapter(Response[SubmitResult])  # type: ignore[index]
+    return adapter.validate_python(resp.json()).model_dump()

--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -20,7 +20,6 @@ from peagen.transport import RPCDispatcher, RPCRequest, RPCResponse
 from peagen.protocols import Request as RPCEnvelope
 from peagen.defaults import WORK_CANCEL, WORK_FINISHED, WORK_START
 from peagen.protocols.methods.worker import (
-
     WORKER_HEARTBEAT,
     WORKER_REGISTER,
     HeartbeatParams,
@@ -279,9 +278,9 @@ class WorkerBase:
         ).model_dump()
         try:
             await self._client.post(self.DQ_GATEWAY, json=body)
-            self.log.debug("sent %s → %s", request.method, request.params)
+            self.log.debug("sent %s → %s", method, payload)
         except Exception as exc:
-            self.log.warning("Failed sending %s to gateway: %s", request.method, exc)
+            self.log.warning("Failed sending %s to gateway: %s", method, exc)
 
     async def _on_startup(self) -> None:
         """

--- a/pkgs/standards/peagen/tests/unit/test_task_submit.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_submit.py
@@ -24,12 +24,16 @@ def test_submit_task_sends_request(monkeypatch):
                 pass
 
             def json(self):
-                return {"ok": True}
+                return {
+                    "jsonrpc": "2.0",
+                    "id": json.get("id"),
+                    "result": {"taskId": json["params"]["task"]["id"]},
+                }
 
         return Resp()
 
     monkeypatch.setattr(httpx, "post", fake_post)
     task = build_task("demo", {})
     reply = submit_task("http://gw/rpc", task)
-    assert captured["json"]["params"]["id"] == task.id
-    assert reply == {"ok": True}
+    assert captured["json"]["params"]["task"]["id"] == task.id
+    assert reply["result"]["taskId"] == task.id


### PR DESCRIPTION
## Summary
- refactor login helpers to build JSON-RPC requests with `Request`
- update task submission utilities to use protocol params and responses
- add compatibility wrappers in the gateway for patch/get
- refactor TUI helpers and git VCS plugin to rely on typed responses
- adjust worker logging for typed RPC
- update tests for protocol-based responses

## Testing
- `uv run --package peagen --directory standards/peagen ruff format .`
- `uv run --package peagen --directory standards/peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68603eae5dec832684d780c70669bb9a