### PR TITLE
Fix JSON serialization for RPC

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/rpc_utils.py
+++ b/pkgs/standards/peagen/peagen/cli/rpc_utils.py
@@ -23,7 +23,7 @@ def rpc_post(
 ) -> Response[R | Dict[str, Any]]:
     """Send a JSON-RPC request and return a typed :class:`Response`."""
     envelope = Request(id=id or str(uuid.uuid4()), method=method, params=params)
-    resp = httpx.post(url, json=envelope.model_dump(), timeout=timeout)
+    resp = httpx.post(url, json=envelope.model_dump(mode="json"), timeout=timeout)
     resp.raise_for_status()
     if result_model is not None:
         adapter = TypeAdapter(Response[result_model])  # type: ignore[index]

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -840,6 +840,7 @@ async def task_patch(*, taskId: str, changes: dict) -> dict:
     """Compatibility wrapper for :func:`_task_patch_rpc`."""
     return await _task_patch_rpc(PatchParams(taskId=taskId, changes=changes))
 
+
 # ─────────────────────────────── Healthcheck ───────────────────────────────
 @app.get("/healthz", tags=["health"])
 async def health() -> dict:


### PR DESCRIPTION
## Summary
- ensure JSON-friendly dump in `rpc_post`
- format gateway module

## Testing
- `uv run --directory pkgs/standards --package peagen ruff format .`
- `uv run --directory pkgs/standards --package peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards pytest` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6860498ba8c48326b72d7e5e0c201c11