### PR TITLE
Refactor CLI to use protocol submit params

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/sort.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/sort.py
@@ -10,8 +10,8 @@ import typer
 from peagen._utils.config_loader import _effective_cfg, load_peagen_toml
 from peagen.handlers.sort_handler import sort_handler
 from peagen.protocols import TASK_SUBMIT
-from peagen.protocols.methods.task import SubmitParams, SubmitResult
-from peagen.schemas import TaskCreate
+from peagen.protocols.methods.task import SubmitResult
+from peagen.cli.task_builder import build_submit_params
 from peagen.cli.rpc_utils import rpc_post
 
 local_sort_app = typer.Typer(help="Sort generated project files.")
@@ -130,16 +130,17 @@ def submit_sort(
         "repo": repo,
         "ref": ref,
     }
-    task_obj = TaskCreate(
+    submit = build_submit_params(
+        "sort",
+        {**args, "cfg_override": cfg_override},
         pool="default",
-        payload={"action": "sort", "args": args, "cfg_override": cfg_override},
     )
 
     try:
         resp = rpc_post(
             ctx.obj.get("gateway_url"),
             TASK_SUBMIT,
-            SubmitParams(task=task_obj).model_dump(),
+            submit.model_dump(),
             timeout=10.0,
             result_model=SubmitResult,
         )

--- a/pkgs/standards/peagen/peagen/cli/task_builder.py
+++ b/pkgs/standards/peagen/peagen/cli/task_builder.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from peagen.orm.status import Status
 from peagen.schemas import TaskCreate
+from peagen.protocols.methods.task import SubmitParams
 
 
 def _build_task(
@@ -30,3 +31,16 @@ def _build_task(
     )
     task.id = str(task.id)
     return task
+
+
+def build_submit_params(
+    action: str,
+    args: dict[str, Any],
+    pool: str = "default",
+    *,
+    status: Status = Status.queued,
+) -> SubmitParams:
+    """Return :class:`SubmitParams` with defaults populated."""
+
+    task = _build_task(action, args, pool, status=status)
+    return SubmitParams(task=task)


### PR DESCRIPTION
## Summary
- switch CLI task builders and commands to generate `SubmitParams`
- use the helper across db, doe, templates, sort and validate commands
- keep TaskCreate creation internal to `task_builder`

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format .`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest` *(fails: two_user_secret_exchange_i9n_test.py, sequences_success, test_task_patch_finalize)*

------
https://chatgpt.com/codex/tasks/task_e_6860494312f883269b75d974063eb9f9