### PR TITLE
Fix JSON serialization in peagen scheduler and worker

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -681,8 +681,8 @@ async def scheduler():
             rpc_req = RPCEnvelope(
                 id=str(uuid.uuid4()),
                 method="Work.start",
-                params={"task": task.model_dump()},
-            ).model_dump()
+                params={"task": task.model_dump(mode="json")},
+            ).model_dump(mode="json")
 
             try:
                 resp = await client.post(target["url"], json=rpc_req)

--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -260,7 +260,7 @@ class WorkerBase:
             id=str(uuid.uuid4()),
             method=WORK_FINISHED,
             params={"taskId": task_id, "status": state, "result": result},
-        ).model_dump()
+        ).model_dump(mode="json")
         try:
             await self._client.post(self.DQ_GATEWAY, json=payload)
             self.log.info("Work.finished sent    task=%s state=%s", task_id, state)
@@ -273,10 +273,12 @@ class WorkerBase:
         if self._client is None:
             raise HTTPClientNotInitializedError()
 
-        payload = params.model_dump() if isinstance(params, BaseModel) else params
+        payload = (
+            params.model_dump(mode="json") if isinstance(params, BaseModel) else params
+        )
         body = RPCEnvelope(
             id=str(uuid.uuid4()), method=method, params=payload
-        ).model_dump()
+        ).model_dump(mode="json")
         try:
             await self._client.post(self.DQ_GATEWAY, json=body)
             self.log.debug("sent %s → %s", method, payload)


### PR DESCRIPTION
## Summary
- ensure gateway scheduler dumps task data in JSON mode
- ensure worker RPC messages use JSON-compatible dumps
- update formatting

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest -x` *(fails: subprocess.CalledProcessError)*
- `uv run --package peagen --directory pkgs/standards/peagen peagen remote -q --gateway-url http://127.0.0.1:8000/rpc evolve tests/examples/simple_evolve_demo/evolve_remote_spec.yaml --watch --repo tests/examples/simple_evolve_demo/workspace` *(fails: repository clone error)*

------
https://chatgpt.com/codex/tasks/task_e_68615ca6a0248326b12ddf9b6bfb0be8