### PR TITLE
Fix remote DOE process and scheduler

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/doe.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/doe.py
@@ -17,6 +17,7 @@ import typer
 from peagen.handlers.doe_handler import doe_handler
 from peagen.handlers.doe_process_handler import doe_process_handler
 from peagen.schemas import TaskCreate
+from peagen.cli.task_builder import _build_task as _generic_build_task
 from peagen.protocols import TASK_SUBMIT, TASK_GET
 from peagen.protocols.methods.task import (
     SubmitParams,
@@ -32,10 +33,8 @@ remote_doe_app = typer.Typer(help="Generate project-payload bundles from DOE spe
 
 
 def _make_task(args: dict, action: str = "doe") -> TaskCreate:
-    return TaskCreate(
-        pool="default",
-        payload={"action": action, "args": args},
-    )
+    """Return a ``TaskCreate`` populated with required defaults."""
+    return _generic_build_task(action, args)
 
 
 # ───────────────────────────── local run ───────────────────────────────────

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -681,7 +681,7 @@ async def scheduler():
             rpc_req = RPCEnvelope(
                 id=str(uuid.uuid4()),
                 method="Work.start",
-                params={"task": task.model_dump()},
+                params={"task": task.model_dump(mode="json")},
             ).model_dump()
 
             try:


### PR DESCRIPTION
## Summary
- use task builder for CLI DOE commands so required fields are populated
- ensure scheduler serialises tasks with `mode="json"` when dispatching

## Testing
- `uv run --package peagen --directory . pytest tests/unit/test_task_patch_finalize.py::test_task_patch_triggers_finalize -q` *(fails: work_finished() got an unexpected keyword argument 'taskId')*

------
https://chatgpt.com/codex/tasks/task_e_68615cccf0ec8326bf92b17b1511faa1