### PR TITLE
Fix peagen task serialization

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -681,7 +681,7 @@ async def scheduler():
             rpc_req = RPCEnvelope(
                 id=str(uuid.uuid4()),
                 method="Work.start",
-                params={"task": task.model_dump()},
+                params={"task": task.model_dump(mode="json")},
             ).model_dump()
 
             try:

--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -213,7 +213,7 @@ class WorkerBase:
     async def _run_task(self, task: TaskRead | Dict[str, Any]) -> None:
         """Execute *task* by dispatching to a registered handler."""
         canonical = ensure_task(task)
-        task_id = canonical.id
+        task_id = str(canonical.id)
         payload = canonical.payload
         action = payload.get("action")
 


### PR DESCRIPTION
## Summary
- ensure gateway scheduler dumps tasks using JSON mode
- convert worker task_id to string when notifying gateway

## Testing
- `peagen remote -q --gateway-url http://127.0.0.1:8000/rpc sort template_two_project.yaml --repo ./testproject`


------
https://chatgpt.com/codex/tasks/task_e_68616794dba08326bd3297638b4bb05b