### PR TITLE
Fix JSON serialization in peagen remote workflow

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -681,7 +681,7 @@ async def scheduler():
             rpc_req = RPCEnvelope(
                 id=str(uuid.uuid4()),
                 method="Work.start",
-                params={"task": task.model_dump()},
+                params={"task": task.model_dump(mode="json")},
             ).model_dump()
 
             try:

--- a/pkgs/standards/peagen/peagen/handlers/fanout.py
+++ b/pkgs/standards/peagen/peagen/handlers/fanout.py
@@ -24,7 +24,7 @@ async def fan_out(
     """Submit *children* and update *parent* with their IDs."""
     gateway = os.getenv("DQ_GATEWAY", "http://localhost:8000/rpc")
     canonical_parent = ensure_task(parent)
-    parent_id = canonical_parent.id
+    parent_id = str(canonical_parent.id)
 
     child_ids: List[str] = []
     async with httpx.AsyncClient(timeout=10.0) as client:
@@ -33,22 +33,22 @@ async def fan_out(
                 id=str(uuid.uuid4()),
                 method=TASK_SUBMIT,
                 params={
-                    "taskId": child.id,
+                    "taskId": str(child.id),
                     "pool": child.pool,
                     "payload": child.payload,
                 },
-            ).model_dump()
+            ).model_dump(mode="json")
             await client.post(gateway, json=req)
-            child_ids.append(child.id)
+            child_ids.append(str(child.id))
 
         patch = RPCEnvelope(
             id=str(uuid.uuid4()),
             method=TASK_PATCH,
             params=PatchParams(
-                taskId=str(parent_id),
+                taskId=parent_id,
                 changes={"result": {"children": child_ids}},
-            ).model_dump(),
-        ).model_dump()
+            ).model_dump(mode="json"),
+        ).model_dump(mode="json")
         await client.post(gateway, json=patch)
 
         finish = RPCEnvelope(
@@ -59,7 +59,7 @@ async def fan_out(
                 "status": final_status.value,
                 "result": result,
             },
-        ).model_dump()
+        ).model_dump(mode="json")
         await client.post(gateway, json=finish)
 
     return {"children": child_ids, "_final_status": final_status.value}

--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -260,7 +260,7 @@ class WorkerBase:
             id=str(uuid.uuid4()),
             method=WORK_FINISHED,
             params={"taskId": task_id, "status": state, "result": result},
-        ).model_dump()
+        ).model_dump(mode="json")
         try:
             await self._client.post(self.DQ_GATEWAY, json=payload)
             self.log.info("Work.finished sent    task=%s state=%s", task_id, state)
@@ -273,10 +273,12 @@ class WorkerBase:
         if self._client is None:
             raise HTTPClientNotInitializedError()
 
-        payload = params.model_dump() if isinstance(params, BaseModel) else params
+        payload = (
+            params.model_dump(mode="json") if isinstance(params, BaseModel) else params
+        )
         body = RPCEnvelope(
             id=str(uuid.uuid4()), method=method, params=payload
-        ).model_dump()
+        ).model_dump(mode="json")
         try:
             await self._client.post(self.DQ_GATEWAY, json=body)
             self.log.debug("sent %s → %s", method, payload)


### PR DESCRIPTION
## Summary
- ensure JSON serialization uses `mode="json"` for task dispatch
- serialize child task IDs as strings in `fanout`
- send JSON-serializable payloads from worker

## Testing
- `peagen remote -q --gateway-url http://localhost:8000/rpc doe process pkgs/standards/peagen/tests/examples/locking_demo/doe_spec.yaml pkgs/standards/peagen/tests/examples/locking_demo/template_project.yaml --output /tmp/peagen_test/payload.yaml --watch --repo "/workspace/swarmauri-sdk" --force`


------
https://chatgpt.com/codex/tasks/task_e_6861679ffad48326aa601bae00489874