### PR TITLE
Fix remote process task serialization

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/process.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/process.py
@@ -209,7 +209,7 @@ def submit(  # noqa: PLR0913 – CLI signature needs many options
 
     typer.secho(f"Submitted task {task.id}", fg=typer.colors.GREEN)
     if reply.result:
-        typer.echo(json.dumps(reply.result, indent=2))
+        typer.echo(json.dumps(reply.result.model_dump(), indent=2))
     if watch:
 
         def _rpc_call() -> GetResult:

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -681,7 +681,7 @@ async def scheduler():
             rpc_req = RPCEnvelope(
                 id=str(uuid.uuid4()),
                 method="Work.start",
-                params={"task": task.model_dump()},
+                params={"task": task.model_dump(mode="json")},
             ).model_dump()
 
             try:

--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -152,7 +152,7 @@ class WorkerBase:
             # Auto-assign id if omitted
             if body.id is None:
                 body.id = str(uuid.uuid4())
-            payload = body.model_dump()
+            payload = body.model_dump(mode="json")
             self.log.debug("RPC  ←  %s", payload)
             try:
                 resp = await self.rpc.dispatch(payload)
@@ -260,7 +260,7 @@ class WorkerBase:
             id=str(uuid.uuid4()),
             method=WORK_FINISHED,
             params={"taskId": task_id, "status": state, "result": result},
-        ).model_dump()
+        ).model_dump(mode="json")
         try:
             await self._client.post(self.DQ_GATEWAY, json=payload)
             self.log.info("Work.finished sent    task=%s state=%s", task_id, state)
@@ -273,10 +273,12 @@ class WorkerBase:
         if self._client is None:
             raise HTTPClientNotInitializedError()
 
-        payload = params.model_dump() if isinstance(params, BaseModel) else params
+        payload = (
+            params.model_dump(mode="json") if isinstance(params, BaseModel) else params
+        )
         body = RPCEnvelope(
             id=str(uuid.uuid4()), method=method, params=payload
-        ).model_dump()
+        ).model_dump(mode="json")
         try:
             await self._client.post(self.DQ_GATEWAY, json=body)
             self.log.debug("sent %s → %s", method, payload)


### PR DESCRIPTION
## Summary
- fix SubmitResult printing in CLI process command
- ensure gateway dispatch serializes tasks to JSON
- ensure worker RPC messages use JSON-friendly serialization

## Testing
- `uv run --package peagen --directory /workspace/swarmauri-sdk/pkgs/standards/peagen peagen remote -q --gateway-url http://127.0.0.1:8000/rpc process /tmp/peagen_demo/project_payloads.yaml --watch`

------
https://chatgpt.com/codex/tasks/task_e_686167bb74f88326bf92175085893b1a