### PR TITLE
Fix work_finished wrapper

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -43,6 +43,7 @@ from peagen.protocols.methods.task import (
     PatchParams,
     GetParams,
 )
+from peagen.protocols.methods.work import FinishedParams
 from peagen.schemas import TaskRead, TaskCreate, TaskUpdate
 from peagen.orm import TaskModel, TaskRunModel
 
@@ -757,7 +758,7 @@ async def delete_secret_route(name: str, tenant_id: str = "default") -> dict:
 
 # expose RPC handler functions for unit tests
 from .rpc.workers import (  # noqa: F401,E402
-    work_finished,
+    work_finished as _work_finished_rpc,
     worker_heartbeat,
     worker_list,
     worker_register,
@@ -839,6 +840,15 @@ async def task_get(taskId: str) -> dict:
 async def task_patch(*, taskId: str, changes: dict) -> dict:
     """Compatibility wrapper for :func:`_task_patch_rpc`."""
     return await _task_patch_rpc(PatchParams(taskId=taskId, changes=changes))
+
+
+async def work_finished(
+    *, taskId: str, status: str, result: dict | None = None
+) -> dict:
+    """Compatibility wrapper for :func:`_work_finished_rpc`."""
+    return await _work_finished_rpc(
+        FinishedParams(taskId=taskId, status=status, result=result)
+    )
 
 
 # ─────────────────────────────── Healthcheck ───────────────────────────────


### PR DESCRIPTION
## Summary
- add wrapper for work_finished rpc method
- keep tests passing with alias for finished params

## Testing
- `PEAGEN_TEST_GATEWAY=http://localhost:9999 uv run --package peagen --directory pkgs/standards/peagen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68616aeeeb488326937d36e69644e3e9