### PR TITLE
Fix fan_out UUID serialization

### DIFF
--- a/pkgs/standards/peagen/peagen/handlers/fanout.py
+++ b/pkgs/standards/peagen/peagen/handlers/fanout.py
@@ -24,7 +24,7 @@ async def fan_out(
     """Submit *children* and update *parent* with their IDs."""
     gateway = os.getenv("DQ_GATEWAY", "http://localhost:8000/rpc")
     canonical_parent = ensure_task(parent)
-    parent_id = canonical_parent.id
+    parent_id = str(canonical_parent.id)
 
     child_ids: List[str] = []
     async with httpx.AsyncClient(timeout=10.0) as client:
@@ -33,19 +33,19 @@ async def fan_out(
                 id=str(uuid.uuid4()),
                 method=TASK_SUBMIT,
                 params={
-                    "taskId": child.id,
+                    "taskId": str(child.id),
                     "pool": child.pool,
                     "payload": child.payload,
                 },
             ).model_dump()
             await client.post(gateway, json=req)
-            child_ids.append(child.id)
+            child_ids.append(str(child.id))
 
         patch = RPCEnvelope(
             id=str(uuid.uuid4()),
             method=TASK_PATCH,
             params=PatchParams(
-                taskId=str(parent_id),
+                taskId=parent_id,
                 changes={"result": {"children": child_ids}},
             ).model_dump(),
         ).model_dump()


### PR DESCRIPTION
## Summary
- fix `fan_out` handler to serialize child task IDs as strings
- ensure parent ID is also serialized to string

## Testing
- `uv run --directory standards --package peagen ruff format .`
- `uv run --directory standards --package peagen ruff check . --fix`
- `uv run --package peagen --directory standards pytest` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68616b2df1e08326a6095c79ff5bf07f