### PR TITLE
Refactor peagen task builder

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/task_builder.py
+++ b/pkgs/standards/peagen/peagen/cli/task_builder.py
@@ -5,7 +5,6 @@ from datetime import datetime
 from typing import Any
 
 from peagen.orm.status import Status
-from peagen.schemas import TaskCreate
 from peagen.protocols.methods.task import SubmitParams
 
 
@@ -15,20 +14,23 @@ def _build_task(
     pool: str = "default",
     *,
     status: Status = Status.queued,
-) -> TaskCreate:
-    """Return a ``TaskCreate`` with *action* and *args* embedded."""
+) -> Any:
+    """Return a Task model (via :class:`SubmitParams`) with *action* and *args* embedded."""
 
-    task = TaskCreate(
-        id=uuid.uuid4(),
-        tenant_id=uuid.uuid4(),
-        git_reference_id=uuid.uuid4(),
-        pool=pool,
-        payload={"action": action, "args": args},
-        status=status,
-        note="",
-        spec_hash="dummy",
-        last_modified=datetime.utcnow(),
+    submit = SubmitParams(
+        task={
+            "id": uuid.uuid4(),
+            "tenant_id": uuid.uuid4(),
+            "git_reference_id": uuid.uuid4(),
+            "pool": pool,
+            "payload": {"action": action, "args": args},
+            "status": status,
+            "note": "",
+            "spec_hash": "dummy",
+            "last_modified": datetime.utcnow(),
+        }
     )
+    task = submit.task
     task.id = str(task.id)
     return task
 


### PR DESCRIPTION
## Summary
- use SubmitParams to build tasks without importing TaskCreate

## Testing
- `uv run --directory .. --package peagen ruff format .`
- `uv run --directory .. --package peagen ruff check . --fix`
- `uv run --package peagen --directory standards pytest` *(fails: ModuleNotFoundError)*
- `uv run --package peagen --directory standards peagen remote -q --gateway-url http://127.0.0.1:8000/rpc process peagen/tests/examples/projects_payloads/projects_payload.yaml` *(fails: TypeError)*
- `uv run --package peagen --directory standards peagen local -q process peagen/tests/examples/projects_payloads/projects_payload.yaml --repo .` *(fails: ProjectsPayloadValidationError)*

------
https://chatgpt.com/codex/tasks/task_e_68616cda8ce48326b19d25ac9c1e096e