### PR TITLE
Fix remote process CLI output and localfs persistence

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/process.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/process.py
@@ -209,7 +209,7 @@ def submit(  # noqa: PLR0913 – CLI signature needs many options
 
     typer.secho(f"Submitted task {task.id}", fg=typer.colors.GREEN)
     if reply.result:
-        typer.echo(json.dumps(reply.result, indent=2))
+        typer.echo(json.dumps(reply.result.model_dump(), indent=2))
     if watch:
 
         def _rpc_call() -> GetResult:

--- a/pkgs/standards/peagen/peagen/plugins/result_backends/localfs_backend.py
+++ b/pkgs/standards/peagen/peagen/plugins/result_backends/localfs_backend.py
@@ -16,4 +16,7 @@ class LocalFsResultBackend(ResultBackendBase):
     async def store(self, task_run: TaskRunModel) -> None:
         path = self.root / f"{task_run.id}.json"
         with path.open("w", encoding="utf-8") as fh:
-            json.dump(task_run.to_dict(), fh, default=str)
+            from peagen.schemas import TaskRunRead
+
+            data = TaskRunRead.model_validate(task_run).model_dump()
+            json.dump(data, fh, default=str)

--- a/pkgs/standards/peagen/tests/unit/test_task_patch_finalize.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_patch_finalize.py
@@ -1,6 +1,7 @@
 import uuid
 import pytest
 from peagen.plugins.queues.in_memory_queue import InMemoryQueue
+from peagen.protocols.methods.work import FinishedParams
 
 
 @pytest.mark.unit
@@ -88,7 +89,7 @@ async def test_task_patch_triggers_finalize(monkeypatch):
         last_modified=datetime.datetime.now(timezone.utc),
     )
     child_id = (await task_submit(child_dto))["taskId"]
-    await work_finished(taskId=child_id, status="success", result=None)
+    await work_finished(FinishedParams(taskId=child_id, status="success", result=None))
 
     await task_patch(taskId=parent_id, changes={"result": {"children": [child_id]}})
     parent = await task_get(parent_id)
@@ -181,7 +182,7 @@ async def test_task_patch_triggers_finalize_rejected(monkeypatch):
         last_modified=datetime.datetime.now(timezone.utc),
     )
     child_id = (await task_submit(child_dto))["taskId"]
-    await work_finished(taskId=child_id, status="rejected", result=None)
+    await work_finished(FinishedParams(taskId=child_id, status="rejected", result=None))
 
     await task_patch(taskId=parent_id, changes={"result": {"children": [child_id]}})
     parent = await task_get(parent_id)


### PR DESCRIPTION
## Summary
- fix JSON dumping for SubmitResult in process CLI
- ensure localfs backend writes valid JSON via TaskRunRead
- update `test_task_patch_finalize` unit tests for new function signature

## Testing
- `uv run --package peagen --directory standards/peagen ruff check peagen/cli/commands/process.py peagen/plugins/result_backends/localfs_backend.py ../../standards/peagen/tests/unit/test_task_patch_finalize.py --fix`
- `PEAGEN_TEST_GATEWAY=http://127.0.0.1:9999 uv run --package peagen --directory standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_68616f16e4ec8326b5ccc418482acaa8