### PR TITLE
Align task RPC with canonical envelope

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_task_id_collision.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_id_collision.py
@@ -44,5 +44,5 @@ async def test_task_submit_id_collision(monkeypatch):
 
     r1 = await task_submit(pool="p", payload={}, taskId="dup")
     r2 = await task_submit(pool="p", payload={}, taskId="dup")
-    assert r1["taskId"] == "dup"
-    assert r2["taskId"] != "dup"
+    assert r1.taskId == "dup"
+    assert r2.taskId != "dup"

--- a/pkgs/standards/peagen/tests/unit/test_task_metadata.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_metadata.py
@@ -110,7 +110,7 @@ async def test_task_submit_roundtrip(monkeypatch):
     )
 
     result = await task_submit(dto)
-    tid = result["taskId"]
+    tid = result.taskId
     stored = await task_get(tid)
-    assert stored["pool"] == "p"
-    assert stored["payload"] == {}
+    assert stored.pool == "p"
+    assert stored.payload == {}

--- a/pkgs/standards/peagen/tests/unit/test_task_patch_finalize.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_patch_finalize.py
@@ -74,7 +74,7 @@ async def test_task_patch_triggers_finalize(monkeypatch):
         spec_hash=uuid.uuid4().hex,
         last_modified=datetime.datetime.now(timezone.utc),
     )
-    parent_id = (await task_submit(parent_dto))["taskId"]
+    parent_id = (await task_submit(parent_dto)).taskId
 
     child_dto = TaskCreate(
         id=uuid.uuid4(),
@@ -87,12 +87,12 @@ async def test_task_patch_triggers_finalize(monkeypatch):
         spec_hash=uuid.uuid4().hex,
         last_modified=datetime.datetime.now(timezone.utc),
     )
-    child_id = (await task_submit(child_dto))["taskId"]
+    child_id = (await task_submit(child_dto)).taskId
     await work_finished(taskId=child_id, status="success", result=None)
 
     await task_patch(taskId=parent_id, changes={"result": {"children": [child_id]}})
     parent = await task_get(parent_id)
-    assert parent["status"] == "success"
+    assert parent.status == "success"
 
 
 @pytest.mark.unit
@@ -167,7 +167,7 @@ async def test_task_patch_triggers_finalize_rejected(monkeypatch):
         spec_hash=uuid.uuid4().hex,
         last_modified=datetime.datetime.now(timezone.utc),
     )
-    parent_id = (await task_submit(parent_dto))["taskId"]
+    parent_id = (await task_submit(parent_dto)).taskId
 
     child_dto = TaskCreate(
         id=uuid.uuid4(),
@@ -180,9 +180,9 @@ async def test_task_patch_triggers_finalize_rejected(monkeypatch):
         spec_hash=uuid.uuid4().hex,
         last_modified=datetime.datetime.now(timezone.utc),
     )
-    child_id = (await task_submit(child_dto))["taskId"]
+    child_id = (await task_submit(child_dto)).taskId
     await work_finished(taskId=child_id, status="rejected", result=None)
 
     await task_patch(taskId=parent_id, changes={"result": {"children": [child_id]}})
     parent = await task_get(parent_id)
-    assert parent["status"] == "success"
+    assert parent.status == "success"

--- a/pkgs/standards/peagen/tests/unit/test_task_patch_labels.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_patch_labels.py
@@ -77,8 +77,8 @@ async def test_task_patch_updates_labels(monkeypatch):
     )
 
     result = await task_submit(dto)
-    tid = result["taskId"]
+    tid = result.taskId
 
     await task_patch(taskId=tid, changes={"labels": ["patched"]})
     patched = await task_get(tid)
-    assert patched["labels"] == ["patched"]
+    assert patched.labels == ["patched"]

--- a/pkgs/standards/peagen/tests/unit/test_task_patch_status.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_patch_status.py
@@ -77,8 +77,8 @@ async def test_task_patch_updates_status(monkeypatch):
     )
 
     result = await task_submit(dto)
-    tid = result["taskId"]
+    tid = result.taskId
 
     await task_patch(taskId=tid, changes={"status": "success"})
     patched = await task_get(tid)
-    assert patched["status"] == "success"
+    assert patched.status == "success"


### PR DESCRIPTION
## Summary
- use canonical Pydantic objects for task RPC handlers
- update unit tests for new task results

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/gateway/rpc/tasks.py tests/unit/test_task_id_collision.py tests/unit/test_task_metadata.py tests/unit/test_task_patch_finalize.py tests/unit/test_task_patch_labels.py tests/unit/test_task_patch_status.py --fix`
- `uv run --directory pkgs/standards/peagen --package peagen pytest` *(fails: tests/i9n/two_user_secret_exchange_i9n_test.py::test_two_user_secret_exchange, tests/sequence_success/test_sequences_success.py::test_sequences_success[example0])*

------
https://chatgpt.com/codex/tasks/task_e_686170c410f8832681c072ad2f9c5336