### PR TITLE
Update gateway and worker to use protocol constants

### DIFF
--- a/pkgs/standards/peagen/peagen/defaults/methods.py
+++ b/pkgs/standards/peagen/peagen/defaults/methods.py
@@ -16,6 +16,9 @@ from peagen.protocols.methods import (
     SECRETS_ADD as PROTO_SECRETS_ADD,
     SECRETS_GET as PROTO_SECRETS_GET,
     SECRETS_DELETE as PROTO_SECRETS_DELETE,
+    WORK_START as PROTO_WORK_START,
+    WORK_CANCEL as PROTO_WORK_CANCEL,
+    GUARD_SET as PROTO_GUARD_SET,
 )
 
 warnings.warn(
@@ -25,8 +28,8 @@ warnings.warn(
 )
 
 # Worker ↔ Gateway
-WORK_START = "Work.start"
-WORK_CANCEL = "Work.cancel"
+WORK_START = PROTO_WORK_START
+WORK_CANCEL = PROTO_WORK_CANCEL
 WORK_FINISHED = "Work.finished"
 WORKER_REGISTER = "Worker.register"
 WORKER_HEARTBEAT = "Worker.heartbeat"
@@ -43,7 +46,7 @@ TASK_PATCH = "Task.patch"
 TASK_GET = "Task.get"
 
 # Gateway-only
-GUARD_SET = "Guard.set"
+GUARD_SET = PROTO_GUARD_SET
 POOL_CREATE = "Pool.create"
 POOL_JOIN = "Pool.join"
 POOL_LIST_TASKS = "Pool.listTasks"

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -43,7 +43,7 @@ from peagen.protocols.methods.task import (
     PatchParams,
     GetParams,
 )
-from peagen.protocols.methods.work import FinishedParams
+from peagen.protocols.methods.work import FinishedParams, WORK_START
 from peagen.schemas import TaskRead, TaskCreate, TaskUpdate
 from peagen.orm import TaskModel, TaskRunModel
 
@@ -681,10 +681,9 @@ async def scheduler():
                 continue
             rpc_req = RPCEnvelope(
                 id=str(uuid.uuid4()),
-                method="Work.start",
+                method=WORK_START,
                 params={"task": task.model_dump(mode="json")},
             ).model_dump()
-
 
             try:
                 resp = await client.post(target["url"], json=rpc_req)

--- a/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
@@ -26,7 +26,7 @@ from peagen.protocols.methods.task import (
     GetParams,
     GetResult,
 )
-from peagen.defaults import GUARD_SET
+from peagen.protocols.methods.guard import GUARD_SET
 
 from .. import (
     READY_QUEUE,

--- a/pkgs/standards/peagen/peagen/protocols/methods/__init__.py
+++ b/pkgs/standards/peagen/peagen/protocols/methods/__init__.py
@@ -12,7 +12,8 @@ from .keys import KEYS_UPLOAD, KEYS_FETCH, KEYS_DELETE
 from .secrets import SECRETS_ADD, SECRETS_GET, SECRETS_DELETE
 from .worker import WORKER_REGISTER, WORKER_HEARTBEAT, WORKER_LIST
 from .pool import POOL_CREATE, POOL_JOIN, POOL_LIST_TASKS
-from .work import WORK_FINISHED
+from .work import WORK_FINISHED, WORK_START, WORK_CANCEL
+from .guard import GUARD_SET
 
 __all__ = [
     "TASK_SUBMIT",
@@ -36,4 +37,7 @@ __all__ = [
     "POOL_JOIN",
     "POOL_LIST_TASKS",
     "WORK_FINISHED",
+    "WORK_START",
+    "WORK_CANCEL",
+    "GUARD_SET",
 ]

--- a/pkgs/standards/peagen/peagen/protocols/methods/guard.py
+++ b/pkgs/standards/peagen/peagen/protocols/methods/guard.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+from .._registry import register
+
+
+class SetParams(BaseModel):
+    """Parameters for the ``Guard.set`` RPC method."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    label: str
+    spec: dict
+
+
+class SetResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    ok: bool
+
+
+GUARD_SET = register(
+    method="Guard.set",
+    params_model=SetParams,
+    result_model=SetResult,
+)

--- a/pkgs/standards/peagen/peagen/protocols/methods/work.py
+++ b/pkgs/standards/peagen/peagen/protocols/methods/work.py
@@ -24,3 +24,49 @@ WORK_FINISHED = register(
     params_model=FinishedParams,
     result_model=FinishedResult,
 )
+
+
+class StartParams(BaseModel):
+    """Parameters for the ``Work.start`` RPC method."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    task: dict
+
+
+class StartResult(BaseModel):
+    """Return value for ``Work.start``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    accepted: bool
+
+
+WORK_START = register(
+    method="Work.start",
+    params_model=StartParams,
+    result_model=StartResult,
+)
+
+
+class CancelParams(BaseModel):
+    """Parameters for the ``Work.cancel`` RPC method."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    taskId: str
+
+
+class CancelResult(BaseModel):
+    """Return value for ``Work.cancel``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    ok: bool
+
+
+WORK_CANCEL = register(
+    method="Work.cancel",
+    params_model=CancelParams,
+    result_model=CancelResult,
+)

--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -19,7 +19,7 @@ from json.decoder import JSONDecodeError
 from peagen.transport import RPCDispatcher
 from peagen.protocols import Request as RPCRequest, Response as RPCResponse
 from peagen.protocols import Request as RPCEnvelope
-from peagen.defaults import WORK_CANCEL, WORK_FINISHED, WORK_START
+from peagen.protocols.methods.work import WORK_START, WORK_CANCEL, WORK_FINISHED
 from peagen.protocols.methods.worker import (
     WORKER_HEARTBEAT,
     WORKER_REGISTER,


### PR DESCRIPTION
## Summary
- define Guard.set, Work.start and Work.cancel JSON‑RPC protocols
- update defaults to forward to new protocol constants
- use typed protocol constants in gateway scheduler
- use typed constants in worker base
- move guard RPC usage to protocol package

## Testing
- `uv run --directory peagen --package peagen ruff format .`
- `uv run --directory peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_6861710085e48326b13e769a10f8fde5