### PR TITLE
Fix gateway skip check

### DIFF
--- a/pkgs/standards/peagen/tests/i9n/two_user_secret_exchange_i9n_test.py
+++ b/pkgs/standards/peagen/tests/i9n/two_user_secret_exchange_i9n_test.py
@@ -12,12 +12,16 @@ GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
 
 
 def _gateway_available(url: str) -> bool:
+    """Return ``True`` if the gateway responds with a valid worker list."""
     envelope = {"jsonrpc": "2.0", "method": WORKER_LIST, "params": {}}
     try:
         response = httpx.post(url, json=envelope, timeout=5)
+        if response.status_code != 200:
+            return False
+        data = response.json()
     except Exception:
         return False
-    return response.status_code == 200
+    return "result" in data
 
 
 @pytest.mark.i9n

--- a/pkgs/standards/peagen/tests/sequence_success/test_sequences_success.py
+++ b/pkgs/standards/peagen/tests/sequence_success/test_sequences_success.py
@@ -13,12 +13,16 @@ GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
 
 
 def _gateway_available(url: str) -> bool:
+    """Return ``True`` if the gateway responds with a valid worker list."""
     envelope = {"jsonrpc": "2.0", "method": WORKER_LIST, "params": {}}
     try:
         response = httpx.post(url, json=envelope, timeout=5)
+        if response.status_code != 200:
+            return False
+        data = response.json()
     except Exception:
         return False
-    return response.status_code == 200
+    return "result" in data
 
 
 def _load_command_batches(path: Path, tmpdir: Path) -> list[list[list[str]]]:


### PR DESCRIPTION
## Summary
- improve gateway check in integration tests
- skip secret exchange and sequence tests when gateway is down

## Testing
- `uv run --package peagen --directory standards/peagen pytest tests/i9n/two_user_secret_exchange_i9n_test.py::test_two_user_secret_exchange -q`
- `uv run --package peagen --directory standards/peagen pytest tests/sequence_success/test_sequences_success.py::test_sequences_success -q`


------
https://chatgpt.com/codex/tasks/task_e_6861705852f08326b0e80ce5c6d76e52