### PR TITLE
Fix remote mutate CLI and gateway wrapper

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/mutate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/mutate.py
@@ -117,14 +117,14 @@ def submit(
         result_model=SubmitResult,
     )
 
-    if "error" in reply:
+    if reply.error:
         typer.secho(
-            f"Remote error {reply['error']['code']}: {reply['error']['message']}",
+            f"Remote error {reply.error.code}: {reply.error.message}",
             fg=typer.colors.RED,
             err=True,
         )
         raise typer.Exit(1)
 
     typer.secho(f"Submitted task {task.id}", fg=typer.colors.GREEN)
-    if reply.get("result"):
-        typer.echo(json.dumps(reply["result"], indent=2))
+    if reply.result:
+        typer.echo(json.dumps(reply.result.model_dump(), indent=2))

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -43,6 +43,7 @@ from peagen.protocols.methods.task import (
     PatchParams,
     GetParams,
 )
+from peagen.protocols.methods.work import FinishedParams
 from peagen.schemas import TaskRead, TaskCreate, TaskUpdate
 from peagen.orm import TaskModel, TaskRunModel
 
@@ -684,7 +685,6 @@ async def scheduler():
                 params={"task": task.model_dump(mode="json")},
             ).model_dump()
 
-
             try:
                 resp = await client.post(target["url"], json=rpc_req)
                 if resp.status_code != 200:
@@ -758,7 +758,7 @@ async def delete_secret_route(name: str, tenant_id: str = "default") -> dict:
 
 # expose RPC handler functions for unit tests
 from .rpc.workers import (  # noqa: F401,E402
-    work_finished,
+    work_finished as _work_finished_rpc,
     worker_heartbeat,
     worker_list,
     worker_register,
@@ -840,6 +840,17 @@ async def task_get(taskId: str) -> dict:
 async def task_patch(*, taskId: str, changes: dict) -> dict:
     """Compatibility wrapper for :func:`_task_patch_rpc`."""
     return await _task_patch_rpc(PatchParams(taskId=taskId, changes=changes))
+
+
+async def work_finished(
+    *, taskId: str, status: str, result: dict | None = None
+) -> dict:
+    """Compatibility wrapper for :func:`rpc.workers.work_finished`."""
+    from .rpc.workers import work_finished as _work_finished
+
+    return await _work_finished(
+        FinishedParams(taskId=taskId, status=status, result=result)
+    )
 
 
 # ─────────────────────────────── Healthcheck ───────────────────────────────


### PR DESCRIPTION
## Summary
- update `remote mutate` to handle new Response object structure
- implement `work_finished` wrapper in gateway for tests

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/cli/commands/mutate.py --fix`
- `PEAGEN_TEST_GATEWAY=http://127.0.0.1:9999/rpc uv run --package peagen --directory pkgs/standards/peagen pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68616f0d600883268fb4ed614dc66d5e