### PR TITLE
Update task builder to use protocols

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/task_builder.py
+++ b/pkgs/standards/peagen/peagen/cli/task_builder.py
@@ -17,17 +17,19 @@ def _build_task(
 ) -> Any:
     """Return a Task model (via :class:`SubmitParams`) with *action* and *args* embedded."""
 
-    submit = SubmitParams(
-        task={
-            "id": uuid.uuid4(),
-            "tenant_id": uuid.uuid4(),
-            "git_reference_id": uuid.uuid4(),
-            "pool": pool,
-            "payload": {"action": action, "args": args},
-            "status": status,
-            "note": "",
-            "spec_hash": "dummy",
-            "last_modified": datetime.utcnow(),
+    submit = SubmitParams.model_validate(
+        {
+            "task": {
+                "id": uuid.uuid4(),
+                "tenant_id": uuid.uuid4(),
+                "git_reference_id": uuid.uuid4(),
+                "pool": pool,
+                "payload": {"action": action, "args": args},
+                "status": status,
+                "note": "",
+                "spec_hash": "dummy",
+                "last_modified": datetime.utcnow(),
+            }
         }
     )
     task = submit.task


### PR DESCRIPTION
## Summary
- build task via `SubmitParams.model_validate`

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format .`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest`
- `uv run --package peagen --directory pkgs/standards/peagen peagen remote -q --gateway-url http://127.0.0.1:8000/rpc process pkgs/standards/peagen/tests/examples/gateway_demo/template_project.yaml --watch` *(fails: 'pkgs/core/swarmauri_core/parsers/IParser.py' not found)*
- `uv run --package peagen --directory pkgs/standards/peagen peagen local -q process <file> --repo .` *(fails: TemplateNotFound)*

------
https://chatgpt.com/codex/tasks/task_e_68617260a90c8326a3c46585eb4d951b