### PR TITLE
Use protocols for peagen handlers

### DIFF
--- a/pkgs/standards/peagen/peagen/handlers/__init__.py
+++ b/pkgs/standards/peagen/peagen/handlers/__init__.py
@@ -7,43 +7,43 @@ from typing import Any, Dict
 import uuid
 
 from peagen.orm.status import Status
-from peagen.schemas import TaskCreate, TaskRead
+from peagen.protocols.methods.task import PatchResult
 
 
-def ensure_task(task: TaskRead | TaskCreate | Dict[str, Any]) -> TaskRead:
-    """Return ``task`` as a :class:`~peagen.schemas.TaskRead` instance."""
+def ensure_task(task: PatchResult | Dict[str, Any]) -> PatchResult:
+    """Return ``task`` as a :class:`~peagen.protocols.methods.task.PatchResult` instance."""
 
-    if isinstance(task, TaskRead):
+    if isinstance(task, PatchResult):
         return task
 
-    if isinstance(task, TaskCreate):
-        task = task.model_dump()
-
     if not isinstance(task, dict):  # pragma: no cover - defensive
-        raise TypeError(f"Expected dict or TaskRead or TaskCreate, got {type(task)!r}")
+        if hasattr(task, "model_dump"):
+            task = task.model_dump(mode="json")
+        else:
+            raise TypeError(f"Expected dict or PatchResult, got {type(task)!r}")
 
     # If the incoming mapping is missing required fields, assume it comes from
     # a local CLI invocation and populate sane defaults so handler logic can
-    # operate on a complete ``TaskRead`` model.
+    # operate on a complete ``PatchResult`` model.
     defaults = {
-        "id": uuid.uuid4(),
-        "tenant_id": uuid.uuid4(),
-        "git_reference_id": uuid.uuid4(),
+        "id": str(uuid.uuid4()),
+        "tenant_id": str(uuid.uuid4()),
+        "git_reference_id": str(uuid.uuid4()),
         "pool": task.get("pool", "default"),
         "payload": task.get("payload", {}),
         "status": Status.queued,
         "note": "",
         "spec_hash": uuid.uuid4().hex * 2,
-        "date_created": datetime.now(timezone.utc),
-        "last_modified": datetime.now(timezone.utc),
+        "date_created": datetime.now(timezone.utc).isoformat(),
+        "last_modified": datetime.now(timezone.utc).isoformat(),
     }
 
     merged = {**defaults, **task}
     try:
-        return TaskRead.model_validate(merged)
+        return PatchResult.model_validate(merged)
     except Exception:  # pragma: no cover - fallback for invalid input
-        merged["id"] = uuid.uuid4()
-        return TaskRead.model_validate(merged)
+        merged["id"] = str(uuid.uuid4())
+        return PatchResult.model_validate(merged)
 
 
 __all__ = ["ensure_task"]

--- a/pkgs/standards/peagen/peagen/handlers/analysis_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/analysis_handler.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 from peagen._utils import maybe_clone_repo
 
 from peagen.core.analysis_core import analyze_runs
-from peagen.schemas import TaskRead
+from peagen.protocols.methods.task import PatchResult
 from . import ensure_task
 from peagen._utils.config_loader import resolve_cfg
 from peagen.plugins import PluginManager
@@ -14,7 +14,9 @@ from peagen.plugins.vcs import pea_ref
 from .repo_utils import fetch_repo, cleanup_repo
 
 
-async def analysis_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
+async def analysis_handler(
+    task_or_dict: Dict[str, Any] | PatchResult,
+) -> Dict[str, Any]:
     task = ensure_task(task_or_dict)
     payload = task.payload
     args: Dict[str, Any] = payload.get("args", {})

--- a/pkgs/standards/peagen/peagen/handlers/control_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/control_handler.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Iterable
 
 from peagen.plugins.queues import QueueBase
-from peagen.schemas import TaskRead
+from peagen.protocols.methods.task import PatchResult
 from peagen.core import control_core
 from peagen import defaults
 
@@ -13,7 +13,7 @@ from peagen import defaults
 TASK_KEY = defaults.CONFIG["task_key"]
 
 
-async def save_task(queue: QueueBase, task: TaskRead, ttl: int) -> None:
+async def save_task(queue: QueueBase, task: PatchResult, ttl: int) -> None:
     await queue.hset(
         TASK_KEY.format(task.id),
         mapping={"blob": task.model_dump_json(), "status": task.status.value},
@@ -24,7 +24,7 @@ async def save_task(queue: QueueBase, task: TaskRead, ttl: int) -> None:
 async def apply(
     op: str,
     queue: QueueBase,
-    tasks: Iterable[TaskRead],
+    tasks: Iterable[PatchResult],
     ready_prefix: str,
     ttl: int,
 ) -> int:

--- a/pkgs/standards/peagen/peagen/handlers/doe_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/doe_handler.py
@@ -10,14 +10,14 @@ from peagen.core.doe_core import (
     create_factor_branches,
     create_run_branches,
 )
-from peagen.schemas import TaskRead
+from peagen.protocols.methods.task import PatchResult
 from . import ensure_task
 from peagen._utils.config_loader import resolve_cfg
 from peagen.plugins import PluginManager
 import yaml
 
 
-async def doe_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
+async def doe_handler(task_or_dict: Dict[str, Any] | PatchResult) -> Dict[str, Any]:
     task = ensure_task(task_or_dict)
     payload = task.payload
     args: Dict[str, Any] = payload.get("args", {})

--- a/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Tuple
 import yaml
 
 from peagen.core.doe_core import generate_payload
-from peagen.schemas import TaskRead
+from peagen.protocols.methods.task import PatchResult
 from peagen.orm.status import Status
 from peagen._utils.config_loader import resolve_cfg
 from peagen.plugins import PluginManager
@@ -19,7 +19,7 @@ from . import ensure_task
 
 
 async def doe_process_handler(
-    task_or_dict: Dict[str, Any] | TaskRead,
+    task_or_dict: Dict[str, Any] | PatchResult,
 ) -> Dict[str, Any]:
     """Expand the DOE spec and spawn a process task for each project."""
     task = ensure_task(task_or_dict)
@@ -122,7 +122,7 @@ async def doe_process_handler(
     result["outputs"] = uploaded
 
     pool = task.pool
-    children: List[TaskRead] = []
+    children: List[PatchResult] = []
     for path, proj in projects:
         children.append(
             ensure_task(

--- a/pkgs/standards/peagen/peagen/handlers/eval_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/eval_handler.py
@@ -3,7 +3,7 @@
 Async task-handler for “eval” jobs.
 
 The worker runtime (or a local CLI run) calls this coroutine with
-either a plain dict (decoded JSON-RPC) or a peagen.schemas.TaskRead object.
+either a plain dict (decoded JSON-RPC) or a peagen.protocols.methods.task.PatchResult object.
 
 Returns a JSON-serialisable mapping:
   { "report": {…}, "strict_failed": bool }
@@ -19,11 +19,11 @@ import os
 
 from peagen.core.eval_core import evaluate_workspace
 from peagen._utils.config_loader import resolve_cfg
-from peagen.schemas import TaskRead
+from peagen.protocols.methods.task import PatchResult
 from . import ensure_task
 
 
-async def eval_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
+async def eval_handler(task_or_dict: Dict[str, Any] | PatchResult) -> Dict[str, Any]:
     task = ensure_task(task_or_dict)
     payload = task.payload
     args: Dict[str, Any] = payload.get("args", {})

--- a/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List
 
 import yaml
 
-from peagen.schemas import TaskRead
+from peagen.protocols.methods.task import PatchResult
 from peagen.orm.status import Status
 from .fanout import fan_out
 from . import ensure_task
@@ -33,7 +33,7 @@ def _load_spec(path_or_text: str) -> tuple[Path | None, dict]:
     return None, yaml.safe_load(path_or_text)
 
 
-async def evolve_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
+async def evolve_handler(task_or_dict: Dict[str, Any] | PatchResult) -> Dict[str, Any]:
     task = ensure_task(task_or_dict)
     payload = task.payload
     args: Dict[str, Any] = payload.get("args", {})
@@ -75,7 +75,7 @@ async def evolve_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, A
                 return str(resolved)
         return str(resolved)
 
-    children: List[TaskRead] = []
+    children: List[PatchResult] = []
     for job in jobs:
         if mutations is not None:
             job.setdefault("mutations", mutations)

--- a/pkgs/standards/peagen/peagen/handlers/extras_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/extras_handler.py
@@ -10,11 +10,11 @@ from . import ensure_task
 from peagen._utils import maybe_clone_repo
 
 from peagen.core.extras_core import generate_schemas
-from peagen.schemas import TaskRead
+from peagen.protocols.methods.task import PatchResult
 from .repo_utils import fetch_repo, cleanup_repo
 
 
-async def extras_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
+async def extras_handler(task_or_dict: Dict[str, Any] | PatchResult) -> Dict[str, Any]:
     """Generate EXTRAS schemas based on template-set ``EXTRAS.md`` files."""
     task = ensure_task(task_or_dict)
     payload = task.payload

--- a/pkgs/standards/peagen/peagen/handlers/fanout.py
+++ b/pkgs/standards/peagen/peagen/handlers/fanout.py
@@ -6,7 +6,7 @@ from typing import Iterable, List, Dict, Any
 
 import httpx
 
-from peagen.schemas import TaskRead
+from peagen.protocols.methods.task import PatchResult
 from peagen.orm.status import Status
 from peagen.protocols import Request as RPCEnvelope
 from peagen.protocols.methods import TASK_SUBMIT, TASK_PATCH
@@ -15,8 +15,8 @@ from . import ensure_task
 
 
 async def fan_out(
-    parent: TaskRead | Dict[str, Any],
-    children: Iterable[TaskRead],
+    parent: PatchResult | Dict[str, Any],
+    children: Iterable[PatchResult],
     *,
     result: Dict[str, Any] | None = None,
     final_status: Status = Status.waiting,

--- a/pkgs/standards/peagen/peagen/handlers/fetch_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/fetch_handler.py
@@ -2,7 +2,7 @@
 """
 Async entry-point for the *fetch* pipeline.
 
-• Accepts either a plain dict (decoded JSON-RPC) or a peagen.schemas.TaskRead.
+• Accepts either a plain dict (decoded JSON-RPC) or a peagen.protocols.methods.task.PatchResult.
 • Delegates all heavy-lifting to core.fetch_core.fetch_many().
 • Returns a lightweight JSON-serialisable summary.
 """
@@ -15,10 +15,10 @@ from typing import Any, Dict, List
 from . import ensure_task
 
 from peagen.core.fetch_core import fetch_many
-from peagen.schemas import TaskRead
+from peagen.protocols.methods.task import PatchResult
 
 
-async def fetch_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
+async def fetch_handler(task_or_dict: Dict[str, Any] | PatchResult) -> Dict[str, Any]:
     """
     Parameters (in task.payload.args)
     ---------------------------------

--- a/pkgs/standards/peagen/peagen/handlers/init_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/init_handler.py
@@ -3,7 +3,7 @@
 
 Asynchronous entry-point for initialisation tasks.
 
-The handler accepts either a plain dictionary or a :class:`peagen.schemas.TaskRead`
+The handler accepts either a plain dictionary or a :class:`peagen.protocols.methods.task.PatchResult`
 and delegates to :mod:`peagen.core.init_core`.
 """
 
@@ -13,11 +13,11 @@ from pathlib import Path
 from typing import Any, Dict
 
 from peagen.core import init_core
-from peagen.schemas import TaskRead
+from peagen.protocols.methods.task import PatchResult
 from . import ensure_task
 
 
-async def init_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
+async def init_handler(task_or_dict: Dict[str, Any] | PatchResult) -> Dict[str, Any]:
     """Dispatch to the correct init function based on ``kind``."""
     task = ensure_task(task_or_dict)
     payload = task.payload

--- a/pkgs/standards/peagen/peagen/handlers/keys_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/keys_handler.py
@@ -6,11 +6,11 @@ from pathlib import Path
 from typing import Any, Dict
 
 from peagen.core import keys_core
-from peagen.schemas import TaskRead
+from peagen.protocols.methods.task import PatchResult
 from . import ensure_task
 
 
-async def keys_handler(task: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
+async def keys_handler(task: Dict[str, Any] | PatchResult) -> Dict[str, Any]:
     """Handle key management actions."""
     task = ensure_task(task)
     payload = task.payload

--- a/pkgs/standards/peagen/peagen/handlers/login_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/login_handler.py
@@ -6,11 +6,11 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from peagen.core.login_core import login
-from peagen.schemas import TaskRead
+from peagen.protocols.methods.task import PatchResult
 from . import ensure_task
 
 
-async def login_handler(task: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
+async def login_handler(task: Dict[str, Any] | PatchResult) -> Dict[str, Any]:
     """Handle a login task."""
     task = ensure_task(task)
     payload = task.payload

--- a/pkgs/standards/peagen/peagen/handlers/migrate_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/migrate_handler.py
@@ -9,11 +9,11 @@ from peagen.core.migrate_core import (
     alembic_revision,
     alembic_upgrade,
 )
-from peagen.schemas import TaskRead
+from peagen.protocols.methods.task import PatchResult
 from . import ensure_task
 
 
-async def migrate_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
+async def migrate_handler(task_or_dict: Dict[str, Any] | PatchResult) -> Dict[str, Any]:
     task = ensure_task(task_or_dict)
     args: Dict[str, Any] = task.payload["args"]
     op: str = args["op"]

--- a/pkgs/standards/peagen/peagen/handlers/mutate_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/mutate_handler.py
@@ -9,13 +9,13 @@ from typing import Any, Dict
 from . import ensure_task
 
 from peagen.core.mutate_core import mutate_workspace
-from peagen.schemas import TaskRead
+from peagen.protocols.methods.task import PatchResult
 from peagen._utils.config_loader import resolve_cfg
 from peagen.plugins import PluginManager
 from peagen.plugins.vcs import pea_ref
 
 
-async def mutate_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
+async def mutate_handler(task_or_dict: Dict[str, Any] | PatchResult) -> Dict[str, Any]:
     task = ensure_task(task_or_dict)
     payload = task.payload
     args: Dict[str, Any] = payload.get("args", {})

--- a/pkgs/standards/peagen/peagen/handlers/process_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/process_handler.py
@@ -4,7 +4,7 @@ Unified entry-point for “process” tasks.
 
 A worker (or a local CLI run) will pass in either:
   • a plain ``dict`` decoded from JSON-RPC, or
-  • a ``peagen.schemas.TaskRead`` instance.
+  • a ``peagen.protocols.methods.task.PatchResult`` instance.
 
 The handler merges CLI-style overrides with ``.peagen.toml``,
 invokes the appropriate functions in **process_core**, and
@@ -25,16 +25,16 @@ from peagen.core.process_core import (
     process_single_project,
     process_all_projects,
 )
-from peagen.schemas import TaskRead
+from peagen.protocols.methods.task import PatchResult
 from . import ensure_task
 
 logger = Logger(name=__name__)
 
 
-async def process_handler(task: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
+async def process_handler(task: Dict[str, Any] | PatchResult) -> Dict[str, Any]:
     """Main coroutine invoked by workers and synchronous CLI runs."""
     # ------------------------------------------------------------------ #
-    # 0) Normalise input – accept TaskRead *or* plain dict
+    # 0) Normalise input – accept PatchResult *or* plain dict
     # ------------------------------------------------------------------ #
     canonical = ensure_task(task)
     payload: Dict[str, Any] = canonical.payload

--- a/pkgs/standards/peagen/peagen/handlers/secrets_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/secrets_handler.py
@@ -6,11 +6,11 @@ from pathlib import Path
 from typing import Any, Dict
 
 from peagen.core import secrets_core
-from peagen.schemas import TaskRead
+from peagen.protocols.methods.task import PatchResult
 from . import ensure_task
 
 
-async def secrets_handler(task: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
+async def secrets_handler(task: Dict[str, Any] | PatchResult) -> Dict[str, Any]:
     """Dispatch secret management actions."""
     task = ensure_task(task)
     payload = task.payload

--- a/pkgs/standards/peagen/peagen/handlers/sort_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/sort_handler.py
@@ -21,7 +21,7 @@ Expected task payload
 from __future__ import annotations
 from typing import Any, Dict
 
-from peagen.schemas import TaskRead
+from peagen.protocols.methods.task import PatchResult
 
 from . import ensure_task
 
@@ -31,7 +31,7 @@ from peagen.core.sort_core import sort_single_project, sort_all_projects
 from peagen._utils.config_loader import resolve_cfg
 
 
-async def sort_handler(task: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
+async def sort_handler(task: Dict[str, Any] | PatchResult) -> Dict[str, Any]:
     """
     Async handler registered under JSON-RPC method ``Task.sort`` (or similar).
 

--- a/pkgs/standards/peagen/peagen/handlers/templates_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/templates_handler.py
@@ -16,11 +16,11 @@ from peagen.core.templates_core import (
     add_template_set,
     remove_template_set,
 )
-from peagen.schemas import TaskRead
+from peagen.protocols.methods.task import PatchResult
 from . import ensure_task
 
 
-async def templates_handler(task: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
+async def templates_handler(task: Dict[str, Any] | PatchResult) -> Dict[str, Any]:
     """Dispatch template-set operations based on ``args.operation``."""
     task = ensure_task(task)
     payload = task.payload

--- a/pkgs/standards/peagen/peagen/handlers/validate_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/validate_handler.py
@@ -8,10 +8,12 @@ from . import ensure_task
 from peagen._utils import maybe_clone_repo
 
 from peagen.core.validate_core import validate_artifact
-from peagen.schemas import TaskRead
+from peagen.protocols.methods.task import PatchResult
 
 
-async def validate_handler(task_or_dict: Dict[str, Any] | TaskRead) -> Dict[str, Any]:
+async def validate_handler(
+    task_or_dict: Dict[str, Any] | PatchResult,
+) -> Dict[str, Any]:
     task = ensure_task(task_or_dict)
     args: Dict[str, Any] = task.payload["args"]
     repo = args.get("repo")

--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -31,7 +31,7 @@ from peagen._utils.config_loader import resolve_cfg
 from peagen.plugins import PluginManager
 from peagen.errors import HTTPClientNotInitializedError
 from peagen.handlers import ensure_task
-from peagen.schemas import TaskRead
+from peagen.protocols.methods.task import PatchResult
 
 
 # ──────────────────────────── utils  ────────────────────────────
@@ -211,7 +211,7 @@ class WorkerBase:
         return list(self._handler_registry.keys())
 
     # ───────────────────────── Dispatch & Task Execution ─────────────────────────
-    async def _run_task(self, task: TaskRead | Dict[str, Any]) -> None:
+    async def _run_task(self, task: PatchResult | Dict[str, Any]) -> None:
         """Execute *task* by dispatching to a registered handler."""
         canonical = ensure_task(task)
         task_id = str(canonical.id)


### PR DESCRIPTION
## Summary
- refactor peagen handlers to depend on `peagen.protocols`
- update `ensure_task` helper to produce `PatchResult` and accept dataclasses
- adjust worker to use new task type

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `PEAGEN_TEST_GATEWAY=http://127.0.0.1:9999 uv run --package peagen --directory pkgs/standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_686173edd4b88326b12ba04a309f34ce