### PR TITLE
Refactor gateway RPC methods

### DIFF
--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -19,7 +19,12 @@ from json.decoder import JSONDecodeError
 from peagen.transport import RPCDispatcher
 from peagen.protocols import Request as RPCRequest, Response as RPCResponse
 from peagen.protocols import Request as RPCEnvelope
-from peagen.protocols.methods.work import WORK_START, WORK_CANCEL, WORK_FINISHED
+from peagen.protocols.methods.work import (
+    WORK_START,
+    WORK_CANCEL,
+    WORK_FINISHED,
+    FinishedParams,
+)
 from peagen.protocols.methods.worker import (
     WORKER_HEARTBEAT,
     WORKER_REGISTER,

--- a/pkgs/standards/peagen/tests/unit/test_task_patch_finalize.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_patch_finalize.py
@@ -1,7 +1,6 @@
 import uuid
 import pytest
 from peagen.plugins.queues.in_memory_queue import InMemoryQueue
-from peagen.protocols.methods.work import FinishedParams
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- remove duplicate implementations from gateway
- delegate RPC method exposure through `__getattr__`
- add missing import for `FinishedParams`

## Testing
- `ruff check . --fix`
- `pytest` *(fails: 10 failed, 219 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6861760f25ac8326a4f865dfbfbbf6b9