### PR TITLE
Fix peagen protocol imports

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/process.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/process.py
@@ -201,7 +201,7 @@ def submit(  # noqa: PLR0913 – CLI signature needs many options
 
     if reply.error:
         typer.secho(
-            f"Remote error {reply['error']['code']}: {reply['error']['message']}",
+            f"Remote error {reply.error.code}: {reply.error.message}",
             fg=typer.colors.RED,
             err=True,
         )

--- a/pkgs/standards/peagen/peagen/handlers/__init__.py
+++ b/pkgs/standards/peagen/peagen/handlers/__init__.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from typing import Any, Dict
+
 import uuid
 
 from peagen.orm.status import Status
@@ -26,16 +26,13 @@ def ensure_task(task: PatchResult | Dict[str, Any]) -> PatchResult:
     # a local CLI invocation and populate sane defaults so handler logic can
     # operate on a complete ``PatchResult`` model.
     defaults = {
-        "id": str(uuid.uuid4()),
-        "tenant_id": str(uuid.uuid4()),
-        "git_reference_id": str(uuid.uuid4()),
         "pool": task.get("pool", "default"),
         "payload": task.get("payload", {}),
         "status": Status.queued,
         "note": "",
-        "spec_hash": uuid.uuid4().hex * 2,
-        "date_created": datetime.now(timezone.utc).isoformat(),
-        "last_modified": datetime.now(timezone.utc).isoformat(),
+        "config_toml": None,
+        "labels": [],
+        "result": None,
     }
 
     merged = {**defaults, **task}

--- a/pkgs/standards/peagen/peagen/protocols/methods/pool.py
+++ b/pkgs/standards/peagen/peagen/protocols/methods/pool.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, RootModel
+from typing import List
+
+from pydantic import BaseModel, ConfigDict, Field
 
 from .._registry import register
 
@@ -15,6 +17,7 @@ class CreateResult(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     name: str
+
 
 class JoinParams(BaseModel):
     model_config = ConfigDict(extra="forbid")
@@ -36,8 +39,8 @@ class ListParams(BaseModel):
     offset: int = 0
 
 
-class ListResult(RootModel[list[dict]]):
-    model_config = ConfigDict(extra="forbid")   
+class ListResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
 
     poolName: str
     limit: int | None = None

--- a/pkgs/standards/peagen/peagen/protocols/methods/task.py
+++ b/pkgs/standards/peagen/peagen/protocols/methods/task.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import Optional
 
 from pydantic import BaseModel, ConfigDict
+from peagen.schemas import TaskCreate
 
 from peagen.orm import Status
 from peagen.protocols._registry import register
@@ -12,18 +13,7 @@ class SubmitParams(BaseModel):
 
     model_config = ConfigDict(extra="allow")
 
-    id: str = Field(default=str(uuid.uuid4()))
-    pool: str
-    payload: dict
-    status: Status = Status.waiting
-    result: Optional[dict] = None
-    deps: List[str] = Field(default_factory=list)
-    edge_pred: str | None = None
-    labels: List[str] = Field(default_factory=list)
-    in_degree: int = 0
-    config_toml: str | None = None
-    date_created: float | None = None
-    last_modified: float | None = None
+    task: TaskCreate
 
 
 class SubmitResult(BaseModel):
@@ -43,8 +33,10 @@ class SubmitResult(BaseModel):
 class PatchParams(SubmitParams):
     """Parameters for the ``Task.patch`` RPC method."""
 
+
 class PatchResult(SubmitResult):
     """Patched task representation."""
+
 
 class SimpleSelectorParams(BaseModel):
     """Common selector parameter used by control RPC methods."""


### PR DESCRIPTION
## Summary
- fix imports for SubmitParams and Pool protocol
- adjust task builder and process CLI after schema changes
- update handler utils to avoid extra fields

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format peagen/protocols/methods/task.py peagen/protocols/methods/pool.py peagen/cli/task_builder.py peagen/cli/commands/process.py peagen/handlers/__init__.py`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/protocols/methods/task.py peagen/protocols/methods/pool.py peagen/cli/task_builder.py peagen/cli/commands/process.py peagen/handlers/__init__.py --fix`

------
https://chatgpt.com/codex/tasks/task_e_68617f903158832688f24530bf4a7853