### PR TITLE
Refactor gateway RPC exports

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -722,61 +722,13 @@ app.add_event_handler("startup", _on_start)
 app.add_event_handler("shutdown", _on_shutdown)
 
 
-# expose RPC handlers lazily to avoid circular imports
-__all__ = [
-    "keys_upload",
-    "keys_fetch",
-    "keys_delete",
-    "pool_create",
-    "pool_join",
-    "pool_list",
-    "task_submit",
-    "task_cancel",
-    "task_pause",
-    "task_resume",
-    "task_retry",
-    "task_retry_from",
-    "guard_set",
-    "secrets_add",
-    "secrets_get",
-    "secrets_delete",
-    "task_patch",
-    "task_get",
-    "worker_register",
-    "worker_heartbeat",
-    "worker_list",
-    "work_finished",
-]
+# export RPC handlers from the dedicated ``rpc`` package
+from . import rpc  # noqa: E402
+
+__all__ = list(rpc.__all__)
 
 
 def __getattr__(name: str):
-    if name in __all__:
-        from .rpc import keys, pool, tasks, workers, secrets
+    """Delegate RPC handler lookups to :mod:`peagen.gateway.rpc`."""
 
-        modules = {
-            "keys_upload": keys,
-            "keys_fetch": keys,
-            "keys_delete": keys,
-            "pool_create": pool,
-            "pool_join": pool,
-            "pool_list": pool,
-            "task_submit": tasks,
-            "task_cancel": tasks,
-            "task_pause": tasks,
-            "task_resume": tasks,
-            "task_retry": tasks,
-            "task_retry_from": tasks,
-            "guard_set": tasks,
-            "secrets_add": secrets,
-            "secrets_get": secrets,
-            "secrets_delete": secrets,
-            "task_patch": tasks,
-            "task_get": tasks,
-            "worker_register": workers,
-            "worker_heartbeat": workers,
-            "worker_list": workers,
-            "work_finished": workers,
-        }
-        module = modules[name]
-        return getattr(module, name)
-    raise AttributeError(name)
+    return getattr(rpc, name)

--- a/pkgs/standards/peagen/peagen/gateway/rpc/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/__init__.py
@@ -1,0 +1,61 @@
+"""Convenience accessors for gateway RPC handlers."""
+
+from __future__ import annotations
+
+__all__ = [
+    "keys_upload",
+    "keys_fetch",
+    "keys_delete",
+    "pool_create",
+    "pool_join",
+    "pool_list",
+    "task_submit",
+    "task_cancel",
+    "task_pause",
+    "task_resume",
+    "task_retry",
+    "task_retry_from",
+    "guard_set",
+    "secrets_add",
+    "secrets_get",
+    "secrets_delete",
+    "task_patch",
+    "task_get",
+    "worker_register",
+    "worker_heartbeat",
+    "worker_list",
+    "work_finished",
+]
+
+
+def __getattr__(name: str):
+    if name in __all__:
+        from . import keys, pool, secrets, tasks, workers
+
+        modules = {
+            "keys_upload": keys,
+            "keys_fetch": keys,
+            "keys_delete": keys,
+            "pool_create": pool,
+            "pool_join": pool,
+            "pool_list": pool,
+            "task_submit": tasks,
+            "task_cancel": tasks,
+            "task_pause": tasks,
+            "task_resume": tasks,
+            "task_retry": tasks,
+            "task_retry_from": tasks,
+            "guard_set": tasks,
+            "secrets_add": secrets,
+            "secrets_get": secrets,
+            "secrets_delete": secrets,
+            "task_patch": tasks,
+            "task_get": tasks,
+            "worker_register": workers,
+            "worker_heartbeat": workers,
+            "worker_list": workers,
+            "work_finished": workers,
+        }
+        module = modules[name]
+        return getattr(module, name)
+    raise AttributeError(name)


### PR DESCRIPTION
## Summary
- centralize RPC handler exports in `gateway.rpc`
- delegate handler lookups to the `rpc` package

## Testing
- `uv run --directory standards/peagen --package peagen ruff check peagen/gateway/rpc/__init__.py peagen/gateway/__init__.py --fix`
- `uv run --directory standards/peagen --package peagen ruff format peagen/gateway/rpc/__init__.py peagen/gateway/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_686182b5c83c8326ad640836a959e1cf