### PR TITLE
Fix CLI submit models for peagen

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/db.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/db.py
@@ -55,7 +55,8 @@ def _submit_task(op: str, gateway_url: str, message: str | None = None) -> str:
     )
     if reply.error:
         raise RuntimeError(reply.error.message)
-    return str(reply.result.taskId if reply.result else submit.task.id)
+    task_id = reply.result.taskId if reply.result else submit.id
+    return str(task_id)
 
 
 @local_db_app.command("upgrade")

--- a/pkgs/standards/peagen/peagen/cli/commands/doe.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/doe.py
@@ -164,7 +164,8 @@ def submit_gen(  # noqa: PLR0913
         )
         raise typer.Exit(1)
 
-    typer.secho(f"Submitted task {submit.task.id}", fg=typer.colors.GREEN)
+    task_id = reply.result.taskId if reply.result else submit.id
+    typer.secho(f"Submitted task {task_id}", fg=typer.colors.GREEN)
 
 
 # ───────────────────────────── local process ─────────────────────────────

--- a/pkgs/standards/peagen/peagen/cli/task_builder.py
+++ b/pkgs/standards/peagen/peagen/cli/task_builder.py
@@ -17,11 +17,13 @@ def _build_task(
 ) -> Any:
     """Return a Task model (via :class:`SubmitParams`) with *action* and *args* embedded."""
 
+    repo = args.pop("repo", "")
     return {
         "id": str(uuid.uuid4()),
         "tenant_id": str(uuid.uuid4()),
         "git_reference_id": str(uuid.uuid4()),
         "pool": pool,
+        "repo": repo,
         "payload": {"action": action, "args": args},
         "status": status,
         "note": "",

--- a/pkgs/standards/peagen/peagen/services/__init__.py
+++ b/pkgs/standards/peagen/peagen/services/__init__.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Optional
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from peagen.schemas import TaskCreate, TaskUpdate, TaskRead
+from peagen.orm.task.task import TaskModel
+from peagen.orm.task.task_run import TaskRunModel
+from peagen.orm.status import Status
+
+
+async def create_task(session: AsyncSession, task: TaskCreate) -> TaskRead:
+    """Insert a new task row and return the created ``TaskRead``."""
+    orm = TaskModel(**task.model_dump())
+    session.add(orm)
+    session.add(TaskRunModel(task_id=orm.id, status=Status.queued))
+    await session.commit()
+    await session.refresh(orm)
+    return TaskRead.from_orm(orm)
+
+
+async def get_task(session: AsyncSession, task_id: str) -> Optional[TaskRead]:
+    """Return a ``TaskRead`` for *task_id* or ``None`` if missing."""
+    row = await session.get(TaskModel, task_id)
+    return TaskRead.from_orm(row) if row else None
+
+
+async def update_task(session: AsyncSession, task_id: str, changes: TaskUpdate) -> None:
+    """Apply ``changes`` to the existing task."""
+    data = changes.model_dump(exclude_unset=True)
+    if data:
+        await session.execute(
+            sa.update(TaskModel).where(TaskModel.id == task_id).values(**data)
+        )
+        await session.commit()
+
+
+# helper used by RPC layer
+
+
+def _to_schema(row: TaskModel) -> TaskRead:
+    """Convert a ``TaskModel`` row to a ``TaskRead`` schema."""
+    return TaskRead.from_orm(row)

--- a/pkgs/standards/peagen/peagen/services/tasks.py
+++ b/pkgs/standards/peagen/peagen/services/tasks.py
@@ -1,0 +1,9 @@
+"""Compatibility helpers for task schema conversions."""
+
+from peagen.schemas import TaskRead
+from peagen.orm.task.task import TaskModel
+
+
+def _to_schema(row: TaskModel) -> TaskRead:
+    """Convert a ``TaskModel`` row to a ``TaskRead`` schema."""
+    return TaskRead.from_orm(row)

--- a/pkgs/standards/peagen/peagen/transport/__init__.py
+++ b/pkgs/standards/peagen/peagen/transport/__init__.py
@@ -4,7 +4,7 @@ from peagen.protocols import (
     Response as RPCResponse,
     Error as RPCErrorData,
 )
-from peagen.transport.schemas import RPCException
+from peagen.transport.jsonrpc import RPCException
 
 __all__ = [
     "RPCDispatcher",


### PR DESCRIPTION
## Summary
- fix transport import for RPCException
- keep repo field when building submit params
- ensure CLI doesn't access missing task attribute
- provide simple DB service helpers for gateway
- handle new SubmitParams structure in task_submit

## Testing
- `uv run --package peagen --directory standards/peagen ruff check .`
- `PEAGEN_TEST_GATEWAY=http://localhost:8000/rpc uv run --package peagen --directory standards/peagen pytest /workspace/swarmauri-sdk/pkgs/standards/peagen/tests/smoke/test_remote_doe_cli.py::test_remote_doe_gen -q` *(fails: skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68618fde6c4083269a8ac804c36c4964