### PR TITLE
Update method references to new transport path

### DIFF
--- a/pkgs/standards/peagen/peagen/_utils/_init.py
+++ b/pkgs/standards/peagen/peagen/_utils/_init.py
@@ -60,10 +60,10 @@ def _submit_task(
     if not allow_pat and ("pat" in args or _contains_pat(args)):
         raise PATNotAllowedError()
     task = TaskCreate(pool="default", payload={"action": "init", "args": args})
-    from peagen.protocols.methods import TASK_SUBMIT
+    from peagen.transport.json_rpcschemas import TASK_SUBMIT
 
     try:
-        from peagen.protocols.methods.task import SubmitParams, SubmitResult
+        from peagen.transport.json_rpcschemas.task import SubmitParams, SubmitResult
         from peagen.cli.rpc_utils import rpc_post
 
         reply = rpc_post(

--- a/pkgs/standards/peagen/peagen/cli/commands/analysis.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/analysis.py
@@ -11,7 +11,7 @@ from functools import partial
 
 from peagen.handlers.analysis_handler import analysis_handler
 from peagen.protocols import TASK_SUBMIT
-from peagen.protocols.methods.task import SubmitParams, SubmitResult
+from peagen.transport.json_rpcschemas.task import SubmitParams, SubmitResult
 from peagen.cli.task_builder import _build_task as _generic_build_task
 
 DEFAULT_GATEWAY = "http://localhost:8000/rpc"

--- a/pkgs/standards/peagen/peagen/cli/commands/db.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/db.py
@@ -14,7 +14,7 @@ import typer
 from peagen.handlers.migrate_handler import migrate_handler
 
 from peagen.protocols import TASK_SUBMIT
-from peagen.protocols.methods.task import SubmitResult
+from peagen.transport.json_rpcschemas.task import SubmitResult
 from peagen.cli.task_builder import build_submit_params
 
 

--- a/pkgs/standards/peagen/peagen/cli/commands/doe.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/doe.py
@@ -17,7 +17,7 @@ import typer
 from peagen.handlers.doe_handler import doe_handler
 from peagen.handlers.doe_process_handler import doe_process_handler
 from peagen.protocols import TASK_SUBMIT, TASK_GET
-from peagen.protocols.methods.task import (
+from peagen.transport.json_rpcschemas.task import (
     SubmitParams,
     SubmitResult,
     GetParams,

--- a/pkgs/standards/peagen/peagen/cli/commands/eval.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/eval.py
@@ -22,7 +22,7 @@ from peagen._utils.config_loader import load_peagen_toml
 
 from peagen.handlers.eval_handler import eval_handler
 from peagen.protocols import TASK_SUBMIT
-from peagen.protocols.methods.task import SubmitParams, SubmitResult
+from peagen.transport.json_rpcschemas.task import SubmitParams, SubmitResult
 from peagen.cli.task_builder import _build_task as _generic_build_task
 
 DEFAULT_GATEWAY = "http://localhost:8000/rpc"

--- a/pkgs/standards/peagen/peagen/cli/commands/evolve.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/evolve.py
@@ -15,7 +15,7 @@ from peagen.handlers.evolve_handler import evolve_handler
 from peagen.orm.status import Status
 from peagen.core.validate_core import validate_evolve_spec
 from peagen.protocols import TASK_SUBMIT, TASK_GET
-from peagen.protocols.methods.task import (
+from peagen.transport.json_rpcschemas.task import (
     SubmitParams,
     SubmitResult,
     GetParams,

--- a/pkgs/standards/peagen/peagen/cli/commands/extras.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/extras.py
@@ -12,7 +12,7 @@ from functools import partial
 from peagen.handlers.extras_handler import extras_handler
 from swarmauri_standard.loggers.Logger import Logger
 from peagen.protocols import TASK_SUBMIT
-from peagen.protocols.methods.task import SubmitParams, SubmitResult
+from peagen.transport.json_rpcschemas.task import SubmitParams, SubmitResult
 from peagen.cli.rpc_utils import rpc_post
 from peagen.cli.task_builder import _build_task as _generic_build_task
 

--- a/pkgs/standards/peagen/peagen/cli/commands/keys.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/keys.py
@@ -12,7 +12,7 @@ import typer
 from peagen.plugins.secret_drivers import AutoGpgDriver
 from peagen.core import keys_core
 from peagen.protocols import KEYS_UPLOAD, KEYS_DELETE, KEYS_FETCH
-from peagen.protocols.methods.keys import (
+from peagen.transport.json_rpcschemas.keys import (
     UploadParams,
     DeleteParams,
     FetchParams,

--- a/pkgs/standards/peagen/peagen/cli/commands/login.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/login.py
@@ -10,7 +10,7 @@ import typer
 
 from peagen.plugins.secret_drivers import AutoGpgDriver
 from peagen.protocols import KEYS_UPLOAD
-from peagen.protocols.methods.keys import UploadParams, UploadResult
+from peagen.transport.json_rpcschemas.keys import UploadParams, UploadResult
 
 
 login_app = typer.Typer(help="Authenticate and upload your public key.")

--- a/pkgs/standards/peagen/peagen/cli/commands/mutate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/mutate.py
@@ -14,7 +14,7 @@ from functools import partial
 
 from peagen.handlers.mutate_handler import mutate_handler
 from peagen.protocols import TASK_SUBMIT
-from peagen.protocols.methods.task import SubmitParams, SubmitResult
+from peagen.transport.json_rpcschemas.task import SubmitParams, SubmitResult
 from peagen.cli.task_builder import _build_task as _generic_build_task
 
 DEFAULT_GATEWAY = "http://localhost:8000/rpc"

--- a/pkgs/standards/peagen/peagen/cli/commands/process.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/process.py
@@ -22,7 +22,7 @@ from functools import partial
 from peagen._utils.config_loader import _effective_cfg, load_peagen_toml
 from peagen.handlers.process_handler import process_handler
 from peagen.protocols import TASK_SUBMIT, TASK_GET, Request
-from peagen.protocols.methods.task import (
+from peagen.transport.json_rpcschemas.task import (
     GetParams,
     GetResult,
 )

--- a/pkgs/standards/peagen/peagen/cli/commands/secrets.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/secrets.py
@@ -11,7 +11,7 @@ import typer
 
 from peagen.plugins.secret_drivers import AutoGpgDriver
 from peagen.protocols import SECRETS_ADD, SECRETS_GET, SECRETS_DELETE
-from peagen.protocols.methods.secrets import (
+from peagen.transport.json_rpcschemas.secrets import (
     AddParams,
     GetParams,
     DeleteParams,
@@ -19,7 +19,7 @@ from peagen.protocols.methods.secrets import (
     GetResult,
     DeleteResult,
 )
-from peagen.protocols.methods.worker import WORKER_LIST, ListParams, ListResult
+from peagen.transport.json_rpcschemas.worker import WORKER_LIST, ListParams, ListResult
 
 
 local_secrets_app = typer.Typer(help="Manage local secret store.")

--- a/pkgs/standards/peagen/peagen/cli/commands/sort.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/sort.py
@@ -10,7 +10,7 @@ import typer
 from peagen._utils.config_loader import _effective_cfg, load_peagen_toml
 from peagen.handlers.sort_handler import sort_handler
 from peagen.protocols import TASK_SUBMIT
-from peagen.protocols.methods.task import SubmitResult
+from peagen.transport.json_rpcschemas.task import SubmitResult
 from peagen.cli.task_builder import build_submit_params
 from peagen.cli.rpc_utils import rpc_post
 

--- a/pkgs/standards/peagen/peagen/cli/commands/task.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/task.py
@@ -18,7 +18,7 @@ from peagen.protocols import (
     TASK_RETRY,
     TASK_RETRY_FROM,
 )
-from peagen.protocols.methods.task import (
+from peagen.transport.json_rpcschemas.task import (
     GetParams,
     GetResult,
     PatchParams,

--- a/pkgs/standards/peagen/peagen/cli/commands/templates.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/templates.py
@@ -9,7 +9,7 @@ import typer
 
 from peagen.handlers.templates_handler import templates_handler
 from peagen.protocols import TASK_SUBMIT
-from peagen.protocols.methods.task import SubmitResult
+from peagen.transport.json_rpcschemas.task import SubmitResult
 from peagen.cli.task_builder import build_submit_params
 
 # ──────────────────────────────────────

--- a/pkgs/standards/peagen/peagen/cli/commands/validate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/validate.py
@@ -7,7 +7,7 @@ import typer
 
 from peagen.handlers.validate_handler import validate_handler
 from peagen.protocols import TASK_SUBMIT
-from peagen.protocols.methods.task import SubmitResult
+from peagen.transport.json_rpcschemas.task import SubmitResult
 from peagen.cli.task_builder import build_submit_params
 from peagen.cli.rpc_utils import rpc_post
 

--- a/pkgs/standards/peagen/peagen/core/keys_core.py
+++ b/pkgs/standards/peagen/peagen/core/keys_core.py
@@ -13,7 +13,7 @@ from peagen.plugins import PluginManager
 from pydantic import TypeAdapter
 
 from peagen.protocols import Request, Response
-from peagen.protocols.methods.keys import (
+from peagen.transport.json_rpcschemas.keys import (
     KEYS_UPLOAD,
     KEYS_DELETE,
     KEYS_FETCH,

--- a/pkgs/standards/peagen/peagen/core/secrets_core.py
+++ b/pkgs/standards/peagen/peagen/core/secrets_core.py
@@ -13,7 +13,7 @@ from peagen.plugins.secret_drivers import AutoGpgDriver
 from pydantic import TypeAdapter
 
 from peagen.protocols import Request, Response
-from peagen.protocols.methods.secrets import (
+from peagen.transport.json_rpcschemas.secrets import (
     SECRETS_ADD,
     SECRETS_GET,
     SECRETS_DELETE,
@@ -24,7 +24,7 @@ from peagen.protocols.methods.secrets import (
     DeleteParams,
     DeleteResult,
 )
-from peagen.protocols.methods.worker import WORKER_LIST, ListParams, ListResult
+from peagen.transport.json_rpcschemas.worker import WORKER_LIST, ListParams, ListResult
 
 R = TypeVar("R")
 

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -34,7 +34,7 @@ from peagen.transport.jsonrpc import RPCException as RPCException
 from peagen.orm import Base
 from peagen.orm.status import Status
 from pydantic import ValidationError
-from peagen.protocols.methods.work import WORK_START
+from peagen.transport.json_rpcschemas.work import WORK_START
 from peagen.schemas import TaskRead, TaskCreate, TaskUpdate
 from peagen.orm import TaskModel, TaskRunModel
 

--- a/pkgs/standards/peagen/peagen/gateway/rpc/keys.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/keys.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pgpy import PGPKey
 
 from .. import dispatcher, log, TRUSTED_USERS
-from peagen.protocols.methods.keys import (
+from peagen.transport.json_rpcschemas.keys import (
     KEYS_UPLOAD,
     KEYS_FETCH,
     KEYS_DELETE,

--- a/pkgs/standards/peagen/peagen/gateway/rpc/pool.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/pool.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 
 from .. import READY_QUEUE, dispatcher, log, queue
-from peagen.protocols.methods.pool import (
+from peagen.transport.json_rpcschemas.pool import (
     POOL_CREATE,
     POOL_JOIN,
     POOL_LIST_TASKS,

--- a/pkgs/standards/peagen/peagen/gateway/rpc/secrets.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/secrets.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from .. import Session, dispatcher, log
-from peagen.protocols.methods.secrets import (
+from peagen.transport.json_rpcschemas.secrets import (
     SECRETS_ADD,
     SECRETS_GET,
     SECRETS_DELETE,

--- a/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
@@ -16,7 +16,7 @@ from peagen.protocols import (
     TASK_PATCH,
     TASK_GET,
 )
-from peagen.protocols.methods.task import (
+from peagen.transport.json_rpcschemas.task import (
     SubmitParams,
     SubmitResult,
     PatchParams,
@@ -26,7 +26,7 @@ from peagen.protocols.methods.task import (
     GetParams,
     GetResult,
 )
-from peagen.protocols.methods.guard import GUARD_SET
+from peagen.transport.json_rpcschemas.guard import GUARD_SET
 
 from .. import (
     READY_QUEUE,

--- a/pkgs/standards/peagen/peagen/gateway/rpc/workers.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/workers.py
@@ -21,8 +21,12 @@ from .. import (
 
 from peagen.orm.status import Status
 from peagen.transport.jsonrpc import RPCException
-from peagen.protocols.methods.work import WORK_FINISHED, FinishedParams, FinishedResult
-from peagen.protocols.methods.worker import (
+from peagen.transport.json_rpcschemas.work import (
+    WORK_FINISHED,
+    FinishedParams,
+    FinishedResult,
+)
+from peagen.transport.json_rpcschemas.worker import (
     WORKER_REGISTER,
     WORKER_HEARTBEAT,
     WORKER_LIST,

--- a/pkgs/standards/peagen/peagen/handlers/__init__.py
+++ b/pkgs/standards/peagen/peagen/handlers/__init__.py
@@ -6,11 +6,11 @@ from __future__ import annotations
 import uuid
 
 from peagen.orm.status import Status
-from peagen.protocols.methods.task import SubmitParams
+from peagen.transport.json_rpcschemas.task import SubmitParams
 
 
 def ensure_task(task: SubmitParams) -> SubmitParams:
-    """Return ``task`` as a :class:`~peagen.protocols.methods.task.PatchResult` instance."""
+    """Return ``task`` as a :class:`~peagen.transport.json_rpcschemas.task.PatchResult` instance."""
 
     if isinstance(task, SubmitParams):
         return task

--- a/pkgs/standards/peagen/peagen/handlers/analysis_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/analysis_handler.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 from peagen._utils import maybe_clone_repo
 
 from peagen.core.analysis_core import analyze_runs
-from peagen.protocols.methods.task import SubmitParams, SubmitResult
+from peagen.transport.json_rpcschemas.task import SubmitParams, SubmitResult
 from . import ensure_task
 from peagen._utils.config_loader import resolve_cfg
 from peagen.plugins import PluginManager

--- a/pkgs/standards/peagen/peagen/handlers/control_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/control_handler.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Iterable
 
 from peagen.plugins.queues import QueueBase
-from peagen.protocols.methods.task import PatchResult, SubmitResult
+from peagen.transport.json_rpcschemas.task import PatchResult, SubmitResult
 from peagen.core import control_core
 from peagen import defaults
 

--- a/pkgs/standards/peagen/peagen/handlers/doe_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/doe_handler.py
@@ -10,7 +10,7 @@ from peagen.core.doe_core import (
     create_factor_branches,
     create_run_branches,
 )
-from peagen.protocols.methods.task import SubmitParams, SubmitResult
+from peagen.transport.json_rpcschemas.task import SubmitParams, SubmitResult
 from . import ensure_task
 from peagen._utils.config_loader import resolve_cfg
 from peagen.plugins import PluginManager

--- a/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
@@ -9,7 +9,11 @@ from typing import Any, Dict, List, Tuple
 import yaml
 
 from peagen.core.doe_core import generate_payload
-from peagen.protocols.methods.task import PatchResult, SubmitParams, SubmitResult
+from peagen.transport.json_rpcschemas.task import (
+    PatchResult,
+    SubmitParams,
+    SubmitResult,
+)
 from peagen.orm.status import Status
 from peagen._utils.config_loader import resolve_cfg
 from peagen.plugins import PluginManager

--- a/pkgs/standards/peagen/peagen/handlers/eval_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/eval_handler.py
@@ -3,7 +3,7 @@
 Async task-handler for “eval” jobs.
 
 The worker runtime (or a local CLI run) calls this coroutine with
-either a plain dict (decoded JSON-RPC) or a peagen.protocols.methods.task.PatchResult object.
+either a plain dict (decoded JSON-RPC) or a peagen.transport.json_rpcschemas.task.PatchResult object.
 
 Returns a JSON-serialisable mapping:
   { "report": {…}, "strict_failed": bool }
@@ -19,7 +19,7 @@ import os
 
 from peagen.core.eval_core import evaluate_workspace
 from peagen._utils.config_loader import resolve_cfg
-from peagen.protocols.methods.task import SubmitParams, SubmitResult
+from peagen.transport.json_rpcschemas.task import SubmitParams, SubmitResult
 from . import ensure_task
 
 

--- a/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
@@ -7,7 +7,11 @@ from typing import Any, Dict, List
 
 import yaml
 
-from peagen.protocols.methods.task import PatchResult, SubmitParams, SubmitResult
+from peagen.transport.json_rpcschemas.task import (
+    PatchResult,
+    SubmitParams,
+    SubmitResult,
+)
 from peagen.orm.status import Status
 from .fanout import fan_out
 from . import ensure_task

--- a/pkgs/standards/peagen/peagen/handlers/extras_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/extras_handler.py
@@ -10,7 +10,7 @@ from . import ensure_task
 from peagen._utils import maybe_clone_repo
 
 from peagen.core.extras_core import generate_schemas
-from peagen.protocols.methods.task import SubmitParams, SubmitResult
+from peagen.transport.json_rpcschemas.task import SubmitParams, SubmitResult
 from .repo_utils import fetch_repo, cleanup_repo
 
 

--- a/pkgs/standards/peagen/peagen/handlers/fanout.py
+++ b/pkgs/standards/peagen/peagen/handlers/fanout.py
@@ -8,8 +8,8 @@ import httpx
 
 from peagen.orm.status import Status
 from peagen.protocols import Request as RPCEnvelope
-from peagen.protocols.methods import TASK_SUBMIT, TASK_PATCH
-from peagen.protocols.methods.task import PatchParams, PatchResult
+from peagen.transport.json_rpcschemas import TASK_SUBMIT, TASK_PATCH
+from peagen.transport.json_rpcschemas.task import PatchParams, PatchResult
 from . import ensure_task
 
 

--- a/pkgs/standards/peagen/peagen/handlers/fetch_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/fetch_handler.py
@@ -2,7 +2,7 @@
 """
 Async entry-point for the *fetch* pipeline.
 
-• Accepts either a plain dict (decoded JSON-RPC) or a peagen.protocols.methods.task.PatchResult.
+• Accepts either a plain dict (decoded JSON-RPC) or a peagen.transport.json_rpcschemas.task.PatchResult.
 • Delegates all heavy-lifting to core.fetch_core.fetch_many().
 • Returns a lightweight JSON-serialisable summary.
 """
@@ -15,7 +15,7 @@ from typing import Any, Dict, List
 from . import ensure_task
 
 from peagen.core.fetch_core import fetch_many
-from peagen.protocols.methods.task import SubmitParams, SubmitResult
+from peagen.transport.json_rpcschemas.task import SubmitParams, SubmitResult
 
 
 async def fetch_handler(task_or_dict: Dict[str, Any] | SubmitParams) -> SubmitResult:

--- a/pkgs/standards/peagen/peagen/handlers/init_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/init_handler.py
@@ -3,7 +3,7 @@
 
 Asynchronous entry-point for initialisation tasks.
 
-The handler accepts either a plain dictionary or a :class:`peagen.protocols.methods.task.PatchResult`
+The handler accepts either a plain dictionary or a :class:`peagen.transport.json_rpcschemas.task.PatchResult`
 and delegates to :mod:`peagen.core.init_core`.
 """
 
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 from peagen.core import init_core
-from peagen.protocols.methods.task import SubmitParams, SubmitResult
+from peagen.transport.json_rpcschemas.task import SubmitParams, SubmitResult
 from . import ensure_task
 
 

--- a/pkgs/standards/peagen/peagen/handlers/keys_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/keys_handler.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 from peagen.core import keys_core
-from peagen.protocols.methods.task import SubmitParams, SubmitResult
+from peagen.transport.json_rpcschemas.task import SubmitParams, SubmitResult
 from . import ensure_task
 
 

--- a/pkgs/standards/peagen/peagen/handlers/login_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/login_handler.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from peagen.core.login_core import login
-from peagen.protocols.methods.task import SubmitParams, SubmitResult
+from peagen.transport.json_rpcschemas.task import SubmitParams, SubmitResult
 from . import ensure_task
 
 

--- a/pkgs/standards/peagen/peagen/handlers/migrate_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/migrate_handler.py
@@ -9,7 +9,7 @@ from peagen.core.migrate_core import (
     alembic_revision,
     alembic_upgrade,
 )
-from peagen.protocols.methods.task import SubmitParams, SubmitResult
+from peagen.transport.json_rpcschemas.task import SubmitParams, SubmitResult
 from . import ensure_task
 
 

--- a/pkgs/standards/peagen/peagen/handlers/mutate_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/mutate_handler.py
@@ -9,7 +9,7 @@ from typing import Any, Dict
 from . import ensure_task
 
 from peagen.core.mutate_core import mutate_workspace
-from peagen.protocols.methods.task import SubmitParams, SubmitResult
+from peagen.transport.json_rpcschemas.task import SubmitParams, SubmitResult
 from peagen._utils.config_loader import resolve_cfg
 from peagen.plugins import PluginManager
 from peagen.plugins.vcs import pea_ref

--- a/pkgs/standards/peagen/peagen/handlers/process_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/process_handler.py
@@ -4,7 +4,7 @@ Unified entry-point for “process” tasks.
 
 A worker (or a local CLI run) will pass in either:
   • a plain ``dict`` decoded from JSON-RPC, or
-  • a ``peagen.protocols.methods.task.PatchResult`` instance.
+  • a ``peagen.transport.json_rpcschemas.task.PatchResult`` instance.
 
 The handler merges CLI-style overrides with ``.peagen.toml``,
 invokes the appropriate functions in **process_core**, and
@@ -25,7 +25,7 @@ from peagen.core.process_core import (
     process_single_project,
     process_all_projects,
 )
-from peagen.protocols.methods.task import SubmitParams, SubmitResult
+from peagen.transport.json_rpcschemas.task import SubmitParams, SubmitResult
 from . import ensure_task
 
 logger = Logger(name=__name__)

--- a/pkgs/standards/peagen/peagen/handlers/secrets_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/secrets_handler.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 from peagen.core import secrets_core
-from peagen.protocols.methods.task import SubmitParams, SubmitResult
+from peagen.transport.json_rpcschemas.task import SubmitParams, SubmitResult
 from . import ensure_task
 
 

--- a/pkgs/standards/peagen/peagen/handlers/sort_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/sort_handler.py
@@ -21,7 +21,7 @@ Expected task payload
 from __future__ import annotations
 from typing import Any, Dict
 
-from peagen.protocols.methods.task import SubmitParams, SubmitResult
+from peagen.transport.json_rpcschemas.task import SubmitParams, SubmitResult
 
 from . import ensure_task
 

--- a/pkgs/standards/peagen/peagen/handlers/templates_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/templates_handler.py
@@ -16,7 +16,7 @@ from peagen.core.templates_core import (
     add_template_set,
     remove_template_set,
 )
-from peagen.protocols.methods.task import SubmitParams, SubmitResult
+from peagen.transport.json_rpcschemas.task import SubmitParams, SubmitResult
 from . import ensure_task
 
 

--- a/pkgs/standards/peagen/peagen/handlers/validate_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/validate_handler.py
@@ -8,7 +8,7 @@ from . import ensure_task
 from peagen._utils import maybe_clone_repo
 
 from peagen.core.validate_core import validate_artifact
-from peagen.protocols.methods.task import SubmitParams, SubmitResult
+from peagen.transport.json_rpcschemas.task import SubmitParams, SubmitResult
 
 
 async def validate_handler(task_or_dict: Dict[str, Any] | SubmitParams) -> SubmitResult:

--- a/pkgs/standards/peagen/peagen/transport/json_rpcschemas/__init__.py
+++ b/pkgs/standards/peagen/peagen/transport/json_rpcschemas/__init__.py
@@ -1,0 +1,25 @@
+"""Compatibility wrapper for :mod:`peagen.transport.jsonrpc_schemas`."""
+
+from importlib import import_module
+import sys
+
+# Re-export all names from the canonical package
+from peagen.transport.jsonrpc_schemas import *  # noqa: F401,F403
+
+# Provide submodule aliases so imports like
+# ``peagen.transport.json_rpcschemas.task`` work as expected.
+_submods = [
+    "guard",
+    "keys",
+    "pool",
+    "secrets",
+    "task",
+    "work",
+    "worker",
+]
+for _m in _submods:
+    sys.modules[__name__ + "." + _m] = import_module(
+        f"peagen.transport.jsonrpc_schemas.{_m}"
+    )
+
+del import_module, sys, _submods

--- a/pkgs/standards/peagen/peagen/transport/jsonrpc_schemas/task.py
+++ b/pkgs/standards/peagen/peagen/transport/jsonrpc_schemas/task.py
@@ -12,7 +12,7 @@ class SubmitParams(BaseModel):
 
     model_config = ConfigDict(extra="allow")
 
-    id:   str
+    id: str
     pool: str
     repo: str | None = None
     ref: str | None = None

--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -19,13 +19,13 @@ from json.decoder import JSONDecodeError
 from peagen.transport import RPCDispatcher
 from peagen.protocols import Request as RPCRequest, Response as RPCResponse
 from peagen.protocols import Request as RPCEnvelope
-from peagen.protocols.methods.work import (
+from peagen.transport.json_rpcschemas.work import (
     WORK_START,
     WORK_CANCEL,
     WORK_FINISHED,
     FinishedParams,
 )
-from peagen.protocols.methods.worker import (
+from peagen.transport.json_rpcschemas.worker import (
     WORKER_HEARTBEAT,
     WORKER_REGISTER,
     HeartbeatParams,
@@ -35,7 +35,7 @@ from peagen._utils.config_loader import resolve_cfg
 from peagen.plugins import PluginManager
 from peagen.errors import HTTPClientNotInitializedError
 from peagen.handlers import ensure_task
-from peagen.protocols.methods.task import PatchResult
+from peagen.transport.json_rpcschemas.task import PatchResult
 
 
 # ──────────────────────────── utils  ────────────────────────────

--- a/pkgs/standards/peagen/tests/e2e/test_local_evolve.py
+++ b/pkgs/standards/peagen/tests/e2e/test_local_evolve.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import httpx
 import pytest
-from peagen.protocols.methods.worker import WORKER_LIST
+from peagen.transport.json_rpcschemas.worker import WORKER_LIST
 
 pytestmark = pytest.mark.e2e
 

--- a/pkgs/standards/peagen/tests/i9n/two_user_secret_exchange_i9n_test.py
+++ b/pkgs/standards/peagen/tests/i9n/two_user_secret_exchange_i9n_test.py
@@ -6,7 +6,7 @@ import shutil
 
 import httpx
 import pytest
-from peagen.protocols.methods.worker import WORKER_LIST
+from peagen.transport.json_rpcschemas.worker import WORKER_LIST
 
 GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
 

--- a/pkgs/standards/peagen/tests/sequence_success/test_sequences_success.py
+++ b/pkgs/standards/peagen/tests/sequence_success/test_sequences_success.py
@@ -6,7 +6,7 @@ import os
 import yaml
 import pytest
 import httpx
-from peagen.protocols.methods.worker import WORKER_LIST
+from peagen.transport.json_rpcschemas.worker import WORKER_LIST
 
 EXAMPLES = Path(__file__).resolve().parent / "examples"
 GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")

--- a/pkgs/standards/peagen/tests/smoke/test_cli_task_submit.py
+++ b/pkgs/standards/peagen/tests/smoke/test_cli_task_submit.py
@@ -6,7 +6,7 @@ from typer.testing import CliRunner
 
 from peagen.cli import app
 from peagen.cli.commands import process as process_mod
-from peagen.protocols.methods import TASK_SUBMIT
+from peagen.transport.json_rpcschemas import TASK_SUBMIT
 
 
 @pytest.mark.smoke

--- a/pkgs/standards/peagen/tests/smoke/test_gateway_login_keys_secrets_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_gateway_login_keys_secrets_cli.py
@@ -4,7 +4,7 @@ import subprocess
 
 import httpx
 import pytest
-from peagen.protocols.methods.worker import WORKER_LIST
+from peagen.transport.json_rpcschemas.worker import WORKER_LIST
 
 pytestmark = pytest.mark.smoke
 GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")

--- a/pkgs/standards/peagen/tests/smoke/test_gateway_remote_doe.py
+++ b/pkgs/standards/peagen/tests/smoke/test_gateway_remote_doe.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import httpx
 import pytest
-from peagen.protocols.methods.worker import WORKER_LIST
+from peagen.transport.json_rpcschemas.worker import WORKER_LIST
 
 pytestmark = pytest.mark.smoke
 

--- a/pkgs/standards/peagen/tests/smoke/test_remote_doe_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_doe_cli.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import httpx
 import pytest
-from peagen.protocols.methods.worker import WORKER_LIST
+from peagen.transport.json_rpcschemas.worker import WORKER_LIST
 
 pytestmark = pytest.mark.smoke
 

--- a/pkgs/standards/peagen/tests/smoke/test_remote_doe_process_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_doe_process_cli.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import httpx
 import pytest
-from peagen.protocols.methods.worker import WORKER_LIST
+from peagen.transport.json_rpcschemas.worker import WORKER_LIST
 
 pytestmark = pytest.mark.smoke
 

--- a/pkgs/standards/peagen/tests/smoke/test_remote_eval_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_eval_cli.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import httpx
 import pytest
-from peagen.protocols.methods.worker import WORKER_LIST
+from peagen.transport.json_rpcschemas.worker import WORKER_LIST
 
 pytestmark = pytest.mark.smoke
 

--- a/pkgs/standards/peagen/tests/smoke/test_remote_eval_rpc.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_eval_rpc.py
@@ -2,7 +2,7 @@ import os
 import uuid
 import httpx
 import pytest
-from peagen.protocols.methods.worker import WORKER_LIST
+from peagen.transport.json_rpcschemas.worker import WORKER_LIST
 
 pytestmark = pytest.mark.smoke
 
@@ -46,7 +46,7 @@ def test_eval_submit_returns_task_id() -> None:
             "program_glob": "*.py",
         },
     }
-    from peagen.protocols.methods import TASK_SUBMIT
+    from peagen.transport.json_rpcschemas import TASK_SUBMIT
 
     envelope = {
         "jsonrpc": "2.0",

--- a/pkgs/standards/peagen/tests/smoke/test_remote_evolve.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_evolve.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import httpx
 import pytest
-from peagen.protocols.methods.worker import WORKER_LIST
+from peagen.transport.json_rpcschemas.worker import WORKER_LIST
 
 pytestmark = pytest.mark.smoke
 

--- a/pkgs/standards/peagen/tests/smoke/test_remote_full_flow.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_full_flow.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import httpx
 import pytest
-from peagen.protocols.methods.worker import WORKER_LIST
+from peagen.transport.json_rpcschemas.worker import WORKER_LIST
 
 pytestmark = pytest.mark.smoke
 

--- a/pkgs/standards/peagen/tests/smoke/test_remote_mutate_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_mutate_cli.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import httpx
 import pytest
-from peagen.protocols.methods.worker import WORKER_LIST
+from peagen.transport.json_rpcschemas.worker import WORKER_LIST
 
 pytestmark = pytest.mark.smoke
 

--- a/pkgs/standards/peagen/tests/smoke/test_remote_process_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_process_cli.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import httpx
 import pytest
-from peagen.protocols.methods.worker import WORKER_LIST
+from peagen.transport.json_rpcschemas.worker import WORKER_LIST
 
 pytestmark = pytest.mark.smoke
 

--- a/pkgs/standards/peagen/tests/smoke/test_remote_process_rpc.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_process_rpc.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import httpx
 import pytest
-from peagen.protocols.methods.worker import WORKER_LIST
+from peagen.transport.json_rpcschemas.worker import WORKER_LIST
 from peagen.tui.task_submit import build_task, submit_task
 
 pytestmark = pytest.mark.smoke

--- a/pkgs/standards/peagen/tests/smoke/test_remote_sort_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_sort_cli.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import httpx
 import pytest
-from peagen.protocols.methods.worker import WORKER_LIST
+from peagen.transport.json_rpcschemas.worker import WORKER_LIST
 
 pytestmark = pytest.mark.smoke
 

--- a/pkgs/standards/peagen/tests/unit/test_doe_process_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_doe_process_handler.py
@@ -1,7 +1,7 @@
 import pytest
 
 from peagen.handlers import doe_process_handler as handler
-from peagen.protocols.methods import TASK_SUBMIT, TASK_PATCH
+from peagen.transport.json_rpcschemas import TASK_SUBMIT, TASK_PATCH
 from peagen.defaults import WORK_FINISHED
 
 

--- a/pkgs/standards/peagen/tests/unit/test_evolve_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_evolve_handler.py
@@ -46,7 +46,7 @@ async def test_evolve_handler_fanout(monkeypatch, tmp_path):
     assert result["jobs"] == 1
     assert sent and sent[-1]["method"] == "Work.finished"
     submit = sent[0]
-    from peagen.protocols.methods import TASK_SUBMIT
+    from peagen.transport.json_rpcschemas import TASK_SUBMIT
 
     assert submit["method"] == TASK_SUBMIT
     assert submit["params"]["payload"]["action"] == "mutate"

--- a/pkgs/standards/peagen/tests/unit/test_keys_cli.py
+++ b/pkgs/standards/peagen/tests/unit/test_keys_cli.py
@@ -5,7 +5,7 @@ import pytest
 
 from peagen.cli.commands import keys as keys_mod
 from peagen.protocols import KEYS_UPLOAD, KEYS_DELETE, Response
-from peagen.protocols.methods.keys import FetchResult
+from peagen.transport.json_rpcschemas.keys import FetchResult
 
 
 @pytest.mark.unit

--- a/pkgs/standards/peagen/tests/unit/test_scheduler_remove_bad_worker.py
+++ b/pkgs/standards/peagen/tests/unit/test_scheduler_remove_bad_worker.py
@@ -43,7 +43,7 @@ async def test_scheduler_removes_bad_worker(monkeypatch):
     monkeypatch.setattr(gw, "_persist", noop)
     monkeypatch.setattr(gw, "_publish_task", noop)
 
-    from peagen.protocols.methods.worker import RegisterParams
+    from peagen.transport.json_rpcschemas.worker import RegisterParams
 
     await gw.worker_register(
         RegisterParams(

--- a/pkgs/standards/peagen/tests/unit/test_secret_store.py
+++ b/pkgs/standards/peagen/tests/unit/test_secret_store.py
@@ -5,7 +5,7 @@ import pytest
 from peagen.orm import Base
 import peagen.gateway as gw
 import peagen.gateway.db as db
-from peagen.protocols.methods.secrets import AddParams, GetParams, DeleteParams
+from peagen.transport.json_rpcschemas.secrets import AddParams, GetParams, DeleteParams
 
 
 @pytest.mark.unit

--- a/pkgs/standards/peagen/tests/unit/test_secret_store_versioning.py
+++ b/pkgs/standards/peagen/tests/unit/test_secret_store_versioning.py
@@ -5,7 +5,7 @@ import pytest
 from peagen.orm import Base
 import peagen.gateway as gw
 import peagen.gateway.db as db
-from peagen.protocols.methods.secrets import AddParams, GetParams, DeleteParams
+from peagen.transport.json_rpcschemas.secrets import AddParams, GetParams, DeleteParams
 
 
 @pytest.mark.asyncio

--- a/pkgs/standards/peagen/tests/unit/test_secrets_cli.py
+++ b/pkgs/standards/peagen/tests/unit/test_secrets_cli.py
@@ -2,8 +2,8 @@ import json
 import pytest
 import typer
 from peagen.cli.commands import secrets as secrets_cli
-from peagen.protocols.methods.worker import WORKER_LIST
-from peagen.protocols.methods.secrets import GetResult
+from peagen.transport.json_rpcschemas.worker import WORKER_LIST
+from peagen.transport.json_rpcschemas.secrets import GetResult
 from peagen.protocols import Response
 
 

--- a/pkgs/standards/peagen/tests/unit/test_task_submit_unknown.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_submit_unknown.py
@@ -46,7 +46,7 @@ async def test_task_submit_unknown_action(monkeypatch):
     monkeypatch.setattr(gw, "_persist", noop)
     monkeypatch.setattr(gw, "_publish_event", noop)
 
-    from peagen.protocols.methods.worker import RegisterParams
+    from peagen.transport.json_rpcschemas.worker import RegisterParams
 
     await gw.worker_register(
         RegisterParams(

--- a/pkgs/standards/peagen/tests/unit/test_worker_list.py
+++ b/pkgs/standards/peagen/tests/unit/test_worker_list.py
@@ -43,7 +43,7 @@ async def test_worker_list(monkeypatch):
     monkeypatch.setattr(gw, "_persist", noop)
     monkeypatch.setattr(gw, "_publish_event", noop)
 
-    from peagen.protocols.methods.worker import RegisterParams, ListParams
+    from peagen.transport.json_rpcschemas.worker import RegisterParams, ListParams
 
     await gw.worker_register(
         RegisterParams(

--- a/pkgs/standards/peagen/tests/unit/test_worker_register_handlers.py
+++ b/pkgs/standards/peagen/tests/unit/test_worker_register_handlers.py
@@ -41,7 +41,7 @@ async def test_worker_register_records_handlers(monkeypatch):
     monkeypatch.setattr(gw, "_persist", noop)
     monkeypatch.setattr(gw, "_publish_event", noop)
 
-    from peagen.protocols.methods.worker import RegisterParams
+    from peagen.transport.json_rpcschemas.worker import RegisterParams
 
     await gw.worker_register(
         RegisterParams(

--- a/pkgs/standards/peagen/tests/unit/test_worker_register_reject_empty.py
+++ b/pkgs/standards/peagen/tests/unit/test_worker_register_reject_empty.py
@@ -40,7 +40,7 @@ async def test_worker_register_rejects_no_handlers(monkeypatch):
     monkeypatch.setattr(gw, "_persist", noop)
     monkeypatch.setattr(gw, "_publish_event", noop)
 
-    from peagen.protocols.methods.worker import RegisterParams
+    from peagen.transport.json_rpcschemas.worker import RegisterParams
 
     with pytest.raises(gw.RPCException) as exc:
         await gw.worker_register(

--- a/pkgs/standards/peagen/tests/unit/test_worker_register_well_known.py
+++ b/pkgs/standards/peagen/tests/unit/test_worker_register_well_known.py
@@ -65,7 +65,7 @@ async def test_worker_register_fetches_well_known(monkeypatch):
     monkeypatch.setattr(gw, "_persist", noop)
     monkeypatch.setattr(gw, "_publish_event", noop)
 
-    from peagen.protocols.methods.worker import RegisterParams
+    from peagen.transport.json_rpcschemas.worker import RegisterParams
 
     await gw.worker_register(
         RegisterParams(workerId="w1", pool="p", url="http://w1/rpc", advertises={})


### PR DESCRIPTION
## Summary
- use `peagen.transport.json_rpcschemas` instead of deprecated `peagen.protocols.methods`
- add compatibility package `peagen.transport.json_rpcschemas` for submodule aliasing

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --directory pkgs/standards/peagen --package peagen pytest` *(fails: ModuleNotFoundError: No module named 'peagen.protocols')*

------
https://chatgpt.com/codex/tasks/task_e_6861aebcb1f88326b0c5bc600d29edb8