### PR TITLE
Update peagen imports from protocols to transport

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/analysis.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/analysis.py
@@ -10,7 +10,7 @@ import typer
 from functools import partial
 
 from peagen.handlers.analysis_handler import analysis_handler
-from peagen.protocols import TASK_SUBMIT
+from peagen.transport import TASK_SUBMIT
 from peagen.transport.json_rpcschemas.task import SubmitParams, SubmitResult
 from peagen.cli.task_builder import _build_task as _generic_build_task
 

--- a/pkgs/standards/peagen/peagen/cli/commands/db.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/db.py
@@ -13,7 +13,7 @@ import typer
 
 from peagen.handlers.migrate_handler import migrate_handler
 
-from peagen.protocols import TASK_SUBMIT
+from peagen.transport import TASK_SUBMIT
 from peagen.transport.json_rpcschemas.task import SubmitResult
 from peagen.cli.task_builder import build_submit_params
 

--- a/pkgs/standards/peagen/peagen/cli/commands/doe.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/doe.py
@@ -16,7 +16,7 @@ import typer
 
 from peagen.handlers.doe_handler import doe_handler
 from peagen.handlers.doe_process_handler import doe_process_handler
-from peagen.protocols import TASK_SUBMIT, TASK_GET
+from peagen.transport import TASK_SUBMIT, TASK_GET
 from peagen.transport.json_rpcschemas.task import (
     SubmitParams,
     SubmitResult,

--- a/pkgs/standards/peagen/peagen/cli/commands/eval.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/eval.py
@@ -21,7 +21,7 @@ from functools import partial
 from peagen._utils.config_loader import load_peagen_toml
 
 from peagen.handlers.eval_handler import eval_handler
-from peagen.protocols import TASK_SUBMIT
+from peagen.transport import TASK_SUBMIT
 from peagen.transport.json_rpcschemas.task import SubmitParams, SubmitResult
 from peagen.cli.task_builder import _build_task as _generic_build_task
 

--- a/pkgs/standards/peagen/peagen/cli/commands/evolve.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/evolve.py
@@ -14,7 +14,7 @@ from functools import partial
 from peagen.handlers.evolve_handler import evolve_handler
 from peagen.transport.jsonrpc_schemas import Status
 from peagen.core.validate_core import validate_evolve_spec
-from peagen.protocols import TASK_SUBMIT, TASK_GET
+from peagen.transport import TASK_SUBMIT, TASK_GET
 from peagen.transport.json_rpcschemas.task import (
     SubmitParams,
     SubmitResult,

--- a/pkgs/standards/peagen/peagen/cli/commands/extras.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/extras.py
@@ -11,7 +11,7 @@ from functools import partial
 
 from peagen.handlers.extras_handler import extras_handler
 from swarmauri_standard.loggers.Logger import Logger
-from peagen.protocols import TASK_SUBMIT
+from peagen.transport import TASK_SUBMIT
 from peagen.transport.json_rpcschemas.task import SubmitParams, SubmitResult
 from peagen.cli.rpc_utils import rpc_post
 from peagen.cli.task_builder import _build_task as _generic_build_task

--- a/pkgs/standards/peagen/peagen/cli/commands/keys.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/keys.py
@@ -11,7 +11,7 @@ import typer
 
 from peagen.plugins.secret_drivers import AutoGpgDriver
 from peagen.core import keys_core
-from peagen.protocols import KEYS_UPLOAD, KEYS_DELETE, KEYS_FETCH
+from peagen.transport import KEYS_UPLOAD, KEYS_DELETE, KEYS_FETCH
 from peagen.transport.json_rpcschemas.keys import (
     UploadParams,
     DeleteParams,

--- a/pkgs/standards/peagen/peagen/cli/commands/login.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/login.py
@@ -9,7 +9,7 @@ from peagen.cli.rpc_utils import rpc_post
 import typer
 
 from peagen.plugins.secret_drivers import AutoGpgDriver
-from peagen.protocols import KEYS_UPLOAD
+from peagen.transport import KEYS_UPLOAD
 from peagen.transport.json_rpcschemas.keys import UploadParams, UploadResult
 
 

--- a/pkgs/standards/peagen/peagen/cli/commands/mutate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/mutate.py
@@ -13,7 +13,7 @@ import typer
 from functools import partial
 
 from peagen.handlers.mutate_handler import mutate_handler
-from peagen.protocols import TASK_SUBMIT
+from peagen.transport import TASK_SUBMIT
 from peagen.transport.json_rpcschemas.task import SubmitParams, SubmitResult
 from peagen.cli.task_builder import _build_task as _generic_build_task
 

--- a/pkgs/standards/peagen/peagen/cli/commands/process.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/process.py
@@ -21,7 +21,7 @@ import typer
 from functools import partial
 from peagen._utils.config_loader import _effective_cfg, load_peagen_toml
 from peagen.handlers.process_handler import process_handler
-from peagen.protocols import TASK_SUBMIT, TASK_GET, Request
+from peagen.transport import TASK_SUBMIT, TASK_GET, Request
 from peagen.transport.json_rpcschemas.task import (
     GetParams,
     GetResult,

--- a/pkgs/standards/peagen/peagen/cli/commands/secrets.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/secrets.py
@@ -10,7 +10,7 @@ from peagen.cli.rpc_utils import rpc_post
 import typer
 
 from peagen.plugins.secret_drivers import AutoGpgDriver
-from peagen.protocols import SECRETS_ADD, SECRETS_GET, SECRETS_DELETE
+from peagen.transport import SECRETS_ADD, SECRETS_GET, SECRETS_DELETE
 from peagen.transport.json_rpcschemas.secrets import (
     AddParams,
     GetParams,

--- a/pkgs/standards/peagen/peagen/cli/commands/sort.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/sort.py
@@ -9,7 +9,7 @@ import typer
 
 from peagen._utils.config_loader import _effective_cfg, load_peagen_toml
 from peagen.handlers.sort_handler import sort_handler
-from peagen.protocols import TASK_SUBMIT
+from peagen.transport import TASK_SUBMIT
 from peagen.transport.json_rpcschemas.task import SubmitResult
 from peagen.cli.task_builder import build_submit_params
 from peagen.cli.rpc_utils import rpc_post

--- a/pkgs/standards/peagen/peagen/cli/commands/task.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/task.py
@@ -9,7 +9,7 @@ import time
 
 import typer
 
-from peagen.protocols import (
+from peagen.transport import (
     TASK_GET,
     TASK_PATCH,
     TASK_PAUSE,

--- a/pkgs/standards/peagen/peagen/cli/commands/templates.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/templates.py
@@ -8,7 +8,7 @@ from peagen.cli.rpc_utils import rpc_post
 import typer
 
 from peagen.handlers.templates_handler import templates_handler
-from peagen.protocols import TASK_SUBMIT
+from peagen.transport import TASK_SUBMIT
 from peagen.transport.json_rpcschemas.task import SubmitResult
 from peagen.cli.task_builder import build_submit_params
 

--- a/pkgs/standards/peagen/peagen/cli/commands/validate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/validate.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 import typer
 
 from peagen.handlers.validate_handler import validate_handler
-from peagen.protocols import TASK_SUBMIT
+from peagen.transport import TASK_SUBMIT
 from peagen.transport.json_rpcschemas.task import SubmitResult
 from peagen.cli.task_builder import build_submit_params
 from peagen.cli.rpc_utils import rpc_post

--- a/pkgs/standards/peagen/peagen/cli/rpc_utils.py
+++ b/pkgs/standards/peagen/peagen/cli/rpc_utils.py
@@ -7,7 +7,7 @@ import httpx
 
 from pydantic import TypeAdapter
 
-from peagen.protocols import Request, Response
+from peagen.transport import Request, Response
 
 R = TypeVar("R")
 

--- a/pkgs/standards/peagen/peagen/core/keys_core.py
+++ b/pkgs/standards/peagen/peagen/core/keys_core.py
@@ -12,7 +12,7 @@ from peagen._utils.config_loader import load_peagen_toml
 from peagen.plugins import PluginManager
 from pydantic import TypeAdapter
 
-from peagen.protocols import Request, Response
+from peagen.transport import Request, Response
 from peagen.transport.json_rpcschemas.keys import (
     KEYS_UPLOAD,
     KEYS_DELETE,

--- a/pkgs/standards/peagen/peagen/core/secrets_core.py
+++ b/pkgs/standards/peagen/peagen/core/secrets_core.py
@@ -12,7 +12,7 @@ import httpx
 from peagen.plugins.secret_drivers import AutoGpgDriver
 from pydantic import TypeAdapter
 
-from peagen.protocols import Request, Response
+from peagen.transport import Request, Response
 from peagen.transport.json_rpcschemas.secrets import (
     SECRETS_ADD,
     SECRETS_GET,

--- a/pkgs/standards/peagen/peagen/defaults/__init__.py
+++ b/pkgs/standards/peagen/peagen/defaults/__init__.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from .abuse import BAN_THRESHOLD
 from .events import CONTROL_QUEUE, READY_QUEUE, PUBSUB_CHANNEL, TASK_KEY
 from .methods import *  # noqa: F401,F403 re-export rpc method names
-from peagen.protocols.error_codes import Code as ErrorCode
+from peagen.transport.error_codes import Code as ErrorCode
 
 # Default directory for repository lock files.
 LOCK_DIR = "~/.cache/peagen/locks"

--- a/pkgs/standards/peagen/peagen/defaults/error_codes.py
+++ b/pkgs/standards/peagen/peagen/defaults/error_codes.py
@@ -1,5 +1,5 @@
 """Backward compatible re-export of the canonical error codes."""
 
-from peagen.protocols.error_codes import Code as ErrorCode
+from peagen.transport.error_codes import Code as ErrorCode
 
 __all__ = ["ErrorCode"]

--- a/pkgs/standards/peagen/peagen/defaults/methods.py
+++ b/pkgs/standards/peagen/peagen/defaults/methods.py
@@ -1,7 +1,7 @@
 """Common JSON-RPC method names used across Peagen components.
 
 .. deprecated:: 0.9.0
-   Import method names from :mod:`peagen.protocols` instead.
+   Import method names from :mod:`peagen.transport` instead.
 """
 
 from __future__ import annotations

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -24,7 +24,7 @@ from fastapi import FastAPI, Request, Response, HTTPException
 from peagen.plugins.queues import QueueBase
 
 from peagen.transport import RPCDispatcher
-from peagen.protocols import (
+from peagen.transport import (
     Request as RPCRequest,
     Request as RPCEnvelope,
     parse_request,
@@ -54,7 +54,7 @@ from peagen.errors import (
 )
 import peagen.defaults as defaults
 from peagen.defaults import BAN_THRESHOLD
-from peagen.protocols.error_codes import Code as ErrorCode
+from peagen.transport.error_codes import Code as ErrorCode
 from peagen.core import migrate_core
 from peagen.services import create_task, get_task, update_task
 

--- a/pkgs/standards/peagen/peagen/gateway/rpc/secrets.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/secrets.py
@@ -13,7 +13,7 @@ from peagen.transport.json_rpcschemas.secrets import (
     DeleteResult,
 )
 from ..db_helpers import delete_secret, fetch_secret, upsert_secret
-from peagen.protocols.error_codes import Code as ErrorCode
+from peagen.transport.error_codes import Code as ErrorCode
 from peagen.transport.jsonrpc import RPCException
 
 

--- a/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
@@ -4,9 +4,9 @@ import json
 import uuid
 import typing as t
 from peagen.transport.jsonrpc import RPCException
-from peagen.protocols.error_codes import Code as ErrorCode
+from peagen.transport.error_codes import Code as ErrorCode
 
-from peagen.protocols import (
+from peagen.transport import (
     TASK_SUBMIT,
     TASK_CANCEL,
     TASK_PAUSE,

--- a/pkgs/standards/peagen/peagen/handlers/fanout.py
+++ b/pkgs/standards/peagen/peagen/handlers/fanout.py
@@ -7,7 +7,7 @@ from typing import Iterable, List, Dict, Any
 import httpx
 
 from peagen.transport.jsonrpc_schemas import Status
-from peagen.protocols import Request as RPCEnvelope
+from peagen.transport import Request as RPCEnvelope
 from peagen.transport.json_rpcschemas import TASK_SUBMIT, TASK_PATCH
 from peagen.transport.json_rpcschemas.task import PatchParams, PatchResult
 from . import ensure_task

--- a/pkgs/standards/peagen/peagen/transport/__init__.py
+++ b/pkgs/standards/peagen/peagen/transport/__init__.py
@@ -1,7 +1,7 @@
 """Typed JSON-RPC protocol primitives and method registry."""
 
 from peagen.transport.jsonrpc import RPCDispatcher
-from peagen.protocols import (
+from peagen.transport import (
     Request as RPCRequest,
     Response as RPCResponse,
     Error as RPCErrorData,

--- a/pkgs/standards/peagen/peagen/transport/jsonrpc.py
+++ b/pkgs/standards/peagen/peagen/transport/jsonrpc.py
@@ -4,9 +4,9 @@ import inspect
 from typing import Callable, Dict
 
 from pydantic import BaseModel
-from peagen.protocols import _registry
+from peagen.transport import _registry
 
-from peagen.protocols import Error
+from peagen.transport import Error
 
 
 class RPCException(Exception):

--- a/pkgs/standards/peagen/peagen/transport/jsonrpc_schemas/keys.py
+++ b/pkgs/standards/peagen/peagen/transport/jsonrpc_schemas/keys.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pydantic import BaseModel, ConfigDict, Field
 from typing import Dict
 
-from peagen.protocols._registry import register
+from peagen.transport._registry import register
 
 
 class UploadParams(BaseModel):

--- a/pkgs/standards/peagen/peagen/transport/jsonrpc_schemas/secrets.py
+++ b/pkgs/standards/peagen/peagen/transport/jsonrpc_schemas/secrets.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from peagen.protocols._registry import register
+from peagen.transport._registry import register
 
 
 class AddParams(BaseModel):

--- a/pkgs/standards/peagen/peagen/transport/jsonrpc_schemas/task.py
+++ b/pkgs/standards/peagen/peagen/transport/jsonrpc_schemas/task.py
@@ -4,7 +4,7 @@ from typing import Optional
 from pydantic import BaseModel, ConfigDict
 
 from peagen.transport.jsonrpc_schemas import Status
-from peagen.protocols._registry import register
+from peagen.transport._registry import register
 
 
 class SubmitParams(BaseModel):

--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -17,8 +17,8 @@ from fastapi import Body, FastAPI, Request, HTTPException
 from json.decoder import JSONDecodeError
 
 from peagen.transport import RPCDispatcher
-from peagen.protocols import Request as RPCRequest, Response as RPCResponse
-from peagen.protocols import Request as RPCEnvelope
+from peagen.transport import Request as RPCRequest, Response as RPCResponse
+from peagen.transport import Request as RPCEnvelope
 from peagen.transport.json_rpcschemas.work import (
     WORK_START,
     WORK_CANCEL,

--- a/pkgs/standards/peagen/tests/test_protocols_basic.py
+++ b/pkgs/standards/peagen/tests/test_protocols_basic.py
@@ -1,4 +1,4 @@
-from peagen.protocols import (
+from peagen.transport import (
     Response,
     parse_request,
     _registry,

--- a/pkgs/standards/peagen/tests/unit/test_cli_login.py
+++ b/pkgs/standards/peagen/tests/unit/test_cli_login.py
@@ -4,7 +4,7 @@ import pytest
 
 from peagen.cli import app
 import peagen.cli.commands.login as login_mod
-from peagen.protocols import Response, Error
+from peagen.transport import Response, Error
 
 
 class DummyDriver:

--- a/pkgs/standards/peagen/tests/unit/test_keys_cli.py
+++ b/pkgs/standards/peagen/tests/unit/test_keys_cli.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 from peagen.cli.commands import keys as keys_mod
-from peagen.protocols import KEYS_UPLOAD, KEYS_DELETE, Response
+from peagen.transport import KEYS_UPLOAD, KEYS_DELETE, Response
 from peagen.transport.json_rpcschemas.keys import FetchResult
 
 

--- a/pkgs/standards/peagen/tests/unit/test_secrets_cli.py
+++ b/pkgs/standards/peagen/tests/unit/test_secrets_cli.py
@@ -4,7 +4,7 @@ import typer
 from peagen.cli.commands import secrets as secrets_cli
 from peagen.transport.json_rpcschemas.worker import WORKER_LIST
 from peagen.transport.json_rpcschemas.secrets import GetResult
-from peagen.protocols import Response
+from peagen.transport import Response
 
 
 class DummyDriver:


### PR DESCRIPTION
## Summary
- point all `peagen` references from `peagen.protocols` to `peagen.transport`

## Testing
- `uv run --directory standards/peagen --package peagen ruff format .` *(fails: could not fetch from pypi)*
- `uv run --directory standards/peagen --package peagen ruff check . --fix` *(fails: could not fetch from pypi)*
- `uv run --package peagen --directory standards/peagen pytest` *(fails: could not fetch from pypi)*

------
https://chatgpt.com/codex/tasks/task_e_6861b5cfa79c8326ba0c1ac3ec7f06c6