### PR TITLE
Run ruff on peagen transport modules

### DIFF
--- a/pkgs/standards/peagen/peagen/transport/error_codes.py
+++ b/pkgs/standards/peagen/peagen/transport/error_codes.py
@@ -1,5 +1,6 @@
 from enum import IntEnum
 
+
 class ErrorCode(IntEnum):
     PARSE_ERROR = -32700
     INVALID_REQUEST = -32600

--- a/pkgs/standards/peagen/peagen/transport/jsonrpc.py
+++ b/pkgs/standards/peagen/peagen/transport/jsonrpc.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 from peagen.transport import _registry
 from peagen.transport.envelope import Error
 
+
 class RPCException(Exception):
     """Exception carrying JSON-RPC error details."""
 


### PR DESCRIPTION
## Summary
- format peagen's `transport` modules with ruff
- run unit tests for `peagen` package

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest -q` *(fails: 78 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6861b9a43084832691819db7e9569c9b