### PR TITLE
Update CLI to use jsonrpc schemas

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/db.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/db.py
@@ -13,9 +13,10 @@ import typer
 
 from peagen.handlers.migrate_handler import migrate_handler
 
-from peagen.transport import TASK_SUBMIT
-from peagen.transport.json_rpcschemas.task import SubmitResult
-from peagen.cli.task_builder import build_submit_params
+from uuid import uuid4
+
+from peagen.transport.jsonrpc_schemas import TASK_SUBMIT
+from peagen.transport.jsonrpc_schemas.task import SubmitParams, SubmitResult
 
 
 # ``alembic.ini`` lives in the package root next to ``migrations``.
@@ -41,10 +42,10 @@ def _submit_task(op: str, gateway_url: str, message: str | None = None) -> str:
     args = {"op": op, "alembic_ini": str(ALEMBIC_CFG)}
     if message:
         args["message"] = message
-    submit = build_submit_params(
-        "migrate",
-        args,
+    submit = SubmitParams(
+        id=str(uuid4()),
         pool="default",
+        payload={"action": "migrate", "args": args},
     )
     reply = rpc_post(
         gateway_url,

--- a/pkgs/standards/peagen/peagen/cli/commands/sort.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/sort.py
@@ -9,9 +9,10 @@ import typer
 
 from peagen._utils.config_loader import _effective_cfg, load_peagen_toml
 from peagen.handlers.sort_handler import sort_handler
-from peagen.transport import TASK_SUBMIT
-from peagen.transport.json_rpcschemas.task import SubmitResult
-from peagen.cli.task_builder import build_submit_params
+from uuid import uuid4
+
+from peagen.transport.jsonrpc_schemas import TASK_SUBMIT
+from peagen.transport.jsonrpc_schemas.task import SubmitParams, SubmitResult
 from peagen.cli.rpc_utils import rpc_post
 
 local_sort_app = typer.Typer(help="Sort generated project files.")
@@ -130,10 +131,10 @@ def submit_sort(
         "repo": repo,
         "ref": ref,
     }
-    submit = build_submit_params(
-        "sort",
-        {**args, "cfg_override": cfg_override},
+    submit = SubmitParams(
+        id=str(uuid4()),
         pool="default",
+        payload={"action": "sort", "args": {**args, "cfg_override": cfg_override}},
     )
 
     try:


### PR DESCRIPTION
## Summary
- refactor db/doe/sort/templates/validate CLI commands
- remove old build_submit_params usage
- create SubmitParams directly with jsonrpc_schemas

## Testing
- `uv run --directory peagen --package peagen ruff format .`
- `uv run --directory peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest` *(fails: ImportError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6861baa1287483268011ffbe3a0a6d3c