### PR TITLE
Remove ensure_task

### DIFF
--- a/pkgs/standards/peagen/peagen/handlers/__init__.py
+++ b/pkgs/standards/peagen/peagen/handlers/__init__.py
@@ -1,7 +1,1 @@
-"""Utilities for task handler modules."""
 
-from __future__ import annotations
-
-from peagen.transport.jsonrpc_schemas.task import SubmitParams
-
-__all__ = ["SubmitParams"]

--- a/pkgs/standards/peagen/peagen/handlers/__init__.py
+++ b/pkgs/standards/peagen/peagen/handlers/__init__.py
@@ -2,41 +2,6 @@
 
 from __future__ import annotations
 
-
-import uuid
-
-from peagen.transport.jsonrpc_schemas import Status
 from peagen.transport.jsonrpc_schemas.task import SubmitParams
 
-
-def ensure_task(task: SubmitParams) -> SubmitParams:
-    """Return ``task`` as a :class:`~peagen.transport.jsonrpc_schemas.task.PatchResult` instance."""
-
-    if isinstance(task, SubmitParams):
-        return task
-
-    if not isinstance(task, dict):  # pragma: no cover - defensive
-        if hasattr(task, "model_dump"):
-            task = task.model_dump(mode="json")
-        else:
-            raise TypeError(f"Expected dict or PatchResult, got {type(task)!r}")
-
-    # If the incoming mapping is missing required fields, assume it comes from
-    # a local CLI invocation and populate sane defaults so handler logic can
-    # operate on a complete ``PatchResult`` model.
-    defaults = {
-        "pool": task.get("pool", "default"),
-        "payload": task.get("payload", {}),
-        "status": Status.queued,
-        "note": "",
-    }
-
-    merged = {**defaults, **task}
-    try:
-        return SubmitParams.model_validate(merged)
-    except Exception:  # pragma: no cover - fallback for invalid input
-        merged["id"] = str(uuid.uuid4())
-        return SubmitParams.model_validate(merged)
-
-
-__all__ = ["ensure_task"]
+__all__ = ["SubmitParams"]

--- a/pkgs/standards/peagen/peagen/handlers/analysis_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/analysis_handler.py
@@ -7,15 +7,13 @@ from peagen._utils import maybe_clone_repo
 
 from peagen.core.analysis_core import analyze_runs
 from peagen.transport.jsonrpc_schemas.task import SubmitParams, SubmitResult
-from . import ensure_task
 from peagen._utils.config_loader import resolve_cfg
 from peagen.plugins import PluginManager
 from peagen.plugins.vcs import pea_ref
 from .repo_utils import fetch_repo, cleanup_repo
 
 
-async def analysis_handler(task_or_dict: Dict[str, Any] | SubmitParams) -> SubmitResult:
-    task = ensure_task(task_or_dict)
+async def analysis_handler(task: SubmitParams) -> SubmitResult:
     payload = task.payload
     args: Dict[str, Any] = payload.get("args", {})
     repo = args.get("repo")

--- a/pkgs/standards/peagen/peagen/handlers/doe_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/doe_handler.py
@@ -11,14 +11,12 @@ from peagen.core.doe_core import (
     create_run_branches,
 )
 from peagen.transport.jsonrpc_schemas.task import SubmitParams, SubmitResult
-from . import ensure_task
 from peagen._utils.config_loader import resolve_cfg
 from peagen.plugins import PluginManager
 import yaml
 
 
-async def doe_handler(task_or_dict: Dict[str, Any] | SubmitParams) -> SubmitResult:
-    task = ensure_task(task_or_dict)
+async def doe_handler(task: SubmitParams) -> SubmitResult:
     payload = task.payload
     args: Dict[str, Any] = payload.get("args", {})
 

--- a/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
@@ -8,25 +8,19 @@ from typing import Any, Dict, List, Tuple
 
 import yaml
 
+import uuid
+
 from peagen.core.doe_core import generate_payload
-from peagen.transport.jsonrpc_schemas.task import (
-    PatchResult,
-    SubmitParams,
-    SubmitResult,
-)
+from peagen.transport.jsonrpc_schemas.task import SubmitParams, SubmitResult
 from peagen.transport.jsonrpc_schemas import Status
 from peagen._utils.config_loader import resolve_cfg
 from peagen.plugins import PluginManager
 from peagen.plugins.storage_adapters.file_storage_adapter import FileStorageAdapter
 from .fanout import fan_out
-from . import ensure_task
 
 
-async def doe_process_handler(
-    task_or_dict: Dict[str, Any] | SubmitParams,
-) -> SubmitResult:
+async def doe_process_handler(task: SubmitParams) -> SubmitResult:
     """Expand the DOE spec and spawn a process task for each project."""
-    task = ensure_task(task_or_dict)
     payload = task.payload
     args: Dict[str, Any] = payload.get("args", {})
     repo = args.get("repo")
@@ -126,11 +120,12 @@ async def doe_process_handler(
     result["outputs"] = uploaded
 
     pool = task.pool
-    children: List[PatchResult] = []
+    children: List[SubmitParams] = []
     for path, proj in projects:
         children.append(
-            ensure_task(
+            SubmitParams.model_validate(
                 {
+                    "id": str(uuid.uuid4()),
                     "pool": pool,
                     "status": Status.waiting,
                     "payload": {

--- a/pkgs/standards/peagen/peagen/handlers/eval_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/eval_handler.py
@@ -1,9 +1,9 @@
 # peagen/handlers/eval_handler.py
 """
-Async task-handler for “eval” jobs.
+Async task-handler for "eval" jobs.
 
-The worker runtime (or a local CLI run) calls this coroutine with
-either a plain dict (decoded JSON-RPC) or a peagen.transport.jsonrpc_schemas.task.PatchResult object.
+The worker runtime or a local CLI run calls this coroutine with a
+``SubmitParams`` instance.
 
 Returns a JSON-serialisable mapping:
   { "report": {…}, "strict_failed": bool }
@@ -20,11 +20,9 @@ import os
 from peagen.core.eval_core import evaluate_workspace
 from peagen._utils.config_loader import resolve_cfg
 from peagen.transport.jsonrpc_schemas.task import SubmitParams, SubmitResult
-from . import ensure_task
 
 
-async def eval_handler(task_or_dict: Dict[str, Any] | SubmitParams) -> SubmitResult:
-    task = ensure_task(task_or_dict)
+async def eval_handler(task: SubmitParams) -> SubmitResult:
     payload = task.payload
     args: Dict[str, Any] = payload.get("args", {})
     cfg_override: Dict[str, Any] = payload.get("cfg_override", {})

--- a/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
@@ -5,16 +5,13 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, List
 
+import uuid
+
 import yaml
 
-from peagen.transport.jsonrpc_schemas.task import (
-    PatchResult,
-    SubmitParams,
-    SubmitResult,
-)
+from peagen.transport.jsonrpc_schemas.task import SubmitParams, SubmitResult
 from peagen.transport.jsonrpc_schemas import Status
 from .fanout import fan_out
-from . import ensure_task
 from peagen._utils.config_loader import resolve_cfg
 from peagen.plugins import PluginManager
 from peagen.plugins.vcs import pea_ref
@@ -37,8 +34,7 @@ def _load_spec(path_or_text: str) -> tuple[Path | None, dict]:
     return None, yaml.safe_load(path_or_text)
 
 
-async def evolve_handler(task_or_dict: Dict[str, Any] | SubmitParams) -> SubmitResult:
-    task = ensure_task(task_or_dict)
+async def evolve_handler(task: SubmitParams) -> SubmitResult:
     payload = task.payload
     args: Dict[str, Any] = payload.get("args", {})
 
@@ -79,7 +75,7 @@ async def evolve_handler(task_or_dict: Dict[str, Any] | SubmitParams) -> SubmitR
                 return str(resolved)
         return str(resolved)
 
-    children: List[PatchResult] = []
+    children: List[SubmitParams] = []
     for job in jobs:
         if mutations is not None:
             job.setdefault("mutations", mutations)
@@ -106,8 +102,9 @@ async def evolve_handler(task_or_dict: Dict[str, Any] | SubmitParams) -> SubmitR
                 mut["uri"] = _resolve_path(uri)
 
         children.append(
-            ensure_task(
+            SubmitParams.model_validate(
                 {
+                    "id": str(uuid.uuid4()),
                     "pool": pool,
                     "status": Status.waiting,
                     "payload": {"action": "mutate", "args": job},

--- a/pkgs/standards/peagen/peagen/handlers/extras_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/extras_handler.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict
 
-from . import ensure_task
 
 from peagen._utils import maybe_clone_repo
 
@@ -14,9 +13,8 @@ from peagen.transport.jsonrpc_schemas.task import SubmitParams, SubmitResult
 from .repo_utils import fetch_repo, cleanup_repo
 
 
-async def extras_handler(task_or_dict: Dict[str, Any] | SubmitParams) -> SubmitResult:
+async def extras_handler(task: SubmitParams) -> SubmitResult:
     """Generate EXTRAS schemas based on template-set ``EXTRAS.md`` files."""
-    task = ensure_task(task_or_dict)
     payload = task.payload
     args: Dict[str, Any] = payload.get("args", {})
     repo = args.get("repo")

--- a/pkgs/standards/peagen/peagen/handlers/fanout.py
+++ b/pkgs/standards/peagen/peagen/handlers/fanout.py
@@ -9,21 +9,19 @@ import httpx
 from peagen.transport.jsonrpc_schemas import Status
 from peagen.transport import Request as RPCEnvelope
 from peagen.transport.jsonrpc_schemas import TASK_SUBMIT, TASK_PATCH
-from peagen.transport.jsonrpc_schemas.task import PatchParams, PatchResult
-from . import ensure_task
+from peagen.transport.jsonrpc_schemas.task import PatchParams, PatchResult, SubmitParams
 
 
 async def fan_out(
-    parent: PatchResult | Dict[str, Any],
-    children: Iterable[PatchResult],
+    parent: SubmitParams,
+    children: Iterable[SubmitParams],
     *,
     result: Dict[str, Any] | None = None,
     final_status: Status = Status.waiting,
 ) -> Dict[str, Any]:
     """Submit *children* and update *parent* with their IDs."""
     gateway = os.getenv("DQ_GATEWAY", "http://localhost:8000/rpc")
-    canonical_parent = ensure_task(parent)
-    parent_id = str(canonical_parent.id)
+    parent_id = str(parent.id)
 
     child_ids: List[str] = []
     async with httpx.AsyncClient(timeout=10.0) as client:

--- a/pkgs/standards/peagen/peagen/handlers/fetch_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/fetch_handler.py
@@ -2,8 +2,7 @@
 """
 Async entry-point for the *fetch* pipeline.
 
-• Accepts either a plain dict (decoded JSON-RPC) or a peagen.transport.jsonrpc_schemas.task.PatchResult.
-• Delegates all heavy-lifting to core.fetch_core.fetch_many().
+• Delegates all heavy-lifting to ``core.fetch_core.fetch_many``.
 • Returns a lightweight JSON-serialisable summary.
 """
 
@@ -12,13 +11,12 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, List
 
-from . import ensure_task
 
 from peagen.core.fetch_core import fetch_many
 from peagen.transport.jsonrpc_schemas.task import SubmitParams, SubmitResult
 
 
-async def fetch_handler(task_or_dict: Dict[str, Any] | SubmitParams) -> SubmitResult:
+async def fetch_handler(task: SubmitParams) -> SubmitResult:
     """
     Parameters (in task.payload.args)
     ---------------------------------
@@ -28,7 +26,6 @@ async def fetch_handler(task_or_dict: Dict[str, Any] | SubmitParams) -> SubmitRe
     install_template_sets: bool – ignored
     """
     # normalise ---------------------------------------------
-    task = ensure_task(task_or_dict)
     payload = task.payload
     args: Dict[str, Any] = payload.get("args", {})
     uris: List[str] = args.get("workspaces", [])

--- a/pkgs/standards/peagen/peagen/handlers/init_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/init_handler.py
@@ -3,8 +3,7 @@
 
 Asynchronous entry-point for initialisation tasks.
 
-The handler accepts either a plain dictionary or a :class:`peagen.transport.jsonrpc_schemas.task.PatchResult`
-and delegates to :mod:`peagen.core.init_core`.
+This handler delegates to :mod:`peagen.core.init_core`.
 """
 
 from __future__ import annotations
@@ -14,12 +13,10 @@ from typing import Any, Dict
 
 from peagen.core import init_core
 from peagen.transport.jsonrpc_schemas.task import SubmitParams, SubmitResult
-from . import ensure_task
 
 
-async def init_handler(task_or_dict: Dict[str, Any] | SubmitParams) -> SubmitResult:
+async def init_handler(task: SubmitParams) -> SubmitResult:
     """Dispatch to the correct init function based on ``kind``."""
-    task = ensure_task(task_or_dict)
     payload = task.payload
     args: Dict[str, Any] = payload.get("args", {})
     kind = args.get("kind")

--- a/pkgs/standards/peagen/peagen/handlers/keys_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/keys_handler.py
@@ -7,12 +7,10 @@ from typing import Any, Dict
 
 from peagen.core import keys_core
 from peagen.transport.jsonrpc_schemas.task import SubmitParams, SubmitResult
-from . import ensure_task
 
 
-async def keys_handler(task: Dict[str, Any] | SubmitParams) -> SubmitResult:
+async def keys_handler(task: SubmitParams) -> SubmitResult:
     """Handle key management actions."""
-    task = ensure_task(task)
     payload = task.payload
     action = payload.get("action")
     args: Dict[str, Any] = payload.get("args", {})

--- a/pkgs/standards/peagen/peagen/handlers/login_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/login_handler.py
@@ -7,12 +7,10 @@ from typing import Any, Dict, Optional
 
 from peagen.core.login_core import login
 from peagen.transport.jsonrpc_schemas.task import SubmitParams, SubmitResult
-from . import ensure_task
 
 
-async def login_handler(task: Dict[str, Any] | SubmitParams) -> SubmitResult:
+async def login_handler(task: SubmitParams) -> SubmitResult:
     """Handle a login task."""
-    task = ensure_task(task)
     payload = task.payload
     args: Dict[str, Any] = payload.get("args", {})
     key_dir = args.get("key_dir")

--- a/pkgs/standards/peagen/peagen/handlers/migrate_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/migrate_handler.py
@@ -10,11 +10,9 @@ from peagen.core.migrate_core import (
     alembic_upgrade,
 )
 from peagen.transport.jsonrpc_schemas.task import SubmitParams, SubmitResult
-from . import ensure_task
 
 
-async def migrate_handler(task_or_dict: Dict[str, Any] | SubmitParams) -> SubmitResult:
-    task = ensure_task(task_or_dict)
+async def migrate_handler(task: SubmitParams) -> SubmitResult:
     args: Dict[str, Any] = task.payload["args"]
     op: str = args["op"]
     cfg_path_str: str | None = args.get("alembic_ini")

--- a/pkgs/standards/peagen/peagen/handlers/mutate_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/mutate_handler.py
@@ -6,7 +6,6 @@ import os
 from pathlib import Path
 from typing import Any, Dict
 
-from . import ensure_task
 
 from peagen.core.mutate_core import mutate_workspace
 from peagen.transport.jsonrpc_schemas.task import SubmitParams, SubmitResult
@@ -15,8 +14,7 @@ from peagen.plugins import PluginManager
 from peagen.plugins.vcs import pea_ref
 
 
-async def mutate_handler(task_or_dict: Dict[str, Any] | SubmitParams) -> SubmitResult:
-    task = ensure_task(task_or_dict)
+async def mutate_handler(task: SubmitParams) -> SubmitResult:
     payload = task.payload
     args: Dict[str, Any] = payload.get("args", {})
     repo = args.get("repo")

--- a/pkgs/standards/peagen/peagen/handlers/process_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/process_handler.py
@@ -1,10 +1,6 @@
 # peagen/handlers/process_handler.py
 """
-Unified entry-point for “process” tasks.
-
-A worker (or a local CLI run) will pass in either:
-  • a plain ``dict`` decoded from JSON-RPC, or
-  • a ``peagen.transport.jsonrpc_schemas.task.PatchResult`` instance.
+Unified entry-point for ``process`` tasks.
 
 The handler merges CLI-style overrides with ``.peagen.toml``,
 invokes the appropriate functions in **process_core**, and
@@ -26,18 +22,16 @@ from peagen.core.process_core import (
     process_all_projects,
 )
 from peagen.transport.jsonrpc_schemas.task import SubmitParams, SubmitResult
-from . import ensure_task
 
 logger = Logger(name=__name__)
 
 
-async def process_handler(task: Dict[str, Any] | SubmitParams) -> SubmitResult:
+async def process_handler(task: SubmitParams) -> SubmitResult:
     """Main coroutine invoked by workers and synchronous CLI runs."""
     # ------------------------------------------------------------------ #
-    # 0) Normalise input – accept PatchResult *or* plain dict
+    # 0) Normalise input
     # ------------------------------------------------------------------ #
-    canonical = ensure_task(task)
-    payload: Dict[str, Any] = canonical.payload
+    payload: Dict[str, Any] = task.payload
     args: Dict[str, Any] = payload.get("args", {})
     cfg_override = payload.get("cfg_override", {})
     # Mandatory flag

--- a/pkgs/standards/peagen/peagen/handlers/secrets_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/secrets_handler.py
@@ -7,12 +7,10 @@ from typing import Any, Dict
 
 from peagen.core import secrets_core
 from peagen.transport.jsonrpc_schemas.task import SubmitParams, SubmitResult
-from . import ensure_task
 
 
-async def secrets_handler(task: Dict[str, Any] | SubmitParams) -> SubmitResult:
+async def secrets_handler(task: SubmitParams) -> SubmitResult:
     """Dispatch secret management actions."""
-    task = ensure_task(task)
     payload = task.payload
     action = payload.get("action")
     args: Dict[str, Any] = payload.get("args", {})

--- a/pkgs/standards/peagen/peagen/handlers/sort_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/sort_handler.py
@@ -5,22 +5,19 @@ from typing import Any, Dict
 
 from peagen.transport.jsonrpc_schemas.task import SubmitParams, SubmitResult
 
-from . import ensure_task
-
 from peagen._utils import maybe_clone_repo
 
 from peagen.core.sort_core import sort_single_project, sort_all_projects
 from peagen._utils.config_loader import resolve_cfg
 
 
-async def sort_handler(task: Dict[str, Any] | SubmitParams) -> SubmitResult:
+async def sort_handler(task: SubmitParams) -> SubmitResult:
     """
     Async handler registered under JSON-RPC method ``Task.sort`` (or similar).
 
     • Delegates to sort_core.
     • Returns whatever the core returns (sorted list or error dict).
     """
-    task = ensure_task(task)
     payload = task.payload
     args = payload.get("args", {})
     repo = args.get("repo")

--- a/pkgs/standards/peagen/peagen/handlers/templates_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/templates_handler.py
@@ -17,12 +17,10 @@ from peagen.core.templates_core import (
     remove_template_set,
 )
 from peagen.transport.jsonrpc_schemas.task import SubmitParams, SubmitResult
-from . import ensure_task
 
 
-async def templates_handler(task: Dict[str, Any] | SubmitParams) -> SubmitResult:
+async def templates_handler(task: SubmitParams) -> SubmitResult:
     """Dispatch template-set operations based on ``args.operation``."""
-    task = ensure_task(task)
     payload = task.payload
     args: Dict[str, Any] = payload.get("args", {})
     repo = args.get("repo")

--- a/pkgs/standards/peagen/peagen/handlers/validate_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/validate_handler.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict
 
-from . import ensure_task
 
 from peagen._utils import maybe_clone_repo
 
@@ -11,8 +10,7 @@ from peagen.core.validate_core import validate_artifact
 from peagen.transport.jsonrpc_schemas.task import SubmitParams, SubmitResult
 
 
-async def validate_handler(task_or_dict: Dict[str, Any] | SubmitParams) -> SubmitResult:
-    task = ensure_task(task_or_dict)
+async def validate_handler(task: SubmitParams) -> SubmitResult:
     args: Dict[str, Any] = task.payload["args"]
     repo = args.get("repo")
     ref = args.get("ref", "HEAD")


### PR DESCRIPTION
## Summary
- drop `ensure_task` helper and rely on pydantic validation
- update all handlers to require `SubmitParams`
- switch worker to validate tasks via `SubmitParams`

## Testing
- `uv run --directory peagen --package peagen ruff format .` *(fails: could not fetch psutil)*
- `uv run --directory peagen --package peagen ruff check . --fix` *(fails: could not fetch filelock)*
- `uv run --package peagen --directory peagen pytest` *(fails: could not fetch minio)*

------
https://chatgpt.com/codex/tasks/task_e_6861c62cb5dc8326b45c0b527fa97254