### PR TITLE
Update peagen CLI helpers

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/analysis.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/analysis.py
@@ -7,19 +7,14 @@ from typing import List
 
 from peagen.cli.rpc_utils import rpc_post
 import typer
-from functools import partial
-
 from peagen.handlers.analysis_handler import analysis_handler
 from peagen.transport import TASK_SUBMIT
-from peagen.transport.jsonrpc_schemas.task import SubmitParams, SubmitResult
-from peagen.cli.task_builder import _build_task as _generic_build_task
+from peagen.transport.jsonrpc_schemas.task import SubmitResult
+from peagen.cli.task_helpers import build_task, submit_task
 
 DEFAULT_GATEWAY = "http://localhost:8000/rpc"
 local_analysis_app = typer.Typer(help="Aggregate run evaluation results.")
 remote_analysis_app = typer.Typer(help="Aggregate run evaluation results.")
-
-
-_build_task = partial(_generic_build_task, "analysis")
 
 
 @local_analysis_app.command("analysis")
@@ -34,7 +29,7 @@ def run(
     args = {"run_dirs": [str(p) for p in run_dirs], "spec_name": spec_name}
     if repo:
         args.update({"repo": repo, "ref": ref})
-    task = _build_task(args, ctx.obj.get("pool", "default"))
+    task = build_task("analysis", args, pool=ctx.obj.get("pool", "default"))
     result = asyncio.run(analysis_handler(task))
     typer.echo(
         json.dumps(result, indent=2) if json_out else json.dumps(result, indent=2)
@@ -52,19 +47,14 @@ def submit(
     args = {"run_dirs": [str(p) for p in run_dirs], "spec_name": spec_name}
     if repo:
         args.update({"repo": repo, "ref": ref})
-    task = _build_task(args, ctx.obj.get("pool", "default"))
-    reply = rpc_post(
-        ctx.obj.get("gateway_url"),
-        TASK_SUBMIT,
-        SubmitParams(task=task).model_dump(),
-        result_model=SubmitResult,
-    )
-    if reply.error:
+    task = build_task("analysis", args, pool=ctx.obj.get("pool", "default"))
+    reply = submit_task(ctx.obj.get("gateway_url"), task)
+    if "error" in reply:
         typer.secho(
-            f"Remote error {reply.error.code}: {reply.error.message}",
+            f"Remote error {reply['error']['code']}: {reply['error']['message']}",
             fg=typer.colors.RED,
             err=True,
         )
         raise typer.Exit(1)
     typer.secho(f"Submitted task {task.id}", fg=typer.colors.GREEN)
-    typer.echo(json.dumps(reply.result.model_dump() if reply.result else {}, indent=2))
+    typer.echo(json.dumps(reply.get("result", {}), indent=2))

--- a/pkgs/standards/peagen/peagen/cli/commands/eval.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/eval.py
@@ -17,13 +17,12 @@ from typing import Any, Dict, Optional
 
 from peagen.cli.rpc_utils import rpc_post
 import typer
-from functools import partial
 from peagen._utils.config_loader import load_peagen_toml
 
 from peagen.handlers.eval_handler import eval_handler
 from peagen.transport import TASK_SUBMIT
-from peagen.transport.jsonrpc_schemas.task import SubmitParams, SubmitResult
-from peagen.cli.task_builder import _build_task as _generic_build_task
+from peagen.transport.jsonrpc_schemas.task import SubmitResult
+from peagen.cli.task_helpers import build_task, submit_task
 
 DEFAULT_GATEWAY = "http://localhost:8000/rpc"
 local_eval_app = typer.Typer(
@@ -35,7 +34,6 @@ remote_eval_app = typer.Typer(
 
 
 # ───────────────────────── helpers ─────────────────────────────────────────
-_build_task = partial(_generic_build_task, "eval")
 
 
 # ───────────────────────── local run ───────────────────────────────────────
@@ -64,7 +62,7 @@ def run(  # noqa: PLR0913 – CLI needs many options
     }
     if repo:
         args.update({"repo": repo, "ref": ref})
-    task = _build_task(args, ctx.obj.get("pool", "default"))
+    task = build_task("eval", args, pool=ctx.obj.get("pool", "default"))
     result = asyncio.run(eval_handler(task))
     report = result["report"]
 
@@ -113,7 +111,7 @@ def submit(  # noqa: PLR0913
         "strict": strict,
         "skip_failed": skip_failed,
     }
-    task = _build_task(args, ctx.obj.get("pool", "default"))
+    task = build_task("eval", args, pool=ctx.obj.get("pool", "default"))
 
     # ─────────────────────── cfg override  ──────────────────────────────
     inline = ctx.obj.get("task_override_inline")
@@ -125,16 +123,11 @@ def submit(  # noqa: PLR0913
         cfg_override.update(load_peagen_toml(Path(file_), required=True))
     task.payload["cfg_override"] = cfg_override
 
-    reply = rpc_post(
-        ctx.obj.get("gateway_url"),
-        TASK_SUBMIT,
-        SubmitParams(task=task).model_dump(),
-        result_model=SubmitResult,
-    )
+    reply = submit_task(ctx.obj.get("gateway_url"), task)
 
-    if reply.error:
+    if "error" in reply:
         typer.secho(
-            f"Remote error {reply.error.code}: {reply.error.message}",
+            f"Remote error {reply['error']['code']}: {reply['error']['message']}",
             fg=typer.colors.RED,
             err=True,
         )

--- a/pkgs/standards/peagen/peagen/cli/commands/extras.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/extras.py
@@ -7,20 +7,18 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 import typer
-from functools import partial
 
 from peagen.handlers.extras_handler import extras_handler
 from swarmauri_standard.loggers.Logger import Logger
 from peagen.transport import TASK_SUBMIT
-from peagen.transport.jsonrpc_schemas.task import SubmitParams, SubmitResult
+from peagen.transport.jsonrpc_schemas.task import SubmitResult
 from peagen.cli.rpc_utils import rpc_post
-from peagen.cli.task_builder import _build_task as _generic_build_task
+from peagen.cli.task_helpers import build_task, submit_task
 
 local_extras_app = typer.Typer(help="Manage EXTRAS schemas.")
 remote_extras_app = typer.Typer(help="Manage EXTRAS schemas remotely.")
 
 
-_build_task = partial(_generic_build_task, "extras")
 
 
 @local_extras_app.command("extras")
@@ -45,7 +43,7 @@ def run_extras(
     }
     if repo:
         args.update({"repo": repo, "ref": ref})
-    task = _build_task(args, ctx.obj.get("pool", "default"))
+    task = build_task("extras", args, pool=ctx.obj.get("pool", "default"))
 
     try:
         result: Dict[str, Any] = asyncio.run(extras_handler(task))
@@ -81,20 +79,16 @@ def submit_extras(
     }
     if repo:
         args.update({"repo": repo, "ref": ref})
-    task = _build_task(args, ctx.obj.get("pool", "default"))
+    task = build_task("extras", args, pool=ctx.obj.get("pool", "default"))
 
     try:
-        reply = rpc_post(
-            gateway_url,
-            TASK_SUBMIT,
-            SubmitParams(task=task).model_dump(),
-            timeout=10.0,
-            result_model=SubmitResult,
-        )
-        if reply.error:
-            typer.echo(f"[ERROR] {reply.error.message}")
+        reply = submit_task(gateway_url, task)
+        if "error" in reply:
+            typer.echo(f"[ERROR] {reply['error']['message']}")
             raise typer.Exit(1)
-        typer.echo(f"Submitted extras generation → taskId={reply.result.taskId}")
+        typer.echo(
+            f"Submitted extras generation → taskId={reply['result']['taskId']}"
+        )
     except Exception as exc:
         typer.echo(f"[ERROR] Could not reach gateway at {gateway_url}: {exc}")
         raise typer.Exit(1)

--- a/pkgs/standards/peagen/peagen/cli/commands/fetch.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/fetch.py
@@ -13,17 +13,15 @@ from pathlib import Path
 from typing import List, Optional
 
 import typer
-from functools import partial
 
 from peagen.handlers.fetch_handler import fetch_handler
 from peagen.transport.jsonrpc_schemas import Status
-from peagen.cli.task_builder import _build_task as _generic_build_task
+from peagen.cli.task_helpers import build_task
 
 fetch_app = typer.Typer(help="Materialise Peagen workspaces from URIs.")
 
 
 # ───────────────────────── helpers ─────────────────────────
-_build_task = partial(_generic_build_task, "fetch", status=Status.waiting)
 
 
 def _collect_args(
@@ -71,7 +69,7 @@ def run(
     pool = "default"
     if ctx is not None and getattr(ctx, "obj", None):
         pool = ctx.obj.get("pool", "default")
-    task = _build_task(args, pool)
+    task = build_task("fetch", args, pool=pool, status=Status.waiting)
 
     result = asyncio.run(fetch_handler(task))
     typer.echo(json.dumps(result, indent=2))

--- a/pkgs/standards/peagen/peagen/cli/task_helpers.py
+++ b/pkgs/standards/peagen/peagen/cli/task_helpers.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any, Dict
+
+import httpx
+
+from peagen.transport import Request
+from peagen.transport.jsonrpc_schemas import TASK_SUBMIT, Status
+from peagen.transport.jsonrpc_schemas.task import SubmitParams
+
+
+def build_task(
+    action: str,
+    args: Dict[str, Any],
+    *,
+    pool: str = "default",
+    repo: str | None = None,
+    ref: str | None = None,
+    status: Status = Status.waiting,
+    note: str | None = None,
+    config_toml: str | None = None,
+    labels: list[str] | None = None,
+) -> SubmitParams:
+    """Return a :class:`SubmitParams` instance for *action* and *args*."""
+
+    return SubmitParams(
+        id=str(uuid.uuid4()),
+        pool=pool,
+        repo=repo,
+        ref=ref,
+        payload={"action": action, "args": args},
+        status=status,
+        note=note,
+        config_toml=config_toml,
+        labels=labels,
+    )
+
+
+def submit_task(gateway_url: str, task: SubmitParams, *, timeout: float = 30.0) -> dict:
+    """Submit *task* to *gateway_url* via JSON-RPC and return the response."""
+
+    envelope = Request(id=str(uuid.uuid4()), method=TASK_SUBMIT, params=task.model_dump())
+    resp = httpx.post(gateway_url, json=envelope.model_dump(mode="json"), timeout=timeout)
+    resp.raise_for_status()
+    return resp.json()

--- a/pkgs/standards/peagen/tests/smoke/test_cli_task_submit.py
+++ b/pkgs/standards/peagen/tests/smoke/test_cli_task_submit.py
@@ -51,9 +51,9 @@ def test_cli_task_submit_local(monkeypatch, tmp_path: Path) -> None:
 
     monkeypatch.setattr(
         process_mod,
-        "_build_task",
-        lambda args, pool: DummyTask(
-            pool=pool, payload={"action": "process", "args": args}
+        "build_task",
+        lambda action, args, pool="default", **k: DummyTask(
+            pool=pool, payload={"action": action, "args": args}
         ),
     )
 

--- a/pkgs/standards/peagen/tests/unit/test_evolve_cli.py
+++ b/pkgs/standards/peagen/tests/unit/test_evolve_cli.py
@@ -1,9 +1,10 @@
 import pytest
 from peagen.cli.commands import evolve
+from peagen.cli.task_helpers import build_task
 
 
 @pytest.mark.unit
 def test_build_task_payload():
-    task = evolve._build_task({"evolve_spec": "foo.yaml"})
+    task = build_task("evolve", {"evolve_spec": "foo.yaml"})
     assert task.payload["action"] == "evolve"
     assert task.payload["args"] == {"evolve_spec": "foo.yaml"}

--- a/pkgs/standards/peagen/tests/unit/test_fetch_cli.py
+++ b/pkgs/standards/peagen/tests/unit/test_fetch_cli.py
@@ -6,12 +6,13 @@ import typer
 
 from peagen.cli.commands import fetch
 from peagen.orm.status import Status
+from peagen.cli.task_helpers import build_task
 
 
 @pytest.mark.unit
 def test_build_task_embeds_action_and_args():
     args = {"workspaces": ["w"]}
-    task = fetch._build_task(args)
+    task = build_task("fetch", args)
     assert task.payload == {"action": "fetch", "args": args}
     assert task.pool == "default"
     assert task.status == Status.waiting

--- a/pkgs/standards/peagen/tests/unit/test_task_submit.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_submit.py
@@ -1,7 +1,7 @@
 import httpx
 import pytest
 
-from peagen.tui.task_submit import build_task, submit_task
+from peagen.cli.task_helpers import build_task, submit_task
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- add `task_helpers.build_task` and `task_helpers.submit_task`
- refactor CLI commands to use the new helpers
- update unit and smoke tests for new helper functions

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format .` *(fails: no such file or directory)*
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix` *(fails: unable to fetch packages)*
- `uv run --package peagen --directory pkgs/standards/peagen pytest` *(fails: unable to fetch packages)*

------
https://chatgpt.com/codex/tasks/task_e_6861cb800d9c83268289d2817f9fa5cb