### PR TITLE
Implement typed task submission

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/sort.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/sort.py
@@ -9,10 +9,7 @@ import typer
 
 from peagen._utils.config_loader import _effective_cfg, load_peagen_toml
 from peagen.handlers.sort_handler import sort_handler
-from peagen.transport import TASK_SUBMIT
-from peagen.transport.jsonrpc_schemas.task import SubmitResult
 from peagen.cli.task_helpers import build_task, submit_task
-from peagen.cli.rpc_utils import rpc_post
 
 local_sort_app = typer.Typer(help="Sort generated project files.")
 remote_sort_app = typer.Typer(help="Sort generated project files via JSON-RPC.")
@@ -134,10 +131,10 @@ def submit_sort(
 
     try:
         resp = submit_task(ctx.obj.get("gateway_url"), task)
-        if "error" in resp:
-            typer.echo(f"[ERROR] {resp['error']['message']}")
+        if resp.error:
+            typer.echo(f"[ERROR] {resp.error.message}")
             raise typer.Exit(1)
-        typer.echo(f"Submitted sort → taskId={resp['result']['taskId']}")
+        typer.echo(f"Submitted sort → taskId={resp.result.id}")
     except Exception as exc:
         typer.echo(
             f"[ERROR] Could not reach gateway at {ctx.obj.get('gateway_url')}: {exc}"

--- a/pkgs/standards/peagen/tests/smoke/test_remote_process_rpc.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_process_rpc.py
@@ -42,9 +42,9 @@ def test_rpc_submit_remote_process(tmp_path: Path) -> None:
         {"projects_payload": payload_text, "repo": REPO, "ref": "HEAD"},
     )
     reply = submit_task(GATEWAY, task)
-    if "error" in reply:
-        pytest.skip(f"remote submit failed: {reply['error']['message']}")
-    assert "result" in reply and "taskId" in reply["result"]
+    if reply.error:
+        pytest.skip(f"remote submit failed: {reply.error.message}")
+    assert reply.result and reply.result.id
 
 
 @pytest.mark.i9n
@@ -58,10 +58,10 @@ def test_rpc_watch_remote_process(tmp_path: Path) -> None:
         {"projects_payload": payload_text, "repo": REPO, "ref": "HEAD"},
     )
     reply = submit_task(GATEWAY, task)
-    if "error" in reply:
-        pytest.skip(f"remote submit failed: {reply['error']['message']}")
+    if reply.error:
+        pytest.skip(f"remote submit failed: {reply.error.message}")
 
-    tid = reply.get("result", {}).get("taskId")
+    tid = reply.result.id if reply.result else None
     assert tid
 
     envelope = {

--- a/pkgs/standards/peagen/tests/unit/test_task_submit.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_submit.py
@@ -24,7 +24,11 @@ def test_submit_task_sends_request(monkeypatch):
                 pass
 
             def json(self):
-                return {"ok": True}
+                return {
+                    "jsonrpc": "2.0",
+                    "id": json["id"],
+                    "result": {"id": "t1"},
+                }
 
         return Resp()
 
@@ -32,4 +36,4 @@ def test_submit_task_sends_request(monkeypatch):
     task = build_task("demo", {})
     reply = submit_task("http://gw/rpc", task)
     assert captured["json"]["params"]["id"] == task.id
-    assert reply == {"ok": True}
+    assert reply.result and reply.result.id == "t1"


### PR DESCRIPTION
## Summary
- refine `submit_task` to return a typed Response
- update sort CLI to handle typed submit results
- adjust tests for updated task helpers

## Testing
- `ruff format pkgs/standards/peagen/peagen/cli/task_helpers.py pkgs/standards/peagen/tests/unit/test_task_submit.py pkgs/standards/peagen/tests/smoke/test_remote_process_rpc.py pkgs/standards/peagen/peagen/cli/commands/sort.py`
- `ruff check pkgs/standards/peagen/peagen/cli/task_helpers.py pkgs/standards/peagen/tests/unit/test_task_submit.py pkgs/standards/peagen/tests/smoke/test_remote_process_rpc.py pkgs/standards/peagen/peagen/cli/commands/sort.py --fix`
- `uv run --directory pkgs/standards --package peagen pytest` *(fails: no internet)*

------
https://chatgpt.com/codex/tasks/task_e_6861d63b6a008326a981661e25eae826