### PR TITLE
Fix circular import when loading Peagen ORM schemas

### DIFF
--- a/pkgs/standards/peagen/peagen/orm/__init__.py
+++ b/pkgs/standards/peagen/peagen/orm/__init__.py
@@ -84,24 +84,6 @@ from .result.analysis_result import AnalysisResultModel  # noqa: F401
 from .abuse_record import AbuseRecordModel  # noqa: F401
 from .security.public_key import PublicKeyModel  # noqa: F401
 
-from .schemas import TaskCreate, TaskUpdate, TaskRead
-
-def task_schema_to_orm(data: TaskCreate | TaskUpdate) -> TaskModel:
-    """Convert a :class:`TaskCreate` or :class:`TaskUpdate` to a ``TaskModel``."""
-
-    return TaskModel(**data.model_dump())
-
-
-def task_orm_to_schema(row: TaskModel) -> TaskRead:
-    """Convert a ``TaskModel`` row to its ``TaskRead`` schema."""
-
-    return TaskRead.from_orm(row)
-
-
-
-# ----------------------------------------------------------------------
-# Public re-exports
-# ----------------------------------------------------------------------
 __all__: list[str] = [
     # base
     "Base",
@@ -150,3 +132,17 @@ try:  # pragma: no cover - best effort
     importlib.import_module("peagen.orm.schemas")
 except Exception:  # noqa: BLE001
     pass
+
+from .schemas import TaskCreate, TaskUpdate, TaskRead
+
+
+def task_schema_to_orm(data: TaskCreate | TaskUpdate) -> TaskModel:
+    """Convert a :class:`TaskCreate` or :class:`TaskUpdate` to a ``TaskModel``."""
+
+    return TaskModel(**data.model_dump())
+
+
+def task_orm_to_schema(row: TaskModel) -> TaskRead:
+    """Convert a ``TaskModel`` row to its ``TaskRead`` schema."""
+
+    return TaskRead.from_orm(row)


### PR DESCRIPTION
## Summary
- reorder schema imports in Peagen ORM package

## Testing
- `uv run --package peagen --directory . ruff format peagen/orm/__init__.py`
- `uv run --package peagen --directory . ruff check peagen/orm/__init__.py --fix`
- `uv run --package peagen --directory standards/peagen pytest` *(fails: ModuleNotFoundError: No module named 'peagen.cli.rpc_utils')*

------
https://chatgpt.com/codex/tasks/task_e_6861d910624483268d70af6f7f0cb821