### PR TITLE
Unify task get RPC in peagen CLI

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/process.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/process.py
@@ -13,20 +13,16 @@ from __future__ import annotations
 import asyncio
 import json
 import time
-import uuid
 from pathlib import Path
 import tempfile
 from typing import Any, Dict, Optional
 
-import httpx
 
 import typer
 from peagen._utils.config_loader import _effective_cfg, load_peagen_toml
 from peagen.handlers.process_handler import process_handler
-from peagen.transport import Request, Response, TASK_GET
-from peagen.transport.jsonrpc_schemas.task import GetParams, GetResult
 from peagen.transport.jsonrpc_schemas import Status
-from peagen.cli.task_helpers import build_task, submit_task
+from peagen.cli.task_helpers import build_task, submit_task, get_task
 
 local_process_app = typer.Typer(help="Render / generate project files.")
 remote_process_app = typer.Typer(help="Render / generate project files.")
@@ -193,24 +189,8 @@ def submit(  # noqa: PLR0913 – CLI signature needs many options
     if data.get("result") is not None:
         typer.echo(json.dumps(data["result"], indent=2))
     if watch:
-
-        def _rpc_call() -> GetResult:
-            envelope = Request(
-                id=str(uuid.uuid4()),
-                method=TASK_GET,
-                params=GetParams(taskId=tid).model_dump(),
-            )
-            resp = httpx.post(
-                ctx.obj.get("gateway_url"),
-                json=envelope.model_dump(mode="json"),
-                timeout=30.0,
-            )
-            resp.raise_for_status()
-            parsed = Response[GetResult].model_validate_json(resp.json())
-            return parsed.result  # type: ignore[return-value]
-
         while True:
-            task_reply = _rpc_call()
+            task_reply = get_task(ctx.obj.get("gateway_url"), tid)
             typer.echo(json.dumps(task_reply.model_dump(), indent=2))
             if Status.is_terminal(task_reply.status):
                 break

--- a/pkgs/standards/peagen/peagen/cli/task_helpers.py
+++ b/pkgs/standards/peagen/peagen/cli/task_helpers.py
@@ -5,9 +5,10 @@ from typing import Any, Dict
 
 import httpx
 
-from peagen.transport import Request
+from peagen.defaults import RPC_TIMEOUT
+from peagen.transport import Request, Response, TASK_GET
 from peagen.transport.jsonrpc_schemas import TASK_SUBMIT, Status
-from peagen.transport.jsonrpc_schemas.task import SubmitParams
+from peagen.transport.jsonrpc_schemas.task import GetParams, GetResult, SubmitParams
 
 
 def build_task(
@@ -48,3 +49,24 @@ def submit_task(gateway_url: str, task: SubmitParams, *, timeout: float = 30.0) 
     )
     resp.raise_for_status()
     return resp.json()
+
+
+def get_task(
+    gateway_url: str,
+    task_id: str,
+    *,
+    timeout: float = RPC_TIMEOUT,
+) -> GetResult:
+    """Return task information from *gateway_url* via JSON-RPC."""
+
+    envelope = Request(
+        id=str(uuid.uuid4()),
+        method=TASK_GET,
+        params=GetParams(taskId=task_id).model_dump(),
+    )
+    resp = httpx.post(
+        gateway_url, json=envelope.model_dump(mode="json"), timeout=timeout
+    )
+    resp.raise_for_status()
+    parsed = Response[GetResult].model_validate_json(resp.json())
+    return parsed.result  # type: ignore[return-value]

--- a/pkgs/standards/peagen/peagen/defaults/__init__.py
+++ b/pkgs/standards/peagen/peagen/defaults/__init__.py
@@ -11,6 +11,9 @@ from .events import CONTROL_QUEUE, READY_QUEUE, PUBSUB_CHANNEL, TASK_KEY
 from .methods import *  # noqa: F401,F403 re-export rpc method names
 from peagen.transport.error_codes import ErrorCode
 
+# Default timeout for JSON-RPC requests in seconds.
+RPC_TIMEOUT = 30.0
+
 # Default directory for repository lock files.
 LOCK_DIR = "~/.cache/peagen/locks"
 
@@ -69,5 +72,6 @@ __all__ = [
     "LOCK_DIR",
     "lock_dir",
     "DEFAULT_POOL",
+    "RPC_TIMEOUT",
     "ErrorCode",
 ]


### PR DESCRIPTION
## Summary
- centralize task querying logic under `task_helpers.get_task`
- export RPC timeout constant in `peagen.defaults`
- replace inline RPC code in CLI commands with unified helper

## Testing
- `uv run --directory standards --package peagen ruff format peagen`
- `uv run --directory standards --package peagen ruff check peagen --fix`
- `uv run --package peagen --directory standards pytest` *(fails: 64 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6861e7c01d8883269738a09cec7f5c4f