### PR TITLE
Fix peagen test collection

### DIFF
--- a/pkgs/standards/peagen/peagen/_utils/_init.py
+++ b/pkgs/standards/peagen/peagen/_utils/_init.py
@@ -1,12 +1,17 @@
+import asyncio
 import textwrap
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict
 import re
 import sys
 import types
 import uuid
 
 import typer
+from peagen.handlers.init_handler import init_handler
+from peagen.plugins import discover_and_register_plugins
+from peagen.transport.jsonrpc_schemas import Status
+from peagen.transport.jsonrpc_schemas.task import SubmitParams
 
 
 # Allow tests to monkeypatch ``uuid.uuid4`` without affecting the global ``uuid``
@@ -27,6 +32,19 @@ def _contains_pat(obj: Any) -> bool:
     if isinstance(obj, list):
         return any(_contains_pat(v) for v in obj)
     return False
+
+
+def _call_handler(args: Dict[str, Any]) -> Dict[str, Any]:
+    """Invoke :func:`init_handler` synchronously."""
+
+    discover_and_register_plugins()
+    task = SubmitParams(
+        id=str(_real_uuid4()),
+        pool="default",
+        payload={"action": "init", "args": args},
+        status=Status.waiting,
+    )
+    return asyncio.run(init_handler(task))
 
 
 def _summary(created_in: Path, next_cmd: str) -> None:


### PR DESCRIPTION
## Summary
- restore `_call_handler` to avoid ImportErrors

## Testing
- `uv run --directory peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest -q` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_6861e8237e0083269ee2da1fe6185cf2