### PR TITLE
Fix login CLI when run standalone

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/login.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/login.py
@@ -37,7 +37,8 @@ def login(
             "passphrase": passphrase,
             "gateway_url": gateway_url,
         }
-        task = build_task("login", args, pool=ctx.obj.get("pool", "default"))
+        pool = (ctx.obj or {}).get("pool", "default")
+        task = build_task("login", args, pool=pool)
         reply = submit_task(gateway_url, task)
     except Exception as e:  # pragma: no cover - network errors
         typer.echo(f"HTTP error: {e}", err=True)


### PR DESCRIPTION
## Summary
- ensure `peagen login` handles missing context
- update to use default pool when invoked directly

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_cli_login.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6861f04e73ac83268d1a2490565c597e