### PR TITLE
Fix eval handler test

### DIFF
--- a/pkgs/standards/peagen/peagen/handlers/eval_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/eval_handler.py
@@ -22,8 +22,10 @@ from peagen._utils.config_loader import resolve_cfg
 from peagen.transport.jsonrpc_schemas.task import SubmitParams, SubmitResult
 
 
-async def eval_handler(task: SubmitParams) -> SubmitResult:
-    payload = task.payload
+async def eval_handler(task: SubmitParams | dict) -> SubmitResult:
+    """Evaluate a workspace task and return the results."""
+
+    payload = task.payload if hasattr(task, "payload") else task.get("payload", {})
     args: Dict[str, Any] = payload.get("args", {})
     cfg_override: Dict[str, Any] = payload.get("cfg_override", {})
     repo = args.get("repo")


### PR DESCRIPTION
## Summary
- ensure `eval_handler` accepts dictionaries in tests

## Testing
- `uv run --package peagen --directory . ruff check . --fix`
- `uv run --package peagen --directory . pytest tests/unit/test_eval_handler.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6861f06b49bc83268e0f005d1d33754b