### PR TITLE
Fix secrets CLI worker key parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ pkgs/community/swarmauri_vectorstore_annoy/test_annoy.ann
 peagen_artifacts/
 gateway.db
 pkgs/standards/peagen/peagen.zip
+/pkgs/uv.lock
+pkgs/standards/peagen/.pymon

--- a/pkgs/standards/peagen/peagen/cli/commands/secrets.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/secrets.py
@@ -33,13 +33,17 @@ def _pool_worker_pubs(pool: str, gateway_url: str) -> list[str]:
             gateway_url, json=envelope.model_dump(mode="json"), timeout=10.0
         )
         resp.raise_for_status()
-        parsed = Response[ListResult].model_validate_json(resp.json())
-        if parsed.result is None:
-            workers = []
-        elif hasattr(parsed.result, "root"):
-            workers = parsed.result.root
+        data = resp.json()
+        if isinstance(data, list):
+            workers = data
         else:
-            workers = parsed.result
+            parsed = Response[ListResult].model_validate(data)
+            if parsed.result is None:
+                workers = []
+            elif hasattr(parsed.result, "root"):
+                workers = parsed.result.root
+            else:
+                workers = parsed.result
     except Exception:
         return []
     keys = []


### PR DESCRIPTION
## Summary
- handle non-JSON-RPC responses when collecting worker public keys
- ignore uv.lock and `.pymon` artifacts

## Testing
- `ruff format .`
- `ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_secrets_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6861f0e022e88326a63bd66f1d4d8170