### PR TITLE
Fix key retrieval logic in peagen CLI

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/secrets.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/secrets.py
@@ -33,13 +33,17 @@ def _pool_worker_pubs(pool: str, gateway_url: str) -> list[str]:
             gateway_url, json=envelope.model_dump(mode="json"), timeout=10.0
         )
         resp.raise_for_status()
-        parsed = Response[ListResult].model_validate_json(resp.json())
-        if parsed.result is None:
-            workers = []
-        elif hasattr(parsed.result, "root"):
-            workers = parsed.result.root
+        data = resp.json()
+        if isinstance(data, list):
+            workers = data
         else:
-            workers = parsed.result
+            parsed = Response[ListResult].model_validate(data)
+            if parsed.result is None:
+                workers = []
+            elif hasattr(parsed.result, "root"):
+                workers = parsed.result.root
+            else:
+                workers = parsed.result
     except Exception:
         return []
     keys = []


### PR DESCRIPTION
## Summary
- handle both JSON-RPC responses and plain lists when collecting worker public keys
- parse list responses without failing

## Testing
- `uv run --package peagen --directory standards/peagen ruff format peagen/cli/commands/secrets.py`
- `uv run --package peagen --directory standards/peagen ruff check peagen/cli/commands/secrets.py --fix`
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_secrets_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6861f0e0b224832681932abf04933780