### PR TITLE
Fix doe_handler for unit test

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_doe_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_doe_handler.py
@@ -2,6 +2,7 @@ import pytest
 from pathlib import Path
 
 from peagen.handlers import doe_handler as handler
+from peagen.cli.task_helpers import build_task
 
 
 @pytest.mark.unit
@@ -26,7 +27,8 @@ async def test_doe_handler_calls_generate_payload(monkeypatch):
         "skip_validate": True,
     }
 
-    result = await handler.doe_handler({"payload": {"args": args}})
+    task = build_task("doe", args)
+    result = await handler.doe_handler(task)
 
     assert result == {"done": True}
     assert captured["spec_path"] == Path("spec.yml")


### PR DESCRIPTION
## Summary
- revert `doe_handler` signature back to only `SubmitParams`
- build a proper task object in `test_doe_handler`

## Testing
- `uv run --directory standards --package peagen ruff check . --fix`
- `uv run --package peagen --directory standards pytest peagen/tests/unit/test_doe_handler.py`


------
https://chatgpt.com/codex/tasks/task_e_6861f05592088326afa33e528c16390c