### PR TITLE
Fix fetch handler test to build SubmitParams

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_fetch_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_fetch_handler.py
@@ -2,6 +2,7 @@ import pytest
 from pathlib import Path
 
 from peagen.handlers import fetch_handler as handler
+from peagen.cli.task_helpers import build_task
 
 
 @pytest.mark.unit
@@ -22,7 +23,8 @@ async def test_fetch_handler_passes_args(monkeypatch):
         "install_template_sets": False,
     }
 
-    result = await handler.fetch_handler({"payload": {"args": args}})
+    task = build_task("fetch", args)
+    result = await handler.fetch_handler(task)
 
     assert result == {"count": 2}
     assert captured["workspace_uris"] == ["w1", "w2"]


### PR DESCRIPTION
## Summary
- restore original `fetch_handler` function signature
- adjust unit test to build `SubmitParams`

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/handlers/fetch_handler.py --fix`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check tests/unit/test_fetch_handler.py --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_fetch_handler.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6861f089664483269db6e760f6dfa79d