### PR TITLE
Fix patch API test

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_task_patch_not_found.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_patch_not_found.py
@@ -44,6 +44,7 @@ async def test_task_patch_missing(monkeypatch):
     task_patch = gw.task_patch
 
     from peagen.errors import TaskNotFoundError
+    from peagen.transport.jsonrpc_schemas.task import PatchParams
 
     with pytest.raises(TaskNotFoundError):
-        await task_patch(taskId="missing", changes={"status": "success"})
+        await task_patch(PatchParams(taskId="missing", changes={"status": "success"}))


### PR DESCRIPTION
## Summary
- update `test_task_patch_not_found` to pass a `PatchParams` object

## Testing
- `uv run --package peagen --directory standards ruff format .`
- `uv run --package peagen --directory standards ruff check . --fix`
- `uv run --package peagen --directory standards pytest peagen/tests/unit/test_task_patch_not_found.py::test_task_patch_missing -q`


------
https://chatgpt.com/codex/tasks/task_e_6861f104a3988326824b9495188d619a