### PR TITLE
Fix test to use build_task helper

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_evolve_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_evolve_handler.py
@@ -36,11 +36,9 @@ async def test_evolve_handler_fanout(monkeypatch, tmp_path):
         "JOBS:\n- workspace_uri: ws\n  target_file: t.py\n  import_path: mod\n  entry_fn: f\noperators:\n  mutation:\n    - kind: echo_mutator\n      probability: 1\n      uri: patch.p\n"
     )
 
-    task = {
-        "id": "P1",
-        "pool": "default",
-        "payload": {"args": {"evolve_spec": str(spec)}},
-    }
+    from peagen.cli.task_helpers import build_task
+
+    task = build_task("evolve", {"evolve_spec": str(spec)})
     result = await handler.evolve_handler(task)
 
     assert result["jobs"] == 1


### PR DESCRIPTION
## Summary
- update evolve_handler unit test to use `build_task`

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format .`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_evolve_handler.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6861f07246fc83269cbedf7588ecb1b7