### PR TITLE
Fix extras_handler to use SubmitParams in tests

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_extras_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_extras_handler.py
@@ -2,6 +2,7 @@ import pytest
 from pathlib import Path
 
 from peagen.handlers import extras_handler as handler
+from peagen.cli.task_helpers import build_task
 
 
 @pytest.mark.unit
@@ -28,7 +29,8 @@ async def test_extras_handler_calls_generate_schemas(
     if schemas_dir:
         args["schemas_dir"] = schemas_dir
 
-    result = await handler.extras_handler({"payload": {"args": args}})
+    task = build_task("extras", args)
+    result = await handler.extras_handler(task)
 
     base = Path(handler.__file__).resolve().parents[1]
     expected_templates = (


### PR DESCRIPTION
## Summary
- revert extras_handler to only accept SubmitParams
- update extras_handler unit tests to build tasks via `build_task`

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format .`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_extras_handler.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6861f078b074832681d274b2a651fc9d