### PR TITLE
Fix mutate_handler test

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_mutate_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_mutate_handler.py
@@ -1,6 +1,7 @@
 import pytest
 
 from peagen.handlers import mutate_handler as handler
+from peagen.cli.task_helpers import build_task
 
 
 @pytest.mark.unit
@@ -26,7 +27,9 @@ async def test_mutate_handler_invokes_core(monkeypatch):
         "evaluator_ref": "ev",
     }
 
-    result = await handler.mutate_handler({"payload": {"args": args}})
+    task = build_task("mutate", args, pool="default")
+
+    result = await handler.mutate_handler(task)
 
     assert result == {"winner": "w.py", "score": "1", "meta": {"ok": True}}
     assert captured["workspace_uri"] == "ws"

--- a/pkgs/standards/peagen/tests/unit/test_mutate_handler_repo.py
+++ b/pkgs/standards/peagen/tests/unit/test_mutate_handler_repo.py
@@ -2,6 +2,7 @@ import pytest
 from pathlib import Path
 from peagen.core.mirror_core import ensure_repo
 from peagen.handlers import mutate_handler as handler
+from peagen.cli.task_helpers import build_task
 
 
 @pytest.mark.unit
@@ -40,7 +41,8 @@ async def test_mutate_handler_repo(tmp_path: Path, monkeypatch):
         "evaluator_ref": "ev",
     }
 
-    result = await handler.mutate_handler({"payload": {"args": args}})
+    task = build_task("mutate", args, pool="default")
+    result = await handler.mutate_handler(task)
 
     assert not Path(captured["workspace_uri"]).exists()
     assert result["score"] == "0"


### PR DESCRIPTION
## Summary
- use `build_task` when invoking `mutate_handler` in unit tests
- ensure CLI's mutate command uses `build_task`

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format .`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_mutate_handler.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6861f09f37ac8326aff330184a4d3313