### PR TITLE
Fix CLI use of build_task for sort_handler

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/sort.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/sort.py
@@ -50,14 +50,8 @@ def run_sort(  # ← now receives the Typer context
     }
     if repo:
         args.update({"repo": repo, "ref": ref})
-    task = {
-        "pool": "default",
-        "payload": {
-            "action": "sort",
-            "args": args,
-            "cfg_override": cfg_override,
-        },
-    }
+    task = build_task("sort", args, pool="default")
+    task.payload["cfg_override"] = cfg_override
 
     # ─────────────────────── 3) call handler ────────────────────────────
     try:
@@ -127,7 +121,8 @@ def submit_sort(
         "repo": repo,
         "ref": ref,
     }
-    task = build_task("sort", {**args, "cfg_override": cfg_override}, pool="default")
+    task = build_task("sort", args, pool="default")
+    task.payload["cfg_override"] = cfg_override
 
     try:
         resp = submit_task(ctx.obj.get("gateway_url"), task)

--- a/pkgs/standards/peagen/tests/unit/test_sort_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_sort_handler.py
@@ -1,6 +1,7 @@
 import pytest
 
 from peagen.handlers import sort_handler as handler
+from peagen.cli.task_helpers import build_task
 
 
 @pytest.mark.unit
@@ -28,7 +29,8 @@ async def test_sort_handler_delegates(monkeypatch, project_name):
     if project_name:
         args["project_name"] = project_name
 
-    result = await handler.sort_handler({"payload": {"args": args}})
+    task = build_task("sort", args)
+    result = await handler.sort_handler(task)
 
     if project_name:
         assert "single" in calls


### PR DESCRIPTION
## Summary
- revert `sort_handler` to accept `SubmitParams`
- update local and remote sort CLI to build tasks with `build_task`
- adjust sort handler unit test accordingly

## Testing
- `uv run --package peagen --directory standards ruff check . --fix`
- `uv run --package peagen --directory standards pytest peagen/tests/unit/test_sort_handler.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6861f0ea0b4483268ec6aed557dfe09f