### PR TITLE
Fix peagen protocol test

### DIFF
--- a/pkgs/standards/peagen/tests/test_protocols_basic.py
+++ b/pkgs/standards/peagen/tests/test_protocols_basic.py
@@ -1,36 +1,42 @@
+import httpx
+import pytest
+
 from peagen.transport import (
     Response,
     parse_request,
     _registry,
-    TASK_SUBMIT,
     KEYS_UPLOAD,
     SECRETS_ADD,
 )
+from peagen.cli.task_helpers import build_task, submit_task
 
 
-def test_parse_and_registry() -> None:
-    raw = {
-        "jsonrpc": "2.0",
-        "id": 1,
-        "method": TASK_SUBMIT,
-        "params": {
-            "task": {
-                "tenant_id": "01234567-89ab-cdef-0123-456789abcdef",
-                "git_reference_id": "fedcba98-7654-3210-fedc-ba9876543210",
-                "pool": "default",
-                "payload": {"action": "demo"},
-                "status": "queued",
-                "note": "",
-                "spec_hash": "dummy",
-                "id": "11111111-2222-3333-4444-555555555555",
-                "last_modified": "2024-01-01T00:00:00Z",
-            }
-        },
-    }
+def test_parse_and_registry(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_post(url: str, json: dict, timeout: float) -> object:
+        captured["json"] = json
+
+        class Resp:
+            def raise_for_status(self) -> None:
+                pass
+
+            def json(self) -> dict:
+                return {"ok": True}
+
+        return Resp()
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+
+    task = build_task("demo", {}, pool="default")
+    submit_task("http://gw/rpc", task)
+
+    raw = captured["json"]
+    assert isinstance(raw, dict)
     req = parse_request(raw)
     PModel = _registry.params_model(req.method)
     params = PModel.model_validate(req.params)
-    assert params.task.pool == "default"
+    assert params.pool == "default"
     res = Response.ok(id=req.id, result={"taskId": "ABCDEFGHIJKL"})
     assert res.jsonrpc == "2.0"
 


### PR DESCRIPTION
## Summary
- update `test_protocols_basic.py` to use `build_task` and `submit_task`

## Testing
- `uv run --directory standards/peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest tests/test_protocols_basic.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6861eff6a59883268ca8120d9dfecd28