### PR TITLE
Fix peagen tests to use build_task helper

### DIFF
--- a/pkgs/standards/peagen/peagen/_utils/_init.py
+++ b/pkgs/standards/peagen/peagen/_utils/_init.py
@@ -11,7 +11,6 @@ import typer
 from peagen.handlers.init_handler import init_handler
 from peagen.plugins import discover_and_register_plugins
 from peagen.transport.jsonrpc_schemas import Status
-from peagen.transport.jsonrpc_schemas.task import SubmitParams
 
 
 # Allow tests to monkeypatch ``uuid.uuid4`` without affecting the global ``uuid``
@@ -38,12 +37,15 @@ def _call_handler(args: Dict[str, Any]) -> Dict[str, Any]:
     """Invoke :func:`init_handler` synchronously."""
 
     discover_and_register_plugins()
-    task = SubmitParams(
-        id=str(_real_uuid4()),
+    from peagen.cli.task_helpers import build_task
+
+    task = build_task(
+        "init",
+        args,
         pool="default",
-        payload={"action": "init", "args": args},
         status=Status.waiting,
     )
+    task.id = str(_uuid_alias.uuid4())
     return asyncio.run(init_handler(task))
 
 

--- a/pkgs/standards/peagen/tests/unit/test_doe_process_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_doe_process_handler.py
@@ -2,6 +2,7 @@ import pytest
 
 from peagen.handlers import doe_process_handler as handler
 from peagen.transport.jsonrpc_schemas import TASK_SUBMIT, TASK_PATCH
+from peagen.cli.task_helpers import build_task
 from peagen.defaults import WORK_FINISHED
 
 
@@ -59,13 +60,14 @@ async def test_doe_process_handler_dispatches(monkeypatch, tmp_path):
 
     monkeypatch.setattr(handler, "generate_payload", fake_generate_payload)
 
-    task = {
-        "id": "T0",
-        "pool": "default",
-        "payload": {
-            "args": {"spec": "s", "template": "t", "output": str(tmp_path / "out.yaml")}
+    task = build_task(
+        "doe_process",
+        {
+            "spec": "s",
+            "template": "t",
+            "output": str(tmp_path / "out.yaml"),
         },
-    }
+    )
     result = await handler.doe_process_handler(task)
 
     assert len(sent) == 4
@@ -138,18 +140,15 @@ async def test_doe_process_handler_dry_run(monkeypatch, tmp_path):
 
     monkeypatch.setattr(handler, "generate_payload", fake_generate_payload)
 
-    task = {
-        "id": "T0",
-        "pool": "default",
-        "payload": {
-            "args": {
-                "spec": "s",
-                "template": "t",
-                "output": str(tmp_path / "out.yaml"),
-                "dry_run": True,
-            }
+    task = build_task(
+        "doe_process",
+        {
+            "spec": "s",
+            "template": "t",
+            "output": str(tmp_path / "out.yaml"),
+            "dry_run": True,
         },
-    }
+    )
     result = await handler.doe_process_handler(task)
 
     assert sent == []

--- a/pkgs/standards/peagen/tests/unit/test_process_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_process_handler.py
@@ -1,6 +1,7 @@
 import pytest
 
 from peagen.handlers import process_handler as handler
+from peagen.cli.task_helpers import build_task
 
 
 class DummyPM:
@@ -46,7 +47,9 @@ async def test_process_handler_dispatch(monkeypatch, project_name):
     if project_name:
         args["project_name"] = project_name
 
-    result = await handler.process_handler({"payload": {"args": args}})
+    task = build_task("process", args)
+
+    result = await handler.process_handler(task)
 
     if project_name:
         assert calls["single"] == {"NAME": project_name}


### PR DESCRIPTION
## Summary
- ensure `_call_handler` sets task IDs via alias `uuid4`
- rewrite process handler tests to build tasks using `build_task`
- adjust DOE process handler tests to use `build_task`

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_process_handler.py -vv`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_doe_process_handler.py -vv`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_utils_init.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_6861f0bb839c83268dd7b6e65195ad9a