### PR TITLE
Fix templates handler tests

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_templates_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_templates_handler.py
@@ -1,6 +1,7 @@
 import pytest
 
 from peagen.handlers import templates_handler as handler
+from peagen.cli.task_helpers import build_task
 
 
 @pytest.mark.unit
@@ -28,9 +29,8 @@ async def test_templates_handler_dispatch(monkeypatch, op, func, args):
 
     monkeypatch.setattr(handler, func, fake)
 
-    result = await handler.templates_handler(
-        {"payload": {"args": {"operation": op, **args}}}
-    )
+    task = build_task("templates", {"operation": op, **args})
+    result = await handler.templates_handler(task)
 
     assert result == {"op": op}
     assert called


### PR DESCRIPTION
## Summary
- restore `templates_handler` signature
- use `build_task` helper in templates handler unit tests

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_templates_handler.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6861f10ae18483269514b254d2a77e09