### PR TITLE
Update peagen init handler tests

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_init_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_init_handler.py
@@ -3,7 +3,8 @@ from pathlib import Path
 
 from peagen.handlers import init_handler as handler
 from peagen.core import init_core
-from peagen.transport.jsonrpc_schemas.task import SubmitParams, Status
+from peagen.cli.task_helpers import build_task
+from peagen.transport.jsonrpc_schemas.task import Status
 
 
 @pytest.mark.unit
@@ -26,9 +27,7 @@ async def test_init_handler_dispatch(monkeypatch, kind, func):
 
     monkeypatch.setattr(init_core, func, fake)
     args = {"kind": kind, "path": "~/p"}
-    task = SubmitParams(
-        id="1", pool="default", payload={"args": args}, status=Status.waiting
-    )
+    task = build_task("init", args, status=Status.waiting)
     result = await handler.init_handler(task)
 
     assert result == {"kind": kind}
@@ -39,16 +38,13 @@ async def test_init_handler_dispatch(monkeypatch, kind, func):
 @pytest.mark.asyncio
 async def test_init_handler_errors(monkeypatch):
     with pytest.raises(ValueError):
-        task = SubmitParams(
-            id="1", pool="default", payload={"args": {}}, status=Status.waiting
-        )
+        task = build_task("init", {}, status=Status.waiting)
         await handler.init_handler(task)
 
     with pytest.raises(ValueError):
-        task = SubmitParams(
-            id="1",
-            pool="default",
-            payload={"args": {"kind": "unknown"}},
+        task = build_task(
+            "init",
+            {"kind": "unknown"},
             status=Status.waiting,
         )
         await handler.init_handler(task)


### PR DESCRIPTION
## Summary
- use `build_task` for creating test tasks
- keep tests passing

## Testing
- `uv run --package peagen --directory standards/peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_init_handler.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6861fa59af0883269147a518e6016c18