### PR TITLE
Fix Pool.listTasks result model

### DIFF
--- a/pkgs/standards/peagen/peagen/transport/jsonrpc_schemas/pool.py
+++ b/pkgs/standards/peagen/peagen/transport/jsonrpc_schemas/pool.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from typing import List
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, RootModel
 
 from .._registry import register
 
@@ -39,13 +38,10 @@ class ListParams(BaseModel):
     offset: int = 0
 
 
-class ListResult(BaseModel):
-    model_config = ConfigDict(extra="forbid")
+class ListResult(RootModel[list[dict]]):
+    """Result returned by ``Pool.listTasks``."""
 
-    poolName: str
-    limit: int | None = None
-    offset: int = 0
-    members: List[str] = Field(default_factory=list)
+    pass
 
 
 POOL_CREATE = register(


### PR DESCRIPTION
## Summary
- adjust Pool.listTasks schema to return a list of tasks

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen pytest` *(fails: two_user_secret_exchange_i9n_test.py::test_two_user_secret_exchange, test_sequences_success[example0])*

------
https://chatgpt.com/codex/tasks/task_e_686208463ac08326bae795036b71006a