### PR TITLE
Fix remote sort CLI integration

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/sort.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/sort.py
@@ -129,7 +129,10 @@ def submit_sort(
         if "error" in resp:
             typer.echo(f"[ERROR] {resp['error']['message']}")
             raise typer.Exit(1)
-        typer.echo(f"Submitted sort → taskId={resp['result']['taskId']}")
+        task_id = resp.get("result", {}).get("taskId") or resp.get("result", {}).get(
+            "id"
+        )
+        typer.echo(f"Submitted sort → taskId={task_id}")
     except Exception as exc:
         typer.echo(
             f"[ERROR] Could not reach gateway at {ctx.obj.get('gateway_url')}: {exc}"

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -391,7 +391,9 @@ async def _persist(task: TaskModel | dict) -> None:
         if isinstance(task, TaskModel):
             orm_task = task
         else:  # raw JSON / DTO
-            orm_task = TaskModel(**task)
+            allowed = {c.name for c in TaskModel.__table__.columns}
+            filtered = {k: v for k, v in task.items() if k in allowed}
+            orm_task = TaskModel(**filtered)
 
         log.info("persisting task %s", orm_task.id)
 


### PR DESCRIPTION
## Summary
- filter extra fields before persisting tasks
- fallback to alternate key in remote sort CLI output

## Testing
- `uv run --package peagen --directory standards/peagen pytest -m smoke tests/smoke/test_remote_sort_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_6862102b2c708326bc876ff529425df1