### PR TITLE
Fix remote sort CLI integration

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/sort.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/sort.py
@@ -129,7 +129,10 @@ def submit_sort(
         if "error" in resp:
             typer.echo(f"[ERROR] {resp['error']['message']}")
             raise typer.Exit(1)
-        typer.echo(f"Submitted sort → taskId={resp['result']['taskId']}")
+        task_id = resp.get("result", {}).get("taskId") or resp.get("result", {}).get(
+            "id"
+        )
+        typer.echo(f"Submitted sort → taskId={task_id}")
     except Exception as exc:
         typer.echo(
             f"[ERROR] Could not reach gateway at {ctx.obj.get('gateway_url')}: {exc}"

--- a/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
@@ -138,6 +138,8 @@ async def task_submit(params: SubmitParams) -> SubmitResult:
         persist = True
     except ValueError:
         persist = False
+    if task_blob.get("tenant_id") is None:
+        persist = False
 
     if persist:
         async with engine.begin() as conn:
@@ -145,7 +147,7 @@ async def task_submit(params: SubmitParams) -> SubmitResult:
 
         async with Session() as ses:
             model = TaskModel(**task_blob)
-            ses.merge(model)  # insert or update
+            await ses.merge(model)  # insert or update
             ses.add(TaskRunModel(task_id=model.id, status=Status.queued))
             await ses.commit()
 

--- a/pkgs/standards/peagen/peagen/migrations/versions/dc70c8bef823_add_labels_column.py
+++ b/pkgs/standards/peagen/peagen/migrations/versions/dc70c8bef823_add_labels_column.py
@@ -1,0 +1,33 @@
+"""add labels column to tasks
+
+Revision ID: dc70c8bef823
+Revises:
+Create Date: 2025-06-30 05:20:00
+"""
+
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "dc70c8bef823"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add labels column to tasks."""
+    op.add_column(
+        "tasks",
+        sa.Column(
+            "labels",
+            sa.JSON(),
+            nullable=False,
+            server_default=sa.text("'[]'"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Remove labels column from tasks."""
+    op.drop_column("tasks", "labels")

--- a/pkgs/standards/peagen/peagen/orm/task/task.py
+++ b/pkgs/standards/peagen/peagen/orm/task/task.py
@@ -64,6 +64,13 @@ class TaskModel(BaseModel):
         JSON, nullable=False, default=dict, doc="Arbitrary task payload"
     )
 
+    labels: Mapped[list[str]] = mapped_column(
+        JSON,
+        nullable=False,
+        default=list,
+        doc="Optional labels for grouping and filtering",
+    )
+
     status: Mapped[Status] = mapped_column(
         Enum(Status, name="task_status_enum"),
         nullable=False,


### PR DESCRIPTION
## Summary
- filter extra fields before persisting tasks
- fallback to alternate key in remote sort CLI output
- persist tasks only when a tenant is provided
- add missing async merge call
- expand TaskModel with `labels` column and new Alembic revision

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format .`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_6862102b2c708326bc876ff529425df1