### PR TITLE
Fix Peagen worker handlers and ORM persistence

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
@@ -144,7 +144,18 @@ async def task_submit(params: SubmitParams) -> SubmitResult:
             await conn.run_sync(Base.metadata.create_all)
 
         async with Session() as ses:
-            model = TaskModel(**task_blob)
+            orm_fields = {
+                k: task_blob[k]
+                for k in _ORM_COLUMNS
+                if k in task_blob and task_blob[k] is not None
+            }
+            for col in ("id", "tenant_id", "git_reference_id"):
+                if col in orm_fields and isinstance(orm_fields[col], str):
+                    try:
+                        orm_fields[col] = uuid.UUID(str(orm_fields[col]))
+                    except ValueError:
+                        pass
+            model = TaskModel(**orm_fields)
             ses.merge(model)  # insert or update
             ses.add(TaskRunModel(task_id=model.id, status=Status.queued))
             await ses.commit()

--- a/pkgs/standards/peagen/peagen/worker/__init__.py
+++ b/pkgs/standards/peagen/peagen/worker/__init__.py
@@ -9,6 +9,9 @@ from peagen.handlers.process_handler import process_handler
 from peagen.handlers.sort_handler import sort_handler
 from peagen.handlers.mutate_handler import mutate_handler
 from peagen.handlers.evolve_handler import evolve_handler
+from peagen.handlers.login_handler import login_handler
+from peagen.handlers.keys_handler import keys_handler
+from peagen.handlers.secrets_handler import secrets_handler
 
 
 # ----------------------------------------------------------------------------
@@ -29,6 +32,9 @@ class PeagenWorker(WorkerBase):
         self.register_handler("sort", sort_handler)
         self.register_handler("mutate", mutate_handler)
         self.register_handler("evolve", evolve_handler)
+        self.register_handler("login", login_handler)
+        self.register_handler("keys", keys_handler)
+        self.register_handler("secrets", secrets_handler)
         # In the future, you might also do:
         #   from peagen.handlers.render_handler import render_handler
         #   self.register_handler("render", render_handler)


### PR DESCRIPTION
## Summary
- register login/keys/secrets handlers in `PeagenWorker`
- filter task fields before persisting to the ORM
- convert string IDs to UUIDs when storing tasks
- expose ORM column list for gateway

## Testing
- `ruff format peagen/worker/__init__.py peagen/gateway/rpc/tasks.py peagen/gateway/__init__.py`
- `ruff check peagen/worker/__init__.py peagen/gateway/rpc/tasks.py peagen/gateway/__init__.py --fix`
- ❌ `pytest tests/i9n/two_user_secret_exchange_i9n_test.py -vv` *(fails: subprocess.CalledProcessError)*

------
https://chatgpt.com/codex/tasks/task_e_68620fb899bc83268fe0522fde7a8e31