### PR TITLE
Fix task status retrieval for peagen CLI

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/task_helpers.py
+++ b/pkgs/standards/peagen/peagen/cli/task_helpers.py
@@ -68,5 +68,5 @@ def get_task(
         gateway_url, json=envelope.model_dump(mode="json"), timeout=timeout
     )
     resp.raise_for_status()
-    parsed = Response[GetResult].model_validate_json(resp.json())
+    parsed = Response[GetResult].model_validate_json(resp.text)
     return parsed.result  # type: ignore[return-value]

--- a/pkgs/standards/peagen/peagen/transport/jsonrpc_schemas/task.py
+++ b/pkgs/standards/peagen/peagen/transport/jsonrpc_schemas/task.py
@@ -60,7 +60,9 @@ class GetParams(BaseModel):
 
 
 class GetResult(SubmitResult):
-    """Result returned by ``Task.get`` -- identical to :class:`SubmitResult`."""
+    """Result returned by ``Task.get`` including the task ``status``."""
+
+    status: Status | None = None
 
 
 class PatchParams(BaseModel):


### PR DESCRIPTION
## Summary
- return parsed RPC responses using `resp.text`
- expose `status` field for RPC task responses

## Testing
- `uv run --package peagen --directory standards/peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest tests/smoke/test_remote_doe_cli.py -m smoke -vv`

------
https://chatgpt.com/codex/tasks/task_e_68621b9ad9048326873c757769f636c4