### PR TITLE
Fix CLI context and task result handling

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/evolve.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/evolve.py
@@ -110,7 +110,7 @@ def submit(
 
         while True:
             task_reply = get_task(ctx.obj.get("gateway_url"), task.id)
-            typer.echo(json.dumps(task_reply.model_dump(), indent=2))
-            if Status.is_terminal(task_reply.status):
+            typer.echo(json.dumps(task_reply, indent=2))
+            if Status.is_terminal(task_reply.get("status")):
                 break
             time.sleep(interval)

--- a/pkgs/standards/peagen/peagen/cli/commands/keys.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/keys.py
@@ -38,7 +38,8 @@ def upload(
     drv = AutoGpgDriver(key_dir=key_dir)
     drv.pub_path.read_text()
     args = {"key_dir": str(key_dir), "gateway_url": gateway_url}
-    pool = ctx.obj.get("pool", "default") if ctx is not None else "default"
+    ctx_data = ctx.obj if ctx is not None and ctx.obj is not None else {}
+    pool = ctx_data.get("pool", "default")
     task = build_task("upload", args, pool=pool)
     reply = submit_task(gateway_url, task)
     if "error" in reply:
@@ -58,7 +59,8 @@ def remove(
         "fingerprint": fingerprint,
         "gateway_url": gateway_url,
     }
-    pool = ctx.obj.get("pool", "default") if ctx is not None else "default"
+    ctx_data = ctx.obj if ctx is not None and ctx.obj is not None else {}
+    pool = ctx_data.get("pool", "default")
     task = build_task("remove", args, pool=pool)
     reply = submit_task(gateway_url, task)
     if "error" in reply:
@@ -74,7 +76,8 @@ def fetch_server(
 ) -> None:
     """Fetch trusted public keys from the gateway."""
     args = {"gateway_url": gateway_url}
-    pool = ctx.obj.get("pool", "default") if ctx is not None else "default"
+    ctx_data = ctx.obj if ctx is not None and ctx.obj is not None else {}
+    pool = ctx_data.get("pool", "default")
     task = build_task("fetch-server", args, pool=pool)
     res = submit_task(gateway_url, task)
     if "error" in res:

--- a/pkgs/standards/peagen/peagen/cli/task_helpers.py
+++ b/pkgs/standards/peagen/peagen/cli/task_helpers.py
@@ -68,5 +68,5 @@ def get_task(
         gateway_url, json=envelope.model_dump(mode="json"), timeout=timeout
     )
     resp.raise_for_status()
-    parsed = Response[GetResult].model_validate_json(resp.json())
-    return parsed.result  # type: ignore[return-value]
+    parsed = Response[dict].model_validate(resp.json())
+    return parsed.result

--- a/pkgs/standards/peagen/peagen/transport/jsonrpc_schemas/task.py
+++ b/pkgs/standards/peagen/peagen/transport/jsonrpc_schemas/task.py
@@ -60,7 +60,9 @@ class GetParams(BaseModel):
 
 
 class GetResult(SubmitResult):
-    """Result returned by ``Task.get`` -- identical to :class:`SubmitResult`."""
+    """Result returned by ``Task.get`` with optional status."""
+
+    status: Status | None = None
 
 
 class PatchParams(BaseModel):


### PR DESCRIPTION
## Summary
- handle missing ctx.obj in keys CLI
- fix evolve CLI watch loop with dict results
- correct task result parsing
- include status in Task.get JSON schema

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff check peagen/cli/commands/evolve.py --fix`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check peagen/cli/commands/keys.py --fix`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check peagen/cli/task_helpers.py --fix`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check peagen/transport/jsonrpc_schemas/task.py --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest -m smoke tests/smoke/test_remote_full_flow.py` *(fails: subprocess.TimeoutExpired)*

------
https://chatgpt.com/codex/tasks/task_e_68621bd14a4483268f43f662ef1adc51