### PR TITLE
Fix remote process RPC smoke test

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/rpc/workers.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/workers.py
@@ -152,16 +152,16 @@ async def work_finished(params: FinishedParams) -> dict:
         log.warning("Work.finished for unknown task %s", taskId)
         return {"ok": False}
 
-    t.status = Status(status)
-    t.result = result
+    t["status"] = Status(status)
+    t["result"] = result
     now = time.time()
-    started = getattr(t, "started_at", None)
+    started = t.get("started_at")
     if status == "running" and started is None:
-        t.started_at = now
+        t["started_at"] = now
     elif Status.is_terminal(status):
         if started is None:
-            t.started_at = now
-        t.finished_at = now
+            t["started_at"] = now
+        t["finished_at"] = now
 
     await _save_task(t)
     await _persist(t)

--- a/pkgs/standards/peagen/tests/smoke/test_remote_process_rpc.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_process_rpc.py
@@ -44,7 +44,7 @@ def test_rpc_submit_remote_process(tmp_path: Path) -> None:
     reply = submit_task(GATEWAY, task)
     if "error" in reply:
         pytest.skip(f"remote submit failed: {reply['error']['message']}")
-    assert "result" in reply and "taskId" in reply["result"]
+    assert "result" in reply and "id" in reply["result"]
 
 
 @pytest.mark.i9n
@@ -61,7 +61,7 @@ def test_rpc_watch_remote_process(tmp_path: Path) -> None:
     if "error" in reply:
         pytest.skip(f"remote submit failed: {reply['error']['message']}")
 
-    tid = reply.get("result", {}).get("taskId")
+    tid = reply.get("result", {}).get("id")
     assert tid
 
     envelope = {


### PR DESCRIPTION
## Summary
- update `work_finished` to handle task dicts
- fix smoke test expectations for Task.submit

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`
- `PEAGEN_TEST_GATEWAY=http://127.0.0.1:8000/rpc uv run --package peagen --directory pkgs/standards/peagen pytest -vv -m smoke tests/smoke/test_remote_process_rpc.py`


------
https://chatgpt.com/codex/tasks/task_e_686232e3dae88326b3cb78d030c2b495