### PR TITLE
Fix timestamp handling in task workflows

### DIFF
--- a/pkgs/standards/peagen/peagen/core/task_core.py
+++ b/pkgs/standards/peagen/peagen/core/task_core.py
@@ -22,8 +22,8 @@ async def get_task_result(task_id: str) -> Dict:
         {"status": "running|finished|failed",
          "result":        {... or None},
          "oids":         [... or None],
-         "started_at":    "2025-06-04T12:34:56Z" | None,
-         "finished_at":   "... | None"}
+         "date_created":  "2025-06-04T12:34:56Z" | None,
+         "last_modified": "... | None"}
     """
     async with Session() as s:
         try:
@@ -38,11 +38,11 @@ async def get_task_result(task_id: str) -> Dict:
             "result": tr.result,
             "oids": tr.oids,
             "commit_hexsha": tr.commit_hexsha,
-            "started_at": tr.started_at.isoformat() if tr.started_at else None,
-            "finished_at": tr.finished_at.isoformat() if tr.finished_at else None,
+            "date_created": tr.date_created.isoformat() if tr.date_created else None,
+            "last_modified": tr.last_modified.isoformat() if tr.last_modified else None,
             "duration": (
-                int((tr.finished_at - tr.started_at).total_seconds())
-                if tr.started_at and tr.finished_at
+                int((tr.last_modified - tr.date_created).total_seconds())
+                if tr.date_created and tr.last_modified
                 else None
             ),
         }

--- a/pkgs/standards/peagen/peagen/gateway/rpc/workers.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/workers.py
@@ -152,16 +152,17 @@ async def work_finished(params: FinishedParams) -> dict:
         log.warning("Work.finished for unknown task %s", taskId)
         return {"ok": False}
 
-    t.status = Status(status)
-    t.result = result
+    t["status"] = Status(status)
+    t["result"] = result
     now = time.time()
-    started = getattr(t, "started_at", None)
+    started = t.get("date_created")
     if status == "running" and started is None:
-        t.started_at = now
+        t["date_created"] = now
+        t["last_modified"] = now
     elif Status.is_terminal(status):
         if started is None:
-            t.started_at = now
-        t.finished_at = now
+            t["date_created"] = now
+        t["last_modified"] = now
 
     await _save_task(t)
     await _persist(t)

--- a/pkgs/standards/peagen/peagen/plugins/result_backends/base.py
+++ b/pkgs/standards/peagen/peagen/plugins/result_backends/base.py
@@ -22,8 +22,8 @@ class ResultBackendBase:
             for t in getattr(self, "tasks").values():
                 data = t.to_dict() if hasattr(t, "to_dict") else t
                 data["id"] = str(data.get("id"))
-                if data.get("started_at") is not None:
-                    data["started_at"] = str(data["started_at"])
+                if data.get("date_created") is not None:
+                    data["date_created"] = str(data["date_created"])
                 out.append(data)
             return out
         if hasattr(self, "root"):

--- a/pkgs/standards/peagen/peagen/plugins/selectors/selector_base.py
+++ b/pkgs/standards/peagen/peagen/plugins/selectors/selector_base.py
@@ -28,7 +28,7 @@ class SelectorBase:
         self, tasks: List[Dict[str, Any]]
     ) -> List[Dict[str, Any]]:
         running = [t for t in tasks if t.get("status") == Status.running.value]
-        running.sort(key=lambda d: str(d.get("started_at") or ""))
+        running.sort(key=lambda d: str(d.get("date_created") or ""))
         return running[: self.num_candidates]
 
     async def select(self) -> Dict[str, Any]:

--- a/pkgs/standards/peagen/peagen/tui/app.py
+++ b/pkgs/standards/peagen/peagen/tui/app.py
@@ -250,8 +250,8 @@ class QueueDashboardApp(App):
         "label",
         "duration",
         "id",
-        "started_at",
-        "finished_at",
+        "date_created",
+        "last_modified",
         "error",
     ]
 
@@ -263,8 +263,8 @@ class QueueDashboardApp(App):
         "Status": "status",
         "Action": "action",
         "Labels": "label",
-        "Started": "started_at",
-        "Finished": "finished_at",
+        "Started": "date_created",
+        "Finished": "last_modified",
         "Duration (s)": "duration",
         "Error": "error",
     }
@@ -489,7 +489,7 @@ class QueueDashboardApp(App):
         for t in tasks:
             if t.get("duration") is None:
                 t["duration"] = _calc_duration(
-                    t.get("started_at"), t.get("finished_at")
+                    t.get("date_created"), t.get("last_modified")
                 )
 
         sort_key = criteria.get("sort_key")
@@ -505,7 +505,9 @@ class QueueDashboardApp(App):
                     return task_item.get("duration") or 0
                 if sort_key == "time":
                     return (
-                        task_item.get("started_at") or task_item.get("finished_at") or 0
+                        task_item.get("date_created")
+                        or task_item.get("last_modified")
+                        or 0
                     )
                 if sort_key == "status":
                     from peagen.transport.jsonrpc_schemas import Status
@@ -622,8 +624,8 @@ class QueueDashboardApp(App):
                     t_data.get("status", ""),
                     t_data.get("payload", {}).get("action", ""),
                     ",".join(t_data.get("labels", [])),
-                    _format_ts(t_data.get("started_at")),
-                    _format_ts(t_data.get("finished_at")),
+                    _format_ts(t_data.get("date_created")),
+                    _format_ts(t_data.get("last_modified")),
                     str(t_data.get("duration", ""))
                     if t_data.get("duration") is not None
                     else "",
@@ -648,8 +650,8 @@ class QueueDashboardApp(App):
                                 child_task.get("status", ""),
                                 child_task.get("payload", {}).get("action", ""),
                                 ",".join(child_task.get("labels", [])),
-                                _format_ts(child_task.get("started_at")),
-                                _format_ts(child_task.get("finished_at")),
+                                _format_ts(child_task.get("date_created")),
+                                _format_ts(child_task.get("last_modified")),
                                 str(child_task.get("duration", ""))
                                 if child_task.get("duration") is not None
                                 else "",
@@ -695,8 +697,8 @@ class QueueDashboardApp(App):
                         t_data.get("status", ""),
                         t_data.get("payload", {}).get("action", ""),
                         ",".join(t_data.get("labels", [])),
-                        _format_ts(t_data.get("started_at")),
-                        _format_ts(t_data.get("finished_at")),
+                        _format_ts(t_data.get("date_created")),
+                        _format_ts(t_data.get("last_modified")),
                         str(t_data.get("duration", ""))
                         if t_data.get("duration") is not None
                         else "",

--- a/pkgs/standards/peagen/tests/smoke/test_remote_process_rpc.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_process_rpc.py
@@ -44,7 +44,7 @@ def test_rpc_submit_remote_process(tmp_path: Path) -> None:
     reply = submit_task(GATEWAY, task)
     if "error" in reply:
         pytest.skip(f"remote submit failed: {reply['error']['message']}")
-    assert "result" in reply and "taskId" in reply["result"]
+    assert "result" in reply and "id" in reply["result"]
 
 
 @pytest.mark.i9n
@@ -61,7 +61,7 @@ def test_rpc_watch_remote_process(tmp_path: Path) -> None:
     if "error" in reply:
         pytest.skip(f"remote submit failed: {reply['error']['message']}")
 
-    tid = reply.get("result", {}).get("taskId")
+    tid = reply.get("result", {}).get("id")
     assert tid
 
     envelope = {

--- a/pkgs/standards/peagen/tests/unit/test_scheduler_fail_no_worker.py
+++ b/pkgs/standards/peagen/tests/unit/test_scheduler_fail_no_worker.py
@@ -82,6 +82,7 @@ async def test_scheduler_fails_task_without_worker(monkeypatch):
         status=gw.Status.queued,
         note="",
         spec_hash=uuid.uuid4().hex,
+        labels={},
         date_created=datetime.datetime.now(datetime.timezone.utc),
         last_modified=datetime.datetime.now(datetime.timezone.utc),
     )

--- a/pkgs/standards/peagen/tests/unit/test_scheduler_remove_bad_worker.py
+++ b/pkgs/standards/peagen/tests/unit/test_scheduler_remove_bad_worker.py
@@ -66,6 +66,7 @@ async def test_scheduler_removes_bad_worker(monkeypatch):
         status=gw.Status.queued,
         note="",
         spec_hash=uuid.uuid4().hex,
+        labels={},
         date_created=datetime.datetime.now(datetime.timezone.utc),
         last_modified=datetime.datetime.now(datetime.timezone.utc),
     )


### PR DESCRIPTION
## Summary
- use date_created and last_modified for timestamp tracking
- update parent finalisation and result backend logic
- adjust selector sorting and TUI columns
- fix scheduler unit tests to include labels

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest -q` *(fails: two_user_secret_exchange_i9n_test, test_sequences_success, test_alembic_upgrade_and_current)*

------
https://chatgpt.com/codex/tasks/task_e_686232e3dae88326b3cb78d030c2b495