### PR TITLE
Fix tenant handling for peagen tasks

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/task_helpers.py
+++ b/pkgs/standards/peagen/peagen/cli/task_helpers.py
@@ -22,6 +22,7 @@ def build_task(
     note: str | None = None,
     config_toml: str | None = None,
     labels: list[str] | None = None,
+    tenant_id: str = "default",
 ) -> SubmitParams:
     """Return a :class:`SubmitParams` instance for *action* and *args*."""
 
@@ -35,6 +36,7 @@ def build_task(
         note=note,
         config_toml=config_toml,
         labels=labels,
+        tenant_id=tenant_id,
     )
 
 

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -401,7 +401,8 @@ async def _persist(task: TaskModel | dict) -> None:
                     try:
                         data[col] = uuid.UUID(str(data[col]))
                     except ValueError:
-                        pass
+                        if col == "tenant_id":
+                            data[col] = db_helpers._tenant_uuid(data[col])
             orm_task = TaskModel(**data)
 
         log.info("persisting task %s", orm_task.id)

--- a/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
@@ -64,9 +64,16 @@ def _normalise_submit_payload(raw: dict) -> TaskBlob:
     Ensure required fields exist and assign sensible defaults.
     This is the only validation performed at the RPC layer.
     """
+    tenant_id = raw.get("tenant_id") or "default"
+    try:
+        uuid.UUID(str(tenant_id))
+        tenant_uuid = str(tenant_id)
+    except (ValueError, TypeError):
+        tenant_uuid = uuid.uuid5(uuid.NAMESPACE_DNS, str(tenant_id)).hex
+
     blob: TaskBlob = {
         "id": raw.get("id") or uuid.uuid4().hex,
-        "tenant_id": raw.get("tenant_id"),
+        "tenant_id": tenant_uuid,
         "git_reference_id": raw.get("git_reference_id"),
         "pool": raw.get("pool", "default"),
         "payload": raw.get("payload", {}),


### PR DESCRIPTION
## Summary
- ensure tasks include a tenant_id when built
- normalise tenant_id to UUID during RPC payload normalisation
- coerce tenant_id slug to UUID when persisting

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format .`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`
- `PEAGEN_TEST_GATEWAY=http://127.0.0.1:8000/rpc uv run --package peagen --directory pkgs/standards/peagen pytest -m smoke`

------
https://chatgpt.com/codex/tasks/task_e_686238049d448326ad97dc4441774d98