### PR TITLE
Fix task helper tenant ID

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/task_helpers.py
+++ b/pkgs/standards/peagen/peagen/cli/task_helpers.py
@@ -16,6 +16,7 @@ def build_task(
     args: Dict[str, Any],
     *,
     pool: str = "default",
+    tenant_id: str | None = None,
     repo: str | None = None,
     ref: str | None = None,
     status: Status = Status.waiting,
@@ -25,9 +26,13 @@ def build_task(
 ) -> SubmitParams:
     """Return a :class:`SubmitParams` instance for *action* and *args*."""
 
+    if tenant_id is None:
+        tenant_id = pool
+
     return SubmitParams(
         id=str(uuid.uuid4()),
         pool=pool,
+        tenant_id=tenant_id,
         repo=repo,
         ref=ref,
         payload={"action": action, "args": args},


### PR DESCRIPTION
## Summary
- support `tenant_id` in `build_task` so remote tasks persist

## Testing
- `ruff format .`
- `ruff check . --fix`
- `pytest peagen/tests/smoke/test_remote_doe_cli.py -m smoke -vv` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68623b6f8d9c8326a2f235dff4cea447