### PR TITLE
Fix DOE process CLI watch output for test

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/doe.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/doe.py
@@ -296,19 +296,23 @@ def submit_process(  # noqa: PLR0913
     if watch:
         while True:
             task_reply = get_task(ctx.obj.get("gateway_url"), task.id)
-            typer.echo(json.dumps(task_reply.model_dump(), indent=2))
             if Status.is_terminal(task_reply.status):
                 break
             time.sleep(interval)
 
+        typer.echo(json.dumps(task_reply.model_dump(), indent=2))
         children = task_reply.result.get("children", []) if task_reply.result else []
         for cid in children:
             while True:
                 child_reply = get_task(ctx.obj.get("gateway_url"), cid)
-                typer.echo(json.dumps(child_reply.model_dump(), indent=2))
                 if Status.is_terminal(child_reply.status):
                     break
                 time.sleep(interval)
+            typer.echo(json.dumps(child_reply.model_dump(), indent=2))
             if child_reply.status != "success":
-                typer.secho(f"Child task {cid} failed", fg=typer.colors.RED, err=True)
+                typer.secho(
+                    f"Child task {cid} failed",
+                    fg=typer.colors.RED,
+                    err=True,
+                )
                 raise typer.Exit(1)


### PR DESCRIPTION
## Summary
- fix `doe process` CLI watch mode to only emit final JSON result
- keep JSON logging for child tasks

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format .`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`
- `PEAGEN_TEST_GATEWAY=http://127.0.0.1:8000/rpc uv run --package peagen --directory pkgs/standards/peagen pytest -m smoke tests/smoke/test_remote_doe_process_cli.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_68623f2adad483268ea63258fe633491