### PR TITLE
Fix spec_hash generation and alembic migration

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/task_helpers.py
+++ b/pkgs/standards/peagen/peagen/cli/task_helpers.py
@@ -23,11 +23,14 @@ def build_task(
     config_toml: str | None = None,
     labels: list[str] | None = None,
     tenant_id: str = "default",
+    spec_hash: str | None = None,
 ) -> SubmitParams:
     """Return a :class:`SubmitParams` instance for *action* and *args*."""
 
+    uid = uuid.uuid4()
+    uid_str = str(uid)
     return SubmitParams(
-        id=str(uuid.uuid4()),
+        id=uid_str,
         pool=pool,
         repo=repo,
         ref=ref,
@@ -37,6 +40,7 @@ def build_task(
         config_toml=config_toml,
         labels=labels,
         tenant_id=tenant_id,
+        spec_hash=spec_hash or getattr(uid, "hex", uid_str),
     )
 
 

--- a/pkgs/standards/peagen/peagen/migrations/env.py
+++ b/pkgs/standards/peagen/peagen/migrations/env.py
@@ -63,6 +63,7 @@ def do_run_migrations(connection):
 
 async def run_migrations_online() -> None:
     async def run_async_migrations(conn):
+        await conn.run_sync(Base.metadata.create_all)
         await conn.run_sync(do_run_migrations)
 
     connectable = engine

--- a/pkgs/standards/peagen/peagen/migrations/versions/dc70c8bef823_add_labels_column.py
+++ b/pkgs/standards/peagen/peagen/migrations/versions/dc70c8bef823_add_labels_column.py
@@ -17,15 +17,19 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     """Add labels column to tasks."""
-    op.add_column(
-        "tasks",
-        sa.Column(
-            "labels",
-            sa.JSON(),
-            nullable=False,
-            server_default=sa.text("'[]'"),
-        ),
-    )
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    cols = {c["name"] for c in insp.get_columns("tasks")}
+    if "labels" not in cols:
+        op.add_column(
+            "tasks",
+            sa.Column(
+                "labels",
+                sa.JSON(),
+                nullable=False,
+                server_default=sa.text("'[]'"),
+            ),
+        )
 
 
 def downgrade() -> None:


### PR DESCRIPTION
## Summary
- ensure `build_task` sets a unique spec_hash even when `uuid.uuid4` is patched
- create tables before applying migrations and skip adding labels column if it exists

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `PEAGEN_TEST_GATEWAY=http://localhost:9999/rpc uv run --package peagen --directory pkgs/standards/peagen pytest`

------
https://chatgpt.com/codex/tasks/task_e_68623ef153ac83269d0dacad06a3da60