### PR TITLE
Fix spec hashing and datetime coercion

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/task_helpers.py
+++ b/pkgs/standards/peagen/peagen/cli/task_helpers.py
@@ -37,6 +37,7 @@ def build_task(
         config_toml=config_toml,
         labels=labels,
         tenant_id=tenant_id,
+        spec_hash=uuid.uuid4().hex,
     )
 
 

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -403,6 +403,12 @@ async def _persist(task: TaskModel | dict) -> None:
                     except ValueError:
                         if col == "tenant_id":
                             data[col] = db_helpers._tenant_uuid(data[col])
+            for ts in ("date_created", "last_modified"):
+                val = data.get(ts)
+                if isinstance(val, (int, float)):
+                    data[ts] = db_helpers.dt.datetime.fromtimestamp(
+                        val, tz=db_helpers.dt.timezone.utc
+                    )
             orm_task = TaskModel(**data)
 
         log.info("persisting task %s", orm_task.id)

--- a/pkgs/standards/peagen/peagen/gateway/db_helpers.py
+++ b/pkgs/standards/peagen/peagen/gateway/db_helpers.py
@@ -51,6 +51,8 @@ def _coerce(row_dict: Dict[str, Any]) -> Dict[str, Any]:
             out[k] = uuid.UUID(v)
         elif isinstance(v, dt.datetime) and v.tzinfo is None:
             out[k] = v.replace(tzinfo=dt.timezone.utc)
+        elif isinstance(v, (int, float)) and k in {"date_created", "last_modified"}:
+            out[k] = dt.datetime.fromtimestamp(v, tz=dt.timezone.utc)
         else:
             out[k] = v
     return out


### PR DESCRIPTION
## Summary
- ensure tasks have a `spec_hash` when submitted
- coerce numeric timestamps to timezone-aware datetimes when persisting
- handle numeric timestamps in gateway persist logic

## Testing
- `ruff format peagen/gateway/db_helpers.py peagen/cli/task_helpers.py`
- `ruff check peagen/gateway/db_helpers.py peagen/cli/task_helpers.py --fix`
- `pytest tests/smoke/test_remote_evolve.py -vv -m smoke` *(fails: no worker advertising 'evolve')*


------
https://chatgpt.com/codex/tasks/task_e_68623f3bcd0483269de0c337454f9b61