### PR TITLE
Fix timestamp coercion in gateway

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/db_helpers.py
+++ b/pkgs/standards/peagen/peagen/gateway/db_helpers.py
@@ -51,6 +51,8 @@ def _coerce(row_dict: Dict[str, Any]) -> Dict[str, Any]:
             out[k] = uuid.UUID(v)
         elif isinstance(v, dt.datetime) and v.tzinfo is None:
             out[k] = v.replace(tzinfo=dt.timezone.utc)
+        elif isinstance(v, (int, float)) and k in {"date_created", "last_modified"}:
+            out[k] = dt.datetime.fromtimestamp(v, tz=dt.timezone.utc)
         else:
             out[k] = v
     return out

--- a/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
@@ -80,7 +80,7 @@ def _normalise_submit_payload(raw: dict) -> TaskBlob:
         "status": raw.get("status", Status.queued),
         "note": raw.get("note", ""),
         "labels": raw.get("labels", []),
-        "spec_hash": raw.get("spec_hash", ""),
+        "spec_hash": raw.get("spec_hash") or "",
         "last_modified": raw.get("last_modified"),
     }
     return blob


### PR DESCRIPTION
## Summary
- normalize `spec_hash` in task payloads
- coerce numeric timestamps to datetimes when persisting task runs

## Testing
- `uv run --package peagen --directory standards/peagen ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68623f4350dc8326b43359b5d9f6d32e