### PR TITLE
Fix Redis URL handling for Peagen gateway

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/runtime_cfg.py
+++ b/pkgs/standards/peagen/peagen/gateway/runtime_cfg.py
@@ -20,7 +20,10 @@ class Settings(BaseSettings):
 
     @property
     def redis_url(self) -> str:
-        return f"redis://:{self.redis_password}@{self.redis_host}:{self.redis_port}/{self.redis_db}"
+        """Return a valid Redis connection URL."""
+        host = self.redis_host or "localhost"
+        cred = f":{self.redis_password}@" if self.redis_password else ""
+        return f"redis://{cred}{host}:{self.redis_port}/{self.redis_db}"
 
     # ───────── Postgres results-backend ─────────
     pg_dsn_env: Optional[str] = Field(default=os.environ.get("PG_DSN"))


### PR DESCRIPTION
## Summary
- fix redis_url construction when REDIS_PASSWORD is unset

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `PEAGEN_TEST_GATEWAY=http://127.0.0.1:8000/rpc uv run --package peagen --directory standards/peagen pytest -m smoke tests/smoke/test_gateway_login_keys_secrets_cli.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_686246430b6c8326937559049d7214a5