### PR TITLE
Fix uuid alias patching in peagen utils init

### DIFF
--- a/pkgs/standards/peagen/peagen/_utils/_init.py
+++ b/pkgs/standards/peagen/peagen/_utils/_init.py
@@ -19,6 +19,9 @@ _real_uuid4 = uuid.uuid4
 _uuid_alias = types.ModuleType("uuid_alias")
 _uuid_alias.uuid4 = _real_uuid4
 sys.modules[__name__ + ".uuid"] = _uuid_alias
+# Expose the alias as ``uuid`` within this module so tests can patch
+# ``peagen._utils._init.uuid.uuid4`` without affecting the real ``uuid`` module.
+uuid = _uuid_alias
 
 _PAT_RE = re.compile(r"(gh[pousr]_\w+|github_pat_[0-9A-Za-z]+)", re.IGNORECASE)
 


### PR DESCRIPTION
## Summary
- ensure `peagen._utils._init` exposes its uuid alias as `uuid`
- format with ruff and run tests using gateway/worker

## Testing
- `uv run --directory standards/peagen --package peagen ruff format .`
- `uv run --directory standards/peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_utils_init.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686246c80fd88326ab27f6c4860fd2dd