### PR TITLE
Fix peagen CLI tests for new RPC helpers

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_cli_login.py
+++ b/pkgs/standards/peagen/tests/unit/test_cli_login.py
@@ -17,12 +17,14 @@ class DummyDriver:
 def test_login_success(monkeypatch, tmp_path):
     captured = {}
 
-    def fake_submit_task(url, task, *, timeout=30.0):
-        captured.update({"url": url, "task": task})
+    def fake_login(*, key_dir, passphrase, gateway_url):
+        captured.update(
+            {"key_dir": key_dir, "passphrase": passphrase, "gateway_url": gateway_url}
+        )
         return {}
 
     monkeypatch.setattr(login_mod, "AutoGpgDriver", DummyDriver)
-    monkeypatch.setattr(login_mod, "submit_task", fake_submit_task)
+    monkeypatch.setattr(login_mod, "core_login", fake_login)
 
     runner = CliRunner()
     result = runner.invoke(
@@ -32,18 +34,18 @@ def test_login_success(monkeypatch, tmp_path):
 
     assert result.exit_code == 0
     assert "Logged in and uploaded public key" in result.output
-    assert captured["url"] == "http://gw/rpc"
-    assert captured["task"].payload["action"] == "login"
+    assert captured["gateway_url"] == "http://gw/rpc"
+    assert captured["key_dir"] == tmp_path
 
 
 @pytest.mark.unit
 def test_login_http_error(monkeypatch, tmp_path):
     monkeypatch.setattr(login_mod, "AutoGpgDriver", DummyDriver)
 
-    def fake_submit_task(*_a, **_k):
+    def fake_login(*_a, **_k):
         return {"error": {"code": -1, "message": "fail"}}
 
-    monkeypatch.setattr(login_mod, "submit_task", fake_submit_task)
+    monkeypatch.setattr(login_mod, "core_login", fake_login)
 
     runner = CliRunner()
     result = runner.invoke(app, ["login", "--key-dir", str(tmp_path)])
@@ -54,11 +56,11 @@ def test_login_http_error(monkeypatch, tmp_path):
 
 @pytest.mark.unit
 def test_login_request_error(monkeypatch, tmp_path):
-    def fake_submit_task(*_a, **_k):
+    def fake_login(*_a, **_k):
         raise RequestError("oops")
 
     monkeypatch.setattr(login_mod, "AutoGpgDriver", DummyDriver)
-    monkeypatch.setattr(login_mod, "submit_task", fake_submit_task)
+    monkeypatch.setattr(login_mod, "core_login", fake_login)
 
     runner = CliRunner()
     result = runner.invoke(app, ["login", "--key-dir", str(tmp_path)])
@@ -77,7 +79,7 @@ def test_login_passphrase(monkeypatch, tmp_path):
             captured.update(self.called)
 
     monkeypatch.setattr(login_mod, "AutoGpgDriver", CaptureDriver)
-    monkeypatch.setattr(login_mod, "submit_task", lambda *a, **k: {})
+    monkeypatch.setattr(login_mod, "core_login", lambda **_k: {})
 
     runner = CliRunner()
     result = runner.invoke(

--- a/pkgs/standards/peagen/tests/unit/test_keys_cli.py
+++ b/pkgs/standards/peagen/tests/unit/test_keys_cli.py
@@ -10,16 +10,12 @@ from peagen.cli.commands import keys as keys_mod
 def test_create_generates_key_pair(monkeypatch, tmp_path, capsys):
     captured = {}
 
-    def fake_driver(key_dir, passphrase=None):
+    def fake_create(key_dir, passphrase=None):
         captured["key_dir"] = key_dir
         captured["passphrase"] = passphrase
+        return {}
 
-        class Dummy:
-            pass
-
-        return Dummy()
-
-    monkeypatch.setattr(keys_mod, "AutoGpgDriver", fake_driver)
+    monkeypatch.setattr(keys_mod.keys_core, "create_keypair", fake_create)
 
     keys_mod.create(passphrase="secret", key_dir=tmp_path)
     out = capsys.readouterr().out
@@ -31,27 +27,20 @@ def test_create_generates_key_pair(monkeypatch, tmp_path, capsys):
 
 @pytest.mark.unit
 def test_upload_sends_public_key(monkeypatch, tmp_path, capsys):
-    (tmp_path / "public.asc").write_text("PUB")
-
-    class DummyDriver:
-        def __init__(self, key_dir):
-            self.pub_path = Path(key_dir) / "public.asc"
-
-    monkeypatch.setattr(keys_mod, "AutoGpgDriver", DummyDriver)
     captured = {}
 
-    def fake_submit_task(url, task, *, timeout=30.0):
-        captured["url"] = url
-        captured["task"] = task
-        return {}
+    def fake_upload(*, key_dir, gateway_url):
+        captured["key_dir"] = key_dir
+        captured["gateway_url"] = gateway_url
+        return {"fingerprint": "FP"}
 
-    monkeypatch.setattr(keys_mod, "submit_task", fake_submit_task)
+    monkeypatch.setattr(keys_mod.keys_core, "upload_public_key", fake_upload)
 
     keys_mod.upload(ctx=None, key_dir=tmp_path, gateway_url="http://gw/rpc")
     out = capsys.readouterr().out
 
-    assert captured["url"] == "http://gw/rpc"
-    assert captured["task"].payload["action"] == "upload"
+    assert captured["gateway_url"] == "http://gw/rpc"
+    assert captured["key_dir"] == tmp_path
     assert "Uploaded public key" in out
 
 
@@ -59,27 +48,27 @@ def test_upload_sends_public_key(monkeypatch, tmp_path, capsys):
 def test_remove_posts_delete(monkeypatch, capsys):
     captured = {}
 
-    def fake_submit_task(url, task, *, timeout=30.0):
-        captured["url"] = url
-        captured["task"] = task
-        return {}
+    def fake_remove(*, fingerprint, gateway_url):
+        captured["fingerprint"] = fingerprint
+        captured["gateway_url"] = gateway_url
+        return {"ok": True}
 
-    monkeypatch.setattr(keys_mod, "submit_task", fake_submit_task)
+    monkeypatch.setattr(keys_mod.keys_core, "remove_public_key", fake_remove)
 
     keys_mod.remove(ctx=None, fingerprint="abc", gateway_url="http://gw")
     out = capsys.readouterr().out
 
-    assert captured["task"].payload["action"] == "remove"
-    assert captured["task"].payload["args"]["fingerprint"] == "abc"
+    assert captured["fingerprint"] == "abc"
+    assert captured["gateway_url"] == "http://gw"
     assert "Removed key abc" in out
 
 
 @pytest.mark.unit
 def test_fetch_server_prints_response(monkeypatch, capsys):
-    def fake_submit_task(url, task, *, timeout=30.0):
-        return {"result": {"keys": {"k": "v"}}}
+    def fake_fetch(*, gateway_url):
+        return {"keys": {"k": "v"}}
 
-    monkeypatch.setattr(keys_mod, "submit_task", fake_submit_task)
+    monkeypatch.setattr(keys_mod.keys_core, "fetch_server_keys", fake_fetch)
 
     keys_mod.fetch_server(ctx=None, gateway_url="http://gw")
     out = capsys.readouterr().out


### PR DESCRIPTION
## Summary
- update login, keys, and secrets CLI tests to patch core helpers instead of task helpers
- adapt fixtures and helpers for new JSON-RPC flow

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862ff08fd3c8326a21900dc9ea0755d