### PR TITLE
Add default user in public tenant migration

### DIFF
--- a/pkgs/standards/peagen/peagen/core/git_shadow_core.py
+++ b/pkgs/standards/peagen/peagen/core/git_shadow_core.py
@@ -1,11 +1,15 @@
 """Idempotent helpers for shadow repo management."""
+
 from __future__ import annotations
-import os, httpx, asyncio
+from urllib.parse import urlparse
+
+import httpx
 
 from peagen.defaults import (
-    GIT_SHADOW_BASE, 
+    GIT_SHADOW_BASE,
     GIT_SHADOW_TOKEN,
-    )
+)
+
 
 def _split_github(url: str) -> tuple[str, str]:
     """
@@ -25,20 +29,29 @@ async def _req(method: str, path: str, **kw):
         r.raise_for_status()
         return r.json()
 
+
 async def ensure_org(slug: str):
     try:
         await _req("GET", f"/api/v1/orgs/{slug}")
     except FileNotFoundError:
-        await _req("POST", "/api/v1/orgs",
-                   json={"username": slug, "visibility": "private"})
+        await _req(
+            "POST", "/api/v1/orgs", json={"username": slug, "visibility": "private"}
+        )
+
 
 async def ensure_mirror(slug: str, repo: str, upstream: str):
     try:
         await _req("GET", f"/api/v1/repos/{slug}/{repo}")
     except FileNotFoundError:
-        body = {"name": repo, "private": True, "mirror": True,
-                "mirror_interval": "1m", "clone_addr": upstream}
+        body = {
+            "name": repo,
+            "private": True,
+            "mirror": True,
+            "mirror_interval": "1m",
+            "clone_addr": upstream,
+        }
         await _req("POST", f"/api/v1/orgs/{slug}/repos", json=body)
+
 
 async def attach_deploy_key(slug: str, repo: str, pub_key: str, rw=True) -> int:
     keys = await _req("GET", f"/api/v1/repos/{slug}/{repo}/keys")

--- a/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
+++ b/pkgs/standards/peagen/peagen/gateway/rpc/tasks.py
@@ -128,9 +128,8 @@ async def task_submit(params: SubmitParams) -> SubmitResult:
     # 2. Shadow-repo guarantees ───────────────────────────────────────────
     # Expect these keys in payload (client responsibility)
     payload = task_blob["payload"] or {}
-    repo_url   = payload.get("repo")        # GitHub URL
+    repo_url = payload.get("repo")  # GitHub URL
     deploy_key = payload.get("deploy_key")  # public key (str)
-    ref        = payload.get("ref")         # branch / sha (optionally used later)
 
     if repo_url and deploy_key:
         try:
@@ -170,7 +169,8 @@ async def task_submit(params: SubmitParams) -> SubmitResult:
 
     # 5. Optional Postgres persistence (unchanged) ────────────────────────
     try:
-        uuid.UUID(task_blob["id"]); persist = task_blob.get("tenant_id") is not None
+        uuid.UUID(task_blob["id"])
+        persist = task_blob.get("tenant_id") is not None
     except ValueError:
         persist = False
 
@@ -203,8 +203,9 @@ async def task_submit(params: SubmitParams) -> SubmitResult:
     await _save_task(task_blob)
     await _publish_task(task_blob)
 
-    log.info("task %s queued in %s (ttl=%ss)",
-             task_blob["id"], task_blob["pool"], TASK_TTL)
+    log.info(
+        "task %s queued in %s (ttl=%ss)", task_blob["id"], task_blob["pool"], TASK_TTL
+    )
 
     return SubmitResult(id=str(task_blob["id"]))
 

--- a/pkgs/standards/peagen/peagen/migrations/versions/69f4d7c302fa_create_public_tenant.py
+++ b/pkgs/standards/peagen/peagen/migrations/versions/69f4d7c302fa_create_public_tenant.py
@@ -1,0 +1,111 @@
+"""create public tenant and default user
+
+Revision ID: 69f4d7c302fa
+Revises: dc70c8bef823
+Create Date: 2025-07-01 00:00:00
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "69f4d7c302fa"
+down_revision: Union[str, None] = "dc70c8bef823"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create a public tenant and a default user if they do not exist."""
+    bind = op.get_bind()
+
+    result = bind.execute(
+        sa.text("SELECT id FROM tenants WHERE slug=:slug"), {"slug": "public"}
+    )
+    row = result.fetchone()
+    tenant_id = uuid.uuid4() if row is None else row[0]
+    if row is None:
+        tenants = sa.table(
+            "tenants",
+            sa.column("id", sa.String),
+            sa.column("slug", sa.String),
+            sa.column("name", sa.String),
+            sa.column("date_created", sa.DateTime),
+            sa.column("last_modified", sa.DateTime),
+        )
+        now = datetime.now(timezone.utc)
+        op.bulk_insert(
+            tenants,
+            [
+                {
+                    "id": str(tenant_id),
+                    "slug": "public",
+                    "name": "Public",
+                    "date_created": now,
+                    "last_modified": now,
+                }
+            ],
+        )
+    else:
+        now = datetime.now(timezone.utc)
+
+    user_id = uuid.UUID("00000000-0000-0000-0000-000000000001")
+    result = bind.execute(
+        sa.text("SELECT id FROM users WHERE id=:id"), {"id": str(user_id)}
+    )
+    if result.fetchone() is None:
+        users = sa.table(
+            "users",
+            sa.column("id", sa.String),
+            sa.column("username", sa.String),
+            sa.column("email", sa.String),
+            sa.column("role", sa.String),
+            sa.column("date_created", sa.DateTime),
+            sa.column("last_modified", sa.DateTime),
+        )
+        op.bulk_insert(
+            users,
+            [
+                {
+                    "id": str(user_id),
+                    "username": "public",
+                    "email": "public@example.com",
+                    "role": "member",
+                    "date_created": now,
+                    "last_modified": now,
+                }
+            ],
+        )
+
+        assoc = sa.table(
+            "tenant_user_associations",
+            sa.column("id", sa.String),
+            sa.column("tenant_id", sa.String),
+            sa.column("user_id", sa.String),
+            sa.column("role", sa.String),
+            sa.column("date_created", sa.DateTime),
+            sa.column("last_modified", sa.DateTime),
+        )
+        op.bulk_insert(
+            assoc,
+            [
+                {
+                    "id": str(uuid.uuid4()),
+                    "tenant_id": str(tenant_id),
+                    "user_id": str(user_id),
+                    "role": "owner",
+                    "date_created": now,
+                    "last_modified": now,
+                }
+            ],
+        )
+
+
+def downgrade() -> None:
+    """No-op downgrade."""
+    pass


### PR DESCRIPTION
## Summary
- extend migration to create default `public` user if missing

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format peagen/migrations/versions/69f4d7c302fa_create_public_tenant.py`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check peagen/migrations/versions/69f4d7c302fa_create_public_tenant.py --fix`

------
https://chatgpt.com/codex/tasks/task_e_686347d50128832683230f1c6aad724f