### PR TITLE
Fix Role export in autoapi tables

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/tables/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v2/tables/__init__.py
@@ -1,37 +1,67 @@
-"""
-Public façade for all table classes.
+"""Public façade for all table classes.
 
 Usage
 -----
-    from autoapi.v2.tables import Tenant, User, Group
+    from autoapi.v2.tables import (
+        Tenant,
+        User,
+        Group,
+        Role,
+    )
 """
 
 import importlib
-import sys
 from typing import TYPE_CHECKING, Any
 from ._base import Base
 
-__all__ = ["Tenant", "User", "Group", "Base"]
+__all__ = [
+    "Tenant",
+    "User",
+    "Group",
+    "Org",
+    "Role",
+    "RolePerm",
+    "RoleGrant",
+    "StatusEnum",
+    "Change",
+    "Base",
+]
 
 # ------------------------------------------------------------------ #
 # Lazy attribute loader (PEP 562). Keeps import graphs light-weight.
 # ------------------------------------------------------------------ #
-_module_map = {name: f"{__name__}.{name.lower()}" for name in __all__}
+_module_map = {
+    "Tenant": f"{__name__}.tenant",
+    "User": f"{__name__}.user",
+    "Group": f"{__name__}.group",
+    "Org": f"{__name__}.org",
+    "Role": f"{__name__}.rbac",
+    "RolePerm": f"{__name__}.rbac",
+    "RoleGrant": f"{__name__}.rbac",
+    "StatusEnum": f"{__name__}.status",
+    "Change": f"{__name__}.audit",
+}
 
-def __getattr__(name: str) -> Any:                # noqa: D401
+
+def __getattr__(name: str) -> Any:  # noqa: D401
     """Dynamically import `tenant`, `user`, or `group` on first use."""
     if name not in _module_map:
         raise AttributeError(name)
     module = importlib.import_module(_module_map[name])
     obj = getattr(module, name)
-    globals()[name] = obj      # cache for future look-ups
+    globals()[name] = obj  # cache for future look-ups
     return obj
+
 
 # ------------------------------------------------------------------ #
 # Static typing support – imported eagerly only during type checking.
 # ------------------------------------------------------------------ #
-if TYPE_CHECKING:                           # pragma: no cover
+if TYPE_CHECKING:  # pragma: no cover
     from ._base import Base
     from .tenant import Tenant
     from .user import User
     from .group import Group
+    from .org import Org
+    from .rbac import Role, RoleGrant, RolePerm
+    from .status import StatusEnum
+    from .audit import Change


### PR DESCRIPTION
## Summary
- expose Role and related tables from `autoapi.v2.tables`

## Testing
- `ruff format autoapi/v2/tables/__init__.py`
- `ruff check autoapi/v2/tables/__init__.py --fix`
- `ruff check . --fix` *(fails: `F401 datetime.datetime imported but unused`)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686c58877f548326bc368544da6ad5f5