### PR TITLE
Fix CLI imports and gateway helper

### DIFF
--- a/pkgs/standards/peagen/peagen/core/login_core.py
+++ b/pkgs/standards/peagen/peagen/core/login_core.py
@@ -7,6 +7,7 @@ The function still:
 2. Uploads the *public* key to the JSON-RPC gateway.
 3. Returns the validated success envelope or raises for any error.
 """
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -14,9 +15,9 @@ from typing import Any, Optional
 
 import httpx
 
-from autoapi_client import AutoAPIClient           # ← new client
-from autoapi.v2         import AutoAPI               # ← for .get_schema()
-from peagen.orm import PublicKey       # ORM resource
+from autoapi_client import AutoAPIClient  # ← new client
+from autoapi.v2 import AutoAPI  # ← for .get_schema()
+from peagen.orm import DeployKey  # ORM resource
 
 from peagen.defaults import DEFAULT_GATEWAY
 from peagen.plugins.secret_drivers import AutoGpgDriver
@@ -26,8 +27,8 @@ __all__ = ["login"]
 
 # ----------------------------------------------------------------------
 def _schema(tag: str):
-    """Shortcut to the server-generated schema for the PublicKey resource."""
-    return AutoAPI.get_schema(PublicKey, tag)
+    """Shortcut to the server-generated schema for the DeployKey resource."""
+    return AutoAPI.get_schema(DeployKey, tag)
 
 
 def login(
@@ -52,18 +53,15 @@ def login(
 
     # 2 ─ build request/response schemas dynamically
     SCreate = _schema("create")
-    SRead   = _schema("read")
+    SRead = _schema("read")
 
-    params  = SCreate(public_key=public_key)
+    params = SCreate(public_key=public_key)
 
     # 3 ─ JSON-RPC call via AutoAPIClient
-    with AutoAPIClient(gateway_url,
-                       client=httpx.Client(timeout=timeout_s)) as rpc:
+    with AutoAPIClient(gateway_url, client=httpx.Client(timeout=timeout_s)) as rpc:
         try:
-            result = rpc.call("PublicKeys.create",
-                              params=params,
-                              out_schema=SRead)
-        except (httpx.HTTPError, RuntimeError) as exc:
+            result = rpc.call("PublicKeys.create", params=params, out_schema=SRead)
+        except (httpx.HTTPError, RuntimeError):
             raise
 
     # 4 ─ return success as plain dict for callers that expect JSON


### PR DESCRIPTION
## Summary
- fix Task model import in analysis handler
- correct default gateway alias in keys CLI
- update login helper to use DeployKey ORM model
- add compatibility alias `_get_client_ip` in gateway

## Testing
- `uv run --directory . --package peagen ruff check peagen/gateway/__init__.py peagen/core/login_core.py peagen/handlers/analysis_handler.py peagen/cli/commands/keys.py --fix`
- `uv run --directory . --package peagen pytest` *(fails: 30 failed, 120 passed, 29 skipped)*
- `uvicorn pkgs.standards.peagen.peagen.gateway:app ...` *(fails: Redis URL not configured)*

------
https://chatgpt.com/codex/tasks/task_e_686dcb39be24832680e4779b1c548fc5