### PR TITLE
Add init tests for AutoAPIClient

### DIFF
--- a/pkgs/standards/autoapi_client/tests/unit/autoapi_client_init_test.py
+++ b/pkgs/standards/autoapi_client/tests/unit/autoapi_client_init_test.py
@@ -1,0 +1,22 @@
+import pytest
+import httpx
+from autoapi_client import AutoAPIClient
+
+
+@pytest.mark.unit
+def test_init_sets_properties():
+    client = AutoAPIClient("https://example.com")
+    assert client._endpoint == "https://example.com"
+    assert client._own is True
+    assert isinstance(client._client, httpx.Client)
+
+
+@pytest.mark.unit
+def test_init_uses_provided_client():
+    mock_client = httpx.Client()
+    try:
+        client = AutoAPIClient("https://example.com", client=mock_client)
+        assert client._client is mock_client
+        assert client._own is False
+    finally:
+        mock_client.close()


### PR DESCRIPTION
## Summary
- add unit tests for AutoAPIClient initialization

## Testing
- `uv run --directory standards/autoapi_client --package autoapi_client ruff format .`
- `uv run --directory standards/autoapi_client --package autoapi_client ruff check . --fix`
- `uv run --package autoapi_client --directory standards/autoapi_client pytest`


------
https://chatgpt.com/codex/tasks/task_e_686df821367c8326b9210d9067ec8236