### PR TITLE
Add AutoAPIClient call parameter tests

### DIFF
--- a/pkgs/standards/autoapi_client/tests/unit/autoapi_client_call_params_test.py
+++ b/pkgs/standards/autoapi_client/tests/unit/autoapi_client_call_params_test.py
@@ -1,0 +1,75 @@
+import json
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from autoapi_client import AutoAPIClient
+
+
+class DummySchema:
+    def __init__(self, **data):
+        self._data = data
+
+    @classmethod
+    def model_validate(cls, data):
+        return cls(**data)
+
+    def model_dump_json(self):
+        return json.dumps(self._data)
+
+
+@pytest.mark.unit
+def test_call_serializes_schema_params():
+    schema = DummySchema(foo="bar", num=1)
+    captured = {}
+
+    def fake_post(self, url, *, json=None, headers=None):
+        captured.update(json=json)
+        request = httpx.Request("POST", url)
+        return httpx.Response(
+            200, request=request, json={"jsonrpc": "2.0", "result": None}
+        )
+
+    with patch.object(httpx.Client, "post", new=fake_post):
+        client = AutoAPIClient("http://example.com")
+        client.call("dummy", params=schema)
+
+    assert captured["json"]["params"] == {"foo": "bar", "num": 1}
+
+
+@pytest.mark.unit
+def test_call_uses_dict_params():
+    params = {"a": 1, "b": 2}
+    captured = {}
+
+    def fake_post(self, url, *, json=None, headers=None):
+        captured.update(json=json)
+        request = httpx.Request("POST", url)
+        return httpx.Response(
+            200, request=request, json={"jsonrpc": "2.0", "result": None}
+        )
+
+    with patch.object(httpx.Client, "post", new=fake_post):
+        client = AutoAPIClient("http://example.com")
+        client.call("dummy", params=params)
+
+    assert captured["json"]["params"] == params
+
+
+@pytest.mark.unit
+def test_call_defaults_to_empty_params():
+    captured = {}
+
+    def fake_post(self, url, *, json=None, headers=None):
+        captured.update(json=json)
+        request = httpx.Request("POST", url)
+        return httpx.Response(
+            200, request=request, json={"jsonrpc": "2.0", "result": None}
+        )
+
+    with patch.object(httpx.Client, "post", new=fake_post):
+        client = AutoAPIClient("http://example.com")
+        client.call("dummy")
+
+    assert captured["json"]["params"] == {}


### PR DESCRIPTION
## Summary
- add unit tests for AutoAPIClient.call parameter handling

## Testing
- `uv run --directory standards/autoapi_client --package autoapi_client pytest`


------
https://chatgpt.com/codex/tasks/task_e_686df8578890832685e6b476e1f88cb3