### PR TITLE
Add AutoAPIClient context manager tests

### DIFF
--- a/pkgs/standards/autoapi_client/tests/unit/autoapi_client_context_test.py
+++ b/pkgs/standards/autoapi_client/tests/unit/autoapi_client_context_test.py
@@ -1,0 +1,27 @@
+import pytest
+from autoapi_client import AutoAPIClient
+from unittest.mock import MagicMock
+
+
+@pytest.mark.unit
+def test_enter_returns_self():
+    client = AutoAPIClient("http://example.com")
+    with client as ctx:
+        assert ctx is client
+
+
+@pytest.mark.unit
+def test_exit_closes_owned_client():
+    client = AutoAPIClient("http://example.com")
+    client._client.close = MagicMock()
+    with client:
+        pass
+    client._client.close.assert_called_once_with()
+
+
+@pytest.mark.unit
+def test_close_does_not_close_unowned_client():
+    mock = MagicMock()
+    client = AutoAPIClient("http://example.com", client=mock)
+    client.close()
+    mock.close.assert_not_called()


### PR DESCRIPTION
## Summary
- add tests for AutoAPIClient context manager behavior

## Testing
- `uv run --package autoapi_client --directory pkgs/standards/autoapi_client pytest`


------
https://chatgpt.com/codex/tasks/task_e_686df8749bc083268fde75add390cf2a