### PR TITLE
Fix ruff errors in autoapi

### DIFF
--- a/pkgs/standards/autoapi/autoapi/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/__init__.py
@@ -4,7 +4,6 @@ from functools import wraps
 from inspect import signature
 from typing import (
     Any,
-    Awaitable,
     Callable,
     Dict,
     Literal,
@@ -14,7 +13,7 @@ from typing import (
     get_origin,
 )
 
-from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, ConfigDict, Field, create_model
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, declarative_base

--- a/pkgs/standards/autoapi/autoapi/mixins.py
+++ b/pkgs/standards/autoapi/autoapi/mixins.py
@@ -11,7 +11,6 @@ from sqlalchemy import (
     Index,
 )
 from sqlalchemy.dialects.postgresql import JSONB, TSVECTOR
-from sqlalchemy.ext.declarative import declarative_mixin
 
 
 # ----------------------------------------------------------------------

--- a/pkgs/standards/autoapi/autoapi/tables.py
+++ b/pkgs/standards/autoapi/autoapi/tables.py
@@ -1,3 +1,28 @@
+"""Example ORM tables used for demos and tests."""
+
+import datetime as dt
+from sqlalchemy import (
+    BigInteger,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+from .mixins import (
+    GUIDPk,
+    MaskableEdge,
+    RelationEdge,
+    Slugged,
+    TenantBound,
+    Timestamped,
+    Audited,
+)
+from .v2.tables._base import Base
+
+
 class Change(Base):
     __tablename__ = "changes"
     seq = Column(BigInteger, primary_key=True, autoincrement=True)

--- a/pkgs/standards/autoapi/autoapi/v2/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v2/__init__.py
@@ -13,7 +13,7 @@ from typing import Any, AsyncIterator, Callable, Dict, Iterator, Optional, Type
 
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import Session, declarative_base
+from sqlalchemy.orm import Session
 
 from .endpoints import attach_health_and_methodz
 from .gateway import build_gateway
@@ -26,7 +26,7 @@ from .impl import (
     _wrap_rpc,
 )
 from .routes import _nested_prefix  # path builder
-from .tables._base import Base
+from .tables._base import Base as Base
 
 # ─── local helpers  (thin sub-modules) ──────────────────────────────
 from .types import (

--- a/pkgs/standards/autoapi/autoapi/v2/engines/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v2/engines/__init__.py
@@ -3,9 +3,6 @@ from sqlalchemy import create_engine
 from sqlalchemy.pool import StaticPool  # only for SQLite
 from sqlalchemy.orm import sessionmaker
 
-from contextlib import asynccontextmanager
-from sqlalchemy.orm import Session
-
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
 
 

--- a/pkgs/standards/autoapi/autoapi/v2/gateway.py
+++ b/pkgs/standards/autoapi/autoapi/v2/gateway.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm import Session
 from typing import Any, Dict
 
 from .hooks import Phase
-from .jsonrpc_models import _RPCReq, _RPCRes, _ok, _err  # tiny utility file
+from .jsonrpc_models import _RPCReq, _RPCRes, _err, _ok, _http_exc_to_rpc
 
 
 def build_gateway(api) -> APIRouter:

--- a/pkgs/standards/autoapi/autoapi/v2/get_schema.py
+++ b/pkgs/standards/autoapi/autoapi/v2/get_schema.py
@@ -19,8 +19,6 @@ def get_autoapi_schema(
     """
     from . import AutoAPI
 
-    pk = next(iter(orm_cls.__table__.primary_key.columns)).name
-
     # -- define the four core variants ---------------------------------
     def _schema(verb: str):
         return AutoAPI._schema(AutoAPI, orm_cls, verb=verb)

--- a/pkgs/standards/autoapi/autoapi/v2/impl.py
+++ b/pkgs/standards/autoapi/autoapi/v2/impl.py
@@ -181,7 +181,7 @@ def _register_routes_and_rpcs(  # noqa: N802
                 200,
                 SCreate,
                 SRead,
-                lambda i, p, db: _update(i, p, db, full=True),
+                functools.partial(_update, full=True),
             )
         )
     if issubclass(model, BulkCapable):
@@ -398,7 +398,8 @@ def _crud(self, model: type) -> None:  # noqa: N802
     pk = next(iter(model.__table__.primary_key.columns)).name
 
     # ----- generate the five canonical schemas ------------------------
-    _S = lambda verb, **kw: self._schema(model, verb=verb, **kw)
+    def _S(verb: str, **kw):
+        return self._schema(model, verb=verb, **kw)
 
     SCreate = _S("create")  # PK excluded
     SRead = _S("read")  # full set

--- a/pkgs/standards/autoapi/autoapi/v2/jsonrpc_models.py
+++ b/pkgs/standards/autoapi/autoapi/v2/jsonrpc_models.py
@@ -40,7 +40,8 @@ class _RPCRes(BaseModel):
     id: str | int | None = None
 
 
-_ok = lambda x, q: _RPCRes(result=x, id=q.id)
+def _ok(x: Any, q: _RPCReq) -> _RPCRes:
+    return _RPCRes(result=x, id=q.id)
 
 
 def _err(code: int, msg: str, q: _RPCReq, data: dict | None = None) -> _RPCRes:

--- a/pkgs/standards/autoapi/autoapi/v2/routes.py
+++ b/pkgs/standards/autoapi/autoapi/v2/routes.py
@@ -1,5 +1,4 @@
-"""
-autoapi_routes.py
+"""autoapi_routes.py
 Helpers that build path prefixes for nested REST endpoints.
 The logic is intentionally minimal; extend or override as needed.
 """
@@ -9,10 +8,11 @@ from typing import Type, Optional
 
 
 def _nested_prefix(self, model: Type) -> Optional[str]:
-    """
-    Return the user-supplied hierarchical prefix or *None*.
+    """Return the user-supplied hierarchical prefix or *None*.
 
     • If the SQLAlchemy model defines a `_nested_path` string
       → return it verbatim.
-    • Otherwise → signal “no nested route wanted” with *None*.
-    """    return getattr(model, "_nested_path", None)
+    • Otherwise → signal ``no nested route wanted`` with ``None``.
+    """
+
+    return getattr(model, "_nested_path", None)

--- a/pkgs/standards/autoapi/autoapi/v2/row_filters.py
+++ b/pkgs/standards/autoapi/autoapi/v2/row_filters.py
@@ -1,4 +1,21 @@
-def _apply_row_filters(model, q, ctx, *, strategy: str = "intersection") -> Query:
+from typing import Any
+from sqlalchemy.orm import Query
+from sqlalchemy import or_
+
+
+class AuthnBound:
+    @staticmethod
+    def filter_for_ctx(q: Query, ctx: Any) -> Query:
+        raise NotImplementedError
+
+
+class MemberBound:
+    @staticmethod
+    def filter_for_ctx(q: Query, ctx: Any) -> Query:
+        raise NotImplementedError
+
+
+def _apply_row_filters(model, q: Query, ctx: Any, *, strategy: str = "intersection") -> Query:
     """Return *q* filtered by every mix-in the model inherits.
 
     strategy = "intersection"  → AND all predicates
@@ -15,5 +32,6 @@ def _apply_row_filters(model, q, ctx, *, strategy: str = "intersection") -> Quer
     if strategy == "intersection":
         for p in predicates:
             q = q.filter(p)
-        return q    else:  # union
+        return q
+    else:  # union
         return q.filter(or_(*predicates))

--- a/pkgs/standards/autoapi/autoapi/v2/tables/_base.py
+++ b/pkgs/standards/autoapi/autoapi/v2/tables/_base.py
@@ -26,4 +26,6 @@ __all__ = ["Base"]
 
 
 def __dir__():
-    """Tighten `dir()` output for interactive sessions."""    return sorted(__all__)
+    """Tighten ``dir()`` output for interactive sessions."""
+
+    return sorted(__all__)

--- a/pkgs/standards/autoapi/autoapi/v2/tables/audit.py
+++ b/pkgs/standards/autoapi/autoapi/v2/tables/audit.py
@@ -25,4 +25,6 @@ for _name in list(globals()):
 
 
 def __dir__():
-    """Tighten `dir()` output for interactive sessions."""    return sorted(__all__)
+    """Tighten ``dir()`` output for interactive sessions."""
+
+    return sorted(__all__)

--- a/pkgs/standards/autoapi/autoapi/v2/tables/group.py
+++ b/pkgs/standards/autoapi/autoapi/v2/tables/group.py
@@ -19,4 +19,6 @@ for _name in list(globals()):
 
 
 def __dir__():
-    """Tighten `dir()` output for interactive sessions."""    return sorted(__all__)
+    """Tighten ``dir()`` output for interactive sessions."""
+
+    return sorted(__all__)

--- a/pkgs/standards/autoapi/autoapi/v2/tables/org.py
+++ b/pkgs/standards/autoapi/autoapi/v2/tables/org.py
@@ -19,4 +19,6 @@ for _name in list(globals()):
 
 
 def __dir__():
-    """Tighten `dir()` output for interactive sessions."""    return sorted(__all__)
+    """Tighten ``dir()`` output for interactive sessions."""
+
+    return sorted(__all__)

--- a/pkgs/standards/autoapi/autoapi/v2/tables/rbac.py
+++ b/pkgs/standards/autoapi/autoapi/v2/tables/rbac.py
@@ -39,4 +39,6 @@ for _name in list(globals()):
 
 
 def __dir__():
-    """Tighten `dir()` output for interactive sessions."""    return sorted(__all__)
+    """Tighten ``dir()`` output for interactive sessions."""
+
+    return sorted(__all__)

--- a/pkgs/standards/autoapi/autoapi/v2/tables/status.py
+++ b/pkgs/standards/autoapi/autoapi/v2/tables/status.py
@@ -83,4 +83,6 @@ for _name in list(globals()):
 
 
 def __dir__():
-    """Tighten `dir()` output for interactive sessions."""    return sorted(__all__)
+    """Tighten ``dir()`` output for interactive sessions."""
+
+    return sorted(__all__)

--- a/pkgs/standards/autoapi/autoapi/v2/tables/tenant.py
+++ b/pkgs/standards/autoapi/autoapi/v2/tables/tenant.py
@@ -19,4 +19,6 @@ for _name in list(globals()):
 
 
 def __dir__():
-    """Tighten `dir()` output for interactive sessions."""    return sorted(__all__)
+    """Tighten ``dir()`` output for interactive sessions."""
+
+    return sorted(__all__)

--- a/pkgs/standards/autoapi/autoapi/v2/tables/user.py
+++ b/pkgs/standards/autoapi/autoapi/v2/tables/user.py
@@ -19,4 +19,6 @@ for _name in list(globals()):
 
 
 def __dir__():
-    """Tighten `dir()` output for interactive sessions."""    return sorted(__all__)
+    """Tighten ``dir()`` output for interactive sessions."""
+
+    return sorted(__all__)

--- a/pkgs/standards/autoapi/autoapi/v2/transactional.py
+++ b/pkgs/standards/autoapi/autoapi/v2/transactional.py
@@ -1,3 +1,9 @@
+from functools import wraps
+from typing import Any, Callable
+
+from sqlalchemy.orm import Session
+
+
 def transactional(self, fn: Callable[..., Any]):
     """
     Decorator to wrap an RPC handler in an explicit DB transaction.
@@ -13,4 +19,5 @@ def transactional(self, fn: Callable[..., Any]):
         except Exception:
             db.rollback()
             raise
+
     return wrapper


### PR DESCRIPTION
## Summary
- address ruff lint errors across the autoapi package
- add missing imports and stub classes for row filtering helpers
- improve docstrings and remove unused imports
- replace lambda expressions with functions/partials

## Testing
- `uv run --directory . --package autoapi ruff format .`
- `uv run --directory . --package autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest`

------
https://chatgpt.com/codex/tasks/task_e_686dfcc0eef083269ccefb2e0dad5794