### PR TITLE
Fix newline in public tenant migration

### DIFF
--- a/pkgs/standards/peagen/peagen/migrations/versions/69f4d7c302fa_create_public_tenant.py
+++ b/pkgs/standards/peagen/peagen/migrations/versions/69f4d7c302fa_create_public_tenant.py
@@ -115,4 +115,5 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    """Intentionally left empty; keep the public tenant and user."""    pass
+    """Intentionally left empty; keep the public tenant and user."""
+    pass


### PR DESCRIPTION
## Summary
- fix missing newline in `create_public_tenant` migration

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format peagen/migrations/versions/69f4d7c302fa_create_public_tenant.py`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check peagen/migrations/versions/69f4d7c302fa_create_public_tenant.py --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest -q` *(fails: 27 failed, 123 passed, 26 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_686e1196e1208326b5f7702fb569fe31