### PR TITLE
Fix metadata naming and task index

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/tables/_base.py
+++ b/pkgs/standards/autoapi/autoapi/v2/tables/_base.py
@@ -13,6 +13,7 @@ class Base(DeclarativeBase):
         naming_convention={
             "pk": "pk_%(table_name)s",
             "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+            "ix": "ix_%(table_name)s_%(column_0_name)s",
         }
     )
 

--- a/pkgs/standards/peagen/peagen/orm/__init__.py
+++ b/pkgs/standards/peagen/peagen/orm/__init__.py
@@ -212,7 +212,7 @@ class Task(
             "spec_kind",
             "spec_uuid",
             unique=True,
-            postgresql_where=text("status != 'error'"),
+            postgresql_where=text("status != 'failed'"),
         ),
     )
     # ───────── routing & ownership ──────────────────────────


### PR DESCRIPTION
## Summary
- add index naming convention so autogen indexes have stable names
- use existing status enum in partial index condition

## Testing
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff format .`
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen ruff format .`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest -m smoke tests/smoke -vv -s` *(fails: Could not reach gateway)*

------
https://chatgpt.com/codex/tasks/task_e_686e28b220d88326a53954568ca313db