### PR TITLE
Set local gateway for tests

### DIFF
--- a/pkgs/standards/peagen/tests/i9n/two_user_secret_exchange_i9n_test.py
+++ b/pkgs/standards/peagen/tests/i9n/two_user_secret_exchange_i9n_test.py
@@ -9,7 +9,7 @@ import pytest
 
 WORKER_LIST = "Workers.list"
 
-GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
+GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "http://localhost:8000/rpc")
 
 
 def _gateway_available(url: str) -> bool:

--- a/pkgs/standards/peagen/tests/sequence_success/test_sequences_success.py
+++ b/pkgs/standards/peagen/tests/sequence_success/test_sequences_success.py
@@ -10,7 +10,7 @@ import httpx
 WORKER_LIST = "Workers.list"
 
 EXAMPLES = Path(__file__).resolve().parent / "examples"
-GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
+GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "http://localhost:8000/rpc")
 
 
 def _gateway_available(url: str) -> bool:

--- a/pkgs/standards/peagen/tests/smoke/test_gateway_login_keys_secrets_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_gateway_login_keys_secrets_cli.py
@@ -8,7 +8,7 @@ import pytest
 WORKER_LIST = "Workers.list"
 
 pytestmark = pytest.mark.smoke
-GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
+GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "http://localhost:8000/rpc")
 
 
 def _gateway_available(url: str) -> bool:

--- a/pkgs/standards/peagen/tests/smoke/test_gateway_ops.py
+++ b/pkgs/standards/peagen/tests/smoke/test_gateway_ops.py
@@ -1,11 +1,12 @@
 import subprocess
 from pathlib import Path
 
+import os
 import pytest
 
 pytestmark = pytest.mark.smoke
 
-gateway = "https://gw.peagen.com/rpc"
+gateway = os.environ.get("PEAGEN_TEST_GATEWAY", "http://localhost:8000/rpc")
 
 
 def run(cmd: list[str]) -> subprocess.CompletedProcess:

--- a/pkgs/standards/peagen/tests/smoke/test_gateway_remote_doe.py
+++ b/pkgs/standards/peagen/tests/smoke/test_gateway_remote_doe.py
@@ -10,7 +10,7 @@ WORKER_LIST = "Workers.list"
 
 pytestmark = pytest.mark.smoke
 
-GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
+GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "http://localhost:8000/rpc")
 REPO = "testproject"
 
 

--- a/pkgs/standards/peagen/tests/smoke/test_remote_doe_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_doe_cli.py
@@ -9,7 +9,7 @@ WORKER_LIST = "Workers.list"
 
 pytestmark = pytest.mark.smoke
 
-GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
+GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "http://localhost:8000/rpc")
 REPO = "testproject"
 
 

--- a/pkgs/standards/peagen/tests/smoke/test_remote_doe_process_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_doe_process_cli.py
@@ -10,7 +10,7 @@ WORKER_LIST = "Workers.list"
 
 pytestmark = pytest.mark.smoke
 
-GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
+GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "http://localhost:8000/rpc")
 BASE = Path(__file__).resolve().parents[2] / "tests" / "examples" / "gateway_demo"
 SPEC = BASE / "doe_spec.yaml"
 TEMPLATE = BASE / "template_project.yaml"

--- a/pkgs/standards/peagen/tests/smoke/test_remote_eval_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_eval_cli.py
@@ -11,7 +11,7 @@ WORKER_LIST = "Workers.list"
 
 pytestmark = pytest.mark.smoke
 
-GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
+GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "http://localhost:8000/rpc")
 REPO = "testproject"
 
 

--- a/pkgs/standards/peagen/tests/smoke/test_remote_evolve.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_evolve.py
@@ -10,7 +10,7 @@ WORKER_LIST = "Workers.list"
 
 pytestmark = pytest.mark.smoke
 
-GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
+GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "http://localhost:8000/rpc")
 REPO = "testproject"
 
 SPEC_PATH = (

--- a/pkgs/standards/peagen/tests/smoke/test_remote_full_flow.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_full_flow.py
@@ -10,7 +10,7 @@ WORKER_LIST = "Workers.list"
 
 pytestmark = pytest.mark.smoke
 
-GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
+GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "http://localhost:8000/rpc")
 BASE = Path(__file__).resolve().parents[2] / "tests" / "examples"
 DOE_SPEC = BASE / "gateway_demo" / "doe_spec.yaml"
 DOE_TEMPLATE = BASE / "gateway_demo" / "template_project.yaml"

--- a/pkgs/standards/peagen/tests/smoke/test_remote_mutate_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_mutate_cli.py
@@ -9,7 +9,7 @@ WORKER_LIST = "Workers.list"
 
 pytestmark = pytest.mark.smoke
 
-GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
+GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "http://localhost:8000/rpc")
 
 
 def _gateway_available(url: str) -> bool:

--- a/pkgs/standards/peagen/tests/smoke/test_remote_process_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_process_cli.py
@@ -9,7 +9,7 @@ WORKER_LIST = "Workers.list"
 
 pytestmark = pytest.mark.smoke
 
-GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
+GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "http://localhost:8000/rpc")
 PROJECTS_FILE = (
     Path(__file__).resolve().parent.parent
     / "examples"

--- a/pkgs/standards/peagen/tests/smoke/test_remote_sort_cli.py
+++ b/pkgs/standards/peagen/tests/smoke/test_remote_sort_cli.py
@@ -9,7 +9,7 @@ WORKER_LIST = "Workers.list"
 
 pytestmark = pytest.mark.smoke
 
-GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "https://gw.peagen.com/rpc")
+GATEWAY = os.environ.get("PEAGEN_TEST_GATEWAY", "http://localhost:8000/rpc")
 EXAMPLES = Path(__file__).resolve().parents[1] / "examples" / "projects_payloads"
 BASE_URL = GATEWAY.removesuffix("/rpc")
 REPO = "testproject"


### PR DESCRIPTION
## Summary
- default `PEAGEN_TEST_GATEWAY` to `http://localhost:8000/rpc`
- use env based gateway constant in gateway ops test

## Testing
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_utils_config_loader.py::test_expand_env_in_text -q`

------
https://chatgpt.com/codex/tasks/task_e_686e28b711b883268aac3bb0197b9660