### PR TITLE
Fix worker registration and index naming

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/tables/_base.py
+++ b/pkgs/standards/autoapi/autoapi/v2/tables/_base.py
@@ -13,6 +13,7 @@ class Base(DeclarativeBase):
         naming_convention={
             "pk": "pk_%(table_name)s",
             "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+            "ix": "ix_%(table_name)s_%(column_0_name)s",
         }
     )
 

--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -18,6 +18,8 @@ from autoapi_client import AutoAPIClient
 from autoapi.v2 import AutoAPI  # façade for get_schema
 from peagen.orm import Worker, Work
 
+DEFAULT_POOL_ID = uuid.UUID(int=0)
+
 # Auto-generated schemas
 SWorkerCreate = AutoAPI.get_schema(Worker, "create")
 SWorkerRead = AutoAPI.get_schema(Worker, "read")
@@ -61,7 +63,7 @@ class WorkerBase:
         # ----- env / defaults --------------------------------------
         self.pool = pool or os.getenv("DQ_POOL", "default")
         self.gateway = gateway or os.getenv("DQ_GATEWAY", "http://localhost:8000/rpc")
-        self.worker_id = worker_id or os.getenv("DQ_WORKER_ID", str(uuid.uuid4())[:8])
+        self.worker_id = worker_id or os.getenv("DQ_WORKER_ID", str(uuid.uuid4()))
         self.port = port or int(os.getenv("PORT", 8001))
         self.host = host or os.getenv("DQ_HOST") or _local_ip()
         self.listen_at = f"http://{self.host}:{self.port}/rpc"
@@ -130,7 +132,7 @@ class WorkerBase:
         try:
             payload = SWorkerCreate(
                 id=self.worker_id,
-                pool=self.pool,
+                pool_id=DEFAULT_POOL_ID,
                 url=self.listen_at,
                 advertises={"cpu": True},
                 handlers=list(self._handlers),


### PR DESCRIPTION
## Summary
- add index naming convention for autoapi tables
- ensure workers use full UUIDs and default pool id

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `uv run --directory pkgs/standards/peagen --package peagen ruff format peagen/worker/base.py`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest -m smoke` *(fails: TypeAdapter class not fully defined)*

------
https://chatgpt.com/codex/tasks/task_e_686e2fe2c0dc8326aee62e96ea16f6ae