### PR TITLE
Update tests for new build_task API

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_doe_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_doe_handler.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 from peagen.handlers import doe_handler as handler
 from peagen.cli.task_helpers import build_task
+from peagen.orm import Action
+from uuid import uuid4
 
 
 @pytest.mark.unit
@@ -27,7 +29,14 @@ async def test_doe_handler_calls_generate_payload(monkeypatch):
         "skip_validate": True,
     }
 
-    task = build_task("doe", args)
+    task = build_task(
+        action=Action.VALIDATE,
+        args=args,
+        tenant_id=str(uuid4()),
+        pool_id=str(uuid4()),
+        repo="repo",
+        ref="HEAD",
+    )
     result = await handler.doe_handler(task)
 
     assert result == {"done": True}

--- a/pkgs/standards/peagen/tests/unit/test_eval_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_eval_handler.py
@@ -2,6 +2,8 @@ import pytest
 
 from peagen.handlers import eval_handler as handler
 from peagen.cli.task_helpers import build_task
+from peagen.orm import Action
+from uuid import uuid4
 
 
 @pytest.mark.unit
@@ -15,7 +17,14 @@ async def test_eval_handler(monkeypatch):
     monkeypatch.setattr(handler, "evaluate_workspace", fake_evaluate_workspace)
 
     args = {}
-    params = build_task("eval", args, repo="repo", ref="HEAD")
+    params = build_task(
+        action=Action.EVAL,
+        args=args,
+        tenant_id=str(uuid4()),
+        pool_id=str(uuid4()),
+        repo="repo",
+        ref="HEAD",
+    )
     result = await handler.eval_handler(params)
 
     assert result["report"]["results"][0]["score"] == 0

--- a/pkgs/standards/peagen/tests/unit/test_evolve_cli.py
+++ b/pkgs/standards/peagen/tests/unit/test_evolve_cli.py
@@ -1,9 +1,18 @@
 import pytest
 from peagen.cli.task_helpers import build_task
+from peagen.orm import Action
+from uuid import uuid4
 
 
 @pytest.mark.unit
 def test_build_task_payload():
-    task = build_task("evolve", {"evolve_spec": "foo.yaml"})
-    assert task.payload["action"] == "evolve"
-    assert task.payload["args"] == {"evolve_spec": "foo.yaml"}
+    task = build_task(
+        action=Action.EVOLVE,
+        args={"evolve_spec": "foo.yaml"},
+        tenant_id=str(uuid4()),
+        pool_id=str(uuid4()),
+        repo="repo",
+        ref="HEAD",
+    )
+    assert task.action == Action.EVOLVE
+    assert task.args == {"evolve_spec": "foo.yaml"}

--- a/pkgs/standards/peagen/tests/unit/test_extras_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_extras_handler.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 from peagen.handlers import extras_handler as handler
 from peagen.cli.task_helpers import build_task
+from peagen.orm import Action
+from uuid import uuid4
 
 
 @pytest.mark.unit
@@ -29,7 +31,14 @@ async def test_extras_handler_calls_generate_schemas(
     if schemas_dir:
         args["schemas_dir"] = schemas_dir
 
-    task = build_task("extras", args)
+    task = build_task(
+        action=Action.VALIDATE,
+        args=args,
+        tenant_id=str(uuid4()),
+        pool_id=str(uuid4()),
+        repo="repo",
+        ref="HEAD",
+    )
     result = await handler.extras_handler(task)
 
     base = Path(handler.__file__).resolve().parents[1]

--- a/pkgs/standards/peagen/tests/unit/test_fetch_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_fetch_handler.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 from peagen.handlers import fetch_handler as handler
 from peagen.cli.task_helpers import build_task
+from peagen.orm import Action
+from uuid import uuid4
 
 
 @pytest.mark.unit
@@ -23,7 +25,14 @@ async def test_fetch_handler_passes_args(monkeypatch):
         "install_template_sets": False,
     }
 
-    task = build_task("fetch", args)
+    task = build_task(
+        action=Action.FETCH,
+        args=args,
+        tenant_id=str(uuid4()),
+        pool_id=str(uuid4()),
+        repo="repo",
+        ref="HEAD",
+    )
     result = await handler.fetch_handler(task)
 
     assert result == {"count": 2}

--- a/pkgs/standards/peagen/tests/unit/test_init_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_init_handler.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from peagen.handlers import init_handler as handler
 from peagen.core import init_core
 from peagen.cli.task_helpers import build_task
+from peagen.orm import Action
+from uuid import uuid4
 
 
 @pytest.mark.unit
@@ -26,7 +28,14 @@ async def test_init_handler_dispatch(monkeypatch, kind, func):
 
     monkeypatch.setattr(init_core, func, fake)
     args = {"kind": kind, "path": "~/p"}
-    task = build_task("init", args)
+    task = build_task(
+        action=Action.VALIDATE,
+        args=args,
+        tenant_id=str(uuid4()),
+        pool_id=str(uuid4()),
+        repo="repo",
+        ref="HEAD",
+    )
     result = await handler.init_handler(task)
 
     assert result == {"kind": kind}
@@ -37,7 +46,25 @@ async def test_init_handler_dispatch(monkeypatch, kind, func):
 @pytest.mark.asyncio
 async def test_init_handler_errors(monkeypatch):
     with pytest.raises(ValueError):
-        await handler.init_handler(build_task("init", {}))
+        await handler.init_handler(
+            build_task(
+                action=Action.VALIDATE,
+                args={},
+                tenant_id=str(uuid4()),
+                pool_id=str(uuid4()),
+                repo="repo",
+                ref="HEAD",
+            )
+        )
 
     with pytest.raises(ValueError):
-        await handler.init_handler(build_task("init", {"kind": "unknown"}))
+        await handler.init_handler(
+            build_task(
+                action=Action.VALIDATE,
+                args={"kind": "unknown"},
+                tenant_id=str(uuid4()),
+                pool_id=str(uuid4()),
+                repo="repo",
+                ref="HEAD",
+            )
+        )

--- a/pkgs/standards/peagen/tests/unit/test_mutate_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_mutate_handler.py
@@ -2,6 +2,8 @@ import pytest
 
 from peagen.handlers import mutate_handler as handler
 from peagen.cli.task_helpers import build_task
+from peagen.orm import Action
+from uuid import uuid4
 
 
 @pytest.mark.unit
@@ -27,7 +29,14 @@ async def test_mutate_handler_invokes_core(monkeypatch):
         "evaluator_ref": "ev",
     }
 
-    task = build_task("mutate", args, pool="default")
+    task = build_task(
+        action=Action.MUTATE,
+        args=args,
+        tenant_id=str(uuid4()),
+        pool_id=str(uuid4()),
+        repo="repo",
+        ref="HEAD",
+    )
 
     result = await handler.mutate_handler(task)
 

--- a/pkgs/standards/peagen/tests/unit/test_process_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_process_handler.py
@@ -2,6 +2,8 @@ import pytest
 
 from peagen.handlers import process_handler as handler
 from peagen.cli.task_helpers import build_task
+from peagen.orm import Action
+from uuid import uuid4
 
 
 class DummyPM:
@@ -47,7 +49,14 @@ async def test_process_handler_dispatch(monkeypatch, project_name):
     if project_name:
         args["project_name"] = project_name
 
-    task = build_task("process", args)
+    task = build_task(
+        action=Action.PROCESS,
+        args=args,
+        tenant_id=str(uuid4()),
+        pool_id=str(uuid4()),
+        repo="repo",
+        ref="HEAD",
+    )
 
     result = await handler.process_handler(task)
 

--- a/pkgs/standards/peagen/tests/unit/test_sort_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_sort_handler.py
@@ -2,6 +2,8 @@ import pytest
 
 from peagen.handlers import sort_handler as handler
 from peagen.cli.task_helpers import build_task
+from peagen.orm import Action
+from uuid import uuid4
 
 
 @pytest.mark.unit
@@ -29,7 +31,14 @@ async def test_sort_handler_delegates(monkeypatch, project_name):
     if project_name:
         args["project_name"] = project_name
 
-    task = build_task("sort", args)
+    task = build_task(
+        action=Action.SORT,
+        args=args,
+        tenant_id=str(uuid4()),
+        pool_id=str(uuid4()),
+        repo="repo",
+        ref="HEAD",
+    )
     result = await handler.sort_handler(task)
 
     if project_name:

--- a/pkgs/standards/peagen/tests/unit/test_task_submit.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_submit.py
@@ -2,13 +2,22 @@ import httpx
 import pytest
 
 from peagen.cli.task_helpers import build_task, submit_task
+from peagen.orm import Action
+from uuid import uuid4
 
 
 @pytest.mark.unit
 def test_build_task_creates_task():
-    task = build_task("demo", {"x": 1})
-    assert task.payload["action"] == "demo"
-    assert task.payload["args"] == {"x": 1}
+    task = build_task(
+        action=Action.SORT,
+        args={"x": 1},
+        tenant_id=str(uuid4()),
+        pool_id=str(uuid4()),
+        repo="repo",
+        ref="HEAD",
+    )
+    assert task.action == "demo"
+    assert task.args == {"x": 1}
 
 
 @pytest.mark.unit
@@ -28,8 +37,21 @@ def test_submit_task_sends_request(monkeypatch):
 
         return Resp()
 
-    monkeypatch.setattr(httpx, "post", fake_post)
-    task = build_task("demo", {})
+    monkeypatch.setattr(
+        httpx,
+        "Client",
+        lambda timeout: type(
+            "C", (), {"post": fake_post, "close": lambda self: None}
+        )(),
+    )
+    task = build_task(
+        action=Action.SORT,
+        args={},
+        tenant_id=str(uuid4()),
+        pool_id=str(uuid4()),
+        repo="repo",
+        ref="HEAD",
+    )
     reply = submit_task("http://gw/rpc", task)
-    assert captured["json"]["params"]["id"] == task.id
+    assert captured["json"]["params"]["id"] == str(task.id)
     assert reply == {"ok": True}

--- a/pkgs/standards/peagen/tests/unit/test_templates_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_templates_handler.py
@@ -2,6 +2,8 @@ import pytest
 
 from peagen.handlers import templates_handler as handler
 from peagen.cli.task_helpers import build_task
+from peagen.orm import Action
+from uuid import uuid4
 
 
 @pytest.mark.unit
@@ -29,7 +31,14 @@ async def test_templates_handler_dispatch(monkeypatch, op, func, args):
 
     monkeypatch.setattr(handler, func, fake)
 
-    task = build_task("templates", {"operation": op, **args})
+    task = build_task(
+        action=Action.VALIDATE,
+        args={"operation": op, **args},
+        tenant_id=str(uuid4()),
+        pool_id=str(uuid4()),
+        repo="repo",
+        ref="HEAD",
+    )
     result = await handler.templates_handler(task)
 
     assert result == {"op": op}


### PR DESCRIPTION
## Summary
- update peagen test suite for the new `build_task` signature
- format and lint the updated package

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format .`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest -q` *(fails: TypeError: build_task() got an unexpected keyword argument 'pool')*

------
https://chatgpt.com/codex/tasks/task_e_686e35ddbf18832686a18597d3e2e5ba