### PR TITLE
Fix tests for updated build_task

### DIFF
--- a/pkgs/standards/peagen/tests/unit/conftest.py
+++ b/pkgs/standards/peagen/tests/unit/conftest.py
@@ -1,0 +1,35 @@
+import uuid
+import pytest
+from pydantic import BaseModel, Field
+from peagen.cli import task_helpers
+
+
+class DummyTaskModel(BaseModel):
+    id: uuid.UUID = Field(default_factory=uuid.uuid4)
+    tenant_id: str
+    pool_id: str
+    action: str
+    repo: str
+    ref: str
+    args: dict | None = None
+    labels: dict | None = None
+    note: str | None = None
+    status: str = "waiting"
+    repository_id: str | None = None
+    config_toml: str | None = None
+    spec_kind: str | None = None
+    spec_uuid: str | None = None
+
+    @property
+    def payload(self):
+        return {"action": self.action, "args": self.args or {}}
+
+
+@pytest.fixture(autouse=True)
+def patch_build_task_schema(monkeypatch):
+    original = task_helpers.AutoAPI.get_schema
+    monkeypatch.setattr(
+        task_helpers.AutoAPI, "get_schema", lambda *a, **k: DummyTaskModel
+    )
+    yield
+    monkeypatch.setattr(task_helpers.AutoAPI, "get_schema", original)

--- a/pkgs/standards/peagen/tests/unit/test_doe_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_doe_handler.py
@@ -27,7 +27,14 @@ async def test_doe_handler_calls_generate_payload(monkeypatch):
         "skip_validate": True,
     }
 
-    task = build_task("doe", args)
+    task = build_task(
+        action="doe",
+        args=args,
+        tenant_id="t",
+        pool_id="p",
+        repo="repo",
+        ref="HEAD",
+    )
     result = await handler.doe_handler(task)
 
     assert result == {"done": True}

--- a/pkgs/standards/peagen/tests/unit/test_eval_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_eval_handler.py
@@ -14,8 +14,15 @@ async def test_eval_handler(monkeypatch):
 
     monkeypatch.setattr(handler, "evaluate_workspace", fake_evaluate_workspace)
 
-    args = {}
-    params = build_task("eval", args, repo="repo", ref="HEAD")
+    args = {"repo": "repo", "ref": "HEAD"}
+    params = build_task(
+        action="eval",
+        args=args,
+        tenant_id="t",
+        pool_id="p",
+        repo="repo",
+        ref="HEAD",
+    )
     result = await handler.eval_handler(params)
 
     assert result["report"]["results"][0]["score"] == 0

--- a/pkgs/standards/peagen/tests/unit/test_evolve_cli.py
+++ b/pkgs/standards/peagen/tests/unit/test_evolve_cli.py
@@ -4,6 +4,13 @@ from peagen.cli.task_helpers import build_task
 
 @pytest.mark.unit
 def test_build_task_payload():
-    task = build_task("evolve", {"evolve_spec": "foo.yaml"})
-    assert task.payload["action"] == "evolve"
-    assert task.payload["args"] == {"evolve_spec": "foo.yaml"}
+    task = build_task(
+        action="evolve",
+        args={"evolve_spec": "foo.yaml"},
+        tenant_id="t",
+        pool_id="p",
+        repo="repo",
+        ref="HEAD",
+    )
+    assert task.action == "evolve"
+    assert task.args == {"evolve_spec": "foo.yaml"}

--- a/pkgs/standards/peagen/tests/unit/test_extras_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_extras_handler.py
@@ -29,7 +29,14 @@ async def test_extras_handler_calls_generate_schemas(
     if schemas_dir:
         args["schemas_dir"] = schemas_dir
 
-    task = build_task("extras", args)
+    task = build_task(
+        action="extras",
+        args=args,
+        tenant_id="t",
+        pool_id="p",
+        repo="repo",
+        ref="HEAD",
+    )
     result = await handler.extras_handler(task)
 
     base = Path(handler.__file__).resolve().parents[1]

--- a/pkgs/standards/peagen/tests/unit/test_fetch_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_fetch_handler.py
@@ -23,7 +23,14 @@ async def test_fetch_handler_passes_args(monkeypatch):
         "install_template_sets": False,
     }
 
-    task = build_task("fetch", args)
+    task = build_task(
+        action="fetch",
+        args=args,
+        tenant_id="t",
+        pool_id="p",
+        repo="repo",
+        ref="HEAD",
+    )
     result = await handler.fetch_handler(task)
 
     assert result == {"count": 2}

--- a/pkgs/standards/peagen/tests/unit/test_init_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_init_handler.py
@@ -26,7 +26,14 @@ async def test_init_handler_dispatch(monkeypatch, kind, func):
 
     monkeypatch.setattr(init_core, func, fake)
     args = {"kind": kind, "path": "~/p"}
-    task = build_task("init", args)
+    task = build_task(
+        action="init",
+        args=args,
+        tenant_id="t",
+        pool_id="p",
+        repo="repo",
+        ref="HEAD",
+    )
     result = await handler.init_handler(task)
 
     assert result == {"kind": kind}
@@ -37,7 +44,25 @@ async def test_init_handler_dispatch(monkeypatch, kind, func):
 @pytest.mark.asyncio
 async def test_init_handler_errors(monkeypatch):
     with pytest.raises(ValueError):
-        await handler.init_handler(build_task("init", {}))
+        await handler.init_handler(
+            build_task(
+                action="init",
+                args={},
+                tenant_id="t",
+                pool_id="p",
+                repo="repo",
+                ref="HEAD",
+            )
+        )
 
     with pytest.raises(ValueError):
-        await handler.init_handler(build_task("init", {"kind": "unknown"}))
+        await handler.init_handler(
+            build_task(
+                action="init",
+                args={"kind": "unknown"},
+                tenant_id="t",
+                pool_id="p",
+                repo="repo",
+                ref="HEAD",
+            )
+        )

--- a/pkgs/standards/peagen/tests/unit/test_mutate_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_mutate_handler.py
@@ -15,6 +15,15 @@ async def test_mutate_handler_invokes_core(monkeypatch):
 
     monkeypatch.setattr(handler, "mutate_workspace", fake_mutate_workspace)
 
+    class DummyPM:
+        def __init__(self, cfg):
+            self.cfg = cfg
+
+        def get(self, name):
+            raise Exception
+
+    monkeypatch.setattr(handler, "PluginManager", DummyPM)
+
     args = {
         "workspace_uri": "ws",
         "target_file": "t.py",
@@ -27,7 +36,14 @@ async def test_mutate_handler_invokes_core(monkeypatch):
         "evaluator_ref": "ev",
     }
 
-    task = build_task("mutate", args, pool="default")
+    task = build_task(
+        action="mutate",
+        args=args,
+        tenant_id="t",
+        pool_id="default",
+        repo="repo",
+        ref="HEAD",
+    )
 
     result = await handler.mutate_handler(task)
 

--- a/pkgs/standards/peagen/tests/unit/test_process_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_process_handler.py
@@ -47,7 +47,14 @@ async def test_process_handler_dispatch(monkeypatch, project_name):
     if project_name:
         args["project_name"] = project_name
 
-    task = build_task("process", args)
+    task = build_task(
+        action="process",
+        args=args,
+        tenant_id="t",
+        pool_id="p",
+        repo="repo",
+        ref="HEAD",
+    )
 
     result = await handler.process_handler(task)
 

--- a/pkgs/standards/peagen/tests/unit/test_sort_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_sort_handler.py
@@ -29,7 +29,14 @@ async def test_sort_handler_delegates(monkeypatch, project_name):
     if project_name:
         args["project_name"] = project_name
 
-    task = build_task("sort", args)
+    task = build_task(
+        action="sort",
+        args=args,
+        tenant_id="t",
+        pool_id="p",
+        repo="repo",
+        ref="HEAD",
+    )
     result = await handler.sort_handler(task)
 
     if project_name:

--- a/pkgs/standards/peagen/tests/unit/test_task_submit.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_submit.py
@@ -1,4 +1,3 @@
-import httpx
 import pytest
 
 from peagen.cli.task_helpers import build_task, submit_task
@@ -6,30 +5,44 @@ from peagen.cli.task_helpers import build_task, submit_task
 
 @pytest.mark.unit
 def test_build_task_creates_task():
-    task = build_task("demo", {"x": 1})
-    assert task.payload["action"] == "demo"
-    assert task.payload["args"] == {"x": 1}
+    task = build_task(
+        action="demo",
+        args={"x": 1},
+        tenant_id="t",
+        pool_id="p",
+        repo="repo",
+        ref="HEAD",
+    )
+    assert task.action == "demo"
+    assert task.args == {"x": 1}
 
 
 @pytest.mark.unit
 def test_submit_task_sends_request(monkeypatch):
     captured = {}
 
-    def fake_post(url, json, timeout):
-        captured["url"] = url
-        captured["json"] = json
+    def fake_call(self, method, *, params=None, out_schema=None):
+        captured["json"] = {
+            "params": params if isinstance(params, dict) else params.model_dump()
+        }
 
-        class Resp:
-            def raise_for_status(self):
-                pass
-
-            def json(self):
+        class Res:
+            def model_dump(self):
                 return {"ok": True}
 
-        return Resp()
+        return Res()
 
-    monkeypatch.setattr(httpx, "post", fake_post)
-    task = build_task("demo", {})
+    from autoapi_client import AutoAPIClient
+
+    monkeypatch.setattr(AutoAPIClient, "call", fake_call)
+    task = build_task(
+        action="demo",
+        args={},
+        tenant_id="t",
+        pool_id="p",
+        repo="repo",
+        ref="HEAD",
+    )
     reply = submit_task("http://gw/rpc", task)
     assert captured["json"]["params"]["id"] == task.id
     assert reply == {"ok": True}

--- a/pkgs/standards/peagen/tests/unit/test_templates_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_templates_handler.py
@@ -29,7 +29,14 @@ async def test_templates_handler_dispatch(monkeypatch, op, func, args):
 
     monkeypatch.setattr(handler, func, fake)
 
-    task = build_task("templates", {"operation": op, **args})
+    task = build_task(
+        action=op,
+        args=args,
+        tenant_id="t",
+        pool_id="p",
+        repo="repo",
+        ref="HEAD",
+    )
     result = await handler.templates_handler(task)
 
     assert result == {"op": op}


### PR DESCRIPTION
## Summary
- patch `AutoAPI.get_schema` in tests
- update peagen tests for keyword-only `build_task`
- patch plugin manager usage in mutate handler tests

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_doe_handler.py::test_doe_handler_calls_generate_payload -q`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_eval_handler.py::test_eval_handler -q`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_evolve_cli.py::test_build_task_payload -q`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_extras_handler.py::test_extras_handler_calls_generate_schemas[None-None] -q`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_extras_handler.py::test_extras_handler_calls_generate_schemas[/tmp/tmpl-/tmp/schema] -q`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_fetch_handler.py::test_fetch_handler_passes_args -q`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_init_handler.py::test_init_handler_dispatch[project-init_project] -q`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_init_handler.py::test_init_handler_dispatch[template-set-init_template_set] -q`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_init_handler.py::test_init_handler_dispatch[doe-spec-init_doe_spec] -q`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_init_handler.py::test_init_handler_dispatch[ci-init_ci] -q`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_mutate_handler.py::test_mutate_handler_invokes_core -q`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_process_handler.py::test_process_handler_dispatch[proj] -q`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_process_handler.py::test_process_handler_dispatch[None] -q`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_sort_handler.py::test_sort_handler_delegates[proj] -q`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_sort_handler.py::test_sort_handler_delegates[None] -q`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_templates_handler.py::test_templates_handler_dispatch[list-list_template_sets-args0] -q`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_templates_handler.py::test_templates_handler_dispatch[show-show_template_set-args1] -q`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_templates_handler.py::test_templates_handler_dispatch[add-add_template_set-args2] -q`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_templates_handler.py::test_templates_handler_dispatch[remove-remove_template_set-args3] -q`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_task_submit.py::test_build_task_creates_task -q`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_task_submit.py::test_submit_task_sends_request -q`


------
https://chatgpt.com/codex/tasks/task_e_686e3601bc0c8326bebe5b4717176ebd