### PR TITLE
Fix plugin import for mutate handler

### DIFF
--- a/pkgs/standards/peagen/peagen/core/mutate_core.py
+++ b/pkgs/standards/peagen/peagen/core/mutate_core.py
@@ -26,7 +26,6 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from peagen._utils.config_loader import resolve_cfg
 from peagen.plugin_manager import PluginManager, resolve_plugin_spec
-from peagen.plugins.vcs import open_repo         # optional; may raise
 from peagen.core.fetch_core import fetch_single  # shallow clone helper
 from swarmauri_standard.programs.Program import Program
 
@@ -69,9 +68,7 @@ def mutate_workspace(  # noqa: PLR0913 – many tunables by design
     profile_mod: str | None = None,
     cfg_path: Optional[Path] = None,
     mutations: Optional[List[Dict[str, Any]]] = None,
-    evaluator_ref: str = (
-        "performance_evaluator"
-    ),
+    evaluator_ref: str = ("performance_evaluator"),
 ) -> Dict[str, Optional[str]]:
     """
     Run a very small GA-style search over *target_file* in *repo@ref*.


### PR DESCRIPTION
## Summary
- update `mutate_core` to stop importing from `peagen.plugins.vcs`
- ensure tests run via package `peagen`

## Testing
- `uv run --package peagen --directory . ruff format peagen/core/mutate_core.py`
- `uv run --package peagen --directory . ruff check peagen/core/mutate_core.py --fix`
- `uv run --package peagen --directory . pytest` *(fails: 9 failed, 140 passed, 26 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_686e47f48eb48326a46b1291b6ba4f1a