### PR TITLE
Fix pydantic forward reference crash

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/impl.py
+++ b/pkgs/standards/autoapi/autoapi/v2/impl.py
@@ -5,12 +5,11 @@ Compatible with FastAPI 1.5, Pydantic 2.x, SQLAlchemy 2.x.
 
 import re
 from inspect import isawaitable, signature
-from typing import Any, List, Union, get_args, get_origin
+from typing import Any, List, get_args, get_origin
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, Request
 from pydantic import BaseModel, ConfigDict, Field, create_model
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
-from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
 from .mixins import AsyncCapable, BulkCapable, Replaceable
@@ -274,9 +273,7 @@ def _register_routes_and_rpcs(  # noqa: N802
                 inspect.Parameter(
                     "db",
                     inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                    annotation=Annotated[
-                        Union[AsyncSession, Session], Depends(provider)
-                    ],
+                    annotation=Annotated[Any, Depends(provider)],
                 )
             )
 


### PR DESCRIPTION
## Summary
- avoid Pydantic inspecting SQLAlchemy Session constructor
- trim unused import

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff check . --fix`
- `uv run --directory standards/autoapi --package autoapi pytest -q` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_e_686e47f48eb48326a46b1291b6ba4f1a