### PR TITLE
Fix templates_handler tests for new schema

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_templates_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_templates_handler.py
@@ -29,9 +29,10 @@ async def test_templates_handler_dispatch(monkeypatch, op, func, args):
 
     monkeypatch.setattr(handler, func, fake)
 
+    payload = {"action": op, **args}
     task = build_task(
-        action=op,
-        args=args,
+        action="templates",
+        args=payload,
         tenant_id="t",
         pool_id="p",
         repo="repo",


### PR DESCRIPTION
## Summary
- update templates handler tests to include action in args
- run format and lint

## Testing
- `uv run --package peagen --directory . ruff check tests/unit/test_templates_handler.py --fix`
- `uv run --package peagen --directory . pytest tests/unit/test_templates_handler.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686f18476f8083268a662e92abd51ca2