### PR TITLE
Fix peagen sort handler unit test

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_sort_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_sort_handler.py
@@ -7,10 +7,10 @@ from peagen.cli.task_helpers import build_task
 @pytest.mark.unit
 @pytest.mark.asyncio
 @pytest.mark.parametrize("project_name", ["proj", None])
-async def test_sort_handler_delegates(monkeypatch, project_name):
+async def test_sort_handler_delegates(monkeypatch, tmp_path, project_name):
     calls = {}
 
-    def fake_resolve_cfg(toml_text=None):
+    def fake_resolve_cfg(toml_path=None):
         return {"cfg": True}
 
     def fake_single(params):
@@ -25,7 +25,7 @@ async def test_sort_handler_delegates(monkeypatch, project_name):
     monkeypatch.setattr(handler, "sort_single_project", fake_single)
     monkeypatch.setattr(handler, "sort_all_projects", fake_all)
 
-    args = {"projects_payload": "payload"}
+    args = {"projects_payload": "payload", "worktree": str(tmp_path)}
     if project_name:
         args["project_name"] = project_name
 


### PR DESCRIPTION
## Summary
- update peagen `test_sort_handler` for new `worktree` argument

## Testing
- `uv run --package peagen --directory pkgs/standards pytest peagen/tests/unit/test_sort_handler.py`


------
https://chatgpt.com/codex/tasks/task_e_686f184aaa3c832685fbcc449c51a108