### PR TITLE
Fix process handler tests for new worktree parameter

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_process_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_process_handler.py
@@ -9,21 +9,19 @@ class DummyPM:
         self.cfg = cfg
 
     def get(self, name):
-        return "adapter"
-
-
-class DummyAdapter:
-    def __init__(self, **kw):
-        pass
+        raise Exception
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
 @pytest.mark.parametrize("project_name", ["proj", None])
-async def test_process_handler_dispatch(monkeypatch, project_name):
-    monkeypatch.setattr(handler, "resolve_cfg", lambda toml_text=None: {})
+async def test_process_handler_dispatch(monkeypatch, tmp_path, project_name):
+    monkeypatch.setattr(
+        handler,
+        "resolve_cfg",
+        lambda toml_text=None, toml_path=".peagen.toml": {},
+    )
     monkeypatch.setattr(handler, "PluginManager", DummyPM)
-    monkeypatch.setattr(handler, "FileStorageAdapter", DummyAdapter)
 
     calls = {}
 
@@ -43,7 +41,7 @@ async def test_process_handler_dispatch(monkeypatch, project_name):
     monkeypatch.setattr(handler, "process_single_project", fake_single)
     monkeypatch.setattr(handler, "process_all_projects", fake_all)
 
-    args = {"projects_payload": "pp"}
+    args = {"projects_payload": "pp", "worktree": str(tmp_path)}
     if project_name:
         args["project_name"] = project_name
 


### PR DESCRIPTION
## Summary
- update unit test to match the new `process_handler` signature
- patch PluginManager to raise when plugins are unavailable
- specify worktree path via `tmp_path`

## Testing
- `uv run --package peagen --directory . pytest tests/unit/test_process_handler.py::test_process_handler_dispatch[proj] -q`
- `uv run --package peagen --directory . pytest tests/unit/test_process_handler.py::test_process_handler_dispatch[None] -q`
- `uv run --package peagen --directory . pytest -q` *(fails: test_sequences_failure, test_doe_handler, test_extras_handler, test_fetch_handler, test_load_projects_payload_remote, test_mutate_handler, test_process_core, test_sort_handler, test_templates_handler, test_utils_search_template_sets)*

------
https://chatgpt.com/codex/tasks/task_e_686f1856330483269918e1ee7e61e797