### PR TITLE
Fix test for updated process handler

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_process_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_process_handler.py
@@ -12,18 +12,12 @@ class DummyPM:
         return "adapter"
 
 
-class DummyAdapter:
-    def __init__(self, **kw):
-        pass
-
-
 @pytest.mark.unit
 @pytest.mark.asyncio
 @pytest.mark.parametrize("project_name", ["proj", None])
-async def test_process_handler_dispatch(monkeypatch, project_name):
-    monkeypatch.setattr(handler, "resolve_cfg", lambda toml_text=None: {})
+async def test_process_handler_dispatch(monkeypatch, tmp_path, project_name):
+    monkeypatch.setattr(handler, "resolve_cfg", lambda *a, **kw: {})
     monkeypatch.setattr(handler, "PluginManager", DummyPM)
-    monkeypatch.setattr(handler, "FileStorageAdapter", DummyAdapter)
 
     calls = {}
 
@@ -43,7 +37,7 @@ async def test_process_handler_dispatch(monkeypatch, project_name):
     monkeypatch.setattr(handler, "process_single_project", fake_single)
     monkeypatch.setattr(handler, "process_all_projects", fake_all)
 
-    args = {"projects_payload": "pp"}
+    args = {"projects_payload": "pp", "worktree": str(tmp_path)}
     if project_name:
         args["project_name"] = project_name
 


### PR DESCRIPTION
## Summary
- update process handler test to include worktree argument

## Testing
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_process_handler.py::test_process_handler_dispatch[proj] -q`
- `uv run --package peagen --directory standards/peagen pytest -q` *(fails: 18 failed, 131 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686f1909349c8326942e70728eb9e90a