### PR TITLE
Fix new handler API in doe test

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_doe_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_doe_handler.py
@@ -1,5 +1,8 @@
 import pytest
 from pathlib import Path
+import tempfile
+from contextlib import contextmanager
+from peagen.plugins.vcs.git_vcs import GitVCS
 
 from peagen.handlers import doe_handler as handler
 from peagen.cli.task_helpers import build_task
@@ -12,9 +15,41 @@ async def test_doe_handler_calls_generate_payload(monkeypatch):
 
     def fake_generate_payload(**kwargs):
         captured.update(kwargs)
-        return {"done": True}
+        return {"done": True, "dry_run": True}
 
     monkeypatch.setattr(handler, "generate_payload", fake_generate_payload)
+
+    class DummyPM:
+        def __init__(self, cfg):
+            self.cfg = cfg
+
+        def get(self, name):
+            raise Exception
+
+    monkeypatch.setattr(handler, "PluginManager", DummyPM)
+
+    @contextmanager
+    def dummy_lock(_repo: str):
+        yield
+
+    def fake_open_repo(path, remote_url=None):
+        tmp = Path(tempfile.mkdtemp())
+        return GitVCS(tmp)
+
+    monkeypatch.setattr(handler, "repo_lock", dummy_lock)
+    monkeypatch.setattr(handler, "open_repo", fake_open_repo)
+    monkeypatch.setattr(handler, "fetch_git_remote", lambda *_: None)
+    monkeypatch.setattr(handler, "add_git_worktree", lambda *_: None)
+
+    async def fake_fan_out(**_):
+        return {"children": [], "jobs": 0}
+
+    monkeypatch.setattr(handler, "fan_out", fake_fan_out)
+
+    class DummyStatus:
+        waiting = object()
+
+    monkeypatch.setattr(handler, "Status", DummyStatus)
 
     args = {
         "spec": "spec.yml",
@@ -25,6 +60,8 @@ async def test_doe_handler_calls_generate_payload(monkeypatch):
         "dry_run": True,
         "force": True,
         "skip_validate": True,
+        "repo": "repo",
+        "ref": "HEAD",
     }
 
     task = build_task(
@@ -37,6 +74,6 @@ async def test_doe_handler_calls_generate_payload(monkeypatch):
     )
     result = await handler.doe_handler(task)
 
-    assert result == {"done": True}
-    assert captured["spec_path"] == Path("spec.yml")
+    assert result == {"done": True, "dry_run": True, "children": [], "jobs": 0}
+    assert captured["spec_path"].name == "spec.yml"
     assert captured["dry_run"] is True


### PR DESCRIPTION
## Summary
- update doe_handler test to supply repo/ref in args
- stub git interactions and fan_out for unit test

## Testing
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_doe_handler.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686f1872bdb88326bee38ae035f5e952