### PR TITLE
Fix tests for updated search path APIs

### DIFF
--- a/pkgs/standards/peagen/tests/sequence_failure/examples/demo_failure.yaml
+++ b/pkgs/standards/peagen/tests/sequence_failure/examples/demo_failure.yaml
@@ -1,3 +1,3 @@
 commands:
-  - ["init", "project", "{tmpdir}/badproj"]
-  - ["init", "ci", "{tmpdir}/badproj"]
+  - ["local", "init", "project", "{tmpdir}/badproj"]
+  - ["local", "init", "ci", "{tmpdir}/badproj"]

--- a/pkgs/standards/peagen/tests/unit/test_process_core.py
+++ b/pkgs/standards/peagen/tests/unit/test_process_core.py
@@ -98,8 +98,6 @@ def test_render_package_ptree(
     """
     # Build minimal global search path
     global_search_paths = [tmp_template_set.parent]
-    workspace_root = tmp_path / "workspace"
-    workspace_root.mkdir()
 
     # Load project and package dict
     payload = yaml.safe_load(tmp_project_payload.read_text())
@@ -110,8 +108,8 @@ def test_render_package_ptree(
         project=project,
         pkg=pkg,
         global_search_paths=global_search_paths,
-        workspace_root=workspace_root,
-        logger=None,
+        project_dir=tmp_path,
+        log=None,
     )
 
     # Expect exactly one record for module "mod1"
@@ -151,10 +149,10 @@ def test_process_single_project_integration(
 
     cfg = {
         "logger": None,
-        "source_packages": [],
         "storage_adapter": DummyAdapter(),
         "peagen_version": "test",
         "agent_env": {},
+        "worktree": tmp_path,
     }
 
     sorted_records, next_idx, commit_sha, oids = process_single_project(
@@ -171,7 +169,7 @@ def test_process_single_project_integration(
     assert isinstance(oids, list)
 
     # Check that the file was written
-    out_file = Path.cwd() / project["NAME"] / rec["RENDERED_FILE_NAME"]
+    out_file = Path(cfg["worktree"]) / rec["RENDERED_FILE_NAME"]
     assert out_file.exists()
 
     # The content should match the template ("Generated for test_project: pkgA.mod1")

--- a/pkgs/standards/peagen/tests/unit/test_utils_search_template_sets.py
+++ b/pkgs/standards/peagen/tests/unit/test_utils_search_template_sets.py
@@ -9,116 +9,57 @@ from peagen._utils._search_template_sets import (
 
 @pytest.fixture
 def tmp_dirs(tmp_path: Path):
-    """
-    Creates a temporary directory structure for testing:
-      - workspace_root
-      - two source-package dests under workspace_root
-      - a base_dir
-      - a template_base_dir
-      - some built-in or plugin paths (simulated)
-    """
-    workspace_root = tmp_path / "workspace"
-    workspace_root.mkdir()
-
-    # Simulate two source-package dests
-    src1 = {"dest": "pkgA"}
-    src2 = {"dest": "pkgB"}
-    (workspace_root / "pkgA").mkdir()
-    (workspace_root / "pkgB").mkdir()
-
-    # template_base_dir override
-    template_base_dir = tmp_path / "base_templates"
-    template_base_dir.mkdir()
-
-    # base_dir (project root)
+    """Create temporary base and template directories for search path tests."""
     base_dir = tmp_path / "cwd"
     base_dir.mkdir()
 
+    template_base_dir = tmp_path / "base_templates"
+    template_base_dir.mkdir()
+
     return {
-        "workspace_root": workspace_root,
-        "source_packages": [src1, src2],
-        "template_base_dir": template_base_dir,
         "base_dir": base_dir,
+        "template_base_dir": template_base_dir,
     }
 
 
 def test_build_global_template_search_paths(tmp_dirs):
-    """
-    Verify that build_global_template_search_paths orders entries as:
-      [workspace_root,
-       built-in paths (peagen.templates),
-       plugin paths,
-       workspace_root/pkgA, workspace_root/pkgB,
-       template_base_dir,
-       base_dir]
-    """
-    # We can't easily check built-ins or plugins here without mocking,
-    # but we can check that workspace_root is first and template_base_dir/base_dir are last two.
-    paths = build_global_template_search_paths(
-        workspace_root=tmp_dirs["workspace_root"],
-        source_packages=tmp_dirs["source_packages"],
-        base_dir=tmp_dirs["base_dir"],
-    )
+    """build_global_template_search_paths ends with the caller-supplied base_dir."""
 
-    # 1st must be workspace_root
-    assert paths[0] == tmp_dirs["workspace_root"].resolve()
-    # Last path must be base_dir
+    paths = build_global_template_search_paths(base_dir=tmp_dirs["base_dir"])
+
     assert paths[-1] == tmp_dirs["base_dir"].resolve()
 
 
 def test_build_ptree_template_search_paths(tmp_dirs):
-    """
-    Verify build_ptree_template_search_paths returns exactly:
-      [package_template_dir,
-       base_dir,
-       workspace_root/pkgA, workspace_root/pkgB]
-    """
+    """ptree search path is [package_template_dir, base_dir]."""
+
     package_template_dir = tmp_dirs["template_base_dir"] / "my_set"
     package_template_dir.mkdir()
 
     ptree_paths = build_ptree_template_search_paths(
         package_template_dir=package_template_dir,
         base_dir=tmp_dirs["base_dir"],
-        workspace_root=tmp_dirs["workspace_root"],
-        source_packages=tmp_dirs["source_packages"],
     )
 
     expected = [
         package_template_dir.resolve(),
         tmp_dirs["base_dir"].resolve(),
-        (tmp_dirs["workspace_root"] / "pkgA").resolve(),
-        (tmp_dirs["workspace_root"] / "pkgB").resolve(),
     ]
     assert ptree_paths == expected
 
 
 def test_build_file_template_search_paths(tmp_dirs):
-    """
-    Verify build_file_template_search_paths prepends record_template_dir and workspace_root,
-    then appends everything except the first element of ptree_paths.
-    """
+    """build_file_template_search_paths prepends record dir then ptree paths."""
     record_dir = tmp_dirs["template_base_dir"] / "my_set"
     record_dir.mkdir()
 
     # Suppose ptree_paths is:
-    ptree_paths = [
-        record_dir,
-        tmp_dirs["base_dir"],
-        (tmp_dirs["workspace_root"] / "pkgA"),
-    ]
+    ptree_paths = [record_dir, tmp_dirs["base_dir"]]
 
     file_paths = build_file_template_search_paths(
         record_template_dir=record_dir,
-        workspace_root=tmp_dirs["workspace_root"],
         ptree_search_paths=ptree_paths,
     )
 
-    # Expected:
-    # [record_dir, workspace_root, base_dir, workspace_root/pkgA]
-    expected = [
-        record_dir.resolve(),
-        tmp_dirs["workspace_root"].resolve(),
-        tmp_dirs["base_dir"].resolve(),
-        (tmp_dirs["workspace_root"] / "pkgA").resolve(),
-    ]
+    expected = [record_dir.resolve(), *[p.resolve() for p in ptree_paths]]
     assert file_paths == expected


### PR DESCRIPTION
## Summary
- update `demo_failure.yaml` CLI usage
- adjust process core integration test for new worktree-based API
- update template search path tests for simplified helpers

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff check tests/unit/test_process_core.py tests/unit/test_utils_search_template_sets.py --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_process_core.py::test_render_package_ptree tests/unit/test_utils_search_template_sets.py::test_build_global_template_search_paths tests/unit/test_utils_search_template_sets.py::test_build_ptree_template_search_paths tests/unit/test_utils_search_template_sets.py::test_build_file_template_search_paths -q`

------
https://chatgpt.com/codex/tasks/task_e_686f18e939b88326aefc4a12d6bfad74