### PR TITLE
Fix sequence failure example for new CLI

### DIFF
--- a/pkgs/standards/peagen/tests/sequence_failure/examples/demo_failure.yaml
+++ b/pkgs/standards/peagen/tests/sequence_failure/examples/demo_failure.yaml
@@ -1,3 +1,3 @@
 commands:
-  - ["init", "project", "{tmpdir}/badproj"]
-  - ["init", "ci", "{tmpdir}/badproj"]
+  - ["--help"]
+  - ["remote", "--gateway-url", "http://127.0.0.1:9999/rpc", "sort", "tests/examples/projects_payloads/template_two_project.yaml", "--repo", "testproject"]


### PR DESCRIPTION
## Summary
- update failing sequence failure example
- keep ruff/format

## Testing
- `uv run --package peagen --directory standards/peagen pytest tests/sequence_failure -k example0 -q`
- `uv run --package peagen --directory standards/peagen pytest tests/sequence_success -q`

------
https://chatgpt.com/codex/tasks/task_e_686f1bb247908326926b6bb875dd1fcd