### PR TITLE
Allow repo creation on push

### DIFF
--- a/infra/peagen/docker-compose.yml
+++ b/infra/peagen/docker-compose.yml
@@ -154,6 +154,7 @@ services:
       GITEA__service__REGISTER_EMAIL_CONFIRM: "false"
       GITEA__service__DISABLE_REGISTRATION:  "true"
       GITEA__repository__ENABLE_PUSH_CREATE_USER: "true"
+      GITEA__repository__ENABLE_PUSH_CREATE_ORG:  "true"
 
     volumes:
       - /mnt/data/gitea:/data             # <- all repos & config live here


### PR DESCRIPTION
## Summary
- enable automatic repository creation for organizations in gitea

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686fe6df319483268f6b82a83c454987