### PR TITLE
Add worker CRUD integration test

### DIFF
--- a/pkgs/standards/peagen/peagen/orm/__init__.py
+++ b/pkgs/standards/peagen/peagen/orm/__init__.py
@@ -18,9 +18,14 @@ from autoapi.v2.types import (
     Integer,
     String,
     UniqueConstraint,
-    PgEnum, ARRAY, UUID,
-    MutableDict, MutableList,
-    relationship, foreign, remote, declarative_mixin, declared_attr
+    PgEnum,
+    UUID,
+    MutableDict,
+    relationship,
+    foreign,
+    remote,
+    declarative_mixin,
+    declared_attr,
 )
 
 # ---------------------------------------------------------------------
@@ -42,7 +47,6 @@ from autoapi.v2.mixins import (
     BlobRef,
 )
 from peagen.defaults import (
-    DEFAULT_GATEWAY,
     DEFAULT_POOL_NAME,
     DEFAULT_POOL_ID,
     DEFAULT_TENANT_ID,
@@ -221,14 +225,14 @@ class Worker(Base, GUIDPk, Timestamped):
     )
     url = Column(String, nullable=False)
     advertises = Column(
-        MutableDict.as_mutable(JSON),   # or JSON
-        default=lambda: {},       # ✔ correct for SQLAlchemy
-        nullable=True
+        MutableDict.as_mutable(JSON),  # or JSON
+        default=lambda: {},  # ✔ correct for SQLAlchemy
+        nullable=True,
     )
-    handlers =  Column(
-        MutableDict.as_mutable(JSON),   # or JSON
-        default=lambda: {},       # ✔ correct for SQLAlchemy
-        nullable=True
+    handlers = Column(
+        MutableDict.as_mutable(JSON),  # or JSON
+        default=lambda: {},  # ✔ correct for SQLAlchemy
+        nullable=True,
     )
 
     pool = relationship(Pool, backref="workers")

--- a/pkgs/standards/peagen/tests/i9n/test_worker_crud.py
+++ b/pkgs/standards/peagen/tests/i9n/test_worker_crud.py
@@ -1,0 +1,98 @@
+"""
+tests/test_worker_crud.py
+End-to-end CRUD check for the Workers table.
+
+Requires:
+    • A running gateway at http://127.0.0.1:8000/v1
+    • pytest
+    • The AutoAPIClient helper shipped with Peagen/AutoAutoAPI
+"""
+
+import uuid
+import httpx
+import pytest
+
+# ❶ ------------------------------------------------------------------------
+# Runtime wiring
+from autoapi.v2 import AutoAPI  # your AutoAutoAPI import
+from peagen.orm import Worker  # ORM class
+from peagen.defaults import DEFAULT_POOL_ID
+from autoapi_client import AutoAPIClient  # JSON-RPC helper
+
+# GATEWAY_RPC = "https://gw.peagen.com/rpc"
+GATEWAY_RPC = "http://127.0.0.1:8000/rpc"
+
+
+def _gateway_available(url: str) -> bool:
+    """Return ``True`` if the gateway RPC endpoint accepts POST requests."""
+    envelope = {"jsonrpc": "2.0", "method": "Workers.list", "params": {}, "id": 0}
+    try:
+        response = httpx.post(url, json=envelope, timeout=5)
+    except Exception:
+        return False
+    return response.status_code == 200
+
+
+# ❷ ------------------------------------------------------------------------
+# Schemas generated on-the-fly so the test never drifts from the server
+SWorkerCreate = AutoAPI.get_schema(Worker, "create")
+SWorkerUpdate = AutoAPI.get_schema(Worker, "update")
+SWorkerRead = AutoAPI.get_schema(Worker, "read")
+
+
+# ❸ ------------------------------------------------------------------------
+@pytest.mark.i9n
+def test_worker_create_and_update():
+    if not _gateway_available(GATEWAY_RPC):
+        pytest.skip("gateway not reachable")
+    worker_id = str(uuid.uuid4())
+    print(worker_id, type(worker_id), str(DEFAULT_POOL_ID), type(str(DEFAULT_POOL_ID)))
+    create_payload = SWorkerCreate(
+        id=worker_id,
+        pool_id=str(DEFAULT_POOL_ID),  # or omit if server fills
+        url="http://worker-test:9000",
+        handlers={"doe": True, "evolve": True},
+        advertises={"cpu": 4, "ram_gb": 8},
+    )
+    print(create_payload)
+    with AutoAPIClient(GATEWAY_RPC) as c:
+        # --- CREATE -------------------------------------------------------
+        created = c.call(
+            "Workers.create",
+            params=create_payload,
+            out_schema=SWorkerRead,
+        )
+        assert created.id == str(worker_id)
+        assert created.url == create_payload.url
+        assert created.handlers == create_payload.handlers
+
+        # --- UPDATE (heartbeat-like) -------------------------------------
+        upd_payload = SWorkerUpdate(
+            id=str(worker_id),
+            handlers={"doe": True, "evolve": True, "fetch": True},
+            advertises={"cpu": 8, "ram_gb": 16},
+            # pool_id omitted → immutable (info={"no_update": True})
+        )
+        updated = c.call(
+            "Workers.update",
+            params=upd_payload,
+            out_schema=SWorkerRead,
+        )
+        assert "fetch" in updated.handlers
+        assert updated.advertises["cpu"] == 8
+
+        # --- READ back ----------------------------------------------------
+        reread = c.call(
+            "Workers.read",
+            params={"id": worker_id},
+            out_schema=SWorkerRead,
+        )
+        assert reread.handlers == updated.handlers
+        assert reread.advertises == updated.advertises
+
+        # --- LIST filter --------------------------------------------------
+        listed = c.call(
+            "Workers.list",
+            params={"skip": 0, "limit": 10},
+        )
+        assert any(w["id"] == str(worker_id) for w in listed)


### PR DESCRIPTION
## Summary
- add integration test for Workers CRUD API
- skip the test when the gateway is unreachable
- clean up unused imports in peagen ORM

## Testing
- `uv run --package peagen --directory standards/peagen pytest tests/i9n/test_worker_crud.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6871607ae35c8326b6d8c9b6ec53bac8