### PR TITLE
Fix AutoAPI compatibility with Pydantic 2

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/impl.py
+++ b/pkgs/standards/autoapi/autoapi/v2/impl.py
@@ -429,8 +429,10 @@ def _schema(  # noqa: N802
     model_name = name or f"{orm_cls.__name__}_{verb.capitalize()}"
     cfg = dict(from_attributes=True)
 
-    schema_cls = create_model(  # type: ignore[arg-type]
-        model_name, __config__=type("Cfg", (), cfg), **fields
+    schema_cls = create_model(
+        model_name,
+        __config__=ConfigDict(**cfg),
+        **fields,
     )
     _SchemaCache[cache_key] = schema_cls
     return schema_cls


### PR DESCRIPTION
## Summary
- fix schema creation in autoapi to pass ConfigDict instead of custom type
- keep formatting consistent with ruff

## Testing
- `uv run --package autoapi --directory standards -- pytest autoapi/tests/i9n/test_basic_http.py::test_basic_endpoints[sync] -q`

------
https://chatgpt.com/codex/tasks/task_e_68808c71a2648326b236a4eabbcb6a1d