### PR TITLE
Fix AutoAPI schema names

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/impl.py
+++ b/pkgs/standards/autoapi/autoapi/v2/impl.py
@@ -440,7 +440,7 @@ def _schema(  # noqa: N802
 
         fields[attr_name] = (py_t, fld)
 
-    model_name = name or f"{orm_cls.__name__}_{verb.capitalize()}"
+    model_name = name or f"{orm_cls.__name__}{verb.capitalize()}"
     cfg = ConfigDict(from_attributes=True)
 
     schema_cls = create_model(

--- a/pkgs/standards/autoapi/tests/i9n/test_schema.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_schema.py
@@ -13,11 +13,11 @@ async def test_schema_generation(api_client):
     delete_model = AutoAPI.get_schema(Item, "delete")
     list_model = AutoAPI.get_schema(Item, "list")
 
-    assert create_model.__name__ == "Item_Create"
-    assert read_model.__name__ == "Item_Read"
-    assert update_model.__name__ == "Item_Update"
-    assert delete_model.__name__ == "Item_Delete"
-    assert list_model.__name__ == "Item_ListParams"
+    assert create_model.__name__ == "ItemCreate"
+    assert read_model.__name__ == "ItemRead"
+    assert update_model.__name__ == "ItemUpdate"
+    assert delete_model.__name__ == "ItemDelete"
+    assert list_model.__name__ == "ItemListParams"
 
     spec = (await client.get("/openapi.json")).json()
     schemas = spec["components"]["schemas"]


### PR DESCRIPTION
## Summary
- remove underscores from generated schema names
- update schema generation test

## Testing
- `uv run --package autoapi --directory pkgs/standards/autoapi pytest tests/i9n/test_schema.py::test_schema_generation[sync] -q`
- `uv run --package autoapi --directory pkgs/standards/autoapi pytest tests/i9n/test_schema.py::test_schema_generation[async] -q`


------
https://chatgpt.com/codex/tasks/task_e_68809692a088832687a966a547baf273