### PR TITLE
Fix AutoAPI hook handling

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/_runner.py
+++ b/pkgs/standards/autoapi/autoapi/v2/_runner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from inspect import isawaitable, iscoroutinefunction
 from typing import Callable, Mapping, MutableMapping, Any, Optional
+from types import SimpleNamespace
 
 from .hooks import Phase
 
@@ -40,7 +41,7 @@ async def _invoke(
         await api._run(Phase.PRE_TX_BEGIN, ctx)
 
         # ─── business logic call -------------------------------------------
-        if exec_fn is not None:                           # custom executor
+        if exec_fn is not None:  # custom executor
             result = await exec_fn(method, params, db)
         else:
             maybe = api.rpc[method](params, db)
@@ -54,15 +55,16 @@ async def _invoke(
             await api._run(Phase.PRE_COMMIT, ctx)
 
             if iscoroutinefunction(db.commit):
-                await db.commit()         # AsyncSession
+                await db.commit()  # AsyncSession
             else:
-                db.commit()               # plain Session
+                db.commit()  # plain Session
 
             await api._run(Phase.POST_COMMIT, ctx)
 
         # ─── POST hook ──────────────────────────────────────────────────────
+        ctx["response"] = SimpleNamespace(result=result)
         await api._run(Phase.POST_RESPONSE, ctx)
-        return result
+        return ctx["response"].result
 
     # ─────────────── error path ─────────────────────────────────────────────
     except Exception as exc:

--- a/pkgs/standards/autoapi/autoapi/v2/impl.py
+++ b/pkgs/standards/autoapi/autoapi/v2/impl.py
@@ -312,7 +312,7 @@ def _register_routes_and_rpcs(  # noqa: N802 – bound as method
                     )
 
                 # synchronous DB
-                def _direct_call(_m, _p, _db=db):
+                async def _direct_call(_m, _p, _db=db):
                     return core(p if verb == "create" else rpc_params, _db)
 
                 return await _invoke(
@@ -582,11 +582,7 @@ def _crud(self, model: type) -> None:  # noqa: N802
 def _wrap_rpc(self, core, IN, OUT, pk_name, model):  # noqa: N802
     p = iter(signature(core).parameters.values())
     first = next(p, None)
-    exp_pm = (
-        bool(first)
-        and isinstance(first.annotation, type)
-        and issubclass(first.annotation, BaseModel)
-    )
+    exp_pm = bool(first) and hasattr(IN, "model_validate")
     out_lst = get_origin(OUT) is list
     elem = get_args(OUT)[0] if out_lst else None
     elem_md = callable(getattr(elem, "model_validate", None)) if elem else False


### PR DESCRIPTION
## Summary
- ensure sync execution path uses async function
- expose SimpleNamespace response for POST_RESPONSE hooks
- detect pydantic params via `IN` type rather than annotation

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_hooks.py::test_hooks_modify_request_and_response[sync] -q`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_hooks.py::test_hooks_modify_request_and_response[async] -q`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_hooks.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688096b36edc8326baddc0f956a05047