### PR TITLE
Fix autoapi transactional decorator

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/transactional.py
+++ b/pkgs/standards/autoapi/autoapi/v2/transactional.py
@@ -1,6 +1,8 @@
 from functools import wraps
+from inspect import isawaitable
 from typing import Any, Callable
 
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
 
@@ -9,15 +11,34 @@ def transactional(self, fn: Callable[..., Any]):
     Decorator to wrap an RPC handler in an explicit DB transaction.
     """
 
-    @wraps(fn)
-    def wrapper(params, db: Session, *a, **k):
+    def _sync(params, db: Session, *a, **k):
         db.begin()
         try:
-            res = fn(params, db, *a, **k)
+            result = fn(params, db, *a, **k)
             db.commit()
-            return res
+            return result
         except Exception:
             db.rollback()
             raise
+
+    async def _async(params, db: AsyncSession, *a, **k):
+        await db.begin()
+        try:
+            result = fn(params, db, *a, **k)
+            if isawaitable(result):
+                result = await result
+            await db.commit()
+            return result
+        except Exception:
+            await db.rollback()
+            raise
+
+    @wraps(fn)
+    def wrapper(params, db: Session | AsyncSession, *a, **k):
+        return (
+            _async(params, db, *a, **k)
+            if isinstance(db, AsyncSession)
+            else _sync(params, db, *a, **k)
+        )
 
     return wrapper


### PR DESCRIPTION
## Summary
- handle async sessions in `transactional` decorator
- fix REST execution logic to send proper args to CRUD helpers
- ensure transactional tests pass

## Testing
- `uv run --package autoapi --directory pkgs/standards/autoapi pytest -k test_transaction_decorator -vv`

------
https://chatgpt.com/codex/tasks/task_e_68809ccc03c88326b482f3a6ff2453b0