### PR TITLE
Add service principals to AutoAuthN

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/routers/auth_flows.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/routers/auth_flows.py
@@ -144,8 +144,8 @@ async def refresh(body: RefreshIn):
 @router.post("/apikeys/introspect", response_model=IntrospectOut)
 async def introspect_key(body: ApiKeyIn, db: AsyncSession = Depends(get_async_db)):
     try:
-        user = await _api_backend.authenticate(db, body.api_key)
+        principal = await _api_backend.authenticate(db, body.api_key)
     except AuthError as exc:
         raise HTTPException(status.HTTP_404_NOT_FOUND, exc.reason)
 
-    return IntrospectOut(sub=str(user.id), tid=str(user.tenant_id))
+    return IntrospectOut(sub=str(principal.id), tid=str(principal.tenant_id))

--- a/pkgs/standards/auto_authn/auto_authn/v2/routers/crud.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/routers/crud.py
@@ -28,6 +28,8 @@ from auto_authn.v2.orm.tables import (
     User,
     Client,
     ApiKey,
+    Service,
+    ServiceKey,
 )
 from ..db import get_async_db  # same module as before
 
@@ -36,7 +38,7 @@ from ..db import get_async_db  # same module as before
 # ----------------------------------------------------------------------
 crud_api = AutoAPI(
     base=Base,
-    include={Tenant, User, Client, ApiKey},
+    include={Tenant, User, Client, ApiKey, Service, ServiceKey},
     get_async_db=get_async_db,
 )
 

--- a/pkgs/standards/peagen/peagen/core/keys_core.py
+++ b/pkgs/standards/peagen/peagen/core/keys_core.py
@@ -17,7 +17,10 @@ from pathlib import Path
 import httpx
 from autoapi_client import AutoAPIClient
 from autoapi.v2 import AutoAPI
-from peagen._utils.config_loader import resolve_cfg
+from peagen._utils.config_loader import (
+    load_peagen_toml,
+    resolve_cfg,
+)
 from peagen.defaults import DEFAULT_GATEWAY
 from peagen.orm import DeployKey
 from peagen.plugins import PluginManager
@@ -119,3 +122,12 @@ def fetch_server_keys(gateway_url: str = DEFAULT_GATEWAY) -> list[dict]:
             out_schema=list[SRead],  # type: ignore[arg-type]
         )
     return [k.model_dump() for k in res]
+
+
+__all__ = [
+    "create_keypair",
+    "upload_public_key",
+    "remove_public_key",
+    "fetch_server_keys",
+    "load_peagen_toml",
+]


### PR DESCRIPTION
## Summary
- support Service and ServiceKey models in AutoAuthN
- expose service tables via CRUD router
- allow ApiKeyBackend to authenticate service keys
- export load_peagen_toml for tests

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen pytest` *(fails: 5 failed, 144 passed, 27 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688303b0ac08832699ec486e2dbfb158