### PR TITLE
feat: add API key support to AutoAPIClient

### DIFF
--- a/pkgs/standards/autoapi_client/tests/unit/autoapi_client_api_key_test.py
+++ b/pkgs/standards/autoapi_client/tests/unit/autoapi_client_api_key_test.py
@@ -1,0 +1,39 @@
+import httpx
+import pytest
+from unittest.mock import patch
+
+from autoapi_client import AutoAPIClient
+
+
+@pytest.mark.unit
+def test_api_key_included_in_rest_request():
+    captured = {}
+
+    def fake_get(self, url, *, params=None, headers=None):
+        captured.update(headers=headers)
+        request = httpx.Request("GET", url)
+        return httpx.Response(200, request=request, json={})
+
+    with patch.object(httpx.Client, "get", new=fake_get):
+        client = AutoAPIClient("http://example.com", api_key="secret")
+        client.get("/resource")
+
+    assert captured["headers"]["x-api-key"] == "secret"
+
+
+@pytest.mark.unit
+def test_api_key_included_in_rpc_call():
+    captured = {}
+
+    def fake_post(self, url, *, json=None, headers=None):
+        captured.update(headers=headers)
+        request = httpx.Request("POST", url)
+        return httpx.Response(
+            200, request=request, json={"jsonrpc": "2.0", "result": None}
+        )
+
+    with patch.object(httpx.Client, "post", new=fake_post):
+        client = AutoAPIClient("http://example.com/rpc", api_key="topsecret")
+        client.call("ping")
+
+    assert captured["headers"]["x-api-key"] == "topsecret"

--- a/pkgs/standards/autoapi_client/tests/unit/test_autoapi_rpc.py
+++ b/pkgs/standards/autoapi_client/tests/unit/test_autoapi_rpc.py
@@ -123,7 +123,7 @@ def test_rpc_call_error_handling():
 
     with patch.object(httpx.Client, "post", new=fake_post):
         client = AutoAPIClient("http://example.com/api")
-        with pytest.raises(RuntimeError, match="RPC -32602: Invalid params"):
+        with pytest.raises(RuntimeError, match="RPC error -32602: Invalid params"):
             client.call("invalid.method")
 
 


### PR DESCRIPTION
## Summary
- add optional `api_key` parameter and property to `AutoAPIClient`
- ensure requests include `x-api-key` header
- cover API key behaviour with unit tests

## Testing
- `uv run --package autoapi_client --directory standards/autoapi_client pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68904a82f56883269c856a9df6a80b76