### PR TITLE
feat(peagen): add autoapi client with api key support

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/analysis.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/analysis.py
@@ -9,7 +9,6 @@ import typer
 from peagen.handlers.analysis_handler import analysis_handler
 from peagen.cli.task_helpers import build_task, submit_task
 
-DEFAULT_GATEWAY = "http://localhost:8000/rpc"
 local_analysis_app = typer.Typer(help="Aggregate run evaluation results.")
 remote_analysis_app = typer.Typer(help="Aggregate run evaluation results.")
 
@@ -45,7 +44,7 @@ def submit(
     if repo:
         args.update({"repo": repo, "ref": ref})
     task = build_task("analysis", args, pool=ctx.obj.get("pool", "default"))
-    reply = submit_task(ctx.obj.get("gateway_url"), task)
+    reply = submit_task(ctx.obj["rpc"], task)
     if "error" in reply:
         typer.secho(
             f"Remote error {reply['error']['code']}: {reply['error']['message']}",

--- a/pkgs/standards/peagen/peagen/cli/commands/doe.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/doe.py
@@ -26,7 +26,7 @@ from peagen.cli.task_helpers import (
 from peagen.handlers.doe_handler import doe_handler
 from peagen.handlers.doe_process_handler import doe_process_handler
 from peagen.orm import Status
-from peagen.defaults import DEFAULT_GATEWAY, DEFAULT_POOL_ID, DEFAULT_TENANT_ID
+from peagen.defaults import DEFAULT_POOL_ID, DEFAULT_TENANT_ID
 
 # ────────────────────────── apps ───────────────────────────────
 
@@ -118,7 +118,7 @@ def submit_gen(  # noqa: PLR0913
     ref: str = typer.Option("HEAD", "--ref"),
 ) -> None:
     """Submit a DOE generation task to the gateway."""
-    gw = ctx.obj.get("gateway_url", DEFAULT_GATEWAY)
+    rpc = ctx.obj["rpc"]
 
     args = _assemble_args(
         spec,
@@ -139,7 +139,7 @@ def submit_gen(  # noqa: PLR0913
         ref=ref,
     )
 
-    reply = submit_task(gw, task)
+    reply = submit_task(rpc, task)
     typer.echo(f"Submitted task {reply['id']} (status={reply['status']})")
 
 
@@ -204,7 +204,7 @@ def submit_process(  # noqa: PLR0913
     ref: str = typer.Option("HEAD", "--ref"),
 ) -> None:
     """Submit DOE processing to the gateway and optionally watch progress."""
-    gw = ctx.obj.get("gateway_url", DEFAULT_GATEWAY)
+    rpc = ctx.obj["rpc"]
 
     def _rel(p: Path) -> str:
         try:
@@ -233,12 +233,12 @@ def submit_process(  # noqa: PLR0913
         ref=ref,
     )
 
-    created = submit_task(gw, task)
+    created = submit_task(rpc, task)
     typer.echo(f"Submitted task {created['id']}")
 
     if watch:
         while True:
-            cur = get_task(gw, created["id"])
+            cur = get_task(rpc, created["id"])
             if Status.is_terminal(cur.status):
                 break
             time.sleep(interval)

--- a/pkgs/standards/peagen/peagen/cli/commands/evolve.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/evolve.py
@@ -24,7 +24,7 @@ from peagen.handlers.evolve_handler import evolve_handler
 from peagen.core.validate_core import validate_evolve_spec
 from peagen.orm import Status, Action
 
-from peagen.defaults import DEFAULT_GATEWAY, DEFAULT_POOL_ID, DEFAULT_TENANT_ID
+from peagen.defaults import DEFAULT_POOL_ID, DEFAULT_TENANT_ID
 
 # ────────────────────────── apps ───────────────────────────────
 
@@ -94,8 +94,6 @@ def submit(
             typer.secho(err, fg=typer.colors.RED, err=True)
         raise typer.Exit(1)
 
-    gw = ctx.obj.get("gateway_url", DEFAULT_GATEWAY)
-
     task = build_task(
         action=Action.EVOLVE,
         args=_args_for_task(spec, repo, ref),
@@ -105,12 +103,14 @@ def submit(
         ref=ref,
     )
 
-    created = submit_task(gw, task)
+    rpc = ctx.obj["rpc"]
+
+    created = submit_task(rpc, task)
     typer.secho(f"Submitted task {created['id']}", fg=typer.colors.GREEN)
 
     if watch:
         while True:
-            cur = get_task(gw, created["id"])
+            cur = get_task(rpc, created["id"])
             if Status.is_terminal(cur.status):
                 break
             time.sleep(interval)

--- a/pkgs/standards/peagen/peagen/cli/commands/extras.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/extras.py
@@ -63,9 +63,6 @@ def submit_extras(
     ),
     repo: str = typer.Option(..., "--repo", help="Git repository URI"),
     ref: str = typer.Option("HEAD", "--ref", help="Git ref or commit SHA"),
-    gateway_url: str = typer.Option(
-        "http://localhost:8000/rpc", "--gateway-url", help="JSON-RPC gateway endpoint"
-    ),
 ) -> None:
     """Submit EXTRAS schema generation as a background task."""
     args = {
@@ -77,11 +74,11 @@ def submit_extras(
     task = build_task("extras", args, pool=ctx.obj.get("pool", "default"))
 
     try:
-        reply = submit_task(gateway_url, task)
+        reply = submit_task(ctx.obj["rpc"], task)
         if "error" in reply:
             typer.echo(f"[ERROR] {reply['error']['message']}")
             raise typer.Exit(1)
         typer.echo(f"Submitted extras generation → taskId={reply['result']['taskId']}")
     except Exception as exc:
-        typer.echo(f"[ERROR] Could not reach gateway at {gateway_url}: {exc}")
+        typer.echo(f"[ERROR] Could not reach gateway: {exc}")
         raise typer.Exit(1)

--- a/pkgs/standards/peagen/peagen/cli/commands/init.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/init.py
@@ -17,7 +17,6 @@ from peagen.errors import PATNotAllowedError
 from peagen.defaults import DEFAULT_POOL_ID, DEFAULT_TENANT_ID
 
 
-
 # --------------------------------------------------------------------- helpers
 def _parse_remotes(values: Optional[List[str]]) -> Dict[str, str]:
     remotes: Dict[str, str] = {}
@@ -217,7 +216,7 @@ def _remote_task(
         repo=repo,
         ref=ref,
     )
-    reply = submit_task(ctx.obj.get("gateway_url"), task)
+    reply = submit_task(ctx.obj["rpc"], task)
     if "error" in reply:
         raise PATNotAllowedError(reply["error"]["message"])
 

--- a/pkgs/standards/peagen/peagen/cli/commands/mutate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/mutate.py
@@ -114,8 +114,6 @@ def submit(  # noqa: PLR0913
     interval: float = typer.Option(2.0, "--interval", "-i"),
 ) -> None:
     """Submit a mutate task to the gateway (optionally watch progress)."""
-    gw = ctx.obj.get("gateway_url")
-
     args = _args_dict(
         target_file, import_path, entry_fn, profile_mod, fitness, mutator, gens
     ) | {"repo": repo, "ref": ref}
@@ -129,12 +127,12 @@ def submit(  # noqa: PLR0913
         ref=ref,
     )
 
-    created = submit_task(gw, task)
+    created = submit_task(ctx.obj["rpc"], task)
     typer.echo(f"Submitted task {created['id']}")
 
     if watch:
         while True:
-            cur = get_task(gw, created["id"])
+            cur = get_task(ctx.obj["rpc"], created["id"])
             if Status.is_terminal(cur.status):
                 break
             time.sleep(interval)

--- a/pkgs/standards/peagen/peagen/cli/commands/process.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/process.py
@@ -24,7 +24,7 @@ from peagen.cli.task_helpers import build_task, submit_task, get_task
 from peagen.handlers.process_handler import process_handler
 from peagen.orm import Status
 
-from peagen.defaults import DEFAULT_GATEWAY, DEFAULT_POOL_ID, DEFAULT_TENANT_ID
+from peagen.defaults import DEFAULT_POOL_ID, DEFAULT_TENANT_ID
 
 # ────────────────────────── apps ───────────────────────────────
 
@@ -158,13 +158,13 @@ def submit(  # noqa: PLR0913
         ref=ref,
     )
 
-    gw = ctx.obj.get("gateway_url", DEFAULT_GATEWAY)
-    created = submit_task(gw, task)
+    rpc = ctx.obj["rpc"]
+    created = submit_task(rpc, task)
     typer.secho(f"Submitted task {created['id']}", fg=typer.colors.GREEN)
 
     if watch:
         while True:
-            cur = get_task(gw, created["id"])
+            cur = get_task(rpc, created["id"])
             if Status.is_terminal(cur.status):
                 break
             time.sleep(interval)

--- a/pkgs/standards/peagen/peagen/cli/commands/secrets.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/secrets.py
@@ -21,8 +21,6 @@ from autoapi.v2 import AutoAPI
 from peagen.orm import RepoSecret
 from peagen.core import secrets_core
 
-from peagen.defaults import DEFAULT_GATEWAY
-
 # ────────────────────────── apps ───────────────────────────────
 
 local_secrets_app = typer.Typer(help="Manage secrets in the local .peagen store")
@@ -30,8 +28,8 @@ remote_secrets_app = typer.Typer(help="Manage secrets on the gateway via JSON-RP
 
 
 # ─────────────────────── helper shortcuts ────────────────────────────
-def _rpc(url: str) -> AutoAPIClient:
-    return AutoAPIClient(url)
+def _rpc(ctx: typer.Context) -> AutoAPIClient:
+    return ctx.obj["rpc"]
 
 
 def _schema(tag: str):
@@ -75,12 +73,12 @@ def remove_local_secret(name: str) -> None:
 # ─────────────────────── REMOTE COMMANDS (RPC) ────────────────────────
 @remote_secrets_app.command("add")
 def add_remote_secret(  # noqa: PLR0913
+    ctx: typer.Context,
     secret_id: str,
     value: str,
     version: int = typer.Option(0, "--version"),
     recipient: List[Path] = typer.Option([], "--recipient"),
     pool: str = typer.Option("default", "--pool"),
-    gateway_url: str = typer.Option(DEFAULT_GATEWAY, "--gateway-url"),
 ) -> None:
     SCreate = _schema("create")
     SRead = _schema("read")
@@ -92,8 +90,8 @@ def add_remote_secret(  # noqa: PLR0913
         pool=pool,
     )
     try:
-        with _rpc(gateway_url) as rpc:
-            res = rpc.call("RepoSecrets.create", params=params, out_schema=SRead)
+        rpc = _rpc(ctx)
+        res = rpc.call("RepoSecrets.create", params=params, out_schema=SRead)
         typer.echo(f"🚀  uploaded secret '{res.secretId}' (v{res.version})")
     except Exception as exc:  # noqa: BLE001
         typer.echo(f"❌  {exc}", err=True)
@@ -102,18 +100,18 @@ def add_remote_secret(  # noqa: PLR0913
 
 @remote_secrets_app.command("get")
 def get_remote_secret(
+    ctx: typer.Context,
     secret_id: str,
     version: int = typer.Option(0, "--version"),
-    gateway_url: str = typer.Option(DEFAULT_GATEWAY, "--gateway-url"),
 ) -> None:
     SRead = _schema("read")
     try:
-        with _rpc(gateway_url) as rpc:
-            secret = rpc.call(
-                "RepoSecrets.read",
-                params={"secretId": secret_id, "version": version},
-                out_schema=SRead,
-            )
+        rpc = _rpc(ctx)
+        secret = rpc.call(
+            "RepoSecrets.read",
+            params={"secretId": secret_id, "version": version},
+            out_schema=SRead,
+        )
         typer.echo(secret.plainValue)
     except Exception as exc:
         typer.echo(f"❌  {exc}", err=True)
@@ -122,15 +120,15 @@ def get_remote_secret(
 
 @remote_secrets_app.command("remove")
 def remove_remote_secret(
+    ctx: typer.Context,
     secret_id: str,
     version: Optional[int] = typer.Option(None, "--version"),
-    gateway_url: str = typer.Option(DEFAULT_GATEWAY, "--gateway-url"),
 ) -> None:
     SDel = _schema("delete")
     try:
         params = SDel(secretId=secret_id, version=version)
-        with _rpc(gateway_url) as rpc:
-            rpc.call("RepoSecrets.delete", params=params, out_schema=dict)
+        rpc = _rpc(ctx)
+        rpc.call("RepoSecrets.delete", params=params, out_schema=dict)
         typer.echo(f"🗑️  removed secret '{secret_id}' from gateway")
     except Exception as exc:
         typer.echo(f"❌  {exc}", err=True)
@@ -139,13 +137,13 @@ def remove_remote_secret(
 
 @remote_secrets_app.command("fetch-server")
 def fetch_server_secrets(
-    gateway_url: str = typer.Option(DEFAULT_GATEWAY, "--gateway-url"),
+    ctx: typer.Context,
 ) -> None:
     SListIn = _schema("list")
     SRead = _schema("read")
     try:
-        with _rpc(gateway_url) as rpc:
-            lst = rpc.call("RepoSecrets.list", params=SListIn(), out_schema=list[SRead])  # type: ignore[arg-type]
+        rpc = _rpc(ctx)
+        lst = rpc.call("RepoSecrets.list", params=SListIn(), out_schema=list[SRead])  # type: ignore[arg-type]
         typer.echo(json.dumps([s.model_dump() for s in lst], indent=2))
     except Exception as exc:
         typer.echo(f"❌  {exc}", err=True)

--- a/pkgs/standards/peagen/peagen/cli/commands/sort.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/sort.py
@@ -151,7 +151,7 @@ def submit_sort(  # noqa: PLR0913
     )
 
     # 4) submit via gateway
-    resp = submit_task(ctx.obj.get("gateway_url"), task)
+    resp = submit_task(ctx.obj["rpc"], task)
     if "error" in resp:
         typer.echo(f"[ERROR] {resp['error']['message']}", err=True)
         raise typer.Exit(1)
@@ -162,7 +162,7 @@ def submit_sort(  # noqa: PLR0913
     # optional watch
     if watch:
         while True:
-            cur = get_task(ctx.obj.get("gateway_url"), tid)
+            cur = get_task(ctx.obj["rpc"], tid)
             if Status.is_terminal(cur.status):
                 break
             time.sleep(interval)

--- a/pkgs/standards/peagen/peagen/cli/commands/validate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/validate.py
@@ -84,13 +84,11 @@ def submit_validate(
 
     # 2) Build Task.submit envelope using Task fields
     try:
-        reply = submit_task(ctx.obj.get("gateway_url"), task)
+        reply = submit_task(ctx.obj["rpc"], task)
         if "error" in reply:
             typer.echo(f"[ERROR] {reply['error']['message']}")
             raise typer.Exit(1)
         typer.echo(f"Submitted validation → taskId={reply['result']['taskId']}")
     except Exception as exc:
-        typer.echo(
-            f"[ERROR] Could not reach gateway at {ctx.obj.get('gateway_url')}: {exc}"
-        )
+        typer.echo(f"[ERROR] Could not reach gateway: {exc}")
         raise typer.Exit(1)

--- a/pkgs/standards/peagen/peagen/cli/task_helpers.py
+++ b/pkgs/standards/peagen/peagen/cli/task_helpers.py
@@ -2,12 +2,10 @@
 from __future__ import annotations
 
 import uuid
-import httpx
 from typing import Any, Dict, Optional
 
 from autoapi_client import AutoAPIClient
 from autoapi.v2 import AutoAPI
-from peagen.defaults import RPC_TIMEOUT
 from peagen.orm import Status, Task, Action, SpecKind
 
 
@@ -55,36 +53,28 @@ def build_task(
 
 # ─────────────────── RPC helpers ────────────────────────────────────────
 def submit_task(
-    gateway_url: str,
+    rpc: AutoAPIClient,
     task_model: Any,  # instance from build_task()
-    *,
-    timeout: float = RPC_TIMEOUT,
 ) -> Dict[str, Any]:
-    """POST tasks.create and return the validated TaskRead dict."""
+    """POST ``tasks.create`` and return the validated TaskRead dict."""
     SRead = AutoAPI.get_schema(Task, "read")
-
-    with AutoAPIClient(gateway_url, client=httpx.Client(timeout=timeout)) as rpc:
-        res = rpc.call(
-            "tasks.create",
-            params=task_model.model_dump(),  # AutoAPIClient expects dict
-            out_schema=SRead,
-        )
+    res = rpc.call(
+        "tasks.create",
+        params=task_model.model_dump(),  # AutoAPIClient expects dict
+        out_schema=SRead,
+    )
     return res.model_dump()
 
 
 def get_task(
-    gateway_url: str,
+    rpc: AutoAPIClient,
     task_id: str,
-    *,
-    timeout: float = RPC_TIMEOUT,
 ):
     """Return a validated TaskRead Pydantic object for *task_id*."""
     SRead = AutoAPI.get_schema(Task, "read")
-
-    with AutoAPIClient(gateway_url, client=httpx.Client(timeout=timeout)) as rpc:
-        result = rpc.call(
-            "tasks.read",
-            params={"id": task_id},
-            out_schema=SRead,
-        )
+    result = rpc.call(
+        "tasks.read",
+        params={"id": task_id},
+        out_schema=SRead,
+    )
     return result


### PR DESCRIPTION
## Summary
- load API key and preconfigure AutoAPIClient in remote CLI context
- use shared AutoAPI client across task helper functions
- wire CLI commands to submit tasks via configured client

## Testing
- `ruff check peagen/cli/__init__.py peagen/cli/task_helpers.py peagen/cli/commands/analysis.py peagen/cli/commands/db.py peagen/cli/commands/doe.py peagen/cli/commands/eval.py peagen/cli/commands/evolve.py peagen/cli/commands/extras.py peagen/cli/commands/init.py peagen/cli/commands/mutate.py peagen/cli/commands/process.py peagen/cli/commands/secrets.py peagen/cli/commands/sort.py peagen/cli/commands/task.py peagen/cli/commands/templates.py peagen/cli/commands/validate.py --fix`

------
https://chatgpt.com/codex/tasks/task_e_6890506ad14c8326ad521f8fc0236f73