### PR TITLE
Fix autoapi method naming and sync sqlite setup

### DIFF
--- a/pkgs/standards/autoapi/tests/conftest.py
+++ b/pkgs/standards/autoapi/tests/conftest.py
@@ -7,6 +7,7 @@ from autoapi.v2.mixins import BulkCapable, GUIDPk
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import Column, ForeignKey, String, create_engine
+from sqlalchemy.pool import StaticPool
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import Session, sessionmaker
@@ -38,7 +39,9 @@ def pytest_generate_tests(metafunc):
 def sync_db_session():
     """Create a sync database session for testing."""
     engine = create_engine(
-        "sqlite:///:memory:", connect_args={"check_same_thread": False}
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
     )
     SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
 
@@ -161,7 +164,9 @@ async def api_client(db_mode):
 
     else:
         engine = create_engine(
-            "sqlite:///:memory:", connect_args={"check_same_thread": False}
+            "sqlite:///:memory:",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
         )
 
         SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)


### PR DESCRIPTION
## Summary
- keep canonical RPC names plural and dot-separated
- key method registry by canonical names for accurate hook/method listings
- stabilize SQLite-based tests by sharing in-memory DB and annotating auth dependency

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890760e38108326bcf4064f140a2481