### PR TITLE
feat(worker): persist api key after registration

### DIFF
--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -139,8 +139,15 @@ class WorkerBase:
                 advertises={"cpu": True},
                 handlers={"handlers": list(self._handlers)},
             )
-            self._client.call("Worker.create", params=payload, out_schema=SWorkerRead)
+            created = self._client.call(
+                "Worker.create", params=payload, out_schema=SWorkerRead
+            )
             self.log.info("registered @ gateway as %s", self.worker_id)
+            api_key = getattr(created, "api_key", None)
+            if api_key:
+                self._api_key = api_key
+                os.environ["DQ_API_KEY"] = api_key
+                self._client.api_key = api_key
         except Exception as exc:  # pragma: no cover
             self.log.error("registration failed: %s", exc, exc_info=True)
 


### PR DESCRIPTION
## Summary
- store API key returned from worker registration
- attach stored API key to subsequent gateway requests

## Testing
- `uv run --directory . --package peagen ruff format peagen/worker/base.py`
- `uv run --directory . --package peagen ruff check peagen/worker/base.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_6890893c82688326bd2ae077512b76d0