### PR TITLE
Auto-generate API key on creation

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/hooks.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/hooks.py
@@ -1,21 +1,50 @@
 # auto_authn/hooks.py  (inside the AuthN package)
 
+
 def register_inject_hook(api):
     from autoapi.v2.hooks import Phase
+    from secrets import token_urlsafe
+    from .orm.tables import ApiKey
 
-    @api.hook(Phase.PRE_TX_BEGIN)            # PRE‑DB, works for CRUD & RPC
+    @api.hook(Phase.PRE_TX_BEGIN)  # PRE‑DB, works for CRUD & RPC
     async def _inject(ctx):
         p = ctx["request"].state.principal
         if not p:
             return
 
-        prm = ctx["env"].params               # Pydantic model OR raw dict
+        prm = ctx["env"].params  # Pydantic model OR raw dict
         for fld, val in (("tenant_id", p["tid"]), ("owner_id", p["sub"])):
             if hasattr(prm, "__pydantic_fields__"):
                 if fld in prm.model_fields and getattr(prm, fld, None) in (None, val):
                     setattr(prm, fld, val)
             elif isinstance(prm, dict):
                 prm.setdefault(fld, val)
+
+    @api.hook(Phase.PRE_TX_BEGIN, model="ApiKey", op="create")
+    async def _generate_key(ctx):
+        prm = ctx["env"].params
+        if hasattr(prm, "__pydantic_fields__"):
+            if getattr(prm, "raw_key", None):
+                raise ValueError("raw_key cannot be provided")
+            prm.digest = ApiKey.digest_of(raw := token_urlsafe(8))
+        elif isinstance(prm, dict):
+            if prm.get("raw_key"):
+                raise ValueError("raw_key cannot be provided")
+            raw = token_urlsafe(8)
+            prm["digest"] = ApiKey.digest_of(raw)
+        else:
+            raw = token_urlsafe(8)
+        ctx["raw_api_key"] = raw
+
+    @api.hook(Phase.POST_RESPONSE, model="ApiKey", op="create")
+    async def _inject_key(ctx):
+        raw = ctx.get("raw_api_key")
+        if not raw:
+            return
+        result = dict(ctx.get("result", {}))
+        result["api_key"] = raw
+        ctx["result"] = result
+
 
 __all__ = ["register_inject_hook"]
 

--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/tables.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/tables.py
@@ -157,8 +157,8 @@ class ApiKey(ApiKeyBase):
     raw_key.onupdate = token_urlsafe(8)
     raw_key.info = {
         "autoapi": {
-            "hybrid": True,  # ← opt-in
-            "write_only": True,  # hide on READ/LIST
+            "hybrid": True,
+            "disable_on": ["create", "read", "list", "update", "replace"],
             "py_type": str,
             "default_factory": token_urlsafe(8),
             "examples": [token_urlsafe(8)],  # Swagger placeholder

--- a/pkgs/standards/auto_authn/auto_authn/v2/routers/auth_flows.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/routers/auth_flows.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, EmailStr, Field, constr
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..crypto import hash_pw
@@ -81,14 +82,17 @@ class IntrospectOut(BaseModel):
 # ============================================================================
 #  Endpoint implementations
 # ============================================================================
-@router.post("/register", response_model=TokenPair,
-             status_code=status.HTTP_201_CREATED,
-             responses={
-                 400: {"description": "invalid params"},
-                 404: {"description": "tenant not found"},
-                 409: {"description": "duplicate key"},
-                 500: {"description": "database error"},
-             })
+@router.post(
+    "/register",
+    response_model=TokenPair,
+    status_code=status.HTTP_201_CREATED,
+    responses={
+        400: {"description": "invalid params"},
+        404: {"description": "tenant not found"},
+        409: {"description": "duplicate key"},
+        500: {"description": "database error"},
+    },
+)
 async def register(body: RegisterIn, db: AsyncSession = Depends(get_async_db)):
     try:
         # 1. look up pre-existing tenant
@@ -100,24 +104,25 @@ async def register(body: RegisterIn, db: AsyncSession = Depends(get_async_db)):
             raise HTTPException(status.HTTP_404_NOT_FOUND, "tenant not found")
 
         # 2. create user
-        user = User(tenant_id=tenant.id,
-                    username=body.username,
-                    email=body.email,
-                    password_hash=hash_pw(body.password))
+        user = User(
+            tenant_id=tenant.id,
+            username=body.username,
+            email=body.email,
+            password_hash=hash_pw(body.password),
+        )
         db.add(user)
         await db.commit()
     except IntegrityError as exc:
         await db.rollback()
-        raise HTTPException(status.HTTP_409_CONFLICT,
-                            "duplicate key") from exc
+        raise HTTPException(status.HTTP_409_CONFLICT, "duplicate key") from exc
     except Exception as exc:
         await db.rollback()
-        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR,
-                            "database error") from exc
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR, "database error"
+        ) from exc
 
     access, refresh = _jwt.sign_pair(sub=str(user.id), tid=str(tenant.id))
     return TokenPair(access_token=access, refresh_token=refresh)
-
 
 
 @router.post("/login", response_model=TokenPair)
@@ -125,7 +130,7 @@ async def register(body: RegisterIn, db: AsyncSession = Depends(get_async_db)):
 async def login(body: CredsIn, db: AsyncSession = Depends(get_async_db)):
     try:
         user = await _pwd_backend.authenticate(db, body.identifier, body.password)
-    except AuthError as exc:
+    except AuthError:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "invalid credentials")
 
     access, refresh = _jwt.sign_pair(sub=str(user.id), tid=str(user.tenant_id))


### PR DESCRIPTION
## Summary
- generate and inject API keys on user API-key creation
- hide raw keys from all AutoAPI operations and prevent client-provided values
- fix missing import in auth flows router

## Testing
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68908985525c8326b068cb6ff64061c8