### PR TITLE
feat(auto-authn): generate and inject user api keys

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/tables.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/tables.py
@@ -32,6 +32,7 @@ from autoapi.v2.types import (
     hybrid_property,
     PgUUID,
     ForeignKey,
+    HookProvider,
 )
 from autoapi.v2.tables import (
     Tenant,
@@ -130,7 +131,7 @@ class Service(Base, GUIDPk, Timestamped, TenantBound, Principal, ActiveToggle):
     )
 
 
-class ApiKey(ApiKeyBase):
+class ApiKey(ApiKeyBase, HookProvider):
     user = relationship(
         "auto_authn.v2.orm.tables.User",
         back_populates="api_keys",

--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/tables.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/tables.py
@@ -165,6 +165,37 @@ class ApiKey(ApiKeyBase):
         }
     }
 
+    @classmethod
+    async def _pre_create_generate_key(cls, ctx):
+        params = ctx["env"].params
+        raw = token_urlsafe(8)
+        if hasattr(params, "model_copy"):
+            params = params.model_copy(update={"raw_key": raw})
+            ctx["env"].params = params
+        elif isinstance(params, dict):
+            params["raw_key"] = raw
+        ctx["raw_api_key"] = raw
+
+    @classmethod
+    async def _post_create_inject_key(cls, ctx):
+        raw = ctx.get("raw_api_key")
+        if not raw:
+            return
+        result = dict(ctx.get("result", {}))
+        result["api_key"] = raw
+        ctx["result"] = result
+
+    @classmethod
+    def __autoapi_register_hooks__(cls, api) -> None:
+        from autoapi.v2 import Phase
+
+        api.register_hook(Phase.PRE_TX_BEGIN, model="ApiKey", op="create")(
+            cls._pre_create_generate_key
+        )
+        api.register_hook(Phase.POST_RESPONSE, model="ApiKey", op="create")(
+            cls._post_create_inject_key
+        )
+
 
 class ServiceKey(Base, GUIDPk, Created, LastUsed, ValidityWindow):
     """API key bound to a service principal."""

--- a/pkgs/standards/auto_authn/auto_authn/v2/routers/auth_flows.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/routers/auth_flows.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, EmailStr, Field, constr
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..crypto import hash_pw
@@ -81,14 +82,17 @@ class IntrospectOut(BaseModel):
 # ============================================================================
 #  Endpoint implementations
 # ============================================================================
-@router.post("/register", response_model=TokenPair,
-             status_code=status.HTTP_201_CREATED,
-             responses={
-                 400: {"description": "invalid params"},
-                 404: {"description": "tenant not found"},
-                 409: {"description": "duplicate key"},
-                 500: {"description": "database error"},
-             })
+@router.post(
+    "/register",
+    response_model=TokenPair,
+    status_code=status.HTTP_201_CREATED,
+    responses={
+        400: {"description": "invalid params"},
+        404: {"description": "tenant not found"},
+        409: {"description": "duplicate key"},
+        500: {"description": "database error"},
+    },
+)
 async def register(body: RegisterIn, db: AsyncSession = Depends(get_async_db)):
     try:
         # 1. look up pre-existing tenant
@@ -100,24 +104,25 @@ async def register(body: RegisterIn, db: AsyncSession = Depends(get_async_db)):
             raise HTTPException(status.HTTP_404_NOT_FOUND, "tenant not found")
 
         # 2. create user
-        user = User(tenant_id=tenant.id,
-                    username=body.username,
-                    email=body.email,
-                    password_hash=hash_pw(body.password))
+        user = User(
+            tenant_id=tenant.id,
+            username=body.username,
+            email=body.email,
+            password_hash=hash_pw(body.password),
+        )
         db.add(user)
         await db.commit()
     except IntegrityError as exc:
         await db.rollback()
-        raise HTTPException(status.HTTP_409_CONFLICT,
-                            "duplicate key") from exc
+        raise HTTPException(status.HTTP_409_CONFLICT, "duplicate key") from exc
     except Exception as exc:
         await db.rollback()
-        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR,
-                            "database error") from exc
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR, "database error"
+        ) from exc
 
     access, refresh = _jwt.sign_pair(sub=str(user.id), tid=str(tenant.id))
     return TokenPair(access_token=access, refresh_token=refresh)
-
 
 
 @router.post("/login", response_model=TokenPair)
@@ -125,7 +130,7 @@ async def register(body: RegisterIn, db: AsyncSession = Depends(get_async_db)):
 async def login(body: CredsIn, db: AsyncSession = Depends(get_async_db)):
     try:
         user = await _pwd_backend.authenticate(db, body.identifier, body.password)
-    except AuthError as exc:
+    except AuthError:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "invalid credentials")
 
     access, refresh = _jwt.sign_pair(sub=str(user.id), tid=str(user.tenant_id))


### PR DESCRIPTION
## Summary
- auto-generate user API keys server-side and include secret in create response
- fix missing `select` import in auth flows router

## Testing
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff format .`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check auto_authn/v2/orm/tables.py auto_authn/v2/routers/auth_flows.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_68908985525c8326b068cb6ff64061c8