### PR TITLE
refactor(autoapi): remove ABC from table config providers

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/types/allow_anon_provider.py
+++ b/pkgs/standards/autoapi/autoapi/v2/types/allow_anon_provider.py
@@ -1,11 +1,11 @@
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 
 from .table_config_provider import TableConfigProvider
 
 _ALLOW_ANON_PROVIDERS: set[type] = set()
 
 
-class AllowAnonProvider(TableConfigProvider, ABC):
+class AllowAnonProvider(TableConfigProvider):
     """Models that expose operations without authentication."""
 
     @classmethod

--- a/pkgs/standards/autoapi/autoapi/v2/types/hook_provider.py
+++ b/pkgs/standards/autoapi/autoapi/v2/types/hook_provider.py
@@ -1,5 +1,5 @@
 # autoapi/v2/types/hook_provider.py  – tiny helper module
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from typing import TYPE_CHECKING
 
 from .table_config_provider import TableConfigProvider
@@ -10,12 +10,11 @@ if TYPE_CHECKING:  # forward ref avoids circular import
 _HOOK_PROVIDERS: set[type] = set()
 
 
-class HookProvider(TableConfigProvider, ABC):
+class HookProvider(TableConfigProvider):
     """
     Marker-base for mixins / models that attach hooks to an AutoAPI router.
 
     Subclasses **must** implement `__autoapi_register_hooks__`.
-    Failure is caught at *class definition time* (thanks to ABC).
     """
 
     @classmethod

--- a/pkgs/standards/autoapi/autoapi/v2/types/nested_path_provider.py
+++ b/pkgs/standards/autoapi/autoapi/v2/types/nested_path_provider.py
@@ -1,11 +1,11 @@
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 
 from .table_config_provider import TableConfigProvider
 
 _NESTED_PATH_PROVIDERS: set[type] = set()
 
 
-class NestedPathProvider(TableConfigProvider, ABC):
+class NestedPathProvider(TableConfigProvider):
     """Models that supply nested route prefixes."""
 
     @classmethod

--- a/pkgs/standards/autoapi/autoapi/v2/types/table_config_provider.py
+++ b/pkgs/standards/autoapi/autoapi/v2/types/table_config_provider.py
@@ -1,9 +1,7 @@
-from abc import ABC
-
 _TABLE_CONFIG_PROVIDERS: set[type] = set()
 
 
-class TableConfigProvider(ABC):
+class TableConfigProvider:
     """Marker base for table-level configuration providers."""
 
     def __init_subclass__(cls, **kw):


### PR DESCRIPTION
## Summary
- avoid metaclass conflicts by removing ABC inheritance from table config providers
- keep provider subclasses concrete while still exposing abstract methods

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff check autoapi/v2/types/allow_anon_provider.py autoapi/v2/types/hook_provider.py autoapi/v2/types/nested_path_provider.py autoapi/v2/types/table_config_provider.py`
- `uv run --package autoapi --directory standards/autoapi pytest`


------
https://chatgpt.com/codex/tasks/task_e_689092e6f08083269f5080d4c102578a