### PR TITLE
refactor: move repository mixins to separate module

### DIFF
--- a/pkgs/standards/peagen/peagen/orm/__init__.py
+++ b/pkgs/standards/peagen/peagen/orm/__init__.py
@@ -9,16 +9,10 @@ from typing import FrozenSet
 
 from autoapi.v2.types import (
     Column,
-    ForeignKey,
     Integer,
     String,
     UniqueConstraint,
-    PgUUID,
     relationship,
-    foreign,
-    remote,
-    declarative_mixin,
-    declared_attr,
 )
 
 # ---------------------------------------------------------------------
@@ -46,6 +40,7 @@ from .keys import PublicKey, GPGKey, DeployKey
 from .secrets import UserSecret, OrgSecret, RepoSecret
 from .tasks import Action, SpecKind, Task
 from .works import Work
+from .mixins import RepositoryMixin, RepositoryRefMixin
 
 
 # ---------------------------------------------------------------------
@@ -120,33 +115,6 @@ class Repository(Base, GUIDPk, Timestamped, TenantBound, Ownable, StatusMixin):
         back_populates="repository",
         cascade="all, delete-orphan",
     )
-
-
-@declarative_mixin
-class RepositoryMixin:
-    repository_id = Column(
-        PgUUID(as_uuid=True), ForeignKey("repositories.id"), nullable=False
-    )
-
-
-class RepositoryRefMixin:
-    repository_id = Column(
-        PgUUID(as_uuid=True),
-        ForeignKey("repositories.id", ondelete="CASCADE"),
-        nullable=True,  # ← changed
-    )
-    repo = Column(String, nullable=False)  # e.g. "github.com/acme/app"
-    ref = Column(String, nullable=False)  # e.g. "main" / SHA / tag
-
-    @declared_attr
-    def repository(cls):
-        from peagen.orm import Repository  # late import
-
-        return relationship(
-            "Repository",
-            back_populates="tasks",
-            primaryjoin=foreign(cls.repository_id) == remote(Repository.id),
-        )
 
 
 # ---------------------------------------------------------------------

--- a/pkgs/standards/peagen/peagen/orm/keys.py
+++ b/pkgs/standards/peagen/peagen/orm/keys.py
@@ -12,7 +12,7 @@ from autoapi.v2.types import (
 from autoapi.v2.types import relationship
 from autoapi.v2.tables import Base
 from autoapi.v2.mixins import GUIDPk, Timestamped, UserMixin
-from peagen.orm import RepositoryRefMixin
+from peagen.orm.mixins import RepositoryRefMixin
 
 
 class PublicKey(Base, GUIDPk, UserMixin, Timestamped):

--- a/pkgs/standards/peagen/peagen/orm/mixins.py
+++ b/pkgs/standards/peagen/peagen/orm/mixins.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from autoapi.v2.types import (
+    Column,
+    ForeignKey,
+    PgUUID,
+    String,
+    declarative_mixin,
+    declared_attr,
+    foreign,
+    relationship,
+    remote,
+)
+
+
+@declarative_mixin
+class RepositoryMixin:
+    """Mixin providing a required ``repository_id`` foreign key."""
+
+    repository_id = Column(
+        PgUUID(as_uuid=True),
+        ForeignKey("repositories.id"),
+        nullable=False,
+    )
+
+
+@declarative_mixin
+class RepositoryRefMixin:
+    """Mixin holding an optional reference to a repository and ref."""
+
+    repository_id = Column(
+        PgUUID(as_uuid=True),
+        ForeignKey("repositories.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    repo = Column(String, nullable=False)  # e.g. "github.com/acme/app"
+    ref = Column(String, nullable=False)  # e.g. "main" / SHA / tag
+
+    @declared_attr
+    def repository(cls):
+        from peagen.orm import Repository  # late import
+
+        return relationship(
+            "Repository",
+            back_populates="tasks",
+            primaryjoin=foreign(cls.repository_id) == remote(Repository.id),
+        )
+
+
+__all__ = ["RepositoryMixin", "RepositoryRefMixin"]

--- a/pkgs/standards/peagen/peagen/orm/secrets.py
+++ b/pkgs/standards/peagen/peagen/orm/secrets.py
@@ -10,7 +10,8 @@ from autoapi.v2.types import (
 )
 from autoapi.v2.tables import Base
 from autoapi.v2.mixins import GUIDPk, OrgMixin, Timestamped, UserMixin
-from peagen.orm import RepositoryRefMixin
+from peagen.orm.mixins import RepositoryMixin
+
 
 class _SecretCoreMixin:
     name = Column(String(128), nullable=False)

--- a/pkgs/standards/peagen/peagen/orm/tasks.py
+++ b/pkgs/standards/peagen/peagen/orm/tasks.py
@@ -22,7 +22,8 @@ from autoapi.v2.mixins import (
     Ownable,
     StatusMixin,
 )
-from peagen.orm import RepositoryRefMixin
+from peagen.orm.mixins import RepositoryRefMixin
+
 
 class Action(str, Enum):
     SORT = auto()


### PR DESCRIPTION
## Summary
- extract `RepositoryMixin` and `RepositoryRefMixin` into a standalone `mixins` module
- update ORM modules to import repository mixins from the new module

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format peagen/orm/__init__.py peagen/orm/keys.py peagen/orm/secrets.py peagen/orm/tasks.py peagen/orm/mixins.py`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/orm/__init__.py peagen/orm/keys.py peagen/orm/secrets.py peagen/orm/tasks.py peagen/orm/mixins.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_6890a865bce88326ac53093c65b73739