### PR TITLE
feat(autoapi): bootstrap only subclass and register table config

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/mixins/bootstrappable.py
+++ b/pkgs/standards/autoapi/autoapi/v2/mixins/bootstrappable.py
@@ -1,49 +1,40 @@
 # autoapi/v2/mixins/bootstrappable.py
-# from __future__ import annotations
-
 from typing import Any, ClassVar, List
-from ..types import event
-from autoapi.v2.tables import Base
 
-# --------------------------------------------------------------------- #
-# internal registry of every subclass that wants seeding
-_BOOTSTRAPPABLES: list[type["Bootstrappable"]] = []
-# --------------------------------------------------------------------- #
+from ..types import TableConfigProvider, event
 
 
-class Bootstrappable:
-    """Inherit to auto-insert `DEFAULT_ROWS` right after schema creation."""
+class Bootstrappable(TableConfigProvider):
+    """Inherit to auto-insert ``DEFAULT_ROWS`` right after table creation."""
 
     DEFAULT_ROWS: ClassVar[List[dict[str, Any]]] = []
 
-    # keep track of concrete subclasses that define defaults
     def __init_subclass__(cls, **kw):
         super().__init_subclass__(**kw)
+
         if cls.DEFAULT_ROWS:
-            _BOOTSTRAPPABLES.append(cls)
+
+            @event.listens_for(cls.__table__, "after_create", once=True)
+            def _seed(target, connection, **kw):
+                dialect = connection.dialect.name
+
+                if dialect in ("postgres", "postgresql"):
+                    from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+                    stmt = (
+                        pg_insert(cls).values(cls.DEFAULT_ROWS).on_conflict_do_nothing()
+                    )
+                else:  # SQLite ≥ 3.35 or anything that accepts OR IGNORE
+                    import sqlalchemy as sa
+
+                    stmt = (
+                        sa.insert(cls).values(cls.DEFAULT_ROWS).prefix_with("OR IGNORE")
+                    )
+
+                connection.execute(stmt)
 
 
-# --------------------------------------------------------------------- #
-# One single metadata-level hook – fires once per `create_all()` call.
-# --------------------------------------------------------------------- #
-@event.listens_for(Base.metadata, "after_create", once=True)
-def _seed_all(target, connection, **kw):
-    for cls in _BOOTSTRAPPABLES:
-        # build dialect-specific insert --------------------------------
-        dialect = connection.dialect.name
-        if dialect in ("postgres", "postgresql"):
-            from sqlalchemy.dialects.postgresql import insert as pg_insert
-
-            stmt = pg_insert(cls).values(cls.DEFAULT_ROWS).on_conflict_do_nothing()
-        else:  # SQLite ≥ 3.35 or anything that accepts OR IGNORE
-            import sqlalchemy as sa
-
-            stmt = sa.insert(cls).values(cls.DEFAULT_ROWS).prefix_with("OR IGNORE")
-        # --------------------------------------------------------------
-        connection.execute(stmt)
-
-
-__all__ = ["Bootstrappable", "_BOOTSTRAPPABLES"]
+__all__ = ["Bootstrappable"]
 
 
 for _name in list(globals()):


### PR DESCRIPTION
## Summary
- make `Bootstrappable` a `TableConfigProvider`
- seed default rows per subclass rather than globally

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_6890bdae84a883269a230e8cb088a069