### PR TITLE
fix: ensure tenant bootstraps before pool

### DIFF
--- a/pkgs/standards/peagen/peagen/orm/__init__.py
+++ b/pkgs/standards/peagen/peagen/orm/__init__.py
@@ -1,54 +1,25 @@
 """
-peagen/orm/__init__.py  –  all Peagen domain tables in one place
-(uses only sqlalchemy.Column – no mapped_column / JSONB).
+peagen/orm/__init__.py – aggregate of all Peagen domain tables.
 """
 
 from __future__ import annotations
 
 from typing import FrozenSet
 
-from autoapi.v2.types import (
-    Column,
-    Integer,
-    String,
-    UniqueConstraint,
-    relationship,
-)
+from autoapi.v2.tables import Org, Role, RoleGrant, RolePerm, Status, Base
 
-# ---------------------------------------------------------------------
-# bring in the baseline tables that AutoAPI already owns
-# ---------------------------------------------------------------------
-from autoapi.v2.tables import Tenant as TenantBase, User as UserBase, Org
-from autoapi.v2.tables import Role, RoleGrant, RolePerm
-from autoapi.v2.tables import Status
-from autoapi.v2.tables import Base
-from autoapi.v2.mixins import (
-    GUIDPk,
-    # TenantMixin,
-    UserMixin,
-    Ownable,
-    Bootstrappable,
-    Timestamped,
-    TenantBound,
-    StatusMixin,
-    BlobRef,
-)
-
-from .pools import Pool
-from .workers import Worker
+from .tenant import Tenant
+from .user import User
+from .repository import Repository
+from .user_repository import UserRepository
+from .raw_blob import RawBlob
 from .keys import PublicKey, GPGKey, DeployKey
 from .secrets import UserSecret, OrgSecret, RepoSecret
+from .pools import Pool
+from .workers import Worker
 from .tasks import Action, SpecKind, Task
 from .works import Work
 from .mixins import RepositoryMixin, RepositoryRefMixin
-from peagen.defaults import (
-    DEFAULT_TENANT_ID,
-    DEFAULT_TENANT_EMAIL,
-    DEFAULT_TENANT_NAME,
-    DEFAULT_TENANT_SLUG,
-)
-
-# ---------------------------------------------------------------------
 
 
 def _is_terminal(cls, state: str | Status) -> bool:
@@ -59,101 +30,6 @@ def _is_terminal(cls, state: str | Status) -> bool:
 
 
 Status.is_terminal = classmethod(_is_terminal)
-
-
-# ---------------------------------------------------------------------
-# Repository hierarchy
-# ---------------------------------------------------------------------
-class Tenant(TenantBase, Bootstrappable):
-    DEFAULT_ROWS = [
-        {
-            "id": DEFAULT_TENANT_ID,
-            "email": DEFAULT_TENANT_EMAIL,
-            "name": DEFAULT_TENANT_NAME,
-            "slug": DEFAULT_TENANT_SLUG,
-        }
-    ]
-
-
-class User(UserBase, Bootstrappable):
-    pass
-    # DEFAULT_ROWS = [
-    #     {
-    #         "id": DEFAULT_SUPER_USER_ID,
-    #         "email": DEFAULT_SUPER_USER_EMAIL,
-    #         "tenant_id": DEFAULT_TENANT_ID,
-    #     },
-    #     {
-    #         "id": DEFAULT_SUPER_USER_ID_2,
-    #         "email": DEFAULT_SUPER_USER_EMAIL_2,
-    #         "tenant_id": DEFAULT_TENANT_ID,
-    #     }
-    # ]
-
-
-class Repository(Base, GUIDPk, Timestamped, TenantBound, Ownable, StatusMixin):
-    """
-    A code or data repository that lives under a tenant.
-    – parent of Secrets & DeployKeys
-    """
-
-    __tablename__ = "repositories"
-    __table_args__ = (
-        UniqueConstraint("url"),
-        UniqueConstraint("tenant_id", "name"),
-    )
-    name = Column(String, nullable=False)
-    url = Column(String, unique=True, nullable=False)
-    default_branch = Column(String, default="main")
-    commit_sha = Column(String(length=40), nullable=True)
-    remote_name = Column(String, nullable=False, default="origin")
-
-    secrets = relationship(
-        "RepoSecret", back_populates="repository", cascade="all, delete-orphan"
-    )
-    deploy_keys = relationship(
-        "DeployKey", back_populates="repository", cascade="all, delete-orphan"
-    )
-    tasks = relationship(
-        "Task",
-        back_populates="repository",
-        cascade="all, delete-orphan",
-    )
-
-
-# ---------------------------------------------------------------------
-# association edges
-# ---------------------------------------------------------------------
-
-
-# class UserTenant(Base, GUIDPk, TenantMixin, UserMixin):
-#     """
-#     Many-to-many edge between users and tenants.
-#     A user may be invited to / removed from any number of tenants.
-#     """
-
-#     __tablename__ = "user_tenants"
-#     joined_at = Column(tzutcnow, default=dt.timezone.utcnow, nullable=False)
-
-
-class UserRepository(Base, GUIDPk, RepositoryMixin, UserMixin):
-    """
-    Edge capturing *any* per-repository permission or ownership
-    the user may have.  `perm` can be "owner", "push", "pull", etc.
-    """
-
-    __tablename__ = "user_repositories"
-
-
-# ---------------------------------------------------------------------
-# 5) Raw blobs (stand-alone)
-# ---------------------------------------------------------------------
-
-
-class RawBlob(Base, GUIDPk, Timestamped, BlobRef):
-    __tablename__ = "raw_blobs"
-    mime_type = Column(String, nullable=False)
-    size = Column(Integer, nullable=False)
 
 
 __all__ = [

--- a/pkgs/standards/peagen/peagen/orm/raw_blob.py
+++ b/pkgs/standards/peagen/peagen/orm/raw_blob.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from autoapi.v2.mixins import BlobRef, GUIDPk, Timestamped
+from autoapi.v2.tables import Base
+from autoapi.v2.types import Column, Integer, String
+
+
+class RawBlob(Base, GUIDPk, Timestamped, BlobRef):
+    __tablename__ = "raw_blobs"
+    mime_type = Column(String, nullable=False)
+    size = Column(Integer, nullable=False)
+
+
+__all__ = ["RawBlob"]

--- a/pkgs/standards/peagen/peagen/orm/repository.py
+++ b/pkgs/standards/peagen/peagen/orm/repository.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from autoapi.v2.mixins import GUIDPk, Ownable, StatusMixin, TenantBound, Timestamped
+from autoapi.v2.tables import Base
+from autoapi.v2.types import Column, String, UniqueConstraint, relationship
+
+
+class Repository(Base, GUIDPk, Timestamped, TenantBound, Ownable, StatusMixin):
+    """A code or data repository that lives under a tenant."""
+
+    __tablename__ = "repositories"
+    __table_args__ = (
+        UniqueConstraint("url"),
+        UniqueConstraint("tenant_id", "name"),
+    )
+    name = Column(String, nullable=False)
+    url = Column(String, unique=True, nullable=False)
+    default_branch = Column(String, default="main")
+    commit_sha = Column(String(length=40), nullable=True)
+    remote_name = Column(String, nullable=False, default="origin")
+
+    secrets = relationship(
+        "RepoSecret", back_populates="repository", cascade="all, delete-orphan"
+    )
+    deploy_keys = relationship(
+        "DeployKey", back_populates="repository", cascade="all, delete-orphan"
+    )
+    tasks = relationship(
+        "Task",
+        back_populates="repository",
+        cascade="all, delete-orphan",
+    )
+
+
+__all__ = ["Repository"]

--- a/pkgs/standards/peagen/peagen/orm/tenant.py
+++ b/pkgs/standards/peagen/peagen/orm/tenant.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from autoapi.v2.mixins import Bootstrappable
+from autoapi.v2.tables import Tenant as TenantBase
+from peagen.defaults import (
+    DEFAULT_TENANT_EMAIL,
+    DEFAULT_TENANT_ID,
+    DEFAULT_TENANT_NAME,
+    DEFAULT_TENANT_SLUG,
+)
+
+
+class Tenant(TenantBase, Bootstrappable):
+    DEFAULT_ROWS = [
+        {
+            "id": DEFAULT_TENANT_ID,
+            "email": DEFAULT_TENANT_EMAIL,
+            "name": DEFAULT_TENANT_NAME,
+            "slug": DEFAULT_TENANT_SLUG,
+        }
+    ]
+
+
+__all__ = ["Tenant"]

--- a/pkgs/standards/peagen/peagen/orm/user.py
+++ b/pkgs/standards/peagen/peagen/orm/user.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from autoapi.v2.mixins import Bootstrappable
+from autoapi.v2.tables import User as UserBase
+
+
+class User(UserBase, Bootstrappable):
+    pass
+
+
+__all__ = ["User"]

--- a/pkgs/standards/peagen/peagen/orm/user_repository.py
+++ b/pkgs/standards/peagen/peagen/orm/user_repository.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from autoapi.v2.mixins import GUIDPk, UserMixin
+from autoapi.v2.tables import Base
+
+from .mixins import RepositoryMixin
+
+
+class UserRepository(Base, GUIDPk, RepositoryMixin, UserMixin):
+    """Edge capturing per-repository permissions for a user."""
+
+    __tablename__ = "user_repositories"
+
+
+__all__ = ["UserRepository"]


### PR DESCRIPTION
## Summary
- move tenant, user, repository, user_repository, raw_blob tables into dedicated modules
- import Tenant before pools to guarantee default tenant is created first

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format peagen/orm/tenant.py peagen/orm/user.py peagen/orm/repository.py peagen/orm/user_repository.py peagen/orm/raw_blob.py peagen/orm/__init__.py`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/orm/tenant.py peagen/orm/user.py peagen/orm/repository.py peagen/orm/user_repository.py peagen/orm/raw_blob.py peagen/orm/__init__.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_6890be8a10188326a4aa7c85a6b622ae