### PR TITLE
Fix default tenant bootstrap and split ORM modules

### DIFF
--- a/pkgs/standards/peagen/peagen/orm/__init__.py
+++ b/pkgs/standards/peagen/peagen/orm/__init__.py
@@ -1,54 +1,33 @@
 """
-peagen/orm/__init__.py  –  all Peagen domain tables in one place
-(uses only sqlalchemy.Column – no mapped_column / JSONB).
+peagen.orm – aggregate and expose ORM table classes.
 """
 
 from __future__ import annotations
 
 from typing import FrozenSet
 
-from autoapi.v2.types import (
-    Column,
-    Integer,
-    String,
-    UniqueConstraint,
-    relationship,
-)
+from autoapi.v2.tables import Org, Role, RoleGrant, RolePerm, Status, Base
 
-# ---------------------------------------------------------------------
-# bring in the baseline tables that AutoAPI already owns
-# ---------------------------------------------------------------------
-from autoapi.v2.tables import Tenant as TenantBase, User as UserBase, Org
-from autoapi.v2.tables import Role, RoleGrant, RolePerm
-from autoapi.v2.tables import Status
-from autoapi.v2.tables import Base
-from autoapi.v2.mixins import (
-    GUIDPk,
-    # TenantMixin,
-    UserMixin,
-    Ownable,
-    Bootstrappable,
-    Timestamped,
-    TenantBound,
-    StatusMixin,
-    BlobRef,
-)
-
-from .pools import Pool
-from .workers import Worker
+# Import table classes. Ensure Tenant is imported before Pool so bootstrapping
+# default rows inserts the default tenant prior to default pools.
+from .tenants import Tenant
+from .users import User
+from .repositories import Repository
+from .user_repositories import UserRepository
+from .raw_blobs import RawBlob
 from .keys import PublicKey, GPGKey, DeployKey
 from .secrets import UserSecret, OrgSecret, RepoSecret
 from .tasks import Action, SpecKind, Task
 from .works import Work
+from .doe_spec import DoeSpec
+from .evolve_spec import EvolveSpec
+from .project_payload import ProjectPayload
+from .peagen_toml_spec import PeagenTomlSpec
+from .eval_result import EvalResult
+from .analysis_result import AnalysisResult
+from .pools import Pool
+from .workers import Worker
 from .mixins import RepositoryMixin, RepositoryRefMixin
-from peagen.defaults import (
-    DEFAULT_TENANT_ID,
-    DEFAULT_TENANT_EMAIL,
-    DEFAULT_TENANT_NAME,
-    DEFAULT_TENANT_SLUG,
-)
-
-# ---------------------------------------------------------------------
 
 
 def _is_terminal(cls, state: str | Status) -> bool:
@@ -59,102 +38,6 @@ def _is_terminal(cls, state: str | Status) -> bool:
 
 
 Status.is_terminal = classmethod(_is_terminal)
-
-
-# ---------------------------------------------------------------------
-# Repository hierarchy
-# ---------------------------------------------------------------------
-class Tenant(TenantBase, Bootstrappable):
-    DEFAULT_ROWS = [
-        {
-            "id": DEFAULT_TENANT_ID,
-            "email": DEFAULT_TENANT_EMAIL,
-            "name": DEFAULT_TENANT_NAME,
-            "slug": DEFAULT_TENANT_SLUG,
-        }
-    ]
-
-
-class User(UserBase, Bootstrappable):
-    pass
-    # DEFAULT_ROWS = [
-    #     {
-    #         "id": DEFAULT_SUPER_USER_ID,
-    #         "email": DEFAULT_SUPER_USER_EMAIL,
-    #         "tenant_id": DEFAULT_TENANT_ID,
-    #     },
-    #     {
-    #         "id": DEFAULT_SUPER_USER_ID_2,
-    #         "email": DEFAULT_SUPER_USER_EMAIL_2,
-    #         "tenant_id": DEFAULT_TENANT_ID,
-    #     }
-    # ]
-
-
-class Repository(Base, GUIDPk, Timestamped, TenantBound, Ownable, StatusMixin):
-    """
-    A code or data repository that lives under a tenant.
-    – parent of Secrets & DeployKeys
-    """
-
-    __tablename__ = "repositories"
-    __table_args__ = (
-        UniqueConstraint("url"),
-        UniqueConstraint("tenant_id", "name"),
-    )
-    name = Column(String, nullable=False)
-    url = Column(String, unique=True, nullable=False)
-    default_branch = Column(String, default="main")
-    commit_sha = Column(String(length=40), nullable=True)
-    remote_name = Column(String, nullable=False, default="origin")
-
-    secrets = relationship(
-        "RepoSecret", back_populates="repository", cascade="all, delete-orphan"
-    )
-    deploy_keys = relationship(
-        "DeployKey", back_populates="repository", cascade="all, delete-orphan"
-    )
-    tasks = relationship(
-        "Task",
-        back_populates="repository",
-        cascade="all, delete-orphan",
-    )
-
-
-# ---------------------------------------------------------------------
-# association edges
-# ---------------------------------------------------------------------
-
-
-# class UserTenant(Base, GUIDPk, TenantMixin, UserMixin):
-#     """
-#     Many-to-many edge between users and tenants.
-#     A user may be invited to / removed from any number of tenants.
-#     """
-
-#     __tablename__ = "user_tenants"
-#     joined_at = Column(tzutcnow, default=dt.timezone.utcnow, nullable=False)
-
-
-class UserRepository(Base, GUIDPk, RepositoryMixin, UserMixin):
-    """
-    Edge capturing *any* per-repository permission or ownership
-    the user may have.  `perm` can be "owner", "push", "pull", etc.
-    """
-
-    __tablename__ = "user_repositories"
-
-
-# ---------------------------------------------------------------------
-# 5) Raw blobs (stand-alone)
-# ---------------------------------------------------------------------
-
-
-class RawBlob(Base, GUIDPk, Timestamped, BlobRef):
-    __tablename__ = "raw_blobs"
-    mime_type = Column(String, nullable=False)
-    size = Column(Integer, nullable=False)
-
 
 __all__ = [
     "Tenant",
@@ -182,4 +65,10 @@ __all__ = [
     "Task",
     "Work",
     "RawBlob",
+    "DoeSpec",
+    "EvolveSpec",
+    "ProjectPayload",
+    "PeagenTomlSpec",
+    "EvalResult",
+    "AnalysisResult",
 ]

--- a/pkgs/standards/peagen/peagen/orm/analysis_result.py
+++ b/pkgs/standards/peagen/peagen/orm/analysis_result.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from autoapi.v2.types import Column, Text, JSON, UUID, ForeignKey, relationship
+from autoapi.v2.tables import Base
+from autoapi.v2.mixins import GUIDPk, Timestamped, Ownable
+
+from .users import User
+
+
+class AnalysisResult(Base, GUIDPk, Timestamped, Ownable):
+    __tablename__ = "analysis_results"
+    eval_result_id = Column(
+        UUID(as_uuid=True), ForeignKey("eval_results.id", ondelete="CASCADE")
+    )
+    summary = Column(Text)
+    data = Column(JSON, default=dict, nullable=False)
+    owner = relationship(User, lazy="selectin")
+    eval_result = relationship("EvalResult", back_populates="analyses", lazy="selectin")
+
+
+__all__ = ["AnalysisResult"]

--- a/pkgs/standards/peagen/peagen/orm/doe_spec.py
+++ b/pkgs/standards/peagen/peagen/orm/doe_spec.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from autoapi.v2.types import (
+    Column,
+    String,
+    Text,
+    JSON,
+    UniqueConstraint,
+    ForeignKey,
+    UUID,
+    relationship,
+)
+from autoapi.v2.tables import Base
+from autoapi.v2.mixins import GUIDPk, Timestamped, TenantBound, Ownable
+
+from .tenants import Tenant
+from .users import User
+
+
+class DoeSpec(Base, GUIDPk, Timestamped, TenantBound, Ownable):
+    __tablename__ = "doe_specs"
+
+    tenant_id = Column(
+        UUID(as_uuid=True), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
+    )
+    name = Column(String, nullable=False)
+    schema_version = Column(String, nullable=False, default="1.1.0")
+    description = Column(Text, nullable=True)
+    spec = Column(JSON, nullable=False)
+
+    __table_args__ = (UniqueConstraint("tenant_id", "name"),)
+
+    tenant = relationship(Tenant, lazy="selectin")
+    owner = relationship(User, lazy="selectin")
+    project_payloads = relationship(
+        "ProjectPayload",
+        back_populates="doe_spec",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+    )
+
+
+__all__ = ["DoeSpec"]

--- a/pkgs/standards/peagen/peagen/orm/domain_models.py
+++ b/pkgs/standards/peagen/peagen/orm/domain_models.py
@@ -1,150 +1,17 @@
-# domain_models.py
-"""
-All Peagen domain tables in one place,
-now with every table Ownable (i.e. has owner_id FK to users.id)
-and properly named unique constraints.
-"""
+"""Compatibility module re-exporting domain models."""
 
-from __future__ import annotations
+from .doe_spec import DoeSpec
+from .evolve_spec import EvolveSpec
+from .project_payload import ProjectPayload
+from .peagen_toml_spec import PeagenTomlSpec
+from .eval_result import EvalResult
+from .analysis_result import AnalysisResult
 
-from autoapi.v2.types import (
-    Column,
-    String,
-    Text,
-    JSON,
-    UniqueConstraint,
-    ForeignKey,
-    UUID,
-    relationship
-)
-
-from autoapi.v2.tables import Base, Tenant, User
-from autoapi.v2.mixins import (
-    GUIDPk,
-    Timestamped,
-    TenantBound,
-    Ownable,
-)
-
-# ────────────────────────────────────────────────────────────────────────
-class DoeSpec(Base, GUIDPk, Timestamped, TenantBound, Ownable):
-    __tablename__ = "doe_specs"
-
-    tenant_id = Column(
-        UUID(as_uuid=True), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
-    )
-    name = Column(String, nullable=False)
-    schema_version = Column(String, nullable=False, default="1.1.0")
-    description = Column(Text, nullable=True)
-    spec = Column(JSON, nullable=False)
-
-    __table_args__ = (
-        UniqueConstraint("tenant_id", "name"),
-    )
-
-    tenant = relationship(Tenant, lazy="selectin")
-    owner = relationship(User, lazy="selectin")
-    project_payloads = relationship(
-        "ProjectPayload",
-        back_populates="doe_spec",
-        cascade="all, delete-orphan",
-        lazy="selectin",
-    )
-
-
-class EvolveSpec(Base, GUIDPk, Timestamped, TenantBound, Ownable):
-    __tablename__ = "evolve_specs"
-
-    tenant_id = Column(
-        UUID(as_uuid=True), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
-    )
-    name = Column(String, nullable=False)
-    schema_version = Column(String, nullable=False, default="1.0.0")
-    description = Column(Text, nullable=True)
-    spec = Column(JSON, nullable=False)
-
-    __table_args__ = (
-        UniqueConstraint("tenant_id", "name"),
-    )
-
-    tenant = relationship(Tenant, lazy="selectin")
-    owner = relationship(User, lazy="selectin")
-
-
-class ProjectPayload(Base, GUIDPk, Timestamped, TenantBound, Ownable):
-    __tablename__ = "project_payloads"
-
-    tenant_id = Column(
-        UUID(as_uuid=True), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
-    )
-    doe_spec_id = Column(
-        UUID(as_uuid=True),
-        ForeignKey("doe_specs.id", ondelete="SET NULL"),
-        nullable=True,
-    )
-    name = Column(String, nullable=False)
-    schema_version = Column(String, nullable=False, default="1.0.0")
-    description = Column(Text, nullable=True)
-    payload = Column(JSON, nullable=False)
-
-    __table_args__ = (
-        UniqueConstraint("tenant_id", "name"),
-    )
-
-    tenant = relationship(Tenant, lazy="selectin")
-    owner = relationship(User, lazy="selectin")
-    doe_spec = relationship(
-        "DoeSpec", back_populates="project_payloads", lazy="selectin"
-    )
-
-
-class PeagenTomlSpec(Base, GUIDPk, Timestamped, TenantBound, Ownable):
-    __tablename__ = "peagen_toml_specs"
-
-    tenant_id = Column(
-        UUID(as_uuid=True), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
-    )
-    repository_id = Column(
-        UUID(as_uuid=True),
-        ForeignKey("repositories.id", ondelete="SET NULL"),
-        nullable=True,
-    )
-    name = Column(String, nullable=False)
-    schema_version = Column(String, nullable=False, default="1.0.0")
-    raw_toml = Column(Text, nullable=False)
-    parsed = Column(JSON, nullable=False, default=dict)
-
-    __table_args__ = (
-        UniqueConstraint("tenant_id", "name", name="uq_peagen_toml_specs_tenant_name"),
-    )
-
-    tenant = relationship(Tenant, lazy="selectin")
-    owner = relationship(User, lazy="selectin")
-
-
-class EvalResult(Base, GUIDPk, Timestamped, Ownable):
-    __tablename__ = "eval_results"
-    work_id = Column(UUID(as_uuid=True), ForeignKey("works.id", ondelete="CASCADE"))
-    label   = Column(String)
-    metrics = Column(JSON, nullable=False)
-    owner   = relationship(User, lazy="selectin")
-    work    = relationship("Work", back_populates="eval_results", lazy="selectin")
-    analyses = relationship(
-        "AnalysisResult",
-        back_populates="eval_result",
-        cascade="all, delete-orphan",
-        lazy="selectin",
-    )
-
-
-
-class AnalysisResult(Base, GUIDPk, Timestamped, Ownable):
-    __tablename__ = "analysis_results"
-    eval_result_id = Column(
-        UUID(as_uuid=True), ForeignKey("eval_results.id", ondelete="CASCADE")
-    )
-    summary = Column(Text)
-    data    = Column(JSON, default=dict, nullable=False)
-    owner   = relationship(User, lazy="selectin")
-    eval_result = relationship("EvalResult", back_populates="analyses", lazy="selectin")
-
+__all__ = [
+    "DoeSpec",
+    "EvolveSpec",
+    "ProjectPayload",
+    "PeagenTomlSpec",
+    "EvalResult",
+    "AnalysisResult",
+]

--- a/pkgs/standards/peagen/peagen/orm/eval_result.py
+++ b/pkgs/standards/peagen/peagen/orm/eval_result.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from autoapi.v2.types import Column, String, JSON, UUID, ForeignKey, relationship
+from autoapi.v2.tables import Base
+from autoapi.v2.mixins import GUIDPk, Timestamped, Ownable
+
+from .users import User
+
+
+class EvalResult(Base, GUIDPk, Timestamped, Ownable):
+    __tablename__ = "eval_results"
+    work_id = Column(UUID(as_uuid=True), ForeignKey("works.id", ondelete="CASCADE"))
+    label = Column(String)
+    metrics = Column(JSON, nullable=False)
+    owner = relationship(User, lazy="selectin")
+    work = relationship("Work", back_populates="eval_results", lazy="selectin")
+    analyses = relationship(
+        "AnalysisResult",
+        back_populates="eval_result",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+    )
+
+
+__all__ = ["EvalResult"]

--- a/pkgs/standards/peagen/peagen/orm/evolve_spec.py
+++ b/pkgs/standards/peagen/peagen/orm/evolve_spec.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from autoapi.v2.types import (
+    Column,
+    String,
+    Text,
+    JSON,
+    UniqueConstraint,
+    ForeignKey,
+    UUID,
+    relationship,
+)
+from autoapi.v2.tables import Base
+from autoapi.v2.mixins import GUIDPk, Timestamped, TenantBound, Ownable
+
+from .tenants import Tenant
+from .users import User
+
+
+class EvolveSpec(Base, GUIDPk, Timestamped, TenantBound, Ownable):
+    __tablename__ = "evolve_specs"
+
+    tenant_id = Column(
+        UUID(as_uuid=True), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
+    )
+    name = Column(String, nullable=False)
+    schema_version = Column(String, nullable=False, default="1.0.0")
+    description = Column(Text, nullable=True)
+    spec = Column(JSON, nullable=False)
+
+    __table_args__ = (UniqueConstraint("tenant_id", "name"),)
+
+    tenant = relationship(Tenant, lazy="selectin")
+    owner = relationship(User, lazy="selectin")
+
+
+__all__ = ["EvolveSpec"]

--- a/pkgs/standards/peagen/peagen/orm/peagen_toml_spec.py
+++ b/pkgs/standards/peagen/peagen/orm/peagen_toml_spec.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from autoapi.v2.types import (
+    Column,
+    String,
+    Text,
+    JSON,
+    UniqueConstraint,
+    ForeignKey,
+    UUID,
+    relationship,
+)
+from autoapi.v2.tables import Base
+from autoapi.v2.mixins import GUIDPk, Timestamped, TenantBound, Ownable
+
+from .tenants import Tenant
+from .users import User
+
+
+class PeagenTomlSpec(Base, GUIDPk, Timestamped, TenantBound, Ownable):
+    __tablename__ = "peagen_toml_specs"
+
+    tenant_id = Column(
+        UUID(as_uuid=True), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
+    )
+    repository_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("repositories.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    name = Column(String, nullable=False)
+    schema_version = Column(String, nullable=False, default="1.0.0")
+    raw_toml = Column(Text, nullable=False)
+    parsed = Column(JSON, nullable=False, default=dict)
+
+    __table_args__ = (
+        UniqueConstraint("tenant_id", "name", name="uq_peagen_toml_specs_tenant_name"),
+    )
+
+    tenant = relationship(Tenant, lazy="selectin")
+    owner = relationship(User, lazy="selectin")
+
+
+__all__ = ["PeagenTomlSpec"]

--- a/pkgs/standards/peagen/peagen/orm/project_payload.py
+++ b/pkgs/standards/peagen/peagen/orm/project_payload.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from autoapi.v2.types import (
+    Column,
+    String,
+    Text,
+    JSON,
+    UniqueConstraint,
+    ForeignKey,
+    UUID,
+    relationship,
+)
+from autoapi.v2.tables import Base
+from autoapi.v2.mixins import GUIDPk, Timestamped, TenantBound, Ownable
+
+from .tenants import Tenant
+from .users import User
+
+
+class ProjectPayload(Base, GUIDPk, Timestamped, TenantBound, Ownable):
+    __tablename__ = "project_payloads"
+
+    tenant_id = Column(
+        UUID(as_uuid=True), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
+    )
+    doe_spec_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("doe_specs.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    name = Column(String, nullable=False)
+    schema_version = Column(String, nullable=False, default="1.0.0")
+    description = Column(Text, nullable=True)
+    payload = Column(JSON, nullable=False)
+
+    __table_args__ = (UniqueConstraint("tenant_id", "name"),)
+
+    tenant = relationship(Tenant, lazy="selectin")
+    owner = relationship(User, lazy="selectin")
+    doe_spec = relationship(
+        "DoeSpec", back_populates="project_payloads", lazy="selectin"
+    )
+
+
+__all__ = ["ProjectPayload"]

--- a/pkgs/standards/peagen/peagen/orm/raw_blobs.py
+++ b/pkgs/standards/peagen/peagen/orm/raw_blobs.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from autoapi.v2.tables import Base
+from autoapi.v2.types import Column, String, Integer
+from autoapi.v2.mixins import GUIDPk, Timestamped, BlobRef
+
+
+class RawBlob(Base, GUIDPk, Timestamped, BlobRef):
+    __tablename__ = "raw_blobs"
+    mime_type = Column(String, nullable=False)
+    size = Column(Integer, nullable=False)
+
+
+__all__ = ["RawBlob"]

--- a/pkgs/standards/peagen/peagen/orm/repositories.py
+++ b/pkgs/standards/peagen/peagen/orm/repositories.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from autoapi.v2.tables import Base
+from autoapi.v2.types import Column, String, UniqueConstraint, relationship
+from autoapi.v2.mixins import GUIDPk, Timestamped, TenantBound, Ownable, StatusMixin
+
+
+class Repository(Base, GUIDPk, Timestamped, TenantBound, Ownable, StatusMixin):
+    """
+    A code or data repository that lives under a tenant.
+    – parent of Secrets & DeployKeys
+    """
+
+    __tablename__ = "repositories"
+    __table_args__ = (
+        UniqueConstraint("url"),
+        UniqueConstraint("tenant_id", "name"),
+    )
+    name = Column(String, nullable=False)
+    url = Column(String, unique=True, nullable=False)
+    default_branch = Column(String, default="main")
+    commit_sha = Column(String(length=40), nullable=True)
+    remote_name = Column(String, nullable=False, default="origin")
+
+    secrets = relationship(
+        "RepoSecret", back_populates="repository", cascade="all, delete-orphan"
+    )
+    deploy_keys = relationship(
+        "DeployKey", back_populates="repository", cascade="all, delete-orphan"
+    )
+    tasks = relationship(
+        "Task",
+        back_populates="repository",
+        cascade="all, delete-orphan",
+    )
+
+
+__all__ = ["Repository"]

--- a/pkgs/standards/peagen/peagen/orm/tenants.py
+++ b/pkgs/standards/peagen/peagen/orm/tenants.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from autoapi.v2.tables import Tenant as TenantBase
+from autoapi.v2.mixins import Bootstrappable
+from peagen.defaults import (
+    DEFAULT_TENANT_ID,
+    DEFAULT_TENANT_EMAIL,
+    DEFAULT_TENANT_NAME,
+    DEFAULT_TENANT_SLUG,
+)
+
+
+class Tenant(TenantBase, Bootstrappable):
+    DEFAULT_ROWS = [
+        {
+            "id": DEFAULT_TENANT_ID,
+            "email": DEFAULT_TENANT_EMAIL,
+            "name": DEFAULT_TENANT_NAME,
+            "slug": DEFAULT_TENANT_SLUG,
+        }
+    ]
+
+
+__all__ = ["Tenant"]

--- a/pkgs/standards/peagen/peagen/orm/user_repositories.py
+++ b/pkgs/standards/peagen/peagen/orm/user_repositories.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from autoapi.v2.tables import Base
+from autoapi.v2.mixins import GUIDPk, UserMixin
+
+from .mixins import RepositoryMixin
+
+
+class UserRepository(Base, GUIDPk, RepositoryMixin, UserMixin):
+    """Edge capturing any per-repository permission or ownership the user may have."""
+
+    __tablename__ = "user_repositories"
+
+
+__all__ = ["UserRepository"]

--- a/pkgs/standards/peagen/peagen/orm/users.py
+++ b/pkgs/standards/peagen/peagen/orm/users.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from autoapi.v2.tables import User as UserBase
+from autoapi.v2.mixins import Bootstrappable
+
+
+class User(UserBase, Bootstrappable):
+    pass
+
+
+__all__ = ["User"]


### PR DESCRIPTION
## Summary
- split each peagen ORM table into its own module and re-export for backwards compatibility
- import Tenant before Pool to ensure default tenant bootstraps before pool defaults

## Testing
- `uv run --directory standards/peagen --package peagen ruff check peagen/orm --fix`

------
https://chatgpt.com/codex/tasks/task_e_6890be413cbc8326999c31538c52f642