### PR TITLE
fix: link Work to EvalResult in peagen ORM

### DIFF
--- a/pkgs/standards/peagen/peagen/orm/works.py
+++ b/pkgs/standards/peagen/peagen/orm/works.py
@@ -22,6 +22,12 @@ class Work(Base, GUIDPk, Timestamped, StatusMixin, HookProvider):
     duration_s = Column(Integer)
 
     task = relationship(Task, back_populates="works")
+    eval_results = relationship(
+        "EvalResult",
+        back_populates="work",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+    )
 
     @classmethod
     async def _post_update(cls, ctx):


### PR DESCRIPTION
## Summary
- add missing `eval_results` relationship on `Work`

## Testing
- `uv run --directory standards/peagen --package peagen ruff format .`
- `uv run --directory standards/peagen --package peagen ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_6890c48778108326927e6e3ac97f720b