### PR TITLE
Fix worker create call by using singular canonical RPC names

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/hooks.py
+++ b/pkgs/standards/autoapi/autoapi/v2/hooks.py
@@ -61,13 +61,9 @@ def _init_hooks(self) -> None:
             if model is not None and op is not None:
                 # Model + op parameters
                 if isinstance(model, str):
-                    model_name = model
+                    model_name = "".join(w.title() for w in model.split("_"))
                 else:
-                    # Handle object reference - use table name and convert to canonical form
-                    # to match the method naming convention used by _canonical()
-                    table_name = getattr(model, "__tablename__", model.__name__.lower())
-                    # Convert table_name to canonical form (e.g., "items" -> "Items")
-                    model_name = "".join(w.title() for w in table_name.split("_"))
+                    model_name = model.__name__
                 hook_key = f"{model_name}.{op}"
             elif model is not None or op is not None:
                 # Error: both model and op must be provided together

--- a/pkgs/standards/autoapi/tests/i9n/test_error_mappings.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_error_mappings.py
@@ -184,7 +184,7 @@ async def test_error_parity_crud_vs_rpc(api_client):
     rpc_response = await client.post(
         "/rpc",
         json={
-            "method": "Items.read",
+            "method": "Item.read",
             "params": {"id": "00000000-0000-0000-0000-000000000000"},
         },
     )
@@ -215,7 +215,7 @@ async def test_error_parity_validation_errors(api_client):
     # Try via RPC
     rpc_response = await client.post(
         "/rpc",
-        json={"method": "Tenants.create", "params": {}},  # Missing name
+        json={"method": "Tenant.create", "params": {}},  # Missing name
     )
     assert rpc_response.status_code == 200
     rpc_data = rpc_response.json()
@@ -260,7 +260,7 @@ async def test_error_response_structure(api_client):
 
     # Test RPC error structure
     rpc_response = await client.post(
-        "/rpc", json={"method": "Items.read", "params": {"id": "invalid-uuid"}}
+        "/rpc", json={"method": "Item.read", "params": {"id": "invalid-uuid"}}
     )
     rpc_data = rpc_response.json()
 

--- a/pkgs/standards/autoapi/tests/i9n/test_healthz_methodz.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_healthz_methodz.py
@@ -59,18 +59,18 @@ async def test_methodz_endpoint_comprehensive(api_client):
         assert isinstance(method_name, str)
         assert "." in method_name  # Should follow Model.operation pattern
 
-    # Should have methods for Items and Tenants (from conftest)
+    # Should have methods for Item and Tenant (from conftest)
     expected_methods = [
-        "Items.create",
-        "Items.read",
-        "Items.update",
-        "Items.delete",
-        "Items.list",
-        "Tenants.create",
-        "Tenants.read",
-        "Tenants.update",
-        "Tenants.delete",
-        "Tenants.list",
+        "Item.create",
+        "Item.read",
+        "Item.update",
+        "Item.delete",
+        "Item.list",
+        "Tenant.create",
+        "Tenant.read",
+        "Tenant.update",
+        "Tenant.delete",
+        "Tenant.list",
     ]
 
     for method in expected_methods:
@@ -86,14 +86,14 @@ async def test_methodz_basic_functionality(api_client):
     response = await client.get("/methodz")
     data = response.json()
 
-    # Should contain Items.create method
-    assert "Items.create" in data
+    # Should contain Item.create method
+    assert "Item.create" in data
 
     # Should contain basic CRUD operations
     crud_operations = ["create", "read", "update", "delete", "list"]
     for operation in crud_operations:
-        assert f"Items.{operation}" in data
-        assert f"Tenants.{operation}" in data
+        assert f"Item.{operation}" in data
+        assert f"Tenant.{operation}" in data
 
 
 @pytest.mark.i9n
@@ -142,11 +142,11 @@ async def test_methodz_reflects_dynamic_models(api_client):
     initial_data = response.json()
 
     # Should include methods for models from conftest
-    assert "Tenants.create" in initial_data
-    assert "Tenants.read" in initial_data
-    assert "Tenants.update" in initial_data
-    assert "Tenants.delete" in initial_data
-    assert "Tenants.list" in initial_data
+    assert "Tenant.create" in initial_data
+    assert "Tenant.read" in initial_data
+    assert "Tenant.update" in initial_data
+    assert "Tenant.delete" in initial_data
+    assert "Tenant.list" in initial_data
 
 
 @pytest.mark.i9n

--- a/pkgs/standards/autoapi/tests/i9n/test_hook_lifecycle.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_hook_lifecycle.py
@@ -17,30 +17,30 @@ async def test_hook_phases_execution_order(api_client):
     execution_order = []
 
     # Register hooks for all phases
-    @api.hook(Phase.PRE_TX_BEGIN, model="Items", op="create")
+    @api.hook(Phase.PRE_TX_BEGIN, model="Item", op="create")
     async def pre_tx_begin(ctx):
         execution_order.append("PRE_TX_BEGIN")
         ctx["test_data"] = {"started": True}
 
-    @api.hook(Phase.POST_HANDLER, model="Items", op="create")
+    @api.hook(Phase.POST_HANDLER, model="Item", op="create")
     async def post_handler(ctx):
         execution_order.append("POST_HANDLER")
         assert ctx["test_data"]["started"] is True
         ctx["test_data"]["handler_done"] = True
 
-    @api.hook(Phase.PRE_COMMIT, model="Items", op="create")
+    @api.hook(Phase.PRE_COMMIT, model="Item", op="create")
     async def pre_commit(ctx):
         execution_order.append("PRE_COMMIT")
         assert ctx["test_data"]["handler_done"] is True
         ctx["test_data"]["pre_commit_done"] = True
 
-    @api.hook(Phase.POST_COMMIT, model="Items", op="create")
+    @api.hook(Phase.POST_COMMIT, model="Item", op="create")
     async def post_commit(ctx):
         execution_order.append("POST_COMMIT")
         assert ctx["test_data"]["pre_commit_done"] is True
         ctx["test_data"]["committed"] = True
 
-    @api.hook(Phase.POST_RESPONSE, model="Items", op="create")
+    @api.hook(Phase.POST_RESPONSE, model="Item", op="create")
     async def post_response(ctx):
         execution_order.append("POST_RESPONSE")
         assert ctx["test_data"]["committed"] is True
@@ -54,7 +54,7 @@ async def test_hook_phases_execution_order(api_client):
     res = await client.post(
         "/rpc",
         json={
-            "method": "Items.create",
+            "method": "Item.create",
             "params": {"tenant_id": tid, "name": "test-item"},
         },
     )
@@ -82,14 +82,14 @@ async def test_hook_parity_crud_vs_rpc(api_client):
     crud_hooks = []
     rpc_hooks = []
 
-    @api.hook(Phase.PRE_TX_BEGIN, model="Items", op="create")
+    @api.hook(Phase.PRE_TX_BEGIN, model="Item", op="create")
     async def track_hooks(ctx):
         if hasattr(ctx.get("request"), "url") and "/rpc" in str(ctx["request"].url):
             rpc_hooks.append("PRE_TX_BEGIN")
         else:
             crud_hooks.append("PRE_TX_BEGIN")
 
-    @api.hook(Phase.POST_COMMIT, model="Items", op="create")
+    @api.hook(Phase.POST_COMMIT, model="Item", op="create")
     async def track_post_commit(ctx):
         logging.info(f">>>>>>>>>>>>>>>>>POST_COMMIT {ctx}")
         if hasattr(ctx.get("request"), "url") and "/rpc" in str(ctx["request"].url):
@@ -108,7 +108,7 @@ async def test_hook_parity_crud_vs_rpc(api_client):
     await client.post(
         "/rpc",
         json={
-            "method": "Items.create",
+            "method": "Item.create",
             "params": {"tenant_id": tid, "name": "rpc-item"},
         },
     )
@@ -130,7 +130,7 @@ async def test_hook_error_handling(api_client):
         error_hooks.append("ERROR_HANDLED")
         ctx["error_data"] = {"handled": True}
 
-    @api.hook(Phase.PRE_TX_BEGIN, model="Items", op="create")
+    @api.hook(Phase.PRE_TX_BEGIN, model="Item", op="create")
     async def failing_hook(ctx):
         raise ValueError("Intentional test error")
 
@@ -160,20 +160,20 @@ async def test_hook_context_modification(api_client):
 
     hook_executions = []
 
-    @api.hook(Phase.PRE_TX_BEGIN, model="Items", op="create")
+    @api.hook(Phase.PRE_TX_BEGIN, model="Item", op="create")
     async def modify_params(ctx):
         # Track hook execution and add custom data
         hook_executions.append("PRE_TX_BEGIN")
         ctx["custom_data"] = {"modified": True}
 
-    @api.hook(Phase.POST_HANDLER, model="Items", op="create")
+    @api.hook(Phase.POST_HANDLER, model="Item", op="create")
     async def verify_modification(ctx):
         # Verify the modification was applied and add more data
         hook_executions.append("POST_HANDLER")
         assert ctx["custom_data"]["modified"] is True
         ctx["custom_data"]["verified"] = True
 
-    @api.hook(Phase.POST_RESPONSE, model="Items", op="create")
+    @api.hook(Phase.POST_RESPONSE, model="Item", op="create")
     async def enrich_response(ctx):
         # Add custom data to response
         hook_executions.append("POST_RESPONSE")
@@ -242,17 +242,17 @@ async def test_catch_all_hooks(api_client):
 
     # Verify catch-all hook was called for successful operations
     expected_methods = [
-        "Tenants.create",
-        "Items.create",
-        "Items.list",
-        "Items.read",
+        "Tenant.create",
+        "Item.create",
+        "Item.list",
+        "Item.read",
     ]
 
     # Add update and delete to expected methods if they succeeded
     if update_succeeded:
-        expected_methods.append("Items.update")
+        expected_methods.append("Item.update")
     if delete_succeeded:
-        expected_methods.append("Items.delete")
+        expected_methods.append("Item.delete")
 
     assert len(catch_all_executions) == len(expected_methods)
     for method in expected_methods:
@@ -267,7 +267,7 @@ async def test_hook_model_object_reference(api_client):
     string_hooks = []
     object_hooks = []
 
-    @api.hook(Phase.POST_COMMIT, model="Items", op="create")
+    @api.hook(Phase.POST_COMMIT, model="Item", op="create")
     async def string_model_hook(ctx):
         string_hooks.append("executed")
 
@@ -293,15 +293,15 @@ async def test_multiple_hooks_same_phase(api_client):
     client, api, _ = api_client
     executions = []
 
-    @api.hook(Phase.POST_COMMIT, model="Items", op="create")
+    @api.hook(Phase.POST_COMMIT, model="Item", op="create")
     async def first_hook(ctx):
         executions.append("first")
 
-    @api.hook(Phase.POST_COMMIT, model="Items", op="create")
+    @api.hook(Phase.POST_COMMIT, model="Item", op="create")
     async def second_hook(ctx):
         executions.append("second")
 
-    @api.hook(Phase.POST_COMMIT, model="Items", op="create")
+    @api.hook(Phase.POST_COMMIT, model="Item", op="create")
     async def third_hook(ctx):
         executions.append("third")
 

--- a/pkgs/standards/autoapi/tests/i9n/test_symmetry_parity.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_symmetry_parity.py
@@ -22,7 +22,7 @@ async def test_route_and_method_symmetry(api_client):
     for verb, (http_verb, path) in CRUD_MAP.items():
         assert path in paths
         assert http_verb in paths[path]
-        assert f"Items.{verb}" in method_list
+        assert f"Item.{verb}" in method_list
 
     nested_base = "/tenants/{tenant_id}"
     assert nested_base in paths

--- a/pkgs/standards/autoapi/tests/i9n/test_transactional.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_transactional.py
@@ -18,8 +18,8 @@ async def test_transaction_decorator(api_client):
 
     fail = transactional(api, fail)
 
-    api.rpc["Items.fail"] = fail
-    api._method_ids["Items.fail"] = None
+    api.rpc["Item.fail"] = fail
+    api._method_ids["Item.fail"] = None
 
     t = await client.post("/tenants", json={"name": "tx"})
     tid = t.json()["id"]
@@ -27,7 +27,7 @@ async def test_transaction_decorator(api_client):
     bad = await client.post(
         "/rpc",
         json={
-            "method": "Items.fail",
+            "method": "Item.fail",
             "params": {"tenant_id": tid, "name": "a", "fail": True},
         },
     )
@@ -38,7 +38,7 @@ async def test_transaction_decorator(api_client):
 
     ok = await client.post(
         "/rpc",
-        json={"method": "Items.fail", "params": {"tenant_id": tid, "name": "b"}},
+        json={"method": "Item.fail", "params": {"tenant_id": tid, "name": "b"}},
     )
     assert ok.json()["result"]["id"]
     lst2 = await client.get("/items")


### PR DESCRIPTION
## Summary
- derive canonical RPC method names from ORM class names so they’re singular
- update hook registration and tests to match the new method naming

## Testing
- `uv run --directory . --package autoapi ruff format .`
- `uv run --directory . --package autoapi ruff check . --fix`
- `uv run --package autoapi --directory . pytest`
- `uv run --package autoapi --directory . pytest -q | tail -n 2`


------
https://chatgpt.com/codex/tasks/task_e_6890c9011ac483268ac0a2648d0dc63f