### PR TITLE
Fix worker registration policy gate coroutine bug

### DIFF
--- a/pkgs/standards/peagen/peagen/orm/workers.py
+++ b/pkgs/standards/peagen/peagen/orm/workers.py
@@ -89,7 +89,7 @@ class Worker(Base, GUIDPk, Timestamped, HookProvider, AllowAnonProvider):
         pool_id = params["pool_id"]
         ip = cls._client_ip(ctx["request"])
 
-        async def _get_policy_and_count(session):
+        def _get_policy_and_count(session):
             pool = session.get(Pool, pool_id)
             count = session.query(cls).filter(cls.pool_id == pool_id).count()
             return (pool.policy if pool else {}, count)
@@ -170,7 +170,7 @@ class Worker(Base, GUIDPk, Timestamped, HookProvider, AllowAnonProvider):
 
         ip = cls._client_ip(ctx["request"])
 
-        async def _get_policy_and_count(session):
+        def _get_policy_and_count(session):
             pool = session.get(Pool, pool_id)
             count = session.query(cls).filter(cls.pool_id == pool_id).count()
             return (pool.policy if pool else {}, count)


### PR DESCRIPTION
## Summary
- ensure database helper in worker policy gates is synchronous to avoid coroutine unpacking errors during registration

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format peagen/orm/workers.py`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/orm/workers.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_6890d38b97288326809115109cfb1918