### PR TITLE
feat(authn): add service registration and key typing

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/backends.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/backends.py
@@ -22,13 +22,13 @@ is handled in `fastapi_deps.py` or route handlers.
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Optional, Iterable
 
 from sqlalchemy import Select, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .crypto import verify_pw
-from .orm.tables import ApiKey, ServiceKey, User
+from .orm.tables import ApiKey, Client, ServiceKey, User
 from .typing import Principal
 
 
@@ -73,7 +73,7 @@ class PasswordBackend:
 # ---------------------------------------------------------------------
 class ApiKeyBackend:
     """
-    Authenticate a user via raw API key string.
+    Authenticate a principal via raw API key string.
 
     * Only active, non-expired keys are valid.
     * The raw secret is never stored; verification is via BLAKE2b-256 digest.
@@ -93,21 +93,32 @@ class ApiKeyBackend:
             or_(ServiceKey.valid_to.is_(None), ServiceKey.valid_to > now),
         )
 
-    async def authenticate(self, db: AsyncSession, api_key: str) -> Principal:
+    async def _get_client_stmt(self) -> Select[tuple[Client]]:
+        return select(Client).where(Client.is_active.is_(True))
+
+    async def authenticate(
+        self, db: AsyncSession, api_key: str
+    ) -> tuple[Principal, str]:
         digest = ApiKey.digest_of(api_key)
         key_row: Optional[ApiKey] = await db.scalar(await self._get_key_stmt(digest))
         if key_row:
             if not key_row.user.is_active:
                 raise AuthError("user is inactive")
             key_row.touch()
-            return key_row.user
+            return key_row.user, "user"
 
         svc_row: Optional[ServiceKey] = await db.scalar(
             await self._get_service_key_stmt(digest)
         )
-        if not svc_row:
-            raise AuthError("API key invalid, revoked, or expired")
-        if not svc_row.service.is_active:
-            raise AuthError("service is inactive")
-        svc_row.touch()
-        return svc_row.service
+        if svc_row:
+            if not svc_row.service.is_active:
+                raise AuthError("service is inactive")
+            svc_row.touch()
+            return svc_row.service, "service"
+
+        clients: Iterable[Client] = await db.scalars(await self._get_client_stmt())
+        for client in clients:
+            if client.verify_secret(api_key):
+                return client, "client"
+
+        raise AuthError("API key invalid, revoked, or expired")

--- a/pkgs/standards/auto_authn/auto_authn/v2/hooks.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/hooks.py
@@ -1,21 +1,27 @@
 # auto_authn/hooks.py  (inside the AuthN package)
 
+
 def register_inject_hook(api):
     from autoapi.v2.hooks import Phase
 
-    @api.hook(Phase.PRE_TX_BEGIN)            # PRE‑DB, works for CRUD & RPC
+    allow_anon = api._allow_anon
+
+    @api.hook(Phase.PRE_TX_BEGIN)  # PRE‑DB, works for CRUD & RPC
     async def _inject(ctx):
+        if getattr(ctx.get("env"), "method", None) in allow_anon:
+            return
         p = ctx["request"].state.principal
         if not p:
             return
 
-        prm = ctx["env"].params               # Pydantic model OR raw dict
+        prm = ctx["env"].params  # Pydantic model OR raw dict
         for fld, val in (("tenant_id", p["tid"]), ("owner_id", p["sub"])):
             if hasattr(prm, "__pydantic_fields__"):
                 if fld in prm.model_fields and getattr(prm, fld, None) in (None, val):
                     setattr(prm, fld, val)
             elif isinstance(prm, dict):
                 prm.setdefault(fld, val)
+
 
 __all__ = ["register_inject_hook"]
 

--- a/pkgs/standards/auto_authn/auto_authn/v2/routers/auth_flows.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/routers/auth_flows.py
@@ -77,6 +77,7 @@ class ApiKeyIn(BaseModel):
 class IntrospectOut(BaseModel):
     sub: StrUUID
     tid: StrUUID
+    kind: str
 
 
 # ============================================================================
@@ -163,8 +164,8 @@ async def refresh(body: RefreshIn):
 @router.post("/apikeys/introspect", response_model=IntrospectOut)
 async def introspect_key(body: ApiKeyIn, db: AsyncSession = Depends(get_async_db)):
     try:
-        principal = await _api_backend.authenticate(db, body.api_key)
+        principal, kind = await _api_backend.authenticate(db, body.api_key)
     except AuthError as exc:
         raise HTTPException(status.HTTP_404_NOT_FOUND, exc.reason)
 
-    return IntrospectOut(sub=str(principal.id), tid=str(principal.tenant_id))
+    return IntrospectOut(sub=str(principal.id), tid=str(principal.tenant_id), kind=kind)

--- a/pkgs/standards/peagen/peagen/orm/workers.py
+++ b/pkgs/standards/peagen/peagen/orm/workers.py
@@ -129,16 +129,32 @@ class Worker(Base, GUIDPk, Timestamped, HookProvider, AllowAnonProvider):
 
     @classmethod
     async def _post_create_auto_register(cls, ctx):
-        from peagen.gateway import log, authn_adapter
+        from peagen.gateway import authn_adapter, log
 
         created = cls._SRead(**ctx["result"])
         try:
-            resp = await authn_adapter._client.post(
-                f"{authn_adapter._introspect.rsplit('/', 1)[0]}/workers",
-                json={"worker_id": str(created.id)},
+            base = authn_adapter._introspect.rsplit("/", 1)[0]
+
+            def _tenant_id(session):
+                pool = session.get(Pool, created.pool_id)
+                return str(pool.tenant_id) if pool else None
+
+            tenant_id = await ctx["db"].run_sync(_tenant_id)
+
+            svc_resp = await authn_adapter._client.post(
+                f"{base}/services",
+                json={"name": f"worker-{created.id}", "tenant_id": tenant_id},
             )
-            resp.raise_for_status()
-            ctx["raw_worker_key"] = resp.json().get("api_key")
+            svc_resp.raise_for_status()
+            service_id = svc_resp.json()["id"]
+
+            key_resp = await authn_adapter._client.post(
+                f"{base}/service_keys",
+                json={"service_id": service_id, "label": "worker"},
+            )
+            key_resp.raise_for_status()
+            body = key_resp.json()
+            ctx["raw_worker_key"] = body.get("api_key") or body.get("raw_key")
         except Exception as exc:  # pragma: no cover
             log.error("auto-registration failed: %s", exc)
             ctx["raw_worker_key"] = None


### PR DESCRIPTION
## Summary
- auto-register workers by creating AuthN services and service keys
- expose principal type when introspecting API keys
- ignore anonymous methods in AuthN injection hook

## Testing
- `uv run --directory standards/auto_authn --package auto_authn ruff format .`
- `uv run --directory standards/auto_authn --package auto_authn ruff check . --fix`
- `uv run --directory standards/peagen --package peagen ruff format .`
- `uv run --directory standards/peagen --package peagen ruff check . --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest`
- `uv run --package peagen --directory standards/peagen pytest` *(fails: AssertionError, AttributeError, TypeError)*

------
https://chatgpt.com/codex/tasks/task_e_6890db585abc83268338359e950296f7