### PR TITLE
Fix worker pool UUID handling in policy gates

### DIFF
--- a/pkgs/standards/peagen/peagen/orm/workers.py
+++ b/pkgs/standards/peagen/peagen/orm/workers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import uuid
+
 from autoapi.v2.types import (
     JSON,
     Column,
@@ -87,6 +89,8 @@ class Worker(Base, GUIDPk, Timestamped, HookProvider, AllowAnonProvider):
         log.info("entering pre_worker_create_policy_gate")
         params = ctx["env"].params
         pool_id = params["pool_id"]
+        if isinstance(pool_id, str):
+            pool_id = uuid.UUID(pool_id)
         ip = cls._client_ip(ctx["request"])
 
         def _get_policy_and_count(session):
@@ -134,6 +138,7 @@ class Worker(Base, GUIDPk, Timestamped, HookProvider, AllowAnonProvider):
         created = cls._SRead(**ctx["result"])
         try:
             base = authn_adapter.base_url
+
             def _tenant_id(session):
                 pool = session.get(Pool, created.pool_id)
                 return str(pool.tenant_id) if pool else None
@@ -182,6 +187,8 @@ class Worker(Base, GUIDPk, Timestamped, HookProvider, AllowAnonProvider):
             from peagen.gateway import queue
 
             pool_id = await queue.hget(WORKER_KEY.format(worker_id), "pool_id")
+        if isinstance(pool_id, str):
+            pool_id = uuid.UUID(pool_id)
 
         ip = cls._client_ip(ctx["request"])
 

--- a/pkgs/standards/peagen/peagen/orm/workers.py
+++ b/pkgs/standards/peagen/peagen/orm/workers.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import uuid
-
 from autoapi.v2.types import (
     JSON,
     Column,
@@ -90,7 +88,7 @@ class Worker(Base, GUIDPk, Timestamped, HookProvider, AllowAnonProvider):
         params = ctx["env"].params
         pool_id = params["pool_id"]
         if isinstance(pool_id, str):
-            pool_id = uuid.UUID(pool_id)
+            pool_id = PgUUID(pool_id)
         ip = cls._client_ip(ctx["request"])
 
         def _get_policy_and_count(session):
@@ -188,7 +186,7 @@ class Worker(Base, GUIDPk, Timestamped, HookProvider, AllowAnonProvider):
 
             pool_id = await queue.hget(WORKER_KEY.format(worker_id), "pool_id")
         if isinstance(pool_id, str):
-            pool_id = uuid.UUID(pool_id)
+            pool_id = PgUUID(pool_id)
 
         ip = cls._client_ip(ctx["request"])
 


### PR DESCRIPTION
## Summary
- ensure worker pool IDs are parsed as UUID objects during worker registration and update policy gates

## Testing
- `uv run --directory . --package peagen ruff format peagen/orm/workers.py`
- `uv run --directory . --package peagen ruff check peagen/orm/workers.py --fix`
- `PG_DSN='' uvicorn peagen.gateway:app --host 0.0.0.0 --port 8000 --log-level debug` *(logs show `Client error '422 Unprocessable Entity' for url 'https://authn.peagen.com/services'`)*
- `uvicorn peagen.worker:app --host 0.0.0.0 --port 8001 --log-level debug` *(worker registers but heartbeat unauthorized)*

------
https://chatgpt.com/codex/tasks/task_e_6891004d5ca483269260dd0ced1265a0