### PR TITLE
feat: set worker key expiry

### DIFF
--- a/pkgs/standards/peagen/peagen/orm/workers.py
+++ b/pkgs/standards/peagen/peagen/orm/workers.py
@@ -151,9 +151,17 @@ class Worker(Base, GUIDPk, Timestamped, HookProvider, AllowAnonProvider):
             svc_resp.raise_for_status()
             service_id = svc_resp.json()["id"]
 
+            from datetime import datetime, timedelta, timezone
+
+            valid_to = (datetime.now(timezone.utc) + timedelta(days=1)).isoformat()
+
             key_resp = await authn_adapter._client.post(
                 f"{base}/service_keys",
-                json={"service_id": service_id, "label": "worker"},
+                json={
+                    "service_id": service_id,
+                    "label": "worker",
+                    "valid_to": valid_to,
+                },
             )
             key_resp.raise_for_status()
             body = key_resp.json()


### PR DESCRIPTION
## Summary
- expire worker service keys after one day during auto registration

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format peagen/orm/workers.py`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/orm/workers.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_68910ca2d2448326b5ed98326f44b3cb