### PR TITLE
Add default validity window and include expiry in worker auto-registration

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/mixins/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v2/mixins/__init__.py
@@ -28,6 +28,11 @@ def tzutcnow() -> dt.datetime:  # default/on‑update factory
     return dt.datetime.now(dt.timezone.utc)
 
 
+def tzutcnow_plus_day() -> dt.datetime:
+    """Return an aware UTC ``datetime`` one day in the future."""
+    return tzutcnow() + dt.timedelta(days=1)
+
+
 # ----------------------------------------------------------------------
 
 uuid_example = UUID("00000000-dead-beef-cafe-000000000000")
@@ -151,12 +156,11 @@ class Created:
 @declarative_mixin
 class LastUsed:
     last_used_at = Column(
-        TZDateTime, 
-        nullable=True, 
+        TZDateTime,
+        nullable=True,
         onupdate=tzutcnow,
         info=dict(no_create=True, no_update=True),
     )
-        
 
 
 @declarative_mixin
@@ -314,7 +318,7 @@ class StatusMixin:
 @declarative_mixin
 class ValidityWindow:
     valid_from = Column(TZDateTime, default=tzutcnow, nullable=False)
-    valid_to = Column(TZDateTime)
+    valid_to = Column(TZDateTime, default=tzutcnow_plus_day)
 
 
 # ----------------------------------------------------------------------

--- a/pkgs/standards/peagen/peagen/orm/workers.py
+++ b/pkgs/standards/peagen/peagen/orm/workers.py
@@ -13,7 +13,9 @@ from autoapi.v2.types import (
     AllowAnonProvider,
 )
 from autoapi.v2.tables import Base
-from autoapi.v2.mixins import GUIDPk, Timestamped
+import datetime as dt
+
+from autoapi.v2.mixins import GUIDPk, Timestamped, tzutcnow
 from peagen.defaults import DEFAULT_POOL_ID, WORKER_KEY, WORKER_TTL
 
 from .pools import Pool
@@ -150,10 +152,14 @@ class Worker(Base, GUIDPk, Timestamped, HookProvider, AllowAnonProvider):
             )
             svc_resp.raise_for_status()
             service_id = svc_resp.json()["id"]
-
+            valid_to = (tzutcnow() + dt.timedelta(days=1)).isoformat()
             key_resp = await authn_adapter._client.post(
                 f"{base}/service_keys",
-                json={"service_id": service_id, "label": "worker"},
+                json={
+                    "service_id": service_id,
+                    "label": "worker",
+                    "valid_to": valid_to,
+                },
             )
             key_resp.raise_for_status()
             body = key_resp.json()


### PR DESCRIPTION
## Summary
- default `valid_to` now set to one day ahead via `tzutcnow_plus_day`
- worker auto-registration includes a `valid_to` timestamp when creating service keys

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format autoapi/v2/mixins/__init__.py`
- `uv run --package autoapi --directory standards/autoapi ruff check autoapi/v2/mixins/__init__.py --fix`
- `uv run --package peagen --directory standards/peagen ruff format peagen/orm/workers.py`
- `uv run --package peagen --directory standards/peagen ruff check peagen/orm/workers.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_68910cdef1508326aff7af4ea9af4de2