### PR TITLE
Handle ORM results in autoapi hooks

### DIFF
--- a/pkgs/standards/peagen/peagen/orm/pools.py
+++ b/pkgs/standards/peagen/peagen/orm/pools.py
@@ -35,7 +35,7 @@ class Pool(Base, GUIDPk, Bootstrappable, Timestamped, TenantBound, HookProvider)
         from peagen.gateway import log, queue
 
         log.info("entering post_pool_create")
-        created = cls._SRead(**ctx["result"])
+        created = cls._SRead.model_validate(ctx["result"], from_attributes=True)
         await queue.sadd("pools", created.name)
         log.info("pool created: %s", created.name)
         ctx["result"] = created.model_dump()

--- a/pkgs/standards/peagen/peagen/orm/tasks.py
+++ b/pkgs/standards/peagen/peagen/orm/tasks.py
@@ -116,7 +116,7 @@ class Task(
         from peagen.gateway.schedule_helpers import _save_task
 
         log.info("entering post_task_create")
-        created = cls._SRead(**ctx["result"])
+        created = cls._SRead.model_validate(ctx["result"], from_attributes=True)
         submitted = ctx["task_in"]
         wire = submitted.model_copy(update={"id": created.id})
         await queue.rpush(

--- a/pkgs/standards/peagen/peagen/orm/workers.py
+++ b/pkgs/standards/peagen/peagen/orm/workers.py
@@ -104,7 +104,7 @@ class Worker(Base, GUIDPk, Timestamped, HookProvider, AllowAnonProvider):
     async def _post_create_cache_pool(cls, ctx):
         from peagen.gateway import log, queue
 
-        created = cls._SRead(**ctx["result"])
+        created = cls._SRead.model_validate(ctx["result"], from_attributes=True)
         log.info("worker %s joined pool_id %s", created.id, created.pool_id)
         try:
             await queue.sadd(f"pool_id:{created.pool_id}:members", str(created.id))
@@ -115,7 +115,7 @@ class Worker(Base, GUIDPk, Timestamped, HookProvider, AllowAnonProvider):
     async def _post_create_cache_worker(cls, ctx):
         from peagen.gateway import log, queue
 
-        created = cls._SRead(**ctx["result"])
+        created = cls._SRead.model_validate(ctx["result"], from_attributes=True)
         try:
             key = WORKER_KEY.format(str(created.id))
             await queue.hset(key, cls._as_redis_hash(created))
@@ -134,7 +134,7 @@ class Worker(Base, GUIDPk, Timestamped, HookProvider, AllowAnonProvider):
     async def _post_create_auto_register(cls, ctx):
         from peagen.gateway import authn_adapter, log
 
-        created = cls._SRead(**ctx["result"])
+        created = cls._SRead.model_validate(ctx["result"], from_attributes=True)
         try:
             base = authn_adapter.base_url
 
@@ -226,7 +226,7 @@ class Worker(Base, GUIDPk, Timestamped, HookProvider, AllowAnonProvider):
 
         worker_id = ctx["worker_id"]
         try:
-            updated = cls._SRead(**ctx["result"])
+            updated = cls._SRead.model_validate(ctx["result"], from_attributes=True)
             if updated.pool_id:
                 await queue.sadd(f"pool_id:{updated.pool_id}:members", worker_id)
             log.info("cached member `%s` in `%s`", worker_id, updated.pool_id)
@@ -245,7 +245,7 @@ class Worker(Base, GUIDPk, Timestamped, HookProvider, AllowAnonProvider):
 
         worker_id = ctx["worker_id"]
         try:
-            updated = cls._SRead(**ctx["result"])
+            updated = cls._SRead.model_validate(ctx["result"], from_attributes=True)
             key = WORKER_KEY.format(worker_id)
             await queue.hset(key, {"updated_at": str(updated.updated_at)})
             await queue.expire(key, WORKER_TTL)

--- a/pkgs/standards/peagen/peagen/orm/works.py
+++ b/pkgs/standards/peagen/peagen/orm/works.py
@@ -41,7 +41,7 @@ class Work(Base, GUIDPk, Timestamped, StatusMixin, HookProvider):
         from peagen.orm import Status
 
         log.info("entering post_work_update")
-        wr = cls._SRead(**ctx["result"])
+        wr = cls._SRead.model_validate(ctx["result"], from_attributes=True)
         if not Status.is_terminal(wr.status):
             return
         task = await _load_task(queue, str(wr.task_id))


### PR DESCRIPTION
## Summary
- fix worker auto-registration crash by validating ORM objects via Pydantic
- apply same `model_validate(from_attributes=True)` pattern across pool, task, and work hooks

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format peagen/orm/pools.py peagen/orm/tasks.py peagen/orm/workers.py peagen/orm/works.py`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/orm/pools.py peagen/orm/tasks.py peagen/orm/workers.py peagen/orm/works.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_68910fc7db2c832693c7016e64f7d0c9