### PR TITLE
feat: add service key expiration

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/mixins/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v2/mixins/__init__.py
@@ -151,12 +151,15 @@ class Created:
 @declarative_mixin
 class LastUsed:
     last_used_at = Column(
-        TZDateTime, 
-        nullable=True, 
+        TZDateTime,
+        nullable=True,
         onupdate=tzutcnow,
         info=dict(no_create=True, no_update=True),
     )
-        
+
+    def touch(self) -> None:
+        """Mark the object as used now."""
+        self.last_used_at = tzutcnow()
 
 
 @declarative_mixin
@@ -314,7 +317,10 @@ class StatusMixin:
 @declarative_mixin
 class ValidityWindow:
     valid_from = Column(TZDateTime, default=tzutcnow, nullable=False)
-    valid_to = Column(TZDateTime)
+    valid_to = Column(
+        TZDateTime,
+        default=lambda: tzutcnow() + dt.timedelta(days=1),
+    )
 
 
 # ----------------------------------------------------------------------

--- a/pkgs/standards/autoapi/tests/i9n/test_mixins.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_mixins.py
@@ -5,7 +5,7 @@ Tests all mixins and their expected behavior using individual DummyModel instanc
 """
 
 import pytest
-from datetime import datetime
+from datetime import datetime, timedelta
 from sqlalchemy import Column, String
 
 from autoapi.v2.mixins import GUIDPk
@@ -354,6 +354,24 @@ async def test_validity_window_mixin(create_test_api):
     assert "valid_to" in create_schema.model_fields
     assert "valid_from" in read_schema.model_fields
     assert "valid_to" in read_schema.model_fields
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_validity_window_default(create_test_api):
+    api = create_test_api(DummyModelValidityWindow)
+    session = next(api.get_db())
+    try:
+        instance = DummyModelValidityWindow(name="x")
+        session.add(instance)
+        session.flush()
+        vf_default = instance.valid_from
+        vt_default = instance.valid_to
+    finally:
+        session.close()
+    assert vf_default is not None
+    assert vt_default is not None
+    assert abs((vt_default - vf_default) - timedelta(days=1)) < timedelta(seconds=1)
 
 
 @pytest.mark.i9n

--- a/pkgs/standards/peagen/peagen/orm/workers.py
+++ b/pkgs/standards/peagen/peagen/orm/workers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import datetime as dt
+
 from autoapi.v2.types import (
     JSON,
     Column,
@@ -13,7 +15,7 @@ from autoapi.v2.types import (
     AllowAnonProvider,
 )
 from autoapi.v2.tables import Base
-from autoapi.v2.mixins import GUIDPk, Timestamped
+from autoapi.v2.mixins import GUIDPk, Timestamped, tzutcnow
 from peagen.defaults import DEFAULT_POOL_ID, WORKER_KEY, WORKER_TTL
 
 from .pools import Pool
@@ -150,10 +152,14 @@ class Worker(Base, GUIDPk, Timestamped, HookProvider, AllowAnonProvider):
             )
             svc_resp.raise_for_status()
             service_id = svc_resp.json()["id"]
-
+            valid_to = tzutcnow() + dt.timedelta(days=1)
             key_resp = await authn_adapter._client.post(
                 f"{base}/service_keys",
-                json={"service_id": service_id, "label": "worker"},
+                json={
+                    "service_id": service_id,
+                    "label": "worker",
+                    "valid_to": valid_to.isoformat(),
+                },
             )
             key_resp.raise_for_status()
             body = key_resp.json()


### PR DESCRIPTION
## Summary
- add `touch` method to `LastUsed` mixin and default 1-day `valid_to` window
- send `valid_to` when auto-registering worker service keys
- test that `ValidityWindow` defaults to a 1-day window

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest`
- `uv run --package peagen --directory standards/peagen pytest` *(fails: missing plugin manager, AttributeError in keys_core, subprocess TypeError, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68910cdef1508326aff7af4ea9af4de2