### PR TITLE
feat(client): surface 422 validation details

### DIFF
--- a/pkgs/standards/autoapi_client/tests/unit/test_422_error_detail.py
+++ b/pkgs/standards/autoapi_client/tests/unit/test_422_error_detail.py
@@ -1,0 +1,21 @@
+import httpx
+import pytest
+
+from autoapi_client._crud import CRUDMixin
+
+
+class DummyClient(CRUDMixin):
+    pass
+
+
+def test_process_response_422_includes_detail():
+    client = DummyClient()
+    request = httpx.Request("POST", "http://example.com/services")
+    response = httpx.Response(
+        422,
+        json={"detail": [{"loc": ["body", "tenant_id"], "msg": "Field required"}]},
+        request=request,
+    )
+    with pytest.raises(httpx.HTTPStatusError) as exc:
+        client._process_response(response)
+    assert "Field required" in str(exc.value)


### PR DESCRIPTION
## Summary
- capture and surface 422 validation errors in AutoAPIClient responses
- test that 422 responses include validation detail

## Testing
- `uv run --directory pkgs/standards/autoapi_client --package autoapi_client ruff check . --fix`
- `uv run --directory pkgs/standards/autoapi_client --package autoapi_client pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891170df35483268fbf83b1bba6330b