### PR TITLE
feat: clear tables on startup

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/types/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v2/types/__init__.py
@@ -47,6 +47,7 @@ from .table_config_provider import TableConfigProvider
 from .hook_provider import HookProvider
 from .nested_path_provider import NestedPathProvider
 from .allow_anon_provider import AllowAnonProvider
+from .clear_existing_provider import ClearExistingTableProvider
 
 DateTime = _DateTime(timezone=False)
 TZDateTime = _DateTime(timezone=True)
@@ -61,6 +62,7 @@ __all__: list[str] = [
     "HookProvider",
     "NestedPathProvider",
     "AllowAnonProvider",
+    "ClearExistingTableProvider",
     # builtin types
     "MethodType",
     "SimpleNamespace",

--- a/pkgs/standards/autoapi/autoapi/v2/types/clear_existing_provider.py
+++ b/pkgs/standards/autoapi/autoapi/v2/types/clear_existing_provider.py
@@ -1,0 +1,10 @@
+from .table_config_provider import TableConfigProvider
+
+
+class ClearExistingTableProvider(TableConfigProvider):
+    """Marker for tables that should be cleared on API startup."""
+
+    pass
+
+
+__all__ = ["ClearExistingTableProvider"]

--- a/pkgs/standards/peagen/peagen/orm/workers.py
+++ b/pkgs/standards/peagen/peagen/orm/workers.py
@@ -13,6 +13,7 @@ from autoapi.v2.types import (
     relationship,
     HookProvider,
     AllowAnonProvider,
+    ClearExistingTableProvider,
 )
 from autoapi.v2.tables import Base
 from autoapi.v2.mixins import GUIDPk, Timestamped, tzutcnow
@@ -21,7 +22,14 @@ from peagen.defaults import DEFAULT_POOL_ID, WORKER_KEY, WORKER_TTL
 from .pools import Pool
 
 
-class Worker(Base, GUIDPk, Timestamped, HookProvider, AllowAnonProvider):
+class Worker(
+    Base,
+    GUIDPk,
+    Timestamped,
+    HookProvider,
+    AllowAnonProvider,
+    ClearExistingTableProvider,
+):
     __tablename__ = "workers"
     pool_id = Column(
         PgUUID(as_uuid=True),


### PR DESCRIPTION
## Summary
- add ClearExistingTableProvider marker for AutoAPI tables
- purge tables with marker during AutoAPI initialization
- apply table clearing marker to peagen's Worker model

## Testing
- `uv run --directory pkgs/standards --package autoapi ruff format autoapi/autoapi/v2/__init__.py autoapi/autoapi/v2/types/__init__.py autoapi/autoapi/v2/types/clear_existing_provider.py`
- `uv run --directory pkgs/standards --package autoapi ruff check autoapi/autoapi/v2/__init__.py autoapi/autoapi/v2/types/__init__.py autoapi/autoapi/v2/types/clear_existing_provider.py --fix`
- `uv run --directory pkgs/standards --package peagen ruff format peagen/peagen/orm/workers.py`
- `uv run --directory pkgs/standards --package peagen ruff check peagen/peagen/orm/workers.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_689118e3fb90832683407b8b3d8d74e7