### PR TITLE
feat(auto-authn): auto-generate service key

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/tables.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/tables.py
@@ -33,7 +33,6 @@ from autoapi.v2.types import (
     PgUUID,
     ForeignKey,
     HookProvider,
-    UUID,
 )
 from autoapi.v2.tables import (
     Tenant as TenantBase,
@@ -63,6 +62,7 @@ _UUID = Annotated[str, mapped_column(String(36), default=lambda: str(uuid.uuid4(
 
 # Regular-expression for a valid client_id (RFC 6749 allows many forms)
 _CLIENT_ID_RE: Final[re.Pattern[str]] = re.compile(r"^[A-Za-z0-9\-_]{8,64}$")
+
 
 class Tenant(TenantBase, Bootstrappable):
     DEFAULT_ROWS = [
@@ -210,7 +210,7 @@ class ApiKey(ApiKeyBase, HookProvider):
         )
 
 
-class ServiceKey(Base, GUIDPk, Created, LastUsed, ValidityWindow):
+class ServiceKey(Base, GUIDPk, Created, LastUsed, ValidityWindow, HookProvider):
     """API key bound to a service principal."""
 
     __tablename__ = "service_keys"
@@ -262,6 +262,37 @@ class ServiceKey(Base, GUIDPk, Created, LastUsed, ValidityWindow):
             "examples": [token_urlsafe(8)],
         }
     }
+
+    @classmethod
+    async def _pre_create_generate_key(cls, ctx):
+        params = ctx["env"].params
+        raw = token_urlsafe(8)
+        if hasattr(params, "model_copy"):
+            params = params.model_copy(update={"raw_key": raw})
+            ctx["env"].params = params
+        elif isinstance(params, dict):
+            params["raw_key"] = raw
+        ctx["raw_service_key"] = raw
+
+    @classmethod
+    async def _post_create_inject_key(cls, ctx):
+        raw = ctx.get("raw_service_key")
+        if not raw:
+            return
+        result = dict(ctx.get("result", {}))
+        result["service_key"] = raw
+        ctx["result"] = result
+
+    @classmethod
+    def __autoapi_register_hooks__(cls, api) -> None:
+        from autoapi.v2 import Phase
+
+        api.register_hook(Phase.PRE_TX_BEGIN, model="ServiceKey", op="create")(
+            cls._pre_create_generate_key
+        )
+        api.register_hook(Phase.POST_RESPONSE, model="ServiceKey", op="create")(
+            cls._post_create_inject_key
+        )
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- ensure ServiceKey records auto-generate raw key values
- return generated key to caller after creation

## Testing
- `uv run --directory standards/auto_authn --package auto-authn ruff format .`
- `uv run --directory standards/auto_authn --package auto-authn ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_6891224700088326825e50115c100b32