### PR TITLE
feat(auto-authn): return raw service key once

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/tables.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/tables.py
@@ -222,8 +222,8 @@ class ServiceKey(
         unique=True,
         info={
             "autoapi": {
-                # still excluded from create/update schemas
-                "disable_on": ["create", "update", "replace"],
+                # excluded from update/replace request bodies
+                "disable_on": ["update", "replace"],
                 "read_only": True,
             }
         },
@@ -243,37 +243,33 @@ class ServiceKey(
     # Hooks
     # ──────────────────────────────────────────────────────────
     @classmethod
-    async def _pre_tx_generate(cls, ctx):
-        """
-        Runs *after* validation but *before* flush:
-
-        1. Creates a one-time secret.
-        2. Adds its digest + last_used_at to **ctx["env"].params** so the
-           ORM instance receives them automatically.
-        3. Stashes the raw secret for the response phase.
-        """
-        params = ctx["env"].params                     # ← same access pattern
-
-        raw     = token_urlsafe(32)
-        digest  = cls.digest_of(raw)
-        now     = dt.datetime.now(dt.timezone.utc)
-
-        # Pydantic v2 → use model_copy so we keep the same schema instance
-        params = params.model_copy(
-            update={"digest": digest, "last_used_at": now}
-        )
-        ctx["env"].params = params
-        ctx["raw_service_key"] = raw                   # hand off to POST_COMMIT
+    async def _pre_create_generate(cls, ctx):
+        params = ctx["env"].params
+        raw = token_urlsafe(32)
+        digest = cls.digest_of(raw)
+        if hasattr(params, "model_dump"):
+            if getattr(params, "digest", None):
+                raise HTTPException(
+                    status_code=422, detail="digest is server generated"
+                )
+            params = params.model_copy(update={"digest": digest})
+            ctx["env"].params = params
+        elif isinstance(params, dict):
+            if params.get("digest"):
+                raise HTTPException(
+                    status_code=422, detail="digest is server generated"
+                )
+            params["digest"] = digest
+        ctx["raw_service_key"] = raw
 
     @classmethod
     async def _post_commit_inject(cls, ctx):
-        """Swap the digest out of the response and return the raw key once."""
         raw = ctx.pop("raw_service_key", None)
-        if raw:
-            result = dict(ctx.get("result", {}))
-            # `api_key` is the naming convention you already use elsewhere
-            result["api_key"] = raw
-            ctx["result"] = result
+        if not raw:
+            return
+        result = dict(ctx.get("result", {}))
+        result["service_key"] = raw
+        ctx["result"] = result
 
     # ──────────────────────────────────────────────────────────
     # Hook registration
@@ -281,12 +277,13 @@ class ServiceKey(
     @classmethod
     def __autoapi_register_hooks__(cls, api) -> None:
         from autoapi.v2 import Phase
-        api.register_hook(
-            Phase.PRE_TX_BEGIN, model="ServiceKey", op="create"
-        )(cls._pre_tx_generate)
-        api.register_hook(
-            Phase.POST_COMMIT, model="ServiceKey", op="create"
-        )(cls._post_commit_inject)
+
+        api.register_hook(Phase.PRE_TX_BEGIN, model="ServiceKey", op="create")(
+            cls._pre_create_generate
+        )
+        api.register_hook(Phase.POST_COMMIT, model="ServiceKey", op="create")(
+            cls._post_commit_inject
+        )
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- generate and persist service key digest before commit
- inject one-time service key into post-commit response
- rely on automatic last-used timestamps and hide digest on update/replace

## Testing
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff format auto_authn/v2/orm/tables.py`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check auto_authn/v2/orm/tables.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_6891601644d0832691a3b1d85cf4ce4a