### PR TITLE
Fix ServiceKey creation hooks

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/_runner.py
+++ b/pkgs/standards/autoapi/autoapi/v2/_runner.py
@@ -40,6 +40,9 @@ async def _invoke(
         # ─── PRE hook ────────────────────────────────────────────────────────
         await api._run(Phase.PRE_TX_BEGIN, ctx)
 
+        # Allow hooks to mutate request parameters via ``ctx['env'].params``
+        params = ctx["env"].params
+
         # ─── business logic call -------------------------------------------
         if exec_fn is not None:  # custom executor
             maybe = exec_fn(method, params, db)
@@ -61,6 +64,8 @@ async def _invoke(
                 db.commit()  # plain Session
 
             await api._run(Phase.POST_COMMIT, ctx)
+
+        result = ctx.get("result", result)
 
         # ─── POST hook ------------------------------------------------------
         ctx["response"] = SimpleNamespace(result=result)

--- a/pkgs/standards/autoapi/autoapi/v2/hooks.py
+++ b/pkgs/standards/autoapi/autoapi/v2/hooks.py
@@ -64,7 +64,15 @@ def _init_hooks(self) -> None:
                     tab = model if model.endswith(("s", "S")) else f"{model}s"
                 else:
                     tab = getattr(model, "__tablename__", model.__name__)
-                model_name = "".join(w.title() for w in tab.split("_"))
+                # Preserve existing camelCase while upper-casing only the first
+                # letter of underscore-delimited segments. This avoids
+                # lowercasing already-camelcased portions like "ServiceKeys".
+                if "_" in tab:
+                    model_name = "".join(
+                        part[:1].upper() + part[1:] for part in tab.split("_")
+                    )
+                else:
+                    model_name = tab
                 hook_key = f"{model_name}.{op}"
             elif model is not None or op is not None:
                 # Error: both model and op must be provided together

--- a/pkgs/standards/autoapi/autoapi/v2/impl/crud_builder.py
+++ b/pkgs/standards/autoapi/autoapi/v2/impl/crud_builder.py
@@ -92,7 +92,7 @@ def create_crud_operations(model: type, pk_name: str) -> Dict[str, callable]:
 
     def _create(p: SCreate, db: Session):
         """Create a new model instance."""
-        data = p.model_dump()
+        data = p.model_dump() if hasattr(p, "model_dump") else dict(p)
         col_kwargs = {
             k: v for k, v in data.items() if k in {c.key for c in mapper.attrs}
         }


### PR DESCRIPTION
## Summary
- allow CRUD create operations to accept plain dictionaries from hook-mutated params
- rebuild REST route arguments from hook-mutated RPC params and bypass response-model validation for create routes
- generate and inject API and ServiceKey secrets via POST_RESPONSE hooks

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check . --fix`
- `uv run --package auto_authn --directory pkgs/standards/auto_authn uvicorn auto_authn.v2.app:app --host 127.0.0.1 --port 8000`
- `curl -i -s -X POST http://127.0.0.1:8000/service_keys -H 'Content-Type: application/json' -d '{"label":"key13","service_id":"259c789f-204f-4630-bad5-8ba6a0b048ac"}'`


------
https://chatgpt.com/codex/tasks/task_e_689173e7caa88326ae405e31c53d4652