### PR TITLE
fix(worker): retain API key from Workers.create response

### DIFF
--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -139,11 +139,15 @@ class WorkerBase:
                 advertises={"cpu": True},
                 handlers={"handlers": list(self._handlers)},
             )
-            created = self._client.call(
-                "Workers.create", params=payload, out_schema=SWorkerRead
-            )
+            created = self._client.call("Workers.create", params=payload)
             self.log.info("registered @ gateway as %s", self.worker_id)
-            api_key = getattr(created, "service_key", None)
+            api_key = None
+            if isinstance(created, dict):
+                api_key = created.get("api_key") or created.get("service_key")
+            if not api_key:
+                api_key = getattr(created, "api_key", None) or getattr(
+                    created, "service_key", None
+                )
             if api_key:
                 self._api_key = api_key
                 os.environ["DQ_API_KEY"] = api_key


### PR DESCRIPTION
## Summary
- retrieve API key from gateway response when registering worker

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format peagen/worker/base.py`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/worker/base.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_6892c4dba72c8326b02167fe59c58b02