### PR TITLE
fix: require pk in autoapi update rpc calls

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/impl/routes_builder.py
+++ b/pkgs/standards/autoapi/autoapi/v2/impl/routes_builder.py
@@ -315,7 +315,12 @@ def _register_routes_and_rpcs(  # noqa: N802 – bound as method
                 setattr(self.schemas, name, s)
 
         # JSON-RPC shim
-        rpc_fn = _wrap_rpc(core, In or dict, Out, pk, model)
+        rpc_in = In or dict
+        if verb == "update":
+            rpc_in = self._schema(model, verb="update")
+        elif verb == "replace":
+            rpc_in = self._schema(model, verb="create")
+        rpc_fn = _wrap_rpc(core, rpc_in, Out, pk, model)
         self.rpc[m_id] = rpc_fn
 
         # ── in-process convenience wrapper ────────────────────────────────

--- a/pkgs/standards/autoapi/tests/i9n/test_rpc_update_requires_pk.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_rpc_update_requires_pk.py
@@ -1,0 +1,14 @@
+import pytest
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_rpc_update_requires_pk(api_client):
+    """Ensure RPC update calls validate presence of primary key."""
+    client, _, _ = api_client
+    resp = await client.post(
+        "/rpc", json={"method": "Items.update", "params": {"name": "foo"}}
+    )
+    data = resp.json()
+    assert "error" in data
+    assert data["error"]["code"] == -32602


### PR DESCRIPTION
## Summary
- ensure rpc update/replace use schema requiring primary key
- add regression test for rpc update pk enforcement

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_6892d4f12e148326b2e98a356079f7ea