### PR TITLE
fix: require pk for AutoAPI updates

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/mixins/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v2/mixins/__init__.py
@@ -49,7 +49,7 @@ class GUIDPk:
         info=dict(
             autoapi={
                 "default_factory": uuid4,
-                "read_only": True,
+                "read_only": {"create": True},
                 "examples": [uuid_example],
             }
         ),
@@ -161,9 +161,11 @@ class LastUsed:
         onupdate=tzutcnow,
         info=dict(no_create=True, no_update=True),
     )
+
     def touch(self) -> None:
         """Mark the object as used now."""
         self.last_used_at = tzutcnow()
+
 
 @declarative_mixin
 class Timestamped:

--- a/pkgs/standards/autoapi/tests/i9n/test_schema.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_schema.py
@@ -26,6 +26,15 @@ async def test_schema_generation(api_client):
 
 @pytest.mark.i9n
 @pytest.mark.asyncio
+async def test_update_schema_requires_pk(api_client):
+    _, _, Item = api_client
+    update_model = AutoAPI.get_schema(Item, "update")
+    fld = update_model.model_fields.get("id")
+    assert fld is not None and fld.is_required
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
 async def test_bulk_operation_schema(api_client):
     client, _, _ = api_client
     spec = (await client.get("/openapi.json")).json()

--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -133,13 +133,14 @@ class WorkerBase:
         """
         try:
             payload = SWorkerCreate(
-                id=self.worker_id,
                 pool_id=DEFAULT_POOL_ID,
                 url=self.listen_at,
                 advertises={"cpu": True},
                 handlers={"handlers": list(self._handlers)},
             )
             created = self._client.call("Workers.create", params=payload)
+            if created_id := created.get("id"):
+                self.worker_id = str(created_id)
             self.log.info("registered @ gateway as %s", self.worker_id)
             api_key = created.get("api_key") or created.get("service_key")
             if api_key:


### PR DESCRIPTION
## Summary
- require primary key in AutoAPI update/replace schemas
- relax GUIDPk read_only to create-only
- update Peagen worker heartbeat to send returned id

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff check autoapi/v2/impl/schema.py autoapi/v2/mixins/__init__.py tests/i9n/test_schema.py --fix`
- `uv run --directory standards/peagen --package peagen ruff check peagen/worker/base.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_6892db7f82148326a7084595a9ce51cc