### PR TITLE
fix: require pk for rpc updates

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/impl/schema.py
+++ b/pkgs/standards/autoapi/autoapi/v2/impl/schema.py
@@ -87,7 +87,10 @@ def _schema(
             continue
         if meta.get("write_only") and verb == "read":
             continue
-        if meta.get("read_only") and verb != "read":
+        ro = meta.get("read_only")
+        if (ro is True and verb != "read") or (
+            isinstance(ro, (list, tuple, set)) and verb in ro
+        ):
             continue
         if is_hybrid and attr.fset is None and verb in {"create", "update", "replace"}:
             continue

--- a/pkgs/standards/autoapi/autoapi/v2/info_schema.py
+++ b/pkgs/standards/autoapi/autoapi/v2/info_schema.py
@@ -15,6 +15,9 @@ def check(meta: dict, attr: str, model: str):
     unknown = set(meta) - VALID_KEYS
     if unknown:
         raise RuntimeError(f"{model}.{attr}: bad autoapi keys {unknown}")
-    for verb in meta.get("disable_on", []):
-        if verb not in VALID_VERBS:
-            raise RuntimeError(f"{model}.{attr}: invalid verb “{verb}”")
+    for key in ("disable_on", "read_only"):
+        verbs = meta.get(key, [])
+        if isinstance(verbs, (list, tuple, set)):
+            for verb in verbs:
+                if verb not in VALID_VERBS:
+                    raise RuntimeError(f"{model}.{attr}: invalid verb “{verb}”")

--- a/pkgs/standards/autoapi/autoapi/v2/mixins/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v2/mixins/__init__.py
@@ -49,7 +49,7 @@ class GUIDPk:
         info=dict(
             autoapi={
                 "default_factory": uuid4,
-                "read_only": True,
+                "read_only": ["create"],
                 "examples": [uuid_example],
             }
         ),
@@ -161,9 +161,11 @@ class LastUsed:
         onupdate=tzutcnow,
         info=dict(no_create=True, no_update=True),
     )
+
     def touch(self) -> None:
         """Mark the object as used now."""
         self.last_used_at = tzutcnow()
+
 
 @declarative_mixin
 class Timestamped:

--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -174,7 +174,7 @@ class WorkerBase:
                     advertises={"cpu": True},
                     handlers={"handlers": list(self._handlers)},
                 )  # last_seen handled server-side
-                self._client.call("Workers.update", params=upd)
+                self._client.call("Workers.update", params=upd.model_dump())
                 self.log.debug("heartbeat ok")
             except Exception as exc:  # pragma: no cover
                 self.log.warning("heartbeat failed: %s", exc)

--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -133,13 +133,14 @@ class WorkerBase:
         """
         try:
             payload = SWorkerCreate(
-                id=self.worker_id,
                 pool_id=DEFAULT_POOL_ID,
                 url=self.listen_at,
                 advertises={"cpu": True},
                 handlers={"handlers": list(self._handlers)},
             )
             created = self._client.call("Workers.create", params=payload)
+            if created_id := created.get("id"):
+                self.worker_id = str(created_id)
             self.log.info("registered @ gateway as %s", self.worker_id)
             api_key = created.get("api_key") or created.get("service_key")
             if api_key:


### PR DESCRIPTION
## Summary
- ensure JSON-RPC update/replace calls include primary key
- allow per-verb read_only field metadata and expose id for GUIDPk updates
- send worker heartbeat updates with id

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff check . --fix`
- `uv run --directory standards/peagen --package peagen ruff check peagen/worker/base.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_6892db7f82148326a7084595a9ce51cc