### PR TITLE
Ensure primary key required for AutoAPI updates

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/hooks.py
+++ b/pkgs/standards/autoapi/autoapi/v2/hooks.py
@@ -64,10 +64,9 @@ def _init_hooks(self) -> None:
                     tab = model if model.endswith(("s", "S")) else f"{model}s"
                 else:
                     tab = getattr(model, "__tablename__", model.__name__)
-                # Preserve existing camelCase while upper-casing only the first
-                # letter of underscore-delimited segments. This avoids
-                # lowercasing already-camelcased portions like "ServiceKeys".
-                if "_" in tab:
+                if tab.islower():
+                    model_name = "".join(part.title() for part in tab.split("_"))
+                elif "_" in tab:
                     model_name = "".join(
                         part[:1].upper() + part[1:] for part in tab.split("_")
                     )

--- a/pkgs/standards/autoapi/autoapi/v2/mixins/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v2/mixins/__init__.py
@@ -49,7 +49,7 @@ class GUIDPk:
         info=dict(
             autoapi={
                 "default_factory": uuid4,
-                "read_only": True,
+                "read_only": {"create": True},
                 "examples": [uuid_example],
             }
         ),
@@ -161,9 +161,11 @@ class LastUsed:
         onupdate=tzutcnow,
         info=dict(no_create=True, no_update=True),
     )
+
     def touch(self) -> None:
         """Mark the object as used now."""
         self.last_used_at = tzutcnow()
+
 
 @declarative_mixin
 class Timestamped:
@@ -184,7 +186,7 @@ class Timestamped:
 
 @declarative_mixin
 class ActiveToggle:
-    is_active = Column(Boolean, default=True)
+    is_active = Column(Boolean, default=True, nullable=False)
 
 
 @declarative_mixin

--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -139,7 +139,7 @@ class WorkerBase:
                 advertises={"cpu": True},
                 handlers={"handlers": list(self._handlers)},
             )
-            created = self._client.call("Workers.create", params=payload)
+            created = self._client.call("Workers.create", params=payload.model_dump())
             self.log.info("registered @ gateway as %s", self.worker_id)
             api_key = created.get("api_key") or created.get("service_key")
             if api_key:
@@ -174,7 +174,7 @@ class WorkerBase:
                     advertises={"cpu": True},
                     handlers={"handlers": list(self._handlers)},
                 )  # last_seen handled server-side
-                self._client.call("Workers.update", params=upd)
+                self._client.call("Workers.update", params=upd.model_dump())
                 self.log.debug("heartbeat ok")
             except Exception as exc:  # pragma: no cover
                 self.log.warning("heartbeat failed: %s", exc)
@@ -213,7 +213,7 @@ class WorkerBase:
     ) -> None:
         try:
             upd = SWorkUpdate(id=work_id, status=status, result=result)
-            self._client.call("Works.update", params=upd)
+            self._client.call("Works.update", params=upd.model_dump())
             self.log.info("Works.update %s → %s", work_id, status)
         except Exception as exc:  # pragma: no cover
             self.log.error("notify failed: %s", exc)


### PR DESCRIPTION
## Summary
- include primary key fields in update/replace RPC schemas and require them in `GUIDPk`
- adjust hook registration to handle class-based model names consistently
- send worker heartbeats using serialized payloads

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest`
- `uv run --package peagen --directory standards/peagen pytest` *(fails: tests/unit/test_keys_core.py::test_create_keypair_uses_plugin_manager, tests/unit/test_keys_core.py::test_export_public_key_delegates, tests/unit/test_migrate_core.py::test_alembic_upgrade_invokes_subprocess, tests/unit/test_migrate_core.py::test_alembic_revision_invokes_subprocess, tests/unit/test_migrate_core.py::test_alembic_upgrade_stream, tests/unit/test_task_submit.py::test_submit_task_sends_request)*

------
https://chatgpt.com/codex/tasks/task_e_6892db7f82148326a7084595a9ce51cc