### PR TITLE
Fix worker heartbeat serialization and gateway principal parsing

### DIFF
--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -139,7 +139,10 @@ class WorkerBase:
                 advertises={"cpu": True},
                 handlers={"handlers": list(self._handlers)},
             )
-            created = self._client.call("Workers.create", params=payload.model_dump())
+            created = self._client.call(
+                "Workers.create", params=payload.model_dump(mode="json")
+            )
+            self.worker_id = str(created.get("id", self.worker_id))
             self.log.info("registered @ gateway as %s", self.worker_id)
             api_key = created.get("api_key") or created.get("service_key")
             if api_key:
@@ -174,7 +177,7 @@ class WorkerBase:
                     advertises={"cpu": True},
                     handlers={"handlers": list(self._handlers)},
                 )  # last_seen handled server-side
-                self._client.call("Workers.update", params=upd.model_dump())
+                self._client.call("Workers.update", params=upd.model_dump(mode="json"))
                 self.log.debug("heartbeat ok")
             except Exception as exc:  # pragma: no cover
                 self.log.warning("heartbeat failed: %s", exc)
@@ -213,7 +216,7 @@ class WorkerBase:
     ) -> None:
         try:
             upd = SWorkUpdate(id=work_id, status=status, result=result)
-            self._client.call("Works.update", params=upd.model_dump())
+            self._client.call("Works.update", params=upd.model_dump(mode="json"))
             self.log.info("Works.update %s → %s", work_id, status)
         except Exception as exc:  # pragma: no cover
             self.log.error("notify failed: %s", exc)


### PR DESCRIPTION
## Summary
- ensure worker RPC payloads serialize UUIDs and track gateway-assigned IDs
- normalize principal UUIDs in gateway to avoid heartbeat failures

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format peagen/worker/base.py peagen/gateway/__init__.py`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check peagen/worker/base.py peagen/gateway/__init__.py --fix`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn uvicorn auto_authn.v2.app:app --port 7000 --host 0.0.0.0`
- `uv run --directory pkgs/standards/peagen --package peagen uvicorn peagen.gateway:app --port 8000 --host 0.0.0.0`
- `uv run --directory pkgs/standards/peagen --package peagen uvicorn peagen.worker:app --port 8001 --host 0.0.0.0`


------
https://chatgpt.com/codex/tasks/task_e_6892e2c622bc83269ea5758104f481f5