### PR TITLE
fix: ensure rpc params json serializable

### DIFF
--- a/pkgs/standards/autoapi_client/autoapi_client/_rpc.py
+++ b/pkgs/standards/autoapi_client/autoapi_client/_rpc.py
@@ -76,7 +76,8 @@ class RPCMixin:
         if isinstance(params, _Schema):  # pydantic in → dump to dict
             params_dict = json.loads(params.model_dump_json())
         else:
-            params_dict = params or {}
+            # ensure plain dicts contain only JSON-serializable values
+            params_dict = json.loads(json.dumps(params or {}, default=str))
 
         req = {
             "jsonrpc": "2.0",


### PR DESCRIPTION
## Summary
- ensure rpc payloads safely serialize UUIDs or other non-native types

## Testing
- `uv run --directory standards/peagen --package peagen uvicorn peagen.worker:app --host 0.0.0.0 --port 8001` (fails before fix)
- `uv run --directory standards/peagen --package peagen uvicorn peagen.worker:app --host 0.0.0.0 --port 8001`

------
https://chatgpt.com/codex/tasks/task_e_6892e2a1b8a083269933cebf9b9a21de