### PR TITLE
Fix peagen init_repo for GitHub repos

### DIFF
--- a/pkgs/standards/peagen/peagen/_utils/_init.py
+++ b/pkgs/standards/peagen/peagen/_utils/_init.py
@@ -10,6 +10,12 @@ import uuid
 import typer
 from peagen.handlers.init_handler import init_handler
 from peagen.plugins import discover_and_register_plugins
+from peagen.defaults import (
+    DEFAULT_POOL_ID,
+    DEFAULT_TENANT_ID,
+    DEFAULT_SUPER_USER_ID,
+)
+from peagen.orm import Action
 
 
 # Allow tests to monkeypatch ``uuid.uuid4`` without affecting the global ``uuid``
@@ -42,12 +48,13 @@ def _call_handler(args: Dict[str, Any]) -> Dict[str, Any]:
     from peagen.cli.task_helpers import build_task
 
     task = build_task(
-        action="init",
+        action=Action.FETCH,
         args=args,
-        tenant_id="local",
-        pool_id="default",
+        tenant_id=str(DEFAULT_TENANT_ID),
+        pool_id=str(DEFAULT_POOL_ID),
         repo="local",
         ref="HEAD",
+        owner_id=str(DEFAULT_SUPER_USER_ID),
     )
     task = task.model_copy(update={"id": str(_uuid_alias.uuid4())})
     return asyncio.run(init_handler(task))

--- a/pkgs/standards/peagen/peagen/cli/task_helpers.py
+++ b/pkgs/standards/peagen/peagen/cli/task_helpers.py
@@ -19,6 +19,7 @@ def build_task(
     ref: str,
     args: Dict[str, Any] | None = None,
     # Optional columns
+    owner_id: Optional[str] = None,
     repository_id: Optional[str] = None,  # slug-only flow leaves this None
     config_toml: Optional[str] = None,
     spec_kind: Optional[SpecKind | str] = None,
@@ -38,6 +39,7 @@ def build_task(
         tenant_id=tenant_id,
         pool_id=pool_id,
         action=action,
+        owner_id=owner_id,
         repository_id=repository_id,  # may be None → pre-hook resolves it
         repo=repo,
         ref=ref,

--- a/pkgs/standards/peagen/peagen/core/init_core.py
+++ b/pkgs/standards/peagen/peagen/core/init_core.py
@@ -214,7 +214,11 @@ def init_repo(
     try:
         owner = gh.get_organization(tenant)
     except Exception:
-        owner = gh.get_user(tenant)
+        auth_user = gh.get_user()
+        if auth_user.login.lower() == tenant.lower():
+            owner = auth_user
+        else:
+            owner = gh.get_user(tenant)
 
     try:
         repo_obj = owner.create_repo(name, private=True, description=description)


### PR DESCRIPTION
## Summary
- fix `_call_handler` to supply UUID defaults and Action/owner values
- extend `build_task` for owner IDs
- handle personal repos in `init_repo`

## Testing
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_utils_init.py::test_call_handler_invokes_handler -q -p no:pytest_monitor`
- `curl -H "Authorization: token $GITHUB_PAT" https://api.github.com/repos/gslcloud/peagen-demo-20240609`
- `git ls-remote https://git.peagen.com/gslcloud/peagen-demo-20240609.git` *(fails: not found)*
- `uv run --package peagen --directory standards/peagen pytest` *(fails: 6 tests)*

------
https://chatgpt.com/codex/tasks/task_e_6893492400048326a06a36ffc73e069d