### PR TITLE
fix remote repo init

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/init.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/init.py
@@ -351,6 +351,7 @@ def remote_init_repo(
         remote_name=remote_name,
         tenant_id=str(DEFAULT_TENANT_ID),
         owner_id=str(DEFAULT_SUPER_USER_ID),
+        status="waiting",
     )
     rpc = ctx.obj["rpc"]
     try:


### PR DESCRIPTION
## Summary
- ensure `peagen remote init repo` sets a default status when registering repositories

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format peagen/cli/commands/init.py`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/cli/commands/init.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_68935291dc4c83269495da3b296a2963