### PR TITLE
fix: remove duplicate owner_id arg

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/task_helpers.py
+++ b/pkgs/standards/peagen/peagen/cli/task_helpers.py
@@ -27,7 +27,6 @@ def build_task(
     note: Optional[str] = None,
     labels: Optional[Dict[str, Any]] = None,
     status: Status = Status.WAITING,
-    owner_id: Optional[str] = None,
 ):
     """
     Return a TaskCreate Pydantic instance that matches AutoAPI's
@@ -51,7 +50,6 @@ def build_task(
         labels=labels or {},
         note=note,
         status=status,
-        owner_id=owner_id,
     )
 
 


### PR DESCRIPTION
## Summary
- fix duplicate owner_id parameter in build_task helper

## Testing
- `AutoAPIClient` user and api key creation
- `peagen local init repo gslcloud/shadow-demo-repo --pat <redacted>`
- `curl -H "Authorization: token <redacted>" https://api.github.com/repos/gslcloud/shadow-demo-repo`
- `curl -H "Authorization: token <redacted>" http://localhost:9000/api/v1/repos/gslcloud/shadow-demo-repo`


------
https://chatgpt.com/codex/tasks/task_e_68935ce76724832684bb83621fa3840d