### PR TITLE
Configure repo remotes during initialization

### DIFF
--- a/pkgs/standards/peagen/peagen/core/init_core.py
+++ b/pkgs/standards/peagen/peagen/core/init_core.py
@@ -21,6 +21,7 @@ from peagen.plugins import (
     discover_and_register_plugins,
     registry,
 )
+from peagen._utils.config_loader import resolve_cfg
 from peagen.core.doe_core import _sha256
 
 
@@ -262,4 +263,15 @@ def init_repo(
 
 def configure_repo(*, path: Path, remotes: dict[str, str]) -> Dict[str, Any]:
     """Configure an existing repository with additional remotes."""
+    cfg = resolve_cfg()
+    vcs_cfg = cfg.setdefault("vcs", {})
+    adapters = vcs_cfg.setdefault("adapters", {})
+    default = vcs_cfg.get("default_vcs", "git")
+    adapter_cfg = adapters.setdefault(default, {})
+    adapter_cfg["path"] = str(path)
+    if remotes:
+        adapter_cfg.setdefault("remotes", {})
+        adapter_cfg["remotes"].update(remotes)
+    pm = PluginManager(cfg)
+    pm.get("vcs", default)
     return {"configured": str(path), "remotes": remotes}

--- a/pkgs/standards/peagen/tests/unit/test_init_core_repo_config.py
+++ b/pkgs/standards/peagen/tests/unit/test_init_core_repo_config.py
@@ -1,0 +1,19 @@
+import pytest
+from git import Repo
+
+from peagen.core import init_core
+
+
+@pytest.mark.unit
+def test_configure_repo_adds_remotes(tmp_path):
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    remotes = {
+        "origin": "https://example.com/origin.git",
+        "shadow": "https://git.peagen.com/shadow.git",
+    }
+    result = init_core.configure_repo(path=repo_dir, remotes=remotes)
+    repo = Repo(str(repo_dir))
+    configured = {r.name: list(r.urls)[0] for r in repo.remotes}
+    assert configured == remotes
+    assert result == {"configured": str(repo_dir), "remotes": remotes}


### PR DESCRIPTION
## Summary
- configure git remotes using PluginManager in init_core.configure_repo
- add unit test ensuring configure_repo adds remotes

## Testing
- `uv run --directory . --package peagen ruff format .`
- `uv run --directory . --package peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest` *(fails: 6 failed, 144 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6893614f385c83268b27a3cf8b76141f