### PR TITLE
feat(peagen): auto configure and push repo

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/init.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/init.py
@@ -76,7 +76,9 @@ def local_init_repo(
     pat: str = typer.Option(..., envvar="GITHUB_PAT", help="GitHub PAT"),
     description: str = typer.Option("", help="Repository description"),
     deploy_key: Path = typer.Option(None, "--deploy-key", help="Existing private key"),
-    path: Path = typer.Option(None, "--path", help="Existing repository to configure"),
+    path: Path = typer.Option(
+        Path("."), "--path", help="Existing repository to configure"
+    ),
     origin: str = typer.Option(None, "--origin", help="Origin remote URL"),
     upstream: str = typer.Option(None, "--upstream", help="Upstream remote URL"),
 ) -> None:
@@ -89,16 +91,14 @@ def local_init_repo(
         "pat": pat,
         "description": description,
         "deploy_key": str(deploy_key) if deploy_key else None,
+        "path": str(path),
     }
-    if path is not None:
-        args["path"] = str(path)
-    if origin or upstream:
-        remotes: Dict[str, str] = {}
-        if origin:
-            remotes["origin"] = origin
-        if upstream:
-            remotes["upstream"] = upstream
-        args["remotes"] = remotes
+    remotes: Dict[str, str] = {}
+    if origin:
+        remotes["origin"] = origin
+    if upstream:
+        remotes["upstream"] = upstream
+    args["remotes"] = remotes
     result = _call_handler(args)
     _summary(Path("."), result["next"])
     self.logger.info("Exiting local init_repo command")

--- a/pkgs/standards/peagen/tests/unit/test_init_core_init_repo.py
+++ b/pkgs/standards/peagen/tests/unit/test_init_core_init_repo.py
@@ -1,0 +1,47 @@
+import pytest
+from git import Repo
+from unittest.mock import Mock, call, patch
+
+from peagen.core import init_core
+
+
+@pytest.mark.unit
+@patch("peagen.core.init_core.open_repo")
+@patch("peagen.core.init_core.configure_repo")
+@patch("peagen.core.init_core.Github")
+def test_init_repo_configures_and_pushes(
+    GithubMock, configure_repo_mock, open_repo_mock, tmp_path
+):
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    repo = Repo.init(repo_dir)
+    (repo_dir / "README.md").write_text("hi")
+    repo.git.add(all=True)
+    repo.git.commit("-m", "init")
+
+    gh = GithubMock.return_value
+    owner = Mock()
+    gh.get_organization.side_effect = Exception
+    gh.get_user.return_value = owner
+    repo_obj = Mock()
+    repo_obj.clone_url = "https://github.com/tenant/repo.git"
+    repo_obj.ssh_url = "git@github.com:tenant/repo.git"
+    owner.create_repo.return_value = repo_obj
+    repo_obj.create_key.return_value = None
+
+    vcs_mock = Mock()
+    open_repo_mock.return_value = vcs_mock
+
+    result = init_core.init_repo(repo="tenant/repo", pat="TOKEN", path=repo_dir)
+
+    expected_remotes = {
+        "origin": "https://git.peagen.com/tenant/repo.git",
+        "upstream": "git@github.com:tenant/repo.git",
+    }
+    configure_repo_mock.assert_called_once_with(path=repo_dir, remotes=expected_remotes)
+    open_repo_mock.assert_called_once_with(repo_dir, remotes=expected_remotes)
+    assert vcs_mock.push.call_args_list == [
+        call("HEAD", remote="origin"),
+        call("HEAD", remote="upstream"),
+    ]
+    assert result["remotes"] == expected_remotes


### PR DESCRIPTION
## Summary
- automatically configure local repo and remotes during `peagen init repo`
- push initial commit to both shadow and origin remotes
- cover repo initialization with unit test

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format peagen/cli/commands/init.py peagen/core/init_core.py tests/unit/test_init_core_init_repo.py`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/cli/commands/init.py peagen/core/init_core.py tests/unit/test_init_core_init_repo.py --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_init_core_init_repo.py`
- `uv run --package peagen --directory pkgs/standards/peagen pytest` *(fails: test_keys_core, test_migrate_core, test_task_submit)*

------
https://chatgpt.com/codex/tasks/task_e_689366f0dbfc8326b47ea6a83194f0ff