### PR TITLE
Clarify tenant vs principal terminology

### DIFF
--- a/pkgs/standards/auto_authn/README.md
+++ b/pkgs/standards/auto_authn/README.md
@@ -5,6 +5,11 @@ Identity‑Provider written in Python 3.11+.
 It is designed for SaaS vendors who need per‑customer (tenant) isolation while
 running a single scalable cluster.
 
+### Terminology
+
+- **Tenant** – a namespace used to group related resources such as repositories or clients.
+- **Principal** – an owner of resources, for example an individual user or an organization.
+
 ---
 
 ## ✨ Features

--- a/pkgs/standards/autoapi/README.md
+++ b/pkgs/standards/autoapi/README.md
@@ -2,6 +2,11 @@
 
 A high-leverage meta-framework that turns plain SQLAlchemy models into a fully-featured REST+RPC surface with near zero boiler plate.
 
+## Terminology
+
+- **Tenant** – a namespace used to group related resources.
+- **Principal** – an owner of resources, such as an individual user or an organization.
+
 ## Features
 - Unified invocation 
 - Automated REST & RPC symmetry and parity

--- a/pkgs/standards/peagen/README.md
+++ b/pkgs/standards/peagen/README.md
@@ -18,6 +18,11 @@
 
 # Peagen: a Template‑Driven Workflow
 
+## Terminology
+
+- **Tenant** – a namespace used to group related resources, such as repositories.
+- **Principal** – an owner of resources (for example, an individual user or an organization).
+
 ## Why Use the Peagen CLI?
 
 #### Reduced Variance in LLM‑Driven Generation  

--- a/pkgs/standards/peagen/tests/unit/test_init_core_init_repo.py
+++ b/pkgs/standards/peagen/tests/unit/test_init_core_init_repo.py
@@ -24,19 +24,19 @@ def test_init_repo_configures_and_pushes(
     gh.get_organization.side_effect = Exception
     gh.get_user.return_value = owner
     repo_obj = Mock()
-    repo_obj.clone_url = "https://github.com/tenant/repo.git"
-    repo_obj.ssh_url = "git@github.com:tenant/repo.git"
+    repo_obj.clone_url = "https://github.com/principal/repo.git"
+    repo_obj.ssh_url = "git@github.com:principal/repo.git"
     owner.create_repo.return_value = repo_obj
     repo_obj.create_key.return_value = None
 
     vcs_mock = Mock()
     open_repo_mock.return_value = vcs_mock
 
-    result = init_core.init_repo(repo="tenant/repo", pat="TOKEN", path=repo_dir)
+    result = init_core.init_repo(repo="principal/repo", pat="TOKEN", path=repo_dir)
 
     expected_remotes = {
-        "origin": "https://git.peagen.com/tenant/repo.git",
-        "upstream": "git@github.com:tenant/repo.git",
+        "origin": "https://git.peagen.com/principal/repo.git",
+        "upstream": "git@github.com:principal/repo.git",
     }
     configure_repo_mock.assert_called_once_with(path=repo_dir, remotes=expected_remotes)
     open_repo_mock.assert_called_once_with(repo_dir, remotes=expected_remotes)


### PR DESCRIPTION
## Summary
- distinguish principals from tenants in init_repo unit test
- document tenant vs principal terminology for Peagen, AutoAPI, and Auto-AuthN

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68936ede88288326b430ab98f70c47b1