### PR TITLE
feat(peagen): default repo remotes

### DIFF
--- a/pkgs/standards/peagen/docs/git_vcs.md
+++ b/pkgs/standards/peagen/docs/git_vcs.md
@@ -107,6 +107,9 @@ push results back to it.
 
    This calls the GitHub API, creates an Ed25519 key pair and registers the
    public key as a deploy key so the CLI can push via SSH.
+   If ``--origin`` or ``--upstream`` are omitted, the command defaults the
+   former to ``https://git.peagen.com/<principal>/<repo>.git`` and the latter to
+   ``git@github.com:<principal>/<repo>.git``.
 
 2. **Authenticate with the gateway** – upload the same public key so the gateway
    can verify your requests.


### PR DESCRIPTION
## Summary
- default `peagen local init repo` remotes to git.peagen.com and GitHub when unspecified
- use `principal/repo` terminology for default remote URLs in CLI and docs

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format peagen/cli/commands/init.py`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/cli/commands/init.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_68938874100c8326bf2dfe59b7f68852