### PR TITLE
fix peagen init repo defaults

### DIFF
--- a/pkgs/standards/peagen/docs/git_vcs.md
+++ b/pkgs/standards/peagen/docs/git_vcs.md
@@ -108,7 +108,10 @@ push results back to it.
    This calls the GitHub API, creates an Ed25519 key pair and registers the
    public key as a deploy key so the CLI can push via SSH.
    If ``--origin`` or ``--upstream`` are omitted, the command defaults the
-   former to ``https://git.peagen.com/<principal>/<repo>.git`` and the latter to
+   former to ``git@github.com:<principal>/<repo>.git`` and omits the latter.
+
+   For remote repositories, ``peagen remote init repo`` defaults the origin to
+   ``https://git.peagen.com/<principal>/<repo>.git`` and the upstream to
    ``git@github.com:<principal>/<repo>.git``.
 
 2. **Authenticate with the gateway** – upload the same public key so the gateway

--- a/pkgs/standards/peagen/peagen/cli/commands/init.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/init.py
@@ -99,11 +99,9 @@ def local_init_repo(
     if origin:
         remotes["origin"] = origin
     else:
-        remotes["origin"] = f"{GIT_SHADOW_BASE.rstrip('/')}/{principal}/{name}.git"
+        remotes["origin"] = f"git@github.com:{principal}/{name}.git"
     if upstream:
         remotes["upstream"] = upstream
-    else:
-        remotes["upstream"] = f"git@github.com:{principal}/{name}.git"
     args["remotes"] = remotes
     result = _call_handler(args)
     _summary(Path("."), result["next"])
@@ -335,11 +333,11 @@ def remote_init_ci(  # noqa: PLR0913
 def remote_init_repo(
     ctx: typer.Context,
     repo_slug: str = typer.Argument(..., help="principal/repo"),
-    url: str = typer.Option(None, "--url", help="Repository URL"),
+    origin: str = typer.Option(None, "--origin", help="Origin remote URL"),
+    upstream: str = typer.Option(None, "--upstream", help="Upstream remote URL"),
     default_branch: str = typer.Option("main", "--default-branch"),
-    remote_name: str = typer.Option("origin", "--remote-name"),
 ) -> None:
-    """Register *repo_slug* with the gateway via JSON-RPC."""
+    """Register *repo_slug* with the gateway and configure remotes."""
     self = Logger(name="init_repo")
     self.logger.info("Entering remote init_repo command")
     try:
@@ -347,14 +345,15 @@ def remote_init_repo(
     except ValueError:
         typer.echo("❌  repo must be in 'principal/name' format", err=True)
         raise typer.Exit(1)
-    repo_url = url or f"https://github.com/{principal}/{name}"
+    origin_url = origin or f"{GIT_SHADOW_BASE.rstrip('/')}/{principal}/{name}.git"
+    upstream_url = upstream or f"git@github.com:{principal}/{name}.git"
     SCreate = AutoAPI.get_schema(Repository, "create")
     SRead = AutoAPI.get_schema(Repository, "read")
     params = SCreate(
         name=name,
-        url=repo_url,
+        url=origin_url,
         default_branch=default_branch,
-        remote_name=remote_name,
+        remote_name="origin",
         tenant_id=str(DEFAULT_TENANT_ID),
         owner_id=str(DEFAULT_SUPER_USER_ID),
         status="queued",
@@ -366,4 +365,10 @@ def remote_init_repo(
     except Exception as exc:  # noqa: BLE001
         typer.echo(f"❌  {exc}", err=True)
         raise typer.Exit(1)
+    args = {
+        "kind": "repo-config",
+        "path": ".",
+        "remotes": {"origin": origin_url, "upstream": upstream_url},
+    }
+    _remote_task("init", args, ctx, origin_url, default_branch)
     self.logger.info("Exiting remote init_repo command")

--- a/pkgs/standards/peagen/peagen/core/init_core.py
+++ b/pkgs/standards/peagen/peagen/core/init_core.py
@@ -17,7 +17,6 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape, Template
 from github import Github
 
 from peagen.core.git_repo_core import open_repo
-from peagen.defaults import GIT_SHADOW_BASE
 
 from peagen.plugins import (
     PluginManager,
@@ -262,9 +261,7 @@ def init_repo(
         path = Path(".")
 
     final_remotes = remotes.copy() if remotes else {}
-    shadow_url = f"{GIT_SHADOW_BASE.rstrip('/')}/{tenant}/{name}.git"
-    final_remotes.setdefault("origin", shadow_url)
-    final_remotes.setdefault("upstream", repo_obj.ssh_url)
+    final_remotes.setdefault("origin", repo_obj.ssh_url)
     configure_repo(path=path, remotes=final_remotes)
     vcs = open_repo(path, remotes=final_remotes)
     for remote_name in final_remotes:


### PR DESCRIPTION
## Summary
- ensure local `peagen init repo` defaults origin to GitHub and omits upstream
- make `peagen remote init repo` default to git shadow origin and GitHub upstream
- document new remote defaults

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff check peagen/cli/commands/init.py peagen/core/init_core.py --fix`

------
https://chatgpt.com/codex/tasks/task_e_6893913296408326b2e2c2899bd030f4