### PR TITLE
fix: include user id when uploading public key

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/publickey.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/publickey.py
@@ -9,7 +9,7 @@ import typer
 from httpx import HTTPError
 
 from peagen.plugins.cryptos import ParamikoCrypto
-from peagen.core.login_core import login as core_login
+from peagen.core.publickey_core import login as core_login
 from peagen.defaults import DEFAULT_GATEWAY
 
 

--- a/pkgs/standards/peagen/peagen/core/publickey_core.py
+++ b/pkgs/standards/peagen/peagen/core/publickey_core.py
@@ -19,7 +19,7 @@ from autoapi_client import AutoAPIClient  # ← new client
 from autoapi.v2 import AutoAPI  # ← for .get_schema()
 from peagen.orm import PublicKey  # ORM resource
 
-from peagen.defaults import DEFAULT_GATEWAY
+from peagen.defaults import DEFAULT_GATEWAY, DEFAULT_SUPER_USER_ID
 from peagen.plugins.cryptos import ParamikoCrypto
 
 __all__ = ["login"]
@@ -49,13 +49,17 @@ def login(
     """
     # 1 ─ ensure local SSH key-pair
     drv = ParamikoCrypto(key_dir=key_dir, passphrase=passphrase)
-    public_key = drv.public_key_str()          # returns single-line OpenSSH key
+    public_key = drv.public_key_str()  # returns single-line OpenSSH key
 
     # 2 ─ build request/response schemas dynamically
     SCreate = _schema("create")
     SRead = _schema("read")
 
-    params = SCreate(public_key=public_key, title="default")
+    params = SCreate(
+        public_key=public_key,
+        title="default",
+        user_id=str(DEFAULT_SUPER_USER_ID),
+    )
 
     # 3 ─ JSON-RPC call via AutoAPIClient
     with AutoAPIClient(gateway_url, client=httpx.Client(timeout=timeout_s)) as rpc:


### PR DESCRIPTION
## Summary
- include DEFAULT_SUPER_USER_ID when calling PublicKeys.create during login
- rename login_core module to publickey_core and update CLI imports

## Testing
- `uv run --directory standards/peagen --package peagen ruff format peagen/core/publickey_core.py peagen/cli/commands/publickey.py`
- `uv run --directory standards/peagen --package peagen ruff check peagen/core/publickey_core.py peagen/cli/commands/publickey.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_68939dead21483268326ae7bd26d0294