### PR TITLE
Resolve owner for remote repo init

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_cli_remote_init_repo.py
+++ b/pkgs/standards/peagen/tests/unit/test_cli_remote_init_repo.py
@@ -1,0 +1,49 @@
+import importlib
+import uuid
+from unittest.mock import Mock, patch
+
+import click
+import pytest
+import typer
+
+from peagen.cli.commands import init as init_cmd
+from peagen.defaults import DEFAULT_TENANT_ID
+from peagen.orm import Repository
+
+
+@pytest.mark.unit
+def test_remote_init_repo_uses_current_user_id():
+    rpc = Mock()
+    ctx = typer.Context(click.Command("cmd"), obj={"rpc": rpc})
+
+    autoapi_module = importlib.reload(importlib.import_module("autoapi.v2"))
+    orig_get_schema = autoapi_module.AutoAPI.get_schema
+    User = importlib.import_module("autoapi.v2.tables.user").User
+
+    SURead = orig_get_schema(User, "read")
+    user = SURead(username="tester", id=uuid.uuid4(), tenant_id=DEFAULT_TENANT_ID)
+    SRepoRead = orig_get_schema(Repository, "read")
+    repo = SRepoRead(
+        name="repo",
+        url="https://git.peagen.com/foo/repo.git",
+        default_branch="main",
+        remote_name="origin",
+        id=uuid.uuid4(),
+        tenant_id=DEFAULT_TENANT_ID,
+        owner_id=user.id,
+    )
+    rpc.call.side_effect = [user, repo]
+
+    with (
+        patch.object(init_cmd.AutoAPI, "get_schema", orig_get_schema),
+        patch("peagen.cli.commands.init._remote_task"),
+    ):
+        init_cmd.remote_init_repo(
+            ctx, "foo/repo", origin=None, upstream=None, default_branch="main"
+        )
+
+    assert rpc.call.call_args_list[0][0][0] == "Users.me"
+    second_call = rpc.call.call_args_list[1]
+    assert second_call[0][0] == "Repositories.create"
+    params = second_call[1]["params"]
+    assert str(params.owner_id) == str(user.id)


### PR DESCRIPTION
## Summary
- fetch authenticated user via `Users.me` when registering remote repos
- test remote repo init uses current user's id

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format peagen/cli/commands/init.py tests/unit/test_cli_remote_init_repo.py`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check peagen/cli/commands/init.py tests/unit/test_cli_remote_init_repo.py --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_cli_remote_init_repo.py::test_remote_init_repo_uses_current_user_id -q`


------
https://chatgpt.com/codex/tasks/task_e_6893972f1cd08326ba028f0bfa689090