### PR TITLE
fix: use authenticated user for repo owner

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/init.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/init.py
@@ -17,7 +17,6 @@ from peagen.cli.task_helpers import build_task, submit_task
 from peagen.errors import PATNotAllowedError
 from peagen.defaults import (
     DEFAULT_POOL_ID,
-    DEFAULT_SUPER_USER_ID,
     DEFAULT_TENANT_ID,
     GIT_SHADOW_BASE,
 )
@@ -355,7 +354,6 @@ def remote_init_repo(
         default_branch=default_branch,
         remote_name="origin",
         tenant_id=str(DEFAULT_TENANT_ID),
-        owner_id=str(DEFAULT_SUPER_USER_ID),
         status="queued",
     )
     rpc = ctx.obj["rpc"]


### PR DESCRIPTION
## Summary
- rely on authenticated context to set repository owner

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format peagen/cli/commands/init.py`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/cli/commands/init.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_6893972f1cd08326ba028f0bfa689090