### PR TITLE
feat(autoapi): expose hook registry via hookz endpoint

### DIFF
--- a/pkgs/standards/autoapi/README.md
+++ b/pkgs/standards/autoapi/README.md
@@ -16,5 +16,5 @@ A high-leverage meta-framework that turns plain SQLAlchemy models into a fully-f
 - Table level configurations: __autoapi_nested_paths__, __autoapi_allow_anon__, & __autoapi_register_hooks__
 - Column level configurations: info_schema ( disable_on, write_only, read_only, default_factory, examples, hybrid (hybrid properties), py_type)
 - `_apply_row_filters` / _RowBound hook providers
-- Automated route creation: rest paths or nested rest paths, rpc gateway, healthz, methodz
+- Automated route creation: rest paths or nested rest paths, rpc gateway, healthz, methodz, hookz
 - Support for AuthNProvider extensions

--- a/pkgs/standards/autoapi/tests/i9n/test_healthz_methodz_hookz.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_healthz_methodz_hookz.py
@@ -1,7 +1,7 @@
 """
-Healthz and Methodz Endpoints Tests for AutoAPI v2
+Healthz, Methodz and Hookz Endpoints Tests for AutoAPI v2
 
-Tests that healthz and methodz endpoints are properly attached and behave as expected.
+Tests that healthz, methodz and hookz endpoints are properly attached and behave as expected.
 """
 
 import pytest
@@ -79,6 +79,26 @@ async def test_methodz_endpoint_comprehensive(api_client):
 
 @pytest.mark.i9n
 @pytest.mark.asyncio
+async def test_hookz_endpoint_comprehensive(api_client):
+    """Test hookz endpoint attachment, behavior, and response format."""
+    client, api, _ = api_client
+
+    routes = [route.path for route in api.router.routes]
+    assert "/hookz" in routes
+
+    response = await client.get("/hookz")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/json")
+
+    data = response.json()
+    assert isinstance(data, dict)
+    for phase, hooks in data.items():
+        assert isinstance(phase, str)
+        assert isinstance(hooks, dict)
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
 async def test_methodz_basic_functionality(api_client):
     """Test that methodz endpoint provides basic method information."""
     client, api, _ = api_client
@@ -98,8 +118,8 @@ async def test_methodz_basic_functionality(api_client):
 
 @pytest.mark.i9n
 @pytest.mark.asyncio
-async def test_healthz_methodz_in_openapi_schema(api_client):
-    """Test that healthz and methodz endpoints are included in OpenAPI schema."""
+async def test_healthz_methodz_hookz_in_openapi_schema(api_client):
+    """Test that healthz, methodz and hookz endpoints are included in OpenAPI schema."""
     client, api, _ = api_client
 
     # Get OpenAPI schema
@@ -107,9 +127,10 @@ async def test_healthz_methodz_in_openapi_schema(api_client):
     spec = spec_response.json()
     paths = spec["paths"]
 
-    # healthz and methodz should be in OpenAPI spec
+    # healthz, methodz and hookz should be in OpenAPI spec
     assert "/healthz" in paths
     assert "/methodz" in paths
+    assert "/hookz" in paths
 
 
 @pytest.mark.i9n
@@ -152,7 +173,7 @@ async def test_methodz_reflects_dynamic_models(api_client):
 @pytest.mark.i9n
 @pytest.mark.asyncio
 async def test_endpoints_are_synchronous(api_client):
-    """Test that healthz and methodz endpoints work in sync mode."""
+    """Test that healthz, methodz and hookz endpoints work in sync mode."""
     client, api, _ = api_client
 
     # These endpoints should work regardless of async/sync context
@@ -162,6 +183,10 @@ async def test_endpoints_are_synchronous(api_client):
     methodz_response = await client.get("/methodz")
     assert methodz_response.status_code == 200
 
+    hookz_response = await client.get("/hookz")
+    assert hookz_response.status_code == 200
+
     # Responses should be immediate and not require async database operations
     assert healthz_response.json()
     assert methodz_response.json()
+    assert hookz_response.json()


### PR DESCRIPTION
## Summary
- expose hook registry with new `/hookz` diagnostic endpoint
- document hookz alongside existing autoapi routes
- cover hookz endpoint with integration tests

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check autoapi/v2/endpoints.py tests/i9n/test_healthz_methodz_hookz.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_6894dc4ab0688326896a81d7022fbc27