### PR TITLE
Clarify hook names in hookz endpoint

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/hooks.py
+++ b/pkgs/standards/autoapi/autoapi/v2/hooks.py
@@ -55,6 +55,10 @@ def _init_hooks(self) -> None:
                 else (lambda ctx, f=f: f(ctx))  # sync-to-async shim
             )
 
+            # Preserve the original function name for registry visibility
+            async_f.__name__ = getattr(f, "__name__", repr(f))
+            async_f.__qualname__ = getattr(f, "__qualname__", async_f.__name__)
+
             # Determine the hook key based on parameters
             hook_key = None
 

--- a/pkgs/standards/autoapi/tests/i9n/test_healthz_methodz_hookz.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_healthz_methodz_hookz.py
@@ -5,6 +5,7 @@ Tests that healthz, methodz and hookz endpoints are properly attached and behave
 """
 
 import pytest
+from autoapi.v2 import Phase
 
 
 @pytest.mark.i9n
@@ -83,6 +84,10 @@ async def test_hookz_endpoint_comprehensive(api_client):
     """Test hookz endpoint attachment, behavior, and response format."""
     client, api, _ = api_client
 
+    @api.hook(Phase.POST_RESPONSE)
+    def sample_hook(ctx):
+        pass
+
     routes = [route.path for route in api.router.routes]
     assert "/hookz" in routes
 
@@ -92,6 +97,8 @@ async def test_hookz_endpoint_comprehensive(api_client):
 
     data = response.json()
     assert isinstance(data, dict)
+    assert "POST_RESPONSE" in data
+    assert "sample_hook" in data["POST_RESPONSE"]["*"]
     for phase, hooks in data.items():
         assert isinstance(phase, str)
         assert isinstance(hooks, dict)


### PR DESCRIPTION
## Summary
- Preserve original function names when wrapping sync hooks so /hookz reports meaningful identifiers
- Cover hook naming in hookz endpoint with a test registering a sync hook

## Testing
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_6894f43a872c8326aeb656234a3245cd