### PR TITLE
fix authn context injection

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/_runner.py
+++ b/pkgs/standards/autoapi/autoapi/v2/_runner.py
@@ -7,6 +7,11 @@ from types import SimpleNamespace
 from .hooks import Phase
 
 
+class _Ctx(dict):
+    __getattr__ = dict.__getitem__
+    __setattr__ = dict.__setitem__
+
+
 # ---------------------------------------------------------------------------#
 async def _invoke(
     api,
@@ -34,6 +39,7 @@ async def _invoke(
     -------
     The raw result (dict / list / pydantic dump) produced by the business func.
     """
+    ctx = _Ctx(ctx)
     db = ctx["db"]
 
     try:

--- a/pkgs/standards/autoapi/autoapi/v2/hooks.py
+++ b/pkgs/standards/autoapi/autoapi/v2/hooks.py
@@ -93,7 +93,7 @@ def _init_hooks(self) -> None:
 async def _run(self, phase: Phase, ctx: Dict[str, Any]) -> None:
     """Run hooks for *phase* in order and stop on the first error."""
     m = getattr(ctx.get("env"), "method", None)
-    hooks = list(self._hook_registry[phase].get(m, []))
-    hooks.extend(self._hook_registry[phase].get(None, []))
+    hooks = list(self._hook_registry[phase].get(None, []))
+    hooks.extend(self._hook_registry[phase].get(m, []))
     for fn in hooks:
         await fn(ctx)


### PR DESCRIPTION
## Summary
- ensure principal data populates request context for AutoAPI hooks
- run catch-all hooks before model-specific hooks
- support attribute-style access in AutoAPI hook context

## Testing
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff format .`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check . --fix`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn pytest` *(fails: async def functions are not natively supported, AssertionError, ValueError)*
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `uv run --directory pkgs/standards/autoapi --package autoapi pytest` *(fails: AttributeError: type object 'ApiKey' has no attribute 'gen')*

------
https://chatgpt.com/codex/tasks/task_e_6894cef803048326ad5d81f70806996a