### PR TITLE
Fix Repository hook registration

### DIFF
--- a/pkgs/standards/peagen/peagen/orm/repositories.py
+++ b/pkgs/standards/peagen/peagen/orm/repositories.py
@@ -8,7 +8,15 @@ from autoapi.v2.types import (
     relationship,
     HookProvider,
 )
-from autoapi.v2.mixins import GUIDPk, Timestamped, TenantBound, TenantPolicy, Ownable, OwnerPolicy, StatusMixin
+from autoapi.v2.mixins import (
+    GUIDPk,
+    Timestamped,
+    TenantBound,
+    TenantPolicy,
+    Ownable,
+    OwnerPolicy,
+    StatusMixin,
+)
 
 
 class Repository(
@@ -20,9 +28,7 @@ class Repository(
     """
 
     __tablename__ = "repositories"
-    __table_args__ = (
-        UniqueConstraint("url"),
-    )
+    __table_args__ = (UniqueConstraint("url"),)
 
     __autoapi_tenant_policy__ = TenantPolicy.STRICT_SERVER
 
@@ -60,9 +66,7 @@ class Repository(
         from autoapi.v2 import AutoAPI, Phase
 
         cls._SRead = AutoAPI.get_schema(cls, "read")
-        api.register_hook(Phase.POST_COMMIT, model="Repository", op="create")(
-            cls._post_create
-        )
+        api.register_hook(Phase.POST_COMMIT, model=cls, op="create")(cls._post_create)
 
 
 __all__ = ["Repository"]


### PR DESCRIPTION
## Summary
- use Repository class when registering POST_COMMIT create hook to ensure correct key

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format peagen/orm/repositories.py`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check peagen/orm/repositories.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_6894f471aab88326a1620d57d18718ff