### PR TITLE
fix: avoid duplicate shadow_principal hook registration

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -143,9 +143,10 @@ async def _shadow_principal(ctx):
 
 # ensure our hook runs second after the AuthN injection hook
 _pre = api._hook_registry[Phase.PRE_TX_BEGIN][None]
-if _shadow_principal in _pre:
-    _pre.remove(_shadow_principal)
-_pre.insert(1, _shadow_principal)
+for idx, fn in enumerate(_pre):
+    if getattr(fn, "__name__", "") == "_shadow_principal":
+        _pre.insert(1, _pre.pop(idx))
+        break
 
 
 app.include_router(api.router)


### PR DESCRIPTION
## Summary
- avoid duplicate registration of `shadow_principal` hook by repositioning existing entry in the registry

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/gateway/__init__.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_6894fd1246908326a6dc94ef8e2dbb10