### PR TITLE
Handle missing ctx.params in mixins

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/mixins/ownable.py
+++ b/pkgs/standards/autoapi/autoapi/v2/mixins/ownable.py
@@ -4,13 +4,12 @@ from ..hooks import Phase
 from ..jsonrpc_models import create_standardized_error
 from ..info_schema import check as _info_check
 from ..types import Column, ForeignKey, PgUUID, declared_attr
- 
 
 
 class OwnerPolicy(str, Enum):
-    CLIENT_SET      = "client"
+    CLIENT_SET = "client"
     DEFAULT_TO_USER = "default"
-    STRICT_SERVER   = "strict"
+    STRICT_SERVER = "strict"
 
 
 class Ownable:
@@ -32,8 +31,11 @@ class Ownable:
         autoapi_meta = {}
         if pol != OwnerPolicy.CLIENT_SET:
             # Hide on write verbs (create/update/replace) and mark read-only
-            autoapi_meta["disable_on"] = ["update", "replace"]   # add "create" if desired
-            autoapi_meta["read_only"]  = True
+            autoapi_meta["disable_on"] = [
+                "update",
+                "replace",
+            ]  # add "create" if desired
+            autoapi_meta["read_only"] = True
 
         # Validate the metadata keys
         _info_check(autoapi_meta, "owner_id", cls.__name__)
@@ -59,20 +61,33 @@ class Ownable:
 
         # PRE-TX hooks ----------------------------------------------------
         def _before_create(ctx):
-            if "owner_id" in ctx.params and pol == OwnerPolicy.STRICT_SERVER:
+            try:
+                params = ctx.params
+            except KeyError:
+                params = {}
+                ctx.params = params
+            if "owner_id" in params and pol == OwnerPolicy.STRICT_SERVER:
                 _err(400, "owner_id cannot be set explicitly.")
-            ctx.params.setdefault("owner_id", ctx.user_id)
+            params.setdefault("owner_id", ctx.user_id)
 
         def _before_update(ctx, obj):
-            if "owner_id" not in ctx.params:
+            try:
+                params = ctx.params
+            except KeyError:
+                return
+            if "owner_id" not in params:
                 return
 
             if pol != OwnerPolicy.CLIENT_SET:
                 _err(400, "owner_id is immutable.")
 
-            new_val = ctx.params["owner_id"]
+            new_val = params["owner_id"]
             if new_val != obj.owner_id and new_val != ctx.user_id and not ctx.is_admin:
                 _err(403, "Cannot transfer ownership.")
 
-        api.register_hook(model=cls, phase=Phase.PRE_TX_BEGIN, op="create")(_before_create)
-        api.register_hook(model=cls, phase=Phase.PRE_TX_BEGIN, op="update")(_before_update)
+        api.register_hook(model=cls, phase=Phase.PRE_TX_BEGIN, op="create")(
+            _before_create
+        )
+        api.register_hook(model=cls, phase=Phase.PRE_TX_BEGIN, op="update")(
+            _before_update
+        )

--- a/pkgs/standards/autoapi/autoapi/v2/mixins/tenant_bound.py
+++ b/pkgs/standards/autoapi/autoapi/v2/mixins/tenant_bound.py
@@ -18,9 +18,9 @@ from ..info_schema import check as _info_check
 
 
 class TenantPolicy(str, Enum):
-    CLIENT_SET     = "client"   # client may supply tenant_id on create/update
+    CLIENT_SET = "client"  # client may supply tenant_id on create/update
     DEFAULT_TO_CTX = "default"  # server fills tenant_id on create; immutable
-    STRICT_SERVER  = "strict"   # server forces tenant_id and forbids changes
+    STRICT_SERVER = "strict"  # server forces tenant_id and forbids changes
 
 
 class TenantBound(_RowBound):
@@ -81,17 +81,26 @@ class TenantBound(_RowBound):
 
         # INSERT
         def _before_create(ctx):
-            if "tenant_id" in ctx.params and pol == TenantPolicy.STRICT_SERVER:
+            try:
+                params = ctx.params
+            except KeyError:
+                params = {}
+                ctx.params = params
+            if "tenant_id" in params and pol == TenantPolicy.STRICT_SERVER:
                 _err(400, "tenant_id cannot be set explicitly.")
-            ctx.params.setdefault("tenant_id", ctx.tenant_id)
+            params.setdefault("tenant_id", ctx.tenant_id)
 
         # UPDATE
         def _before_update(ctx, obj):
-            if "tenant_id" not in ctx.params:
+            try:
+                params = ctx.params
+            except KeyError:
+                return
+            if "tenant_id" not in params:
                 return
             if pol != TenantPolicy.CLIENT_SET:
                 _err(400, "tenant_id is immutable.")
-            new_val = ctx.params["tenant_id"]
+            new_val = params["tenant_id"]
             if (
                 new_val != obj.tenant_id
                 and new_val != ctx.tenant_id


### PR DESCRIPTION
## Summary
- prevent `KeyError` when `ctx.params` is absent in AutoAPI TenantBound and Ownable mixins

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `python -m py_compile pkgs/standards/autoapi/autoapi/v2/mixins/tenant_bound.py pkgs/standards/autoapi/autoapi/v2/mixins/ownable.py`


------
https://chatgpt.com/codex/tasks/task_e_689506eb49b48326bf8669031be94cae