### PR TITLE
Handle missing tenant_id in TenantBound _before_create

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/mixins/tenant_bound.py
+++ b/pkgs/standards/autoapi/autoapi/v2/mixins/tenant_bound.py
@@ -86,9 +86,14 @@ class TenantBound(_RowBound):
             except KeyError:
                 params = {}
                 ctx.params = params
-            if "tenant_id" in params and pol == TenantPolicy.STRICT_SERVER:
-                _err(400, "tenant_id cannot be set explicitly.")
-            params.setdefault("tenant_id", ctx.tenant_id)
+            if "tenant_id" in params:
+                if pol == TenantPolicy.STRICT_SERVER:
+                    _err(400, "tenant_id cannot be set explicitly.")
+            else:
+                tenant_id = ctx.get("tenant_id")
+                if tenant_id is None:
+                    _err(400, "tenant_id is required.")
+                params["tenant_id"] = tenant_id
 
         # UPDATE
         def _before_update(ctx, obj):


### PR DESCRIPTION
## Summary
- avoid KeyError when context lacks `tenant_id` by guarding lookup

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format autoapi/v2/mixins/tenant_bound.py`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check autoapi/v2/mixins/tenant_bound.py --fix`



------
https://chatgpt.com/codex/tasks/task_e_6895108ce074832693c8d86eed5856f7