### PR TITLE
fix: correct standardized error argument

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/mixins/ownable.py
+++ b/pkgs/standards/autoapi/autoapi/v2/mixins/ownable.py
@@ -56,7 +56,7 @@ class Ownable:
         pol = cls.__autoapi_owner_policy__
 
         def _err(status: int, msg: str):
-            http_exc, _, _ = create_standardized_error(status, detail=msg)
+            http_exc, _, _ = create_standardized_error(status, message=msg)
             raise http_exc
 
         # PRE-TX hooks ----------------------------------------------------

--- a/pkgs/standards/autoapi/autoapi/v2/mixins/tenant_bound.py
+++ b/pkgs/standards/autoapi/autoapi/v2/mixins/tenant_bound.py
@@ -76,7 +76,7 @@ class TenantBound(_RowBound):
         pol = cls.__autoapi_tenant_policy__
 
         def _err(code: int, msg: str):
-            http_exc, _, _ = create_standardized_error(code, detail=msg)
+            http_exc, _, _ = create_standardized_error(code, message=msg)
             raise http_exc
 
         # INSERT


### PR DESCRIPTION
## Summary
- use message parameter when constructing standardized errors in tenant_bound and ownable mixins

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_689517b1fa8883269daffce8016972ef