### PR TITLE
Fix error detail handling in AutoAPI mixins

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/mixins/_RowBound.py
+++ b/pkgs/standards/autoapi/autoapi/v2/mixins/_RowBound.py
@@ -5,7 +5,7 @@ from typing import Any, Mapping, Sequence
 
 from autoapi.v2.hooks import Phase
 from autoapi.v2.types import HookProvider
-from autoapi.v2.jsonrpc_models import create_standardized_error
+from autoapi.v2.jsonrpc_models import HTTP_ERROR_MESSAGES, create_standardized_error
 
 
 class _RowBound(HookProvider):
@@ -28,7 +28,7 @@ class _RowBound(HookProvider):
         # Skip abstract helpers or unmapped mix-ins
         if cls.is_visible is _RowBound.is_visible:
             return
-        if not hasattr(cls, "__table__"):          # not a mapped class
+        if not hasattr(cls, "__table__"):  # not a mapped class
             return
 
         for op in ("read", "list"):
@@ -42,7 +42,7 @@ class _RowBound(HookProvider):
     @classmethod
     def _make_hook(cls):
         def _hook(ctx: Mapping[str, Any]) -> None:
-            if "result" not in ctx:        # nothing to filter
+            if "result" not in ctx:  # nothing to filter
                 return
 
             res = ctx["result"]
@@ -54,7 +54,9 @@ class _RowBound(HookProvider):
 
             # READ → invisible row → pretend 404
             if not cls.is_visible(res, ctx):
-                http_exc, _, _ = create_standardized_error(404)
+                http_exc, _, _ = create_standardized_error(
+                    404, message=HTTP_ERROR_MESSAGES[404]
+                )
                 raise http_exc
 
         return _hook

--- a/pkgs/standards/autoapi/autoapi/v2/mixins/ownable.py
+++ b/pkgs/standards/autoapi/autoapi/v2/mixins/ownable.py
@@ -56,7 +56,7 @@ class Ownable:
         pol = cls.__autoapi_owner_policy__
 
         def _err(status: int, msg: str):
-            http_exc, _, _ = create_standardized_error(status, detail=msg)
+            http_exc, _, _ = create_standardized_error(status, message=msg)
             raise http_exc
 
         # PRE-TX hooks ----------------------------------------------------

--- a/pkgs/standards/autoapi/autoapi/v2/mixins/tenant_bound.py
+++ b/pkgs/standards/autoapi/autoapi/v2/mixins/tenant_bound.py
@@ -76,7 +76,7 @@ class TenantBound(_RowBound):
         pol = cls.__autoapi_tenant_policy__
 
         def _err(code: int, msg: str):
-            http_exc, _, _ = create_standardized_error(code, detail=msg)
+            http_exc, _, _ = create_standardized_error(code, message=msg)
             raise http_exc
 
         # INSERT


### PR DESCRIPTION
## Summary
- ensure tenant error helper passes message to `create_standardized_error`
- update ownership mixin to use `message` in standardized error calls
- forward explicit 404 detail in row visibility checks

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_689518094cc48326a97d3720205503f6