### PR TITLE
refactor: rename generic autoapi hook methods

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/mixins/_RowBound.py
+++ b/pkgs/standards/autoapi/autoapi/v2/mixins/_RowBound.py
@@ -33,15 +33,15 @@ class _RowBound(HookProvider):
 
         for op in ("read", "list"):
             api.register_hook(model=cls, phase=Phase.POST_HANDLER, op=op)(
-                cls._make_hook()
+                cls._make_row_visibility_hook()
             )
 
     # ────────────────────────────────────────────────────────────────────
     # Per-request hook
     # -------------------------------------------------------------------
     @classmethod
-    def _make_hook(cls):
-        def _hook(ctx: Mapping[str, Any]) -> None:
+    def _make_row_visibility_hook(cls):
+        def _row_visibility_hook(ctx: Mapping[str, Any]) -> None:
             if "result" not in ctx:  # nothing to filter
                 return
 
@@ -59,7 +59,7 @@ class _RowBound(HookProvider):
                 )
                 raise http_exc
 
-        return _hook
+        return _row_visibility_hook
 
     # -------------------------------------------------------------------
     # Must be overridden


### PR DESCRIPTION
## Summary
- rename row visibility hook and factory for clarity
- rename upsert method rewrite hook for clearer intent

## Testing
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff format .`
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68951d32dcf88326a5bc5ee9546a67da