### PR TITLE
Handle missing tenant_id in tenant bound visibility

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/mixins/tenant_bound.py
+++ b/pkgs/standards/autoapi/autoapi/v2/mixins/tenant_bound.py
@@ -66,7 +66,14 @@ class TenantBound(_RowBound):
         A row is visible iff it belongs to the caller’s tenant.
         `ctx.tenant_id` is expected to be set by your authn middleware.
         """
-        return getattr(obj, "tenant_id", None) == getattr(ctx, "tenant_id", None)
+        if hasattr(ctx, "get"):
+            tenant_id = ctx.get("tenant_id", None)
+        else:
+            try:
+                tenant_id = ctx.tenant_id
+            except (AttributeError, KeyError):
+                tenant_id = None
+        return getattr(obj, "tenant_id", None) == tenant_id
 
     # -------------------------------------------------------------------
     # Runtime hooks (needs api instance)


### PR DESCRIPTION
## Summary
- avoid KeyError when tenant context lacks tenant_id

## Testing
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff format .`
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_6895209e74e48326a6e66cbd73b00d30