### PR TITLE
fix: handle missing tenant_id in tenant-bound visibility

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/mixins/tenant_bound.py
+++ b/pkgs/standards/autoapi/autoapi/v2/mixins/tenant_bound.py
@@ -66,7 +66,12 @@ class TenantBound(_RowBound):
         A row is visible iff it belongs to the caller’s tenant.
         `ctx.tenant_id` is expected to be set by your authn middleware.
         """
-        return getattr(obj, "tenant_id", None) == getattr(ctx, "tenant_id", None)
+        ctx_tenant_id = (
+            ctx.get("tenant_id")
+            if hasattr(ctx, "get")
+            else getattr(ctx, "tenant_id", None)
+        )
+        return getattr(obj, "tenant_id", None) == ctx_tenant_id
 
     # -------------------------------------------------------------------
     # Runtime hooks (needs api instance)


### PR DESCRIPTION
## Summary
- avoid KeyError when tenant_id missing from context by safely reading it in `TenantBound.is_visible`

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `uv run --package autoapi --directory pkgs/standards/autoapi pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895209e74e48326a6e66cbd73b00d30