### PR TITLE
Handle server-injected owner and tenant IDs in autoapi

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/hooks.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/hooks.py
@@ -20,12 +20,16 @@ def register_inject_hook(api):
 
         prm = ctx["env"].params  # Pydantic model OR raw dict
         ctx["params"] = prm
+        injected = ctx.setdefault("__autoapi_injected_fields_", set())
         for fld, val in (("tenant_id", ctx["tenant_id"]), ("owner_id", ctx["user_id"])):
             if hasattr(prm, "__pydantic_fields__"):
                 if fld in prm.model_fields and getattr(prm, fld, None) in (None, val):
                     setattr(prm, fld, val)
+                    injected.add(fld)
             elif isinstance(prm, dict):
-                prm.setdefault(fld, val)
+                if fld not in prm:
+                    prm[fld] = val
+                    injected.add(fld)
 
 
 __all__ = ["register_inject_hook"]

--- a/pkgs/standards/autoapi/autoapi/v2/mixins/ownable.py
+++ b/pkgs/standards/autoapi/autoapi/v2/mixins/ownable.py
@@ -66,7 +66,16 @@ class Ownable:
             except KeyError:
                 params = {}
                 ctx.params = params
-            if "owner_id" in params and pol == OwnerPolicy.STRICT_SERVER:
+            auto_fields = (
+                ctx.get("__autoapi_injected_fields_", set())
+                if hasattr(ctx, "get")
+                else getattr(ctx, "__autoapi_injected_fields_", set())
+            )
+            if (
+                "owner_id" in params
+                and pol == OwnerPolicy.STRICT_SERVER
+                and "owner_id" not in auto_fields
+            ):
                 _err(400, "owner_id cannot be set explicitly.")
             params.setdefault("owner_id", ctx.user_id)
 

--- a/pkgs/standards/autoapi/autoapi/v2/mixins/tenant_bound.py
+++ b/pkgs/standards/autoapi/autoapi/v2/mixins/tenant_bound.py
@@ -91,8 +91,13 @@ class TenantBound(_RowBound):
             except KeyError:
                 params = {}
                 ctx.params = params
+            auto_fields = (
+                ctx.get("__autoapi_injected_fields_", set())
+                if hasattr(ctx, "get")
+                else getattr(ctx, "__autoapi_injected_fields_", set())
+            )
             if "tenant_id" in params:
-                if pol == TenantPolicy.STRICT_SERVER:
+                if pol == TenantPolicy.STRICT_SERVER and "tenant_id" not in auto_fields:
                     _err(400, "tenant_id cannot be set explicitly.")
             else:
                 tenant_id = ctx.get("tenant_id")


### PR DESCRIPTION
## Summary
- track auth-injected `tenant_id` and `owner_id` values in the request context
- allow Ownable and TenantBound mixins to ignore server-injected identifiers when enforcing policies
- rename injected-field context key to `__autoapi_injected_fields_`

## Testing
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff format .`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check . --fix`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68954e8191c083268e8536641ff8bd36