### PR TITLE
fix: update auto_authn pytest configuration

### DIFF
--- a/pkgs/standards/auto_authn/conftest.py
+++ b/pkgs/standards/auto_authn/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = ("pytest_asyncio",)

--- a/pkgs/standards/auto_authn/pyproject.toml
+++ b/pkgs/standards/auto_authn/pyproject.toml
@@ -83,6 +83,7 @@ log_cli_level = "INFO"
 log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
 log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 asyncio_default_fixture_loop_scope = "function"
+asyncio_mode = "auto"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pkgs/standards/auto_authn/tests/conftest.py
+++ b/pkgs/standards/auto_authn/tests/conftest.py
@@ -390,7 +390,6 @@ async def auth_test_client(async_client: AsyncClient):
 # =============================================================================
 
 # Test markers configuration
-pytest_plugins = ["pytest_asyncio"]
 
 
 # Custom markers


### PR DESCRIPTION
## Summary
- remove deprecated `pytest_plugins` from tests
- enable `pytest_asyncio` via package-level conftest
- configure pytest for `asyncio_mode = auto`

## Testing
- `uv run --package auto_authn --directory standards ruff format auto_authn`
- `uv run --package auto_authn --directory standards ruff check auto_authn --fix`
- `uv run --package auto_authn --directory standards pytest auto_authn/tests` *(fails: TypeError: 'is_active' is an invalid keyword argument for Service)*

------
https://chatgpt.com/codex/tasks/task_e_68955abd9c9c8326b9010731d7a03128