### PR TITLE
fix: enforce strict server injection for tenant and owner

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/mixins/ownable.py
+++ b/pkgs/standards/autoapi/autoapi/v2/mixins/ownable.py
@@ -67,6 +67,7 @@ class Ownable:
                 params = {}
                 ctx.params = params
             user_id = ctx.user_id
+            auto_fields = ctx.get("__autoapi_injected_fields__", set())
             if pol == OwnerPolicy.STRICT_SERVER:
                 if user_id is None:
                     _err(400, "owner_id is required.")
@@ -75,7 +76,8 @@ class Ownable:
                     user_id,
                 ):
                     _err(400, "owner_id mismatch.")
-                params["owner_id"] = user_id
+                if "owner_id" in auto_fields or "owner_id" not in params:
+                    params["owner_id"] = user_id
             else:
                 params.setdefault("owner_id", user_id)
 

--- a/pkgs/standards/autoapi/autoapi/v2/mixins/tenant_bound.py
+++ b/pkgs/standards/autoapi/autoapi/v2/mixins/tenant_bound.py
@@ -96,6 +96,7 @@ class TenantBound(_RowBound):
                 if hasattr(ctx, "get")
                 else getattr(ctx, "tenant_id", None)
             )
+            auto_fields = ctx.get("__autoapi_injected_fields__", set())
             if pol == TenantPolicy.STRICT_SERVER:
                 if tenant_id is None:
                     _err(400, "tenant_id is required.")
@@ -104,7 +105,8 @@ class TenantBound(_RowBound):
                     tenant_id,
                 ):
                     _err(400, "tenant_id mismatch.")
-                params["tenant_id"] = tenant_id
+                if "tenant_id" in auto_fields or "tenant_id" not in params:
+                    params["tenant_id"] = tenant_id
             else:
                 if "tenant_id" not in params:
                     if tenant_id is None:


### PR DESCRIPTION
## Summary
- ensure TenantBound injects server-provided tenant_id under STRICT_SERVER policy
- mirror STRICT_SERVER handling in Ownable for owner_id

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest`

------
https://chatgpt.com/codex/tasks/task_e_68956d41ec9c8326af2388d83075adcb