### PR TITLE
refactor: inject auth fields via context map

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/hooks.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/hooks.py
@@ -14,22 +14,16 @@ def register_inject_hook(api):
         if not p:
             return
 
-        ctx["tenant_id"] = p.get("tid")
-        ctx["user_id"] = p.get("sub")
         ctx["is_admin"] = p.get("is_admin", False)
 
-        prm = ctx["env"].params  # Pydantic model OR raw dict
-        ctx["params"] = prm
-        injected = ctx.setdefault("__autoapi_injected_fields__", set())
-        for fld, val in (("tenant_id", ctx["tenant_id"]), ("owner_id", ctx["user_id"])):
-            if hasattr(prm, "__pydantic_fields__"):
-                if fld in prm.model_fields and getattr(prm, fld, None) in (None, val):
-                    setattr(prm, fld, val)
-                    injected.add(fld)
-            elif isinstance(prm, dict):
-                if fld not in prm or prm.get(fld) in (None, val):
-                    prm[fld] = val
-                    injected.add(fld)
+        injected = ctx.setdefault("__autoapi_injected_fields__", {})
+        tid = p.get("tid")
+        sub = p.get("sub")
+        if tid is not None:
+            injected["tenant_id"] = tid
+        if sub is not None:
+            injected["user_id"] = sub
+            injected["owner_id"] = sub
 
 
 __all__ = ["register_inject_hook"]

--- a/pkgs/standards/autoapi/autoapi/v2/mixins/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v2/mixins/__init__.py
@@ -90,6 +90,7 @@ class OrgMixin:
         info=dict(autoapi={"examples": [uuid_example]}),
     )
 
+
 @declarative_mixin
 class Principal:  # concrete table marker
     __abstract__ = True
@@ -105,7 +106,8 @@ class OwnerBound:
 
     @classmethod
     def filter_for_ctx(cls, q, ctx):
-        return q.filter(cls.owner_id == ctx.user_id)
+        auto_fields = ctx.get("__autoapi_injected_fields__", {})
+        return q.filter(cls.owner_id == auto_fields.get("owner_id"))
 
 
 class UserBound:  # membership rows
@@ -117,7 +119,9 @@ class UserBound:  # membership rows
 
     @classmethod
     def filter_for_ctx(cls, q, ctx):
-        return q.filter(cls.user_id == ctx.user_id)
+        auto_fields = ctx.get("__autoapi_injected_fields__", {})
+        return q.filter(cls.user_id == auto_fields.get("user_id"))
+
 
 # ────────── lifecycle --------------------------------------------------
 @declarative_mixin

--- a/pkgs/standards/autoapi/autoapi/v2/mixins/ownable.py
+++ b/pkgs/standards/autoapi/autoapi/v2/mixins/ownable.py
@@ -61,13 +61,9 @@ class Ownable:
 
         # PRE-TX hooks ----------------------------------------------------
         def _ownable_before_create(ctx):
-            try:
-                params = ctx.params
-            except KeyError:
-                params = {}
-                ctx.params = params
-            user_id = ctx.user_id
-            auto_fields = ctx.get("__autoapi_injected_fields__", set())
+            params = ctx["env"].params if ctx.get("env") else {}
+            auto_fields = ctx.get("__autoapi_injected_fields__", {})
+            user_id = auto_fields.get("owner_id")
             if pol == OwnerPolicy.STRICT_SERVER:
                 if user_id is None:
                     _err(400, "owner_id is required.")
@@ -82,18 +78,21 @@ class Ownable:
                 params.setdefault("owner_id", user_id)
 
         def _ownable_before_update(ctx, obj):
-            try:
-                params = ctx.params
-            except KeyError:
-                return
-            if "owner_id" not in params:
+            params = getattr(ctx.get("env"), "params", None)
+            if not params or "owner_id" not in params:
                 return
 
             if pol != OwnerPolicy.CLIENT_SET:
                 _err(400, "owner_id is immutable.")
 
             new_val = params["owner_id"]
-            if new_val != obj.owner_id and new_val != ctx.user_id and not ctx.is_admin:
+            auto_fields = ctx.get("__autoapi_injected_fields__", {})
+            user_id = auto_fields.get("owner_id")
+            if (
+                new_val != obj.owner_id
+                and new_val != user_id
+                and not ctx.get("is_admin")
+            ):
                 _err(403, "Cannot transfer ownership.")
 
         api.register_hook(model=cls, phase=Phase.PRE_TX_BEGIN, op="create")(

--- a/pkgs/standards/autoapi/autoapi/v2/mixins/tenant_bound.py
+++ b/pkgs/standards/autoapi/autoapi/v2/mixins/tenant_bound.py
@@ -4,7 +4,7 @@ Tenant-level row security mix-in for AutoAPI.
 A table that inherits **TenantBound** gets:
 
 • tenant-scoped *read* / *list* results (via _RowBound.is_visible override)
-• automatic injection of ctx.tenant_id on inserts
+• automatic injection of the authenticated tenant id on inserts
 • policy-driven control over whether the client can set / patch tenant_id
 """
 
@@ -64,13 +64,10 @@ class TenantBound(_RowBound):
     def is_visible(obj, ctx) -> bool:
         """
         A row is visible iff it belongs to the caller’s tenant.
-        `ctx.tenant_id` is expected to be set by your authn middleware.
+        The tenant id is provided via ``__autoapi_injected_fields__``.
         """
-        ctx_tenant_id = (
-            ctx.get("tenant_id")
-            if hasattr(ctx, "get")
-            else getattr(ctx, "tenant_id", None)
-        )
+        auto_fields = ctx.get("__autoapi_injected_fields__", {})
+        ctx_tenant_id = auto_fields.get("tenant_id")
         return getattr(obj, "tenant_id", None) == ctx_tenant_id
 
     # -------------------------------------------------------------------
@@ -86,17 +83,9 @@ class TenantBound(_RowBound):
 
         # INSERT
         def _tenantbound_before_create(ctx):
-            try:
-                params = ctx.params
-            except KeyError:
-                params = {}
-                ctx.params = params
-            tenant_id = (
-                ctx.get("tenant_id")
-                if hasattr(ctx, "get")
-                else getattr(ctx, "tenant_id", None)
-            )
-            auto_fields = ctx.get("__autoapi_injected_fields__", set())
+            params = ctx["env"].params if ctx.get("env") else {}
+            auto_fields = ctx.get("__autoapi_injected_fields__", {})
+            tenant_id = auto_fields.get("tenant_id")
             if pol == TenantPolicy.STRICT_SERVER:
                 if tenant_id is None:
                     _err(400, "tenant_id is required.")
@@ -115,18 +104,17 @@ class TenantBound(_RowBound):
 
         # UPDATE
         def _tenantbound_before_update(ctx, obj):
-            try:
-                params = ctx.params
-            except KeyError:
-                return
-            if "tenant_id" not in params:
+            params = getattr(ctx.get("env"), "params", None)
+            if not params or "tenant_id" not in params:
                 return
             if pol != TenantPolicy.CLIENT_SET:
                 _err(400, "tenant_id is immutable.")
             new_val = params["tenant_id"]
+            auto_fields = ctx.get("__autoapi_injected_fields__", {})
+            tenant_id = auto_fields.get("tenant_id")
             if (
                 new_val != obj.tenant_id
-                and new_val != ctx.get("tenant_id")
+                and new_val != tenant_id
                 and not ctx.get("is_admin")
             ):
                 _err(403, "Cannot switch tenant context.")


### PR DESCRIPTION
## Summary
- derive tenant, user, and owner identifiers from `__autoapi_injected_fields__` instead of mutating context
- enforce TenantBound and Ownable STRICT_SERVER policies using injected parameters
- update query helpers to filter using injected owner/user fields

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check autoapi/v2/mixins/__init__.py autoapi/v2/mixins/ownable.py autoapi/v2/mixins/tenant_bound.py --fix`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check auto_authn/v2/hooks.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_689571beb8848326a86c685a3dde293b