### PR TITLE
Fix user and tenant injection for strict owner policy

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/hooks.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/hooks.py
@@ -23,7 +23,6 @@ def register_inject_hook(api):
             injected["tenant_id"] = tid
         if sub is not None:
             injected["user_id"] = sub
-            injected["owner_id"] = sub
 
 
 __all__ = ["register_inject_hook"]

--- a/pkgs/standards/autoapi/autoapi/v2/mixins/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v2/mixins/__init__.py
@@ -107,7 +107,7 @@ class OwnerBound:
     @classmethod
     def filter_for_ctx(cls, q, ctx):
         auto_fields = ctx.get("__autoapi_injected_fields__", {})
-        return q.filter(cls.owner_id == auto_fields.get("owner_id"))
+        return q.filter(cls.owner_id == auto_fields.get("user_id"))
 
 
 class UserBound:  # membership rows

--- a/pkgs/standards/autoapi/autoapi/v2/mixins/ownable.py
+++ b/pkgs/standards/autoapi/autoapi/v2/mixins/ownable.py
@@ -63,7 +63,7 @@ class Ownable:
         def _ownable_before_create(ctx):
             params = ctx["env"].params if ctx.get("env") else {}
             auto_fields = ctx.get("__autoapi_injected_fields__", {})
-            user_id = auto_fields.get("owner_id")
+            user_id = auto_fields.get("user_id")
             if pol == OwnerPolicy.STRICT_SERVER:
                 if user_id is None:
                     _err(400, "owner_id is required.")
@@ -72,7 +72,7 @@ class Ownable:
                     user_id,
                 ):
                     _err(400, "owner_id mismatch.")
-                if "owner_id" in auto_fields or "owner_id" not in params:
+                if "user_id" in auto_fields or "owner_id" not in params:
                     params["owner_id"] = user_id
             else:
                 params.setdefault("owner_id", user_id)
@@ -87,7 +87,7 @@ class Ownable:
 
             new_val = params["owner_id"]
             auto_fields = ctx.get("__autoapi_injected_fields__", {})
-            user_id = auto_fields.get("owner_id")
+            user_id = auto_fields.get("user_id")
             if (
                 new_val != obj.owner_id
                 and new_val != user_id


### PR DESCRIPTION
## Summary
- ensure AutoAuthn injects only tenant_id and user_id
- derive owner_id from user_id when OwnerPolicy.STRICT_SERVER
- use user_id for owner-scoped query filtering

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format autoapi/v2/mixins/__init__.py autoapi/v2/mixins/ownable.py`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check autoapi/v2/mixins/__init__.py autoapi/v2/mixins/ownable.py --fix`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff format auto_authn/v2/hooks.py`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check auto_authn/v2/hooks.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_689584597df08326b26b0b2a22a7bc95