### PR TITLE
Fix autoapi tenant/owner injection

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/mixins/ownable.py
+++ b/pkgs/standards/autoapi/autoapi/v2/mixins/ownable.py
@@ -62,6 +62,8 @@ class Ownable:
         # PRE-TX hooks ----------------------------------------------------
         def _ownable_before_create(ctx):
             params = ctx["env"].params if ctx.get("env") else {}
+            if hasattr(params, "model_dump"):
+                params = params.model_dump()
             auto_fields = ctx.get("__autoapi_injected_fields__", {})
             user_id = auto_fields.get("user_id")
             if pol == OwnerPolicy.STRICT_SERVER:
@@ -76,6 +78,7 @@ class Ownable:
                     params["owner_id"] = user_id
             else:
                 params.setdefault("owner_id", user_id)
+            ctx["env"].params = params
 
         def _ownable_before_update(ctx, obj):
             params = getattr(ctx.get("env"), "params", None)

--- a/pkgs/standards/autoapi/autoapi/v2/mixins/tenant_bound.py
+++ b/pkgs/standards/autoapi/autoapi/v2/mixins/tenant_bound.py
@@ -84,6 +84,8 @@ class TenantBound(_RowBound):
         # INSERT
         def _tenantbound_before_create(ctx):
             params = ctx["env"].params if ctx.get("env") else {}
+            if hasattr(params, "model_dump"):
+                params = params.model_dump()
             auto_fields = ctx.get("__autoapi_injected_fields__", {})
             tenant_id = auto_fields.get("tenant_id")
             if pol == TenantPolicy.STRICT_SERVER:
@@ -101,6 +103,7 @@ class TenantBound(_RowBound):
                     if tenant_id is None:
                         _err(400, "tenant_id is required.")
                     params["tenant_id"] = tenant_id
+            ctx["env"].params = params
 
         # UPDATE
         def _tenantbound_before_update(ctx, obj):


### PR DESCRIPTION
## Summary
- ensure TenantBound before-create hook writes injected tenant id back to request params
- ensure Ownable before-create hook writes injected owner id back to request params

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `uv run --package autoapi --directory pkgs/standards/autoapi pytest`
- `peagen remote --gateway-url https://gw.peagen.com/rpc --api-key pEBoqzHM_OtJhofd0cw9xZmk5rln_rFFQuKjdgnQwW8 init repo gslcloud/test` *(fails: null value in column "tenant_id")*

------
https://chatgpt.com/codex/tasks/task_e_68958933a5c08326a4fa4b26824b1ec6