### PR TITLE
feat: integrate fastapi security into autoapi router

### DIFF
--- a/pkgs/standards/auto_authn/tests/unit/test_fastapi_deps.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_fastapi_deps.py
@@ -11,6 +11,7 @@ import contextvars
 
 import pytest
 from fastapi import HTTPException, Request
+from fastapi.security import HTTPAuthorizationCredentials
 from sqlalchemy.ext.asyncio import AsyncSession
 from jwt import InvalidTokenError
 
@@ -202,7 +203,7 @@ class TestGetCurrentPrincipal:
             "auto_authn.v2.fastapi_deps._user_from_api_key", return_value=mock_user
         ):
             principal = await get_current_principal(
-                authorization="", api_key=api_key, db=mock_db
+                credentials=None, api_key=api_key, db=mock_db
             )
 
             assert principal is not None
@@ -215,11 +216,13 @@ class TestGetCurrentPrincipal:
         mock_user.id = uuid.uuid4()
 
         mock_db = AsyncMock(spec=AsyncSession)
-        authorization = "Bearer valid.jwt.token"
+        credentials = HTTPAuthorizationCredentials(
+            scheme="Bearer", credentials="valid.jwt.token"
+        )
 
         with patch("auto_authn.v2.fastapi_deps._user_from_jwt", return_value=mock_user):
             principal = await get_current_principal(
-                authorization=authorization, api_key=None, db=mock_db
+                credentials=credentials, api_key=None, db=mock_db
             )
 
             assert principal is not None
@@ -233,7 +236,9 @@ class TestGetCurrentPrincipal:
 
         mock_db = AsyncMock(spec=AsyncSession)
         api_key = "valid-api-key-12345"
-        authorization = "Bearer valid.jwt.token"
+        credentials = HTTPAuthorizationCredentials(
+            scheme="Bearer", credentials="valid.jwt.token"
+        )
 
         with patch(
             "auto_authn.v2.fastapi_deps._user_from_api_key", return_value=mock_user
@@ -242,7 +247,7 @@ class TestGetCurrentPrincipal:
                 "auto_authn.v2.fastapi_deps._user_from_jwt", return_value=mock_user
             ) as mock_jwt:
                 principal = await get_current_principal(
-                    authorization=authorization, api_key=api_key, db=mock_db
+                    credentials=credentials, api_key=api_key, db=mock_db
                 )
 
                 assert principal is not None
@@ -261,14 +266,16 @@ class TestGetCurrentPrincipal:
 
         mock_db = AsyncMock(spec=AsyncSession)
         api_key = "invalid-api-key"
-        authorization = "Bearer valid.jwt.token"
+        credentials = HTTPAuthorizationCredentials(
+            scheme="Bearer", credentials="valid.jwt.token"
+        )
 
         with patch("auto_authn.v2.fastapi_deps._user_from_api_key", return_value=None):
             with patch(
                 "auto_authn.v2.fastapi_deps._user_from_jwt", return_value=mock_user
             ):
                 principal = await get_current_principal(
-                    authorization=authorization, api_key=api_key, db=mock_db
+                    credentials=credentials, api_key=api_key, db=mock_db
                 )
 
                 assert principal is not None
@@ -280,7 +287,7 @@ class TestGetCurrentPrincipal:
         mock_db = AsyncMock(spec=AsyncSession)
 
         with pytest.raises(HTTPException) as exc_info:
-            await get_current_principal(authorization="", api_key=None, db=mock_db)
+            await get_current_principal(credentials=None, api_key=None, db=mock_db)
 
         assert exc_info.value.status_code == 401
         assert "invalid or missing credentials" in exc_info.value.detail
@@ -290,11 +297,13 @@ class TestGetCurrentPrincipal:
     async def test_get_current_principal_with_invalid_bearer_format(self):
         """Test principal resolution with malformed Bearer token."""
         mock_db = AsyncMock(spec=AsyncSession)
-        authorization = "InvalidFormat token"
+        credentials = HTTPAuthorizationCredentials(
+            scheme="InvalidFormat", credentials="token"
+        )
 
         with pytest.raises(HTTPException) as exc_info:
             await get_current_principal(
-                authorization=authorization, api_key=None, db=mock_db
+                credentials=credentials, api_key=None, db=mock_db
             )
 
         assert exc_info.value.status_code == 401
@@ -304,13 +313,15 @@ class TestGetCurrentPrincipal:
         """Test principal resolution with invalid API key and JWT."""
         mock_db = AsyncMock(spec=AsyncSession)
         api_key = "invalid-api-key"
-        authorization = "Bearer invalid.jwt.token"
+        credentials = HTTPAuthorizationCredentials(
+            scheme="Bearer", credentials="invalid.jwt.token"
+        )
 
         with patch("auto_authn.v2.fastapi_deps._user_from_api_key", return_value=None):
             with patch("auto_authn.v2.fastapi_deps._user_from_jwt", return_value=None):
                 with pytest.raises(HTTPException) as exc_info:
                     await get_current_principal(
-                        authorization=authorization, api_key=api_key, db=mock_db
+                        credentials=credentials, api_key=api_key, db=mock_db
                     )
 
                 assert exc_info.value.status_code == 401
@@ -339,7 +350,7 @@ class TestGetPrincipal:
             "auto_authn.v2.fastapi_deps.get_current_principal", return_value=mock_user
         ):
             principal = await get_principal(
-                request=mock_request, authorization="", api_key=api_key, db=mock_db
+                request=mock_request, credentials=None, api_key=api_key, db=mock_db
             )
 
             assert principal == {"sub": str(mock_user.id), "tid": str(tenant_id)}
@@ -359,9 +370,12 @@ class TestGetPrincipal:
         with patch(
             "auto_authn.v2.fastapi_deps.get_current_principal", return_value=mock_user
         ):
+            credentials = HTTPAuthorizationCredentials(
+                scheme="Bearer", credentials="valid.jwt.token"
+            )
             await get_principal(
                 request=mock_request,
-                authorization="Bearer valid.jwt.token",
+                credentials=credentials,
                 api_key=None,
                 db=mock_db,
             )
@@ -388,9 +402,12 @@ class TestGetPrincipal:
         with patch(
             "auto_authn.v2.fastapi_deps.get_current_principal", return_value=mock_user
         ):
+            credentials = HTTPAuthorizationCredentials(
+                scheme="Bearer", credentials="valid.jwt.token"
+            )
             await get_principal(
                 request=mock_request,
-                authorization="Bearer valid.jwt.token",
+                credentials=credentials,
                 api_key=None,
                 db=mock_db,
             )
@@ -415,7 +432,7 @@ class TestGetPrincipal:
 
             with pytest.raises(HTTPException) as exc_info:
                 await get_principal(
-                    request=mock_request, authorization="", api_key=None, db=mock_db
+                    request=mock_request, credentials=None, api_key=None, db=mock_db
                 )
 
             assert exc_info.value.status_code == 401

--- a/pkgs/standards/autoapi/autoapi/v2/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v2/__init__.py
@@ -10,7 +10,7 @@ Public façade for the AutoAPI framework.
 # ─── std / third-party ──────────────────────────────────────────────
 from collections import OrderedDict
 from typing import Any, AsyncIterator, Callable, Dict, Iterator, Type
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Security
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 from pydantic import BaseModel
@@ -123,7 +123,7 @@ class AutoAPI:
         # ---------------- AuthN wiring -----------------
         if authn is not None:  # preferred path
             self._authn = authn
-            self._authn_dep = Depends(authn.get_principal)
+            self._authn_dep = Security(authn.get_principal)
             # Late‑binding of the injection hook
             authn.register_inject_hook(self)
         else:


### PR DESCRIPTION
## Summary
- use FastAPI `Security` for AutoAPI authentication dependencies
- leverage `HTTPBearer` and `APIKeyHeader` in AuthN helpers for proper docs auth
- adjust unit tests for new authentication signatures

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package auto_authn --directory standards/auto_authn ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest`
- `uv run --package auto_authn --directory standards/auto_authn pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895984bbac48326ad0f136200c06f96