### PR TITLE
feat(autoapi): add fastapi security support

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v2/__init__.py
@@ -10,7 +10,7 @@ Public façade for the AutoAPI framework.
 # ─── std / third-party ──────────────────────────────────────────────
 from collections import OrderedDict
 from typing import Any, AsyncIterator, Callable, Dict, Iterator, Type
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Security
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 from pydantic import BaseModel
@@ -123,12 +123,12 @@ class AutoAPI:
         # ---------------- AuthN wiring -----------------
         if authn is not None:  # preferred path
             self._authn = authn
-            self._authn_dep = Depends(authn.get_principal)
+            self._authn_dep = Security(authn.get_principal)
             # Late‑binding of the injection hook
             authn.register_inject_hook(self)
         else:
             self._authn = None
-            self._authn_dep = Depends(lambda: None)
+            self._authn_dep = Security(lambda: None)
 
         if self.get_db:
             attach_health_and_methodz(self, get_db=self.get_db)

--- a/pkgs/standards/autoapi/tests/i9n/test_allow_anon.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_allow_anon.py
@@ -1,5 +1,6 @@
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Security
 from fastapi.testclient import TestClient
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy import Column, String, ForeignKey, create_engine
 from sqlalchemy.pool import StaticPool
 from sqlalchemy.dialects.postgresql import UUID
@@ -8,12 +9,14 @@ from sqlalchemy.orm import sessionmaker
 from autoapi.v2 import AutoAPI, Base
 from autoapi.v2.mixins import GUIDPk
 from autoapi.v2.types import AuthNProvider
-from fastapi import Request
 
 
 class DummyAuth(AuthNProvider):
-    async def get_principal(self, request: Request):
-        if request.headers.get("Authorization") != "Bearer secret":
+    async def get_principal(
+        self,
+        creds: HTTPAuthorizationCredentials = Security(HTTPBearer()),
+    ):
+        if creds.credentials != "secret":
             raise HTTPException(status_code=401)
         return {"sub": "user"}
 


### PR DESCRIPTION
## Summary
- enable FastAPI `Security` for AutoAPI auth dependencies
- adapt dummy auth test to use HTTP bearer credentials

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_6895984bbac48326ad0f136200c06f96