### PR TITLE
Add debug logging for tenant and principal flow

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/hooks.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/hooks.py
@@ -1,5 +1,9 @@
 # auto_authn/hooks.py  (inside the AuthN package)
 
+import logging
+
+log = logging.getLogger(__name__)
+
 
 def register_inject_hook(api):
     from autoapi.v2.hooks import Phase
@@ -17,10 +21,12 @@ def register_inject_hook(api):
         injected = ctx.setdefault("__autoapi_injected_fields__", {})
         tid = p.get("tid")
         sub = p.get("sub")
+        log.debug("Injecting principal tid=%s sub=%s", tid, sub)
         if tid is not None:
             injected["tenant_id"] = tid
         if sub is not None:
             injected["user_id"] = sub
+        log.debug("Injected fields: %s", injected)
 
 
 __all__ = ["register_inject_hook"]

--- a/pkgs/standards/autoapi/autoapi/v2/mixins/ownable.py
+++ b/pkgs/standards/autoapi/autoapi/v2/mixins/ownable.py
@@ -1,9 +1,13 @@
 from enum import Enum
+import logging
 
 from ..hooks import Phase
 from ..jsonrpc_models import create_standardized_error
 from ..info_schema import check as _info_check
 from ..types import Column, ForeignKey, PgUUID, declared_attr
+
+
+log = logging.getLogger(__name__)
 
 
 class OwnerPolicy(str, Enum):
@@ -66,6 +70,12 @@ class Ownable:
                 params = params.model_dump()
             auto_fields = ctx.get("__autoapi_injected_fields__", {})
             user_id = auto_fields.get("user_id")
+            log.debug(
+                "Ownable before_create policy=%s params=%s auto_fields=%s",
+                pol,
+                params,
+                auto_fields,
+            )
             if pol == OwnerPolicy.STRICT_SERVER:
                 if user_id is None:
                     _err(400, "owner_id is required.")
@@ -91,6 +101,12 @@ class Ownable:
             new_val = params["owner_id"]
             auto_fields = ctx.get("__autoapi_injected_fields__", {})
             user_id = auto_fields.get("user_id")
+            log.debug(
+                "Ownable before_update new_val=%s obj_owner=%s injected=%s",
+                new_val,
+                getattr(obj, "owner_id", None),
+                user_id,
+            )
             if (
                 new_val != obj.owner_id
                 and new_val != user_id

--- a/pkgs/standards/autoapi/autoapi/v2/mixins/tenant_bound.py
+++ b/pkgs/standards/autoapi/autoapi/v2/mixins/tenant_bound.py
@@ -9,12 +9,16 @@ A table that inherits **TenantBound** gets:
 """
 
 from enum import Enum
+import logging
 
 from ._RowBound import _RowBound
 from ..types import Column, ForeignKey, PgUUID, declared_attr
 from ..hooks import Phase
 from ..jsonrpc_models import create_standardized_error
 from ..info_schema import check as _info_check
+
+
+log = logging.getLogger(__name__)
 
 
 class TenantPolicy(str, Enum):
@@ -88,6 +92,12 @@ class TenantBound(_RowBound):
                 params = params.model_dump()
             auto_fields = ctx.get("__autoapi_injected_fields__", {})
             tenant_id = auto_fields.get("tenant_id")
+            log.debug(
+                "TenantBound before_create policy=%s params=%s auto_fields=%s",
+                pol,
+                params,
+                auto_fields,
+            )
             if pol == TenantPolicy.STRICT_SERVER:
                 if tenant_id is None:
                     _err(400, "tenant_id is required.")
@@ -115,6 +125,12 @@ class TenantBound(_RowBound):
             new_val = params["tenant_id"]
             auto_fields = ctx.get("__autoapi_injected_fields__", {})
             tenant_id = auto_fields.get("tenant_id")
+            log.debug(
+                "TenantBound before_update new_val=%s obj_tid=%s injected=%s",
+                new_val,
+                getattr(obj, "tenant_id", None),
+                tenant_id,
+            )
             if (
                 new_val != obj.tenant_id
                 and new_val != tenant_id

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -112,18 +112,22 @@ api = AutoAPI(
 async def _shadow_principal(ctx):
     p = getattr(ctx["request"].state, "principal", None)
     if not p:
+        log.debug("Shadow principal: no principal on request")
         return
     db = ctx["db"]
     tid = p.get("tid")
     uid = p.get("sub")
     if not tid or not uid:
+        log.debug("Shadow principal missing tid or uid: %s", p)
         return
     try:
         tid = uuid.UUID(str(tid))
         uid = uuid.UUID(str(uid))
     except (ValueError, AttributeError):
+        log.debug("Shadow principal invalid UUIDs: tid=%s uid=%s", tid, uid)
         return
     slug = p.get("tenant_slug") or p.get("tenant") or str(tid)
+    log.debug("Shadow principal tid=%s uid=%s slug=%s", tid, uid, slug)
     if await db.get(Tenant, tid) is None:
         db.add(
             Tenant(
@@ -133,11 +137,14 @@ async def _shadow_principal(ctx):
                 email=p.get("tenant_email"),
             )
         )
+        log.debug("Inserted shadow tenant %s", tid)
     if await db.get(User, uid) is None:
         db.add(User(id=uid, tenant_id=tid, username=p.get("username") or str(uid)))
+        log.debug("Inserted shadow user %s", uid)
     try:
         await db.commit()
     except IntegrityError:
+        log.debug("Shadow principal commit failed, rolling back")
         await db.rollback()
 
 


### PR DESCRIPTION
## Summary
- add debug logging to authn inject hook for tenant and user IDs
- add debug logging to Ownable and TenantBound mixins
- add debug logging to gateway shadow principal hook

## Testing
- `uv run --package auto_authn --directory pkgs/standards/auto_authn pytest`
- `uv run --package autoapi --directory pkgs/standards/autoapi pytest`
- `uv run --package peagen --directory pkgs/standards/peagen pytest` *(fails: RPC error -32000: 'Workers.create', and other assertions)*
- `peagen remote --gateway-url https://gw.peagen.com/rpc --api-key pEBoqzHM_OtJhofd0cw9xZmk5rln_rFFQuKjdgnQwW8 init repo gslcloud/test` *(fails: null value in column "tenant_id")*
- `peagen remote --gateway-url http://127.0.0.1:8001/rpc --api-key 1ec87ee86ccd9983d986cd693c53045c1c7a36712ca58fdd41221d7e2c27a355 init repo gslcloud/test` *(fails: 401 Unauthorized)*

------
https://chatgpt.com/codex/tasks/task_e_689594aa88a08326aa304efed0fbe1da