### PR TITLE
feat(autoapi): expose hook order per method

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/endpoints.py
+++ b/pkgs/standards/autoapi/autoapi/v2/endpoints.py
@@ -19,16 +19,16 @@ def attach_health_and_methodz(api, get_async_db=None, get_db=None):
         return list(api._method_ids.keys())
 
     @r.get("/hookz", tags=["hooks"])
-    def _hookz() -> dict[str, dict[str | None, list[str]]]:
-        """Expose the current hook registry."""
-        registry: dict[str, dict[str | None, list[str]]] = {}
+    def _hookz() -> dict[str, dict[str, list[str]]]:
+        """Expose the current hook registry organized by method."""
+        registry: dict[str, dict[str, list[str]]] = {}
         for phase, hooks in api._hook_registry.items():
-            registry[phase.name] = {
-                (k if k is not None else "*"): [
-                    getattr(f, "__name__", repr(f)) for f in v
+            for method, fns in hooks.items():
+                key = method if method is not None else "*"
+                method_hooks = registry.setdefault(key, {})
+                method_hooks[phase.name] = [
+                    getattr(fn, "__name__", repr(fn)) for fn in fns
                 ]
-                for k, v in hooks.items()
-            }
         return registry
 
     # Choose the appropriate health endpoint based on available DB provider


### PR DESCRIPTION
## Summary
- organize `/hookz` output by method so hook order is visible per operation
- test for hook registry structure and ordered hooks

## Testing
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `uv run --package autoapi --directory pkgs/standards/autoapi pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895990cb9448326934c9a97e12d6f89