### PR TITLE
feat(peagen): upsert user and tenant

### DIFF
--- a/pkgs/standards/peagen/peagen/orm/tenants.py
+++ b/pkgs/standards/peagen/peagen/orm/tenants.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from autoapi.v2.tables import Tenant as TenantBase
 from autoapi.v2.mixins import Bootstrappable
+from autoapi.v2.mixins.upsertable import Upsertable
 from peagen.defaults import (
     DEFAULT_TENANT_ID,
     DEFAULT_TENANT_EMAIL,
@@ -10,7 +11,8 @@ from peagen.defaults import (
 )
 
 
-class Tenant(TenantBase, Bootstrappable):
+class Tenant(TenantBase, Bootstrappable, Upsertable):
+    __upsert_keys__ = ("slug",)
     DEFAULT_ROWS = [
         {
             "id": DEFAULT_TENANT_ID,

--- a/pkgs/standards/peagen/peagen/orm/users.py
+++ b/pkgs/standards/peagen/peagen/orm/users.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 from autoapi.v2.tables import User as UserBase
 from autoapi.v2.mixins import Bootstrappable
+from autoapi.v2.mixins.upsertable import Upsertable
 
 
-class User(UserBase, Bootstrappable):
-    pass
+class User(UserBase, Bootstrappable, Upsertable):
+    __upsert_keys__ = ("tenant_id", "username")
 
 
 __all__ = ["User"]


### PR DESCRIPTION
## Summary
- enable upsert behavior for peagen User and Tenant models

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format peagen/orm/users.py peagen/orm/tenants.py`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check peagen/orm/users.py peagen/orm/tenants.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_6895ad8873b88326bc43c8a89c47a650