### PR TITLE
refactor: rename gateway module

### DIFF
--- a/pkgs/standards/autoapi/README.md
+++ b/pkgs/standards/autoapi/README.md
@@ -21,5 +21,5 @@ A high-leverage meta-framework that turns plain SQLAlchemy models into a fully-f
 - Table level configurations: __autoapi_nested_paths__, __autoapi_allow_anon__, & __autoapi_register_hooks__
 - Column level configurations: info_schema ( disable_on, write_only, read_only, default_factory, examples, hybrid (hybrid properties), py_type)
 - `_apply_row_filters` / _RowBound hook providers
-- Automated route creation: rest paths or nested rest paths, rpc gateway, healthz, methodz, hookz
+- Automated route creation: rest paths or nested rest paths, rpc dispatch, healthz, methodz, hookz
 - Support for AuthNProvider extensions

--- a/pkgs/standards/autoapi/autoapi/v2/impl/_runner.py
+++ b/pkgs/standards/autoapi/autoapi/v2/impl/_runner.py
@@ -15,6 +15,7 @@ class _Ctx(dict):
 
 # ───────────────────────── helpers ─────────────────────────
 
+
 def _is_async_session(db) -> bool:
     # AsyncSession exposes run_sync; plain Session does not
     return hasattr(db, "run_sync")
@@ -106,14 +107,12 @@ async def _invoke(
     ctx["payload"] = params  # legacy alias used by some hooks
 
     # ─── Ensure a transaction is active for handler phases ───────────────
-    started_here = False
     try:
         if not _in_tx(db):
             if _is_async_session(db):
                 await db.begin()
             else:
                 db.begin()
-            started_here = True
     except Exception as exc:  # unlikely, but treat as pre-handler error
         ctx["exc"] = exc
         # cannot rollback a tx we failed to begin; just signal error
@@ -151,7 +150,9 @@ async def _invoke(
     except Exception as exc:
         ctx["exc"] = exc
         await _rollback_safely(api, db, ctx)
-        await _run_phase(api, _phase("ON_POST_HANDLER_ERROR") or _phase("ON_ERROR"), ctx)
+        await _run_phase(
+            api, _phase("ON_POST_HANDLER_ERROR") or _phase("ON_ERROR"), ctx
+        )
         raise
 
     # ─── PRE_COMMIT ──────────────────────────────────────────────────────
@@ -194,5 +195,7 @@ async def _invoke(
     except Exception as exc:
         # Do not break the request; report via hook and return prior result
         ctx["exc"] = exc
-        await _run_phase(api, _phase("ON_POST_RESPONSE_ERROR") or _phase("ON_ERROR"), ctx)
+        await _run_phase(
+            api, _phase("ON_POST_RESPONSE_ERROR") or _phase("ON_ERROR"), ctx
+        )
         return ctx["response"].result

--- a/pkgs/standards/autoapi/autoapi/v2/rpcdispatch.py
+++ b/pkgs/standards/autoapi/autoapi/v2/rpcdispatch.py
@@ -1,6 +1,6 @@
 """
-autoapi.v2.gateway  – JSON-RPC façade for AutoAPI
--------------------------------------------------
+autoapi.v2.rpcdispatch  – JSON-RPC façade for AutoAPI
+-----------------------------------------------------
 Exposes a single /rpc endpoint that validates a JSON-RPC-2.0 envelope
 and forwards execution to the unified hook-aware runner.
 
@@ -33,13 +33,12 @@ from pydantic import ValidationError
 
 
 # ────────────────────────────────────────────────────────────────────────────
-def build_gateway(api) -> APIRouter:
+def build_rpcdispatch(api) -> APIRouter:
     """
     Return a router exposing a single `/rpc` endpoint that drives JSON-RPC
     through AutoAPI.  Works for both sync and async SQLAlchemy sessions.
     """
     r = APIRouter()
-
 
     # ───────── synchronous SQLAlchemy branch ───────────────────────────────
     if api.get_db:
@@ -49,16 +48,16 @@ def build_gateway(api) -> APIRouter:
             response_model=_RPCRes,
             tags=["rpc"],
         )
-        async def _gateway(
+        async def _rpcdispatch(
             req: Request,
             env: _RPCReq = Body(..., embed=False),
             db: Session = Depends(api.get_db),
             principal: Dict | None = api._authn_dep,
         ):
             req.state.principal = principal
-            print("GW principal:", principal)
-            print("GW allow_anon:", api._allow_anon)
-            print("GW method called:", env.method)
+            print("RPCD principal:", principal)
+            print("RPCD allow_anon:", api._allow_anon)
+            print("RPCD method called:", env.method)
             ctx: Dict[str, Any] = {"request": req, "db": db, "env": env}
             if api._authn and env.method not in api._allow_anon and principal is None:
                 return _err(-32001, HTTP_ERROR_MESSAGES[401], env)
@@ -94,16 +93,16 @@ def build_gateway(api) -> APIRouter:
     else:
 
         @r.post("/rpc", response_model=_RPCRes, tags=["rpc"])
-        async def _gateway(
+        async def _rpcdispatch(
             req: Request,
             env: _RPCReq = Body(..., embed=False),
             db: AsyncSession = Depends(api.get_async_db),
             principal: Dict | None = api._authn_dep,
         ):
             req.state.principal = principal
-            print("GW principal:", principal)
-            print("GW allow_anon:", api._allow_anon)
-            print("GW method called:", env.method)      
+            print("RPCD principal:", principal)
+            print("RPCD allow_anon:", api._allow_anon)
+            print("RPCD method called:", env.method)
             ctx: Dict[str, Any] = {"request": req, "db": db, "env": env}
             if api._authn and env.method not in api._allow_anon and principal is None:
                 return _err(-32001, HTTP_ERROR_MESSAGES[401], env)


### PR DESCRIPTION
## Summary
- rename AutoAPI's gateway module to rpcdispatch and update references
- adjust package README and docs to use new name
- remove unused variable in transaction runner

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68995b6acba8832697b185e0d311fcd3