### PR TITLE
feat: add dual sync/async op wrapper for API cores

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/impl/call_adapter.py
+++ b/pkgs/standards/autoapi/autoapi/v2/impl/call_adapter.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Awaitable, Callable, Coroutine, Generic, TypeVar
+
+import anyio
+
+T = TypeVar("T")
+
+
+def in_event_loop() -> bool:
+    """Return ``True`` if an event loop is currently running."""
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return False
+    return True
+
+
+class OpCall(Generic[T]):
+    """Wrap an async callable for dual sync/async ergonomics."""
+
+    def __init__(self, acall: Callable[..., Awaitable[T]]):
+        self._acall = acall
+
+    def __call__(self, *args: Any, **kw: Any) -> T | Coroutine[Any, Any, T]:
+        if in_event_loop():
+            return self._acall(*args, **kw)
+        return anyio.run(self._acall, *args, **kw)
+
+    def a(self, *args: Any, **kw: Any) -> Awaitable[T]:
+        return self._acall(*args, **kw)

--- a/pkgs/standards/autoapi/tests/test_call_adapter.py
+++ b/pkgs/standards/autoapi/tests/test_call_adapter.py
@@ -1,0 +1,54 @@
+import asyncio
+import inspect
+
+import pytest
+
+from autoapi.v2.impl.call_adapter import OpCall, in_event_loop
+
+
+async def add_one(x: int) -> int:
+    return x + 1
+
+
+async def boom() -> None:
+    raise ValueError("boom")
+
+
+def test_in_event_loop_sync() -> None:
+    assert not in_event_loop()
+
+
+@pytest.mark.asyncio
+async def test_in_event_loop_async() -> None:
+    assert in_event_loop()
+
+
+def test_sync_call() -> None:
+    op = OpCall(add_one)
+    assert op(1) == 2
+
+
+@pytest.mark.asyncio
+async def test_async_call() -> None:
+    op = OpCall(add_one)
+    coro = op(1)
+    assert inspect.iscoroutine(coro)
+    assert await coro == 2
+
+
+def test_a_returns_coroutine() -> None:
+    op = OpCall(add_one)
+    assert asyncio.run(op.a(1)) == 2
+
+
+def test_exception_sync() -> None:
+    op = OpCall(boom)
+    with pytest.raises(ValueError):
+        op()
+
+
+@pytest.mark.asyncio
+async def test_exception_async() -> None:
+    op = OpCall(boom)
+    with pytest.raises(ValueError):
+        await op()


### PR DESCRIPTION
## Summary
- introduce `OpCall` helper to allow core operations to run in both synchronous and asynchronous contexts
- wrap generated core and core_exec operations with `OpCall`
- add tests covering event loop detection and call adapter behavior

## Testing
- `uv run --directory . --package autoapi ruff format autoapi/v2/impl/call_adapter.py autoapi/v2/impl/routes_builder.py tests/test_call_adapter.py`
- `uv run --directory . --package autoapi ruff check autoapi/v2/impl/call_adapter.py autoapi/v2/impl/routes_builder.py tests/test_call_adapter.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/test_call_adapter.py`
- `uv run --package autoapi --directory standards/autoapi pytest` *(failed: AssertionError: assert ['autoapi.v2...)*

------
https://chatgpt.com/codex/tasks/task_e_68994e0f7b188326abff42e5fecabb6e