### PR TITLE
feat(autoapi): add sync/async op wrapper

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/impl/_dual_call.py
+++ b/pkgs/standards/autoapi/autoapi/v2/impl/_dual_call.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import asyncio
+import functools
+import anyio
+from typing import Any, Awaitable, Callable, Coroutine, Generic, ParamSpec, TypeVar
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+def in_event_loop() -> bool:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return False
+    return True
+
+
+class CallableOp(Generic[P, T]):
+    """Wrap an async operation for dual sync/async ergonomics."""
+
+    def __init__(self, fn: Callable[P, Awaitable[T]]):
+        self._fn = fn
+        functools.update_wrapper(self, fn)
+
+    async def _acall(self, *args: P.args, **kwargs: P.kwargs) -> T:
+        return await self._fn(*args, **kwargs)
+
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> T | Coroutine[Any, Any, T]:
+        if in_event_loop():
+            return self._acall(*args, **kwargs)
+        return anyio.run(lambda: self._acall(*args, **kwargs))
+
+    def a(self, *args: P.args, **kwargs: P.kwargs) -> Coroutine[Any, Any, T]:
+        return self._acall(*args, **kwargs)

--- a/pkgs/standards/autoapi/autoapi/v2/impl/_runner.py
+++ b/pkgs/standards/autoapi/autoapi/v2/impl/_runner.py
@@ -15,6 +15,7 @@ class _Ctx(dict):
 
 # ───────────────────────── helpers ─────────────────────────
 
+
 def _is_async_session(db) -> bool:
     # AsyncSession exposes run_sync; plain Session does not
     return hasattr(db, "run_sync")
@@ -106,14 +107,12 @@ async def _invoke(
     ctx["payload"] = params  # legacy alias used by some hooks
 
     # ─── Ensure a transaction is active for handler phases ───────────────
-    started_here = False
     try:
         if not _in_tx(db):
             if _is_async_session(db):
                 await db.begin()
             else:
                 db.begin()
-            started_here = True
     except Exception as exc:  # unlikely, but treat as pre-handler error
         ctx["exc"] = exc
         # cannot rollback a tx we failed to begin; just signal error
@@ -151,7 +150,9 @@ async def _invoke(
     except Exception as exc:
         ctx["exc"] = exc
         await _rollback_safely(api, db, ctx)
-        await _run_phase(api, _phase("ON_POST_HANDLER_ERROR") or _phase("ON_ERROR"), ctx)
+        await _run_phase(
+            api, _phase("ON_POST_HANDLER_ERROR") or _phase("ON_ERROR"), ctx
+        )
         raise
 
     # ─── PRE_COMMIT ──────────────────────────────────────────────────────
@@ -194,5 +195,7 @@ async def _invoke(
     except Exception as exc:
         # Do not break the request; report via hook and return prior result
         ctx["exc"] = exc
-        await _run_phase(api, _phase("ON_POST_RESPONSE_ERROR") or _phase("ON_ERROR"), ctx)
+        await _run_phase(
+            api, _phase("ON_POST_RESPONSE_ERROR") or _phase("ON_ERROR"), ctx
+        )
         return ctx["response"].result

--- a/pkgs/standards/autoapi/tests/test_dual_call.py
+++ b/pkgs/standards/autoapi/tests/test_dual_call.py
@@ -1,0 +1,34 @@
+import inspect
+
+
+import anyio
+
+from autoapi.v2.impl._dual_call import CallableOp, in_event_loop
+
+
+def test_in_event_loop_detection():
+    assert not in_event_loop()
+
+    async def check():
+        assert in_event_loop()
+
+    anyio.run(check)
+
+
+def test_callable_op_sync_and_async():
+    def add(x: int) -> int:
+        return x + 1
+
+    async def add_async(x: int) -> int:
+        return await anyio.to_thread.run_sync(add, x)
+
+    op = CallableOp(add_async)
+    assert op(1) == 2
+
+    async def check():
+        coro = op(1)
+        assert inspect.iscoroutine(coro)
+        assert await coro == 2
+        assert await op.a(1) == 2
+
+    anyio.run(check)


### PR DESCRIPTION
## Summary
- add CallableOp wrapper with event loop detection and synchronous execution
- wrap AutoAPI core and core_exec methods with CallableOp
- exercise new helper in unit tests

## Testing
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff check autoapi/v2/impl/routes_builder.py autoapi/v2/impl/_runner.py autoapi/v2/impl/_dual_call.py tests/test_dual_call.py --fix`
- `uv run --package autoapi --directory pkgs/standards/autoapi pytest tests/test_dual_call.py`
- `uv run --package autoapi --directory pkgs/standards/autoapi pytest` *(fails: test_hookz_endpoint_comprehensive[sync], test_hookz_endpoint_comprehensive[async], test_catch_all_hooks[sync], test_catch_all_hooks[async], test_transaction_decorator[sync], test_transaction_decorator[async])*

------
https://chatgpt.com/codex/tasks/task_e_68994e0f7b188326abff42e5fecabb6e