### PR TITLE
Limit exposed tables to included models in AutoAPI

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v2/__init__.py
@@ -36,7 +36,6 @@ from .types import (
 )
 from .schema import _SchemaNS, get_autoapi_schema as get_schema
 from .transactional import transactional as _register_tx
-from . import tables as tables
 
 # ─── db schema bootstrap (dialect-aware; no flags required) ─────────
 from .bootstrap_dbschema import ensure_schemas
@@ -104,8 +103,8 @@ class AutoAPI:
             raise ValueError("must declare tables to be created")
             self._tables = set(self.base.metadata.tables.values())
 
-        # expose tables namespace
-        self.tables = tables
+        # expose only the included tables
+        self.tables = SimpleNamespace(**{cls.__name__: cls for cls in self._include})
 
         # Store DDL creation for later execution
         self._ddl_executed = False

--- a/pkgs/standards/autoapi/autoapi/v2/hooks.py
+++ b/pkgs/standards/autoapi/autoapi/v2/hooks.py
@@ -78,7 +78,8 @@ def _init_hooks(self) -> None:
 
             # Preserve the original function name for registry visibility
             async_f.__name__ = getattr(f, "__name__", repr(f))
-            async_f.__qualname__ = getattr(f, "__qualname__", async_f.__name__)
+            async_f.__qualname__ = async_f.__name__
+            async_f.__module__ = None
 
             # Determine the hook key based on parameters
             hook_key = None


### PR DESCRIPTION
## Summary
- expose only included SQLAlchemy models on `AutoAPI.tables`
- ensure hook registry records simple function names

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest` *(fails: test_catch_all_hooks[sync], test_catch_all_hooks[async], test_transaction_decorator[sync], test_transaction_decorator[async])*

------
https://chatgpt.com/codex/tasks/task_e_68997d0264588326ba50fc78b1211f36