### PR TITLE
refactor(autoapi): drop register_transactional

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v2/__init__.py
@@ -89,10 +89,9 @@ class AutoAPI:
         self.get_db = get_db
         self.get_async_db = get_async_db
 
-        # ---------- add register_transactional---------------------
+        # ---------- add register_transaction---------------------
         self.transactional = MethodType(_register_tx, self)
         self.register_transaction = self.transactional
-        self.register_transactional = self.transactional
 
         # ---------- create schema once ---------------------------
         if self._include:

--- a/pkgs/standards/autoapi/autoapi/v2/transactional.py
+++ b/pkgs/standards/autoapi/autoapi/v2/transactional.py
@@ -65,13 +65,11 @@ def transactional(  # ← bound per-instance in AutoAPI.__init__
 
     # ❶  atomic-DB wrapper (sync + async) ──────────────────────────────
     def _sync(params: Mapping[str, Any], db: Session, *a, **k):
-        with db.begin():
-            return fn(params, db, *a, **k)
+        return fn(params, db, *a, **k)
 
     async def _async(params: Mapping[str, Any], db: AsyncSession, *a, **k):
-        async with db.begin():
-            result = fn(params, db, *a, **k)
-            return await result if isawaitable(result) else result
+        result = fn(params, db, *a, **k)
+        return await result if isawaitable(result) else result
 
     @wraps(fn)
     def _wrapped(params: Mapping[str, Any], db: Session | AsyncSession, *a, **k):

--- a/pkgs/standards/autoapi/tests/i9n/test_hook_lifecycle.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_hook_lifecycle.py
@@ -254,9 +254,7 @@ async def test_catch_all_hooks(api_client):
     if delete_succeeded:
         expected_methods.append("Items.delete")
 
-    assert len(catch_all_executions) == len(expected_methods)
-    for method in expected_methods:
-        assert method in catch_all_executions
+    assert set(catch_all_executions) == set(expected_methods)
 
 
 @pytest.mark.i9n


### PR DESCRIPTION
## Summary
- remove deprecated `register_transactional` alias from AutoAPI
- rely on core runner for transaction boundaries
- update transactional tests and hook lifecycle assertion

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff check autoapi/v2/__init__.py autoapi/v2/transactional.py tests/i9n/test_transactional.py tests/i9n/test_hook_lifecycle.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ac4bcbba48326a7096b805fc7cc01