### PR TITLE
feat(autoapi_client): add async RPC helper

### DIFF
--- a/pkgs/standards/autoapi_client/autoapi_client/_rpc.py
+++ b/pkgs/standards/autoapi_client/autoapi_client/_rpc.py
@@ -31,6 +31,10 @@ class RPCMixin:
         """Get the HTTP client."""
         return self._client
 
+    def _get_async_client(self) -> httpx.AsyncClient:
+        """Get the async HTTP client."""
+        return self._async_client
+
     # ─────────── public high-level call helpers ────────────────────── #
     @overload
     def call(  # result with schema
@@ -102,6 +106,105 @@ class RPCMixin:
         headers = {"Content-Type": "application/json"}
         headers.update(getattr(self, "_headers", {}))
         r = self._get_client().post(
+            self._get_endpoint(),
+            json=req,
+            headers=headers,
+        )
+
+        if raise_status:
+            r.raise_for_status()
+        res = r.json()
+        err = res.get("error")
+        err_code: int | None = None
+        if err:
+            err_code = err.get("code", -32000)
+            msg = err.get("message", "Unknown error")
+            if raise_error:
+                raise RuntimeError(f"RPC error {err_code}: {msg}")
+
+        result = res.get("result")
+
+        if out_schema is not None and result is not None:
+            result = out_schema.model_validate(result)  # type: ignore[assignment]
+
+        parts = [result]
+        if status_code:
+            parts.append(r.status_code)
+        if error_code:
+            parts.append(err_code)
+        return parts[0] if len(parts) == 1 else tuple(parts)
+
+    # ─────────── Async call helper ──────────────────────────────────── #
+    @overload
+    async def acall(  # result with schema
+        self,
+        method: str,
+        *,
+        params: _Schema[Any] | dict | None = None,
+        out_schema: type[_Schema[T]],
+        status_code: bool = False,
+        error_code: bool = False,
+        raise_status: bool = True,
+        raise_error: bool = True,
+    ) -> T: ...
+
+    @overload
+    async def acall(  # raw / no schema
+        self,
+        method: str,
+        *,
+        params: dict | None = None,
+        out_schema: None = None,
+        status_code: bool = False,
+        error_code: bool = False,
+        raise_status: bool = True,
+        raise_error: bool = True,
+    ) -> Any: ...
+
+    async def acall(
+        self,
+        method: str,
+        *,
+        params: _Schema[Any] | dict | None = None,
+        out_schema: type[_Schema[T]] | None = None,
+        status_code: bool = False,
+        error_code: bool = False,
+        raise_status: bool = True,
+        raise_error: bool = True,
+    ) -> Any:
+        """
+        Make an async JSON-RPC call.
+
+        Args:
+            method: The RPC method name
+            params: Parameters to send (dict or Pydantic schema)
+            out_schema: Optional Pydantic schema for result validation
+
+        Returns:
+            The RPC result, optionally validated through out_schema
+
+        Raises:
+            RuntimeError: If the RPC returns an error
+            httpx.HTTPStatusError: If the HTTP request fails
+        """
+        # ----- payload build ------------------------------------------------
+        if isinstance(params, _Schema):  # pydantic in → dump to dict
+            params_dict = json.loads(params.model_dump_json(exclude_none=True))
+        else:
+            # ensure plain dicts contain only JSON-serializable values
+            params_dict = json.loads(json.dumps(params or {}, default=str))
+
+        req = {
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params_dict,
+            "id": str(uuid.uuid4()),
+        }
+
+        # ----- HTTP roundtrip ----------------------------------------------
+        headers = {"Content-Type": "application/json"}
+        headers.update(getattr(self, "_headers", {}))
+        r = await self._get_async_client().post(
             self._get_endpoint(),
             json=req,
             headers=headers,

--- a/pkgs/standards/autoapi_client/tests/unit/test_autoapi_async_rpc.py
+++ b/pkgs/standards/autoapi_client/tests/unit/test_autoapi_async_rpc.py
@@ -1,0 +1,32 @@
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from autoapi_client import AutoAPIClient
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_acall_basic():
+    """Test basic async RPC call functionality."""
+    captured = {}
+
+    async def fake_post(self, url, *, json=None, headers=None):
+        captured.update(json=json, url=url, headers=headers)
+        request = httpx.Request("POST", url)
+        return httpx.Response(
+            200, request=request, json={"jsonrpc": "2.0", "result": {"success": True}}
+        )
+
+    with patch.object(httpx.AsyncClient, "post", new=fake_post):
+        client = AutoAPIClient("http://example.com/api")
+        result = await client.acall("test.method")
+
+    assert captured["json"]["jsonrpc"] == "2.0"
+    assert captured["json"]["method"] == "test.method"
+    assert captured["json"]["params"] == {}
+    assert "id" in captured["json"]
+    assert captured["url"] == "http://example.com/api"
+    assert captured["headers"]["Content-Type"] == "application/json"
+    assert result == {"success": True}


### PR DESCRIPTION
## Summary
- add `acall` async helper mirroring `call`
- test async RPC request/response flow

## Testing
- `uv run --package autoapi_client --directory standards/autoapi_client ruff format .`
- `uv run --package autoapi_client --directory standards/autoapi_client ruff check . --fix`
- `uv run --package autoapi_client --directory standards/autoapi_client pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ac64464b483268aca8b59afd7cd09