### PR TITLE
chore(autoapi): drop register_transactional

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v2/__init__.py
@@ -89,10 +89,9 @@ class AutoAPI:
         self.get_db = get_db
         self.get_async_db = get_async_db
 
-        # ---------- add register_transactional---------------------
+        # ---------- register transactions ------------------------
         self.transactional = MethodType(_register_tx, self)
         self.register_transaction = self.transactional
-        self.register_transactional = self.transactional
 
         # ---------- create schema once ---------------------------
         if self._include:


### PR DESCRIPTION
## Summary
- remove obsolete register_transactional alias from AutoAPI

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ae21683288326861915bb488d5e0f