### PR TITLE
fix(peagen): allow unauthenticated worker registration

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/impl/routes_builder.py
+++ b/pkgs/standards/autoapi/autoapi/v2/impl/routes_builder.py
@@ -144,7 +144,10 @@ def _register_routes_and_rpcs(  # noqa: N802 – bound as method
     print(f"Nested prefix: {nested_pref} vars: {nested_vars}")
 
     allow_cb = getattr(model, "__autoapi_allow_anon__", None)
-    _allow_verbs = set(allow_cb()) if callable(allow_cb) else set()
+    if callable(allow_cb):
+        _allow_verbs = set(allow_cb())
+    else:
+        _allow_verbs = set(allow_cb or [])
     self._allow_anon.update({_canonical(tab, v) for v in _allow_verbs})
     if _allow_verbs:
         print(f"Anon allowed verbs: {_allow_verbs}")

--- a/pkgs/standards/autoapi/autoapi/v2/types/allow_anon_provider.py
+++ b/pkgs/standards/autoapi/autoapi/v2/types/allow_anon_provider.py
@@ -1,4 +1,4 @@
-from abc import abstractmethod
+from typing import Callable, ClassVar, Iterable
 
 from .table_config_provider import TableConfigProvider
 
@@ -8,10 +8,7 @@ _ALLOW_ANON_PROVIDERS: set[type] = set()
 class AllowAnonProvider(TableConfigProvider):
     """Models that expose operations without authentication."""
 
-    @classmethod
-    @abstractmethod
-    def __autoapi_allow_anon__(cls) -> set[str]:
-        """Return a set of CRUD verb names that allow anonymous access."""
+    __autoapi_allow_anon__: ClassVar[Iterable[str] | Callable[[], Iterable[str]]] = ()
 
     def __init_subclass__(cls, **kw):
         super().__init_subclass__(**kw)

--- a/pkgs/standards/peagen/peagen/orm/workers.py
+++ b/pkgs/standards/peagen/peagen/orm/workers.py
@@ -25,9 +25,7 @@ class Worker(Base, GUIDPk, Timestamped, HookProvider, AllowAnonProvider):
     __tablename__ = "workers"
     __table_args__ = ({"schema": "peagen"},)
 
-    @classmethod
-    def __autoapi_allow_anon__(cls) -> set[str]:
-        return {"create"}
+    __autoapi_allow_anon__ = {"create"}
 
     pool_id = Column(
         PgUUID(as_uuid=True),

--- a/pkgs/standards/peagen/peagen/orm/workers.py
+++ b/pkgs/standards/peagen/peagen/orm/workers.py
@@ -24,7 +24,11 @@ from .pools import Pool
 class Worker(Base, GUIDPk, Timestamped, HookProvider, AllowAnonProvider):
     __tablename__ = "workers"
     __table_args__ = ({"schema": "peagen"},)
-    __autoapi_allow_anon__ = {"create"}
+
+    @classmethod
+    def __autoapi_allow_anon__(cls) -> set[str]:
+        return {"create"}
+
     pool_id = Column(
         PgUUID(as_uuid=True),
         ForeignKey("peagen.pools.id"),


### PR DESCRIPTION
## Summary
- implement `__autoapi_allow_anon__` as a classmethod on `Worker` so `Workers.create` is whitelisted without credentials

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format peagen/orm/workers.py`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/orm/workers.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_689ae59d28d88326ab51841258a5094a