### PR TITLE
refactor: use _authorize hook

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/impl/_runner.py
+++ b/pkgs/standards/autoapi/autoapi/v2/impl/_runner.py
@@ -15,6 +15,7 @@ class _Ctx(dict):
 
 # ───────────────────────── helpers ─────────────────────────
 
+
 def _is_async_session(db) -> bool:
     # AsyncSession exposes run_sync; plain Session does not
     return hasattr(db, "run_sync")
@@ -106,14 +107,12 @@ async def _invoke(
     ctx["payload"] = params  # legacy alias used by some hooks
 
     # ─── Ensure a transaction is active for handler phases ───────────────
-    started_here = False
     try:
         if not _in_tx(db):
             if _is_async_session(db):
                 await db.begin()
             else:
                 db.begin()
-            started_here = True
     except Exception as exc:  # unlikely, but treat as pre-handler error
         ctx["exc"] = exc
         # cannot rollback a tx we failed to begin; just signal error
@@ -151,7 +150,9 @@ async def _invoke(
     except Exception as exc:
         ctx["exc"] = exc
         await _rollback_safely(api, db, ctx)
-        await _run_phase(api, _phase("ON_POST_HANDLER_ERROR") or _phase("ON_ERROR"), ctx)
+        await _run_phase(
+            api, _phase("ON_POST_HANDLER_ERROR") or _phase("ON_ERROR"), ctx
+        )
         raise
 
     # ─── PRE_COMMIT ──────────────────────────────────────────────────────
@@ -194,5 +195,7 @@ async def _invoke(
     except Exception as exc:
         # Do not break the request; report via hook and return prior result
         ctx["exc"] = exc
-        await _run_phase(api, _phase("ON_POST_RESPONSE_ERROR") or _phase("ON_ERROR"), ctx)
+        await _run_phase(
+            api, _phase("ON_POST_RESPONSE_ERROR") or _phase("ON_ERROR"), ctx
+        )
         return ctx["response"].result

--- a/pkgs/standards/autoapi/autoapi/v2/impl/routes_builder.py
+++ b/pkgs/standards/autoapi/autoapi/v2/impl/routes_builder.py
@@ -66,9 +66,9 @@ def _register_routes_and_rpcs(  # noqa: N802 – bound as method
     tab: str,
     pk: str,
     SCreate,
-    SReadOut,     # ← read OUTPUT schema
-    SReadIn,      # ← read INPUT (pk-only) schema
-    SDeleteIn,    # ← delete INPUT (pk-only) schema
+    SReadOut,  # ← read OUTPUT schema
+    SReadIn,  # ← read INPUT (pk-only) schema
+    SDeleteIn,  # ← delete INPUT (pk-only) schema
     SUpdate,
     SListIn,
     _create,
@@ -100,12 +100,12 @@ def _register_routes_and_rpcs(  # noqa: N802 – bound as method
 
     # ---------- verb specification -----------------------------------
     spec: List[tuple] = [
-        ("create", "POST",  "",          201, SCreate,             SReadOut,         _create),
-        ("list",   "GET",   "",          200, SListIn,             List[SReadOut],   _list),
-        ("clear",  "DELETE","",          204, None,                None,             _clear),
-        ("read",   "GET",   "/{item_id}",200, SReadIn,             SReadOut,         _read),
-        ("update", "PATCH", "/{item_id}",200, SUpdate,             SReadOut,         _update),
-        ("delete", "DELETE","/{item_id}",204, SDeleteIn,           None,             _delete),
+        ("create", "POST", "", 201, SCreate, SReadOut, _create),
+        ("list", "GET", "", 200, SListIn, List[SReadOut], _list),
+        ("clear", "DELETE", "", 204, None, None, _clear),
+        ("read", "GET", "/{item_id}", 200, SReadIn, SReadOut, _read),
+        ("update", "PATCH", "/{item_id}", 200, SUpdate, SReadOut, _update),
+        ("delete", "DELETE", "/{item_id}", 204, SDeleteIn, None, _delete),
     ]
     if issubclass(model, Replaceable):
         print("Model is Replaceable; adding replace spec")
@@ -123,8 +123,16 @@ def _register_routes_and_rpcs(  # noqa: N802 – bound as method
     if issubclass(model, BulkCapable):
         print("Model is BulkCapable; adding bulk specs")
         spec += [
-            ("bulk_create", "POST",   "/bulk", 201, List[SCreate],   List[SReadOut], _create),
-            ("bulk_delete", "DELETE", "/bulk", 204, List[SDeleteIn], None,           _delete),
+            (
+                "bulk_create",
+                "POST",
+                "/bulk",
+                201,
+                List[SCreate],
+                List[SReadOut],
+                _create,
+            ),
+            ("bulk_delete", "DELETE", "/bulk", 204, List[SDeleteIn], None, _delete),
         ]
 
     # ---------- nested routing ---------------------------------------
@@ -152,7 +160,7 @@ def _register_routes_and_rpcs(  # noqa: N802 – bound as method
     # ---------- RBAC guard -------------------------------------------
     def _guard(scope: str):
         async def inner(request: Request):
-            if self.authorize and not self.authorize(scope, request):
+            if self._authorize and not self._authorize(scope, request):
                 print(f"Authorization failed for scope {scope}")
                 http_exc, _, _ = create_standardized_error(403, rpc_code=-32095)
                 raise http_exc
@@ -339,7 +347,9 @@ def _register_routes_and_rpcs(  # noqa: N802 – bound as method
 
         # JSON-RPC shim
         rpc_fn = _wrap_rpc(core, rpc_in, Out, pk, model)
-        print(f"Registered RPC method {m_id} with IN={getattr(rpc_in, '__name__', rpc_in)} OUT={getattr(Out, '__name__', Out)}")
+        print(
+            f"Registered RPC method {m_id} with IN={getattr(rpc_in, '__name__', rpc_in)} OUT={getattr(Out, '__name__', Out)}"
+        )
         self.rpc[m_id] = rpc_fn
 
         # ── in-process convenience wrapper ────────────────────────────────
@@ -373,10 +383,12 @@ def _register_routes_and_rpcs(  # noqa: N802 – bound as method
         setattr(self.methods, camel, _runner)
         print(f"Registered helper method {camel}")
 
-
         # Ensure container for core_exec
         if not hasattr(self, "core_raw"):
-            class _CR: pass
+
+            class _CR:
+                pass
+
             self.core_raw = _CR()
 
         async def _core_raw(payload, *, db=None, _core=core, _verb=verb, _pk=pk):
@@ -390,7 +402,7 @@ def _register_routes_and_rpcs(  # noqa: N802 – bound as method
                     case "list":
                         return (_p,)  # already a schema/dict matching list input
                     case "read" | "delete":
-                        if hasattr(_p, "model_dump"):    # pydantic model
+                        if hasattr(_p, "model_dump"):  # pydantic model
                             d = _p.model_dump()
                         else:
                             d = dict(_p)
@@ -406,14 +418,16 @@ def _register_routes_and_rpcs(  # noqa: N802 – bound as method
 
             # 1) Caller supplied a DB
             if db is not None:
-                if hasattr(db, "run_sync"):                         # AsyncSession
+                if hasattr(db, "run_sync"):  # AsyncSession
                     return await db.run_sync(lambda s: _core(*_build_args(payload), s))
                 # Plain Session
                 return _core(*_build_args(payload), db)
 
             # 2) No DB supplied: auto-open a sync session only if available
             if self.get_db is None:
-                raise TypeError("core_exec requires a DB (AsyncSession or Session) when get_db is not configured")
+                raise TypeError(
+                    "core_exec requires a DB (AsyncSession or Session) when get_db is not configured"
+                )
 
             gen = self.get_db()
             s = next(gen)
@@ -421,14 +435,13 @@ def _register_routes_and_rpcs(  # noqa: N802 – bound as method
                 return _core(*_build_args(payload), s)
             finally:
                 try:
-                    next(gen)   # close
+                    next(gen)  # close
                 except StopIteration:
                     pass
 
         # Register helper name (CamelCase like UsersCreate)
         camel = f"{''.join(w.title() for w in tab.split('_'))}{''.join(w.title() for w in verb.split('_'))}"
         setattr(self.core_raw, camel, _core_raw)
-
 
     # include routers
     self.router.include_router(flat_router)

--- a/pkgs/standards/autoapi/autoapi/v2/rpcdispatch.py
+++ b/pkgs/standards/autoapi/autoapi/v2/rpcdispatch.py
@@ -63,7 +63,7 @@ def build_rpcdispatch(api) -> APIRouter:
                 return _err(-32001, HTTP_ERROR_MESSAGES[401], env)
 
             # Authorisation --------------------------------------------------
-            if api.authorize and not api.authorize(env.method, req):
+            if api._authorize and not api._authorize(env.method, req):
                 return _err(403, "Forbidden", env)
 
             try:
@@ -107,7 +107,7 @@ def build_rpcdispatch(api) -> APIRouter:
             if api._authn and env.method not in api._allow_anon and principal is None:
                 return _err(-32001, HTTP_ERROR_MESSAGES[401], env)
 
-            if api.authorize and not api.authorize(env.method, req):
+            if api._authorize and not api._authorize(env.method, req):
                 return _err(403, "Forbidden", env)
 
             try:


### PR DESCRIPTION
## Summary
- switch authorization checks to use internal `_authorize`
- clean up unused variable in runner to satisfy lint

## Testing
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff format autoapi/v2/impl/routes_builder.py autoapi/v2/rpcdispatch.py autoapi/v2/impl/_runner.py`
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff check autoapi/v2/impl/routes_builder.py autoapi/v2/rpcdispatch.py autoapi/v2/impl/_runner.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_689b09a892d88326a95a0b36a7be71a6