### PR TITLE
feat(autoapi): document register_transaction and rebind decorator

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v2/__init__.py
@@ -35,7 +35,7 @@ from .types import (
     SimpleNamespace,
 )
 from .schema import _SchemaNS, get_autoapi_schema as get_schema
-from .transactional import transactional as _register_tx
+from .transactional import register_transaction, transactional
 
 # ─── db schema bootstrap (dialect-aware; no flags required) ─────────
 from .bootstrap_dbschema import ensure_schemas
@@ -90,7 +90,8 @@ class AutoAPI:
         self.get_async_db = get_async_db
 
         # ---------- register transactions ------------------------
-        self.register_transaction = MethodType(_register_tx, self)
+        self.register_transaction = MethodType(register_transaction, self)
+        self.transactional = MethodType(transactional, self)
 
         # ---------- create schema once ---------------------------
         if self._include:

--- a/pkgs/standards/autoapi/autoapi/v2/transactional.py
+++ b/pkgs/standards/autoapi/autoapi/v2/transactional.py
@@ -23,6 +23,80 @@ from sqlalchemy.orm import Session
 from .impl._runner import _invoke  # central lifecycle engine
 
 
+def register_transaction(
+    self,
+    rpc_id: str,
+    fn: Callable[..., Any],
+    rest_uri: str,
+    *,
+    rest_method: str = "POST",
+    tags: tuple[str, ...] = ("txn",),
+) -> None:
+    """Register an RPC handler and expose a REST endpoint.
+
+    Parameters
+    ----------
+    self:
+        The :class:`AutoAPI` instance to bind to.
+    rpc_id:
+        JSON-RPC method name. Must be unique across the API instance.
+    fn:
+        Callable invoked when the RPC executes.
+    rest_uri:
+        Path for the REST façade that forwards to the RPC.
+    rest_method:
+        HTTP method for the REST route. Defaults to ``"POST"``.
+    tags:
+        Optional FastAPI tags applied to the generated route.
+
+    Raises
+    ------
+    RuntimeError
+        If ``rpc_id`` is already registered or if the REST route cannot be
+        created.
+    """
+    if rpc_id in self.rpc:
+        raise RuntimeError(f"RPC '{rpc_id}' already registered")
+
+    self.rpc[rpc_id] = fn
+    if hasattr(self, "_method_ids"):  # populated by /methodz route
+        self._method_ids[rpc_id] = fn
+
+    if hasattr(self, "get_async_db") and self.get_async_db is not None:
+
+        async def _rest_endpoint(
+            request: Request,
+            params: Mapping[str, Any] = Body(...),
+            db: Session = Depends(self.get_db),
+        ):
+            ctx: MutableMapping[str, Any] = {"request": request, "db": db, "env": {}}
+            return await _invoke(self, rpc_id, params=params, ctx=ctx)
+
+    else:  # fallback to sync-DB dependency
+
+        async def _rest_endpoint(
+            request: Request,
+            params: Mapping[str, Any] = Body(...),
+            db: Session = Depends(self.get_db),
+        ):
+            ctx: MutableMapping[str, Any] = {"request": request, "db": db, "env": {}}
+            return await _invoke(self, rpc_id, params=params, ctx=ctx)
+
+    try:
+        self.router.add_api_route(
+            rest_uri,
+            _rest_endpoint,
+            methods=[rest_method],
+            tags=list(tags),
+            name=rpc_id,
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        self.rpc.pop(rpc_id, None)
+        if hasattr(self, "_method_ids"):
+            self._method_ids.pop(rpc_id, None)
+        raise RuntimeError(f"Failed to register transaction '{rpc_id}'") from exc
+
+
 def transactional(  # ← bound per-instance in AutoAPI.__init__
     self,
     fn: Callable[..., Any] | None = None,
@@ -67,41 +141,8 @@ def transactional(  # ← bound per-instance in AutoAPI.__init__
     def _wrapped(params: Mapping[str, Any], db: Session | AsyncSession, *a, **k):
         return fn(params, db, *a, **k)
 
-    # ❷  RPC registration ─────────────────────────────────────────────
-    if rpc_id in self.rpc:
-        raise RuntimeError(f"RPC '{rpc_id}' already registered")
-
-    self.rpc[rpc_id] = _wrapped
-    if hasattr(self, "_method_ids"):  # populated by /methodz route
-        self._method_ids[rpc_id] = _wrapped
-
-    # ❸  REST façade that re-invokes via `_invoke`  ───────────────────
-    if hasattr(self, "get_async_db") and self.get_async_db is not None:
-
-        async def _rest_endpoint(
-            request: Request,  #  ← ✅
-            params: Mapping[str, Any] = Body(...),
-            db: Session = Depends(self.get_db),
-        ):
-            ctx: MutableMapping[str, Any] = {"request": request, "db": db, "env": {}}
-            return await _invoke(self, rpc_id, params=params, ctx=ctx)
-
-    else:  # fallback to sync-DB dependency
-
-        async def _rest_endpoint(
-            request: Request,  #  ← ✅
-            params: Mapping[str, Any] = Body(...),
-            db: Session = Depends(self.get_db),
-        ):
-            ctx: MutableMapping[str, Any] = {"request": request, "db": db, "env": {}}
-            return await _invoke(self, rpc_id, params=params, ctx=ctx)
-
-    self.router.add_api_route(
-        rest_uri,
-        _rest_endpoint,
-        methods=[rest_method],
-        tags=list(tags),
-        name=rpc_id,
+    self.register_transaction(
+        rpc_id, _wrapped, rest_uri, rest_method=rest_method, tags=tags
     )
 
     return _wrapped


### PR DESCRIPTION
## Summary
- document register_transaction parameters and error modes
- expose transactional decorator on AutoAPI for decorator usage

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format autoapi/v2/__init__.py autoapi/v2/transactional.py`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check autoapi/v2/__init__.py autoapi/v2/transactional.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_689b17c2f2408326a91680a5016cc79d