### PR TITLE
feat(autoapi): Add verb aliasing support for RPC methods

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/types/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v2/types/__init__.py
@@ -50,6 +50,8 @@ from .table_config_provider import TableConfigProvider
 from .hook_provider import HookProvider
 from .nested_path_provider import NestedPathProvider
 from .allow_anon_provider import AllowAnonProvider
+from .op_verb_alias_provider import OpVerbAliasProvider, list_verb_alias_providers
+
 
 
 # ── Generics / Extensions ─────────────────────────────────────────────────
@@ -117,4 +119,9 @@ __all__: list[str] = [
     "UUID",
     # pydantic schema support
     "Field",
+]
+
+__all__ += [
+    "OpVerbAliasProvider",
+    "list_verb_alias_providers",
 ]

--- a/pkgs/standards/autoapi/autoapi/v2/types/op_verb_alias_provider.py
+++ b/pkgs/standards/autoapi/autoapi/v2/types/op_verb_alias_provider.py
@@ -1,0 +1,32 @@
+from typing import Callable, ClassVar, Mapping, Literal
+
+from .table_config_provider import TableConfigProvider
+
+_VERB_ALIAS_PROVIDERS: set[type] = set()
+
+class OpVerbAliasProvider(TableConfigProvider):
+    """
+    Table-level config provider to rename operation verbs for RPC exposure.
+    Does not change REST routes or internal canonical semantics.
+    """
+
+    # Map canonical → alias (e.g., {"create": "register"})
+    __autoapi_verb_aliases__: ClassVar[
+        Mapping[str, str] | Callable[[], Mapping[str, str]]
+    ] = {}
+
+    # How to expose names:
+    #  - "both" (default): expose canonical & alias
+    #  - "alias_only": expose alias only
+    #  - "canonical_only": ignore aliases, keep canonical only
+    __autoapi_verb_alias_policy__: ClassVar[
+        Literal["both", "alias_only", "canonical_only"]
+    ] = "both"
+
+    def __init_subclass__(cls, **kw):
+        super().__init_subclass__(**kw)
+        _VERB_ALIAS_PROVIDERS.add(cls)
+
+
+def list_verb_alias_providers():
+    return sorted(_VERB_ALIAS_PROVIDERS, key=lambda c: c.__name__)


### PR DESCRIPTION
Introduces verb aliasing for RPC exposure, allowing operation verbs to be renamed via OpVerbAliasProvider without affecting REST routes. Updates routes_builder to register RPC methods and helpers under both canonical and alias names based on policy, and adds the op_verb_alias_provider module to manage verb alias configuration.