### PR TITLE
Refactor auth context and dependencies in AutoAPI

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v2/__init__.py
@@ -10,7 +10,6 @@ Public façade for the AutoAPI framework.
 # ─── std / third-party ──────────────────────────────────────────────
 from collections import OrderedDict
 from typing import Any, AsyncIterator, Callable, Dict, Iterator, Type
-from fastapi import APIRouter, Security
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 from pydantic import BaseModel
@@ -33,6 +32,11 @@ from .types import (
     AuthNProvider,
     MethodType,
     SimpleNamespace,
+    Request,
+    APIRouter,
+    Security,
+    Depends,
+
 )
 from .schema import _SchemaNS, get_autoapi_schema as get_schema
 from .transactional import transactional as _register_tx
@@ -40,7 +44,7 @@ from .transactional import transactional as _register_tx
 # ─── db schema bootstrap (dialect-aware; no flags required) ─────────
 from .bootstrap_dbschema import ensure_schemas
 
-from fastapi import APIRouter, Security, Depends
+
 # ────────────────────────────────────────────────────────────────────
 class AutoAPI:
     """High-level façade class exposed to user code."""

--- a/pkgs/standards/autoapi/autoapi/v2/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v2/__init__.py
@@ -146,7 +146,7 @@ class AutoAPI:
                 return principal
 
             # Optional variant that never raises (for /rpc where anonymous methods are allowed)
-            async def _optional_security_dep(request: Request, principal=Security(authn.get_principal, auto_error=False)):
+            async def _optional_security_dep(request: Request, principal=Security(authn.get_principal)):
                 if not principal:
                     return None
                 return await _security_dep(request, principal=principal)

--- a/pkgs/standards/autoapi/autoapi/v2/impl/_runner.py
+++ b/pkgs/standards/autoapi/autoapi/v2/impl/_runner.py
@@ -147,6 +147,11 @@ async def _invoke(
                 result = await maybe if isawaitable(maybe) else maybe
 
         ctx["result"] = result
+    except Exception as exc:
+        ctx["exc"] = exc
+        await _rollback_safely(api, db, ctx)
+        await _run_phase(api, _phase("ON_HANDLER_ERROR") or _phase("ON_ERROR"), ctx)
+        raise
 
     # ─── POST_HANDLER (still in transaction; may flush) ──────────────────
     try:

--- a/pkgs/standards/autoapi/autoapi/v2/impl/_runner.py
+++ b/pkgs/standards/autoapi/autoapi/v2/impl/_runner.py
@@ -134,15 +134,19 @@ async def _invoke(
             maybe = exec_fn(method, params, db)
             result = await maybe if isawaitable(maybe) else maybe
         else:
-            maybe = api.rpc[method](params, db)
-            result = await maybe if isawaitable(maybe) else maybe
+            # Default adapter:
+            # - If we are in async mode and the RPC handler is sync, execute it
+            #   inside the engine’s sync context via AsyncSession.run_sync(...),
+            #   passing a real sync Session.
+            # - Otherwise, call directly and await if needed.
+            handler = api.rpc[method]
+            if _is_async_session(db) and not iscoroutinefunction(handler):
+                result = await db.run_sync(lambda s: handler(params, s))
+            else:
+                maybe = handler(params, db)
+                result = await maybe if isawaitable(maybe) else maybe
 
         ctx["result"] = result
-    except Exception as exc:
-        ctx["exc"] = exc
-        await _rollback_safely(api, db, ctx)
-        await _run_phase(api, _phase("ON_HANDLER_ERROR") or _phase("ON_ERROR"), ctx)
-        raise
 
     # ─── POST_HANDLER (still in transaction; may flush) ──────────────────
     try:

--- a/pkgs/standards/autoapi/autoapi/v2/impl/routes_builder.py
+++ b/pkgs/standards/autoapi/autoapi/v2/impl/routes_builder.py
@@ -15,7 +15,7 @@ from typing import Annotated, Any, List
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
-from ..types import APIRouter, Security, Depends, Request, Response, Path
+from ..types import APIRouter, Security, Depends, Request, Response, Path, Body
 from ._runner import _invoke
 from ..jsonrpc_models import _RPCReq, create_standardized_error
 from ..mixins import AsyncCapable, BulkCapable, Replaceable

--- a/pkgs/standards/autoapi/autoapi/v2/impl/routes_builder.py
+++ b/pkgs/standards/autoapi/autoapi/v2/impl/routes_builder.py
@@ -212,7 +212,7 @@ def _register_routes_and_rpcs(  # noqa: N802 – bound as method
                     inspect.Parameter(
                         "item_id",
                         inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                        annotation=pk_type,
+                        annotation=Annotated[pk_type, Path(...)],
                     )
                 )
 
@@ -246,7 +246,7 @@ def _register_routes_and_rpcs(  # noqa: N802 – bound as method
                 inspect.Parameter(
                     "db",
                     inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                    annotation=Annotated[Any, Depends(provider)],
+                    annotation=DBDep,
                 )
             )
 

--- a/pkgs/standards/autoapi/autoapi/v2/mixins/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v2/mixins/__init__.py
@@ -154,7 +154,7 @@ class OwnerBound:
 
     @classmethod
     def filter_for_ctx(cls, q, ctx):
-        auto_fields = ctx.get("__autoapi_injected_fields__", {})
+        auto_fields = ctx.get("__autoapi_auth_context__", {})
         return q.filter(cls.owner_id == auto_fields.get("user_id"))
 
 
@@ -167,7 +167,7 @@ class UserBound:  # membership rows
 
     @classmethod
     def filter_for_ctx(cls, q, ctx):
-        auto_fields = ctx.get("__autoapi_injected_fields__", {})
+        auto_fields = ctx.get("__autoapi_auth_context__", {})
         return q.filter(cls.user_id == auto_fields.get("user_id"))
 
 

--- a/pkgs/standards/autoapi/autoapi/v2/mixins/ownable.py
+++ b/pkgs/standards/autoapi/autoapi/v2/mixins/ownable.py
@@ -76,7 +76,7 @@ class Ownable:
                 # keep None so we can treat it as "missing" explicitly
                 params = params.model_dump()
 
-            auto_fields = ctx.get("__autoapi_injected_fields__", {})
+            auto_fields = ctx.get("__autoapi_auth_context__", {})
             user_id = auto_fields.get("user_id")
             provided = params.get("owner_id")
             missing = _is_missing(provided)

--- a/pkgs/standards/autoapi/autoapi/v2/mixins/tenant_bound.py
+++ b/pkgs/standards/autoapi/autoapi/v2/mixins/tenant_bound.py
@@ -88,7 +88,7 @@ class TenantBound(_RowBound):
     # -------------------------------------------------------------------
     @staticmethod
     def is_visible(obj, ctx) -> bool:
-        auto_fields = ctx.get("__autoapi_injected_fields__", {})
+        auto_fields = ctx.get("__autoapi_auth_context__", {})
         ctx_tenant_id = auto_fields.get("tenant_id")
         return getattr(obj, "tenant_id", None) == ctx_tenant_id
 

--- a/pkgs/standards/autoapi/autoapi/v2/rpcdispatch.py
+++ b/pkgs/standards/autoapi/autoapi/v2/rpcdispatch.py
@@ -66,14 +66,7 @@ def build_rpcdispatch(api) -> APIRouter:
 
         try:
             # If AsyncSession, run sync cores in the async engine's run_sync
-            if isinstance(db, AsyncSession):
-                exec_fn = lambda m, p, s=db: s.run_sync(
-                    lambda sync_sess: api.rpc[m](p, sync_sess)
-                )
-                result = await _invoke(api, env.method, params=env.params, ctx=ctx, exec_fn=exec_fn)
-            else:
-                # Plain Session path
-                result = await _invoke(api, env.method, params=env.params, ctx=ctx)
+            result = await _invoke(api, env.method, params=env.params, ctx=ctx)
 
             return _ok(result, env)
 

--- a/pkgs/standards/autoapi/autoapi/v2/rpcdispatch.py
+++ b/pkgs/standards/autoapi/autoapi/v2/rpcdispatch.py
@@ -52,7 +52,7 @@ def build_rpcdispatch(api) -> APIRouter:
             req: Request,
             env: _RPCReq = Body(..., embed=False),
             db: Session = Depends(api.get_db),
-            principal: Dict | None = api._authn_dep,
+            principal: Dict | None = api._optional_authn_dep,
         ):
             req.state.principal = principal
             print("RPCD principal:", principal)
@@ -96,8 +96,8 @@ def build_rpcdispatch(api) -> APIRouter:
         async def _rpcdispatch(
             req: Request,
             env: _RPCReq = Body(..., embed=False),
-            db: AsyncSession = Depends(api.get_async_db),
-            principal: Dict | None = api._authn_dep,
+            db: Session = Depends(api.get_db),
+            principal: Dict | None = api._optional_authn_dep,
         ):
             req.state.principal = principal
             print("RPCD principal:", principal)

--- a/pkgs/standards/autoapi/autoapi/v2/rpcdispatch.py
+++ b/pkgs/standards/autoapi/autoapi/v2/rpcdispatch.py
@@ -1,38 +1,16 @@
-"""
-autoapi.v2.rpcdispatch  – JSON-RPC façade for AutoAPI
------------------------------------------------------
-Exposes a single /rpc endpoint that validates a JSON-RPC-2.0 envelope
-and forwards execution to the unified hook-aware runner.
-"""
-
+# autoapi/v2/rpcdispatch.py
 from __future__ import annotations
-
 from typing import Annotated, Any, Dict
-
-from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
-
-from .types import APIRouter, Body, Depends, HTTPException, Request
-from .impl._runner import _invoke  # ← central lifecycle engine
-from .jsonrpc_models import (
-    _RPCReq,
-    _RPCRes,
-    _err,
-    _ok,
-    _http_exc_to_rpc,
-    HTTP_ERROR_MESSAGES,
-)
-from pydantic import ValidationError
+from sqlalchemy.ext.asyncio import AsyncSession
+from .types import APIRouter, Body, Depends, HTTPException, Request, ValidationError
+from .impl._runner import _invoke
+from .jsonrpc_models import _RPCReq, _RPCRes, _err, _ok, _http_exc_to_rpc, HTTP_ERROR_MESSAGES
 
 
 def build_rpcdispatch(api) -> APIRouter:
-    """
-    Return a router exposing a single `/rpc` endpoint that drives JSON-RPC
-    through AutoAPI. Works for both sync and async SQLAlchemy sessions.
-    """
     r = APIRouter()
 
-    # Choose one concrete dependency type (no Optional, no unions)
     DBDep = (
         Annotated[AsyncSession, Depends(api.get_async_db)]
         if getattr(api, "get_async_db", None)
@@ -43,47 +21,36 @@ def build_rpcdispatch(api) -> APIRouter:
     async def _rpcdispatch(
         req: Request,
         env: _RPCReq = Body(..., embed=False),
-        db: DBDep = None,  # type: ignore[assignment]  (FastAPI injects via Depends)
+        db: DBDep = None,  # injected via Depends; value is Session or AsyncSession
         principal: Dict | None = api._optional_authn_dep,
     ):
-        # Seed ctx bridge for downstream
         if getattr(req.state, "ctx", None) is None:
             req.state.ctx = {}
-
         req.state.principal = principal
+
+        # Transport-optional, method-required auth
+        if api._authn and env.method not in api._allow_anon and principal is None:
+            return _err(-32001, HTTP_ERROR_MESSAGES[401], env)
+        if api._authorize and not api._authorize(env.method, req):
+            return _err(403, "Forbidden", env)
+
         ctx: Dict[str, Any] = {"request": req, "db": db, "env": env}
         ext = getattr(req.state, "ctx", None)
         if isinstance(ext, dict):
             ctx.update(ext)
 
-        # AuthN: optional at transport, required per method unless allow_anon
-        if api._authn and env.method not in api._allow_anon and principal is None:
-            return _err(-32001, HTTP_ERROR_MESSAGES[401], env)
-
-        # AuthZ
-        if api._authorize and not api._authorize(env.method, req):
-            return _err(403, "Forbidden", env)
-
         try:
-            # If AsyncSession, run sync cores in the async engine's run_sync
             result = await _invoke(api, env.method, params=env.params, ctx=ctx)
-
             return _ok(result, env)
-
         except HTTPException as exc:
             rpc_code, rpc_message, data = _http_exc_to_rpc(exc)
             return _err(rpc_code, rpc_message, env, data=data)
-
         except ValidationError as exc:
             errors = exc.errors()
             missing = [e["loc"][-1] for e in errors if e["type"] == "missing"]
-            msg = "Validation error"
-            if missing:
-                msg += ": missing parameter(s): " + ", ".join(missing)
+            msg = "Validation error" + (": missing parameter(s): " + ", ".join(missing) if missing else "")
             return _err(-32602, msg, env, data=errors)
-
         except Exception as exc:
-            # _invoke() already handled rollback and ON_ERROR hook
             return _err(-32000, str(exc), env)
 
     return r

--- a/pkgs/standards/autoapi/autoapi/v2/rpcdispatch.py
+++ b/pkgs/standards/autoapi/autoapi/v2/rpcdispatch.py
@@ -1,61 +1,101 @@
-# autoapi/v2/rpcdispatch.py
+"""
+autoapi.v2.rpcdispatch  – JSON-RPC façade for AutoAPI
+"""
+
 from __future__ import annotations
-from typing import Annotated, Any, Dict
-from sqlalchemy.orm import Session
+
+from typing import Any, Dict
+
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Session
+
 from .types import APIRouter, Body, Depends, HTTPException, Request, ValidationError
 from .impl._runner import _invoke
-from .jsonrpc_models import _RPCReq, _RPCRes, _err, _ok, _http_exc_to_rpc, HTTP_ERROR_MESSAGES
+from .jsonrpc_models import (
+    _RPCReq,
+    _RPCRes,
+    _err,
+    _ok,
+    _http_exc_to_rpc,
+    HTTP_ERROR_MESSAGES,
+)
 
 
 def build_rpcdispatch(api) -> APIRouter:
     r = APIRouter()
 
-    DBDep = (
-        Annotated[AsyncSession, Depends(api.get_async_db)]
-        if callable(getattr(api, "get_async_db", None))
-        else Annotated[Session, Depends(api.get_db)]
-    )
+    if callable(getattr(api, "get_async_db", None)):
+        # Async engine: inject AsyncSession directly (no alias, no forward-ref)
+        @r.post("/rpc", response_model=_RPCRes, tags=["rpc"])
+        async def _rpcdispatch(
+            req: Request,
+            db: AsyncSession = Depends(api.get_async_db),
+            env: _RPCReq = Body(..., embed=False),
+            principal: Dict | None = api._optional_authn_dep,
+        ):
+            if getattr(req.state, "ctx", None) is None:
+                req.state.ctx = {}
+            req.state.principal = principal
 
-    @r.post("/rpc", response_model=_RPCRes, tags=["rpc"])
-    async def _rpcdispatch(
-        req: Request,
-        env: _RPCReq = Body(..., embed=False),
-        db: DBDep,  # injected via Depends; value is Session or AsyncSession
-        principal: Dict | None = api._optional_authn_dep,
-    ):
-        # Defensive: if DI failed, fail fast rather than passing None through.
-        if db is None:  # pragma: no cover
-            raise RuntimeError("DB dependency did not inject; check get_db/get_async_db wiring")
-            
-        if getattr(req.state, "ctx", None) is None:
-            req.state.ctx = {}
-        req.state.principal = principal
+            if api._authn and env.method not in api._allow_anon and principal is None:
+                return _err(-32001, HTTP_ERROR_MESSAGES[401], env)
+            if api._authorize and not api._authorize(env.method, req):
+                return _err(403, "Forbidden", env)
 
-        # Transport-optional, method-required auth
-        if api._authn and env.method not in api._allow_anon and principal is None:
-            return _err(-32001, HTTP_ERROR_MESSAGES[401], env)
-        if api._authorize and not api._authorize(env.method, req):
-            return _err(403, "Forbidden", env)
+            ctx: Dict[str, Any] = {"request": req, "db": db, "env": env}
+            ext = getattr(req.state, "ctx", None)
+            if isinstance(ext, dict):
+                ctx.update(ext)
 
-        ctx: Dict[str, Any] = {"request": req, "db": db, "env": env}
-        ext = getattr(req.state, "ctx", None)
-        if isinstance(ext, dict):
-            ctx.update(ext)
+            try:
+                result = await _invoke(api, env.method, params=env.params, ctx=ctx)
+                return _ok(result, env)
+            except HTTPException as exc:
+                code, msg, data = _http_exc_to_rpc(exc)
+                return _err(code, msg, env, data=data)
+            except ValidationError as exc:
+                errors = exc.errors()
+                missing = [e["loc"][-1] for e in errors if e["type"] == "missing"]
+                msg = "Validation error" + (": missing parameter(s): " + ", ".join(missing) if missing else "")
+                return _err(-32602, msg, env, data=errors)
+            except Exception as exc:
+                return _err(-32000, str(exc), env)
 
-        try:
-            result = await _invoke(api, env.method, params=env.params, ctx=ctx)
-            return _ok(result, env)
-        except HTTPException as exc:
-            rpc_code, rpc_message, data = _http_exc_to_rpc(exc)
-            return _err(rpc_code, rpc_message, env, data=data)
-        except ValidationError as exc:
-            errors = exc.errors()
-            missing = [e["loc"][-1] for e in errors if e["type"] == "missing"]
-            msg = "Validation error" + (": missing parameter(s): " + ", ".join(missing) if missing else "")
-            return _err(-32602, msg, env, data=errors)
-        except Exception as exc:
-            return _err(-32000, str(exc), env)
+    else:
+        # Sync engine: inject Session directly (no alias, no forward-ref)
+        @r.post("/rpc", response_model=_RPCRes, tags=["rpc"])
+        async def _rpcdispatch(
+            req: Request,
+            db: Session = Depends(api.get_db),
+            env: _RPCReq = Body(..., embed=False),
+            principal: Dict | None = api._optional_authn_dep,
+        ):
+            if getattr(req.state, "ctx", None) is None:
+                req.state.ctx = {}
+            req.state.principal = principal
+
+            if api._authn and env.method not in api._allow_anon and principal is None:
+                return _err(-32001, HTTP_ERROR_MESSAGES[401], env)
+            if api._authorize and not api._authorize(env.method, req):
+                return _err(403, "Forbidden", env)
+
+            ctx: Dict[str, Any] = {"request": req, "db": db, "env": env}
+            ext = getattr(req.state, "ctx", None)
+            if isinstance(ext, dict):
+                ctx.update(ext)
+
+            try:
+                result = await _invoke(api, env.method, params=env.params, ctx=ctx)
+                return _ok(result, env)
+            except HTTPException as exc:
+                code, msg, data = _http_exc_to_rpc(exc)
+                return _err(code, msg, env, data=data)
+            except ValidationError as exc:
+                errors = exc.errors()
+                missing = [e["loc"][-1] for e in errors if e["type"] == "missing"]
+                msg = "Validation error" + (": missing parameter(s): " + ", ".join(missing) if missing else "")
+                return _err(-32602, msg, env, data=errors)
+            except Exception as exc:
+                return _err(-32000, str(exc), env)
 
     return r
-

--- a/pkgs/standards/autoapi/autoapi/v2/rpcdispatch.py
+++ b/pkgs/standards/autoapi/autoapi/v2/rpcdispatch.py
@@ -3,23 +3,16 @@ autoapi.v2.rpcdispatch  – JSON-RPC façade for AutoAPI
 -----------------------------------------------------
 Exposes a single /rpc endpoint that validates a JSON-RPC-2.0 envelope
 and forwards execution to the unified hook-aware runner.
-
-This module is *thin* by design:  it performs only
-  • envelope parsing / authorisation
-  • DB-session acquisition
-  • error translation (HTTP → JSON-RPC)
-
-Everything else (hooks, commit/rollback, result packing)
-lives in autoapi.v2._runner._invoke.
 """
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Request
+from typing import Annotated, Any, Dict
+
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
-from typing import Any, Dict
 
+from .types import APIRouter, Body, Depends, HTTPException, Request
 from .impl._runner import _invoke  # ← central lifecycle engine
 from .jsonrpc_models import (
     _RPCReq,
@@ -32,114 +25,72 @@ from .jsonrpc_models import (
 from pydantic import ValidationError
 
 
-# ────────────────────────────────────────────────────────────────────────────
 def build_rpcdispatch(api) -> APIRouter:
     """
     Return a router exposing a single `/rpc` endpoint that drives JSON-RPC
-    through AutoAPI.  Works for both sync and async SQLAlchemy sessions.
+    through AutoAPI. Works for both sync and async SQLAlchemy sessions.
     """
     r = APIRouter()
 
-    # ───────── synchronous SQLAlchemy branch ───────────────────────────────
-    if api.get_db:
+    # Choose one concrete dependency type (no Optional, no unions)
+    DBDep = (
+        Annotated[AsyncSession, Depends(api.get_async_db)]
+        if getattr(api, "get_async_db", None)
+        else Annotated[Session, Depends(api.get_db)]
+    )
 
-        @r.post(
-            "/rpc",
-            response_model=_RPCRes,
-            tags=["rpc"],
-        )
-        async def _rpcdispatch(
-            req: Request,
-            env: _RPCReq = Body(..., embed=False),
-            db: Session = Depends(api.get_db),
-            principal: Dict | None = api._optional_authn_dep,
-        ):
-            req.state.principal = principal
-            print("RPCD principal:", principal)
-            print("RPCD allow_anon:", api._allow_anon)
-            print("RPCD method called:", env.method)
-            ctx: Dict[str, Any] = {"request": req, "db": db, "env": env}
-            if api._authn and env.method not in api._allow_anon and principal is None:
-                return _err(-32001, HTTP_ERROR_MESSAGES[401], env)
+    @r.post("/rpc", response_model=_RPCRes, tags=["rpc"])
+    async def _rpcdispatch(
+        req: Request,
+        env: _RPCReq = Body(..., embed=False),
+        db: DBDep = None,  # type: ignore[assignment]  (FastAPI injects via Depends)
+        principal: Dict | None = api._optional_authn_dep,
+    ):
+        # Seed ctx bridge for downstream
+        if getattr(req.state, "ctx", None) is None:
+            req.state.ctx = {}
 
-            # Authorisation --------------------------------------------------
-            if api._authorize and not api._authorize(env.method, req):
-                return _err(403, "Forbidden", env)
+        req.state.principal = principal
+        ctx: Dict[str, Any] = {"request": req, "db": db, "env": env}
+        ext = getattr(req.state, "ctx", None)
+        if isinstance(ext, dict):
+            ctx.update(ext)
 
-            try:
-                result = await _invoke(api, env.method, params=env.params, ctx=ctx)
-                return _ok(result, env)
+        # AuthN: optional at transport, required per method unless allow_anon
+        if api._authn and env.method not in api._allow_anon and principal is None:
+            return _err(-32001, HTTP_ERROR_MESSAGES[401], env)
 
-            except HTTPException as exc:
-                rpc_code, rpc_message, data = _http_exc_to_rpc(exc)
-                return _err(rpc_code, rpc_message, env, data=data)
+        # AuthZ
+        if api._authorize and not api._authorize(env.method, req):
+            return _err(403, "Forbidden", env)
 
-            except ValidationError as exc:
-                errors = exc.errors()
-                missing = [e["loc"][-1] for e in errors if e["type"] == "missing"]
-                msg = "Validation error"
-                if missing:
-                    msg += ": missing parameter(s): " + ", ".join(missing)
-                return _err(-32602, msg, env, data=errors)
-
-            except Exception as exc:
-                # _invoke() has already rolled back & fired ON_ERROR hook.
-                return _err(-32000, str(exc), env)
-
-            finally:
-                db.close()
-
-    # ───────── asynchronous SQLAlchemy branch ──────────────────────────────
-    else:
-
-        @r.post("/rpc", response_model=_RPCRes, tags=["rpc"])
-        async def _rpcdispatch(
-            req: Request,
-            env: _RPCReq = Body(..., embed=False),
-            db: Session = Depends(api.get_db),
-            principal: Dict | None = api._optional_authn_dep,
-        ):
-            req.state.principal = principal
-            print("RPCD principal:", principal)
-            print("RPCD allow_anon:", api._allow_anon)
-            print("RPCD method called:", env.method)
-            ctx: Dict[str, Any] = {"request": req, "db": db, "env": env}
-            if api._authn and env.method not in api._allow_anon and principal is None:
-                return _err(-32001, HTTP_ERROR_MESSAGES[401], env)
-
-            if api._authorize and not api._authorize(env.method, req):
-                return _err(403, "Forbidden", env)
-
-            try:
-                # The core CRUD functions are synchronous; run them in the
-                # async engine’s thread-pool via run_sync().
-                result = await _invoke(
-                    api,
-                    env.method,
-                    params=env.params,
-                    ctx=ctx,
-                    exec_fn=lambda m, p, s=db: s.run_sync(  # override executor
-                        lambda sync_sess: api.rpc[m](p, sync_sess)
-                    ),
+        try:
+            # If AsyncSession, run sync cores in the async engine's run_sync
+            if isinstance(db, AsyncSession):
+                exec_fn = lambda m, p, s=db: s.run_sync(
+                    lambda sync_sess: api.rpc[m](p, sync_sess)
                 )
-                return _ok(result, env)
+                result = await _invoke(api, env.method, params=env.params, ctx=ctx, exec_fn=exec_fn)
+            else:
+                # Plain Session path
+                result = await _invoke(api, env.method, params=env.params, ctx=ctx)
 
-            except HTTPException as exc:
-                rpc_code, rpc_message, data = _http_exc_to_rpc(exc)
-                return _err(rpc_code, rpc_message, env, data=data)
+            return _ok(result, env)
 
-            except ValidationError as exc:
-                errors = exc.errors()
-                missing = [e["loc"][-1] for e in errors if e["type"] == "missing"]
-                msg = "Validation error"
-                if missing:
-                    msg += ": missing parameter(s): " + ", ".join(missing)
-                return _err(-32602, msg, env, data=errors)
+        except HTTPException as exc:
+            rpc_code, rpc_message, data = _http_exc_to_rpc(exc)
+            return _err(rpc_code, rpc_message, env, data=data)
 
-            except Exception as exc:
-                return _err(-32000, str(exc), env)
+        except ValidationError as exc:
+            errors = exc.errors()
+            missing = [e["loc"][-1] for e in errors if e["type"] == "missing"]
+            msg = "Validation error"
+            if missing:
+                msg += ": missing parameter(s): " + ", ".join(missing)
+            return _err(-32602, msg, env, data=errors)
 
-            finally:
-                await db.close()
+        except Exception as exc:
+            # _invoke() already handled rollback and ON_ERROR hook
+            return _err(-32000, str(exc), env)
 
     return r

--- a/pkgs/standards/autoapi/autoapi/v2/types/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v2/types/__init__.py
@@ -43,6 +43,8 @@ from sqlalchemy.ext.hybrid import hybrid_property
 
 from pydantic import Field
 
+from fastapi import APIRouter, Security, Depends, Request, Response
+
 # ── local package ─────────────────────────────────────────────────────────
 from .op import _Op, _SchemaVerb
 from .authn_abc import AuthNProvider
@@ -117,4 +119,10 @@ __all__: list[str] = [
     "UUID",
     # pydantic schema support
     "Field",
+    # fastapi support
+    "Request",
+    "Response",
+    "APIRouter",
+    "Security",
+    "Depends",
 ]

--- a/pkgs/standards/autoapi/autoapi/v2/types/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v2/types/__init__.py
@@ -43,7 +43,7 @@ from sqlalchemy.ext.hybrid import hybrid_property
 
 from pydantic import Field
 
-from fastapi import APIRouter, Security, Depends, Request, Response, Path, Body
+from fastapi import APIRouter, Security, Depends, Request, Response, Path, Body, HTTPException
 
 # ── local package ─────────────────────────────────────────────────────────
 from .op import _Op, _SchemaVerb
@@ -127,4 +127,5 @@ __all__: list[str] = [
     "Depends",
     "Path",
     "Body",
+    "HTTPException",
 ]

--- a/pkgs/standards/autoapi/autoapi/v2/types/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v2/types/__init__.py
@@ -43,7 +43,7 @@ from sqlalchemy.ext.hybrid import hybrid_property
 
 from pydantic import Field
 
-from fastapi import APIRouter, Security, Depends, Request, Response
+from fastapi import APIRouter, Security, Depends, Request, Response, Path
 
 # ── local package ─────────────────────────────────────────────────────────
 from .op import _Op, _SchemaVerb
@@ -125,4 +125,5 @@ __all__: list[str] = [
     "APIRouter",
     "Security",
     "Depends",
+    "Path",
 ]

--- a/pkgs/standards/autoapi/autoapi/v2/types/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v2/types/__init__.py
@@ -41,7 +41,7 @@ from sqlalchemy.ext.mutable import MutableDict, MutableList
 from sqlalchemy.ext.hybrid import hybrid_property
 
 
-from pydantic import Field
+from pydantic import Field, ValidationError
 
 from fastapi import APIRouter, Security, Depends, Request, Response, Path, Body, HTTPException
 
@@ -119,6 +119,7 @@ __all__: list[str] = [
     "UUID",
     # pydantic schema support
     "Field",
+    "ValidationError",
     # fastapi support
     "Request",
     "Response",

--- a/pkgs/standards/autoapi/autoapi/v2/types/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v2/types/__init__.py
@@ -43,7 +43,7 @@ from sqlalchemy.ext.hybrid import hybrid_property
 
 from pydantic import Field
 
-from fastapi import APIRouter, Security, Depends, Request, Response, Path
+from fastapi import APIRouter, Security, Depends, Request, Response, Path, Body
 
 # ── local package ─────────────────────────────────────────────────────────
 from .op import _Op, _SchemaVerb
@@ -126,4 +126,5 @@ __all__: list[str] = [
     "Security",
     "Depends",
     "Path",
+    "Body",
 ]


### PR DESCRIPTION
Replaces usage of '__autoapi_injected_fields__' with '__autoapi_auth_context__' across mixins and context handling. Refactors authentication dependencies in AutoAPI to use FastAPI Depends, adds optional authentication for RPC endpoints, and ensures principal is seeded into request state and context variable. This improves consistency and flexibility for authentication and context propagation.