### PR TITLE
Expose operation-specific schema names

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/schema/schema_namespace.py
+++ b/pkgs/standards/autoapi/autoapi/v2/schema/schema_namespace.py
@@ -12,8 +12,8 @@ class _SchemaNS(SimpleNamespace):
     """
     Attribute-style access to generated Pydantic schemas.
 
-        api.schemas.UserCreate          → <class 'UserCreate'>
-        api.schemas.UserCreate(name=…)  → instance of that model
+        api.schemas.UserCreateIn         → <class 'UserCreate'>
+        api.schemas.UserCreateIn(name=…) → instance of that model
     """
 
     def __init__(self, api: "AutoAPI"):
@@ -21,35 +21,16 @@ class _SchemaNS(SimpleNamespace):
         self._api = api  # back-reference to parent
 
     def __dir__(self) -> list[str]:
-        """Limit attribute discovery to registered resources."""
-        return [k for k in self.__dict__ if not k.startswith("_")]
+        """Expose only operation-specific schema names."""
+        return sorted(self._api._schemas.keys())
 
     def __getattr__(self, item: str):  # lazy lookup / build
-        # already cached on the namespace?
         try:
             return self.__dict__[item]
         except KeyError:
             pass
-
-        # check AutoAPI's registry
         if item in self._api._schemas:
             mdl = self._api._schemas[item]
-            setattr(self, item, mdl)  # cache on first use
+            setattr(self, item, mdl)
             return mdl
-
-        # try to *derive* model  verb from the camel-cased key, e.g. "GroupCreate"
-        import re
-
-        m = re.match(r"([A-Z]\w?)(Create|Read|Update|Replace|Delete|List)$", item)
-        if not m:
-            raise AttributeError(item) from None
-
-        model_name, verb = m.groups()
-        orm_cls = self._api._model_registry.get(model_name)
-        if orm_cls is None:
-            raise AttributeError(item) from None
-
-        mdl = self._api.schema(orm_cls, verb=verb.lower())
-        self._api._schemas[item] = mdl
-        setattr(self, item, mdl)
-        return mdl
+        raise AttributeError(item) from None

--- a/pkgs/standards/autoapi/tests/i9n/test_core_access.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_core_access.py
@@ -46,6 +46,13 @@ async def async_api(async_db_session):
     return api, get_async_db
 
 
+def test_schemas_dir_contains_operation_names(sync_api):
+    api, _ = sync_api
+    names = dir(api.schemas)
+    assert "CoreTestUserCreateIn" in names
+    assert "CoreTestUser" not in names
+
+
 class TestApiCore:
     """Test cases for api.core direct access (manual session management)."""
 


### PR DESCRIPTION
## Summary
- register schemas under canonical `<Resource><Verb><In|Out>` names and keep legacy nested access
- restrict schema namespace to expose only operation-specific schema names
- ensure `dir(api.schemas)` lists operation-specific names only

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff check autoapi/v2/impl/routes_builder.py autoapi/v2/schema/schema_namespace.py tests/i9n/test_core_access.py --fix`

------
https://chatgpt.com/codex/tasks/task_e_689b8d528e088326b1f24a8535972a7a