### PR TITLE
fix(peagen): align worker RPC names with singular Work namespace

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/schedule_helpers.py
+++ b/pkgs/standards/peagen/peagen/gateway/schedule_helpers.py
@@ -142,7 +142,7 @@ async def dispatch_work(
         try:
             with AutoAPIClient(endpoint) as rpc:
                 rpc.call(
-                    "Works.create",
+                    "Work.create",
                     params={
                         "task_id": str(task.id),
                         "repository_id": str(task.repository_id)

--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -86,7 +86,7 @@ class WorkerBase:
         # ----- JSON-RPC dispatcher --------------------------------
         self.rpc = RPCDispatcher()
 
-        @self.rpc.method("Works.create")
+        @self.rpc.method("Work.create")
         async def _on_work_start(payload: dict) -> dict:
             asyncio.create_task(self._run_work(payload))
             return {"accepted": True}
@@ -213,7 +213,7 @@ class WorkerBase:
     ) -> None:
         try:
             upd = SWorkUpdate(id=work_id, status=status, result=result)
-            self._client.call("Works.update", params=upd.model_dump(mode="json"))
-            self.log.info("Works.update %s → %s", work_id, status)
+            self._client.call("Work.update", params=upd.model_dump(mode="json"))
+            self.log.info("Work.update %s → %s", work_id, status)
         except Exception as exc:  # pragma: no cover
             self.log.error("notify failed: %s", exc)


### PR DESCRIPTION
## Summary
- use singular `Work.create` when dispatching tasks to workers
- use `Work.update` for worker status heartbeats

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format peagen/gateway/schedule_helpers.py peagen/worker/base.py`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/gateway/schedule_helpers.py peagen/worker/base.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_689b8ecfd3fc8326984ba05dbea39ad0