### PR TITLE
feat: adopt PEAGEN_* env variables

### DIFF
--- a/infra/peagen/Dockerfile.worker
+++ b/infra/peagen/Dockerfile.worker
@@ -23,8 +23,8 @@ RUN uv pip install --directory pkgs/standards/peagen --system .
 EXPOSE 8001
 
 ENV \
-    DQ_POOL=""\
-    DQ_GATEWAY=""\
+    PEAGEN_POOL=""\
+    PEAGEN_GATEWAY=""\
     PORT="8001" \
     PG_PORT="5432"
 

--- a/infra/peagen/docker-compose.yml
+++ b/infra/peagen/docker-compose.yml
@@ -203,8 +203,8 @@ services:
       gateway:
         condition: service_healthy
     environment:
-      DQ_GATEWAY: "http://gateway:8000/rpc"
-      DQ_POOL: "default"
+      PEAGEN_GATEWAY: "http://gateway:8000/rpc"
+      PEAGEN_POOL: "default"
       GROQ_API_KEY: ${GROQ_API_KEY}
       MINIO_ENDPOINT: "minio:9000"
       MINIO_BUCKET: "test"

--- a/pkgs/standards/peagen/docs/secret_workflow_test.md
+++ b/pkgs/standards/peagen/docs/secret_workflow_test.md
@@ -8,7 +8,7 @@ This document records the steps to verify `peagen` CLI public key, deploy key, a
 export PG_DSN="postgresql://peagen:peagen@localhost:5432/peagen"
 export REDIS_URL="redis://localhost:6379/0"
 uvicorn peagen.gateway:app --host 127.0.0.1 --port 8000 --proxy-headers --forwarded-allow-ips="*" &
-DQ_GATEWAY=http://127.0.0.1:8000/rpc uvicorn peagen.worker:app --host 127.0.0.1 --port 8001 &
+PEAGEN_GATEWAY=http://127.0.0.1:8000/rpc uvicorn peagen.worker:app --host 127.0.0.1 --port 8001 &
 ```
 
 A `.peagen.toml` referencing Redis and Postgres was placed in `/tmp/peagen_demo`.

--- a/pkgs/standards/peagen/peagen/cli/__init__.py
+++ b/pkgs/standards/peagen/peagen/cli/__init__.py
@@ -133,7 +133,7 @@ def _global_remote_ctx(  # noqa: D401
     api_key: str | None = typer.Option(
         None,
         "--api-key",
-        envvar="DQ_API_KEY",
+        envvar="PEAGEN_API_KEY",
         help="API key for authenticated gateway access",
     ),
     override: str = typer.Option(
@@ -148,7 +148,7 @@ def _global_remote_ctx(  # noqa: D401
         help="Path to a *second* .peagen.toml that is sent to the worker.",
     ),
     pool: str = typer.Option(
-        os.getenv("DQ_POOL", defaults.DEFAULT_POOL),
+        os.getenv("PEAGEN_POOL", defaults.DEFAULT_POOL),
         "--pool",
         help="Tenant or pool for multi-tenant deployments",
     ),

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -63,7 +63,7 @@ from .ws_server import router as ws_router
 from sqlalchemy.exc import IntegrityError
 
 # ─────────── logging setup ─────────────────────────────────────────────
-LOG_LEVEL = os.getenv("DQ_LOG_LEVEL", "INFO").upper()
+LOG_LEVEL = os.getenv("PEAGEN_LOG_LEVEL", "INFO").upper()
 log = Logger(name="gw", default_level=getattr(logging, LOG_LEVEL, logging.INFO))
 sched_log = Logger(
     name="scheduler", default_level=getattr(logging, LOG_LEVEL, logging.INFO)

--- a/pkgs/standards/peagen/peagen/plugins/vcs/git_vcs.py
+++ b/pkgs/standards/peagen/peagen/plugins/vcs/git_vcs.py
@@ -165,7 +165,7 @@ class GitVCS:
         secret_name = os.getenv("DEPLOY_KEY_SECRET")
         if secret_name:
             gateway = gateway_url or os.getenv(
-                "DQ_GATEWAY", "http://localhost:8000/rpc"
+                "PEAGEN_GATEWAY", "http://localhost:8000/rpc"
             )
             self.push_with_secret(ref, secret_name, remote=remote, gateway_url=gateway)
             return

--- a/pkgs/standards/peagen/peagen/worker/Dockerfile
+++ b/pkgs/standards/peagen/peagen/worker/Dockerfile
@@ -22,8 +22,8 @@ RUN uv pip install --directory pkgs/standards/peagen --system .
 EXPOSE 8000
 
 ENV \
-    DQ_POOL=""\
-    DQ_GATEWAY=""\
+    PEAGEN_POOL=""\
+    PEAGEN_GATEWAY=""\
     PG_PORT="5432"
 
 CMD ["sh", "-c", "python -c 'import uvicorn; uvicorn.run(\"peagen.worker:app\", host=\"0.0.0.0\", port=8000, log_level=\"info\")'"]

--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -61,15 +61,15 @@ class WorkerBase:
         heartbeat_interval: float = 5.0,
     ) -> None:
         # ----- env / defaults --------------------------------------
-        self.pool = pool or os.getenv("DQ_POOL", DEFAULT_POOL_NAME)
-        self.gateway = gateway or os.getenv("DQ_GATEWAY", DEFAULT_GATEWAY)
-        self.worker_id = worker_id or os.getenv("DQ_WORKER_ID", None)
+        self.pool = pool or os.getenv("PEAGEN_POOL", DEFAULT_POOL_NAME)
+        self.gateway = gateway or os.getenv("PEAGEN_GATEWAY", DEFAULT_GATEWAY)
+        self.worker_id = worker_id or os.getenv("PEAGEN_WORKER_ID", None)
         self.port = port or int(os.getenv("PORT", 8001))
-        self.host = host or os.getenv("DQ_HOST") or _local_ip()
+        self.host = host or os.getenv("PEAGEN_HOST") or _local_ip()
         self.listen_at = f"http://{self.host}:{self.port}/rpc"
-        self._api_key = api_key or os.getenv("DQ_API_KEY")
+        self._api_key = api_key or os.getenv("PEAGEN_API_KEY")
 
-        lvl = (log_level or os.getenv("DQ_LOG_LEVEL", "INFO")).upper()
+        lvl = (log_level or os.getenv("PEAGEN_LOG_LEVEL", "INFO")).upper()
         level = getattr(logging, lvl, logging.INFO)
         self.log = Logger(name="worker", default_level=level)
 
@@ -144,7 +144,7 @@ class WorkerBase:
             api_key = created.get("api_key")
             if api_key:
                 self._api_key = api_key
-                os.environ["DQ_API_KEY"] = api_key
+                os.environ["PEAGEN_API_KEY"] = api_key
                 self._client.api_key = api_key
             else:
                 try:

--- a/pkgs/standards/peagen/tests/e2e/test_local_evolve.py
+++ b/pkgs/standards/peagen/tests/e2e/test_local_evolve.py
@@ -31,7 +31,7 @@ def test_local_evolve(tmp_path: Path) -> None:
     shutil.copytree(EXAMPLES, demo)
     env = os.environ.copy()
     env.setdefault("GROQ_API_KEY", "dummy")
-    env.setdefault("DQ_GATEWAY", GATEWAY)
+    env.setdefault("PEAGEN_GATEWAY", GATEWAY)
     spec = demo / "test_evolve_spec.yaml"
     result = subprocess.run(
         ["peagen", "local", "-q", "evolve", str(spec)],

--- a/pkgs/standards/peagen/tests/examples/gateway_demo/README.md
+++ b/pkgs/standards/peagen/tests/examples/gateway_demo/README.md
@@ -11,7 +11,7 @@ This example demonstrates a minimal setup for running the Peagen gateway and wor
 2. Launch a worker connected to the gateway:
 
    ```bash
-   DQ_GATEWAY=http://127.0.0.1:8000/rpc \
+   PEAGEN_GATEWAY=http://127.0.0.1:8000/rpc \
    uvicorn peagen.worker:app --host 0.0.0.0 --port 8001
    ```
 

--- a/pkgs/standards/peagen/tests/examples/simple_evolve_demo/README.md
+++ b/pkgs/standards/peagen/tests/examples/simple_evolve_demo/README.md
@@ -10,7 +10,7 @@ Winning mutants are committed to the repository when a VCS is configured. The ta
 Run the spec locally using the `local` subcommand:
 
 ```bash
-DQ_GATEWAY=http://127.0.0.1:8000/rpc \
+PEAGEN_GATEWAY=http://127.0.0.1:8000/rpc \
 uv run --package peagen --directory pkgs/standards/peagen \
   peagen local -q evolve tests/examples/simple_evolve_demo/evolve_spec_local.yaml
 ```


### PR DESCRIPTION
## Summary
- switch gateway, worker, and CLI to PEAGEN_* env vars
- update docs and examples for new env var prefix

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format peagen/cli/__init__.py peagen/gateway/__init__.py peagen/worker/base.py peagen/plugins/vcs/git_vcs.py tests/e2e/test_local_evolve.py`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check peagen/cli/__init__.py peagen/gateway/__init__.py peagen/worker/base.py peagen/plugins/vcs/git_vcs.py tests/e2e/test_local_evolve.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_689b926a6e4083268e1a1392433ea8e5