### PR TITLE
docs: organize autoapi configuration options

### DIFF
--- a/pkgs/standards/autoapi/README.md
+++ b/pkgs/standards/autoapi/README.md
@@ -18,14 +18,50 @@ A high-leverage meta-framework that turns plain SQLAlchemy models into a fully-f
 - Extended operations: replace (put), bulk create/delete/update
 - 6 Phase Hook Lifecycle
 - Transactionals
-- Table level configurations: __autoapi_nested_paths__, __autoapi_allow_anon__, & __autoapi_register_hooks__
-- Column level configurations: info_schema ( disable_on, write_only, read_only, default_factory, examples, hybrid (hybrid properties), py_type)
 - `_apply_row_filters` (deprecating)
 - _RowBound hook providers
 - phase-level hooks that can be wildcard or per-verb, per-model
 - Automated route creation: rest paths or nested rest paths, rpc dispatch, healthz, methodz, hookz
 - Support for AuthNProvider extensions
 
+
+## Configuration Overview
+
+### Column-Level (`Column.info["autoapi"]`)
+- `disable_on` – omit a field on specified verbs.
+- `write_only` – exclude from `read` responses.
+- `read_only` – exclude from write verbs.
+- `default_factory` – callable that supplies a default value.
+- `examples` – example values for documentation.
+- `hybrid` – expose `@hybrid_property` fields.
+- `py_type` – override the Python type.
+
+### Table-Level
+- `__autoapi_request_extras__` – verb-scoped virtual fields.
+- `__autoapi_register_hooks__` – hook registration entry point.
+- `__autoapi_nested_paths__` – nested REST path segments.
+- `__autoapi_allow_anon__` – verbs permitted without auth.
+- `__autoapi_owner_policy__` / `__autoapi_tenant_policy__` – server vs client field injection.
+- `__autoapi_verb_aliases__` & `__autoapi_verb_alias_policy__` – custom verb names.
+
+### Routing
+- `__autoapi_nested_paths__` for hierarchical routing.
+- `__autoapi_verb_aliases__` for custom verbs.
+- `__autoapi_verb_alias_policy__` to scope alias application.
+
+### Persistence
+- Mixins such as `Upsertable`, `Bootstrappable`, `GUIDPk`, `Timestamped`.
+- Policies `__autoapi_owner_policy__` and `__autoapi_tenant_policy__`.
+- `transactional` decorator for atomic RPC + REST endpoints.
+
+### Security
+- Pluggable `AuthNProvider` interface.
+- `__autoapi_allow_anon__` to permit anonymous access.
+
+### Dependencies
+- SQLAlchemy for ORM integration.
+- Pydantic for schema generation.
+- FastAPI for routing and dependency injection.
 
 ## Glossary
 1. Tables


### PR DESCRIPTION
## Summary
- document autoapi configuration categories in the package README
- clean up unused variable in routes builder

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format autoapi/v2/impl/routes_builder.py`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check autoapi/v2/impl/routes_builder.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_689bebc893b883268a2a393362e2ff1e