### PR TITLE
feat(autoapi): expand configuration catalog

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v2/__init__.py
@@ -39,6 +39,22 @@ from .types import (
 )
 from .schema import _SchemaNS, get_autoapi_schema as get_schema
 from .transactional import register_transaction, transactional
+from .cfgs import (  # noqa: F401
+    COL_LEVEL_CFGS,
+    TAB_LEVEL_CFGS,
+    ROUTING_CFGS,
+    PERSISTENCE_CFGS,
+    PRINCIPAL_CFGS,
+    SECURITY_CFGS,
+    DEPS_CFGS,
+    ROUTING_VERBS,
+    BULK_VERBS,
+    ALL_VERBS,
+    AUTH_CONTEXT_KEY,
+    INJECTED_FIELDS_KEY,
+    TENANT_ID_KEY,
+    USER_ID_KEY,
+)
 
 # ─── db schema bootstrap (dialect-aware; no flags required) ─────────
 from .bootstrap_dbschema import ensure_schemas
@@ -145,7 +161,7 @@ class AutoAPI:
                     request.state.ctx = ctx = {}
                 # stash principal into the standardized auth context slot
                 if isinstance(principal, dict):
-                    ac = ctx.setdefault("__autoapi_auth_context__", {})
+                    ac = ctx.setdefault(AUTH_CONTEXT_KEY, {})
                     ac.update(principal)
                 # keep legacy attribute too
                 request.state.principal = principal

--- a/pkgs/standards/autoapi/autoapi/v2/cfgs.py
+++ b/pkgs/standards/autoapi/autoapi/v2/cfgs.py
@@ -1,0 +1,95 @@
+"""
+cfgs.py
+
+Collect AutoAPI configuration hooks by category.
+
+This module groups the special Column.info keys, class attributes, and
+runtime configuration names recognized by AutoAPI into high level
+categories for easier reference.
+"""
+
+# Column-level configuration keys found in ``Column.info`` or ``info["autoapi"]``
+COL_LEVEL_CFGS: set[str] = {
+    "no_create",
+    "no_update",
+    "hybrid",
+    "disable_on",
+    "write_only",
+    "read_only",
+    "default_factory",
+    "examples",
+    "py_type",
+}
+
+# Table-level configuration attributes on ORM classes
+TAB_LEVEL_CFGS: set[str] = {
+    "__autoapi_request_extras__",
+    "__autoapi_register_hooks__",
+    "__autoapi_owner_policy__",
+    "__autoapi_tenant_policy__",
+    "__autoapi_nested_paths__",
+    "__autoapi_allow_anon__",
+    "__autoapi_verb_aliases__",
+    "__autoapi_verb_alias_policy__",
+}
+
+# Routing configuration attributes
+ROUTING_CFGS: set[str] = {
+    "__autoapi_nested_paths__",
+    "__autoapi_verb_aliases__",
+    "__autoapi_verb_alias_policy__",
+}
+
+# Persistence customization hooks
+PERSISTENCE_CFGS: set[str] = {
+    "__autoapi_register_hooks__",
+}
+
+# Runtime context keys
+AUTH_CONTEXT_KEY = "__autoapi_auth_context__"
+INJECTED_FIELDS_KEY = "__autoapi_injected_fields__"
+TENANT_ID_KEY = "tenant_id"
+USER_ID_KEY = "user_id"
+
+# Principal-related configuration
+PRINCIPAL_CFGS: set[str] = {
+    "__autoapi_tenant_policy__",
+    "__autoapi_owner_policy__",
+    AUTH_CONTEXT_KEY,
+}
+
+# Security related configuration
+SECURITY_CFGS: set[str] = {
+    "authn",
+    AUTH_CONTEXT_KEY,
+    INJECTED_FIELDS_KEY,
+    "authorize",
+}
+
+# Dependency related hooks
+DEPS_CFGS: set[str] = {
+    "get_db",
+    "get_async_db",
+}
+
+# Routing verbs
+ROUTING_VERBS: set[str] = {
+    "create",
+    "read",
+    "update",
+    "delete",
+    "list",
+    "clear",
+    "replace",
+}
+
+# Bulk operation verbs
+BULK_VERBS: set[str] = {
+    "bulk_create",
+    "bulk_update",
+    "bulk_replace",
+    "bulk_delete",
+}
+
+# All supported verbs
+ALL_VERBS: set[str] = ROUTING_VERBS | BULK_VERBS

--- a/pkgs/standards/autoapi/autoapi/v2/impl/routes_builder.py
+++ b/pkgs/standards/autoapi/autoapi/v2/impl/routes_builder.py
@@ -28,6 +28,7 @@ from .schema import _schema
 # Helpers
 # ──────────────────────────────────────────────────────────────────────────────
 
+
 def _attach(root: Any, resource: str, op: str, fn: Any) -> None:
     """Attach *fn* under ``root.resource.op`` creating namespaces as needed."""
     ns = getattr(root, resource, None)
@@ -75,7 +76,11 @@ def _canonical(tab: str, verb: str) -> str:
 
 
 def _resource_pascal(tab_or_cls: str) -> str:
-    return "".join(w.title() for w in tab_or_cls.split("_")) if tab_or_cls.islower() else tab_or_cls
+    return (
+        "".join(w.title() for w in tab_or_cls.split("_"))
+        if tab_or_cls.islower()
+        else tab_or_cls
+    )
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -83,11 +88,21 @@ def _resource_pascal(tab_or_cls: str) -> str:
 # ──────────────────────────────────────────────────────────────────────────────
 
 _VALID_VERBS = {
-    "create", "read", "update", "delete", "list", "clear", "replace",
-    "bulk_create", "bulk_update", "bulk_replace", "bulk_delete",
+    "create",
+    "read",
+    "update",
+    "delete",
+    "list",
+    "clear",
+    "replace",
+    "bulk_create",
+    "bulk_update",
+    "bulk_replace",
+    "bulk_delete",
 }
 
 _alias_re = re.compile(r"^[a-z][a-z0-9_]*$")
+
 
 def _get_verb_alias_map(model) -> dict[str, str]:
     raw = getattr(model, "__autoapi_verb_aliases__", None)
@@ -95,9 +110,11 @@ def _get_verb_alias_map(model) -> dict[str, str]:
         raw = raw()
     return dict(raw or {})
 
+
 def _alias_policy(model) -> str:
     # "both" | "alias_only" | "canonical_only"
     return getattr(model, "__autoapi_verb_alias_policy__", "both")
+
 
 def _public_verb(model, canonical: str) -> str:
     ali = _get_verb_alias_map(model).get(canonical)
@@ -111,6 +128,7 @@ def _public_verb(model, canonical: str) -> str:
             "(must be lowercase [a-z0-9_], start with a letter)"
         )
     return ali
+
 
 def _route_label(resource_name: str, verb: str, model) -> str:
     """Return '{Resource} - {verb/alias}' per policy."""
@@ -126,6 +144,7 @@ def _route_label(resource_name: str, verb: str, model) -> str:
 
 
 # ──────────────────────────────────────────────────────────────────────────────
+
 
 def _register_routes_and_rpcs(  # noqa: N802 – bound as method
     self,
@@ -199,10 +218,34 @@ def _register_routes_and_rpcs(  # noqa: N802 – bound as method
         print("Model is BulkCapable; adding bulk specs")
         # keep REST path style aligned with current codebase ("/bulk")
         spec += [
-            ("bulk_create", "POST", "/bulk", 201, List[SCreate],   List[SReadOut], _create),
-            ("bulk_update", "PATCH", "/bulk", 200, List[SUpdate],  List[SReadOut], _update),
-            ("bulk_replace","PUT",   "/bulk", 200, List[SCreate],  List[SReadOut], functools.partial(_update, full=True)),
-            ("bulk_delete", "DELETE","/bulk", 204, List[SDeleteIn], None,            _delete),
+            (
+                "bulk_create",
+                "POST",
+                "/bulk",
+                201,
+                List[SCreate],
+                List[SReadOut],
+                _create,
+            ),
+            (
+                "bulk_update",
+                "PATCH",
+                "/bulk",
+                200,
+                List[SUpdate],
+                List[SReadOut],
+                _update,
+            ),
+            (
+                "bulk_replace",
+                "PUT",
+                "/bulk",
+                200,
+                List[SCreate],
+                List[SReadOut],
+                functools.partial(_update, full=True),
+            ),
+            ("bulk_delete", "DELETE", "/bulk", 204, List[SDeleteIn], None, _delete),
         ]
 
     # ---------- nested routing ---------------------------------------
@@ -248,7 +291,7 @@ def _register_routes_and_rpcs(  # noqa: N802 – bound as method
             rpc_in = _schema(model, verb=verb)
 
         # Route label (name/summary) using alias policy
-        route_name = _route_label(resource, verb, model)
+        _route_label(resource, verb, model)
 
         def _factory(
             is_nested_router, *, verb=verb, path=path, In=In, core=core, m_id=m_id_canon
@@ -304,7 +347,9 @@ def _register_routes_and_rpcs(  # noqa: N802 – bound as method
                     inspect.Parameter(
                         "p",
                         inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                        annotation=Annotated[Optional[List[SDeleteIn]], Body(default=None)],
+                        annotation=Annotated[
+                            Optional[List[SDeleteIn]], Body(default=None)
+                        ],
                     )
                 )
             elif In is not None and verb not in ("read", "delete", "clear"):
@@ -341,10 +386,15 @@ def _register_routes_and_rpcs(  # noqa: N802 – bound as method
                         return obj.model_dump(exclude_unset=True)
                     return obj
 
-                if verb in {"bulk_create", "bulk_update", "bulk_replace", "bulk_delete"}:
+                if verb in {
+                    "bulk_create",
+                    "bulk_update",
+                    "bulk_replace",
+                    "bulk_delete",
+                }:
                     # p is a list of models/dicts
                     lst = []
-                    for it in (p or []):
+                    for it in p or []:
                         lst.append(_dump(it))
                     rpc_params = lst
                 else:
@@ -364,7 +414,10 @@ def _register_routes_and_rpcs(  # noqa: N802 – bound as method
                     if isinstance(rpc_params, dict):
                         rpc_params.update(parent_kw)
                     elif isinstance(rpc_params, list):
-                        rpc_params = [{**parent_kw, **(e if isinstance(e, dict) else _dump(e))} for e in rpc_params]
+                        rpc_params = [
+                            {**parent_kw, **(e if isinstance(e, dict) else _dump(e))}
+                            for e in rpc_params
+                        ]
 
                 print(f"RPC params built: {rpc_params}")
                 env = _RPCReq(id=None, method=m_id, params=rpc_params)
@@ -378,7 +431,14 @@ def _register_routes_and_rpcs(  # noqa: N802 – bound as method
 
                 def _build_args(_p):
                     match verb:
-                        case "create" | "bulk_create" | "bulk_update" | "bulk_replace" | "bulk_delete" | "list":
+                        case (
+                            "create"
+                            | "bulk_create"
+                            | "bulk_update"
+                            | "bulk_replace"
+                            | "bulk_delete"
+                            | "list"
+                        ):
                             return (_p,)
                         case "clear":
                             return ()
@@ -438,8 +498,10 @@ def _register_routes_and_rpcs(  # noqa: N802 – bound as method
                 response_model=None if verb == "create" else Out,
                 responses=COMMON_ERRORS,
                 dependencies=deps,
-                name=_route_label(resource, verb, model),   # ← route name reflects alias policy
-                summary=_route_label(resource, verb, model),# ← docs summary ditto
+                name=_route_label(
+                    resource, verb, model
+                ),  # ← route name reflects alias policy
+                summary=_route_label(resource, verb, model),  # ← docs summary ditto
             )
 
         # ─── register schemas on API namespace (for discovery / testing) ──
@@ -491,6 +553,7 @@ def _register_routes_and_rpcs(  # noqa: N802 – bound as method
                             pass
                 else:
                     return _api.rpc[_method](payload, db)
+
             return _runner
 
         # Register canonical
@@ -504,21 +567,27 @@ def _register_routes_and_rpcs(  # noqa: N802 – bound as method
 
         # Ensure container for core_raw
         if not hasattr(self, "core_raw"):
+
             class _CE: ...
+
             self.core_raw = _CE()
 
         async def _core_raw(payload, *, db=None, _core=core, _verb=verb, _pk=pk):
             # Build args in the same way your RPC shim would
             def _build_args(_p):
                 def _dump(o):
-                    return o.model_dump(exclude_unset=True) if hasattr(o, "model_dump") else o
+                    return (
+                        o.model_dump(exclude_unset=True)
+                        if hasattr(o, "model_dump")
+                        else o
+                    )
 
                 match _verb:
                     case "create" | "list":
                         return (_p,)
                     case "bulk_create" | "bulk_update" | "bulk_replace" | "bulk_delete":
                         if isinstance(_p, list):
-                            return ([ _dump(x) for x in _p ],)
+                            return ([_dump(x) for x in _p],)
                         return (_dump(_p),)
                     case "clear":
                         return ()

--- a/pkgs/standards/autoapi/autoapi/v2/mixins/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v2/mixins/__init__.py
@@ -24,6 +24,7 @@ from ..types import (
     UUID,
     uuid4,
 )
+from ..cfgs import AUTH_CONTEXT_KEY, USER_ID_KEY
 
 
 def tzutcnow() -> dt.datetime:  # default/on‑update factory
@@ -73,8 +74,8 @@ class GUIDPk:
     )
 
 
-
 # ────────── principals -----------------------------------------
+
 
 @declarative_mixin
 class TenantMixin:
@@ -154,8 +155,8 @@ class OwnerBound:
 
     @classmethod
     def filter_for_ctx(cls, q, ctx):
-        auto_fields = ctx.get("__autoapi_auth_context__", {})
-        return q.filter(cls.owner_id == auto_fields.get("user_id"))
+        auto_fields = ctx.get(AUTH_CONTEXT_KEY, {})
+        return q.filter(cls.owner_id == auto_fields.get(USER_ID_KEY))
 
 
 class UserBound:  # membership rows
@@ -167,8 +168,8 @@ class UserBound:  # membership rows
 
     @classmethod
     def filter_for_ctx(cls, q, ctx):
-        auto_fields = ctx.get("__autoapi_auth_context__", {})
-        return q.filter(cls.user_id == auto_fields.get("user_id"))
+        auto_fields = ctx.get(AUTH_CONTEXT_KEY, {})
+        return q.filter(cls.user_id == auto_fields.get(USER_ID_KEY))
 
 
 # ────────── lifecycle --------------------------------------------------

--- a/pkgs/standards/autoapi/autoapi/v2/mixins/ownable.py
+++ b/pkgs/standards/autoapi/autoapi/v2/mixins/ownable.py
@@ -6,13 +6,16 @@ from ..hooks import Phase
 from ..jsonrpc_models import create_standardized_error
 from ..info_schema import check as _info_check
 from ..types import Column, ForeignKey, PgUUID, declared_attr
+from ..cfgs import AUTH_CONTEXT_KEY, INJECTED_FIELDS_KEY, USER_ID_KEY
 
 log = logging.getLogger(__name__)
+
 
 class OwnerPolicy(str, Enum):
     CLIENT_SET = "client"
     DEFAULT_TO_USER = "default"
     STRICT_SERVER = "strict"
+
 
 def _infer_schema(cls, default: str = "public") -> str:
     args = getattr(cls, "__table_args__", None)
@@ -26,8 +29,10 @@ def _infer_schema(cls, default: str = "public") -> str:
                 return elem["schema"]
     return default
 
+
 def _is_missing(v) -> bool:
     return v is None or (isinstance(v, str) and not v.strip())
+
 
 def _normalize_uuid(v):
     if isinstance(v, UUID):
@@ -38,6 +43,7 @@ def _normalize_uuid(v):
         except ValueError:
             return v
     return v
+
 
 class Ownable:
     __autoapi_owner_policy__: OwnerPolicy = OwnerPolicy.CLIENT_SET
@@ -76,20 +82,24 @@ class Ownable:
                 # keep None so we can treat it as "missing" explicitly
                 params = params.model_dump()
 
-            auto_fields = ctx.get("__autoapi_auth_context__", {})
-            user_id = auto_fields.get("user_id")
+            auto_fields = ctx.get(AUTH_CONTEXT_KEY, {})
+            user_id = auto_fields.get(USER_ID_KEY)
             provided = params.get("owner_id")
             missing = _is_missing(provided)
 
             log.info(
                 "Ownable before_create policy=%s params=%s auto_fields=%s",
-                pol, params, auto_fields,
+                pol,
+                params,
+                auto_fields,
             )
 
             if pol == OwnerPolicy.STRICT_SERVER:
                 if user_id is None:
                     _err(400, "owner_id is required.")
-                if not missing and _normalize_uuid(provided) != _normalize_uuid(user_id):
+                if not missing and _normalize_uuid(provided) != _normalize_uuid(
+                    user_id
+                ):
                     _err(400, "owner_id mismatch.")
                 params["owner_id"] = user_id  # always enforce server value
             else:
@@ -99,7 +109,7 @@ class Ownable:
                     params["owner_id"] = _normalize_uuid(provided)
 
             ctx["env"].params = params
-            print(f'\n🚧 ownable params: {ctx["env"].params}')
+            print(f"\n🚧 ownable params: {ctx['env'].params}")
 
         def _ownable_before_update(ctx, obj):
             params = getattr(ctx.get("env"), "params", None)
@@ -116,12 +126,14 @@ class Ownable:
                 _err(400, "owner_id is immutable.")
 
             new_val = _normalize_uuid(params["owner_id"])
-            auto_fields = ctx.get("__autoapi_injected_fields__", {})
-            user_id = _normalize_uuid(auto_fields.get("user_id"))
+            auto_fields = ctx.get(INJECTED_FIELDS_KEY, {})
+            user_id = _normalize_uuid(auto_fields.get(USER_ID_KEY))
 
             log.info(
                 "Ownable before_update new_val=%s obj_owner=%s injected=%s",
-                new_val, getattr(obj, "owner_id", None), user_id,
+                new_val,
+                getattr(obj, "owner_id", None),
+                user_id,
             )
             if (
                 new_val != obj.owner_id
@@ -130,5 +142,9 @@ class Ownable:
             ):
                 _err(403, "Cannot transfer ownership.")
 
-        api.register_hook(model=cls, phase=Phase.PRE_TX_BEGIN, op="create")(_ownable_before_create)
-        api.register_hook(model=cls, phase=Phase.PRE_TX_BEGIN, op="update")(_ownable_before_update)
+        api.register_hook(model=cls, phase=Phase.PRE_TX_BEGIN, op="create")(
+            _ownable_before_create
+        )
+        api.register_hook(model=cls, phase=Phase.PRE_TX_BEGIN, op="update")(
+            _ownable_before_update
+        )


### PR DESCRIPTION
## Summary
- group principal, security, dependency, and verb configuration catalogs
- add reusable auth context keys and tenant/user identifiers
- replace magic strings in mixins and initializer with new constants

## Testing
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff format autoapi/v2/__init__.py autoapi/v2/cfgs.py autoapi/v2/mixins/__init__.py autoapi/v2/mixins/ownable.py autoapi/v2/mixins/tenant_bound.py`
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff check autoapi/v2/__init__.py autoapi/v2/cfgs.py autoapi/v2/mixins/__init__.py autoapi/v2/mixins/ownable.py autoapi/v2/mixins/tenant_bound.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_689bebec9a8c8326b349686550d02b69