### PR TITLE
Exclude primary key from update RPC schemas

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/impl/routes_builder.py
+++ b/pkgs/standards/autoapi/autoapi/v2/impl/routes_builder.py
@@ -287,8 +287,9 @@ def _register_routes_and_rpcs(  # noqa: N802 – bound as method
         # RPC input model for adapter (distinct from REST signature)
         rpc_in = In or dict
         if verb in {"update", "replace"}:
-            # For update/replace we want the verb-specific model (respects no_update flags)
-            rpc_in = _schema(model, verb=verb)
+            # For update/replace we want the verb-specific model without the PK
+            # (it's supplied separately via the path parameter)
+            rpc_in = _schema(model, verb=verb, exclude={pk})
 
         # Route label (name/summary) using alias policy
         _route_label(resource, verb, model)


### PR DESCRIPTION
## Summary
- ensure AutoAPI update and replace RPC schemas omit the primary key

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check autoapi/v2/impl/routes_builder.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_core_access.py`


------
https://chatgpt.com/codex/tasks/task_e_689c006071d083268f21d4c515a55f86