### PR TITLE
refactor(peagen): rely on security context for tenant id

### DIFF
--- a/pkgs/standards/peagen/peagen/_utils/_init.py
+++ b/pkgs/standards/peagen/peagen/_utils/_init.py
@@ -10,11 +10,7 @@ import uuid
 import typer
 from peagen.handlers.init_handler import init_handler
 from peagen.plugins import discover_and_register_plugins
-from peagen.defaults import (
-    DEFAULT_TENANT_ID,
-    DEFAULT_POOL_ID,
-    DEFAULT_SUPER_USER_ID,
-)
+from peagen.defaults import DEFAULT_POOL_ID
 from peagen.orm import Action
 
 
@@ -50,11 +46,9 @@ def _call_handler(args: Dict[str, Any]) -> Dict[str, Any]:
     task = build_task(
         action=Action.FETCH,
         args=args,
-        tenant_id=str(DEFAULT_TENANT_ID),
         pool_id=str(DEFAULT_POOL_ID),
         repo="local",
         ref="HEAD",
-        owner_id=str(DEFAULT_SUPER_USER_ID),
     )
     task = task.model_copy(update={"id": str(_uuid_alias.uuid4())})
     return asyncio.run(init_handler(task))

--- a/pkgs/standards/peagen/peagen/cli/commands/doe.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/doe.py
@@ -26,7 +26,7 @@ from peagen.cli.task_helpers import (
 from peagen.handlers.doe_handler import doe_handler
 from peagen.handlers.doe_process_handler import doe_process_handler
 from peagen.orm import Status
-from peagen.defaults import DEFAULT_POOL_ID, DEFAULT_TENANT_ID
+from peagen.defaults import DEFAULT_POOL_ID
 
 # ────────────────────────── apps ───────────────────────────────
 
@@ -90,7 +90,6 @@ def run_gen(  # noqa: PLR0913
     task = build_task(
         action="doe",
         args=args,
-        tenant_id=str(DEFAULT_TENANT_ID),
         pool_id=str(DEFAULT_POOL_ID),
         repo=repo,
         ref=ref,
@@ -133,7 +132,6 @@ def submit_gen(  # noqa: PLR0913
     task = build_task(
         action="doe",
         args=args,
-        tenant_id=str(DEFAULT_TENANT_ID),
         pool_id=str(DEFAULT_POOL_ID),
         repo=repo,
         ref=ref,
@@ -176,7 +174,6 @@ def run_process(  # noqa: PLR0913
     task = build_task(
         action="doe_process",
         args=args,
-        tenant_id=str(DEFAULT_TENANT_ID),
         pool_id=str(DEFAULT_POOL_ID),
         repo=repo,
         ref=ref,
@@ -227,7 +224,6 @@ def submit_process(  # noqa: PLR0913
     task = build_task(
         action="doe_process",
         args=args,
-        tenant_id=str(DEFAULT_TENANT_ID),
         pool_id=str(DEFAULT_POOL_ID),
         repo=repo,
         ref=ref,

--- a/pkgs/standards/peagen/peagen/cli/commands/eval.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/eval.py
@@ -21,7 +21,7 @@ import typer
 from peagen.cli.task_helpers import build_task, submit_task, get_task
 from peagen.handlers.eval_handler import eval_handler
 from peagen.orm import Status
-from peagen.defaults import DEFAULT_POOL_ID, DEFAULT_TENANT_ID
+from peagen.defaults import DEFAULT_POOL_ID
 
 # ────────────────────────── apps ───────────────────────────────
 
@@ -69,7 +69,6 @@ def run(  # noqa: PLR0913
     task = build_task(
         action="eval",
         args=args,
-        tenant_id=str(DEFAULT_TENANT_ID),
         pool_id=str(DEFAULT_POOL_ID),
         repo=repo,
         ref=ref,
@@ -114,7 +113,6 @@ def submit(  # noqa: PLR0913
     task = build_task(
         action="eval",
         args=args,
-        tenant_id=str(DEFAULT_TENANT_ID),
         pool_id=str(DEFAULT_POOL_ID),
         repo=repo,
         ref=ref,

--- a/pkgs/standards/peagen/peagen/cli/commands/evolve.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/evolve.py
@@ -24,7 +24,7 @@ from peagen.handlers.evolve_handler import evolve_handler
 from peagen.core.validate_core import validate_evolve_spec
 from peagen.orm import Status, Action
 
-from peagen.defaults import DEFAULT_POOL_ID, DEFAULT_TENANT_ID
+from peagen.defaults import DEFAULT_POOL_ID
 
 # ────────────────────────── apps ───────────────────────────────
 
@@ -61,7 +61,6 @@ def run(
     task = build_task(
         action=Action.EVOLVE,
         args=_args_for_task(spec, repo, ref),
-        tenant_id=str(DEFAULT_TENANT_ID),
         pool_id=str(DEFAULT_POOL_ID),
         repo=repo,
         ref=ref,
@@ -97,7 +96,6 @@ def submit(
     task = build_task(
         action=Action.EVOLVE,
         args=_args_for_task(spec, repo, ref),
-        tenant_id=str(DEFAULT_TENANT_ID),
         pool_id=str(DEFAULT_POOL_ID),
         repo=repo,
         ref=ref,

--- a/pkgs/standards/peagen/peagen/cli/commands/mutate.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/mutate.py
@@ -21,7 +21,7 @@ import typer
 from peagen.handlers.mutate_handler import mutate_handler
 from peagen.cli.task_helpers import build_task, submit_task, get_task
 from peagen.orm import Status
-from peagen.defaults import DEFAULT_POOL_ID, DEFAULT_TENANT_ID
+from peagen.defaults import DEFAULT_POOL_ID
 
 # ────────────────────────── apps ───────────────────────────────
 
@@ -78,7 +78,6 @@ def run(  # noqa: PLR0913
     task = build_task(
         action="mutate",
         args=args,
-        tenant_id=str(DEFAULT_TENANT_ID),
         pool_id=str(DEFAULT_POOL_ID),
         repo=repo,
         ref=ref,
@@ -121,7 +120,6 @@ def submit(  # noqa: PLR0913
     task = build_task(
         action="mutate",
         args=args,
-        tenant_id=str(DEFAULT_TENANT_ID),
         pool_id=str(DEFAULT_POOL_ID),
         repo=repo,
         ref=ref,

--- a/pkgs/standards/peagen/peagen/cli/commands/process.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/process.py
@@ -24,7 +24,7 @@ from peagen.cli.task_helpers import build_task, submit_task, get_task
 from peagen.handlers.process_handler import process_handler
 from peagen.orm import Status
 
-from peagen.defaults import DEFAULT_POOL_ID, DEFAULT_TENANT_ID
+from peagen.defaults import DEFAULT_POOL_ID
 
 # ────────────────────────── apps ───────────────────────────────
 
@@ -92,7 +92,6 @@ def run(  # noqa: PLR0913
     task = build_task(
         action="process",
         args=args,
-        tenant_id=str(DEFAULT_TENANT_ID),
         pool_id=_determine_pool_id(ctx),
         repo=repo,
         ref=ref,
@@ -152,7 +151,6 @@ def submit(  # noqa: PLR0913
     task = build_task(
         action="process",
         args=args,
-        tenant_id=str(DEFAULT_TENANT_ID),
         pool_id=_determine_pool_id(ctx),
         repo=repo,
         ref=ref,

--- a/pkgs/standards/peagen/peagen/cli/commands/sort.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/sort.py
@@ -23,7 +23,7 @@ from peagen.handlers.sort_handler import sort_handler
 from peagen.cli.task_helpers import build_task, submit_task, get_task
 from peagen.orm import Status
 
-from peagen.defaults import DEFAULT_POOL_ID, DEFAULT_TENANT_ID
+from peagen.defaults import DEFAULT_POOL_ID
 
 # ────────────────────────── apps ───────────────────────────────
 local_sort_app = typer.Typer(help="Sort generated project files locally.")
@@ -82,7 +82,6 @@ def run_sort(  # noqa: PLR0913
     task = build_task(
         action="sort",
         args=args,
-        tenant_id=str(DEFAULT_TENANT_ID),
         pool_id=str(DEFAULT_POOL_ID),
         repo=repo,
         ref=ref,
@@ -144,7 +143,6 @@ def submit_sort(  # noqa: PLR0913
     task = build_task(
         action="sort",
         args=args,
-        tenant_id=str(DEFAULT_TENANT_ID),
         pool_id=str(DEFAULT_POOL_ID),
         repo=repo,
         ref=ref,

--- a/pkgs/standards/peagen/peagen/cli/commands/task.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/task.py
@@ -120,9 +120,10 @@ def retry_from(
     new_task = build_task(
         action=original["action"],
         args=original.get("args", {}),
-        pool=original.get("pool", "default"),
-        tenant_id=original.get("tenant_id", "default"),
+        pool_id=original.get("pool_id", "default"),
         labels=original.get("labels") or [],
+        repo=original.get("repo", ""),
+        ref=original.get("ref", "HEAD"),
     )
     submitted = submit_task(_rpc(ctx), new_task)
     typer.echo(json.dumps(submitted, indent=2))

--- a/pkgs/standards/peagen/peagen/handlers/doe_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/doe_handler.py
@@ -137,11 +137,9 @@ async def doe_handler(task: TaskRead) -> Dict[str, Any]:  # noqa: C901 – orche
 
     # ─── 6. create child MUTATE tasks via fan_out -------------------
     pool_id = str(getattr(task, "pool_id", "") or "")
-    tenant_id = str(getattr(task, "tenant_id", "") or "")
     children = [
         {
             "id": str(uuid.uuid4()),
-            "tenant_id": tenant_id,
             "pool_id": pool_id,
             "action": Action.MUTATE,
             "status": Status.waiting,

--- a/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
@@ -95,7 +95,6 @@ async def doe_process_handler(task: TaskRead) -> Dict[str, Any]:  # noqa: C901
         return {"children": [], "_final_status": Status.success.value, **result}
 
     # ── 4. child PROCESS tasks ---------------------------------------
-    tenant_id = str(getattr(task, "tenant_id", ""))
     pool_id = str(getattr(task, "pool_id", "") or "")
     children: List[Dict[str, Any]] = []
 
@@ -105,7 +104,6 @@ async def doe_process_handler(task: TaskRead) -> Dict[str, Any]:  # noqa: C901
         children.append(
             {
                 "id": str(uuid.uuid4()),
-                "tenant_id": tenant_id,
                 "pool_id": pool_id,
                 "action": Action.PROCESS,
                 "status": Status.waiting,

--- a/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
@@ -86,7 +86,6 @@ async def evolve_handler(task: TaskRead) -> Dict[str, Any]:  # noqa: C901 – or
 
     # ─── 4. build child mutate tasks ---------------------------------
     pool_id = str(getattr(task, "pool_id", "") or "")
-    tenant_id = str(getattr(task, "tenant_id", "") or "")
     children: List[Dict[str, Any]] = []
 
     for job in jobs:
@@ -106,7 +105,6 @@ async def evolve_handler(task: TaskRead) -> Dict[str, Any]:  # noqa: C901 – or
         children.append(
             {
                 "id": str(uuid.uuid4()),
-                "tenant_id": tenant_id,
                 "pool_id": pool_id,
                 "action": Action.MUTATE,
                 "status": Status.waiting,

--- a/pkgs/standards/peagen/tests/unit/conftest.py
+++ b/pkgs/standards/peagen/tests/unit/conftest.py
@@ -6,7 +6,6 @@ from peagen.cli import task_helpers
 
 class DummyTaskModel(BaseModel):
     id: uuid.UUID = Field(default_factory=uuid.uuid4)
-    tenant_id: str
     pool_id: str
     action: str
     repo: str

--- a/pkgs/standards/peagen/tests/unit/test_doe_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_doe_handler.py
@@ -67,7 +67,6 @@ async def test_doe_handler_calls_generate_payload(monkeypatch):
     task = build_task(
         action="doe",
         args=args,
-        tenant_id="t",
         pool_id="p",
         repo="repo",
         ref="HEAD",

--- a/pkgs/standards/peagen/tests/unit/test_eval_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_eval_handler.py
@@ -18,7 +18,6 @@ async def test_eval_handler(monkeypatch):
     params = build_task(
         action="eval",
         args=args,
-        tenant_id="t",
         pool_id="p",
         repo="repo",
         ref="HEAD",

--- a/pkgs/standards/peagen/tests/unit/test_evolve_cli.py
+++ b/pkgs/standards/peagen/tests/unit/test_evolve_cli.py
@@ -7,7 +7,6 @@ def test_build_task_payload():
     task = build_task(
         action="evolve",
         args={"evolve_spec": "foo.yaml"},
-        tenant_id="t",
         pool_id="p",
         repo="repo",
         ref="HEAD",

--- a/pkgs/standards/peagen/tests/unit/test_extras_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_extras_handler.py
@@ -32,7 +32,6 @@ async def test_extras_handler_calls_generate_schemas(
     task = build_task(
         action="extras",
         args=args,
-        tenant_id="t",
         pool_id="p",
         repo="repo",
         ref="HEAD",

--- a/pkgs/standards/peagen/tests/unit/test_fetch_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_fetch_handler.py
@@ -27,7 +27,6 @@ async def test_fetch_handler_passes_args(monkeypatch):
     task = build_task(
         action="fetch",
         args=args,
-        tenant_id="t",
         pool_id="p",
         repo="repo",
         ref="main",

--- a/pkgs/standards/peagen/tests/unit/test_init_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_init_handler.py
@@ -29,7 +29,6 @@ async def test_init_handler_dispatch(monkeypatch, kind, func):
     task = build_task(
         action="init",
         args=args,
-        tenant_id="t",
         pool_id="p",
         repo="repo",
         ref="HEAD",
@@ -48,7 +47,6 @@ async def test_init_handler_errors(monkeypatch):
             build_task(
                 action="init",
                 args={},
-                tenant_id="t",
                 pool_id="p",
                 repo="repo",
                 ref="HEAD",
@@ -60,7 +58,6 @@ async def test_init_handler_errors(monkeypatch):
             build_task(
                 action="init",
                 args={"kind": "unknown"},
-                tenant_id="t",
                 pool_id="p",
                 repo="repo",
                 ref="HEAD",

--- a/pkgs/standards/peagen/tests/unit/test_mutate_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_mutate_handler.py
@@ -40,7 +40,6 @@ async def test_mutate_handler_invokes_core(monkeypatch):
     task = build_task(
         action="mutate",
         args=args,
-        tenant_id="t",
         pool_id="default",
         repo="repo",
         ref="HEAD",

--- a/pkgs/standards/peagen/tests/unit/test_process_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_process_handler.py
@@ -48,7 +48,6 @@ async def test_process_handler_dispatch(monkeypatch, tmp_path, project_name):
     task = build_task(
         action="process",
         args=args,
-        tenant_id="t",
         pool_id="p",
         repo="repo",
         ref="HEAD",

--- a/pkgs/standards/peagen/tests/unit/test_sort_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_sort_handler.py
@@ -32,7 +32,6 @@ async def test_sort_handler_delegates(monkeypatch, tmp_path, project_name):
     task = build_task(
         action="sort",
         args=args,
-        tenant_id="t",
         pool_id="p",
         repo="repo",
         ref="HEAD",

--- a/pkgs/standards/peagen/tests/unit/test_task_submit.py
+++ b/pkgs/standards/peagen/tests/unit/test_task_submit.py
@@ -8,7 +8,6 @@ def test_build_task_creates_task():
     task = build_task(
         action="demo",
         args={"x": 1},
-        tenant_id="t",
         pool_id="p",
         repo="repo",
         ref="HEAD",
@@ -38,7 +37,6 @@ def test_submit_task_sends_request(monkeypatch):
     task = build_task(
         action="demo",
         args={},
-        tenant_id="t",
         pool_id="p",
         repo="repo",
         ref="HEAD",

--- a/pkgs/standards/peagen/tests/unit/test_templates_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_templates_handler.py
@@ -33,7 +33,6 @@ async def test_templates_handler_dispatch(monkeypatch, op, func, args):
     task = build_task(
         action="templates",
         args=payload,
-        tenant_id="t",
         pool_id="p",
         repo="repo",
         ref="HEAD",


### PR DESCRIPTION
## Summary
- drop `tenant_id` argument from `build_task` and rely on security dependencies to inject IDs
- remove tenant propagation in handlers and CLI commands
- adjust unit tests to build tasks without tenant IDs

## Testing
- `uv run --directory standards --package peagen ruff format peagen`
- `uv run --directory standards --package peagen ruff check peagen --fix`
- `uv run --package peagen --directory standards pytest peagen/tests/unit/test_doe_handler.py`


------
https://chatgpt.com/codex/tasks/task_e_689c0096c0888326810face9fceb3389