### PR TITLE
refactor: derive routes and methods from model names

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/impl/crud_builder.py
+++ b/pkgs/standards/autoapi/autoapi/v2/impl/crud_builder.py
@@ -75,7 +75,9 @@ def _flush_or_http(db: Session) -> None:
                 if m
                 else "Duplicate key value violates a unique constraint."
             )
-            http_exc, _, _ = create_standardized_error(409, message=msg, rpc_code=-32099)
+            http_exc, _, _ = create_standardized_error(
+                409, message=msg, rpc_code=-32099
+            )
             raise http_exc from exc
         if getattr(exc.orig, "pgcode", None) in ("23503",) or "foreign key" in raw:
             http_exc, _, _ = create_standardized_error(422, rpc_code=-32097)
@@ -85,9 +87,10 @@ def _flush_or_http(db: Session) -> None:
     except SQLAlchemyError as exc:
         # Do NOT rollback here; let the outer transaction manager handle it.
         print(f"SQLAlchemyError encountered during flush: {exc}")
-        http_exc, _, _ = create_standardized_error(500, message=f"Database error: {exc}")
+        http_exc, _, _ = create_standardized_error(
+            500, message=f"Database error: {exc}"
+        )
         raise http_exc from exc
-
 
 
 def create_crud_operations(model: type, pk_name: str) -> Dict[str, callable]:
@@ -107,8 +110,12 @@ def create_crud_operations(model: type, pk_name: str) -> Dict[str, callable]:
     SUpdate = _schema(model, verb="update", exclude={pk_name})
     SListIn = create_list_schema(model)
     # Distinct pk-only *input* models for read vs delete (names differ for clarity)
-    SReadIn = _schema(model, verb="delete", include={pk_name}, name=f"{model.__name__}ReadIn")
-    SDeleteIn = _schema(model, verb="delete", include={pk_name}, name=f"{model.__name__}DeleteIn")
+    SReadIn = _schema(
+        model, verb="delete", include={pk_name}, name=f"{model.__name__}ReadIn"
+    )
+    SDeleteIn = _schema(
+        model, verb="delete", include={pk_name}, name=f"{model.__name__}DeleteIn"
+    )
 
     # ── CRUD impls ────────────────────────────────────────────────────────
     def _create(p: SCreate, db: Session):
@@ -182,7 +189,11 @@ def create_crud_operations(model: type, pk_name: str) -> Dict[str, callable]:
 
     def _list(p: SListIn, db: Session):
         print(f"_list called with params={p}")
-        d = p.model_dump(exclude_defaults=True, exclude_none=True) if hasattr(p, "model_dump") else dict(p)
+        d = (
+            p.model_dump(exclude_defaults=True, exclude_none=True)
+            if hasattr(p, "model_dump")
+            else dict(p)
+        )
         qry = (
             db.query(model)
             .filter_by(**{k: d[k] for k in d if k not in ("skip", "limit")})
@@ -228,16 +239,17 @@ def _crud(self, model: type) -> None:
     """
     Public entry: call `api._crud(User)` to expose canonical CRUD & list routes.
     """
-    tab = model.__tablename__
-    print(f"_crud called for table={tab}")
+    name = model.__name__
+    tab = name.lower()
+    print(f"_crud called for model={name}")
 
     if tab in self._registered_tables:
-        print(f"_crud skipping {tab}, already registered")
+        print(f"_crud skipping {name}, already registered")
         return
     self._registered_tables.add(tab)
 
     pk = next(iter(model.__table__.primary_key.columns)).name
-    print(f"Primary key for {tab} is {pk}")
+    print(f"Primary key for {name} is {pk}")
 
     crud_ops = create_crud_operations(model, pk)
 
@@ -249,8 +261,8 @@ def _crud(self, model: type) -> None:
         pk,
         crud_ops["schemas"]["create"],
         crud_ops["schemas"]["read_out"],
-        crud_ops["schemas"]["read_in"],      # NEW: read input (pk-only)
-        crud_ops["schemas"]["delete_in"],    # NEW: delete input (pk-only)
+        crud_ops["schemas"]["read_in"],  # NEW: read input (pk-only)
+        crud_ops["schemas"]["delete_in"],  # NEW: delete input (pk-only)
         crud_ops["schemas"]["update"],
         crud_ops["schemas"]["list"],
         crud_ops["create"],
@@ -260,6 +272,6 @@ def _crud(self, model: type) -> None:
         crud_ops["list"],
         crud_ops["clear"],
     )
-    print(f"_crud registered routes for {tab}")
+    print(f"_crud registered routes for {name}")
 
     _invoke_all_registrars(model, self)

--- a/pkgs/standards/autoapi/tests/conftest.py
+++ b/pkgs/standards/autoapi/tests/conftest.py
@@ -146,7 +146,7 @@ async def api_client(db_mode):
 
         @classmethod
         def __autoapi_nested_paths__(cls):
-            return "/tenants/{tenant_id}"
+            return "/tenant/{tenant_id}"
 
     if db_mode == "async":
         engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=True)

--- a/pkgs/standards/autoapi/tests/i9n/test_healthz_methodz_hookz.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_healthz_methodz_hookz.py
@@ -62,16 +62,16 @@ async def test_methodz_endpoint_comprehensive(api_client):
 
     # Should have methods for Item and Tenant (from conftest)
     expected_methods = [
-        "Items.create",
-        "Items.read",
-        "Items.update",
-        "Items.delete",
-        "Items.list",
-        "Tenants.create",
-        "Tenants.read",
-        "Tenants.update",
-        "Tenants.delete",
-        "Tenants.list",
+        "Item.create",
+        "Item.read",
+        "Item.update",
+        "Item.delete",
+        "Item.list",
+        "Tenant.create",
+        "Tenant.read",
+        "Tenant.update",
+        "Tenant.delete",
+        "Tenant.list",
     ]
 
     for method in expected_methods:
@@ -92,7 +92,7 @@ async def test_hookz_endpoint_comprehensive(api_client):
     def second_hook(ctx):
         pass
 
-    @api.register_hook(Phase.POST_RESPONSE, model="Items", op="create")
+    @api.register_hook(Phase.POST_RESPONSE, model="Item", op="create")
     def item_hook(ctx):
         pass
 
@@ -115,12 +115,12 @@ async def test_hookz_endpoint_comprehensive(api_client):
         assert isinstance(phases, dict)
         assert phases["POST_RESPONSE"][:2] == expected_global_hooks
 
-    assert "Items.create" in data
-    assert data["Items.create"]["POST_RESPONSE"] == expected_global_hooks + [
+    assert "Item.create" in data
+    assert data["Item.create"]["POST_RESPONSE"] == expected_global_hooks + [
         f"autoapi.v2.hooks.{item_hook.__qualname__}",
     ]
-    assert "Tenants.create" in data
-    assert data["Tenants.create"]["POST_RESPONSE"] == expected_global_hooks
+    assert "Tenant.create" in data
+    assert data["Tenant.create"]["POST_RESPONSE"] == expected_global_hooks
 
 
 @pytest.mark.i9n
@@ -132,14 +132,14 @@ async def test_methodz_basic_functionality(api_client):
     response = await client.get("/methodz")
     data = response.json()
 
-    # Should contain Items.create method
-    assert "Items.create" in data
+    # Should contain Item.create method
+    assert "Item.create" in data
 
     # Should contain basic CRUD operations
     crud_operations = ["create", "read", "update", "delete", "list"]
     for operation in crud_operations:
-        assert f"Items.{operation}" in data
-        assert f"Tenants.{operation}" in data
+        assert f"Item.{operation}" in data
+        assert f"Tenant.{operation}" in data
 
 
 @pytest.mark.i9n
@@ -189,11 +189,11 @@ async def test_methodz_reflects_dynamic_models(api_client):
     initial_data = response.json()
 
     # Should include methods for models from conftest
-    assert "Tenants.create" in initial_data
-    assert "Tenants.read" in initial_data
-    assert "Tenants.update" in initial_data
-    assert "Tenants.delete" in initial_data
-    assert "Tenants.list" in initial_data
+    assert "Tenant.create" in initial_data
+    assert "Tenant.read" in initial_data
+    assert "Tenant.update" in initial_data
+    assert "Tenant.delete" in initial_data
+    assert "Tenant.list" in initial_data
 
 
 @pytest.mark.i9n


### PR DESCRIPTION
## Summary
- default route prefixes and canonical RPC identifiers to the model's class name
- adjust integration tests and fixtures to use singular model names

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_healthz_methodz_hookz.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689c006c25148326b9081ba92e5e145d