### PR TITLE
Use model class names for AutoAPI routes and hooks

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/hooks.py
+++ b/pkgs/standards/autoapi/autoapi/v2/hooks.py
@@ -86,17 +86,12 @@ def _init_hooks(self) -> None:
             if model is not None and op is not None:
                 # Model + op parameters
                 if isinstance(model, str):
-                    tab = model
+                    if hasattr(self, "models") and hasattr(self.models, model):
+                        model_name = getattr(self.models, model).__name__
+                    else:
+                        model_name = model
                 else:
-                    tab = getattr(model, "__name__")
-                if tab.islower():
-                    model_name = "".join(part.title() for part in tab.split("_"))
-                elif "_" in tab:
-                    model_name = "".join(
-                        part[:1].upper() + part[1:] for part in tab.split("_")
-                    )
-                else:
-                    model_name = tab
+                    model_name = getattr(model, "__name__", repr(model))
                 hook_key = f"{model_name}.{op}"
             elif model is not None or op is not None:
                 # Error: both model and op must be provided together

--- a/pkgs/standards/autoapi/autoapi/v2/impl/crud_builder.py
+++ b/pkgs/standards/autoapi/autoapi/v2/impl/crud_builder.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from typing import Dict
 
+import re
+
 from sqlalchemy import inspect as _sa_inspect
 
 from ..jsonrpc_models import create_standardized_error
@@ -75,7 +77,9 @@ def _flush_or_http(db: Session) -> None:
                 if m
                 else "Duplicate key value violates a unique constraint."
             )
-            http_exc, _, _ = create_standardized_error(409, message=msg, rpc_code=-32099)
+            http_exc, _, _ = create_standardized_error(
+                409, message=msg, rpc_code=-32099
+            )
             raise http_exc from exc
         if getattr(exc.orig, "pgcode", None) in ("23503",) or "foreign key" in raw:
             http_exc, _, _ = create_standardized_error(422, rpc_code=-32097)
@@ -85,9 +89,10 @@ def _flush_or_http(db: Session) -> None:
     except SQLAlchemyError as exc:
         # Do NOT rollback here; let the outer transaction manager handle it.
         print(f"SQLAlchemyError encountered during flush: {exc}")
-        http_exc, _, _ = create_standardized_error(500, message=f"Database error: {exc}")
+        http_exc, _, _ = create_standardized_error(
+            500, message=f"Database error: {exc}"
+        )
         raise http_exc from exc
-
 
 
 def create_crud_operations(model: type, pk_name: str) -> Dict[str, callable]:
@@ -107,8 +112,12 @@ def create_crud_operations(model: type, pk_name: str) -> Dict[str, callable]:
     SUpdate = _schema(model, verb="update", exclude={pk_name})
     SListIn = create_list_schema(model)
     # Distinct pk-only *input* models for read vs delete (names differ for clarity)
-    SReadIn = _schema(model, verb="delete", include={pk_name}, name=f"{model.__name__}ReadIn")
-    SDeleteIn = _schema(model, verb="delete", include={pk_name}, name=f"{model.__name__}DeleteIn")
+    SReadIn = _schema(
+        model, verb="delete", include={pk_name}, name=f"{model.__name__}ReadIn"
+    )
+    SDeleteIn = _schema(
+        model, verb="delete", include={pk_name}, name=f"{model.__name__}DeleteIn"
+    )
 
     # ── CRUD impls ────────────────────────────────────────────────────────
     def _create(p: SCreate, db: Session):
@@ -182,7 +191,11 @@ def create_crud_operations(model: type, pk_name: str) -> Dict[str, callable]:
 
     def _list(p: SListIn, db: Session):
         print(f"_list called with params={p}")
-        d = p.model_dump(exclude_defaults=True, exclude_none=True) if hasattr(p, "model_dump") else dict(p)
+        d = (
+            p.model_dump(exclude_defaults=True, exclude_none=True)
+            if hasattr(p, "model_dump")
+            else dict(p)
+        )
         qry = (
             db.query(model)
             .filter_by(**{k: d[k] for k in d if k not in ("skip", "limit")})
@@ -228,16 +241,16 @@ def _crud(self, model: type) -> None:
     """
     Public entry: call `api._crud(User)` to expose canonical CRUD & list routes.
     """
-    tab = model.__tablename__
-    print(f"_crud called for table={tab}")
+    resource = re.sub(r"(?<!^)(?=[A-Z])", "_", model.__name__).lower()
+    print(f"_crud called for model={resource}")
 
-    if tab in self._registered_tables:
-        print(f"_crud skipping {tab}, already registered")
+    if resource in self._registered_tables:
+        print(f"_crud skipping {resource}, already registered")
         return
-    self._registered_tables.add(tab)
+    self._registered_tables.add(resource)
 
     pk = next(iter(model.__table__.primary_key.columns)).name
-    print(f"Primary key for {tab} is {pk}")
+    print(f"Primary key for {resource} is {pk}")
 
     crud_ops = create_crud_operations(model, pk)
 
@@ -245,12 +258,12 @@ def _crud(self, model: type) -> None:
     # Signature: (model, tab, pk, SCreate, SReadOut, SReadIn, SDeleteIn, SUpdate, SListIn, f_create, f_read, f_update, f_delete, f_list, f_clear)
     self._register_routes_and_rpcs(
         model,
-        tab,
+        resource,
         pk,
         crud_ops["schemas"]["create"],
         crud_ops["schemas"]["read_out"],
-        crud_ops["schemas"]["read_in"],      # NEW: read input (pk-only)
-        crud_ops["schemas"]["delete_in"],    # NEW: delete input (pk-only)
+        crud_ops["schemas"]["read_in"],  # NEW: read input (pk-only)
+        crud_ops["schemas"]["delete_in"],  # NEW: delete input (pk-only)
         crud_ops["schemas"]["update"],
         crud_ops["schemas"]["list"],
         crud_ops["create"],
@@ -260,6 +273,6 @@ def _crud(self, model: type) -> None:
         crud_ops["list"],
         crud_ops["clear"],
     )
-    print(f"_crud registered routes for {tab}")
+    print(f"_crud registered routes for {resource}")
 
     _invoke_all_registrars(model, self)

--- a/pkgs/standards/autoapi/autoapi/v2/impl/routes_builder.py
+++ b/pkgs/standards/autoapi/autoapi/v2/impl/routes_builder.py
@@ -259,15 +259,15 @@ def _register_routes_and_rpcs(  # noqa: N802 – bound as method
         _allow_verbs = set(allow_cb())
     else:
         _allow_verbs = set(allow_cb or [])
-    self._allow_anon.update({_canonical(resource, v) for v in _allow_verbs})
+    self._allow_anon.update({_canonical(tab, v) for v in _allow_verbs})
     if _allow_verbs:
         print(f"Anon allowed verbs: {_allow_verbs}")
 
-    flat_router = APIRouter(prefix=f"/{tab}", tags=[tab])
+    flat_router = APIRouter(prefix=f"/{tab}", tags=[resource])
     routers = (
         (flat_router,)
         if nested_pref is None
-        else (flat_router, APIRouter(prefix=nested_pref, tags=[f"nested-{tab}"]))
+        else (flat_router, APIRouter(prefix=nested_pref, tags=[f"nested-{resource}"]))
     )
 
     # ---------- RBAC guard -------------------------------------------
@@ -282,7 +282,7 @@ def _register_routes_and_rpcs(  # noqa: N802 – bound as method
 
     # ---------- endpoint factory -------------------------------------
     for verb, http, path, status, In, Out, core in spec:
-        m_id_canon = _canonical(resource, verb)
+        m_id_canon = _canonical(tab, verb)
 
         # RPC input model for adapter (distinct from REST signature)
         rpc_in = In or dict
@@ -347,9 +347,8 @@ def _register_routes_and_rpcs(  # noqa: N802 – bound as method
                     inspect.Parameter(
                         "p",
                         inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                        annotation=Annotated[
-                            Optional[List[SDeleteIn]], Body(default=None)
-                        ],
+                        annotation=Annotated[Optional[List[SDeleteIn]], Body()],
+                        default=None,
                     )
                 )
             elif In is not None and verb not in ("read", "delete", "clear"):
@@ -367,6 +366,7 @@ def _register_routes_and_rpcs(  # noqa: N802 – bound as method
                     "db",
                     inspect.Parameter.POSITIONAL_OR_KEYWORD,
                     annotation=DBDep,
+                    default=None,
                 )
             )
 
@@ -383,7 +383,7 @@ def _register_routes_and_rpcs(  # noqa: N802 – bound as method
                 # assemble RPC-style param dict
                 def _dump(obj):
                     if hasattr(obj, "model_dump"):
-                        return obj.model_dump(exclude_unset=True)
+                        return obj.model_dump(exclude_unset=True, exclude_none=True)
                     return obj
 
                 if verb in {
@@ -514,14 +514,15 @@ def _register_routes_and_rpcs(  # noqa: N802 – bound as method
                 self._schemas[canon] = s
                 setattr(self.schemas, canon, s)
 
-            # Preserve legacy nested access (api.schemas.User.create)
-            name = s.__name__
-            base = model.__name__
-            if not name.startswith(base):
-                base = resource
-            op = name[len(base) :]
-            op = re.sub(r"(?<!^)(?=[A-Z])", "_", op).lstrip("_").lower() or "base"
-            _attach(self.schemas, base, op, s)
+            if suffix != "RpcIn":
+                # Preserve legacy nested access (api.schemas.User.create)
+                name = s.__name__
+                base = model.__name__
+                if not name.startswith(base):
+                    base = resource
+                op = name[len(base) :]
+                op = re.sub(r"(?<!^)(?=[A-Z])", "_", op).lstrip("_").lower() or "base"
+                _attach(self.schemas, base, op, s)
 
         # JSON-RPC shim (single callable for this canonical op)
         rpc_fn = _wrap_rpc(core, rpc_in, Out, pk, model)
@@ -577,7 +578,7 @@ def _register_routes_and_rpcs(  # noqa: N802 – bound as method
             def _build_args(_p):
                 def _dump(o):
                     return (
-                        o.model_dump(exclude_unset=True)
+                        o.model_dump(exclude_unset=True, exclude_none=True)
                         if hasattr(o, "model_dump")
                         else o
                     )
@@ -630,7 +631,7 @@ def _register_routes_and_rpcs(  # noqa: N802 – bound as method
         pol = _alias_policy(model)
         pub = _public_verb(model, verb)
         if pub != verb and pol in ("both", "alias_only"):
-            m_id_alias = _canonical(resource, pub)
+            m_id_alias = _canonical(tab, pub)
             # Same rpc_fn handles alias
             self.rpc.add(m_id_alias, rpc_fn)
 
@@ -652,4 +653,4 @@ def _register_routes_and_rpcs(  # noqa: N802 – bound as method
     self.router.include_router(flat_router)
     if len(routers) > 1:
         self.router.include_router(routers[1])
-    print(f"Routes registered for {tab}")
+    print(f"Routes registered for {resource}")

--- a/pkgs/standards/autoapi/autoapi/v2/schema/get_schema.py
+++ b/pkgs/standards/autoapi/autoapi/v2/schema/get_schema.py
@@ -27,7 +27,7 @@ def get_autoapi_schema(
     SUpdate = _schema("update")
     SDelete = _schema("delete")
 
-    tab = "".join(w.title() for w in orm_cls.__tablename__.split("_"))
+    tab = orm_cls.__name__
 
     def _make_list():
         base = dict(

--- a/pkgs/standards/autoapi/tests/conftest.py
+++ b/pkgs/standards/autoapi/tests/conftest.py
@@ -146,7 +146,7 @@ async def api_client(db_mode):
 
         @classmethod
         def __autoapi_nested_paths__(cls):
-            return "/tenants/{tenant_id}"
+            return "/tenant/{tenant_id}"
 
     if db_mode == "async":
         engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=True)

--- a/pkgs/standards/autoapi/tests/i9n/test_allow_anon.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_allow_anon.py
@@ -92,37 +92,33 @@ def _build_client_attr():
 
 def test_allow_anon_list_and_read():
     client = _build_client()
-    assert client.get("/items").status_code == 200
+    assert client.get("/item").status_code == 200
     tenant = {"name": "acme"}
     res = client.post(
-        "/tenants", json=tenant, headers={"Authorization": "Bearer secret"}
+        "/tenant", json=tenant, headers={"Authorization": "Bearer secret"}
     )
     tid = res.json()["id"]
     payload = {"tenant_id": tid, "name": "thing"}
-    res = client.post(
-        "/items", json=payload, headers={"Authorization": "Bearer secret"}
-    )
+    res = client.post("/item", json=payload, headers={"Authorization": "Bearer secret"})
     iid = res.json()["id"]
-    assert client.get(f"/items/{iid}").status_code == 200
+    assert client.get(f"/item/{iid}").status_code == 200
     # FastAPI's HTTPBearer returns 403 when the Authorization header is
     # completely missing (as opposed to a malformed token).  The AutoAPI
     # endpoint mirrors this behaviour for unauthenticated access to routes
     # that are not whitelisted via ``__autoapi_allow_anon__``.
-    assert client.post("/items", json=payload).status_code == 403
+    assert client.post("/item", json=payload).status_code == 403
 
 
 def test_allow_anon_list_and_read_attr():
     client = _build_client_attr()
-    assert client.get("/items").status_code == 200
+    assert client.get("/item").status_code == 200
     tenant = {"name": "acme"}
     res = client.post(
-        "/tenants", json=tenant, headers={"Authorization": "Bearer secret"}
+        "/tenant", json=tenant, headers={"Authorization": "Bearer secret"}
     )
     tid = res.json()["id"]
     payload = {"tenant_id": tid, "name": "thing"}
-    res = client.post(
-        "/items", json=payload, headers={"Authorization": "Bearer secret"}
-    )
+    res = client.post("/item", json=payload, headers={"Authorization": "Bearer secret"})
     iid = res.json()["id"]
-    assert client.get(f"/items/{iid}").status_code == 200
-    assert client.post("/items", json=payload).status_code == 403
+    assert client.get(f"/item/{iid}").status_code == 200
+    assert client.post("/item", json=payload).status_code == 403

--- a/pkgs/standards/autoapi/tests/i9n/test_apikey_generation.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_apikey_generation.py
@@ -30,7 +30,7 @@ async def test_api_key_creation_returns_raw_key(sync_db_session):
     transport = ASGITransport(app=app)
 
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        res = await client.post("/api_keys", json={"label": "test"})
+        res = await client.post("/api_key", json={"label": "test"})
 
     assert res.status_code == 201
     data = res.json()

--- a/pkgs/standards/autoapi/tests/i9n/test_error_mappings.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_error_mappings.py
@@ -189,7 +189,7 @@ async def test_error_parity_crud_vs_rpc(api_client):
 
     # Test 404 error parity
     # Try to read non-existent item via REST
-    rest_response = await client.get("/items/00000000-0000-0000-0000-000000000000")
+    rest_response = await client.get("/item/00000000-0000-0000-0000-000000000000")
     assert rest_response.status_code == 404
     rest_error = rest_response.json()
 
@@ -197,7 +197,7 @@ async def test_error_parity_crud_vs_rpc(api_client):
     rpc_response = await client.post(
         "/rpc",
         json={
-            "method": "Items.read",
+            "method": "Item.read",
             "params": {"id": "00000000-0000-0000-0000-000000000000"},
         },
     )
@@ -221,14 +221,14 @@ async def test_error_parity_validation_errors(api_client):
 
     # Test validation error - missing required field
     # Try via REST
-    rest_response = await client.post("/tenants", json={})  # Missing name
+    rest_response = await client.post("/tenant", json={})  # Missing name
     assert rest_response.status_code == 422
     rest_error = rest_response.json()
 
     # Try via RPC
     rpc_response = await client.post(
         "/rpc",
-        json={"method": "Tenants.create", "params": {}},  # Missing name
+        json={"method": "Tenant.create", "params": {}},  # Missing name
     )
     assert rpc_response.status_code == 200
     rpc_data = rpc_response.json()
@@ -266,7 +266,7 @@ async def test_error_response_structure(api_client):
     client, api, _ = api_client
 
     # Test REST error structure
-    rest_response = await client.get("/items/invalid-uuid")
+    rest_response = await client.get("/item/invalid-uuid")
     rest_error = rest_response.json()
 
     # REST errors should have detail field
@@ -274,7 +274,7 @@ async def test_error_response_structure(api_client):
 
     # Test RPC error structure
     rpc_response = await client.post(
-        "/rpc", json={"method": "Items.read", "params": {"id": "invalid-uuid"}}
+        "/rpc", json={"method": "Item.read", "params": {"id": "invalid-uuid"}}
     )
     rpc_data = rpc_response.json()
 

--- a/pkgs/standards/autoapi/tests/i9n/test_healthz_methodz_hookz.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_healthz_methodz_hookz.py
@@ -62,16 +62,16 @@ async def test_methodz_endpoint_comprehensive(api_client):
 
     # Should have methods for Item and Tenant (from conftest)
     expected_methods = [
-        "Items.create",
-        "Items.read",
-        "Items.update",
-        "Items.delete",
-        "Items.list",
-        "Tenants.create",
-        "Tenants.read",
-        "Tenants.update",
-        "Tenants.delete",
-        "Tenants.list",
+        "Item.create",
+        "Item.read",
+        "Item.update",
+        "Item.delete",
+        "Item.list",
+        "Tenant.create",
+        "Tenant.read",
+        "Tenant.update",
+        "Tenant.delete",
+        "Tenant.list",
     ]
 
     for method in expected_methods:
@@ -92,7 +92,7 @@ async def test_hookz_endpoint_comprehensive(api_client):
     def second_hook(ctx):
         pass
 
-    @api.register_hook(Phase.POST_RESPONSE, model="Items", op="create")
+    @api.register_hook(Phase.POST_RESPONSE, model="Item", op="create")
     def item_hook(ctx):
         pass
 
@@ -115,12 +115,12 @@ async def test_hookz_endpoint_comprehensive(api_client):
         assert isinstance(phases, dict)
         assert phases["POST_RESPONSE"][:2] == expected_global_hooks
 
-    assert "Items.create" in data
-    assert data["Items.create"]["POST_RESPONSE"] == expected_global_hooks + [
+    assert "Item.create" in data
+    assert data["Item.create"]["POST_RESPONSE"] == expected_global_hooks + [
         f"autoapi.v2.hooks.{item_hook.__qualname__}",
     ]
-    assert "Tenants.create" in data
-    assert data["Tenants.create"]["POST_RESPONSE"] == expected_global_hooks
+    assert "Tenant.create" in data
+    assert data["Tenant.create"]["POST_RESPONSE"] == expected_global_hooks
 
 
 @pytest.mark.i9n
@@ -132,14 +132,14 @@ async def test_methodz_basic_functionality(api_client):
     response = await client.get("/methodz")
     data = response.json()
 
-    # Should contain Items.create method
-    assert "Items.create" in data
+    # Should contain Item.create method
+    assert "Item.create" in data
 
     # Should contain basic CRUD operations
     crud_operations = ["create", "read", "update", "delete", "list"]
     for operation in crud_operations:
-        assert f"Items.{operation}" in data
-        assert f"Tenants.{operation}" in data
+        assert f"Item.{operation}" in data
+        assert f"Tenant.{operation}" in data
 
 
 @pytest.mark.i9n
@@ -189,11 +189,11 @@ async def test_methodz_reflects_dynamic_models(api_client):
     initial_data = response.json()
 
     # Should include methods for models from conftest
-    assert "Tenants.create" in initial_data
-    assert "Tenants.read" in initial_data
-    assert "Tenants.update" in initial_data
-    assert "Tenants.delete" in initial_data
-    assert "Tenants.list" in initial_data
+    assert "Tenant.create" in initial_data
+    assert "Tenant.read" in initial_data
+    assert "Tenant.update" in initial_data
+    assert "Tenant.delete" in initial_data
+    assert "Tenant.list" in initial_data
 
 
 @pytest.mark.i9n

--- a/pkgs/standards/autoapi/tests/i9n/test_hook_lifecycle.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_hook_lifecycle.py
@@ -47,14 +47,14 @@ async def test_hook_phases_execution_order(api_client):
         ctx["response"].result["hook_completed"] = True
 
     # Create a tenant first
-    t = await client.post("/tenants", json={"name": "test-tenant"})
+    t = await client.post("/tenant", json={"name": "test-tenant"})
     tid = t.json()["id"]
 
     # Create an item via RPC
     res = await client.post(
         "/rpc",
         json={
-            "method": "Items.create",
+            "method": "Item.create",
             "params": {"tenant_id": tid, "name": "test-item"},
         },
     )
@@ -98,17 +98,17 @@ async def test_hook_parity_crud_vs_rpc(api_client):
             crud_hooks.append("POST_COMMIT")
 
     # Create tenant
-    t = await client.post("/tenants", json={"name": "test-tenant"})
+    t = await client.post("/tenant", json={"name": "test-tenant"})
     tid = t.json()["id"]
 
     # Test via REST CRUD
-    await client.post("/items", json={"tenant_id": tid, "name": "crud-item"})
+    await client.post("/item", json={"tenant_id": tid, "name": "crud-item"})
 
     # Test via RPC
     await client.post(
         "/rpc",
         json={
-            "method": "Items.create",
+            "method": "Item.create",
             "params": {"tenant_id": tid, "name": "rpc-item"},
         },
     )
@@ -135,13 +135,13 @@ async def test_hook_error_handling(api_client):
         raise ValueError("Intentional test error")
 
     # Create tenant
-    t = await client.post("/tenants", json={"name": "test-tenant"})
+    t = await client.post("/tenant", json={"name": "test-tenant"})
     tid = t.json()["id"]
 
     # This should trigger the error hook - expect the exception to propagate
     # but the error hook should still execute
     try:
-        res = await client.post("/items", json={"tenant_id": tid, "name": "error-item"})
+        res = await client.post("/item", json={"tenant_id": tid, "name": "error-item"})
         # If no exception, should have error status code
         assert res.status_code >= 400
     except Exception:
@@ -183,11 +183,11 @@ async def test_hook_context_modification(api_client):
         assert hasattr(ctx["response"].result, "name")
 
     # Create tenant
-    t = await client.post("/tenants", json={"name": "test-tenant"})
+    t = await client.post("/tenant", json={"name": "test-tenant"})
     tid = t.json()["id"]
 
     # Create item
-    res = await client.post("/items", json={"tenant_id": tid, "name": "test-item"})
+    res = await client.post("/item", json={"tenant_id": tid, "name": "test-item"})
 
     assert res.status_code == 201
     data = res.json()
@@ -219,40 +219,40 @@ async def test_catch_all_hooks(api_client):
             catch_all_executions.append(method)
 
     # Create tenant
-    t = await client.post("/tenants", json={"name": "test-tenant"})
+    t = await client.post("/tenant", json={"name": "test-tenant"})
     tid = t.json()["id"]
 
     # Create item
-    await client.post("/items", json={"tenant_id": tid, "name": "test-item"})
+    await client.post("/item", json={"tenant_id": tid, "name": "test-item"})
 
     # Read item
-    items = await client.get("/items")
+    items = await client.get("/item")
     item_id = items.json()[0]["id"]
-    await client.get(f"/items/{item_id}")
+    await client.get(f"/item/{item_id}")
 
     # Update item - need to provide tenant_id as well
     update_res = await client.patch(
-        f"/items/{item_id}", json={"tenant_id": tid, "name": "updated-item"}
+        f"/item/{item_id}", json={"tenant_id": tid, "name": "updated-item"}
     )
     update_succeeded = update_res.status_code < 400
 
     # Delete item
-    delete_res = await client.delete(f"/items/{item_id}")
+    delete_res = await client.delete(f"/item/{item_id}")
     delete_succeeded = delete_res.status_code < 400
 
     # Verify catch-all hook was called for successful operations
     expected_methods = [
-        "Tenants.create",
-        "Items.create",
-        "Items.list",
-        "Items.read",
+        "Tenant.create",
+        "Item.create",
+        "Item.list",
+        "Item.read",
     ]
 
     # Add update and delete to expected methods if they succeeded
     if update_succeeded:
-        expected_methods.append("Items.update")
+        expected_methods.append("Item.update")
     if delete_succeeded:
-        expected_methods.append("Items.delete")
+        expected_methods.append("Item.delete")
 
     # Deduplicate because the fallback POST_HANDLER hook runs before POST_COMMIT
     unique_methods = list(dict.fromkeys(catch_all_executions))
@@ -277,11 +277,11 @@ async def test_hook_model_object_reference(api_client):
         object_hooks.append("executed")
 
     # Create tenant
-    t = await client.post("/tenants", json={"name": "test-tenant"})
+    t = await client.post("/tenant", json={"name": "test-tenant"})
     tid = t.json()["id"]
 
     # Create item - both hooks should execute
-    await client.post("/items", json={"tenant_id": tid, "name": "test-item"})
+    await client.post("/item", json={"tenant_id": tid, "name": "test-item"})
 
     assert string_hooks == ["executed"]
     assert object_hooks == ["executed"]
@@ -307,11 +307,11 @@ async def test_multiple_hooks_same_phase(api_client):
         executions.append("third")
 
     # Create tenant
-    t = await client.post("/tenants", json={"name": "test-tenant"})
+    t = await client.post("/tenant", json={"name": "test-tenant"})
     tid = t.json()["id"]
 
     # Create item
-    await client.post("/items", json={"tenant_id": tid, "name": "test-item"})
+    await client.post("/item", json={"tenant_id": tid, "name": "test-item"})
 
     # All hooks should have executed
     assert len(executions) == 3

--- a/pkgs/standards/autoapi/tests/i9n/test_mixins.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_mixins.py
@@ -266,7 +266,9 @@ async def test_bulk_capable_mixin(create_test_api):
     routes = [route.path for route in api.router.routes]
 
     # Should have bulk create and bulk delete routes
-    assert "/dummy_bulk_capable/bulk" in [route for route in routes if "/bulk" in route]
+    assert "/dummy_model_bulk_capable/bulk" in [
+        route for route in routes if "/bulk" in route
+    ]
 
 
 @pytest.mark.i9n

--- a/pkgs/standards/autoapi/tests/i9n/test_schema.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_schema.py
@@ -17,7 +17,7 @@ async def test_schema_generation(api_client):
     assert read_model.__name__ == "ItemRead"
     assert update_model.__name__ == "ItemUpdate"
     assert delete_model.__name__ == "ItemDelete"
-    assert list_model.__name__ == "ItemsListParams"
+    assert list_model.__name__ == "ItemListParams"
 
     spec = (await client.get("/openapi.json")).json()
     schemas = spec["components"]["schemas"]
@@ -29,6 +29,6 @@ async def test_schema_generation(api_client):
 async def test_bulk_operation_schema(api_client):
     client, _, _ = api_client
     spec = (await client.get("/openapi.json")).json()
-    assert "/items/bulk" in spec["paths"]
-    ops = spec["paths"]["/items/bulk"]
+    assert "/item/bulk" in spec["paths"]
+    ops = spec["paths"]["/item/bulk"]
     assert "post" in ops and "delete" in ops

--- a/pkgs/standards/autoapi/tests/i9n/test_symmetry_parity.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_symmetry_parity.py
@@ -1,12 +1,12 @@
 import pytest
 
 CRUD_MAP = {
-    "create": ("post", "/items"),
-    "list": ("get", "/items"),
-    "clear": ("delete", "/items"),
-    "read": ("get", "/items/{item_id}"),
-    "update": ("patch", "/items/{item_id}"),
-    "delete": ("delete", "/items/{item_id}"),
+    "create": ("post", "/item"),
+    "list": ("get", "/item"),
+    "clear": ("delete", "/item"),
+    "read": ("get", "/item/{item_id}"),
+    "update": ("patch", "/item/{item_id}"),
+    "delete": ("delete", "/item/{item_id}"),
 }
 
 
@@ -22,13 +22,13 @@ async def test_route_and_method_symmetry(api_client):
     for verb, (http_verb, path) in CRUD_MAP.items():
         assert path in paths
         assert http_verb in paths[path]
-        assert f"Items.{verb}" in method_list
+        assert f"Item.{verb}" in method_list
 
-    nested_base = "/tenants/{tenant_id}"
+    nested_base = "/tenant/{tenant_id}"
     assert nested_base in paths
     for verb in ("create", "list", "clear"):
         assert CRUD_MAP[verb][0] in paths[nested_base]
-    nested_item = "/tenants/{tenant_id}/{item_id}"
+    nested_item = "/tenant/{tenant_id}/{item_id}"
     assert nested_item in paths
     for verb in ("read", "update", "delete"):
         assert CRUD_MAP[verb][0] in paths[nested_item]

--- a/pkgs/standards/autoapi/tests/i9n/test_transactional.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_transactional.py
@@ -18,28 +18,28 @@ async def test_transaction_decorator(api_client):
 
     fail = transactional(api, fail)
 
-    api.rpc["Items.fail"] = fail
-    api._method_ids["Items.fail"] = None
+    api.rpc["Item.fail"] = fail
+    api._method_ids["Item.fail"] = None
 
-    t = await client.post("/tenants", json={"name": "tx"})
+    t = await client.post("/tenant", json={"name": "tx"})
     tid = t.json()["id"]
 
     bad = await client.post(
         "/rpc",
         json={
-            "method": "Items.fail",
+            "method": "Item.fail",
             "params": {"tenant_id": tid, "name": "a", "fail": True},
         },
     )
     assert bad.json()["error"] is not None
 
-    lst = await client.get("/items")
+    lst = await client.get("/item")
     assert lst.json() == []
 
     ok = await client.post(
         "/rpc",
-        json={"method": "Items.fail", "params": {"tenant_id": tid, "name": "b"}},
+        json={"method": "Item.fail", "params": {"tenant_id": tid, "name": "b"}},
     )
     assert ok.json()["result"]["id"]
-    lst2 = await client.get("/items")
+    lst2 = await client.get("/item")
     assert len(lst2.json()) == 1


### PR DESCRIPTION
## Summary
- derive REST paths, RPC ids, and hook keys from model class names rather than table names
- generate schemas and nested paths using singular model names and update tests accordingly

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c004f1c3c832681746bf8affa9dd1