### PR TITLE
refactor: drop legacy payload from init util

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_utils_init.py
+++ b/pkgs/standards/peagen/tests/unit/test_utils_init.py
@@ -17,7 +17,7 @@ def test_call_handler_invokes_handler(monkeypatch):
     called = {}
 
     async def fake_handler(task):
-        called["payload"] = task.payload
+        called["args"] = task.args
         return {"ok": True}
 
     monkeypatch.setattr("peagen._utils._init.init_handler", fake_handler)
@@ -25,4 +25,4 @@ def test_call_handler_invokes_handler(monkeypatch):
 
     result = _call_handler({"x": 1})
     assert result == {"ok": True}
-    assert called["payload"]["args"] == {"x": 1}
+    assert called["args"] == {"x": 1}


### PR DESCRIPTION
## Summary
- remove deprecated payload compatibility from `_call_handler`
- update `test_utils_init` to assert args directly

## Testing
- `uv run --package peagen --directory standards/peagen ruff format peagen/_utils/_init.py tests/unit/test_utils_init.py`
- `uv run --package peagen --directory standards/peagen ruff check peagen/_utils/_init.py tests/unit/test_utils_init.py --fix`
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_utils_init.py`


------
https://chatgpt.com/codex/tasks/task_e_689c011c5718832692ed6f5272b6639b