### PR TITLE
fix transactional async dependency

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/transactional.py
+++ b/pkgs/standards/autoapi/autoapi/v2/transactional.py
@@ -67,7 +67,7 @@ def register_transaction(
         async def _rest_endpoint(
             request: Request,
             params: Mapping[str, Any] = Body(...),
-            db: Session = Depends(self.get_db),
+            db: AsyncSession = Depends(self.get_async_db),
         ):
             ctx: MutableMapping[str, Any] = {"request": request, "db": db, "env": {}}
             return await _invoke(self, rpc_id, params=params, ctx=ctx)


### PR DESCRIPTION
## Summary
- use the async DB dependency when registering transactional REST endpoints

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_689c0ddc7ffc832680ea95ef5047e84f