### PR TITLE
test: add performance benchmark for swarmauri namespace

### DIFF
--- a/pkgs/swarmauri/tests/test_performance.py
+++ b/pkgs/swarmauri/tests/test_performance.py
@@ -1,0 +1,41 @@
+import importlib
+import time
+
+from swarmauri.plugin_manager import (
+    discover_and_register_plugins,
+    invalidate_entry_point_cache,
+)
+from swarmauri.plugin_citizenship_registry import PluginCitizenshipRegistry
+
+
+def test_startup_and_registration_performance():
+    start = time.perf_counter()
+    importlib.import_module("swarmauri")
+    startup_time = time.perf_counter() - start
+
+    PluginCitizenshipRegistry.SECOND_CLASS_REGISTRY.clear()
+    PluginCitizenshipRegistry.THIRD_CLASS_REGISTRY.clear()
+    invalidate_entry_point_cache()
+    start = time.perf_counter()
+    discover_and_register_plugins()
+    registration_time = time.perf_counter() - start
+
+    PluginCitizenshipRegistry.SECOND_CLASS_REGISTRY.clear()
+    PluginCitizenshipRegistry.THIRD_CLASS_REGISTRY.clear()
+    invalidate_entry_point_cache()
+    start = time.perf_counter()
+    discover_and_register_plugins()
+    rebuild_time = time.perf_counter() - start
+
+    print(
+        f"Startup: {startup_time:.4f}s, Register: {registration_time:.4f}s, "
+        f"Rebuild: {rebuild_time:.4f}s",
+    )
+
+    assert startup_time >= 0
+    assert registration_time >= 0
+    assert rebuild_time >= 0
+
+
+if __name__ == "__main__":
+    test_startup_and_registration_performance()


### PR DESCRIPTION
## Summary
- add performance test measuring startup, registration, and rebuild times for swarmauri namespace

## Testing
- `uv run --directory pkgs/swarmauri --package swarmauri ruff format .`
- `uv run --directory pkgs/swarmauri --package swarmauri ruff check . --fix`
- `python tests/test_performance.py`


------
https://chatgpt.com/codex/tasks/task_e_689c2578918883269637fc583e621639