### PR TITLE
feat(autoapi): add response extras provider

### DIFF
--- a/pkgs/standards/autoapi/README.md
+++ b/pkgs/standards/autoapi/README.md
@@ -28,7 +28,8 @@ A high-leverage meta-framework that turns plain SQLAlchemy models into a fully-f
 ## Configuration Overview
 
 ### Table-Level
-- `__autoapi_request_extras__` – verb-scoped virtual fields.
+- `__autoapi_request_extras__` – verb-scoped virtual request fields.
+- `__autoapi_response_extras__` – verb-scoped virtual response fields.
 - `__autoapi_register_hooks__` – hook registration entry point.
 - `__autoapi_nested_paths__` – nested REST path segments.
 - `__autoapi_allow_anon__` – verbs permitted without auth.

--- a/pkgs/standards/autoapi/autoapi/v2/cfgs.py
+++ b/pkgs/standards/autoapi/autoapi/v2/cfgs.py
@@ -24,6 +24,7 @@ COL_LEVEL_CFGS: set[str] = {
 # Table-level configuration attributes on ORM classes
 TAB_LEVEL_CFGS: set[str] = {
     "__autoapi_request_extras__",
+    "__autoapi_response_extras__",
     "__autoapi_register_hooks__",
     "__autoapi_owner_policy__",
     "__autoapi_tenant_policy__",

--- a/pkgs/standards/autoapi/autoapi/v2/tables/apikey.py
+++ b/pkgs/standards/autoapi/autoapi/v2/tables/apikey.py
@@ -7,7 +7,13 @@ from secrets import token_urlsafe
 
 from fastapi import HTTPException
 
-from ..types import Column, String, UniqueConstraint, HookProvider
+from ..types import (
+    Column,
+    String,
+    HookProvider,
+    Field,
+    ResponseExtrasProvider,
+)
 from ._base import Base
 from ..mixins import (
     GUIDPk,
@@ -25,6 +31,7 @@ class ApiKey(
     LastUsed,
     ValidityWindow,
     HookProvider,
+    ResponseExtrasProvider,
 ):
     __tablename__ = "api_keys"
     __abstract__ = True
@@ -44,6 +51,8 @@ class ApiKey(
             }
         },
     )
+
+    __autoapi_response_extras__ = {"*": {"api_key": (str | None, Field(None))}}
 
     # ------------------------------------------------------------------
     # Digest helpers

--- a/pkgs/standards/autoapi/autoapi/v2/types/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v2/types/__init__.py
@@ -43,7 +43,16 @@ from sqlalchemy.ext.hybrid import hybrid_property
 
 from pydantic import Field, ValidationError
 
-from fastapi import APIRouter, Security, Depends, Request, Response, Path, Body, HTTPException
+from fastapi import (
+    APIRouter,
+    Security,
+    Depends,
+    Request,
+    Response,
+    Path,
+    Body,
+    HTTPException,
+)
 
 # ── local package ─────────────────────────────────────────────────────────
 from .op import _Op, _SchemaVerb
@@ -52,14 +61,18 @@ from .table_config_provider import TableConfigProvider
 from .hook_provider import HookProvider
 from .nested_path_provider import NestedPathProvider
 from .allow_anon_provider import AllowAnonProvider
+from .response_extras_provider import (
+    ResponseExtrasProvider,
+    list_response_extras_providers,
+)
 
 from .op_verb_alias_provider import OpVerbAliasProvider, list_verb_alias_providers
-
 
 
 # ── Generics / Extensions ─────────────────────────────────────────────────
 DateTime = _DateTime(timezone=False)
 TZDateTime = _DateTime(timezone=True)
+
 
 class PgUUID(_PgUUID):
     @property
@@ -77,6 +90,7 @@ __all__: list[str] = [
     "HookProvider",
     "NestedPathProvider",
     "AllowAnonProvider",
+    "ResponseExtrasProvider",
     # builtin types
     "MethodType",
     "SimpleNamespace",
@@ -137,4 +151,5 @@ __all__: list[str] = [
 __all__ += [
     "OpVerbAliasProvider",
     "list_verb_alias_providers",
+    "list_response_extras_providers",
 ]

--- a/pkgs/standards/autoapi/autoapi/v2/types/response_extras_provider.py
+++ b/pkgs/standards/autoapi/autoapi/v2/types/response_extras_provider.py
@@ -1,0 +1,22 @@
+from typing import Callable, ClassVar, Mapping
+
+from .table_config_provider import TableConfigProvider
+
+_RESPONSE_EXTRAS_PROVIDERS: set[type] = set()
+
+
+class ResponseExtrasProvider(TableConfigProvider):
+    """Models that expose response-only virtual fields."""
+
+    __autoapi_response_extras__: ClassVar[
+        Mapping[str, Mapping[str, object]]
+        | Callable[[], Mapping[str, Mapping[str, object]]]
+    ] = {}
+
+    def __init_subclass__(cls, **kw):
+        super().__init_subclass__(**kw)
+        _RESPONSE_EXTRAS_PROVIDERS.add(cls)
+
+
+def list_response_extras_providers():
+    return sorted(_RESPONSE_EXTRAS_PROVIDERS, key=lambda c: c.__name__)

--- a/pkgs/standards/autoapi/tests/i9n/test_response_extras_provider.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_response_extras_provider.py
@@ -1,0 +1,22 @@
+import pytest
+
+from autoapi.v2 import Base
+from autoapi.v2.types import Column, String, Field, ResponseExtrasProvider
+from autoapi.v2.mixins import GUIDPk
+from autoapi.v2.impl.schema import _schema
+from autoapi.v2.types.response_extras_provider import list_response_extras_providers
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_response_extras_provider_in_schema():
+    Base.metadata.clear()
+
+    class Widget(Base, GUIDPk, ResponseExtrasProvider):
+        __tablename__ = "widgets"
+        name = Column(String, nullable=False)
+        __autoapi_response_extras__ = {"read": {"extra": (int | None, Field(None))}}
+
+    SRead = _schema(Widget, verb="read")
+    assert "extra" in SRead.model_fields
+    assert Widget in list_response_extras_providers()


### PR DESCRIPTION
## Summary
- support response-only extras via new table config provider
- expose ApiKey's raw key through `__autoapi_response_extras__`
- cover response extras provider in tests

## Testing
- `uv run --directory standards --package autoapi ruff format autoapi`
- `uv run --directory standards --package autoapi ruff check autoapi --fix`
- `uv run --package autoapi --directory standards pytest autoapi/tests`


------
https://chatgpt.com/codex/tasks/task_e_689c232f9bd083268bb72e70dd6bf565