### PR TITLE
Add runtime config tests for env URLs in auto-authn

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
@@ -6,13 +6,13 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import Field
 from typing import Optional
 
-# ─── Load environment variables from a .env file (if present) ─────────────────────────
+# ─── Load environment variables from a .env file (if present) ─────────────────────
 load_dotenv()
 
 
 class Settings(BaseSettings):
-    # ───────── Redis connection ─────────
-    # Default each field to the corresponding os.environ[...] (or fallback literal).
+    # ─────── Redis connection ───────
+    redis_url_env: Optional[str] = Field(default=os.environ.get("REDIS_URL"))
     redis_host: Optional[str] = Field(default=os.environ.get("REDIS_HOST"))
     redis_port: int = Field(default=int(os.environ.get("REDIS_PORT", "6379")))
     redis_db: int = Field(default=int(os.environ.get("REDIS_DB", "0")))
@@ -21,35 +21,46 @@ class Settings(BaseSettings):
     @property
     def redis_url(self) -> str:
         """Return a valid Redis connection URL."""
+        if self.redis_url_env:
+            return self.redis_url_env
         host = self.redis_host or "localhost"
         cred = f":{self.redis_password}@" if self.redis_password else ""
         return f"redis://{cred}{host}:{self.redis_port}/{self.redis_db}"
 
-    # ───────── Postgres results-backend ─────────
-    pg_dsn_env: Optional[str] = Field(default=os.environ.get("PG_DSN"))
+    # ─────── Postgres results-backend ───────
+    pg_dsn_env: Optional[str] = Field(
+        default=os.environ.get("POSTGRES_URL") or os.environ.get("PG_DSN")
+    )
     pg_host: Optional[str] = Field(default=os.environ.get("PG_HOST"))
     pg_port: int = Field(default=int(os.environ.get("PG_PORT", "5432")))
     pg_db: Optional[str] = Field(default=os.environ.get("PG_DB"))
     pg_user: Optional[str] = Field(default=os.environ.get("PG_USER"))
     pg_pass: Optional[str] = Field(default=os.environ.get("PG_PASS"))
+    async_fallback_db: Optional[str] = Field(
+        default=os.environ.get("ASYNC_FALLBACK_DB")
+    )
 
     @property
     def pg_dsn(self) -> str:
         if self.pg_dsn_env:
             return self.pg_dsn_env
-        return (
-            f"postgresql://{self.pg_user}:{self.pg_pass}"
-            f"@{self.pg_host}:{self.pg_port}/{self.pg_db}"
-        )
+        if self.pg_host and self.pg_db and self.pg_user:
+            return (
+                f"postgresql://{self.pg_user}:{self.pg_pass}"
+                f"@{self.pg_host}:{self.pg_port}/{self.pg_db}"
+            )
+        return ""
 
     @property
     def apg_dsn(self) -> str:
         dsn = self.pg_dsn
         if dsn.startswith("postgresql://"):
             return dsn.replace("postgresql://", "postgresql+asyncpg://", 1)
+        if not dsn and self.async_fallback_db:
+            return self.async_fallback_db
         return dsn
 
-    # ───────── Other global settings ─────────
+    # ─────── Other global settings ───────
     jwt_secret: str = Field(os.environ.get("JWT_SECRET", "insecure-dev-secret"))
     log_level: str = Field(os.environ.get("LOG_LEVEL", "INFO"))
 

--- a/pkgs/standards/auto_authn/tests/unit/test_runtime_cfg.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_runtime_cfg.py
@@ -1,0 +1,44 @@
+"""Tests for runtime configuration environment variables."""
+
+from importlib import reload
+
+import pytest
+
+from auto_authn.v2 import runtime_cfg
+
+
+@pytest.mark.unit
+def test_settings_build_from_urls(monkeypatch):
+    """Settings should honor explicit Redis and Postgres URLs."""
+    pg_url = "postgresql://user:pass@localhost:5432/db"
+    redis_url = "redis://:password@localhost:6379/1"
+
+    monkeypatch.setenv("POSTGRES_URL", pg_url)
+    monkeypatch.setenv("REDIS_URL", redis_url)
+    monkeypatch.delenv("ASYNC_FALLBACK_DB", raising=False)
+
+    reload(runtime_cfg)
+    settings = runtime_cfg.Settings()
+
+    assert settings.pg_dsn == pg_url
+    assert settings.apg_dsn == "postgresql+asyncpg://user:pass@localhost:5432/db"
+    assert settings.redis_url == redis_url
+
+
+@pytest.mark.unit
+def test_apg_dsn_fallback(monkeypatch):
+    """When Postgres is unset, apg_dsn falls back to ASYNC_FALLBACK_DB."""
+    fallback = "sqlite+aiosqlite:///./gateway.db"
+
+    monkeypatch.delenv("POSTGRES_URL", raising=False)
+    monkeypatch.delenv("PG_DSN", raising=False)
+    monkeypatch.delenv("PG_HOST", raising=False)
+    monkeypatch.delenv("PG_DB", raising=False)
+    monkeypatch.delenv("PG_USER", raising=False)
+    monkeypatch.setenv("ASYNC_FALLBACK_DB", fallback)
+
+    reload(runtime_cfg)
+    settings = runtime_cfg.Settings()
+
+    assert settings.pg_dsn == ""
+    assert settings.apg_dsn == fallback


### PR DESCRIPTION
## Summary
- support REDIS_URL, POSTGRES_URL and ASYNC_FALLBACK_DB in settings
- test DSN construction and async fallback behavior

## Testing
- `uv run --package auto_authn --directory standards/auto_authn ruff format .`
- `uv run --package auto_authn --directory standards/auto_authn ruff check . --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c2467e2688326a6f74f72328cc2f8