### PR TITLE
test: cover hooks and adapters

### DIFF
--- a/pkgs/standards/auto_authn/tests/unit/test_hooks.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_hooks.py
@@ -1,0 +1,45 @@
+"""Unit tests for auto_authn.v2.hooks module.
+
+Ensure the registration helper wires the injection hook and populates
+principal fields in the context.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from auto_authn.v2.hooks import register_inject_hook
+from autoapi.v2.hooks import Phase
+
+
+class DummyAPI:
+    """Minimal API stub capturing registered hooks."""
+
+    def __init__(self) -> None:
+        self.hooks = {}
+
+    def register_hook(self, phase):
+        def decorator(func):
+            self.hooks[phase] = func
+            return func
+
+        return decorator
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_register_inject_hook_injects_principal():
+    """Hook registers for PRE_TX_BEGIN and injects tenant/user IDs."""
+    api = DummyAPI()
+    register_inject_hook(api)
+
+    assert Phase.PRE_TX_BEGIN in api.hooks
+
+    request = SimpleNamespace(
+        state=SimpleNamespace(principal={"tid": "t1", "sub": "u1"})
+    )
+    ctx = {"request": request}
+
+    await api.hooks[Phase.PRE_TX_BEGIN](ctx)
+
+    assert ctx["__autoapi_injected_fields__"] == {"tenant_id": "t1", "user_id": "u1"}

--- a/pkgs/standards/auto_authn/tests/unit/test_providers.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_providers.py
@@ -1,0 +1,54 @@
+"""Unit tests for AuthN provider adapters.
+
+Verify adapter delegation and hook registration behavior."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import auto_authn.v2.providers.local_adapter as local_adapter_mod
+import auto_authn.v2.providers.remote_adapter as remote_adapter_mod
+from auto_authn.v2.providers.local_adapter import LocalAuthNAdapter
+from auto_authn.v2.providers.remote_adapter import RemoteAuthNAdapter
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_local_adapter_delegates_get_principal(monkeypatch):
+    """LocalAuthNAdapter forwards to fastapi dependency."""
+    adapter = LocalAuthNAdapter()
+    request = MagicMock()
+    mock_get = AsyncMock(return_value={"ok": True})
+    monkeypatch.setattr(local_adapter_mod, "get_principal", mock_get)
+
+    result = await adapter.get_principal(request)
+
+    mock_get.assert_awaited_once_with(request)
+    assert result == {"ok": True}
+
+
+@pytest.mark.unit
+def test_local_adapter_register_inject_hook(monkeypatch):
+    """Hook registration delegates to module helper."""
+    adapter = LocalAuthNAdapter()
+    api = MagicMock()
+    hook = MagicMock()
+    monkeypatch.setattr(local_adapter_mod, "register_inject_hook", hook)
+
+    adapter.register_inject_hook(api)
+
+    hook.assert_called_once_with(api)
+
+
+@pytest.mark.unit
+def test_remote_adapter_register_hook_noop(monkeypatch):
+    """RemoteAuthNAdapter does not register hooks but warns."""
+    adapter = RemoteAuthNAdapter(base_url="https://auth.example")
+    api = MagicMock()
+    warn = MagicMock()
+    monkeypatch.setattr(remote_adapter_mod.warnings, "warn", warn)
+
+    adapter.register_inject_hook(api)
+
+    api.register_hook.assert_not_called()
+    warn.assert_called_once()


### PR DESCRIPTION
## Summary
- test hook registration injects principal fields
- ensure local and remote authn adapters delegate as expected

## Testing
- `uv run --package auto-authn --directory standards/auto_authn pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c24929be08326a7295357e8985416