### PR TITLE
test: add nested routing depth coverage

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_nested_routing_depth.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_nested_routing_depth.py
@@ -1,0 +1,127 @@
+import pytest
+import pytest_asyncio
+from autoapi.v2 import AutoAPI, Base
+from autoapi.v2.mixins import GUIDPk
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import Column, ForeignKey, String
+
+
+@pytest_asyncio.fixture
+async def three_level_api_client(db_mode, sync_db_session, async_db_session):
+    Base.metadata.clear()
+
+    class Company(Base, GUIDPk):
+        __tablename__ = "companies"
+        name = Column(String, nullable=False)
+
+    class Department(Base, GUIDPk):
+        __tablename__ = "departments"
+        company_id = Column(String, ForeignKey("companies.id"), nullable=False)
+        name = Column(String, nullable=False)
+
+        @classmethod
+        def __autoapi_nested_paths__(cls):
+            return "/company/{company_id}"
+
+    class Employee(Base, GUIDPk):
+        __tablename__ = "employees"
+        company_id = Column(String, ForeignKey("companies.id"), nullable=False)
+        department_id = Column(String, ForeignKey("departments.id"), nullable=False)
+        name = Column(String, nullable=False)
+
+        @classmethod
+        def __autoapi_nested_paths__(cls):
+            return "/company/{company_id}/department/{department_id}"
+
+    if db_mode == "async":
+        _, get_async_db = async_db_session
+        api = AutoAPI(
+            base=Base,
+            include={Company, Department, Employee},
+            get_async_db=get_async_db,
+        )
+        await api.initialize_async()
+    else:
+        _, get_sync_db = sync_db_session
+        api = AutoAPI(
+            base=Base, include={Company, Department, Employee}, get_db=get_sync_db
+        )
+        api.initialize_sync()
+
+    app = FastAPI()
+    app.include_router(api.router)
+    transport = ASGITransport(app=app)
+    client = AsyncClient(transport=transport, base_url="http://test")
+    return client
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_nested_routing_depth(three_level_api_client):
+    client = three_level_api_client
+
+    # Create company
+    res = await client.post("/company", json={"name": "Acme"})
+    assert res.status_code == 201
+    company_id = res.json()["id"]
+
+    # Create department
+    res = await client.post(
+        f"/company/{company_id}",
+        json={"company_id": company_id, "name": "Engineering"},
+    )
+    assert res.status_code == 201
+    department_id = res.json()["id"]
+
+    # Create employee
+    res = await client.post(
+        f"/company/{company_id}/department/{department_id}",
+        json={
+            "company_id": company_id,
+            "department_id": department_id,
+            "name": "Alice",
+        },
+    )
+    assert res.status_code == 201
+    employee_id = res.json()["id"]
+
+    # Verify generated REST paths and HTTP methods
+    paths = (await client.get("/openapi.json")).json()["paths"]
+    expected = {
+        "/company": {"post", "get", "delete"},
+        "/company/{item_id}": {"get", "patch", "delete"},
+        "/company/{company_id}": {"post", "get", "delete"},
+        "/company/{company_id}/{item_id}": {"get", "patch", "delete"},
+        "/company/{company_id}/department/{department_id}": {
+            "post",
+            "get",
+            "delete",
+        },
+        "/company/{company_id}/department/{department_id}/{item_id}": {
+            "get",
+            "patch",
+            "delete",
+        },
+    }
+    for path, verbs in expected.items():
+        assert path in paths
+        for verb in verbs:
+            assert verb in paths[path]
+
+    # Verify RPC methods exist
+    methods = (await client.get("/methodz")).json()
+    for model in ("Company", "Department", "Employee"):
+        for verb in ("create", "list", "clear", "read", "update", "delete"):
+            assert f"{model}.{verb}" in methods
+
+    # Confirm nested routes resolve to correct handlers
+    res = await client.get(f"/company/{company_id}/{department_id}")
+    assert res.status_code == 200
+    assert res.json()["id"] == department_id
+
+    res = await client.get(
+        f"/company/{company_id}/department/{department_id}/{employee_id}"
+    )
+    assert res.status_code == 200
+    assert res.json()["id"] == employee_id


### PR DESCRIPTION
## Summary
- test autoapi nested routing across three hierarchy levels

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format tests/i9n/test_nested_routing_depth.py`
- `uv run --package autoapi --directory standards/autoapi ruff check tests/i9n/test_nested_routing_depth.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_nested_routing_depth.py`
- `uv run --package autoapi --directory standards/autoapi pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c24b6a4f483269e68e8627c4a0788