### PR TITLE
test: verify custom AuthNProvider integration

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_authn_provider_integration.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_authn_provider_integration.py
@@ -1,0 +1,91 @@
+from fastapi import FastAPI, HTTPException, Security
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from fastapi.testclient import TestClient
+from sqlalchemy import Column, ForeignKey, String, create_engine
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from autoapi.v2 import AutoAPI, Base
+from autoapi.v2.cfgs import AUTH_CONTEXT_KEY
+from autoapi.v2.hooks import Phase
+from autoapi.v2.mixins import GUIDPk
+from autoapi.v2.types import AuthNProvider
+
+
+class HookedAuth(AuthNProvider):
+    """Simple AuthN provider that records context via a hook."""
+
+    def __init__(self) -> None:
+        self.ctx_principal: dict | None = None
+
+    async def get_principal(
+        self,
+        creds: HTTPAuthorizationCredentials = Security(HTTPBearer()),
+    ) -> dict:
+        if creds.credentials != "secret":
+            raise HTTPException(status_code=401)
+        return {"sub": "user", "tid": "tenant"}
+
+    def register_inject_hook(self, api) -> None:  # pragma: no cover - runtime wiring
+        @api.register_hook(Phase.PRE_TX_BEGIN)
+        async def _capture(ctx):  # pragma: no cover - executed in tests
+            self.ctx_principal = ctx.get(AUTH_CONTEXT_KEY)
+
+
+def _build_client_with_auth():
+    Base.metadata.clear()
+
+    class Tenant(Base, GUIDPk):
+        __tablename__ = "tenants"
+        name = Column(String, nullable=False)
+
+    class Item(Base, GUIDPk):
+        __tablename__ = "items"
+        tenant_id = Column(UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False)
+        name = Column(String, nullable=False)
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+
+    def get_db():
+        with SessionLocal() as session:
+            yield session
+
+    auth = HookedAuth()
+    api = AutoAPI(base=Base, include={Tenant, Item}, get_db=get_db, authn=auth)
+    auth.register_inject_hook(api)
+    app = FastAPI()
+    app.include_router(api.router)
+    api.initialize_sync()
+    return TestClient(app), auth
+
+
+def test_authn_hooks_and_context_injection():
+    client, auth = _build_client_with_auth()
+
+    tenant = {"name": "acme"}
+    res = client.post(
+        "/tenant", json=tenant, headers={"Authorization": "Bearer secret"}
+    )
+    tid = res.json()["id"]
+
+    auth.ctx_principal = None
+    payload = {"tenant_id": tid, "name": "widget"}
+    res = client.post("/item", json=payload, headers={"Authorization": "Bearer secret"})
+    assert res.status_code == 201
+    assert auth.ctx_principal == {"sub": "user", "tid": "tenant"}
+
+
+def test_authn_unauthorized_errors():
+    client, _ = _build_client_with_auth()
+
+    assert client.get("/item").status_code == 403
+    assert (
+        client.get("/item", headers={"Authorization": "Bearer wrong"}).status_code
+        == 401
+    )


### PR DESCRIPTION
## Summary
- add integration tests for custom AuthNProvider hook registration and context propagation
- confirm unauthorized requests return appropriate errors

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff format tests/i9n/test_authn_provider_integration.py`
- `uv run --directory standards/autoapi --package autoapi ruff check tests/i9n/test_authn_provider_integration.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_authn_provider_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_689c24e4858c8326811ea63c2a9120e3