### PR TITLE
test: verify async context manager cleanup

### DIFF
--- a/pkgs/standards/autoapi_client/tests/unit/test_autoapi_async_context.py
+++ b/pkgs/standards/autoapi_client/tests/unit/test_autoapi_async_context.py
@@ -1,0 +1,23 @@
+import pytest
+from autoapi_client import AutoAPIClient
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_async_context_manages_session():
+    client = AutoAPIClient("http://example.com")
+    assert not client._async_client.is_closed
+
+    async with AutoAPIClient("http://example.com") as ctx:
+        assert ctx is not None
+        assert not ctx._async_client.is_closed
+
+    assert ctx._async_client.is_closed
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_aclose_closes_async_client():
+    client = AutoAPIClient("http://example.com")
+    await client.aclose()
+    assert client._async_client.is_closed


### PR DESCRIPTION
## Summary
- add async context manager tests for AutoAPIClient ensuring sessions are opened and closed properly

## Testing
- `uv run --package autoapi_client --directory standards/autoapi_client pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c25820f7c8326bafe239e6e4c5047