### PR TITLE
test: cover _process_response edge cases

### DIFF
--- a/pkgs/standards/autoapi_client/tests/unit/test_process_response_edge_cases.py
+++ b/pkgs/standards/autoapi_client/tests/unit/test_process_response_edge_cases.py
@@ -1,0 +1,21 @@
+import httpx
+
+from autoapi_client._crud import CRUDMixin
+
+
+class DummyClient(CRUDMixin):
+    pass
+
+
+def test_process_response_empty_body_returns_none():
+    client = DummyClient()
+    request = httpx.Request("GET", "http://example.com/empty")
+    response = httpx.Response(200, content=b"", request=request)
+    assert client._process_response(response) is None
+
+
+def test_process_response_plain_text_returns_raw_text():
+    client = DummyClient()
+    request = httpx.Request("GET", "http://example.com/text")
+    response = httpx.Response(200, text="plain text", request=request)
+    assert client._process_response(response) == "plain text"


### PR DESCRIPTION
## Summary
- add tests for `_process_response` to handle empty responses and non-JSON content

## Testing
- `uv run --directory pkgs/standards/autoapi_client --package autoapi_client ruff format .`
- `uv run --directory pkgs/standards/autoapi_client --package autoapi_client ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_689c25ab9a6083268053667146dbc5cd