### PR TITLE
Expand async RPC acall tests

### DIFF
--- a/pkgs/standards/autoapi_client/tests/unit/test_autoapi_async_rpc.py
+++ b/pkgs/standards/autoapi_client/tests/unit/test_autoapi_async_rpc.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+import json
 import httpx
 import pytest
 
@@ -30,3 +31,58 @@ async def test_acall_basic():
     assert captured["url"] == "http://example.com/api"
     assert captured["headers"]["Content-Type"] == "application/json"
     assert result == {"success": True}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_acall_status_code():
+    """Ensure status code is returned and JSON parses correctly."""
+
+    async def fake_post(self, url, *, json=None, headers=None):
+        request = httpx.Request("POST", url)
+        return httpx.Response(
+            201, request=request, json={"jsonrpc": "2.0", "result": {"value": 1}}
+        )
+
+    with patch.object(httpx.AsyncClient, "post", new=fake_post):
+        client = AutoAPIClient("http://example.com/api")
+        result, status = await client.acall("test.method", status_code=True)
+
+    assert result == {"value": 1}
+    assert status == 201
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_acall_no_raise_on_http_error():
+    """Verify raise_status=False returns response on HTTP errors."""
+
+    async def fake_post(self, url, *, json=None, headers=None):
+        request = httpx.Request("POST", url)
+        return httpx.Response(
+            500, request=request, json={"jsonrpc": "2.0", "result": {"error": True}}
+        )
+
+    with patch.object(httpx.AsyncClient, "post", new=fake_post):
+        client = AutoAPIClient("http://example.com/api")
+        result, status = await client.acall(
+            "test.method", status_code=True, raise_status=False
+        )
+
+    assert result == {"error": True}
+    assert status == 500
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_acall_invalid_json_propagates():
+    """Invalid JSON should propagate JSON errors."""
+
+    async def fake_post(self, url, *, json=None, headers=None):
+        request = httpx.Request("POST", url)
+        return httpx.Response(200, request=request, content=b"not-json")
+
+    with patch.object(httpx.AsyncClient, "post", new=fake_post):
+        client = AutoAPIClient("http://example.com/api")
+        with pytest.raises(json.JSONDecodeError):
+            await client.acall("test.method")


### PR DESCRIPTION
## Summary
- add tests exercising acall's ability to return custom status codes
- ensure acall can bypass HTTP errors when raise_status is False
- verify invalid JSON responses surface JSONDecodeError

## Testing
- `uv run --package autoapi_client --directory standards/autoapi_client pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c25b020788326974e1be24cb68c49