### PR TITLE
test: benchmark first-class registration

### DIFF
--- a/pkgs/swarmauri/tests/test_performance.py
+++ b/pkgs/swarmauri/tests/test_performance.py
@@ -1,41 +1,35 @@
 import importlib
 import time
 
-from swarmauri.plugin_manager import (
-    discover_and_register_plugins,
-    invalidate_entry_point_cache,
-)
 from swarmauri.plugin_citizenship_registry import PluginCitizenshipRegistry
 
 
-def test_startup_and_registration_performance():
+def test_startup_and_first_class_registration_performance() -> None:
     start = time.perf_counter()
     importlib.import_module("swarmauri")
     startup_time = time.perf_counter() - start
 
-    PluginCitizenshipRegistry.SECOND_CLASS_REGISTRY.clear()
-    PluginCitizenshipRegistry.THIRD_CLASS_REGISTRY.clear()
-    invalidate_entry_point_cache()
+    original_registry = PluginCitizenshipRegistry.FIRST_CLASS_REGISTRY.copy()
+    PluginCitizenshipRegistry.FIRST_CLASS_REGISTRY.clear()
+
     start = time.perf_counter()
-    discover_and_register_plugins()
+    for resource_path, module_path in original_registry.items():
+        try:
+            importlib.import_module(module_path)
+        except ModuleNotFoundError:
+            continue
+        PluginCitizenshipRegistry.add_to_registry("first", resource_path, module_path)
     registration_time = time.perf_counter() - start
 
-    PluginCitizenshipRegistry.SECOND_CLASS_REGISTRY.clear()
-    PluginCitizenshipRegistry.THIRD_CLASS_REGISTRY.clear()
-    invalidate_entry_point_cache()
-    start = time.perf_counter()
-    discover_and_register_plugins()
-    rebuild_time = time.perf_counter() - start
+    PluginCitizenshipRegistry.FIRST_CLASS_REGISTRY = original_registry
 
     print(
-        f"Startup: {startup_time:.4f}s, Register: {registration_time:.4f}s, "
-        f"Rebuild: {rebuild_time:.4f}s",
+        f"Startup: {startup_time:.4f}s, First-class registration: {registration_time:.4f}s"
     )
 
     assert startup_time >= 0
     assert registration_time >= 0
-    assert rebuild_time >= 0
 
 
 if __name__ == "__main__":
-    test_startup_and_registration_performance()
+    test_startup_and_first_class_registration_performance()


### PR DESCRIPTION
## Summary
- measure swarmauri startup time and registration time for first-class plugins

## Testing
- `uv run --package swarmauri --directory swarmauri pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c27a458688326809280f569a5f87b