### PR TITLE
feat(autoapi): add column response extras

### DIFF
--- a/pkgs/standards/autoapi/README.md
+++ b/pkgs/standards/autoapi/README.md
@@ -68,6 +68,7 @@ The following `col.info["autoapi"]` keys are recognized by AutoAPI and related p
 | `examples` | Provides example values for documentation or schema generation. Used widely in mixins (`tenant_id`, `user_id`, etc.) and explicitly in Peagen's `User.id` column. | autoapi, auto-authn, peagen ORM |
 | `hybrid` | Enables hybrid properties in the schema. Demonstrated with a `full_name` hybrid property marked in tests. | autoapi (tests) |
 | `py_type` | Specifies Python type for hybrids. Shown in tests where a computed field is declared as an `int`. | autoapi (tests) |
+| `response_extras` | Verb-scoped virtual response fields defined on a column, equivalent to table-level `__autoapi_response_extras__`. | autoapi (tests) |
 
 
 ## Glossary

--- a/pkgs/standards/autoapi/autoapi/v2/cfgs.py
+++ b/pkgs/standards/autoapi/autoapi/v2/cfgs.py
@@ -19,6 +19,7 @@ COL_LEVEL_CFGS: set[str] = {
     "default_factory",
     "examples",
     "py_type",
+    "response_extras",
 }
 
 # Table-level configuration attributes on ORM classes

--- a/pkgs/standards/autoapi/autoapi/v2/info_schema.py
+++ b/pkgs/standards/autoapi/autoapi/v2/info_schema.py
@@ -7,6 +7,7 @@ VALID_KEYS = {
     "examples",
     "hybrid",
     "py_type",
+    "response_extras",
 }
 VALID_VERBS = {"create", "read", "update", "replace", "list", "delete", "clear"}
 


### PR DESCRIPTION
## Summary
- allow response extras to be configured in column metadata
- validate new `response_extras` key in AutoAPI info schema
- test column-level response extras handling

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c28b108088326b948ae19ac0f32b9