### PR TITLE
fix(peagen): add lowercase status aliases for Status enum

### DIFF
--- a/pkgs/standards/peagen/peagen/orm/__init__.py
+++ b/pkgs/standards/peagen/peagen/orm/__init__.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import FrozenSet
 
-#from autoapi.v2.tables import Role, RoleGrant, RolePerm
+# from autoapi.v2.tables import Role, RoleGrant, RolePerm
 from autoapi.v2.tables import Status, Base
 
 # Import table classes. Ensure Tenant is imported before Pool so bootstrapping
@@ -40,6 +40,13 @@ def _is_terminal(cls, state: str | Status) -> bool:
 
 
 Status.is_terminal = classmethod(_is_terminal)
+
+# Convenience aliases for lowercase access
+for _member in Status:
+    setattr(Status, _member.value, _member)
+
+# Legacy alias used by CLI for retries
+setattr(Status, "retry", Status.queued)
 
 __all__ = [
     "Tenant",


### PR DESCRIPTION
## Summary
- expose lowercase status aliases for peagen's AutoAPI Status enum
- map `Status.retry` to `Status.queued`

## Testing
- `uv run --package peagen --directory standards/peagen ruff format peagen/orm/__init__.py`
- `uv run --package peagen --directory standards/peagen ruff check peagen/orm/__init__.py --fix`
- `uv run --package peagen --directory standards/peagen pytest` *(fails: tests/unit/test_alembic_integration.py::test_alembic_upgrade_and_current, tests/unit/test_extras_cli.py::test_extras_cli_generates_schemas, tests/unit/test_extras_cli.py::test_extras_cli_handles_error, tests/unit/test_keys_core.py::test_create_keypair_uses_plugin_manager, tests/unit/test_keys_core.py::test_export_public_key_delegates, tests/unit/test_task_submit.py::test_submit_task_sends_request, tests/unit/test_validate_cli.py::test_local_validate_cli_invokes_handler, tests/unit/test_validate_cli.py::test_remote_validate_cli_submits_task)*

------
https://chatgpt.com/codex/tasks/task_e_689c326e6360832698d65f1ec931ae68