### PR TITLE
feat(autoapi): add RequestExtrasProvider for request extras

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/types/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v2/types/__init__.py
@@ -61,6 +61,10 @@ from .table_config_provider import TableConfigProvider
 from .hook_provider import HookProvider
 from .nested_path_provider import NestedPathProvider
 from .allow_anon_provider import AllowAnonProvider
+from .request_extras_provider import (
+    RequestExtrasProvider,
+    list_request_extras_providers,
+)
 from .response_extras_provider import (
     ResponseExtrasProvider,
     list_response_extras_providers,
@@ -90,6 +94,7 @@ __all__: list[str] = [
     "HookProvider",
     "NestedPathProvider",
     "AllowAnonProvider",
+    "RequestExtrasProvider",
     "ResponseExtrasProvider",
     # builtin types
     "MethodType",
@@ -151,5 +156,6 @@ __all__: list[str] = [
 __all__ += [
     "OpVerbAliasProvider",
     "list_verb_alias_providers",
+    "list_request_extras_providers",
     "list_response_extras_providers",
 ]

--- a/pkgs/standards/autoapi/autoapi/v2/types/request_extras_provider.py
+++ b/pkgs/standards/autoapi/autoapi/v2/types/request_extras_provider.py
@@ -1,0 +1,22 @@
+from typing import Callable, ClassVar, Mapping
+
+from .table_config_provider import TableConfigProvider
+
+_REQUEST_EXTRAS_PROVIDERS: set[type] = set()
+
+
+class RequestExtrasProvider(TableConfigProvider):
+    """Models that expose request-only virtual fields."""
+
+    __autoapi_request_extras__: ClassVar[
+        Mapping[str, Mapping[str, object]]
+        | Callable[[], Mapping[str, Mapping[str, object]]]
+    ] = {}
+
+    def __init_subclass__(cls, **kw):
+        super().__init_subclass__(**kw)
+        _REQUEST_EXTRAS_PROVIDERS.add(cls)
+
+
+def list_request_extras_providers():
+    return sorted(_REQUEST_EXTRAS_PROVIDERS, key=lambda c: c.__name__)

--- a/pkgs/standards/autoapi/tests/i9n/test_request_extras_provider.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_request_extras_provider.py
@@ -1,0 +1,27 @@
+import pytest
+
+from autoapi.v2 import Base
+from autoapi.v2.types import Column, String, Field, RequestExtrasProvider
+from autoapi.v2.mixins import GUIDPk
+from autoapi.v2.impl.schema import _schema
+from autoapi.v2.types.request_extras_provider import list_request_extras_providers
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_request_extras_provider_in_schema():
+    Base.metadata.clear()
+
+    class Widget(Base, GUIDPk, RequestExtrasProvider):
+        __tablename__ = "widgets"
+        name = Column(String, nullable=False)
+        __autoapi_request_extras__ = {
+            "create": {"extra": (int | None, Field(None, exclude=True))}
+        }
+
+    SCreate = _schema(Widget, verb="create")
+    SRead = _schema(Widget, verb="read")
+
+    assert "extra" in SCreate.model_fields
+    assert "extra" not in SRead.model_fields
+    assert Widget in list_request_extras_providers()


### PR DESCRIPTION
## Summary
- add RequestExtrasProvider to support request-only virtual fields via TableConfigProvider
- expose RequestExtrasProvider in public types API
- test request extras provider appears only in request schemas

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c39b44b9083268849449b0881dd1a