### PR TITLE
Handle acronym model names when generating routes

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/impl/crud_builder.py
+++ b/pkgs/standards/autoapi/autoapi/v2/impl/crud_builder.py
@@ -19,6 +19,13 @@ from ..types import Session
 
 
 # ----------------------------------------------------------------------
+def _camel_to_snake(name: str) -> str:
+    """Convert ``CamelCase`` *name* to ``snake_case`` preserving acronyms."""
+    s1 = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", name)
+    return re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
+
+
+# ----------------------------------------------------------------------
 def _invoke_all_registrars(model: type, api) -> None:
     """
     Call every distinct  __autoapi_register_hooks__  found in the MRO,
@@ -241,7 +248,7 @@ def _crud(self, model: type) -> None:
     """
     Public entry: call `api._crud(User)` to expose canonical CRUD & list routes.
     """
-    resource = re.sub(r"(?<!^)(?=[A-Z])", "_", model.__name__).lower()
+    resource = _camel_to_snake(model.__name__)
     print(f"_crud called for model={resource}")
 
     if resource in self._registered_tables:

--- a/pkgs/standards/autoapi/tests/i9n/test_acronym_route_name.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_acronym_route_name.py
@@ -1,0 +1,16 @@
+import pytest
+from autoapi.v2 import Base
+from autoapi.v2.mixins import GUIDPk
+from sqlalchemy import Column, String
+
+
+@pytest.mark.i9n
+def test_acronym_model_route(create_test_api):
+    class GPGKey(Base, GUIDPk):
+        __tablename__ = "gpg_keys"
+        key = Column(String, nullable=False)
+
+    api = create_test_api(GPGKey)
+    paths = {route.path for route in api.router.routes}
+    assert "/gpg_key" in paths
+    assert all("g_p_g_key" not in p for p in paths)


### PR DESCRIPTION
## Summary
- preserve acronyms when converting model names to resource identifiers in AutoAPI
- test AutoAPI routing for acronym-named models

## Testing
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff format .`
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff check autoapi/v2/impl/crud_builder.py tests/i9n/test_acronym_route_name.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_689c405e84d88326bda570628aeb485a