### PR TITLE
refactor: centralize AutoAPI naming utilities

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/impl/crud_builder.py
+++ b/pkgs/standards/autoapi/autoapi/v2/impl/crud_builder.py
@@ -9,20 +9,12 @@ from __future__ import annotations
 
 from typing import Dict
 
-import re
-
 from sqlalchemy import inspect as _sa_inspect
 
 from ..jsonrpc_models import create_standardized_error
 from .schema import _schema, create_list_schema
 from ..types import Session
-
-
-# ----------------------------------------------------------------------
-def _camel_to_snake(name: str) -> str:
-    """Convert ``CamelCase`` *name* to ``snake_case`` preserving acronyms."""
-    s1 = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", name)
-    return re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
+from ..naming import camel_to_snake
 
 
 # ----------------------------------------------------------------------
@@ -248,7 +240,7 @@ def _crud(self, model: type) -> None:
     """
     Public entry: call `api._crud(User)` to expose canonical CRUD & list routes.
     """
-    resource = _camel_to_snake(model.__name__)
+    resource = camel_to_snake(model.__name__)
     print(f"_crud called for model={resource}")
 
     if resource in self._registered_tables:

--- a/pkgs/standards/autoapi/autoapi/v2/impl/op_wiring.py
+++ b/pkgs/standards/autoapi/autoapi/v2/impl/op_wiring.py
@@ -1,18 +1,30 @@
 from __future__ import annotations
-from typing import Any, Iterable, Type, List
+from typing import Type, List
 from fastapi import Depends, Request
-from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import Session
 from .schema import _schema
-from .rpc_adapter import _wrap_rpc
 from ..ops.spec import OpSpec
 from ..ops.registry import get_registered_ops
 from ..types.op_config_provider import OpConfigProvider
 from ..types.op_verb_alias_provider import OpVerbAliasProvider  # back-compat
-from ..hooks import Phase
+from ..naming import resource_pascal, snake_to_pascal
+
 
 def _arity_for(target: str) -> str:
-    return "collection" if target in {"create","list","bulk_create","bulk_update","bulk_replace","bulk_delete","clear"} else "member"
+    return (
+        "collection"
+        if target
+        in {
+            "create",
+            "list",
+            "bulk_create",
+            "bulk_update",
+            "bulk_replace",
+            "bulk_delete",
+            "clear",
+        }
+        else "member"
+    )
+
 
 def collect_all_specs_for_table(table: Type) -> List[OpSpec]:
     out: List[OpSpec] = []
@@ -30,44 +42,73 @@ def collect_all_specs_for_table(table: Type) -> List[OpSpec]:
     # 4) back-compat: __autoapi_verb_aliases__ → specs
     if issubclass(table, OpVerbAliasProvider):
         raw = getattr(table, "__autoapi_verb_aliases__", {}) or {}
-        if callable(raw): raw = raw()
+        if callable(raw):
+            raw = raw()
         for tgt, alias in dict(raw).items():
             out.append(OpSpec(alias=alias, target=tgt, table=table))
     # fill defaults
     final: List[OpSpec] = []
     for s in out:
-        final.append(OpSpec(
-            alias=s.alias, target=s.target, table=table,
-            expose_routes=s.expose_routes, expose_rpc=s.expose_rpc, expose_method=s.expose_method,
-            arity=s.arity or _arity_for(s.target), persist=s.persist, returns=s.returns,
-            handler=s.handler, request_model=s.request_model, response_model=s.response_model,
-            http_methods=s.http_methods, path_suffix=s.path_suffix, tags=s.tags,
-            rbac_guard_op=s.rbac_guard_op or s.target, hooks=s.hooks,
-        ))
+        final.append(
+            OpSpec(
+                alias=s.alias,
+                target=s.target,
+                table=table,
+                expose_routes=s.expose_routes,
+                expose_rpc=s.expose_rpc,
+                expose_method=s.expose_method,
+                arity=s.arity or _arity_for(s.target),
+                persist=s.persist,
+                returns=s.returns,
+                handler=s.handler,
+                request_model=s.request_model,
+                response_model=s.response_model,
+                http_methods=s.http_methods,
+                path_suffix=s.path_suffix,
+                tags=s.tags,
+                rbac_guard_op=s.rbac_guard_op or s.target,
+                hooks=s.hooks,
+            )
+        )
     return final
 
+
 def _http_methods(spec: OpSpec) -> list[str]:
-    if spec.http_methods: return list(spec.http_methods)
+    if spec.http_methods:
+        return list(spec.http_methods)
     return {
-        "read":["GET"], "list":["GET"], "delete":["DELETE"],
-        "update":["PATCH"], "replace":["PUT"], "create":["POST"],
-        "bulk_create":["POST"], "bulk_update":["PATCH"], "bulk_replace":["PUT"], "bulk_delete":["DELETE"],
-        "clear":["DELETE"],
+        "read": ["GET"],
+        "list": ["GET"],
+        "delete": ["DELETE"],
+        "update": ["PATCH"],
+        "replace": ["PUT"],
+        "create": ["POST"],
+        "bulk_create": ["POST"],
+        "bulk_update": ["PATCH"],
+        "bulk_replace": ["PUT"],
+        "bulk_delete": ["DELETE"],
+        "clear": ["DELETE"],
     }.get(spec.target, ["POST"])
+
 
 def _rest_path(table: Type, spec: OpSpec) -> str:
     base = _schema(table).path
-    if spec.target in {"bulk_create","bulk_update","bulk_replace","bulk_delete"}:
+    if spec.target in {"bulk_create", "bulk_update", "bulk_replace", "bulk_delete"}:
         return f"{base}/bulk"
     if spec.target == "custom":
-        if spec.arity == "member": return f"{base}/{{item_id}}/{spec.path_suffix or spec.alias}"
+        if spec.arity == "member":
+            return f"{base}/{{item_id}}/{spec.path_suffix or spec.alias}"
         return f"{base}/{spec.path_suffix or spec.alias}"
     if spec.arity == "member":
         return f"{base}/{{item_id}}"
     return base
 
+
 def _in_model(table: Type, spec: OpSpec):
-    return spec.request_model or _schema(table, verb=(spec.target if spec.target!="custom" else "create"))
+    return spec.request_model or _schema(
+        table, verb=(spec.target if spec.target != "custom" else "create")
+    )
+
 
 def _out_model(table: Type, spec: OpSpec):
     if spec.returns == "raw":
@@ -75,7 +116,10 @@ def _out_model(table: Type, spec: OpSpec):
     if spec.target == "create":  # your builder uses None for create REST response_model
         return spec.response_model or None
     # default to canonical target
-    return spec.response_model or _schema(table, verb=("read" if spec.target=="delete" else spec.target))
+    return spec.response_model or _schema(
+        table, verb=("read" if spec.target == "delete" else spec.target)
+    )
+
 
 def attach_op_specs(api, router, table: Type) -> None:
     """
@@ -90,16 +134,22 @@ def attach_op_specs(api, router, table: Type) -> None:
     for spec in specs:
         # REST
         if spec.expose_routes:
-            In  = _in_model(table, spec)
+            In = _in_model(table, spec)
             Out = _out_model(table, spec)
 
             # choose DB dep style identical to canonical (we inspect api.get_db/get_async_db in routes_builder)
-            is_async = bool(api.get_async_db) if api.get_db is None else issubclass(table, api._include.__class__)  # trivial heuristic; reuse routes_builder's exact check if desired
+            is_async = (
+                bool(api.get_async_db)
+                if api.get_db is None
+                else issubclass(table, api._include.__class__)
+            )  # trivial heuristic; reuse routes_builder's exact check if desired
 
-            DBDep = (Depends(api.get_async_db) if is_async else Depends(api.get_db))
-            def _DB(db): return db  # sentinel to keep Annotated out; we only need kw name
+            DBDep = Depends(api.get_async_db) if is_async else Depends(api.get_db)
 
-            async def _handler(request: Request, p: In = Depends(In), db = DBDep):
+            def _DB(db):
+                return db  # sentinel to keep Annotated out; we only need kw name
+
+            async def _handler(request: Request, p: In = Depends(In), db=DBDep):
                 # ctx enrichment for per-verb control
                 if getattr(request.state, "ctx", None) is None:
                     request.state.ctx = {}
@@ -109,28 +159,51 @@ def attach_op_specs(api, router, table: Type) -> None:
                 if spec.persist == "skip":
                     request.state.ctx["__autoapi_skip_persist__"] = True
                 # run per-verb pre-hooks
-                for h in sorted([x for x in spec.hooks if x.phase.name=="PRE_TX_BEGIN"], key=lambda x:x.order):
+                for h in sorted(
+                    [x for x in spec.hooks if x.phase.name == "PRE_TX_BEGIN"],
+                    key=lambda x: x.order,
+                ):
                     if h.when is None or h.when(request.state.ctx):
-                        await h.fn(table=table, ctx=request.state.ctx, db=db, request=request, payload=p)
+                        await h.fn(
+                            table=table,
+                            ctx=request.state.ctx,
+                            db=db,
+                            request=request,
+                            payload=p,
+                        )
                 # delegate to canonical RPC method id (or a custom one we register just below)
-                method_id = f"{table.__name__}.{(spec.target if spec.target!='custom' else spec.alias).title().replace('_','')}"
+                method_id = (
+                    f"{resource_pascal(table.__name__)}."
+                    f"{snake_to_pascal(spec.target if spec.target != 'custom' else spec.alias)}"
+                )
                 from ..jsonrpc_models import _RPCReq
+
                 env = _RPCReq(id=None, method=method_id, params=p)
                 ctx = {"request": request, "db": db, "env": env, "params": env.params}
                 ext = getattr(request.state, "ctx", None)
-                if isinstance(ext, dict): ctx.update(ext)
+                if isinstance(ext, dict):
+                    ctx.update(ext)
                 # use the unified engine
                 from ._runner import _invoke
+
                 result = await _invoke(api, env.method, params=env.params, ctx=ctx)
                 # run per-verb post-hooks
-                for h in sorted([x for x in spec.hooks if x.phase.name=="POST_TX_END"], key=lambda x:x.order):
+                for h in sorted(
+                    [x for x in spec.hooks if x.phase.name == "POST_TX_END"],
+                    key=lambda x: x.order,
+                ):
                     if h.when is None or h.when(ctx):
-                        await h.fn(table=table, ctx=ctx, db=db, request=request, payload=p)
+                        await h.fn(
+                            table=table, ctx=ctx, db=db, request=request, payload=p
+                        )
                 return result
 
             router.add_api_route(
-                _rest_path(table, spec), _handler, methods=_http_methods(spec),
-                response_model=Out, tags=list(spec.tags or (table.__name__,)),
+                _rest_path(table, spec),
+                _handler,
+                methods=_http_methods(spec),
+                response_model=Out,
+                tags=list(spec.tags or (table.__name__,)),
                 name=f"{table.__name__} - {spec.alias}",
                 summary=f"{table.__name__} - {spec.alias}",
             )
@@ -140,29 +213,50 @@ def attach_op_specs(api, router, table: Type) -> None:
             # If target is canonical → point alias to existing core (IN/OUT auto)
             # If custom/override → we still wrap the provided handler as a core
             if spec.target == "custom" and spec.handler:
-                IN  = _in_model(table, spec)
+                IN = _in_model(table, spec)
                 OUT = _out_model(table, spec)
+
                 # normalize handler to (payload, db) signature
                 async def _core(payload, db, _h=spec.handler):
                     return await _h(table, ctx={}, db=db, request=None, payload=payload)
-                name = f"{table.__name__}.{spec.alias.title().replace('_','')}"
+
+                name = (
+                    f"{resource_pascal(table.__name__)}.{snake_to_pascal(spec.alias)}"
+                )
                 api._wrap_rpc(_core, IN, OUT, pk, table)
-                api._method_ids[name] = api._method_ids.get(name)  # _wrap_rpc already registers into api.rpc
+                api._method_ids[name] = api._method_ids.get(
+                    name
+                )  # _wrap_rpc already registers into api.rpc
             else:
                 # alias → canonical: register an extra method id that points to the same core
                 # (we reuse the existing canonical core via its method id)
-                canon = f"{table.__name__}.{spec.target.title().replace('_','')}"
-                alias = f"{table.__name__}.{spec.alias.title().replace('_','')}"
+                canon = (
+                    f"{resource_pascal(table.__name__)}.{snake_to_pascal(spec.target)}"
+                )
+                alias = (
+                    f"{resource_pascal(table.__name__)}.{snake_to_pascal(spec.alias)}"
+                )
                 api._method_ids[alias] = api._method_ids[canon]
 
         # METHODS
         if spec.expose_method:
+
             async def _callable(db, request, payload):
                 from ..jsonrpc_models import _RPCReq
-                method_id = f"{table.__name__}.{(spec.target if spec.target!='custom' else spec.alias).title().replace('_','')}"
+
+                method_id = (
+                    f"{resource_pascal(table.__name__)}."
+                    f"{snake_to_pascal(spec.target if spec.target != 'custom' else spec.alias)}"
+                )
                 env = _RPCReq(id=None, method=method_id, params=payload)
                 ctx = {"request": request, "db": db, "env": env, "params": env.params}
                 from ._runner import _invoke
+
                 return await _invoke(api, env.method, params=env.params, ctx=ctx)
-            setattr(api.core, f"{table.__name__}{spec.alias.title().replace('_','')}", _callable)
+
+            setattr(
+                api.core,
+                f"{resource_pascal(table.__name__)}{snake_to_pascal(spec.alias)}",
+                _callable,
+            )
             # do not overwrite self.methods; canonical wiring already attaches helpers there

--- a/pkgs/standards/autoapi/autoapi/v2/naming.py
+++ b/pkgs/standards/autoapi/autoapi/v2/naming.py
@@ -1,0 +1,54 @@
+"""Utility helpers for AutoAPI naming conventions.
+
+This module centralizes helpers that convert between common casing styles and
+construct canonical names and labels used across the AutoAPI package.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+def camel_to_snake(name: str) -> str:
+    """Convert ``CamelCase`` ``name`` to ``snake_case`` preserving acronyms."""
+    s1 = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", name)
+    return re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
+
+
+def snake_to_pascal(name: str) -> str:
+    """Convert ``snake_case`` ``name`` to ``PascalCase``."""
+    return "".join(word.title() for word in name.split("_"))
+
+
+def resource_pascal(tab_or_cls: str) -> str:
+    """Return ``tab_or_cls`` converted to ``PascalCase`` if needed."""
+    return snake_to_pascal(tab_or_cls) if tab_or_cls.islower() else tab_or_cls
+
+
+def canonical(tab: str, verb: str) -> str:
+    """Return canonical RPC method name ``{Resource}.{verb}``."""
+    cls_name = resource_pascal(tab)
+    name = f"{cls_name}.{verb}"
+    print(f"canonical generated {name}")
+    return name
+
+
+def route_label(
+    resource_name: str, verb: str, alias_policy: str, public_verb: str
+) -> str:
+    """Return a label ``{Resource} - {verb/alias}`` based on alias policy."""
+    if alias_policy == "alias_only" and public_verb != verb:
+        lab = public_verb
+    elif alias_policy == "both" and public_verb != verb:
+        lab = f"{verb}/{public_verb}"
+    else:
+        lab = verb
+    return f"{resource_pascal(resource_name)} - {lab}"
+
+
+def label_hook_callable(fn: Any) -> str:
+    """Return a fully qualified label for hook callable ``fn``."""
+    n = getattr(fn, "__qualname__", getattr(fn, "__name__", repr(fn)))
+    m = getattr(fn, "__module__", None)
+    return f"{m}.{n}" if m else n


### PR DESCRIPTION
## Summary
- add reusable naming utilities for casing, labels, and canonical RPC IDs
- update AutoAPI components to consume centralized naming helpers
- rename hook labeling helper to `label_hook_callable` and update diagnostics to use it

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check autoapi/v2/endpoints.py autoapi/v2/naming.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_689d9976cc808326a53dd5cb27f95bbb