### PR TITLE
Refactor naming utilities into shared module

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/impl/crud_builder.py
+++ b/pkgs/standards/autoapi/autoapi/v2/impl/crud_builder.py
@@ -9,20 +9,12 @@ from __future__ import annotations
 
 from typing import Dict
 
-import re
-
 from sqlalchemy import inspect as _sa_inspect
 
 from ..jsonrpc_models import create_standardized_error
 from .schema import _schema, create_list_schema
 from ..types import Session
-
-
-# ----------------------------------------------------------------------
-def _camel_to_snake(name: str) -> str:
-    """Convert ``CamelCase`` *name* to ``snake_case`` preserving acronyms."""
-    s1 = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", name)
-    return re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
+from ..naming import camel_to_snake
 
 
 # ----------------------------------------------------------------------
@@ -248,7 +240,7 @@ def _crud(self, model: type) -> None:
     """
     Public entry: call `api._crud(User)` to expose canonical CRUD & list routes.
     """
-    resource = _camel_to_snake(model.__name__)
+    resource = camel_to_snake(model.__name__)
     print(f"_crud called for model={resource}")
 
     if resource in self._registered_tables:

--- a/pkgs/standards/autoapi/autoapi/v2/naming.py
+++ b/pkgs/standards/autoapi/autoapi/v2/naming.py
@@ -1,0 +1,54 @@
+"""Utility helpers for naming conventions.
+
+This module centralizes helpers for converting between naming styles,
+constructing canonical operation identifiers, and labeling callables.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+def camel_to_snake(name: str) -> str:
+    """Convert ``CamelCase`` *name* to ``snake_case`` preserving acronyms."""
+    s1 = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", name)
+    return re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
+
+
+def snake_to_camel(name: str) -> str:
+    """Convert ``snake_case`` *name* to ``PascalCase``."""
+    return "".join(w.title() for w in name.split("_")) if name.islower() else name
+
+
+def canonical_name(resource: str, verb: str) -> str:
+    """Return the canonical RPC method name for *resource* and *verb*."""
+    cls_name = snake_to_camel(resource)
+    name = f"{cls_name}.{verb}"
+    print(f"_canonical generated {name}")
+    return name
+
+
+def resource_pascal(resource: str) -> str:
+    """Return ``PascalCase`` form of *resource*."""
+    return snake_to_camel(resource)
+
+
+def route_label(
+    resource_name: str, verb: str, alias_policy: str, public_verb: str
+) -> str:
+    """Return '{Resource} - {verb/alias}' per policy."""
+    if alias_policy == "alias_only" and public_verb != verb:
+        lab = public_verb
+    elif alias_policy == "both" and public_verb != verb:
+        lab = f"{verb}/{public_verb}"
+    else:
+        lab = verb
+    return f"{resource_pascal(resource_name)} - {lab}"
+
+
+def label_hook_callable(fn: Any) -> str:
+    """Return a module-qualified label for *fn* suitable for hook listings."""
+    n = getattr(fn, "__qualname__", getattr(fn, "__name__", repr(fn)))
+    m = getattr(fn, "__module__", None)
+    return f"{m}.{n}" if m else n


### PR DESCRIPTION
## Summary
- centralize case conversion, canonical naming, and labeling helpers in `autoapi.v2.naming`
- wire new helpers through CRUD, routing, endpoint, and op-spec logic
- rename `label_callable` to `label_hook_callable`

## Testing
- `uv run --directory . --package autoapi ruff format .`
- `uv run --directory . --package autoapi ruff check . --fix`
- `uv run --package autoapi --directory . pytest`


------
https://chatgpt.com/codex/tasks/task_e_689da79348f08326a8479c73baaa3725