### PR TITLE
refactor: reorganize autoapi endpoints

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v2/__init__.py
@@ -3,7 +3,7 @@
 Public façade for the AutoAPI framework.
 
 •  Keeps only lightweight glue code.
-•  Delegates real work to sub-modules (impl, hooks, endpoints, rpcdispatch, …).
+•  Delegates real work to sub-modules (impl, hooks, endpoints, rpcdispatcher, …).
 •  Preserves the historical surface: AutoAPI._crud, …
 """
 
@@ -14,8 +14,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 from pydantic import BaseModel
 
-from .endpoints import attach_health_and_methodz
-from .rpcdispatch import build_rpcdispatch
+# Diagnostic and RPC endpoints
+from .endpoints.endpoints import attach_health_and_methodz
+from .endpoints.rpcdispatcher import build_rpcdispatch
 from .hooks import Phase, _init_hooks, _run
 from .impl import (
     _crud,

--- a/pkgs/standards/autoapi/autoapi/v2/endpoints/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v2/endpoints/__init__.py
@@ -1,0 +1,6 @@
+"""Diagnostic and RPC endpoints for the AutoAPI framework."""
+
+__all__ = ["attach_health_and_methodz", "build_rpcdispatch"]
+
+from .endpoints import attach_health_and_methodz
+from .rpcdispatcher import build_rpcdispatch

--- a/pkgs/standards/autoapi/autoapi/v2/endpoints/rpcdispatcher.py
+++ b/pkgs/standards/autoapi/autoapi/v2/endpoints/rpcdispatcher.py
@@ -1,5 +1,5 @@
 """
-autoapi.v2.rpcdispatch  – JSON-RPC façade for AutoAPI
+autoapi.v2.endpoints.rpcdispatcher – JSON-RPC façade for AutoAPI
 """
 
 from __future__ import annotations
@@ -9,9 +9,9 @@ from typing import Any, Dict
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
-from .types import APIRouter, Body, Depends, HTTPException, Request, ValidationError
-from .impl._runner import _invoke
-from .jsonrpc_models import (
+from ..types import APIRouter, Body, Depends, HTTPException, Request, ValidationError
+from ..impl._runner import _invoke
+from ..jsonrpc_models import (
     _RPCReq,
     _RPCRes,
     _err,
@@ -56,7 +56,9 @@ def build_rpcdispatch(api) -> APIRouter:
             except ValidationError as exc:
                 errors = exc.errors()
                 missing = [e["loc"][-1] for e in errors if e["type"] == "missing"]
-                msg = "Validation error" + (": missing parameter(s): " + ", ".join(missing) if missing else "")
+                msg = "Validation error" + (
+                    ": missing parameter(s): " + ", ".join(missing) if missing else ""
+                )
                 return _err(-32602, msg, env, data=errors)
             except Exception as exc:
                 return _err(-32000, str(exc), env)
@@ -93,7 +95,9 @@ def build_rpcdispatch(api) -> APIRouter:
             except ValidationError as exc:
                 errors = exc.errors()
                 missing = [e["loc"][-1] for e in errors if e["type"] == "missing"]
-                msg = "Validation error" + (": missing parameter(s): " + ", ".join(missing) if missing else "")
+                msg = "Validation error" + (
+                    ": missing parameter(s): " + ", ".join(missing) if missing else ""
+                )
                 return _err(-32602, msg, env, data=errors)
             except Exception as exc:
                 return _err(-32000, str(exc), env)


### PR DESCRIPTION
## Summary
- move diagnostic and RPC dispatcher modules into `autoapi.v2.endpoints`
- adjust imports for new package structure
- export relocated helpers from `autoapi.v2.endpoints`

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff format autoapi/v2/__init__.py autoapi/v2/endpoints/__init__.py autoapi/v2/endpoints/endpoints.py autoapi/v2/endpoints/rpcdispatcher.py`
- `uv run --directory standards/autoapi --package autoapi ruff check autoapi/v2/__init__.py autoapi/v2/endpoints/__init__.py autoapi/v2/endpoints/endpoints.py autoapi/v2/endpoints/rpcdispatcher.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_689dc216e7fc832687d05d7bbb6deda6