### PR TITLE
refactor: centralize verb alias helpers

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/naming.py
+++ b/pkgs/standards/autoapi/autoapi/v2/naming.py
@@ -10,6 +10,48 @@ import re
 from typing import Any
 
 
+VALID_VERBS = {
+    "create",
+    "read",
+    "update",
+    "delete",
+    "list",
+    "clear",
+    "replace",
+    "bulk_create",
+    "bulk_update",
+    "bulk_replace",
+    "bulk_delete",
+}
+
+_alias_re = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+def get_verb_alias_map(model) -> dict[str, str]:
+    raw = getattr(model, "__autoapi_verb_aliases__", None)
+    if callable(raw):
+        raw = raw()
+    return dict(raw or {})
+
+
+def alias_policy(model) -> str:
+    return getattr(model, "__autoapi_verb_alias_policy__", "both")
+
+
+def public_verb(model, canonical: str) -> str:
+    ali = get_verb_alias_map(model).get(canonical)
+    if not ali or ali == canonical:
+        return canonical
+    if canonical not in VALID_VERBS:
+        raise RuntimeError(f"{model.__name__}: unsupported verb {canonical!r}")
+    if not _alias_re.match(ali):
+        raise RuntimeError(
+            f"{model.__name__}.__autoapi_verb_aliases__: bad alias {ali!r} for {canonical!r} "
+            "(must be lowercase [a-z0-9_], start with a letter)"
+        )
+    return ali
+
+
 def camel_to_snake(name: str) -> str:
     """Convert ``CamelCase`` *name* to ``snake_case`` preserving acronyms."""
     s1 = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", name)
@@ -52,3 +94,17 @@ def label_hook_callable(fn: Any) -> str:
     n = getattr(fn, "__qualname__", getattr(fn, "__name__", repr(fn)))
     m = getattr(fn, "__module__", None)
     return f"{m}.{n}" if m else n
+
+
+__all__ = [
+    "camel_to_snake",
+    "snake_to_camel",
+    "canonical_name",
+    "resource_pascal",
+    "route_label",
+    "label_hook_callable",
+    "VALID_VERBS",
+    "get_verb_alias_map",
+    "alias_policy",
+    "public_verb",
+]


### PR DESCRIPTION
## Summary
- centralize verb alias helper utilities in `naming`
- route builder consumes shared naming helpers

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff format .`
- `uv run --directory standards/autoapi --package autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest`

------
https://chatgpt.com/codex/tasks/task_e_689dc391bc7c83268e3ccef58a7f4174