### PR TITLE
Fix AutoAPI v3 imports

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/schema/builder.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/builder.py
@@ -15,7 +15,18 @@ from __future__ import annotations
 
 import logging
 import uuid
-from typing import Any, Dict, Iterable, Mapping, Set, Tuple, Type, Union, get_type_hints
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    Mapping,
+    Set,
+    Tuple,
+    Type,
+    Union,
+    get_type_hints,
+    Literal,
+)
 
 from pydantic import BaseModel, ConfigDict, Field, create_model
 
@@ -23,22 +34,28 @@ try:
     # Optional: validate column meta (if available in your tree)
     from ..info_schema import check as _info_check  # type: ignore
 except Exception:  # pragma: no cover
+
     def _info_check(meta: Mapping[str, Any], attr_name: str, model_name: str) -> None:
         return None  # no-op if v3.info_schema is absent
+
 
 try:
     # Use SQLAlchemy's hybrid_property
     from sqlalchemy.ext.hybrid import hybrid_property  # type: ignore
 except Exception:  # pragma: no cover
+
     class hybrid_property:  # minimal shim
         pass
+
 
 try:
     # Pydantic v2 sentinel for "no default"
     from pydantic_core import PydanticUndefined  # type: ignore
 except Exception:  # pragma: no cover
+
     class PydanticUndefinedClass:  # shim
         pass
+
     PydanticUndefined = PydanticUndefinedClass()  # type: ignore
 
 
@@ -50,12 +67,12 @@ logger = logging.getLogger(__name__)
 
 _SchemaVerb = Union[
     # Canonical AutoAPI verbs
-    Literal["create"],  # type: ignore[name-defined]
-    Literal["read"],    # type: ignore[name-defined]
-    Literal["update"],  # type: ignore[name-defined]
-    Literal["replace"], # type: ignore[name-defined]
-    Literal["delete"],  # type: ignore[name-defined]
-    Literal["list"],    # type: ignore[name-defined]
+    Literal["create"],
+    Literal["read"],
+    Literal["update"],
+    Literal["replace"],
+    Literal["delete"],
+    Literal["list"],
 ]
 
 _SchemaCache: Dict[Tuple[type, str, frozenset, frozenset], Type[BaseModel]] = {}
@@ -64,6 +81,7 @@ _SchemaCache: Dict[Tuple[type, str, frozenset, frozenset], Type[BaseModel]] = {}
 # ───────────────────────────────────────────────────────────────────────────────
 # Internal helpers
 # ───────────────────────────────────────────────────────────────────────────────
+
 
 def _bool(x: Any) -> bool:
     try:
@@ -122,7 +140,12 @@ def _merge_request_extras(
             else:
                 py_t, fld = (spec or Any), Field(None)
             _add_field(fields, name=name, py_t=py_t, field=fld)
-            logger.debug("schema: added request-extra field %s (verb=%s, type=%r)", name, verb, py_t)
+            logger.debug(
+                "schema: added request-extra field %s (verb=%s, type=%r)",
+                name,
+                verb,
+                py_t,
+            )
 
 
 def _merge_response_extras(
@@ -149,7 +172,12 @@ def _merge_response_extras(
             else:
                 py_t, fld = (spec or Any), Field(None)
             _add_field(fields, name=name, py_t=py_t, field=fld)
-            logger.debug("schema: added response-extra field %s (verb=%s, type=%r)", name, verb, py_t)
+            logger.debug(
+                "schema: added response-extra field %s (verb=%s, type=%r)",
+                name,
+                verb,
+                py_t,
+            )
 
 
 def _python_type(col: Any) -> type | Any:
@@ -168,13 +196,16 @@ def _is_required(col: Any, verb: str) -> bool:
     if getattr(col, "primary_key", False) and verb in {"update", "replace", "delete"}:
         return True
     is_nullable = bool(getattr(col, "nullable", True))
-    has_default = (getattr(col, "default", None) is not None) or (getattr(col, "server_default", None) is not None)
+    has_default = (getattr(col, "default", None) is not None) or (
+        getattr(col, "server_default", None) is not None
+    )
     return not is_nullable and not has_default
 
 
 # ───────────────────────────────────────────────────────────────────────────────
 # Public builders
 # ───────────────────────────────────────────────────────────────────────────────
+
 
 def _schema(
     orm_cls: type,
@@ -205,7 +236,13 @@ def _schema(
         logger.debug("schema: cache hit %s verb=%s", orm_cls.__name__, verb)
         return cached
 
-    logger.debug("schema: building %s verb=%s include=%s exclude=%s", orm_cls.__name__, verb, include, exclude)
+    logger.debug(
+        "schema: building %s verb=%s include=%s exclude=%s",
+        orm_cls.__name__,
+        verb,
+        include,
+        exclude,
+    )
     fields: Dict[str, Tuple[type, Field]] = {}
 
     # ── PASS 1: table-backed columns only (avoid mapper relationships)
@@ -229,7 +266,9 @@ def _schema(
         # Legacy flags
         if verb == "create" and getattr(meta_src, "get", lambda *_: None)("no_create"):
             continue
-        if verb in {"update", "replace"} and getattr(meta_src, "get", lambda *_: None)("no_update"):
+        if verb in {"update", "replace"} and getattr(meta_src, "get", lambda *_: None)(
+            "no_update"
+        ):
             continue
 
         # Disable on verb
@@ -271,7 +310,9 @@ def _schema(
             py_t = Union[py_t, None]
 
         _add_field(fields, name=attr_name, py_t=py_t, field=fld)
-        logger.debug("schema: added field %s required=%s type=%r", attr_name, required, py_t)
+        logger.debug(
+            "schema: added field %s required=%s type=%r", attr_name, required, py_t
+        )
 
     # ── PASS 2: @hybrid_property (opt-in via meta["hybrid"])
     for attr_name, attr in list(getattr(orm_cls, "__dict__", {}).items()):
@@ -291,7 +332,11 @@ def _schema(
             continue
 
         # Write-phase without setter is not usable
-        if getattr(attr, "fset", None) is None and verb in {"create", "update", "replace"}:
+        if getattr(attr, "fset", None) is None and verb in {
+            "create",
+            "update",
+            "replace",
+        }:
             continue
 
         py_t = getattr(attr, "python_type", meta.get("py_type", Any))
@@ -338,8 +383,12 @@ def create_list_schema(model: type) -> Type[BaseModel]:
     table = getattr(model, "__table__", None)
     if table is None or not getattr(table, "columns", None):
         # No table info; return a minimal pager schema
-        schema = create_model(f"{tab}ListParams", __config__=ConfigDict(extra="forbid"), **base)  # type: ignore[arg-type]
-        logger.debug("schema: create_list_schema generated %s (no columns)", schema.__name__)
+        schema = create_model(
+            f"{tab}ListParams", __config__=ConfigDict(extra="forbid"), **base
+        )  # type: ignore[arg-type]
+        logger.debug(
+            "schema: create_list_schema generated %s (no columns)", schema.__name__
+        )
         return schema
 
     # Determine primary key name (first PK column)
@@ -379,10 +428,18 @@ def _strip_parent_fields(base: Type[BaseModel], *, drop: Set[str]) -> Type[BaseM
         if name in (drop or ()):
             continue
         typ = hints.get(name, Any)
-        default = finfo.default if getattr(finfo, "default", PydanticUndefined) is not PydanticUndefined else ...
+        default = (
+            finfo.default
+            if getattr(finfo, "default", PydanticUndefined) is not PydanticUndefined
+            else ...
+        )
         new_fields[name] = (typ, default)
 
-    clone = create_model(f"{base.__name__}Pruned", __config__=getattr(base, "model_config", None), **new_fields)  # type: ignore[arg-type]
+    clone = create_model(
+        f"{base.__name__}Pruned",
+        __config__=getattr(base, "model_config", None),
+        **new_fields,
+    )  # type: ignore[arg-type]
     clone.model_rebuild(force=True)
     return clone
 

--- a/pkgs/standards/autoapi/autoapi/v3/transport/jsonrpc/dispatcher.py
+++ b/pkgs/standards/autoapi/autoapi/v3/transport/jsonrpc/dispatcher.py
@@ -24,7 +24,16 @@ You would usually mount the returned router at `/rpc`, e.g.:
 from __future__ import annotations
 
 import logging
-from typing import Any, Awaitable, Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple, Union
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+)
 
 try:
     from fastapi import APIRouter, Request, Body, Depends, HTTPException
@@ -34,30 +43,40 @@ except Exception:  # pragma: no cover
     class APIRouter:  # type: ignore
         def __init__(self, *a, **kw):
             self.routes = []
-        def add_api_route(self, path: str, endpoint: Callable, methods: Sequence[str], **opts):
+
+        def add_api_route(
+            self, path: str, endpoint: Callable, methods: Sequence[str], **opts
+        ):
             self.routes.append((path, methods, endpoint, opts))
+
     class Request:  # type: ignore
         def __init__(self, scope=None):
             self.scope = scope or {}
             self.state = type("S", (), {})()
             self.query_params = {}
+
         async def json(self) -> Any:
             return {}
+
     def Body(default=None, **kw):  # type: ignore
         return default
+
     def Depends(fn):  # type: ignore
         return fn
+
     class Response:  # type: ignore
         def __init__(self, status_code: int = 200, content: Any = None):
             self.status_code = status_code
             self.body = content
+
     class HTTPException(Exception):  # type: ignore
         def __init__(self, status_code: int, detail: Any = None):
             super().__init__(detail)
             self.status_code = status_code
             self.detail = detail
 
-from ...runtime.errors import (
+
+from ...impl.runtime.errors import (
     _http_exc_to_rpc,
     ERROR_MESSAGES,
 )
@@ -71,14 +90,21 @@ Batch = Sequence[Mapping[str, Any]]
 # Utilities
 # --------------------------------------------------------------------------- #
 
+
 def _ok(result: Any, id_: Any) -> Dict[str, Any]:
     return {"jsonrpc": "2.0", "result": result, "id": id_}
 
+
 def _err(code: int, msg: str, id_: Any, data: Any | None = None) -> Dict[str, Any]:
-    e: Dict[str, Any] = {"jsonrpc": "2.0", "error": {"code": code, "message": msg}, "id": id_}
+    e: Dict[str, Any] = {
+        "jsonrpc": "2.0",
+        "error": {"code": code, "message": msg},
+        "id": id_,
+    }
     if data is not None:
         e["error"]["data"] = data
     return e
+
 
 def _normalize_params(params: Any) -> Mapping[str, Any]:
     if params is None:
@@ -87,6 +113,7 @@ def _normalize_params(params: Any) -> Mapping[str, Any]:
         return dict(params)
     # Positional params are not supported in AutoAPI adapters
     raise HTTPException(status_code=400, detail="Invalid params: expected object")
+
 
 def _model_for(api: Any, name: str) -> Optional[type]:
     models: Dict[str, type] = getattr(api, "models", {}) or {}
@@ -99,6 +126,7 @@ def _model_for(api: Any, name: str) -> Optional[type]:
         if k.lower() == lower:
             return v
     return None
+
 
 async def _dispatch_one(
     *,
@@ -161,7 +189,7 @@ async def _dispatch_one(
         if rid is None:
             return None
         return _err(code, msg, rid, data)
-    except Exception as exc:
+    except Exception:
         logger.exception("jsonrpc dispatch failed")
         # Internal error (per JSON-RPC); do not leak details
         if rid is None:
@@ -172,6 +200,7 @@ async def _dispatch_one(
 # --------------------------------------------------------------------------- #
 # Public router factory
 # --------------------------------------------------------------------------- #
+
 
 def build_jsonrpc_router(
     api: Any,
@@ -192,12 +221,16 @@ def build_jsonrpc_router(
 
     if dep is not None:
         # Inject DB via FastAPI dependency for proper lifecycle management.
-        async def _endpoint(request: Request, body: Any = Body(...), db: Any = Depends(dep)):
+        async def _endpoint(
+            request: Request, body: Any = Body(...), db: Any = Depends(dep)
+        ):
             # Accept single or batch requests
             if isinstance(body, list):
                 responses: List[Dict[str, Any]] = []
                 for item in body:
-                    resp = await _dispatch_one(api=api, request=request, db=db, obj=item)
+                    resp = await _dispatch_one(
+                        api=api, request=request, db=db, obj=item
+                    )
                     if resp is not None:
                         responses.append(resp)
                 # Per JSON-RPC: an empty response array is valid for a batch of only notifications.
@@ -218,7 +251,9 @@ def build_jsonrpc_router(
             if isinstance(body, list):
                 responses: List[Dict[str, Any]] = []
                 for item in body:
-                    resp = await _dispatch_one(api=api, request=request, db=db, obj=item)
+                    resp = await _dispatch_one(
+                        api=api, request=request, db=db, obj=item
+                    )
                     if resp is not None:
                         responses.append(resp)
                 return responses


### PR DESCRIPTION
## Summary
- import Literal for schema builder
- correct dispatcher to load runtime errors from impl module

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff check autoapi/v3/schema/builder.py autoapi/v3/transport/jsonrpc/dispatcher.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest` *(fails: ModuleNotFoundError: No module named 'autoapi.v2.impl.errors')*

------
https://chatgpt.com/codex/tasks/task_e_689e172953b883269066d746539c2afc