### PR TITLE
refactor: migrate autoapi v3 mixins

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/mixins/_RowBound.py
+++ b/pkgs/standards/autoapi/autoapi/v3/mixins/_RowBound.py
@@ -1,11 +1,13 @@
-# autoapi/v2/mixins/bound.py
+# autoapi/v3/mixins/_RowBound.py
 from __future__ import annotations
 
 from typing import Any, Mapping, Sequence
 
-from autoapi.v2.hooks import Phase
-from autoapi.v2.types import HookProvider
-from autoapi.v2.jsonrpc_models import HTTP_ERROR_MESSAGES, create_standardized_error
+from ..types import HookProvider
+from ..impl.runtime.errors import (
+    HTTP_ERROR_MESSAGES,
+    create_standardized_error_from_status,
+)
 
 
 class _RowBound(HookProvider):
@@ -32,7 +34,7 @@ class _RowBound(HookProvider):
             return
 
         for op in ("read", "list"):
-            api.register_hook(model=cls, phase=Phase.POST_HANDLER, op=op)(
+            api.register_hook(model=cls, phase="POST_HANDLER", op=op)(
                 cls._make_row_visibility_hook()
             )
 
@@ -54,7 +56,7 @@ class _RowBound(HookProvider):
 
             # READ → invisible row → pretend 404
             if not cls.is_visible(res, ctx):
-                http_exc, _, _ = create_standardized_error(
+                http_exc, _, _ = create_standardized_error_from_status(
                     404, message=HTTP_ERROR_MESSAGES[404]
                 )
                 raise http_exc

--- a/pkgs/standards/autoapi/autoapi/v3/mixins/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/mixins/__init__.py
@@ -24,7 +24,7 @@ from ..types import (
     UUID,
     uuid4,
 )
-from ..cfgs import AUTH_CONTEXT_KEY, USER_ID_KEY
+from ..config.constants import CTX_USER_ID_KEY
 
 
 def tzutcnow() -> dt.datetime:  # default/on‑update factory
@@ -155,8 +155,7 @@ class OwnerBound:
 
     @classmethod
     def filter_for_ctx(cls, q, ctx):
-        auto_fields = ctx.get(AUTH_CONTEXT_KEY, {})
-        return q.filter(cls.owner_id == auto_fields.get(USER_ID_KEY))
+        return q.filter(cls.owner_id == ctx.get(CTX_USER_ID_KEY))
 
 
 class UserBound:  # membership rows
@@ -168,8 +167,7 @@ class UserBound:  # membership rows
 
     @classmethod
     def filter_for_ctx(cls, q, ctx):
-        auto_fields = ctx.get(AUTH_CONTEXT_KEY, {})
-        return q.filter(cls.user_id == auto_fields.get(USER_ID_KEY))
+        return q.filter(cls.user_id == ctx.get(CTX_USER_ID_KEY))
 
 
 # ────────── lifecycle --------------------------------------------------

--- a/pkgs/standards/autoapi/autoapi/v3/mixins/upsertable.py
+++ b/pkgs/standards/autoapi/autoapi/v3/mixins/upsertable.py
@@ -2,8 +2,8 @@
 from __future__ import annotations
 from typing import Any, Mapping, Sequence, Optional, Tuple
 from sqlalchemy import and_, inspect as sa_inspect
-from autoapi.v2.hooks import Phase
-from autoapi.v2.types import Session, HookProvider
+from ..types import Session, HookProvider
+
 
 class Upsertable(HookProvider):
     """
@@ -12,13 +12,14 @@ class Upsertable(HookProvider):
       • Else if all PK parts are present            -> decide by PK
       • Else                                        -> no rewrite
     """
+
     __upsert_keys__: Sequence[str] | None = None  # optional natural key list
 
     @classmethod
     def __autoapi_register_hooks__(cls, api) -> None:
         model = cls.__tablename__
         for op in ("create", "update", "replace"):
-            api.register_hook(Phase.PRE_TX_BEGIN, model=model, op=op)(
+            api.register_hook("PRE_TX_BEGIN", model=model, op=op)(
                 cls._make_upsert_rewrite_hook(op)
             )
 
@@ -57,7 +58,10 @@ class Upsertable(HookProvider):
 
         return _rewrite
 
-def _extract_values(p: Mapping[str, Any], names: Sequence[str]) -> Optional[Tuple[Any, ...]]:
+
+def _extract_values(
+    p: Mapping[str, Any], names: Sequence[str]
+) -> Optional[Tuple[Any, ...]]:
     vals = []
     for n in names:
         v = p.get(n)
@@ -66,11 +70,15 @@ def _extract_values(p: Mapping[str, Any], names: Sequence[str]) -> Optional[Tupl
         vals.append(v)
     return tuple(vals)
 
-def _exists_by_names(model, db: Session, names: Sequence[str], vals: Tuple[Any, ...]) -> bool:
+
+def _exists_by_names(
+    model, db: Session, names: Sequence[str], vals: Tuple[Any, ...]
+) -> bool:
     q = db.query(model)
     for n, v in zip(names, vals):
         q = q.filter(getattr(model, n) == v)
     return db.query(q.exists()).scalar() is True
+
 
 def _exists_by_pk(model, db: Session, pk_cols, pk_vals: Tuple[Any, ...]) -> bool:
     if len(pk_cols) == 1:
@@ -78,6 +86,7 @@ def _exists_by_pk(model, db: Session, pk_cols, pk_vals: Tuple[Any, ...]) -> bool
         return db.get(model, pk_vals[0]) is not None
     conds = [getattr(model, c.key) == v for c, v in zip(pk_cols, pk_vals)]
     return db.query(db.query(model).filter(and_(*conds)).exists()).scalar() is True
+
 
 def _rewrite_by_existence(ctx, tab: str, verb: str, exists: bool) -> None:
     if verb == "create" and exists:


### PR DESCRIPTION
## Summary
- drop v2 dependencies in AutoAPI v3 mixins
- use HookPhase strings and v3 runtime error helpers
- switch context key imports to config.constants

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff format autoapi/v3/mixins/_RowBound.py autoapi/v3/mixins/upsertable.py autoapi/v3/mixins/ownable.py autoapi/v3/mixins/tenant_bound.py autoapi/v3/mixins/__init__.py`
- `uv run --directory standards/autoapi --package autoapi ruff check autoapi/v3/mixins/_RowBound.py autoapi/v3/mixins/upsertable.py autoapi/v3/mixins/ownable.py autoapi/v3/mixins/tenant_bound.py autoapi/v3/mixins/__init__.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest` *(fails: ModuleNotFoundError: No module named 'autoapi.v2.impl.errors')*

------
https://chatgpt.com/codex/tasks/task_e_689e2f8269d483268fd0d136d4530993