### PR TITLE
feat(auto_authn): add v3 layout aligned with autoapi

### DIFF
--- a/pkgs/standards/auto_authn/README.md
+++ b/pkgs/standards/auto_authn/README.md
@@ -68,6 +68,13 @@ To run the API locally with Uvicorn:
 uvicorn auto_authn.v2.app:app --reload
 ```
 
+## v3 Layout
+
+The `auto_authn.v3` module mirrors the directory structure of `autoapi.v3`,
+re-exporting existing v2 components under `config`, `core`, and `bindings`
+namespaces. This alignment enables projects using AutoAPI v3 to adopt the
+authentication package without rewriting imports.
+
 The service exposes an OpenID Connect discovery document at
 `/.well-known/openid-configuration` and publishes its JSON Web Key Set at
 `/.well-known/jwks.json`.

--- a/pkgs/standards/auto_authn/auto_authn/__init__.py
+++ b/pkgs/standards/auto_authn/auto_authn/__init__.py
@@ -1,0 +1,13 @@
+"""Swarmauri auto-authn package."""
+
+from importlib import import_module
+from types import ModuleType
+
+
+def __getattr__(name: str) -> ModuleType:
+    if name in {"v2", "v3"}:
+        return import_module(f"{__name__}.{name}")
+    raise AttributeError(name)
+
+
+__all__ = ["v2", "v3"]

--- a/pkgs/standards/auto_authn/auto_authn/v3/__init__.py
+++ b/pkgs/standards/auto_authn/auto_authn/v3/__init__.py
@@ -1,0 +1,5 @@
+"""auto_authn v3 package aligned with autoapi.v3 layout."""
+
+from . import bindings, config, core
+
+__all__ = ["bindings", "config", "core"]

--- a/pkgs/standards/auto_authn/auto_authn/v3/bindings/__init__.py
+++ b/pkgs/standards/auto_authn/auto_authn/v3/bindings/__init__.py
@@ -1,0 +1,5 @@
+"""Framework bindings for auto_authn v3."""
+
+from .fastapi import fastapi_deps, routers
+
+__all__ = ["fastapi_deps", "routers"]

--- a/pkgs/standards/auto_authn/auto_authn/v3/bindings/fastapi.py
+++ b/pkgs/standards/auto_authn/auto_authn/v3/bindings/fastapi.py
@@ -1,0 +1,5 @@
+"""FastAPI bindings for auto_authn v3."""
+
+from ...v2 import fastapi_deps, routers  # noqa: F401
+
+__all__ = ["fastapi_deps", "routers"]

--- a/pkgs/standards/auto_authn/auto_authn/v3/config/__init__.py
+++ b/pkgs/standards/auto_authn/auto_authn/v3/config/__init__.py
@@ -1,0 +1,3 @@
+"""Configuration helpers for auto_authn v3."""
+
+from .runtime import *  # noqa: F401,F403

--- a/pkgs/standards/auto_authn/auto_authn/v3/config/runtime.py
+++ b/pkgs/standards/auto_authn/auto_authn/v3/config/runtime.py
@@ -1,0 +1,3 @@
+"""Re-export of runtime configuration utilities."""
+
+from ...v2.runtime_cfg import *  # noqa: F401,F403

--- a/pkgs/standards/auto_authn/auto_authn/v3/core/__init__.py
+++ b/pkgs/standards/auto_authn/auto_authn/v3/core/__init__.py
@@ -1,0 +1,5 @@
+"""Core authentication utilities for auto_authn v3."""
+
+from . import backends, jwtoken
+
+__all__ = ["backends", "jwtoken"]

--- a/pkgs/standards/auto_authn/auto_authn/v3/core/backends.py
+++ b/pkgs/standards/auto_authn/auto_authn/v3/core/backends.py
@@ -1,0 +1,3 @@
+"""Backward-compatible re-export of authentication backends."""
+
+from ...v2.backends import *  # noqa: F401,F403

--- a/pkgs/standards/auto_authn/auto_authn/v3/core/jwtoken.py
+++ b/pkgs/standards/auto_authn/auto_authn/v3/core/jwtoken.py
@@ -1,0 +1,3 @@
+"""Backward-compatible re-export of JWT helpers."""
+
+from ...v2.jwtoken import *  # noqa: F401,F403


### PR DESCRIPTION
## Summary
- introduce v3 package mirroring autoapi/v3 structure
- expose bindings, config, and core modules for authentication
- document new v3 layout in README

## Testing
- `uv run --package auto_authn --directory pkgs/standards/auto_authn ruff format .`
- `uv run --package auto_authn --directory pkgs/standards/auto_authn ruff check . --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest` *(fails: No module named 'autoapi.v2.impl.errors')*


------
https://chatgpt.com/codex/tasks/task_e_689e4a11626c8326866c63925514d2c7