### PR TITLE
fix(autoapi): update v3 tables to v3 imports

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/tables/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/tables/__init__.py
@@ -2,7 +2,7 @@
 
 Usage
 -----
-    from autoapi.v2.tables import (
+    from autoapi.v3.tables import (
         Tenant,
         User,
         Group,

--- a/pkgs/standards/autoapi/autoapi/v3/tables/apikey.py
+++ b/pkgs/standards/autoapi/autoapi/v3/tables/apikey.py
@@ -107,12 +107,10 @@ class ApiKey(
 
     @classmethod
     def __autoapi_register_hooks__(cls, api) -> None:
-        from autoapi.v2 import Phase
-
         model = cls.__name__
-        api.register_hook(Phase.PRE_TX_BEGIN, model=model, op="create")(
+        api.register_hook("PRE_TX_BEGIN", model=model, op="create")(
             cls._pre_create_generate
         )
-        api.register_hook(Phase.POST_RESPONSE, model=model, op="create")(
+        api.register_hook("POST_RESPONSE", model=model, op="create")(
             cls._post_response_inject
         )


### PR DESCRIPTION
## Summary
- fix tables usage docs to reference autoapi v3
- remove legacy Phase import from ApiKey table hooks

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format autoapi/v3/tables/__init__.py autoapi/v3/tables/apikey.py`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check autoapi/v3/tables/__init__.py autoapi/v3/tables/apikey.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_689e4b988e6083269f61044f1b86cb4c