### PR TITLE
feat(autoapi): update v3 mixins for new hook model

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/mixins/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/mixins/__init__.py
@@ -24,7 +24,7 @@ from ..types import (
     UUID,
     uuid4,
 )
-from ..cfgs import AUTH_CONTEXT_KEY, USER_ID_KEY
+from ..config.constants import CTX_AUTH_KEY, CTX_USER_ID_KEY
 
 
 def tzutcnow() -> dt.datetime:  # default/on‑update factory
@@ -155,8 +155,8 @@ class OwnerBound:
 
     @classmethod
     def filter_for_ctx(cls, q, ctx):
-        auto_fields = ctx.get(AUTH_CONTEXT_KEY, {})
-        return q.filter(cls.owner_id == auto_fields.get(USER_ID_KEY))
+        auto_fields = ctx.get(CTX_AUTH_KEY, {})
+        return q.filter(cls.owner_id == auto_fields.get(CTX_USER_ID_KEY))
 
 
 class UserBound:  # membership rows
@@ -168,8 +168,8 @@ class UserBound:  # membership rows
 
     @classmethod
     def filter_for_ctx(cls, q, ctx):
-        auto_fields = ctx.get(AUTH_CONTEXT_KEY, {})
-        return q.filter(cls.user_id == auto_fields.get(USER_ID_KEY))
+        auto_fields = ctx.get(CTX_AUTH_KEY, {})
+        return q.filter(cls.user_id == auto_fields.get(CTX_USER_ID_KEY))
 
 
 # ────────── lifecycle --------------------------------------------------


### PR DESCRIPTION
## Summary
- refactor mixins to register hooks via `__autoapi_hooks__`
- align tenant-bound mixin with v3 context constants and policies
- switch upsertable mixin to new hook registration pattern

## Testing
- `uv run --directory . --package autoapi ruff format autoapi/v3/mixins/_RowBound.py autoapi/v3/mixins/tenant_bound.py autoapi/v3/mixins/upsertable.py autoapi/v3/mixins/__init__.py`
- `uv run --directory . --package autoapi ruff check autoapi/v3/mixins/_RowBound.py autoapi/v3/mixins/tenant_bound.py autoapi/v3/mixins/upsertable.py autoapi/v3/mixins/__init__.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_689e4b9d379c8326ae904c4d09e7306b