### PR TITLE
refactor: centralize autoapi v3 attribute keys

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/autoapi.py
+++ b/pkgs/standards/autoapi/autoapi/v3/autoapi.py
@@ -3,13 +3,28 @@ from __future__ import annotations
 
 import copy
 from types import SimpleNamespace
-from typing import Any, Awaitable, Callable, Dict, Iterable, Mapping, Optional, Sequence, Tuple
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    Iterable,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+)
 
-from .bindings.api import include_model as _include_model, include_models as _include_models, rpc_call as _rpc_call
+from .bindings.api import (
+    include_model as _include_model,
+    include_models as _include_models,
+    rpc_call as _rpc_call,
+)
 from .bindings.model import rebind as _rebind, bind as _bind
 from .transport import mount_jsonrpc as _mount_jsonrpc
 from .system import attach_diagnostics as _attach_diagnostics
 from .opspec import get_registry, OpSpec
+from .config.constants import AUTOAPI_API_HOOKS_ATTR
 
 # optional compat: legacy transactional decorator
 try:
@@ -43,7 +58,9 @@ class AutoAPI:
         get_async_db: Optional[Callable[..., Awaitable[Any]]] = None,
         jsonrpc_prefix: str = "/rpc",
         system_prefix: str = "/system",
-        api_hooks: Mapping[str, Iterable[Callable]] | Mapping[str, Mapping[str, Iterable[Callable]]] | None = None,
+        api_hooks: Mapping[str, Iterable[Callable]]
+        | Mapping[str, Mapping[str, Iterable[Callable]]]
+        | None = None,
     ) -> None:
         # host app (FastAPI or APIRouter)
         self.app = app
@@ -81,9 +98,9 @@ class AutoAPI:
         """
         if not hooks_map:
             return
-        existing = getattr(model, "__autoapi_api_hooks__", None)
+        existing = getattr(model, AUTOAPI_API_HOOKS_ATTR, None)
         if existing is None:
-            setattr(model, "__autoapi_api_hooks__", copy.deepcopy(hooks_map))
+            setattr(model, AUTOAPI_API_HOOKS_ATTR, copy.deepcopy(hooks_map))
             return
 
         # shallow merge (alias or phase keys); values are lists we extend
@@ -103,24 +120,38 @@ class AutoAPI:
                         merged[k] = list(merged[k]) + list(v or [])
                     else:
                         merged[k] = v
-        setattr(model, "__autoapi_api_hooks__", merged)
+        setattr(model, AUTOAPI_API_HOOKS_ATTR, merged)
 
     # ------------------------- primary operations -------------------------
 
-    def include_model(self, model: type, *, prefix: str | None = None, mount_router: bool = True) -> Tuple[type, Any]:
+    def include_model(
+        self, model: type, *, prefix: str | None = None, mount_router: bool = True
+    ) -> Tuple[type, Any]:
         """
         Bind a model, mount its REST router, and attach all namespaces to this facade.
         """
         # inject API-level hooks so the binder merges them
         self._merge_api_hooks_into_model(model, self._api_hooks_map)
-        return _include_model(self, model, app=self.app, prefix=prefix, mount_router=mount_router)
+        return _include_model(
+            self, model, app=self.app, prefix=prefix, mount_router=mount_router
+        )
 
     def include_models(
-        self, models: Sequence[type], *, base_prefix: str | None = None, mount_router: bool = True
+        self,
+        models: Sequence[type],
+        *,
+        base_prefix: str | None = None,
+        mount_router: bool = True,
     ) -> Dict[str, Any]:
         for m in models:
             self._merge_api_hooks_into_model(m, self._api_hooks_map)
-        return _include_models(self, models, app=self.app, base_prefix=base_prefix, mount_router=mount_router)
+        return _include_models(
+            self,
+            models,
+            app=self.app,
+            base_prefix=base_prefix,
+            mount_router=mount_router,
+        )
 
     async def rpc_call(
         self,
@@ -132,19 +163,29 @@ class AutoAPI:
         request: Any = None,
         ctx: Optional[Dict[str, Any]] = None,
     ) -> Any:
-        return await _rpc_call(self, model_or_name, method, payload, db=db, request=request, ctx=ctx)
+        return await _rpc_call(
+            self, model_or_name, method, payload, db=db, request=request, ctx=ctx
+        )
 
     # ------------------------- extras / mounting -------------------------
 
     def mount_jsonrpc(self, *, prefix: str | None = None) -> Any:
         """Mount JSON-RPC router onto `self.app`."""
         px = prefix if prefix is not None else self.jsonrpc_prefix
-        return _mount_jsonrpc(self, self.app, prefix=px, get_db=self.get_db, get_async_db=self.get_async_db)
+        return _mount_jsonrpc(
+            self,
+            self.app,
+            prefix=px,
+            get_db=self.get_db,
+            get_async_db=self.get_async_db,
+        )
 
     def attach_diagnostics(self, *, prefix: str | None = None) -> Any:
         """Mount diagnostics router onto `self.app`."""
         px = prefix if prefix is not None else self.system_prefix
-        router = _attach_diagnostics(self, get_db=self.get_db, get_async_db=self.get_async_db)
+        router = _attach_diagnostics(
+            self, get_db=self.get_db, get_async_db=self.get_async_db
+        )
         if hasattr(self.app, "include_router") and callable(self.app.include_router):
             self.app.include_router(router, prefix=px)
         return router
@@ -160,7 +201,9 @@ class AutoAPI:
         self._merge_api_hooks_into_model(model, self._api_hooks_map)
         return _bind(model)
 
-    def rebind(self, model: type, *, changed_keys: Optional[set[tuple[str, str]]] = None) -> Tuple[OpSpec, ...]:
+    def rebind(
+        self, model: type, *, changed_keys: Optional[set[tuple[str, str]]] = None
+    ) -> Tuple[OpSpec, ...]:
         """Targeted rebuild of a bound model."""
         return _rebind(model, changed_keys=changed_keys)
 

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/api.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/api.py
@@ -3,10 +3,26 @@ from __future__ import annotations
 
 import logging
 from types import SimpleNamespace
-from typing import Any, Awaitable, Callable, Dict, Iterable, Mapping, Optional, Sequence, Tuple, Type, Union
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 from . import model as _binder  # bind(model) → builds/attaches namespaces
-from ..opspec import OpSpec
+from ..config.constants import (
+    AUTOAPI_AUTH_DEP_ATTR,
+    AUTOAPI_AUTHORIZE_ATTR,
+    AUTOAPI_GET_ASYNC_DB_ATTR,
+    AUTOAPI_GET_DB_ATTR,
+    AUTOAPI_REST_DEPENDENCIES_ATTR,
+    AUTOAPI_RPC_DEPENDENCIES_ATTR,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -18,6 +34,7 @@ ApiLike = Any
 # Helpers: resource/prefix, namespaces, router mounting
 # ───────────────────────────────────────────────────────────────────────────────
 
+
 def _snake(name: str) -> str:
     out = []
     for i, ch in enumerate(name):
@@ -26,14 +43,22 @@ def _snake(name: str) -> str:
         out.append(ch.lower())
     return "".join(out)
 
+
 def _resource_name(model: type) -> str:
-    return getattr(model, "__resource__", None) or getattr(model, "__tablename__", None) or _snake(model.__name__)
+    return (
+        getattr(model, "__resource__", None)
+        or getattr(model, "__tablename__", None)
+        or _snake(model.__name__)
+    )
+
 
 def _default_prefix(model: type) -> str:
     return f"/{_resource_name(model)}"
 
+
 def _has_include_router(obj: Any) -> bool:
     return hasattr(obj, "include_router") and callable(getattr(obj, "include_router"))
+
 
 def _mount_router(app_or_router: Any, router: Any, *, prefix: str) -> None:
     """
@@ -73,6 +98,7 @@ def _ensure_api_ns(api: ApiLike) -> None:
 # Resource proxy: api.core.<ModelName>.<alias>(payload, *, db, request=None, ctx=None)
 # ───────────────────────────────────────────────────────────────────────────────
 
+
 class _ResourceProxy:
     """
     Lightweight dynamic proxy that forwards calls to model.rpc.<alias>.
@@ -93,13 +119,20 @@ class _ResourceProxy:
         if target is None:
             raise AttributeError(f"{self._model.__name__} has no RPC method '{alias}'")
 
-        async def _call(payload: Any = None, *, db: Any, request: Any = None, ctx: Optional[Dict[str, Any]] = None) -> Any:
+        async def _call(
+            payload: Any = None,
+            *,
+            db: Any,
+            request: Any = None,
+            ctx: Optional[Dict[str, Any]] = None,
+        ) -> Any:
             return await target(payload, db=db, request=request, ctx=ctx)
 
         _call.__name__ = f"{self._model.__name__}.{alias}"
         _call.__qualname__ = _call.__name__
         _call.__doc__ = f"Helper for RPC call {self._model.__name__}.{alias}"
         return _call
+
 
 # --- add near top of file ---
 def _seed_security_and_deps(api: Any, model: type) -> None:
@@ -114,9 +147,9 @@ def _seed_security_and_deps(api: Any, model: type) -> None:
     """
     # DB deps
     if getattr(api, "get_db", None):
-        setattr(model, "__autoapi_get_db__", api.get_db)
+        setattr(model, AUTOAPI_GET_DB_ATTR, api.get_db)
     if getattr(api, "get_async_db", None):
-        setattr(model, "__autoapi_get_async_db__", api.get_async_db)
+        setattr(model, AUTOAPI_GET_ASYNC_DB_ATTR, api.get_async_db)
 
     # Authn: prefer required auth if allow_anon is False, else optional if provided
     auth_dep = None
@@ -127,21 +160,23 @@ def _seed_security_and_deps(api: Any, model: type) -> None:
     elif getattr(api, "_authn", None):
         auth_dep = api._authn
     if auth_dep is not None:
-        setattr(model, "__autoapi_auth_dep__", auth_dep)
+        setattr(model, AUTOAPI_AUTH_DEP_ATTR, auth_dep)
 
     # Authz
     if getattr(api, "_authorize", None):
-        setattr(model, "__autoapi_authorize__", api._authorize)
+        setattr(model, AUTOAPI_AUTHORIZE_ATTR, api._authorize)
 
     # Extra deps (router-level)
     if getattr(api, "rest_dependencies", None):
-        setattr(model, "__autoapi_rest_dependencies__", list(api.rest_dependencies))
+        setattr(model, AUTOAPI_REST_DEPENDENCIES_ATTR, list(api.rest_dependencies))
     if getattr(api, "rpc_dependencies", None):
-        setattr(model, "__autoapi_rpc_dependencies__", list(api.rpc_dependencies))
+        setattr(model, AUTOAPI_RPC_DEPENDENCIES_ATTR, list(api.rpc_dependencies))
+
 
 # ───────────────────────────────────────────────────────────────────────────────
 # Inclusion logic
 # ───────────────────────────────────────────────────────────────────────────────
+
 
 def _attach_to_api(api: ApiLike, model: type) -> None:
     """
@@ -161,9 +196,17 @@ def _attach_to_api(api: ApiLike, model: type) -> None:
     setattr(api.rpc, mname, getattr(model, "rpc", SimpleNamespace()))
     # rest (router lives on model.rest.router)
     rest_ns = getattr(api, "rest")
-    setattr(rest_ns, mname, SimpleNamespace(router=getattr(getattr(model, "rest", SimpleNamespace()), "router", None)))
+    setattr(
+        rest_ns,
+        mname,
+        SimpleNamespace(
+            router=getattr(getattr(model, "rest", SimpleNamespace()), "router", None)
+        ),
+    )
     # also keep a flat routers dict for quick access
-    api.routers[mname] = getattr(getattr(model, "rest", SimpleNamespace()), "router", None)
+    api.routers[mname] = getattr(
+        getattr(model, "rest", SimpleNamespace()), "router", None
+    )
 
     # Table metadata
     api.columns[mname] = tuple(getattr(model, "columns", ()))
@@ -197,7 +240,7 @@ def include_model(
     """
     # 0) seed deps/security so binders can see them
     _seed_security_and_deps(api, model)
-    
+
     # 1) Build/bind model namespaces (idempotent)
     _binder.bind(model)
 
@@ -233,7 +276,9 @@ def include_models(
     results: Dict[str, Any] = {}
     for mdl in models:
         px = (base_prefix.rstrip("/") if base_prefix else "") + _default_prefix(mdl)
-        _, router = include_model(api, mdl, app=app, prefix=px, mount_router=mount_router)
+        _, router = include_model(
+            api, mdl, app=app, prefix=px, mount_router=mount_router
+        )
         results[mdl.__name__] = router
     return results
 
@@ -241,6 +286,7 @@ def include_models(
 # ───────────────────────────────────────────────────────────────────────────────
 # Optional: generic RPC dispatcher on the api facade
 # ───────────────────────────────────────────────────────────────────────────────
+
 
 async def rpc_call(
     api: ApiLike,
@@ -267,7 +313,9 @@ async def rpc_call(
 
     fn = getattr(getattr(mdl, "rpc", SimpleNamespace()), method, None)
     if fn is None:
-        raise AttributeError(f"{getattr(mdl, '__name__', mdl)} has no RPC method '{method}'")
+        raise AttributeError(
+            f"{getattr(mdl, '__name__', mdl)} has no RPC method '{method}'"
+        )
 
     return await fn(payload, db=db, request=request, ctx=ctx)
 

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
@@ -4,7 +4,16 @@ from __future__ import annotations
 import inspect
 import logging
 from types import SimpleNamespace
-from typing import Any, Awaitable, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+)
 
 try:
     from fastapi import APIRouter, Request, Body, Depends, HTTPException
@@ -14,30 +23,46 @@ except Exception:  # pragma: no cover
     class APIRouter:  # type: ignore
         def __init__(self, *a, **kw):
             self.routes = []
-        def add_api_route(self, path: str, endpoint: Callable, methods: Sequence[str], **opts):
+
+        def add_api_route(
+            self, path: str, endpoint: Callable, methods: Sequence[str], **opts
+        ):
             self.routes.append((path, methods, endpoint, opts))
+
     class Request:  # type: ignore
         def __init__(self, scope=None):
             self.scope = scope or {}
             self.query_params = {}
             self.state = SimpleNamespace()
+
     def Body(default=None, **kw):  # type: ignore
         return default
+
     def Depends(fn):  # type: ignore
         return fn
+
     class HTTPException(Exception):  # type: ignore
         def __init__(self, status_code: int, detail: Any = None):
             super().__init__(detail)
             self.status_code = status_code
             self.detail = detail
+
     class _status:  # type: ignore
         HTTP_200_OK = 200
         HTTP_201_CREATED = 201
+
 
 from pydantic import BaseModel
 
 from ..opspec import OpSpec
 from ..opspec.types import PHASES
+from ..config.constants import (
+    AUTOAPI_AUTH_DEP_ATTR,
+    AUTOAPI_AUTHORIZE_ATTR,
+    AUTOAPI_GET_ASYNC_DB_ATTR,
+    AUTOAPI_GET_DB_ATTR,
+    AUTOAPI_REST_DEPENDENCIES_ATTR,
+)
 from ..runtime import executor as _executor  # expects _invoke(request, db, phases, ctx)
 
 logger = logging.getLogger(__name__)
@@ -49,16 +74,23 @@ _Key = Tuple[str, str]  # (alias, target)
 # Helpers: resource names, pk, schemas, phases, IO shaping
 # ───────────────────────────────────────────────────────────────────────────────
 
+
 def _snake(name: str) -> str:
     out = []
     for i, ch in enumerate(name):
-        if ch.isupper() and i and (not name[i-1].isupper()):
+        if ch.isupper() and i and (not name[i - 1].isupper()):
             out.append("_")
         out.append(ch.lower())
     return "".join(out)
 
+
 def _resource_name(model: type) -> str:
-    return getattr(model, "__resource__", None) or getattr(model, "__tablename__", None) or _snake(model.__name__)
+    return (
+        getattr(model, "__resource__", None)
+        or getattr(model, "__tablename__", None)
+        or _snake(model.__name__)
+    )
+
 
 def _pk_name(model: type) -> str:
     table = getattr(model, "__table__", None)
@@ -71,7 +103,10 @@ def _pk_name(model: type) -> str:
         return "id"
     return getattr(cols[0], "name", "id")
 
-def _get_phase_chains(model: type, alias: str) -> Dict[str, Sequence[Callable[..., Awaitable[Any]]]]:
+
+def _get_phase_chains(
+    model: type, alias: str
+) -> Dict[str, Sequence[Callable[..., Awaitable[Any]]]]:
     hooks_root = getattr(model, "hooks", None) or SimpleNamespace()
     alias_ns = getattr(hooks_root, alias, None)
     out: Dict[str, Sequence[Callable[..., Awaitable[Any]]]] = {}
@@ -79,7 +114,10 @@ def _get_phase_chains(model: type, alias: str) -> Dict[str, Sequence[Callable[..
         out[ph] = list(getattr(alias_ns, ph, []) or [])
     return out
 
-def _serialize_output(model: type, alias: str, target: str, sp: OpSpec, result: Any) -> Any:
+
+def _serialize_output(
+    model: type, alias: str, target: str, sp: OpSpec, result: Any
+) -> Any:
     if sp.returns != "model":
         return result
     schemas_root = getattr(model, "schemas", None)
@@ -89,17 +127,32 @@ def _serialize_output(model: type, alias: str, target: str, sp: OpSpec, result: 
     if not alias_ns:
         return result
     out_model = getattr(alias_ns, "out", None)
-    if not out_model or not inspect.isclass(out_model) or not issubclass(out_model, BaseModel):
+    if (
+        not out_model
+        or not inspect.isclass(out_model)
+        or not issubclass(out_model, BaseModel)
+    ):
         return result
     try:
         if target == "list" and isinstance(result, (list, tuple)):
-            return [out_model.model_validate(x).model_dump(exclude_none=True) for x in result]
+            return [
+                out_model.model_validate(x).model_dump(exclude_none=True)
+                for x in result
+            ]
         return out_model.model_validate(result).model_dump(exclude_none=True)
     except Exception:
-        logger.debug("rest output serialization failed for %s.%s", model.__name__, alias, exc_info=True)
+        logger.debug(
+            "rest output serialization failed for %s.%s",
+            model.__name__,
+            alias,
+            exc_info=True,
+        )
         return result
 
-def _validate_body(model: type, alias: str, target: str, body: Mapping[str, Any] | None) -> Mapping[str, Any]:
+
+def _validate_body(
+    model: type, alias: str, target: str, body: Mapping[str, Any] | None
+) -> Mapping[str, Any]:
     body = body or {}
     schemas_root = getattr(model, "schemas", None)
     if not schemas_root:
@@ -118,11 +171,19 @@ def _validate_body(model: type, alias: str, target: str, body: Mapping[str, Any]
             inst = in_model.model_validate(body)  # type: ignore[arg-type]
             return inst.model_dump(exclude_none=True)
         except Exception:
-            logger.debug("rest input body validation failed for %s.%s", model.__name__, alias, exc_info=True)
+            logger.debug(
+                "rest input body validation failed for %s.%s",
+                model.__name__,
+                alias,
+                exc_info=True,
+            )
             return body
     return body
 
-def _validate_query(model: type, alias: str, target: str, query: Mapping[str, Any]) -> Mapping[str, Any]:
+
+def _validate_query(
+    model: type, alias: str, target: str, query: Mapping[str, Any]
+) -> Mapping[str, Any]:
     schemas_root = getattr(model, "schemas", None)
     if not schemas_root:
         return dict(query)
@@ -130,13 +191,22 @@ def _validate_query(model: type, alias: str, target: str, query: Mapping[str, An
     if not alias_ns:
         return dict(query)
     # For list/clear, prefer .list
-    in_model = getattr(alias_ns, "list", None if target not in {"list", "clear"} else getattr(alias_ns, "list", None))
+    in_model = getattr(
+        alias_ns,
+        "list",
+        None if target not in {"list", "clear"} else getattr(alias_ns, "list", None),
+    )
     if in_model and inspect.isclass(in_model) and issubclass(in_model, BaseModel):
         try:
             inst = in_model.model_validate(dict(query))  # type: ignore[arg-type]
             return inst.model_dump(exclude_none=True)
         except Exception:
-            logger.debug("rest query validation failed for %s.%s", model.__name__, alias, exc_info=True)
+            logger.debug(
+                "rest query validation failed for %s.%s",
+                model.__name__,
+                alias,
+                exc_info=True,
+            )
     return dict(query)
 
 
@@ -144,16 +214,17 @@ def _validate_query(model: type, alias: str, target: str, query: Mapping[str, An
 # Security / dependency helpers
 # ───────────────────────────────────────────────────────────────────────────────
 
+
 def _router_dependencies(model: type) -> list:
     """
     Collect router-level dependencies: auth dep + extra REST deps.
     Each item may be a Depends(...) or a callable; we wrap callables with Depends.
     """
     deps = []
-    auth_dep = getattr(model, "__autoapi_auth_dep__", None)
+    auth_dep = getattr(model, AUTOAPI_AUTH_DEP_ATTR, None)
     if callable(auth_dep):
         deps.append(Depends(auth_dep))
-    extra = getattr(model, "__autoapi_rest_dependencies__", None) or []
+    extra = getattr(model, AUTOAPI_REST_DEPENDENCIES_ATTR, None) or []
     for d in extra:
         # If it's already a Depends object, let it through; otherwise wrap callable
         try:
@@ -163,19 +234,30 @@ def _router_dependencies(model: type) -> list:
         deps.append(d if is_dep_obj else Depends(d))
     return deps
 
+
 def _db_dep(model: type):
     """Return a FastAPI dependency that yields a DB session (async preferred), or None."""
-    return getattr(model, "__autoapi_get_async_db__", None) or getattr(model, "__autoapi_get_db__", None)
+    return getattr(model, AUTOAPI_GET_ASYNC_DB_ATTR, None) or getattr(
+        model, AUTOAPI_GET_DB_ATTR, None
+    )
+
 
 def _user_from_request(request: Request) -> Any | None:
     return getattr(request.state, "user", None)
 
-def _authorize(model: type, request: Request, alias: str, payload: Mapping[str, Any], user: Any | None) -> None:
+
+def _authorize(
+    model: type,
+    request: Request,
+    alias: str,
+    payload: Mapping[str, Any],
+    user: Any | None,
+) -> None:
     """
     Call per-model authorize callable if present. On error/False, raise 403.
     Signature is user-defined; common form is: fn(request, model, alias, payload, user)
     """
-    fn = getattr(model, "__autoapi_authorize__", None)
+    fn = getattr(model, AUTOAPI_AUTHORIZE_ATTR, None)
     if not fn:
         return
     try:
@@ -208,6 +290,7 @@ _DEFAULT_METHODS: Dict[str, Tuple[str, ...]] = {
     "custom": ("POST",),  # default for custom ops
 }
 
+
 def _default_path_suffix(sp: OpSpec) -> str | None:
     if sp.target.startswith("bulk_"):
         return "/bulk"
@@ -215,7 +298,10 @@ def _default_path_suffix(sp: OpSpec) -> str | None:
         return f"/{sp.alias}"
     return None
 
-def _path_for_spec(model: type, sp: OpSpec, *, resource: str, pk_param: str = "pk") -> Tuple[str, bool]:
+
+def _path_for_spec(
+    model: type, sp: OpSpec, *, resource: str, pk_param: str = "pk"
+) -> Tuple[str, bool]:
     """
     Return (path, is_member). We use a generic {pk} placeholder for all member ops
     and remap it to the model's real PK name inside ctx.path_params.
@@ -228,16 +314,20 @@ def _path_for_spec(model: type, sp: OpSpec, *, resource: str, pk_param: str = "p
         return f"/{resource}/{{{pk_param}}}{suffix}", True
     return f"/{resource}{suffix}", False
 
+
 def _response_model_for(sp: OpSpec, model: type) -> Any | None:
     if sp.returns != "model":
         return None
-    alias_ns = getattr(getattr(model, "schemas", None) or SimpleNamespace(), sp.alias, None)
+    alias_ns = getattr(
+        getattr(model, "schemas", None) or SimpleNamespace(), sp.alias, None
+    )
     out_model = getattr(alias_ns, "out", None)
     if out_model is None:
         return None
     # For list, FastAPI can accept typing.List[out_model]
     if sp.target == "list":
         from typing import List as _List
+
         try:
             return _List[out_model]  # type: ignore[index]
         except Exception:
@@ -249,11 +339,15 @@ def _response_model_for(sp: OpSpec, model: type) -> Any | None:
 # Endpoint factories
 # ───────────────────────────────────────────────────────────────────────────────
 
-def _make_collection_endpoint(model: type, sp: OpSpec, *, resource: str, dbdep=None) -> Callable[..., Awaitable[Any]]:
+
+def _make_collection_endpoint(
+    model: type, sp: OpSpec, *, resource: str, dbdep=None
+) -> Callable[..., Awaitable[Any]]:
     alias = sp.alias
     target = sp.target
 
     if dbdep is not None:
+
         async def _endpoint(
             request: Request,
             db: Any = Depends(dbdep),
@@ -275,7 +369,9 @@ def _make_collection_endpoint(model: type, sp: OpSpec, *, resource: str, dbdep=N
                 "db": db,
                 "payload": payload,
                 "path_params": {},  # no member id
-                "env": SimpleNamespace(method=alias, params=payload, target=target, model=model),
+                "env": SimpleNamespace(
+                    method=alias, params=payload, target=target, model=model
+                ),
             }
             phases = _get_phase_chains(model, alias)
 
@@ -286,9 +382,12 @@ def _make_collection_endpoint(model: type, sp: OpSpec, *, resource: str, dbdep=N
                 ctx=ctx,
             )
             return _serialize_output(model, alias, target, sp, result)
+
         _endpoint.__name__ = f"rest_{model.__name__}_{alias}_collection"
         _endpoint.__qualname__ = _endpoint.__name__
-        _endpoint.__doc__ = f"REST collection endpoint for {model.__name__}.{alias} ({target})"
+        _endpoint.__doc__ = (
+            f"REST collection endpoint for {model.__name__}.{alias} ({target})"
+        )
         return _endpoint
 
     # No DB dependency configured → fall back to request.state.db
@@ -311,7 +410,9 @@ def _make_collection_endpoint(model: type, sp: OpSpec, *, resource: str, dbdep=N
             "db": db,
             "payload": payload,
             "path_params": {},
-            "env": SimpleNamespace(method=alias, params=payload, target=target, model=model),
+            "env": SimpleNamespace(
+                method=alias, params=payload, target=target, model=model
+            ),
         }
         phases = _get_phase_chains(model, alias)
 
@@ -325,16 +426,21 @@ def _make_collection_endpoint(model: type, sp: OpSpec, *, resource: str, dbdep=N
 
     _endpoint.__name__ = f"rest_{model.__name__}_{alias}_collection"
     _endpoint.__qualname__ = _endpoint.__name__
-    _endpoint.__doc__ = f"REST collection endpoint for {model.__name__}.{alias} ({target})"
+    _endpoint.__doc__ = (
+        f"REST collection endpoint for {model.__name__}.{alias} ({target})"
+    )
     return _endpoint
 
 
-def _make_member_endpoint(model: type, sp: OpSpec, *, resource: str, pk_param: str = "pk", dbdep=None) -> Callable[..., Awaitable[Any]]:
+def _make_member_endpoint(
+    model: type, sp: OpSpec, *, resource: str, pk_param: str = "pk", dbdep=None
+) -> Callable[..., Awaitable[Any]]:
     alias = sp.alias
     target = sp.target
     real_pk = _pk_name(model)
 
     if dbdep is not None:
+
         async def _endpoint(
             pk: Any,  # path param captured as a generic 'pk'
             request: Request,
@@ -351,7 +457,9 @@ def _make_member_endpoint(model: type, sp: OpSpec, *, resource: str, pk_param: s
                 "payload": payload,
                 # map generic pk name to real PK column name for handler resolution
                 "path_params": {real_pk: pk, "pk": pk},
-                "env": SimpleNamespace(method=alias, params=payload, target=target, model=model),
+                "env": SimpleNamespace(
+                    method=alias, params=payload, target=target, model=model
+                ),
             }
             phases = _get_phase_chains(model, alias)
 
@@ -362,9 +470,12 @@ def _make_member_endpoint(model: type, sp: OpSpec, *, resource: str, pk_param: s
                 ctx=ctx,
             )
             return _serialize_output(model, alias, target, sp, result)
+
         _endpoint.__name__ = f"rest_{model.__name__}_{alias}_member"
         _endpoint.__qualname__ = _endpoint.__name__
-        _endpoint.__doc__ = f"REST member endpoint for {model.__name__}.{alias} ({target})"
+        _endpoint.__doc__ = (
+            f"REST member endpoint for {model.__name__}.{alias} ({target})"
+        )
         return _endpoint
 
     async def _endpoint(
@@ -382,7 +493,9 @@ def _make_member_endpoint(model: type, sp: OpSpec, *, resource: str, pk_param: s
             "db": db,
             "payload": payload,
             "path_params": {real_pk: pk, "pk": pk},
-            "env": SimpleNamespace(method=alias, params=payload, target=target, model=model),
+            "env": SimpleNamespace(
+                method=alias, params=payload, target=target, model=model
+            ),
         }
         phases = _get_phase_chains(model, alias)
 
@@ -404,6 +517,7 @@ def _make_member_endpoint(model: type, sp: OpSpec, *, resource: str, pk_param: s
 # Router builder
 # ───────────────────────────────────────────────────────────────────────────────
 
+
 def _build_router(model: type, specs: Sequence[OpSpec]) -> APIRouter:
     resource = _resource_name(model)
     router = APIRouter(dependencies=_router_dependencies(model) or None)
@@ -415,7 +529,9 @@ def _build_router(model: type, specs: Sequence[OpSpec]) -> APIRouter:
             continue
 
         # Determine path and membership
-        path, is_member = _path_for_spec(model, sp, resource=resource, pk_param=pk_param)
+        path, is_member = _path_for_spec(
+            model, sp, resource=resource, pk_param=pk_param
+        )
 
         # HTTP methods
         methods = list(sp.http_methods or _DEFAULT_METHODS.get(sp.target, ("POST",)))
@@ -423,12 +539,20 @@ def _build_router(model: type, specs: Sequence[OpSpec]) -> APIRouter:
 
         # Build endpoint
         if is_member:
-            endpoint = _make_member_endpoint(model, sp, resource=resource, pk_param=pk_param, dbdep=dbdep)
+            endpoint = _make_member_endpoint(
+                model, sp, resource=resource, pk_param=pk_param, dbdep=dbdep
+            )
         else:
-            endpoint = _make_collection_endpoint(model, sp, resource=resource, dbdep=dbdep)
+            endpoint = _make_collection_endpoint(
+                model, sp, resource=resource, dbdep=dbdep
+            )
 
         # Default status code (201 for create on collection; else 200)
-        status_code = _status.HTTP_201_CREATED if sp.target == "create" and not is_member else _status.HTTP_200_OK
+        status_code = (
+            _status.HTTP_201_CREATED
+            if sp.target == "create" and not is_member
+            else _status.HTTP_200_OK
+        )
 
         # Attach route
         router.add_api_route(
@@ -443,7 +567,11 @@ def _build_router(model: type, specs: Sequence[OpSpec]) -> APIRouter:
 
         logger.debug(
             "rest: registered %s %s -> %s.%s (response_model=%s)",
-            methods, path, model.__name__, sp.alias, getattr(response_model, "__name__", None) if response_model else None
+            methods,
+            path,
+            model.__name__,
+            sp.alias,
+            getattr(response_model, "__name__", None) if response_model else None,
         )
 
     return router
@@ -453,7 +581,10 @@ def _build_router(model: type, specs: Sequence[OpSpec]) -> APIRouter:
 # Public API
 # ───────────────────────────────────────────────────────────────────────────────
 
-def build_router_and_attach(model: type, specs: Sequence[OpSpec], *, only_keys: Optional[Sequence[_Key]] = None) -> None:
+
+def build_router_and_attach(
+    model: type, specs: Sequence[OpSpec], *, only_keys: Optional[Sequence[_Key]] = None
+) -> None:
     """
     Build an APIRouter for the model and attach it to `model.rest.router`.
     For simplicity and correctness with FastAPI, we **rebuild the entire router**
@@ -463,7 +594,11 @@ def build_router_and_attach(model: type, specs: Sequence[OpSpec], *, only_keys: 
     rest_ns = getattr(model, "rest", None) or SimpleNamespace()
     rest_ns.router = router
     setattr(model, "rest", rest_ns)
-    logger.debug("rest: %s router attached with %d routes", model.__name__, len(getattr(router, "routes", []) or []))
+    logger.debug(
+        "rest: %s router attached with %d routes",
+        model.__name__,
+        len(getattr(router, "routes", []) or []),
+    )
 
 
 __all__ = ["build_router_and_attach"]

--- a/pkgs/standards/autoapi/autoapi/v3/compat/transactional.py
+++ b/pkgs/standards/autoapi/autoapi/v3/compat/transactional.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
 import warnings
-from types import SimpleNamespace
-from typing import Any, Callable, Dict, Optional, Sequence, Tuple
+from typing import Any, Callable
 
 from ..bindings.api import include_model
 from ..bindings.model import bind as bind_model
 from ..opspec import OpSpec, get_registry
+from ..config.constants import AUTOAPI_TX_MODELS_ATTR
+
 
 def _pascal(s: str) -> str:
     return "".join(p.capitalize() or "_" for p in s.replace("-", "_").split("_"))
+
 
 def _split_name(name: str | None, fn_name: str) -> tuple[str, str]:
     """
@@ -23,15 +25,16 @@ def _split_name(name: str | None, fn_name: str) -> tuple[str, str]:
         return (a or "txn", b or fn_name)
     return ("txn", name)
 
+
 def _ensure_tx_model(api: Any, scope: str, *, resource: str | None = None) -> type:
     """
     Get or create a synthetic model class for this transactional scope.
     We keep them on api.__autoapi_tx_models__ to avoid re-creating classes.
     """
-    store = getattr(api, "__autoapi_tx_models__", None)
+    store = getattr(api, AUTOAPI_TX_MODELS_ATTR, None)
     if store is None:
         store = {}
-        setattr(api, "__autoapi_tx_models__", store)
+        setattr(api, AUTOAPI_TX_MODELS_ATTR, store)
 
     key = scope.lower()
     mdl = store.get(key)
@@ -40,11 +43,16 @@ def _ensure_tx_model(api: Any, scope: str, *, resource: str | None = None) -> ty
 
     class_name = _pascal(scope)
     # A tiny, ops-only model (no table); resource controls REST prefix
-    mdl = type(class_name, (), {"__resource__": (resource if resource is not None else "txn")})
+    mdl = type(
+        class_name, (), {"__resource__": (resource if resource is not None else "txn")}
+    )
     store[key] = mdl
     return mdl
 
-def _normalize_rest_path(rest_path: str | None, name_for_default: str, alias: str) -> str:
+
+def _normalize_rest_path(
+    rest_path: str | None, name_for_default: str, alias: str
+) -> str:
     """
     If rest_path is given, use it as an absolute path.
     Else default to '/<name with dots -> slashes>' to mimic v2 behavior.
@@ -55,6 +63,7 @@ def _normalize_rest_path(rest_path: str | None, name_for_default: str, alias: st
         path = "/" + name_for_default.replace(".", "/")
     return path
 
+
 def transactional(  # noqa: D401 (compat docstring in v2)
     api: Any,
     fn: Callable[..., Any] | None = None,
@@ -63,7 +72,7 @@ def transactional(  # noqa: D401 (compat docstring in v2)
     rest_path: str | None = None,
     rest_method: str = "POST",
     tags: tuple[str, ...] = ("txn",),
-    returns: str = "raw",          # v3: 'raw' or 'model'
+    returns: str = "raw",  # v3: 'raw' or 'model'
     expose_rpc: bool = True,
     expose_routes: bool = True,
 ) -> Callable[..., Any]:
@@ -80,7 +89,8 @@ def transactional(  # noqa: D401 (compat docstring in v2)
     warnings.warn(
         "The transactional decorator is deprecated; prefer model-scoped OpSpecs. "
         "This shim wraps your function as a v3 custom op with START_TX/END_TX phases.",
-        DeprecationWarning, stacklevel=2
+        DeprecationWarning,
+        stacklevel=2,
     )
 
     def _wrap(user_fn: Callable[..., Any]) -> Callable[..., Any]:
@@ -91,23 +101,27 @@ def transactional(  # noqa: D401 (compat docstring in v2)
         sp = OpSpec(
             alias=alias,
             target="custom",
-            handler=user_fn,                 # v3 handlers will pass (ctx, db, payload, request, model, op) as needed
+            handler=user_fn,  # v3 handlers will pass (ctx, db, payload, request, model, op) as needed
             expose_rpc=expose_rpc,
             expose_routes=expose_routes,
             http_methods=(rest_method,),
-            path_suffix=_normalize_rest_path(rest_path, name or user_fn.__name__, alias),
+            path_suffix=_normalize_rest_path(
+                rest_path, name or user_fn.__name__, alias
+            ),
             tags=tags,
-            returns=returns,                 # 'raw' by default; set 'model' if you want schema-shaped responses
-            persist="always",                # ensure START_TX/END_TX are injected
+            returns=returns,  # 'raw' by default; set 'model' if you want schema-shaped responses
+            persist="always",  # ensure START_TX/END_TX are injected
         )
 
         # Register on the model's registry and (re)bind the model
         reg = get_registry(model)
-        reg.set(alias, sp)                  # idempotent replace per-alias
-        bind_model(model)                   # builds schemas/hooks/handlers/rpc/rest
+        reg.set(alias, sp)  # idempotent replace per-alias
+        bind_model(model)  # builds schemas/hooks/handlers/rpc/rest
 
         # Ensure router is mounted under the API (prefix '' so our absolute path_suffix is used verbatim)
-        include_model(api, model, app=getattr(api, "app", None), prefix="", mount_router=True)
+        include_model(
+            api, model, app=getattr(api, "app", None), prefix="", mount_router=True
+        )
 
         # For compatibility, return the original function (no wrapper needed)
         return user_fn

--- a/pkgs/standards/autoapi/autoapi/v3/rest/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/rest/__init__.py
@@ -4,7 +4,9 @@ The logic is intentionally minimal; extend or override as needed.
 """
 
 from __future__ import annotations
-from typing import Type, Optional
+from typing import Optional, Type
+
+from ..config.constants import AUTOAPI_NESTED_PATHS_ATTR
 
 
 def _nested_prefix(self, model: Type) -> Optional[str]:
@@ -16,9 +18,10 @@ def _nested_prefix(self, model: Type) -> Optional[str]:
     • Otherwise → signal ``no nested route wanted`` with ``None``.
     """
 
-    cb = getattr(model, "__autoapi_nested_paths__", None)
+    cb = getattr(model, AUTOAPI_NESTED_PATHS_ATTR, None)
     if callable(cb):
         return cb()
     return getattr(model, "_nested_path", None)
+
 
 __all__ = ["_nested_prefix"]

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/executor.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/executor.py
@@ -1,7 +1,19 @@
 # autoapi/v2/impl/runtime/executor.py
 from __future__ import annotations
 
-from typing import Any, Awaitable, Callable, Iterable, Mapping, MutableMapping, Optional, Sequence, Union, Protocol, runtime_checkable
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Iterable,
+    Mapping,
+    MutableMapping,
+    Optional,
+    Sequence,
+    Union,
+    Protocol,
+    runtime_checkable,
+)
 import logging
 
 try:
@@ -17,6 +29,7 @@ except Exception:  # pragma: no cover
     AsyncSession = Any  # type: ignore
 
 from .errors import create_standardized_error
+from ..config.constants import CTX_SKIP_PERSIST_FLAG
 
 logger = logging.getLogger(__name__)
 
@@ -25,13 +38,16 @@ logger = logging.getLogger(__name__)
 # Types
 # ───────────────────────────────────────────────────────────────────────────────
 
+
 @runtime_checkable
 class _Step(Protocol):
     def __call__(self, ctx: "_Ctx") -> Union[Any, Awaitable[Any]]: ...
 
 
 HandlerStep = Union[_Step, Callable[["_Ctx"], Any], Callable[["_Ctx"], Awaitable[Any]]]
-PhaseChains = Mapping[str, Sequence[HandlerStep]]  # {"HANDLER": [...], "COMMIT": [...], ...}
+PhaseChains = Mapping[
+    str, Sequence[HandlerStep]
+]  # {"HANDLER": [...], "COMMIT": [...], ...}
 
 
 class _Ctx(dict):
@@ -44,6 +60,7 @@ class _Ctx(dict):
       • error: last exception caught (on failure paths)
       • response: SimpleNamespace(result=...) for POST_RESPONSE shaping
     """
+
     __slots__ = ()
     __getattr__ = dict.get
     __setattr__ = dict.__setitem__
@@ -74,15 +91,18 @@ class _Ctx(dict):
 # Introspection & helpers
 # ───────────────────────────────────────────────────────────────────────────────
 
+
 def _is_async_db(db: Any) -> bool:
     # AsyncSession exposes run_sync/commit/flush as async
     return isinstance(db, AsyncSession) or hasattr(db, "run_sync")
+
 
 def _bool_call(meth: Any) -> bool:
     try:
         return bool(meth())
     except Exception:  # pragma: no cover
         return False
+
 
 def _in_tx(db: Any) -> bool:
     for name in ("in_transaction", "in_nested_transaction"):
@@ -92,10 +112,12 @@ def _in_tx(db: Any) -> bool:
     val = getattr(db, "in_transaction", False)
     return bool(val)
 
+
 async def _maybe_await(v: Any) -> Any:
     if hasattr(v, "__await__"):
         return await v  # type: ignore[func-returns-value]
     return v
+
 
 async def _run_chain(ctx: _Ctx, chain: Optional[Iterable[HandlerStep]]) -> None:
     if not chain:
@@ -106,19 +128,24 @@ async def _run_chain(ctx: _Ctx, chain: Optional[Iterable[HandlerStep]]) -> None:
         if rv is not None:
             ctx.result = rv  # last non-None wins
 
+
 def _g(phases: Optional[PhaseChains], key: str) -> Sequence[HandlerStep]:
     return () if not phases else phases.get(key, ())
+
 
 # ───────────────────────────────────────────────────────────────────────────────
 # DB guards (enforce per-phase flush/commit policy)
 # ───────────────────────────────────────────────────────────────────────────────
 
+
 class _GuardHandle:
     __slots__ = ("db", "orig_commit", "orig_flush")
+
     def __init__(self, db: Any, orig_commit: Any, orig_flush: Any) -> None:
         self.db = db
         self.orig_commit = orig_commit
         self.orig_flush = orig_flush
+
     def restore(self) -> None:
         if self.orig_commit is not None:
             try:
@@ -130,6 +157,7 @@ class _GuardHandle:
                 setattr(self.db, "flush", self.orig_flush)
             except Exception:  # pragma: no cover
                 pass
+
 
 def _install_db_guards(
     db: Union[Session, AsyncSession],
@@ -153,31 +181,40 @@ def _install_db_guards(
     # commit wrapper
     if not allow_commit:
         if _is_async_db(db):
+
             async def _blocked_commit() -> None:  # type: ignore[func-returns-value]
                 _raise("commit")
         else:
+
             def _blocked_commit() -> None:  # type: ignore[func-returns-value]
                 _raise("commit")
+
         setattr(db, "commit", _blocked_commit)  # type: ignore[assignment]
     else:
         # allow commit, but optionally require that *this* run started the txn
         if require_started_tx_for_commit and not started_tx:
             if _is_async_db(db):
+
                 async def _blocked_commit_started() -> None:  # type: ignore[func-returns-value]
                     _raise("commit")
             else:
+
                 def _blocked_commit_started() -> None:  # type: ignore[func-returns-value]
                     _raise("commit")
+
             setattr(db, "commit", _blocked_commit_started)  # type: ignore[assignment]
 
     # flush wrapper
     if not allow_flush:
         if _is_async_db(db):
+
             async def _blocked_flush() -> None:  # type: ignore[func-returns-value]
                 _raise("flush")
         else:
+
             def _blocked_flush() -> None:  # type: ignore[func-returns-value]
                 _raise("flush")
+
         setattr(db, "flush", _blocked_flush)  # type: ignore[assignment]
 
     return _GuardHandle(db, orig_commit, orig_flush)
@@ -210,6 +247,7 @@ async def _rollback_if_started(
 # Public API
 # ───────────────────────────────────────────────────────────────────────────────
 
+
 async def _invoke(
     *,
     request: Optional[Request],
@@ -235,7 +273,7 @@ async def _invoke(
       • POST_RESPONSE remains non-fatal; errors are reported but the prior result is returned.
     """
     ctx = _Ctx.ensure(request=request, db=db, seed=ctx)
-    skip_persist: bool = bool(ctx.get("__autoapi_skip_persist__") or ctx.get("skip_persist"))
+    skip_persist: bool = bool(ctx.get(CTX_SKIP_PERSIST_FLAG) or ctx.get("skip_persist"))
 
     existed_tx_before = _in_tx(db)
     started_tx = False  # computed after TX_BEGIN
@@ -293,28 +331,42 @@ async def _invoke(
 
     # ─── TX_BEGIN (begin txn via hooks; skip when skip_persist) ────────────────
     if not skip_persist:
-        await _run_phase("START_TX", allow_flush=False, allow_commit=False, in_tx=False, require_started_for_commit=True)
+        await _run_phase(
+            "START_TX",
+            allow_flush=False,
+            allow_commit=False,
+            in_tx=False,
+            require_started_for_commit=True,
+        )
     # compute if *this* run started the transaction
     started_tx = (not existed_tx_before) and _in_tx(db)
 
     # ─── PRE_HANDLER (flush-only) ──────────────────────────────────────────────
-    await _run_phase("PRE_HANDLER", allow_flush=True, allow_commit=False, in_tx=not skip_persist)
+    await _run_phase(
+        "PRE_HANDLER", allow_flush=True, allow_commit=False, in_tx=not skip_persist
+    )
 
     # ─── HANDLER (flush-only; core lives here) ─────────────────────────────────
-    await _run_phase("HANDLER", allow_flush=True, allow_commit=False, in_tx=not skip_persist)
+    await _run_phase(
+        "HANDLER", allow_flush=True, allow_commit=False, in_tx=not skip_persist
+    )
 
     # ─── POST_HANDLER (flush-only) ─────────────────────────────────────────────
-    await _run_phase("POST_HANDLER", allow_flush=True, allow_commit=False, in_tx=not skip_persist)
+    await _run_phase(
+        "POST_HANDLER", allow_flush=True, allow_commit=False, in_tx=not skip_persist
+    )
 
     # ─── PRE_COMMIT (no writes) ────────────────────────────────────────────────
-    await _run_phase("PRE_COMMIT", allow_flush=False, allow_commit=False, in_tx=not skip_persist)
+    await _run_phase(
+        "PRE_COMMIT", allow_flush=False, allow_commit=False, in_tx=not skip_persist
+    )
 
     # ─── COMMIT (commit-only hooks; skip when skip_persist) ────────────────────
     if not skip_persist:
         await _run_phase(
             "END_TX",
-            allow_flush=True,           # a final flush right before commit is OK
-            allow_commit=True,          # commit allowed
+            allow_flush=True,  # a final flush right before commit is OK
+            allow_commit=True,  # commit allowed
             in_tx=True,
             require_started_for_commit=True,
         )
@@ -324,8 +376,15 @@ async def _invoke(
 
     # ─── POST_RESPONSE (non-fatal) ─────────────────────────────────────────────
     from types import SimpleNamespace as _NS
+
     ctx.response = _NS(result=ctx.get("result"))
-    await _run_phase("POST_RESPONSE", allow_flush=False, allow_commit=False, in_tx=False, nonfatal=True)
+    await _run_phase(
+        "POST_RESPONSE",
+        allow_flush=False,
+        allow_commit=False,
+        in_tx=False,
+        nonfatal=True,
+    )
     return ctx.response.result
 
 

--- a/pkgs/standards/autoapi/autoapi/v3/schema/builder.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/builder.py
@@ -15,7 +15,18 @@ from __future__ import annotations
 
 import logging
 import uuid
-from typing import Any, Dict, Iterable, Mapping, Set, Tuple, Type, Union, get_type_hints, Literal
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    Literal,
+    Mapping,
+    Set,
+    Tuple,
+    Type,
+    Union,
+    get_type_hints,
+)
 
 from pydantic import BaseModel, ConfigDict, Field, create_model
 
@@ -23,24 +34,35 @@ try:
     # Optional: validate column meta (if available in your tree)
     from ..info_schema import check as _info_check  # type: ignore
 except Exception:  # pragma: no cover
+
     def _info_check(meta: Mapping[str, Any], attr_name: str, model_name: str) -> None:
         return None  # no-op if v3.info_schema is absent
+
 
 try:
     # Use SQLAlchemy's hybrid_property
     from sqlalchemy.ext.hybrid import hybrid_property  # type: ignore
 except Exception:  # pragma: no cover
+
     class hybrid_property:  # minimal shim
         pass
+
 
 try:
     # Pydantic v2 sentinel for "no default"
     from pydantic_core import PydanticUndefined  # type: ignore
 except Exception:  # pragma: no cover
+
     class PydanticUndefinedClass:  # shim
         pass
+
     PydanticUndefined = PydanticUndefinedClass()  # type: ignore
 
+
+from ..config.constants import (
+    AUTOAPI_REQUEST_EXTRAS_ATTR,
+    AUTOAPI_RESPONSE_EXTRAS_ATTR,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -51,11 +73,11 @@ logger = logging.getLogger(__name__)
 _SchemaVerb = Union[
     # Canonical AutoAPI verbs
     Literal["create"],  # type: ignore[name-defined]
-    Literal["read"],    # type: ignore[name-defined]
+    Literal["read"],  # type: ignore[name-defined]
     Literal["update"],  # type: ignore[name-defined]
-    Literal["replace"], # type: ignore[name-defined]
+    Literal["replace"],  # type: ignore[name-defined]
     Literal["delete"],  # type: ignore[name-defined]
-    Literal["list"],    # type: ignore[name-defined]
+    Literal["list"],  # type: ignore[name-defined]
 ]
 
 _SchemaCache: Dict[Tuple[type, str, frozenset, frozenset], Type[BaseModel]] = {}
@@ -64,6 +86,7 @@ _SchemaCache: Dict[Tuple[type, str, frozenset, frozenset], Type[BaseModel]] = {}
 # ───────────────────────────────────────────────────────────────────────────────
 # Internal helpers
 # ───────────────────────────────────────────────────────────────────────────────
+
 
 def _bool(x: Any) -> bool:
     try:
@@ -105,7 +128,7 @@ def _merge_request_extras(
     • Field(...) is used as-is; if only a type is provided, defaults to Field(None)
     • Recommend Field(exclude=True) for secrets so they drop from .model_dump()
     """
-    buckets = getattr(orm_cls, "__autoapi_request_extras__", None)
+    buckets = getattr(orm_cls, AUTOAPI_REQUEST_EXTRAS_ATTR, None)
     if not buckets:
         return
     if verb not in {"create", "update", "replace", "delete"}:
@@ -122,7 +145,12 @@ def _merge_request_extras(
             else:
                 py_t, fld = (spec or Any), Field(None)
             _add_field(fields, name=name, py_t=py_t, field=fld)
-            logger.debug("schema: added request-extra field %s (verb=%s, type=%r)", name, verb, py_t)
+            logger.debug(
+                "schema: added request-extra field %s (verb=%s, type=%r)",
+                name,
+                verb,
+                py_t,
+            )
 
 
 def _merge_response_extras(
@@ -134,7 +162,7 @@ def _merge_response_extras(
     exclude: Set[str] | None,
 ) -> None:
     """Merge **response-only** virtual fields into the output schema."""
-    buckets = getattr(orm_cls, "__autoapi_response_extras__", None)
+    buckets = getattr(orm_cls, AUTOAPI_RESPONSE_EXTRAS_ATTR, None)
     if not buckets:
         return
 
@@ -149,7 +177,12 @@ def _merge_response_extras(
             else:
                 py_t, fld = (spec or Any), Field(None)
             _add_field(fields, name=name, py_t=py_t, field=fld)
-            logger.debug("schema: added response-extra field %s (verb=%s, type=%r)", name, verb, py_t)
+            logger.debug(
+                "schema: added response-extra field %s (verb=%s, type=%r)",
+                name,
+                verb,
+                py_t,
+            )
 
 
 def _python_type(col: Any) -> type | Any:
@@ -168,13 +201,16 @@ def _is_required(col: Any, verb: str) -> bool:
     if getattr(col, "primary_key", False) and verb in {"update", "replace", "delete"}:
         return True
     is_nullable = bool(getattr(col, "nullable", True))
-    has_default = (getattr(col, "default", None) is not None) or (getattr(col, "server_default", None) is not None)
+    has_default = (getattr(col, "default", None) is not None) or (
+        getattr(col, "server_default", None) is not None
+    )
     return not is_nullable and not has_default
 
 
 # ───────────────────────────────────────────────────────────────────────────────
 # Public builders
 # ───────────────────────────────────────────────────────────────────────────────
+
 
 def _schema(
     orm_cls: type,
@@ -205,7 +241,13 @@ def _schema(
         logger.debug("schema: cache hit %s verb=%s", orm_cls.__name__, verb)
         return cached
 
-    logger.debug("schema: building %s verb=%s include=%s exclude=%s", orm_cls.__name__, verb, include, exclude)
+    logger.debug(
+        "schema: building %s verb=%s include=%s exclude=%s",
+        orm_cls.__name__,
+        verb,
+        include,
+        exclude,
+    )
     fields: Dict[str, Tuple[type, Field]] = {}
 
     # ── PASS 1: table-backed columns only (avoid mapper relationships)
@@ -229,7 +271,9 @@ def _schema(
         # Legacy flags
         if verb == "create" and getattr(meta_src, "get", lambda *_: None)("no_create"):
             continue
-        if verb in {"update", "replace"} and getattr(meta_src, "get", lambda *_: None)("no_update"):
+        if verb in {"update", "replace"} and getattr(meta_src, "get", lambda *_: None)(
+            "no_update"
+        ):
             continue
 
         # Disable on verb
@@ -271,7 +315,9 @@ def _schema(
             py_t = Union[py_t, None]
 
         _add_field(fields, name=attr_name, py_t=py_t, field=fld)
-        logger.debug("schema: added field %s required=%s type=%r", attr_name, required, py_t)
+        logger.debug(
+            "schema: added field %s required=%s type=%r", attr_name, required, py_t
+        )
 
     # ── PASS 2: @hybrid_property (opt-in via meta["hybrid"])
     for attr_name, attr in list(getattr(orm_cls, "__dict__", {}).items()):
@@ -291,7 +337,11 @@ def _schema(
             continue
 
         # Write-phase without setter is not usable
-        if getattr(attr, "fset", None) is None and verb in {"create", "update", "replace"}:
+        if getattr(attr, "fset", None) is None and verb in {
+            "create",
+            "update",
+            "replace",
+        }:
             continue
 
         py_t = getattr(attr, "python_type", meta.get("py_type", Any))
@@ -338,8 +388,12 @@ def create_list_schema(model: type) -> Type[BaseModel]:
     table = getattr(model, "__table__", None)
     if table is None or not getattr(table, "columns", None):
         # No table info; return a minimal pager schema
-        schema = create_model(f"{tab}ListParams", __config__=ConfigDict(extra="forbid"), **base)  # type: ignore[arg-type]
-        logger.debug("schema: create_list_schema generated %s (no columns)", schema.__name__)
+        schema = create_model(
+            f"{tab}ListParams", __config__=ConfigDict(extra="forbid"), **base
+        )  # type: ignore[arg-type]
+        logger.debug(
+            "schema: create_list_schema generated %s (no columns)", schema.__name__
+        )
         return schema
 
     # Determine primary key name (first PK column)
@@ -379,10 +433,18 @@ def _strip_parent_fields(base: Type[BaseModel], *, drop: Set[str]) -> Type[BaseM
         if name in (drop or ()):
             continue
         typ = hints.get(name, Any)
-        default = finfo.default if getattr(finfo, "default", PydanticUndefined) is not PydanticUndefined else ...
+        default = (
+            finfo.default
+            if getattr(finfo, "default", PydanticUndefined) is not PydanticUndefined
+            else ...
+        )
         new_fields[name] = (typ, default)
 
-    clone = create_model(f"{base.__name__}Pruned", __config__=getattr(base, "model_config", None), **new_fields)  # type: ignore[arg-type]
+    clone = create_model(
+        f"{base.__name__}Pruned",
+        __config__=getattr(base, "model_config", None),
+        **new_fields,
+    )  # type: ignore[arg-type]
     clone.model_rebuild(force=True)
     return clone
 

--- a/pkgs/standards/autoapi/autoapi/v3/types/op_config_provider.py
+++ b/pkgs/standards/autoapi/autoapi/v3/types/op_config_provider.py
@@ -2,21 +2,28 @@ from __future__ import annotations
 from typing import Iterable, Literal, Type
 from .table_config_provider import TableConfigProvider
 from ..opspec import OpSpec
-from ..opspec.model_registry import get_registered_ops
+from ..config.constants import (
+    AUTOAPI_DEFAULTS_EXCLUDE_ATTR,
+    AUTOAPI_DEFAULTS_INCLUDE_ATTR,
+    AUTOAPI_DEFAULTS_MODE_ATTR,
+)
 
 
 class OpConfigProvider(TableConfigProvider):
     __autoapi_ops__: Iterable[OpSpec] = ()
 
     # Default canonical verbs wiring policy
-    __autoapi_defaults_mode__: Literal["all","none","some"] = "all"
+    __autoapi_defaults_mode__: Literal["all", "none", "some"] = "all"
     __autoapi_defaults_include__: set[str] = set()
     __autoapi_defaults_exclude__: set[str] = set()
 
+
 def should_wire_canonical(table: Type, op: str) -> bool:
-    mode = getattr(table, "__autoapi_defaults_mode__", "all")
-    inc  = getattr(table, "__autoapi_defaults_include__", set())
-    exc  = getattr(table, "__autoapi_defaults_exclude__", set())
-    if mode == "none": return False
-    if mode == "some": return op in inc
+    mode = getattr(table, AUTOAPI_DEFAULTS_MODE_ATTR, "all")
+    inc = getattr(table, AUTOAPI_DEFAULTS_INCLUDE_ATTR, set())
+    exc = getattr(table, AUTOAPI_DEFAULTS_EXCLUDE_ATTR, set())
+    if mode == "none":
+        return False
+    if mode == "some":
+        return op in inc
     return op not in exc  # mode == "all"


### PR DESCRIPTION
## Summary
- centralize `__autoapi__` attribute names in config constants
- replace string lookups across v3 modules with imports from `config.constants`

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check autoapi/v3/autoapi.py autoapi/v3/bindings/api.py autoapi/v3/bindings/hooks.py autoapi/v3/bindings/model.py autoapi/v3/bindings/rest.py autoapi/v3/compat/transactional.py autoapi/v3/config/constants.py autoapi/v3/mixins/ownable.py autoapi/v3/mixins/tenant_bound.py autoapi/v3/opspec/collect.py autoapi/v3/opspec/decorators.py autoapi/v3/rest/__init__.py autoapi/v3/runtime/executor.py autoapi/v3/schema/builder.py autoapi/v3/types/op_config_provider.py`
- `uv run --package autoapi --directory pkgs/standards/autoapi pytest` *(fails: No module named 'autoapi.v2.impl.errors')*

------
https://chatgpt.com/codex/tasks/task_e_689e4c9eba14832698ddb37f90d99483