### PR TITLE
Rename diagnostics attach function to mount_diagnostics

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/__init__.py
@@ -6,7 +6,7 @@ This package exposes the OpSpec-centric building blocks for binding models,
 wiring schemas/handlers/hooks, registering RPC and REST, and mounting optional
 transports/diagnostics. Keep usage simple and explicit:
 
-    from autoapi.v3 import include_model, build_jsonrpc_router, attach_diagnostics
+    from autoapi.v3 import include_model, build_jsonrpc_router, mount_diagnostics
     from autoapi.v3 import OpSpec, get_registry, op, op_alias
 
     # bind a model
@@ -14,7 +14,7 @@ transports/diagnostics. Keep usage simple and explicit:
 
     # mount JSON-RPC & diagnostics (optional)
     app.include_router(build_jsonrpc_router(api), prefix="/rpc")
-    app.include_router(attach_diagnostics(api), prefix="/system")
+    app.include_router(mount_diagnostics(api), prefix="/system")
 """
 
 from __future__ import annotations
@@ -46,7 +46,7 @@ from .schema import _schema, create_list_schema
 
 # ── Transport(s) & System diagnostics (optional) ───────────────────────────────
 from .transport.jsonrpc import build_jsonrpc_router
-from .system import attach_diagnostics
+from .system import mount_diagnostics
 
 # ── DB/bootstrap helpers (infra; optional) ─────────────────────────────────────
 from .system.dbschema import ensure_schemas, register_sqlite_attach, bootstrap_dbschema
@@ -55,23 +55,40 @@ from .system.dbschema import ensure_schemas, register_sqlite_attach, bootstrap_d
 from .config.constants import DEFAULT_HTTP_METHODS
 
 from .autoapi import AutoAPI
+
 __all__ = [
     # OpSpec
-    "OpSpec", "get_registry", "op", "op_alias", "PHASES", "HookPhase",
+    "OpSpec",
+    "get_registry",
+    "op",
+    "op_alias",
+    "PHASES",
+    "HookPhase",
     # Bindings
-    "bind", "rebind",
-    "build_schemas", "build_hooks", "build_handlers", "register_rpc", "build_rest",
-    "include_model", "include_models", "rpc_call",
+    "bind",
+    "rebind",
+    "build_schemas",
+    "build_hooks",
+    "build_handlers",
+    "register_rpc",
+    "build_rest",
+    "include_model",
+    "include_models",
+    "rpc_call",
     # Runtime
     "_invoke",
     # Schema
-    "_schema", "create_list_schema",
+    "_schema",
+    "create_list_schema",
     # Transport / System
-    "build_jsonrpc_router", "attach_diagnostics",
+    "build_jsonrpc_router",
+    "mount_diagnostics",
     # DB/infra
-    "ensure_schemas", "register_sqlite_attach", "bootstrap_dbschema",
+    "ensure_schemas",
+    "register_sqlite_attach",
+    "bootstrap_dbschema",
     # Config
     "DEFAULT_HTTP_METHODS",
     # Factory"
-    "AutoAPI"
+    "AutoAPI",
 ]

--- a/pkgs/standards/autoapi/autoapi/v3/autoapi.py
+++ b/pkgs/standards/autoapi/autoapi/v3/autoapi.py
@@ -3,12 +3,26 @@ from __future__ import annotations
 
 import copy
 from types import SimpleNamespace
-from typing import Any, Awaitable, Callable, Dict, Iterable, Mapping, Optional, Sequence, Tuple
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    Iterable,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+)
 
-from .bindings.api import include_model as _include_model, include_models as _include_models, rpc_call as _rpc_call
+from .bindings.api import (
+    include_model as _include_model,
+    include_models as _include_models,
+    rpc_call as _rpc_call,
+)
 from .bindings.model import rebind as _rebind, bind as _bind
 from .transport import mount_jsonrpc as _mount_jsonrpc
-from .system import attach_diagnostics as _attach_diagnostics
+from .system import mount_diagnostics as _mount_diagnostics
 from .opspec import get_registry, OpSpec
 
 # optional compat: legacy transactional decorator
@@ -43,7 +57,9 @@ class AutoAPI:
         get_async_db: Optional[Callable[..., Awaitable[Any]]] = None,
         jsonrpc_prefix: str = "/rpc",
         system_prefix: str = "/system",
-        api_hooks: Mapping[str, Iterable[Callable]] | Mapping[str, Mapping[str, Iterable[Callable]]] | None = None,
+        api_hooks: Mapping[str, Iterable[Callable]]
+        | Mapping[str, Mapping[str, Iterable[Callable]]]
+        | None = None,
     ) -> None:
         # host app (FastAPI or APIRouter)
         self.app = app
@@ -107,20 +123,34 @@ class AutoAPI:
 
     # ------------------------- primary operations -------------------------
 
-    def include_model(self, model: type, *, prefix: str | None = None, mount_router: bool = True) -> Tuple[type, Any]:
+    def include_model(
+        self, model: type, *, prefix: str | None = None, mount_router: bool = True
+    ) -> Tuple[type, Any]:
         """
         Bind a model, mount its REST router, and attach all namespaces to this facade.
         """
         # inject API-level hooks so the binder merges them
         self._merge_api_hooks_into_model(model, self._api_hooks_map)
-        return _include_model(self, model, app=self.app, prefix=prefix, mount_router=mount_router)
+        return _include_model(
+            self, model, app=self.app, prefix=prefix, mount_router=mount_router
+        )
 
     def include_models(
-        self, models: Sequence[type], *, base_prefix: str | None = None, mount_router: bool = True
+        self,
+        models: Sequence[type],
+        *,
+        base_prefix: str | None = None,
+        mount_router: bool = True,
     ) -> Dict[str, Any]:
         for m in models:
             self._merge_api_hooks_into_model(m, self._api_hooks_map)
-        return _include_models(self, models, app=self.app, base_prefix=base_prefix, mount_router=mount_router)
+        return _include_models(
+            self,
+            models,
+            app=self.app,
+            base_prefix=base_prefix,
+            mount_router=mount_router,
+        )
 
     async def rpc_call(
         self,
@@ -132,19 +162,29 @@ class AutoAPI:
         request: Any = None,
         ctx: Optional[Dict[str, Any]] = None,
     ) -> Any:
-        return await _rpc_call(self, model_or_name, method, payload, db=db, request=request, ctx=ctx)
+        return await _rpc_call(
+            self, model_or_name, method, payload, db=db, request=request, ctx=ctx
+        )
 
     # ------------------------- extras / mounting -------------------------
 
     def mount_jsonrpc(self, *, prefix: str | None = None) -> Any:
         """Mount JSON-RPC router onto `self.app`."""
         px = prefix if prefix is not None else self.jsonrpc_prefix
-        return _mount_jsonrpc(self, self.app, prefix=px, get_db=self.get_db, get_async_db=self.get_async_db)
+        return _mount_jsonrpc(
+            self,
+            self.app,
+            prefix=px,
+            get_db=self.get_db,
+            get_async_db=self.get_async_db,
+        )
 
-    def attach_diagnostics(self, *, prefix: str | None = None) -> Any:
+    def mount_diagnostics(self, *, prefix: str | None = None) -> Any:
         """Mount diagnostics router onto `self.app`."""
         px = prefix if prefix is not None else self.system_prefix
-        router = _attach_diagnostics(self, get_db=self.get_db, get_async_db=self.get_async_db)
+        router = _mount_diagnostics(
+            self, get_db=self.get_db, get_async_db=self.get_async_db
+        )
         if hasattr(self.app, "include_router") and callable(self.app.include_router):
             self.app.include_router(router, prefix=px)
         return router
@@ -160,7 +200,9 @@ class AutoAPI:
         self._merge_api_hooks_into_model(model, self._api_hooks_map)
         return _bind(model)
 
-    def rebind(self, model: type, *, changed_keys: Optional[set[tuple[str, str]]] = None) -> Tuple[OpSpec, ...]:
+    def rebind(
+        self, model: type, *, changed_keys: Optional[set[tuple[str, str]]] = None
+    ) -> Tuple[OpSpec, ...]:
         """Targeted rebuild of a bound model."""
         return _rebind(model, changed_keys=changed_keys)
 

--- a/pkgs/standards/autoapi/autoapi/v3/system/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/system/__init__.py
@@ -2,11 +2,11 @@
 """
 AutoAPI v3 – System/Diagnostics helpers.
 
-- attach_diagnostics(api, *, get_db=None, get_async_db=None) -> APIRouter
+- mount_diagnostics(api, *, get_db=None, get_async_db=None) -> APIRouter
 """
 
 from __future__ import annotations
 
-from .diagnostics import attach_diagnostics
+from .diagnostics import mount_diagnostics
 
-__all__ = ["attach_diagnostics"]
+__all__ = ["mount_diagnostics"]


### PR DESCRIPTION
## Summary
- rename `attach_diagnostics` to `mount_diagnostics`
- update AutoAPI to expose new `mount_diagnostics` helper
- adjust package exports and docs for `mount_diagnostics`

## Testing
- `uv run --directory standards --package autoapi ruff check autoapi/autoapi/v3/__init__.py autoapi/autoapi/v3/autoapi.py autoapi/autoapi/v3/system/__init__.py autoapi/autoapi/v3/system/diagnostics.py --fix`
- `uv run --directory standards --package autoapi pytest autoapi` *(fails: ModuleNotFoundError: No module named 'autoapi.v2.impl.errors')*


------
https://chatgpt.com/codex/tasks/task_e_689e4dfc11948326a22bb78f3d7a9497