### PR TITLE
chore(autoapi): centralize autoapi dunder keys

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/autoapi.py
+++ b/pkgs/standards/autoapi/autoapi/v3/autoapi.py
@@ -3,13 +3,28 @@ from __future__ import annotations
 
 import copy
 from types import SimpleNamespace
-from typing import Any, Awaitable, Callable, Dict, Iterable, Mapping, Optional, Sequence, Tuple
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    Iterable,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+)
 
-from .bindings.api import include_model as _include_model, include_models as _include_models, rpc_call as _rpc_call
+from .bindings.api import (
+    include_model as _include_model,
+    include_models as _include_models,
+    rpc_call as _rpc_call,
+)
 from .bindings.model import rebind as _rebind, bind as _bind
 from .transport import mount_jsonrpc as _mount_jsonrpc
 from .system import attach_diagnostics as _attach_diagnostics
 from .opspec import get_registry, OpSpec
+from .config.constants import API_HOOKS_ATTR
 
 # optional compat: legacy transactional decorator
 try:
@@ -43,7 +58,9 @@ class AutoAPI:
         get_async_db: Optional[Callable[..., Awaitable[Any]]] = None,
         jsonrpc_prefix: str = "/rpc",
         system_prefix: str = "/system",
-        api_hooks: Mapping[str, Iterable[Callable]] | Mapping[str, Mapping[str, Iterable[Callable]]] | None = None,
+        api_hooks: Mapping[str, Iterable[Callable]]
+        | Mapping[str, Mapping[str, Iterable[Callable]]]
+        | None = None,
     ) -> None:
         # host app (FastAPI or APIRouter)
         self.app = app
@@ -81,9 +98,9 @@ class AutoAPI:
         """
         if not hooks_map:
             return
-        existing = getattr(model, "__autoapi_api_hooks__", None)
+        existing = getattr(model, API_HOOKS_ATTR, None)
         if existing is None:
-            setattr(model, "__autoapi_api_hooks__", copy.deepcopy(hooks_map))
+            setattr(model, API_HOOKS_ATTR, copy.deepcopy(hooks_map))
             return
 
         # shallow merge (alias or phase keys); values are lists we extend
@@ -103,24 +120,38 @@ class AutoAPI:
                         merged[k] = list(merged[k]) + list(v or [])
                     else:
                         merged[k] = v
-        setattr(model, "__autoapi_api_hooks__", merged)
+        setattr(model, API_HOOKS_ATTR, merged)
 
     # ------------------------- primary operations -------------------------
 
-    def include_model(self, model: type, *, prefix: str | None = None, mount_router: bool = True) -> Tuple[type, Any]:
+    def include_model(
+        self, model: type, *, prefix: str | None = None, mount_router: bool = True
+    ) -> Tuple[type, Any]:
         """
         Bind a model, mount its REST router, and attach all namespaces to this facade.
         """
         # inject API-level hooks so the binder merges them
         self._merge_api_hooks_into_model(model, self._api_hooks_map)
-        return _include_model(self, model, app=self.app, prefix=prefix, mount_router=mount_router)
+        return _include_model(
+            self, model, app=self.app, prefix=prefix, mount_router=mount_router
+        )
 
     def include_models(
-        self, models: Sequence[type], *, base_prefix: str | None = None, mount_router: bool = True
+        self,
+        models: Sequence[type],
+        *,
+        base_prefix: str | None = None,
+        mount_router: bool = True,
     ) -> Dict[str, Any]:
         for m in models:
             self._merge_api_hooks_into_model(m, self._api_hooks_map)
-        return _include_models(self, models, app=self.app, base_prefix=base_prefix, mount_router=mount_router)
+        return _include_models(
+            self,
+            models,
+            app=self.app,
+            base_prefix=base_prefix,
+            mount_router=mount_router,
+        )
 
     async def rpc_call(
         self,
@@ -132,19 +163,29 @@ class AutoAPI:
         request: Any = None,
         ctx: Optional[Dict[str, Any]] = None,
     ) -> Any:
-        return await _rpc_call(self, model_or_name, method, payload, db=db, request=request, ctx=ctx)
+        return await _rpc_call(
+            self, model_or_name, method, payload, db=db, request=request, ctx=ctx
+        )
 
     # ------------------------- extras / mounting -------------------------
 
     def mount_jsonrpc(self, *, prefix: str | None = None) -> Any:
         """Mount JSON-RPC router onto `self.app`."""
         px = prefix if prefix is not None else self.jsonrpc_prefix
-        return _mount_jsonrpc(self, self.app, prefix=px, get_db=self.get_db, get_async_db=self.get_async_db)
+        return _mount_jsonrpc(
+            self,
+            self.app,
+            prefix=px,
+            get_db=self.get_db,
+            get_async_db=self.get_async_db,
+        )
 
     def attach_diagnostics(self, *, prefix: str | None = None) -> Any:
         """Mount diagnostics router onto `self.app`."""
         px = prefix if prefix is not None else self.system_prefix
-        router = _attach_diagnostics(self, get_db=self.get_db, get_async_db=self.get_async_db)
+        router = _attach_diagnostics(
+            self, get_db=self.get_db, get_async_db=self.get_async_db
+        )
         if hasattr(self.app, "include_router") and callable(self.app.include_router):
             self.app.include_router(router, prefix=px)
         return router
@@ -160,7 +201,9 @@ class AutoAPI:
         self._merge_api_hooks_into_model(model, self._api_hooks_map)
         return _bind(model)
 
-    def rebind(self, model: type, *, changed_keys: Optional[set[tuple[str, str]]] = None) -> Tuple[OpSpec, ...]:
+    def rebind(
+        self, model: type, *, changed_keys: Optional[set[tuple[str, str]]] = None
+    ) -> Tuple[OpSpec, ...]:
         """Targeted rebuild of a bound model."""
         return _rebind(model, changed_keys=changed_keys)
 

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/hooks.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/hooks.py
@@ -4,10 +4,26 @@ from __future__ import annotations
 import inspect
 import logging
 from types import SimpleNamespace
-from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+)
 
 from ..opspec import OpHook, OpSpec
-from ..opspec.types import PHASES, HookPhase, StepFn
+from ..opspec.types import PHASES, StepFn
+from ..config.constants import (
+    CTX_SKIP_PERSIST_FLAG,
+    API_HOOKS_ATTR,
+    HOOKS_ATTR,
+    IMPERATIVE_HOOKS_ATTR,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -22,21 +38,25 @@ _Key = Tuple[str, str]  # (alias, target)
 
 _PRE_LIKE = frozenset({"PRE_TX_BEGIN", "START_TX", "PRE_HANDLER", "PRE_COMMIT"})
 _POST_LIKE = frozenset({"POST_HANDLER", "POST_COMMIT", "POST_RESPONSE", "FINAL"})
-_ERROR_LIKE = frozenset({
-    "ON_ROLLBACK",
-    "ON_PRE_HANDLER_ERROR",
-    "ON_HANDLER_ERROR",
-    "ON_POST_HANDLER_ERROR",
-    "ON_PRE_COMMIT_ERROR",
-    # v3 uses END_TX; map v2's ON_COMMIT_ERROR → ON_END_TX_ERROR
-    "ON_END_TX_ERROR",
-    "ON_POST_COMMIT_ERROR",
-    "ON_POST_RESPONSE_ERROR",
-    "ON_ERROR",
-})
+_ERROR_LIKE = frozenset(
+    {
+        "ON_ROLLBACK",
+        "ON_PRE_HANDLER_ERROR",
+        "ON_HANDLER_ERROR",
+        "ON_POST_HANDLER_ERROR",
+        "ON_PRE_COMMIT_ERROR",
+        # v3 uses END_TX; map v2's ON_COMMIT_ERROR → ON_END_TX_ERROR
+        "ON_END_TX_ERROR",
+        "ON_POST_COMMIT_ERROR",
+        "ON_POST_RESPONSE_ERROR",
+        "ON_ERROR",
+    }
+)
+
 
 def _is_pre_like(p: str) -> bool:
     return p in _PRE_LIKE
+
 
 def _is_post_or_error(p: str) -> bool:
     return p in _POST_LIKE or p in _ERROR_LIKE
@@ -46,25 +66,32 @@ def _is_post_or_error(p: str) -> bool:
 # ctx helpers
 # ───────────────────────────────────────────────────────────────────────────────
 
+
 def _ctx_get(ctx: Mapping[str, Any], key: str, default: Any = None) -> Any:
     try:
         return ctx[key]
     except Exception:
         return getattr(ctx, key, default)
 
+
 def _ctx_db(ctx: Mapping[str, Any]) -> Any:
     return _ctx_get(ctx, "db")
+
 
 def _ctx_payload(ctx: Mapping[str, Any]) -> Mapping[str, Any]:
     return _ctx_get(ctx, "payload", {}) or {}
 
+
 def _is_async_db(db: Any) -> bool:
-    return hasattr(db, "run_sync") or inspect.iscoroutinefunction(getattr(db, "commit", None))
+    return hasattr(db, "run_sync") or inspect.iscoroutinefunction(
+        getattr(db, "commit", None)
+    )
 
 
 # ───────────────────────────────────────────────────────────────────────────────
 # Default transactional steps
 # ───────────────────────────────────────────────────────────────────────────────
+
 
 def _default_start_tx() -> StepFn:
     async def _step(ctx: Any) -> None:
@@ -78,7 +105,9 @@ def _default_start_tx() -> StepFn:
             await begin()  # type: ignore[misc]
         else:
             begin()
+
     return _step
+
 
 def _default_end_tx() -> StepFn:
     async def _step(ctx: Any) -> None:
@@ -92,14 +121,17 @@ def _default_end_tx() -> StepFn:
             await commit()  # type: ignore[misc]
         else:
             commit()
+
     return _step
+
 
 def _mark_skip_persist() -> StepFn:
     async def _step(ctx: Any) -> None:
         try:
-            ctx["__autoapi_skip_persist__"] = True
+            ctx[CTX_SKIP_PERSIST_FLAG] = True
         except Exception:
-            setattr(ctx, "__autoapi_skip_persist__", True)
+            setattr(ctx, CTX_SKIP_PERSIST_FLAG, True)
+
     return _step
 
 
@@ -107,9 +139,11 @@ def _mark_skip_persist() -> StepFn:
 # Step wrappers
 # ───────────────────────────────────────────────────────────────────────────────
 
+
 def _wrap_hook(h: OpHook) -> StepFn:
     fn = h.fn
     pred = h.when
+
     async def _step(ctx: Any) -> Any:
         if pred is not None:
             payload = _ctx_payload(ctx)
@@ -125,7 +159,9 @@ def _wrap_hook(h: OpHook) -> StepFn:
         if inspect.isawaitable(rv):
             return await rv
         return rv
+
     return _step
+
 
 def _wrap_step_fn(fn: Callable[..., Any]) -> StepFn:
     async def _step(ctx: Any) -> Any:
@@ -133,6 +169,7 @@ def _wrap_step_fn(fn: Callable[..., Any]) -> StepFn:
         if inspect.isawaitable(rv):
             return await rv
         return rv
+
     return _step
 
 
@@ -142,6 +179,7 @@ def _wrap_step_fn(fn: Callable[..., Any]) -> StepFn:
 #   • { phase: Iterable[callable] }                      (applies to all aliases)
 #   • { alias: { phase: Iterable[callable] } }           (per-alias)
 # ───────────────────────────────────────────────────────────────────────────────
+
 
 def _to_phase_map_for_alias(source: Any, alias: str) -> Dict[str, List[StepFn]]:
     """
@@ -177,6 +215,7 @@ def _to_phase_map_for_alias(source: Any, alias: str) -> Dict[str, List[StepFn]]:
 # Precedence merge
 # ───────────────────────────────────────────────────────────────────────────────
 
+
 def _merge_for_phase(
     phase: str,
     *,
@@ -190,6 +229,7 @@ def _merge_for_phase(
       • pre-like  → API + MODEL + OP + IMPERATIVE
       • post/error→ IMPERATIVE + OP + MODEL + API
     """
+
     def _get(m: Mapping[str, List[StepFn]] | None) -> List[StepFn]:
         if not m:
             return []
@@ -204,6 +244,7 @@ def _merge_for_phase(
 # ───────────────────────────────────────────────────────────────────────────────
 # Alias namespace helper
 # ───────────────────────────────────────────────────────────────────────────────
+
 
 def _ensure_alias_hooks_ns(model: type, alias: str) -> SimpleNamespace:
     root = getattr(model, "hooks", None)
@@ -225,6 +266,7 @@ def _ensure_alias_hooks_ns(model: type, alias: str) -> SimpleNamespace:
 # Build / attach (with precedence)
 # ───────────────────────────────────────────────────────────────────────────────
 
+
 def _attach_one(model: type, sp: OpSpec) -> None:
     alias = sp.alias
     ns = _ensure_alias_hooks_ns(model, alias)
@@ -236,11 +278,11 @@ def _attach_one(model: type, sp: OpSpec) -> None:
     # Resolve source maps for this alias
     # API-level hooks may be injected by the API facade before binding:
     #   model.__autoapi_api_hooks__ = {phase:[...]} or {"*":{phase:[...]}, alias:{...}}
-    api_src = getattr(model, "__autoapi_api_hooks__", None)
+    api_src = getattr(model, API_HOOKS_ATTR, None)
     api_map = _to_phase_map_for_alias(api_src, alias)
 
     # Model/table-level defaults
-    model_src = getattr(model, "__autoapi_hooks__", None)
+    model_src = getattr(model, HOOKS_ATTR, None)
     model_map = _to_phase_map_for_alias(model_src, alias)
 
     # Op-level (from OpSpec.hooks)
@@ -250,12 +292,14 @@ def _attach_one(model: type, sp: OpSpec) -> None:
         op_map.setdefault(phase, []).append(_wrap_hook(h))
 
     # Imperative (runtime/registry) – same accepted shapes as API/MODEL
-    imp_src = getattr(model, "__autoapi_imperative_hooks__", None)
+    imp_src = getattr(model, IMPERATIVE_HOOKS_ATTR, None)
     imp_map = _to_phase_map_for_alias(imp_src, alias)
 
     # Build per-phase chains via precedence merge
     for ph in PHASES:
-        merged = _merge_for_phase(ph, api_map=api_map, model_map=model_map, op_map=op_map, imp_map=imp_map)
+        merged = _merge_for_phase(
+            ph, api_map=api_map, model_map=model_map, op_map=op_map, imp_map=imp_map
+        )
 
         # Inject default transactional steps (persistent ops only)
         if sp.persist != "skip":
@@ -272,10 +316,17 @@ def _attach_one(model: type, sp: OpSpec) -> None:
 
         setattr(ns, ph, merged)
 
-    logger.debug("hooks: %s.%s merged with precedence (persist=%s)", model.__name__, alias, sp.persist)
+    logger.debug(
+        "hooks: %s.%s merged with precedence (persist=%s)",
+        model.__name__,
+        alias,
+        sp.persist,
+    )
 
 
-def normalize_and_attach(model: type, specs: Sequence[OpSpec], *, only_keys: Optional[Sequence[_Key]] = None) -> None:
+def normalize_and_attach(
+    model: type, specs: Sequence[OpSpec], *, only_keys: Optional[Sequence[_Key]] = None
+) -> None:
     """
     Build sequential phase chains for each OpSpec and attach them to model.hooks.<alias>.
     If `only_keys` is provided, limit work to those (alias,target) pairs.

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/model.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/model.py
@@ -3,19 +3,37 @@ from __future__ import annotations
 
 import logging
 from types import SimpleNamespace
-from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Set, Tuple, Type
+from typing import (
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+)
 
 from ..opspec import OpSpec
 from ..opspec import resolve as resolve_opspecs
 from ..opspec import get_registry, OpspecRegistry
+from ..config.constants import REGISTRY_LISTENER_ATTR
 
 # These modules will be implemented next in the bindings package.
 # They should expose the functions used below with the given signatures.
-from . import schemas as _schemas_binding          # build_and_attach(model, specs, only_keys=None) -> None
-from . import hooks as _hooks_binding              # normalize_and_attach(model, specs, only_keys=None) -> None
-from . import handlers as _handlers_binding        # build_and_attach(model, specs, only_keys=None) -> None
-from . import rpc as _rpc_binding                  # register_and_attach(model, specs, only_keys=None) -> None
-from . import rest as _rest_binding                # build_router_and_attach(model, specs, only_keys=None) -> None
+from . import (
+    schemas as _schemas_binding,
+)  # build_and_attach(model, specs, only_keys=None) -> None
+from . import (
+    hooks as _hooks_binding,
+)  # normalize_and_attach(model, specs, only_keys=None) -> None
+from . import (
+    handlers as _handlers_binding,
+)  # build_and_attach(model, specs, only_keys=None) -> None
+from . import (
+    rpc as _rpc_binding,
+)  # register_and_attach(model, specs, only_keys=None) -> None
+from . import (
+    rest as _rest_binding,
+)  # build_router_and_attach(model, specs, only_keys=None) -> None
 
 logger = logging.getLogger(__name__)
 
@@ -26,8 +44,10 @@ logger = logging.getLogger(__name__)
 
 _Key = Tuple[str, str]  # (alias, target)
 
+
 def _key(sp: OpSpec) -> _Key:
     return (sp.alias, sp.target)
+
 
 def _ensure_model_namespaces(model: type) -> None:
     """
@@ -55,12 +75,17 @@ def _ensure_model_namespaces(model: type) -> None:
     if not hasattr(model, "columns"):
         table = getattr(model, "__table__", None)
         cols = tuple(getattr(table, "columns", ()) or ())
-        model.columns = tuple(getattr(c, "name", None) for c in cols if getattr(c, "name", None))
+        model.columns = tuple(
+            getattr(c, "name", None) for c in cols if getattr(c, "name", None)
+        )
     if not hasattr(model, "table_config"):
         table = getattr(model, "__table__", None)
         model.table_config = dict(getattr(table, "kwargs", {}) or {})
 
-def _index_specs(specs: Sequence[OpSpec]) -> Tuple[Tuple[OpSpec, ...], Dict[_Key, OpSpec], Dict[str, List[OpSpec]]]:
+
+def _index_specs(
+    specs: Sequence[OpSpec],
+) -> Tuple[Tuple[OpSpec, ...], Dict[_Key, OpSpec], Dict[str, List[OpSpec]]]:
     all_specs: Tuple[OpSpec, ...] = tuple(specs)
     by_key: Dict[_Key, OpSpec] = {}
     by_alias: Dict[str, List[OpSpec]] = {}
@@ -69,6 +94,7 @@ def _index_specs(specs: Sequence[OpSpec]) -> Tuple[Tuple[OpSpec, ...], Dict[_Key
         by_key[k] = sp
         by_alias.setdefault(sp.alias, []).append(sp)
     return all_specs, by_key, by_alias
+
 
 def _drop_old_entries(model: type, *, keys: Set[_Key] | None) -> None:
     """
@@ -120,6 +146,7 @@ def _drop_old_entries(model: type, *, keys: Set[_Key] | None) -> None:
 # Public API
 # ───────────────────────────────────────────────────────────────────────────────
 
+
 def bind(model: type, *, only_keys: Optional[Set[_Key]] = None) -> Tuple[OpSpec, ...]:
     """
     Build (or refresh) all AutoAPI namespaces on the model class.
@@ -167,11 +194,15 @@ def bind(model: type, *, only_keys: Optional[Set[_Key]] = None) -> Tuple[OpSpec,
     # 5) Ensure we have a registry listener to refresh on changes
     _ensure_registry_listener(model)
 
-    logger.debug("autoapi.bindings.model.bind(%s): %d ops bound", model.__name__, len(all_specs))
+    logger.debug(
+        "autoapi.bindings.model.bind(%s): %d ops bound", model.__name__, len(all_specs)
+    )
     return all_specs
 
 
-def rebind(model: type, *, changed_keys: Optional[Set[_Key]] = None) -> Tuple[OpSpec, ...]:
+def rebind(
+    model: type, *, changed_keys: Optional[Set[_Key]] = None
+) -> Tuple[OpSpec, ...]:
     """
     Public helper to trigger a rebind for the model. If `changed_keys` is provided,
     we attempt a targeted refresh; otherwise we rebuild everything.
@@ -183,6 +214,7 @@ def rebind(model: type, *, changed_keys: Optional[Set[_Key]] = None) -> Tuple[Op
 # Registry integration
 # ───────────────────────────────────────────────────────────────────────────────
 
+
 def _ensure_registry_listener(model: type) -> None:
     """
     Subscribe (once) to the per-model OpspecRegistry so future register_ops/add/remove/set
@@ -191,7 +223,7 @@ def _ensure_registry_listener(model: type) -> None:
     reg: OpspecRegistry = get_registry(model)
 
     # If we already subscribed, skip
-    if getattr(model, "__autoapi_registry_listener__", None):
+    if getattr(model, REGISTRY_LISTENER_ATTR, None):
         return
 
     def _on_registry_change(registry: OpspecRegistry, changed: Set[_Key]) -> None:
@@ -199,11 +231,16 @@ def _ensure_registry_listener(model: type) -> None:
             # Targeted rebind using changed keys
             rebind(model, changed_keys=changed)
         except Exception as e:  # pragma: no cover
-            logger.exception("autoapi: rebind failed for %s on ops %s: %s", model.__name__, changed, e)
+            logger.exception(
+                "autoapi: rebind failed for %s on ops %s: %s",
+                model.__name__,
+                changed,
+                e,
+            )
 
     reg.subscribe(_on_registry_change)
     # Keep a reference to avoid GC of the closure and to prevent double-subscribe
-    setattr(model, "__autoapi_registry_listener__", _on_registry_change)
+    setattr(model, REGISTRY_LISTENER_ATTR, _on_registry_change)
 
 
 __all__ = ["bind", "rebind"]

--- a/pkgs/standards/autoapi/autoapi/v3/config/constants.py
+++ b/pkgs/standards/autoapi/autoapi/v3/config/constants.py
@@ -17,7 +17,7 @@ Nothing in this module performs I/O.
 
 from __future__ import annotations
 
-from typing import Dict, Mapping, Tuple
+from typing import Mapping, Tuple
 
 from ..opspec.types import CANON  # canonical op registry (dict-like of targets)
 
@@ -27,13 +27,17 @@ from ..opspec.types import CANON  # canonical op registry (dict-like of targets)
 # ───────────────────────────────────────────────────────────────────────────────
 
 # Source of truth: `CANON` keys (strings like "create", "read", "bulk_update", ...)
-ALL_VERBS: frozenset[str] = frozenset(str(k) for k in (CANON.keys() if hasattr(CANON, "keys") else CANON))  # type: ignore[arg-type]
+ALL_VERBS: frozenset[str] = frozenset(
+    str(k) for k in (CANON.keys() if hasattr(CANON, "keys") else CANON)
+)  # type: ignore[arg-type]
 
 # Bulk targets are those prefixed with "bulk_"
 BULK_VERBS: frozenset[str] = frozenset(v for v in ALL_VERBS if v.startswith("bulk_"))
 
 # Routable canonical (non-bulk) verbs; excludes the synthetic "custom"
-ROUTING_VERBS: frozenset[str] = frozenset(v for v in ALL_VERBS if not v.startswith("bulk_") and v != "custom")
+ROUTING_VERBS: frozenset[str] = frozenset(
+    v for v in ALL_VERBS if not v.startswith("bulk_") and v != "custom"
+)
 
 
 # ───────────────────────────────────────────────────────────────────────────────
@@ -61,34 +65,82 @@ DEFAULT_HTTP_METHODS: Mapping[str, Tuple[str, ...]] = {
 #   See: v3 schema builder & v3 schema.info check(meta, attr, model)
 # ───────────────────────────────────────────────────────────────────────────────
 
-COL_LEVEL_CFGS: frozenset[str] = frozenset({
-    # legacy switches (still recognized)
-    "no_create",            # legacy: exclude column on create
-    "no_update",            # legacy: exclude column on update/replace
-    # modern flags (kept in v3)
-    "disable_on",           # iterable of verbs to disable this field on
-    "write_only",           # omit in OUT/read schemas
-    "read_only",            # omit from IN when True or when verb is in mapping
-    "default_factory",      # callable to produce default Field value
-    "examples",             # example values for OpenAPI/Pydantic
-    "hybrid",               # opt-in for @hybrid_property fields
-    "py_type",              # explicit Python type for hybrids/unknowns
-})
+COL_LEVEL_CFGS: frozenset[str] = frozenset(
+    {
+        # legacy switches (still recognized)
+        "no_create",  # legacy: exclude column on create
+        "no_update",  # legacy: exclude column on update/replace
+        # modern flags (kept in v3)
+        "disable_on",  # iterable of verbs to disable this field on
+        "write_only",  # omit in OUT/read schemas
+        "read_only",  # omit from IN when True or when verb is in mapping
+        "default_factory",  # callable to produce default Field value
+        "examples",  # example values for OpenAPI/Pydantic
+        "hybrid",  # opt-in for @hybrid_property fields
+        "py_type",  # explicit Python type for hybrids/unknowns
+    }
+)
 
 
 # ───────────────────────────────────────────────────────────────────────────────
 # Model-level configuration attributes (looked up on the SQLAlchemy class)
 # ───────────────────────────────────────────────────────────────────────────────
 
-MODEL_LEVEL_CFGS: frozenset[str] = frozenset({
-    "__autoapi_request_extras__",   # request-only virtual fields per verb
-    "__autoapi_response_extras__",  # response-only virtual fields per verb
-    "__autoapi_ops__",              # declarative OpSpec list from decorators
-    "__autoapi_verb_aliases__",     # optional verb alias map
-    "__autoapi_verb_alias_policy__",# alias policy override
-    "__autoapi_nested_paths__",     # nested path callback (optional)
-    "__resource__",                 # resource name override for REST
-})
+MODEL_LEVEL_CFGS: frozenset[str] = frozenset(
+    {
+        "__autoapi_request_extras__",  # request-only virtual fields per verb
+        "__autoapi_response_extras__",  # response-only virtual fields per verb
+        "__autoapi_ops__",  # declarative OpSpec list from decorators
+        "__autoapi_verb_aliases__",  # optional verb alias map
+        "__autoapi_verb_alias_policy__",  # alias policy override
+        "__autoapi_nested_paths__",  # nested path callback (optional)
+        "__autoapi_hooks__",  # static hook map attached to model
+        "__autoapi_api_hooks__",  # API-level hooks merged onto model
+        "__autoapi_imperative_hooks__",  # imperative hook map attached to model
+        "__autoapi_auth_dep__",  # FastAPI dependency for auth
+        "__autoapi_authorize__",  # authorization callback
+        "__autoapi_get_db__",  # sync DB session getter
+        "__autoapi_get_async_db__",  # async DB session getter
+        "__autoapi_rest_dependencies__",  # extra REST dependencies
+        "__autoapi_rpc_dependencies__",  # extra RPC dependencies
+        "__autoapi_registry_listener__",  # registry listener callback
+        "__autoapi_owner_policy__",  # owner policy for Ownable
+        "__autoapi_tenant_policy__",  # tenant policy for TenantBound
+        "__autoapi_defaults_mode__",  # default op config mode
+        "__autoapi_defaults_include__",  # default op config include
+        "__autoapi_defaults_exclude__",  # default op config exclude
+        "__resource__",  # resource name override for REST
+    }
+)
+
+
+# ───────────────────────────────────────────────────────────────────────────────
+# Internal attribute names (attached via ``getattr``/``setattr``)
+# ───────────────────────────────────────────────────────────────────────────────
+
+API_HOOKS_ATTR = "__autoapi_api_hooks__"
+AUTH_DEP_ATTR = "__autoapi_auth_dep__"
+AUTHORIZE_ATTR = "__autoapi_authorize__"
+GET_DB_ATTR = "__autoapi_get_db__"
+GET_ASYNC_DB_ATTR = "__autoapi_get_async_db__"
+REST_DEPS_ATTR = "__autoapi_rest_dependencies__"
+RPC_DEPS_ATTR = "__autoapi_rpc_dependencies__"
+HOOKS_ATTR = "__autoapi_hooks__"
+IMPERATIVE_HOOKS_ATTR = "__autoapi_imperative_hooks__"
+REGISTRY_LISTENER_ATTR = "__autoapi_registry_listener__"
+TX_MODELS_ATTR = "__autoapi_tx_models__"
+OWNER_POLICY_ATTR = "__autoapi_owner_policy__"
+TENANT_POLICY_ATTR = "__autoapi_tenant_policy__"
+CUSTOM_OP_ATTR = "__autoapi_custom_op__"
+OPS_ATTR = "__autoapi_ops__"
+VERB_ALIASES_ATTR = "__autoapi_verb_aliases__"
+VERB_ALIAS_POLICY_ATTR = "__autoapi_verb_alias_policy__"
+REQUEST_EXTRAS_ATTR = "__autoapi_request_extras__"
+RESPONSE_EXTRAS_ATTR = "__autoapi_response_extras__"
+DEFAULTS_MODE_ATTR = "__autoapi_defaults_mode__"
+DEFAULTS_INCLUDE_ATTR = "__autoapi_defaults_include__"
+DEFAULTS_EXCLUDE_ATTR = "__autoapi_defaults_exclude__"
+NESTED_PATHS_ATTR = "__autoapi_nested_paths__"
 
 
 # ───────────────────────────────────────────────────────────────────────────────
@@ -102,7 +154,7 @@ CTX_DB_KEY = "db"
 CTX_PAYLOAD_KEY = "payload"
 CTX_PATH_PARAMS_KEY = "path_params"
 CTX_ENV_KEY = "env"
-CTX_RPC_ID_KEY = "rpc_id"                    # used by the JSON-RPC dispatcher
+CTX_RPC_ID_KEY = "rpc_id"  # used by the JSON-RPC dispatcher
 CTX_SKIP_PERSIST_FLAG = "__autoapi_skip_persist__"  # set by ephemeral ops
 
 # Optional auth/multitenancy keys that middlewares may populate for hooks to read
@@ -118,6 +170,29 @@ __all__ = [
     "DEFAULT_HTTP_METHODS",
     "COL_LEVEL_CFGS",
     "MODEL_LEVEL_CFGS",
+    "API_HOOKS_ATTR",
+    "AUTH_DEP_ATTR",
+    "AUTHORIZE_ATTR",
+    "GET_DB_ATTR",
+    "GET_ASYNC_DB_ATTR",
+    "REST_DEPS_ATTR",
+    "RPC_DEPS_ATTR",
+    "HOOKS_ATTR",
+    "IMPERATIVE_HOOKS_ATTR",
+    "REGISTRY_LISTENER_ATTR",
+    "TX_MODELS_ATTR",
+    "OWNER_POLICY_ATTR",
+    "TENANT_POLICY_ATTR",
+    "CUSTOM_OP_ATTR",
+    "OPS_ATTR",
+    "VERB_ALIASES_ATTR",
+    "VERB_ALIAS_POLICY_ATTR",
+    "REQUEST_EXTRAS_ATTR",
+    "RESPONSE_EXTRAS_ATTR",
+    "DEFAULTS_MODE_ATTR",
+    "DEFAULTS_INCLUDE_ATTR",
+    "DEFAULTS_EXCLUDE_ATTR",
+    "NESTED_PATHS_ATTR",
     "CTX_REQUEST_KEY",
     "CTX_DB_KEY",
     "CTX_PAYLOAD_KEY",

--- a/pkgs/standards/autoapi/autoapi/v3/mixins/ownable.py
+++ b/pkgs/standards/autoapi/autoapi/v3/mixins/ownable.py
@@ -12,13 +12,18 @@ from sqlalchemy.orm import declared_attr
 
 from ..runtime.errors import create_standardized_error
 from ..schema.col_info import check as _info_check
-from ..config.constants import CTX_USER_ID_KEY, CTX_AUTH_KEY
+from ..config.constants import (
+    CTX_USER_ID_KEY,
+    CTX_AUTH_KEY,
+    OWNER_POLICY_ATTR,
+    HOOKS_ATTR,
+)
 
 log = logging.getLogger(__name__)
 
 
 class OwnerPolicy(str, Enum):
-    CLIENT_SET = "client"     # client may set; validated against user_id if provided
+    CLIENT_SET = "client"  # client may set; validated against user_id if provided
     DEFAULT_TO_USER = "default"  # if missing, default to user_id
     STRICT_SERVER = "strict"  # server enforces user_id; client cannot override
 
@@ -61,23 +66,39 @@ def _ctx_user_id(ctx: Mapping[str, Any]) -> Any | None:
       4) ctx["auth_context"]["user_id"] (legacy)
     """
     # 1) direct
-    u = ctx.get(CTX_USER_ID_KEY) if isinstance(ctx, dict) else getattr(ctx, CTX_USER_ID_KEY, None)
+    u = (
+        ctx.get(CTX_USER_ID_KEY)
+        if isinstance(ctx, dict)
+        else getattr(ctx, CTX_USER_ID_KEY, None)
+    )
     if u:
         return _normalize_uuid(u)
 
     # 2) auth dict
-    auth = (ctx.get(CTX_AUTH_KEY) if isinstance(ctx, dict) else getattr(ctx, CTX_AUTH_KEY, None)) or {}
+    auth = (
+        ctx.get(CTX_AUTH_KEY)
+        if isinstance(ctx, dict)
+        else getattr(ctx, CTX_AUTH_KEY, None)
+    ) or {}
     u = auth.get("user_id")
     if u:
         return _normalize_uuid(u)
 
     # 3 & 4) legacy fallbacks
-    inj = (ctx.get("injected_fields") if isinstance(ctx, dict) else getattr(ctx, "injected_fields", None)) or {}
+    inj = (
+        ctx.get("injected_fields")
+        if isinstance(ctx, dict)
+        else getattr(ctx, "injected_fields", None)
+    ) or {}
     u = inj.get("user_id")
     if u:
         return _normalize_uuid(u)
 
-    ac = (ctx.get("auth_context") if isinstance(ctx, dict) else getattr(ctx, "auth_context", None)) or {}
+    ac = (
+        ctx.get("auth_context")
+        if isinstance(ctx, dict)
+        else getattr(ctx, "auth_context", None)
+    ) or {}
     u = ac.get("user_id")
     if u:
         return _normalize_uuid(u)
@@ -105,7 +126,7 @@ class Ownable:
 
     @declared_attr
     def owner_id(cls):
-        pol = getattr(cls, "__autoapi_owner_policy__", OwnerPolicy.CLIENT_SET)
+        pol = getattr(cls, OWNER_POLICY_ATTR, OwnerPolicy.CLIENT_SET)
         schema = _infer_schema(cls, default="public")
 
         autoapi_meta: dict[str, Any] = {}
@@ -144,6 +165,7 @@ class Ownable:
               ...
             }
         """
+
         def _err(status: int, msg: str):
             http_exc, _, _ = create_standardized_error(status, message=msg)
             raise http_exc
@@ -156,14 +178,21 @@ class Ownable:
             user_id = _ctx_user_id(ctx)
             provided = params.get("owner_id")
             missing = _is_missing(provided)
-            pol = getattr(cls, "__autoapi_owner_policy__", OwnerPolicy.CLIENT_SET)
+            pol = getattr(cls, OWNER_POLICY_ATTR, OwnerPolicy.CLIENT_SET)
 
-            log.debug("Ownable PRE_TX_BEGIN(create): policy=%s params=%s user_id=%s", pol, params, user_id)
+            log.debug(
+                "Ownable PRE_TX_BEGIN(create): policy=%s params=%s user_id=%s",
+                pol,
+                params,
+                user_id,
+            )
 
             if pol == OwnerPolicy.STRICT_SERVER:
                 if user_id is None:
                     _err(400, "owner_id is required.")
-                if not missing and _normalize_uuid(provided) != _normalize_uuid(user_id):
+                if not missing and _normalize_uuid(provided) != _normalize_uuid(
+                    user_id
+                ):
                     _err(400, "owner_id mismatch.")
                 params["owner_id"] = user_id  # always enforce server value
             elif pol == OwnerPolicy.DEFAULT_TO_USER:
@@ -189,7 +218,7 @@ class Ownable:
             if "owner_id" not in params:
                 return  # nothing to check
 
-            pol = getattr(cls, "__autoapi_owner_policy__", OwnerPolicy.CLIENT_SET)
+            pol = getattr(cls, OWNER_POLICY_ATTR, OwnerPolicy.CLIENT_SET)
             if _is_missing(params.get("owner_id")):
                 # treat None/"" as not provided → drop it
                 params.pop("owner_id", None)
@@ -206,7 +235,12 @@ class Ownable:
             user_id = _ctx_user_id(ctx)
             is_admin = bool(ctx.get("is_admin"))
 
-            log.debug("Ownable PRE_TX_BEGIN(update): new=%s user_id=%s is_admin=%s", new_val, user_id, is_admin)
+            log.debug(
+                "Ownable PRE_TX_BEGIN(update): new=%s user_id=%s is_admin=%s",
+                new_val,
+                user_id,
+                is_admin,
+            )
 
             if not is_admin and user_id is not None and new_val != user_id:
                 _err(403, "Cannot transfer ownership.")
@@ -218,7 +252,7 @@ class Ownable:
             ctx["payload"] = params
 
         # Attach (merge) into __autoapi_hooks__ without clobbering existing mappings
-        hooks = getattr(cls, "__autoapi_hooks__", None) or {}
+        hooks = getattr(cls, HOOKS_ATTR, None) or {}
         hooks = {**hooks}  # shallow copy
 
         def _append(alias: str, phase: str, fn):
@@ -226,10 +260,12 @@ class Ownable:
             lst = list(phase_map.get(phase) or [])
             if fn not in lst:
                 lst.append(fn)
-            phase_map[phase] = tuple(lst)  # tuples are safer against accidental mutation
+            phase_map[phase] = tuple(
+                lst
+            )  # tuples are safer against accidental mutation
             hooks[alias] = phase_map
 
         _append("create", "PRE_TX_BEGIN", _before_create)
         _append("update", "PRE_TX_BEGIN", _before_update)
 
-        setattr(cls, "__autoapi_hooks__", hooks)
+        setattr(cls, HOOKS_ATTR, hooks)

--- a/pkgs/standards/autoapi/autoapi/v3/mixins/tenant_bound.py
+++ b/pkgs/standards/autoapi/autoapi/v3/mixins/tenant_bound.py
@@ -8,6 +8,7 @@ from ..hooks import Phase
 from ..jsonrpc_models import create_standardized_error
 from ..info_schema import check as _info_check
 from ..cfgs import AUTH_CONTEXT_KEY, INJECTED_FIELDS_KEY, TENANT_ID_KEY
+from ..config.constants import TENANT_POLICY_ATTR
 
 log = logging.getLogger(__name__)
 
@@ -63,7 +64,7 @@ class TenantBound(_RowBound):
     # -------------------------------------------------------------------
     @declared_attr
     def tenant_id(cls):
-        pol = getattr(cls, "__autoapi_tenant_policy__", TenantPolicy.CLIENT_SET)
+        pol = getattr(cls, TENANT_POLICY_ATTR, TenantPolicy.CLIENT_SET)
         schema = _infer_schema(cls, default="public")
 
         autoapi_meta: dict[str, object] = {}

--- a/pkgs/standards/autoapi/autoapi/v3/opspec/collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/opspec/collect.py
@@ -4,26 +4,38 @@ from __future__ import annotations
 from dataclasses import replace
 import logging
 import re
-from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple, Type
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+)
 
 from .types import (
-    Arity,
     CANON,
-    HookPhase,
-    OpHook,
     OpSpec,
-    PersistPolicy,
-    ReturnForm,
     TargetOp,
     VerbAliasPolicy,
+)
+from ..config.constants import (
+    OPS_ATTR,
+    CUSTOM_OP_ATTR,
+    VERB_ALIASES_ATTR,
+    VERB_ALIAS_POLICY_ATTR,
 )
 
 try:
     # Per-model registry (observable, triggers rebind elsewhere)
     from .model_registry import get_registered_ops  # type: ignore
 except Exception:  # pragma: no cover
+
     def get_registered_ops(model: type) -> Sequence[OpSpec]:  # shim
         return ()
+
 
 logger = logging.getLogger(__name__)
 
@@ -34,10 +46,12 @@ _ALIAS_RE = re.compile(r"^[a-z][a-z0-9_]*$")
 # Helpers
 # ───────────────────────────────────────────────────────────────────────────────
 
+
 def _ensure_spec_table(spec: OpSpec, table: type) -> OpSpec:
     if spec.table is table:
         return spec
     return replace(spec, table=table)
+
 
 def _as_specs(value: Any, table: type) -> List[OpSpec]:
     """
@@ -58,7 +72,9 @@ def _as_specs(value: Any, table: type) -> List[OpSpec]:
         try:
             return OpSpec(table=table, **kwargs)  # type: ignore[arg-type]
         except TypeError as e:
-            logger.error("Invalid OpSpec kwargs in __autoapi_ops__ for %s: %s", table.__name__, e)
+            logger.error(
+                "Invalid OpSpec kwargs in %s for %s: %s", OPS_ATTR, table.__name__, e
+            )
             return None
 
     if isinstance(value, OpSpec):
@@ -84,13 +100,17 @@ def _as_specs(value: Any, table: type) -> List[OpSpec]:
                 if sp:
                     specs.append(sp)
     else:
-        logger.warning("__autoapi_ops__ on %s has unsupported type: %r", table.__name__, type(value))
+        logger.warning(
+            "%s on %s has unsupported type: %r", OPS_ATTR, table.__name__, type(value)
+        )
 
     return specs
 
+
 def _collect_class_declared(model: type) -> List[OpSpec]:
-    declared = getattr(model, "__autoapi_ops__", None)
+    declared = getattr(model, OPS_ATTR, None)
     return _as_specs(declared, model)
+
 
 def _collect_decorators(model: type) -> List[OpSpec]:
     """
@@ -100,7 +120,7 @@ def _collect_decorators(model: type) -> List[OpSpec]:
     out: List[OpSpec] = []
     for cls in reversed(model.__mro__):  # base classes first; child overrides later
         for name, attr in cls.__dict__.items():
-            spec_meta = getattr(attr, "__autoapi_custom_op__", None)
+            spec_meta = getattr(attr, CUSTOM_OP_ATTR, None)
             if not spec_meta:
                 continue
             if isinstance(spec_meta, OpSpec):
@@ -115,15 +135,24 @@ def _collect_decorators(model: type) -> List[OpSpec]:
                 sp = OpSpec(table=model, handler=attr, **kwargs)  # type: ignore[arg-type]
                 out.append(sp)
             else:
-                logger.warning("Unknown custom_op payload on %s.%s: %r", cls.__name__, name, type(spec_meta))
+                logger.warning(
+                    "Unknown custom_op payload on %s.%s: %r",
+                    cls.__name__,
+                    name,
+                    type(spec_meta),
+                )
     return out
+
 
 def _collect_registry(model: type) -> List[OpSpec]:
     try:
-        return [ _ensure_spec_table(sp, model) for sp in (get_registered_ops(model) or ()) ]
+        return [
+            _ensure_spec_table(sp, model) for sp in (get_registered_ops(model) or ())
+        ]
     except Exception as e:  # pragma: no cover
         logger.exception("get_registered_ops failed for %s: %s", model.__name__, e)
         return []
+
 
 def _generate_canonical(model: type) -> List[OpSpec]:
     """
@@ -131,7 +160,13 @@ def _generate_canonical(model: type) -> List[OpSpec]:
     Bulk verbs can be added later by registry/decorators if supported.
     """
     canon_targets: Tuple[TargetOp, ...] = (
-        "create", "read", "update", "replace", "delete", "list", "clear"
+        "create",
+        "read",
+        "update",
+        "replace",
+        "delete",
+        "list",
+        "clear",
     )
     out: List[OpSpec] = []
     for target in canon_targets:
@@ -141,7 +176,9 @@ def _generate_canonical(model: type) -> List[OpSpec]:
                 alias=alias,
                 target=target,
                 table=model,
-                arity="member" if target in {"read", "update", "replace", "delete"} else "collection",
+                arity="member"
+                if target in {"read", "update", "replace", "delete"}
+                else "collection",
                 # persistent by default; binder will auto START_TX/END_TX where appropriate
                 persist="default",
                 returns="model" if target != "clear" else "raw",
@@ -149,7 +186,10 @@ def _generate_canonical(model: type) -> List[OpSpec]:
         )
     return out
 
-def _dedupe(existing: Dict[Tuple[str, str], OpSpec], incoming: Iterable[OpSpec]) -> None:
+
+def _dedupe(
+    existing: Dict[Tuple[str, str], OpSpec], incoming: Iterable[OpSpec]
+) -> None:
     """
     Merge specs into `existing` using (alias, target) as the key.
     Later sources overwrite earlier ones.
@@ -161,15 +201,18 @@ def _dedupe(existing: Dict[Tuple[str, str], OpSpec], incoming: Iterable[OpSpec])
             continue
         existing[(sp.alias, sp.target)] = sp  # last wins
 
-def _normalize_alias_map(model: type) -> Tuple[List[Tuple[str, TargetOp]], VerbAliasPolicy]:
+
+def _normalize_alias_map(
+    model: type,
+) -> Tuple[List[Tuple[str, TargetOp]], VerbAliasPolicy]:
     """
     Support both styles:
       {"soft_delete": "delete"}  → alias -> target
       {"delete": "soft_delete"}  → target -> alias
     Returns list of (alias, target). Only allows targets in CANON (including bulk, clear).
     """
-    raw = getattr(model, "__autoapi_verb_aliases__", {}) or {}
-    policy: VerbAliasPolicy = getattr(model, "__autoapi_verb_alias_policy__", "both")  # type: ignore[assignment]
+    raw = getattr(model, VERB_ALIASES_ATTR, {}) or {}
+    policy: VerbAliasPolicy = getattr(model, VERB_ALIAS_POLICY_ATTR, "both")  # type: ignore[assignment]
 
     pairs: List[Tuple[str, TargetOp]] = []
     for k, v in raw.items():
@@ -183,13 +226,21 @@ def _normalize_alias_map(model: type) -> Tuple[List[Tuple[str, TargetOp]], VerbA
 
         if alias and target:
             if not _ALIAS_RE.match(alias):
-                logger.warning("Invalid verb alias %r on %s; must match %s", alias, model.__name__, _ALIAS_RE.pattern)
+                logger.warning(
+                    "Invalid verb alias %r on %s; must match %s",
+                    alias,
+                    model.__name__,
+                    _ALIAS_RE.pattern,
+                )
                 continue
             pairs.append((alias, target))  # type: ignore[arg-type]
         else:
-            logger.warning("Unrecognized alias mapping on %s: %r -> %r", model.__name__, k, v)
+            logger.warning(
+                "Unrecognized alias mapping on %s: %r -> %r", model.__name__, k, v
+            )
 
     return pairs, policy
+
 
 def _apply_aliases(
     specs: List[OpSpec],
@@ -217,7 +268,12 @@ def _apply_aliases(
     for alias, target in pairs:
         base = canon_by_target.get(target)
         if not base:
-            logger.warning("Alias %r → %r has no base canonical spec on %s", alias, target, model.__name__)
+            logger.warning(
+                "Alias %r → %r has no base canonical spec on %s",
+                alias,
+                target,
+                model.__name__,
+            )
             continue
 
         # Clone with new alias; keep everything else; hide REST by default
@@ -249,6 +305,7 @@ def _apply_aliases(
 # ───────────────────────────────────────────────────────────────────────────────
 # Public API
 # ───────────────────────────────────────────────────────────────────────────────
+
 
 def resolve(model: type) -> List[OpSpec]:
     """

--- a/pkgs/standards/autoapi/autoapi/v3/opspec/decorators.py
+++ b/pkgs/standards/autoapi/autoapi/v3/opspec/decorators.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from functools import wraps
-from typing import Any, Callable, Iterable, Optional, Sequence, Tuple, Type
+from typing import Any, Callable, Sequence, Type
 
 from .types import (
     OpSpec,
@@ -12,10 +12,12 @@ from .types import (
     ReturnForm,
     OpHook,  # for optional hook lists passed in
 )
+from ..config.constants import OPS_ATTR, CUSTOM_OP_ATTR
 
 # ───────────────────────────────────────────────────────────────────────────────
 # Class-level alias decorator
 # ───────────────────────────────────────────────────────────────────────────────
+
 
 def op_alias(
     *,
@@ -96,12 +98,17 @@ def op_alias(
 
     def deco(table_cls: Type):
         # attach to __autoapi_ops__ without touching the imperative registry
-        ops = list(getattr(table_cls, "__autoapi_ops__", ()))
+        ops = list(getattr(table_cls, OPS_ATTR, ()))
         spec = OpSpec(
             alias=alias,
             target=target,
             table=table_cls,
-            arity=arity or ("member" if target in {"read","update","replace","delete"} else "collection"),
+            arity=arity
+            or (
+                "member"
+                if target in {"read", "update", "replace", "delete"}
+                else "collection"
+            ),
             persist=persist,
             request_model=request_model,
             response_model=response_model,
@@ -117,14 +124,16 @@ def op_alias(
             expose_method=True if expose_method is None else bool(expose_method),
         )
         ops.append(spec)
-        setattr(table_cls, "__autoapi_ops__", tuple(ops))
+        setattr(table_cls, OPS_ATTR, tuple(ops))
         return table_cls
+
     return deco
 
 
 # ───────────────────────────────────────────────────────────────────────────────
 # Function/method-level custom op decorator
 # ───────────────────────────────────────────────────────────────────────────────
+
 
 def op(
     *,
@@ -233,6 +242,7 @@ def op(
 
         {"degrees": 90}
     """
+
     def deco(fn: Callable[..., Any]):
         @wraps(fn)
         def _raw(*a, **kw):
@@ -240,26 +250,31 @@ def op(
             return fn(*a, **kw)
 
         # Stash an OpSpec shell; binder/collector will set table and handler.
-        _raw.__autoapi_custom_op__ = OpSpec(  # type: ignore[attr-defined]
-            alias=alias,
-            target="custom",
-            table=None,
-            arity=arity,
-            persist=persist,
-            returns=returns,
-            handler=None,  # collector will set to the decorated function if still None
-            request_model=request_model,
-            response_model=response_model,
-            http_methods=tuple(http_methods) if http_methods else None,
-            path_suffix=path_suffix,
-            tags=tuple(tags) if tags else (),
-            rbac_guard_op=rbac_guard_op,
-            hooks=tuple(hooks) if hooks else (),
-            expose_routes=True if expose_routes is None else bool(expose_routes),
-            expose_rpc=True if expose_rpc is None else bool(expose_rpc),
-            expose_method=True if expose_method is None else bool(expose_method),
+        setattr(
+            _raw,
+            CUSTOM_OP_ATTR,
+            OpSpec(  # type: ignore[attr-defined]
+                alias=alias,
+                target="custom",
+                table=None,
+                arity=arity,
+                persist=persist,
+                returns=returns,
+                handler=None,  # collector will set to the decorated function if still None
+                request_model=request_model,
+                response_model=response_model,
+                http_methods=tuple(http_methods) if http_methods else None,
+                path_suffix=path_suffix,
+                tags=tuple(tags) if tags else (),
+                rbac_guard_op=rbac_guard_op,
+                hooks=tuple(hooks) if hooks else (),
+                expose_routes=True if expose_routes is None else bool(expose_routes),
+                expose_rpc=True if expose_rpc is None else bool(expose_rpc),
+                expose_method=True if expose_method is None else bool(expose_method),
+            ),
         )
         return _raw
+
     return deco
 
 

--- a/pkgs/standards/autoapi/autoapi/v3/rest/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/rest/__init__.py
@@ -5,6 +5,7 @@ The logic is intentionally minimal; extend or override as needed.
 
 from __future__ import annotations
 from typing import Type, Optional
+from ..config.constants import NESTED_PATHS_ATTR
 
 
 def _nested_prefix(self, model: Type) -> Optional[str]:
@@ -16,9 +17,10 @@ def _nested_prefix(self, model: Type) -> Optional[str]:
     • Otherwise → signal ``no nested route wanted`` with ``None``.
     """
 
-    cb = getattr(model, "__autoapi_nested_paths__", None)
+    cb = getattr(model, NESTED_PATHS_ATTR, None)
     if callable(cb):
         return cb()
     return getattr(model, "_nested_path", None)
+
 
 __all__ = ["_nested_prefix"]

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/executor.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/executor.py
@@ -1,7 +1,19 @@
 # autoapi/v2/impl/runtime/executor.py
 from __future__ import annotations
 
-from typing import Any, Awaitable, Callable, Iterable, Mapping, MutableMapping, Optional, Sequence, Union, Protocol, runtime_checkable
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Iterable,
+    Mapping,
+    MutableMapping,
+    Optional,
+    Sequence,
+    Union,
+    Protocol,
+    runtime_checkable,
+)
 import logging
 
 try:
@@ -17,6 +29,7 @@ except Exception:  # pragma: no cover
     AsyncSession = Any  # type: ignore
 
 from .errors import create_standardized_error
+from ..config.constants import CTX_SKIP_PERSIST_FLAG
 
 logger = logging.getLogger(__name__)
 
@@ -25,13 +38,16 @@ logger = logging.getLogger(__name__)
 # Types
 # ───────────────────────────────────────────────────────────────────────────────
 
+
 @runtime_checkable
 class _Step(Protocol):
     def __call__(self, ctx: "_Ctx") -> Union[Any, Awaitable[Any]]: ...
 
 
 HandlerStep = Union[_Step, Callable[["_Ctx"], Any], Callable[["_Ctx"], Awaitable[Any]]]
-PhaseChains = Mapping[str, Sequence[HandlerStep]]  # {"HANDLER": [...], "COMMIT": [...], ...}
+PhaseChains = Mapping[
+    str, Sequence[HandlerStep]
+]  # {"HANDLER": [...], "COMMIT": [...], ...}
 
 
 class _Ctx(dict):
@@ -44,6 +60,7 @@ class _Ctx(dict):
       • error: last exception caught (on failure paths)
       • response: SimpleNamespace(result=...) for POST_RESPONSE shaping
     """
+
     __slots__ = ()
     __getattr__ = dict.get
     __setattr__ = dict.__setitem__
@@ -74,15 +91,18 @@ class _Ctx(dict):
 # Introspection & helpers
 # ───────────────────────────────────────────────────────────────────────────────
 
+
 def _is_async_db(db: Any) -> bool:
     # AsyncSession exposes run_sync/commit/flush as async
     return isinstance(db, AsyncSession) or hasattr(db, "run_sync")
+
 
 def _bool_call(meth: Any) -> bool:
     try:
         return bool(meth())
     except Exception:  # pragma: no cover
         return False
+
 
 def _in_tx(db: Any) -> bool:
     for name in ("in_transaction", "in_nested_transaction"):
@@ -92,10 +112,12 @@ def _in_tx(db: Any) -> bool:
     val = getattr(db, "in_transaction", False)
     return bool(val)
 
+
 async def _maybe_await(v: Any) -> Any:
     if hasattr(v, "__await__"):
         return await v  # type: ignore[func-returns-value]
     return v
+
 
 async def _run_chain(ctx: _Ctx, chain: Optional[Iterable[HandlerStep]]) -> None:
     if not chain:
@@ -106,19 +128,24 @@ async def _run_chain(ctx: _Ctx, chain: Optional[Iterable[HandlerStep]]) -> None:
         if rv is not None:
             ctx.result = rv  # last non-None wins
 
+
 def _g(phases: Optional[PhaseChains], key: str) -> Sequence[HandlerStep]:
     return () if not phases else phases.get(key, ())
+
 
 # ───────────────────────────────────────────────────────────────────────────────
 # DB guards (enforce per-phase flush/commit policy)
 # ───────────────────────────────────────────────────────────────────────────────
 
+
 class _GuardHandle:
     __slots__ = ("db", "orig_commit", "orig_flush")
+
     def __init__(self, db: Any, orig_commit: Any, orig_flush: Any) -> None:
         self.db = db
         self.orig_commit = orig_commit
         self.orig_flush = orig_flush
+
     def restore(self) -> None:
         if self.orig_commit is not None:
             try:
@@ -130,6 +157,7 @@ class _GuardHandle:
                 setattr(self.db, "flush", self.orig_flush)
             except Exception:  # pragma: no cover
                 pass
+
 
 def _install_db_guards(
     db: Union[Session, AsyncSession],
@@ -153,31 +181,40 @@ def _install_db_guards(
     # commit wrapper
     if not allow_commit:
         if _is_async_db(db):
+
             async def _blocked_commit() -> None:  # type: ignore[func-returns-value]
                 _raise("commit")
         else:
+
             def _blocked_commit() -> None:  # type: ignore[func-returns-value]
                 _raise("commit")
+
         setattr(db, "commit", _blocked_commit)  # type: ignore[assignment]
     else:
         # allow commit, but optionally require that *this* run started the txn
         if require_started_tx_for_commit and not started_tx:
             if _is_async_db(db):
+
                 async def _blocked_commit_started() -> None:  # type: ignore[func-returns-value]
                     _raise("commit")
             else:
+
                 def _blocked_commit_started() -> None:  # type: ignore[func-returns-value]
                     _raise("commit")
+
             setattr(db, "commit", _blocked_commit_started)  # type: ignore[assignment]
 
     # flush wrapper
     if not allow_flush:
         if _is_async_db(db):
+
             async def _blocked_flush() -> None:  # type: ignore[func-returns-value]
                 _raise("flush")
         else:
+
             def _blocked_flush() -> None:  # type: ignore[func-returns-value]
                 _raise("flush")
+
         setattr(db, "flush", _blocked_flush)  # type: ignore[assignment]
 
     return _GuardHandle(db, orig_commit, orig_flush)
@@ -210,6 +247,7 @@ async def _rollback_if_started(
 # Public API
 # ───────────────────────────────────────────────────────────────────────────────
 
+
 async def _invoke(
     *,
     request: Optional[Request],
@@ -235,7 +273,7 @@ async def _invoke(
       • POST_RESPONSE remains non-fatal; errors are reported but the prior result is returned.
     """
     ctx = _Ctx.ensure(request=request, db=db, seed=ctx)
-    skip_persist: bool = bool(ctx.get("__autoapi_skip_persist__") or ctx.get("skip_persist"))
+    skip_persist: bool = bool(ctx.get(CTX_SKIP_PERSIST_FLAG) or ctx.get("skip_persist"))
 
     existed_tx_before = _in_tx(db)
     started_tx = False  # computed after TX_BEGIN
@@ -293,28 +331,42 @@ async def _invoke(
 
     # ─── TX_BEGIN (begin txn via hooks; skip when skip_persist) ────────────────
     if not skip_persist:
-        await _run_phase("START_TX", allow_flush=False, allow_commit=False, in_tx=False, require_started_for_commit=True)
+        await _run_phase(
+            "START_TX",
+            allow_flush=False,
+            allow_commit=False,
+            in_tx=False,
+            require_started_for_commit=True,
+        )
     # compute if *this* run started the transaction
     started_tx = (not existed_tx_before) and _in_tx(db)
 
     # ─── PRE_HANDLER (flush-only) ──────────────────────────────────────────────
-    await _run_phase("PRE_HANDLER", allow_flush=True, allow_commit=False, in_tx=not skip_persist)
+    await _run_phase(
+        "PRE_HANDLER", allow_flush=True, allow_commit=False, in_tx=not skip_persist
+    )
 
     # ─── HANDLER (flush-only; core lives here) ─────────────────────────────────
-    await _run_phase("HANDLER", allow_flush=True, allow_commit=False, in_tx=not skip_persist)
+    await _run_phase(
+        "HANDLER", allow_flush=True, allow_commit=False, in_tx=not skip_persist
+    )
 
     # ─── POST_HANDLER (flush-only) ─────────────────────────────────────────────
-    await _run_phase("POST_HANDLER", allow_flush=True, allow_commit=False, in_tx=not skip_persist)
+    await _run_phase(
+        "POST_HANDLER", allow_flush=True, allow_commit=False, in_tx=not skip_persist
+    )
 
     # ─── PRE_COMMIT (no writes) ────────────────────────────────────────────────
-    await _run_phase("PRE_COMMIT", allow_flush=False, allow_commit=False, in_tx=not skip_persist)
+    await _run_phase(
+        "PRE_COMMIT", allow_flush=False, allow_commit=False, in_tx=not skip_persist
+    )
 
     # ─── COMMIT (commit-only hooks; skip when skip_persist) ────────────────────
     if not skip_persist:
         await _run_phase(
             "END_TX",
-            allow_flush=True,           # a final flush right before commit is OK
-            allow_commit=True,          # commit allowed
+            allow_flush=True,  # a final flush right before commit is OK
+            allow_commit=True,  # commit allowed
             in_tx=True,
             require_started_for_commit=True,
         )
@@ -324,8 +376,15 @@ async def _invoke(
 
     # ─── POST_RESPONSE (non-fatal) ─────────────────────────────────────────────
     from types import SimpleNamespace as _NS
+
     ctx.response = _NS(result=ctx.get("result"))
-    await _run_phase("POST_RESPONSE", allow_flush=False, allow_commit=False, in_tx=False, nonfatal=True)
+    await _run_phase(
+        "POST_RESPONSE",
+        allow_flush=False,
+        allow_commit=False,
+        in_tx=False,
+        nonfatal=True,
+    )
     return ctx.response.result
 
 

--- a/pkgs/standards/autoapi/autoapi/v3/types/op_config_provider.py
+++ b/pkgs/standards/autoapi/autoapi/v3/types/op_config_provider.py
@@ -2,21 +2,28 @@ from __future__ import annotations
 from typing import Iterable, Literal, Type
 from .table_config_provider import TableConfigProvider
 from ..opspec import OpSpec
-from ..opspec.model_registry import get_registered_ops
+from ..config.constants import (
+    DEFAULTS_MODE_ATTR,
+    DEFAULTS_INCLUDE_ATTR,
+    DEFAULTS_EXCLUDE_ATTR,
+)
 
 
 class OpConfigProvider(TableConfigProvider):
     __autoapi_ops__: Iterable[OpSpec] = ()
 
     # Default canonical verbs wiring policy
-    __autoapi_defaults_mode__: Literal["all","none","some"] = "all"
+    __autoapi_defaults_mode__: Literal["all", "none", "some"] = "all"
     __autoapi_defaults_include__: set[str] = set()
     __autoapi_defaults_exclude__: set[str] = set()
 
+
 def should_wire_canonical(table: Type, op: str) -> bool:
-    mode = getattr(table, "__autoapi_defaults_mode__", "all")
-    inc  = getattr(table, "__autoapi_defaults_include__", set())
-    exc  = getattr(table, "__autoapi_defaults_exclude__", set())
-    if mode == "none": return False
-    if mode == "some": return op in inc
+    mode = getattr(table, DEFAULTS_MODE_ATTR, "all")
+    inc = getattr(table, DEFAULTS_INCLUDE_ATTR, set())
+    exc = getattr(table, DEFAULTS_EXCLUDE_ATTR, set())
+    if mode == "none":
+        return False
+    if mode == "some":
+        return op in inc
     return op not in exc  # mode == "all"


### PR DESCRIPTION
## Summary
- add constants for all `__autoapi__` keys and document them
- replace magic strings with imports from `autoapi.v3.config.constants`

## Testing
- `uv run --directory . --package autoapi ruff format .`
- `uv run --directory . --package autoapi ruff check . --fix` *(fails: Undefined name `_http_exc_to_rpc` and other pre-existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_689e4ca0b9d48326995f7d91100fb84f