### PR TITLE
Migrate auto-kms to autoapi v3

### DIFF
--- a/pkgs/standards/auto_kms/auto_kms/app.py
+++ b/pkgs/standards/auto_kms/auto_kms/app.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 from fastapi import FastAPI
-from autoapi.v2 import AutoAPI, Phase
-from autoapi.v2.tables import Base
+from autoapi.v3 import AutoAPI
 
 from .tables.key import Key
 from .tables.key_version import KeyVersion
@@ -29,16 +28,17 @@ async def get_async_db():
             await s.close()
 
 
-# when constructing AutoAPI:
-api = AutoAPI(
-    base=Base,
-    include={Key, KeyVersion},
-    prefix="/kms",
-    get_async_db=get_async_db,
+app = FastAPI(
+    title="AutoKMS", version="0.1.0", openapi_url="/openapi.json", docs_url="/docs"
 )
 
+api = AutoAPI(app=app, get_async_db=get_async_db)
+api.include_models([Key, KeyVersion], base_prefix="/kms")
+api.mount_jsonrpc(prefix="/kms/rpc")
+api.mount_diagnostics(prefix="/kms/system")
 
-@api.register_hook(Phase.PRE_TX_BEGIN)
+
+@api.register_hook("PRE_TX_BEGIN")
 async def _stash_ctx(ctx):
     global SECRETS, CRYPTO
     try:
@@ -51,23 +51,12 @@ async def _stash_ctx(ctx):
     ctx["_kms_crypto"] = CRYPTO
 
 
-@api.register_hook(Phase.POST_RESPONSE)
+@api.register_hook("POST_RESPONSE")
 async def _finalize_kms_result(ctx):
     if "__kms_result__" in ctx:
         ctx["response"].result = ctx.pop("__kms_result__")
 
 
-app = FastAPI(
-    title="AutoKMS", version="0.1.0", openapi_url="/openapi.json", docs_url="/docs"
-)
-app.include_router(api.router)
-
-
 @app.get("/healthz", include_in_schema=False)
 async def healthz():
     return {"status": "alive"}
-
-
-@app.on_event("startup")
-async def _startup():
-    await api.initialize_async()

--- a/pkgs/standards/auto_kms/auto_kms/tables/key.py
+++ b/pkgs/standards/auto_kms/auto_kms/tables/key.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
-from autoapi.v2.types import Column, String, SAEnum, Integer, relationship, HookProvider
-from autoapi.v2.tables import Base
-from autoapi.v2.mixins import GUIDPk, Timestamped
+from autoapi.v3.types import Column, String, SAEnum, Integer, relationship, HookProvider
+from autoapi.v3.tables import Base
+from autoapi.v3.mixins import GUIDPk, Timestamped
 from swarmauri_core.crypto.types import AEADCiphertext, WrappedKey
 
 
@@ -240,28 +240,15 @@ class Key(Base, GUIDPk, Timestamped, HookProvider):
     @classmethod
     def __autoapi_register_hooks__(cls, api) -> None:
         """Register all hooks for the Key model."""
-        from autoapi.v2 import Phase
 
         # Register all the hook methods
-        api.register_hook(Phase.PRE_HANDLER, model="Key", op="create")(
-            cls._h_key_create
-        )
-        api.register_hook(Phase.PRE_HANDLER, model="Key", op="rotate")(
-            cls._h_key_rotate
-        )
-        api.register_hook(Phase.PRE_HANDLER, model="Key", op="disable")(
-            cls._h_key_disable
-        )
-        api.register_hook(Phase.PRE_HANDLER, model="Key", op="encrypt")(
-            cls._h_key_encrypt
-        )
-        api.register_hook(Phase.PRE_HANDLER, model="Key", op="decrypt")(
-            cls._h_key_decrypt
-        )
-        api.register_hook(Phase.PRE_HANDLER, model="Key", op="wrap")(cls._h_key_wrap)
-        api.register_hook(Phase.PRE_HANDLER, model="Key", op="unwrap")(
-            cls._h_key_unwrap
-        )
-        api.register_hook(Phase.PRE_HANDLER, model="Key", op="encrypt_for_many")(
+        api.register_hook("PRE_HANDLER", model="Key", op="create")(cls._h_key_create)
+        api.register_hook("PRE_HANDLER", model="Key", op="rotate")(cls._h_key_rotate)
+        api.register_hook("PRE_HANDLER", model="Key", op="disable")(cls._h_key_disable)
+        api.register_hook("PRE_HANDLER", model="Key", op="encrypt")(cls._h_key_encrypt)
+        api.register_hook("PRE_HANDLER", model="Key", op="decrypt")(cls._h_key_decrypt)
+        api.register_hook("PRE_HANDLER", model="Key", op="wrap")(cls._h_key_wrap)
+        api.register_hook("PRE_HANDLER", model="Key", op="unwrap")(cls._h_key_unwrap)
+        api.register_hook("PRE_HANDLER", model="Key", op="encrypt_for_many")(
             cls._h_key_encrypt_for_many
         )

--- a/pkgs/standards/auto_kms/auto_kms/tables/key_version.py
+++ b/pkgs/standards/auto_kms/auto_kms/tables/key_version.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
-from autoapi.v2.types import Column, Integer, LargeBinary, SAEnum, ForeignKey
-from autoapi.v2.types import UniqueConstraint, relationship, PgUUID
-from autoapi.v2.tables import Base
-from autoapi.v2.mixins import GUIDPk, Timestamped
+from autoapi.v3.types import (
+    Column,
+    Integer,
+    LargeBinary,
+    SAEnum,
+    ForeignKey,
+    UniqueConstraint,
+    relationship,
+    PgUUID,
+)
+from autoapi.v3.tables import Base
+from autoapi.v3.mixins import GUIDPk, Timestamped
 
 
 class KeyVersion(Base, GUIDPk, Timestamped):
@@ -11,7 +19,10 @@ class KeyVersion(Base, GUIDPk, Timestamped):
     __table_args__ = (UniqueConstraint("key_id", "version"),)
 
     key_id = Column(
-        PgUUID(as_uuid=True), ForeignKey("Key.id", ondelete="CASCADE"), nullable=False, index=True
+        PgUUID(as_uuid=True),
+        ForeignKey("Key.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
     )
     version = Column(Integer, nullable=False)
     status = Column(SAEnum("active", name="VersionStatus"), nullable=False)


### PR DESCRIPTION
## Summary
- switch auto-kms service to use autoapi v3 interfaces
- update key and key_version models for v3 hooks and types

## Testing
- `uv run --directory pkgs/standards/auto_kms --package auto_kms ruff format .`
- `uv run --directory pkgs/standards/auto_kms --package auto_kms ruff check . --fix`
- `uv run --directory pkgs/standards/auto_kms --package auto_kms pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e8c5270588326972a11c06633a0fa