### PR TITLE
fix: resolve autoapi import errors

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/endpoints/endpoints.py
+++ b/pkgs/standards/autoapi/autoapi/v2/endpoints/endpoints.py
@@ -3,7 +3,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
-from .naming import label_hook_callable
+from ..naming import label_hook_callable
 from ..hooks import Phase
 
 

--- a/pkgs/standards/autoapi/autoapi/v2/impl/errors.py
+++ b/pkgs/standards/autoapi/autoapi/v2/impl/errors.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from fastapi import HTTPException
+
+from ..jsonrpc_models import HTTP_ERROR_MESSAGES, _HTTP_TO_RPC
+
+
+def create_standardized_error(exc: BaseException) -> HTTPException:
+    """Normalize *exc* into an HTTPException with RPC metadata."""
+    if isinstance(exc, HTTPException):
+        return exc
+    status = getattr(exc, "status_code", 500)
+    detail = getattr(exc, "detail", str(exc))
+    http_exc = HTTPException(status_code=status, detail=detail)
+    rpc_code = _HTTP_TO_RPC.get(status, -32603)
+    setattr(http_exc, "rpc_code", rpc_code)
+    setattr(http_exc, "rpc_message", HTTP_ERROR_MESSAGES.get(status, detail))
+    setattr(http_exc, "rpc_data", getattr(exc, "data", None))
+    return http_exc


### PR DESCRIPTION
## Summary
- fix relative import for hook labeling in AutoAPI endpoints
- provide local standardized error helper for AutoAPI v2

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest` *(fails: `_invoke() got an unexpected keyword argument 'params'`)*

------
https://chatgpt.com/codex/tasks/task_e_689e994dbb0c8326a1835d5a73d509c8