### PR TITLE
fix: correct relative imports in AutoAPI

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/endpoints/endpoints.py
+++ b/pkgs/standards/autoapi/autoapi/v2/endpoints/endpoints.py
@@ -3,7 +3,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
-from .naming import label_hook_callable
+from ..naming import label_hook_callable
 from ..hooks import Phase
 
 

--- a/pkgs/standards/autoapi/autoapi/v2/impl/_runner.py
+++ b/pkgs/standards/autoapi/autoapi/v2/impl/_runner.py
@@ -28,7 +28,7 @@ except Exception:  # pragma: no cover
     Session = Any  # type: ignore
     AsyncSession = Any  # type: ignore
 
-from .errors import create_standardized_error
+from ..jsonrpc_models import create_standardized_error
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- fix broken relative import in AutoAPI diagnostic endpoints
- fix create_standardized_error import in v2 runner

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_allow_anon.py::test_allow_anon_list_and_read -vv` *(fails: TypeError: _invoke() got an unexpected keyword argument 'params')*
- `uv run --package autoapi_client --directory standards/autoapi_client pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e99210e7483268d8ac64a0834ec3a