### PR TITLE
fix: add missing auto kms deps

### DIFF
--- a/pkgs/standards/auto_kms/README.md
+++ b/pkgs/standards/auto_kms/README.md
@@ -1,1 +1,21 @@
 ## Auto KMS
+
+Auto KMS provides a lightweight key management service built on FastAPI. 
+
+### Deploy
+
+Run the service with the provided CLI:
+
+```bash
+uv run --package auto_kms --directory pkgs/standards/auto_kms auto-kms serve --host 127.0.0.1 --port 8000 --no-reload
+```
+
+### Verify
+
+Once the service starts, you can verify it is running:
+
+```bash
+curl http://127.0.0.1:8000/healthz
+```
+
+The endpoint returns `{"status": "alive"}` when deployment succeeds.

--- a/pkgs/standards/auto_kms/pyproject.toml
+++ b/pkgs/standards/auto_kms/pyproject.toml
@@ -17,16 +17,23 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+    "autoapi",
     "fastapi>=0.100.0",
     "pydantic>=2.0.0",
     "typer>=0.12.3",
+    "uvicorn[standard]>=0.29",
     "sqlalchemy[asyncio]>=2.0.0",
+    "swarmauri_secret_autogpg",
+    "swarmauri_crypto_paramiko",
 ]
 
 [tool.uv.sources]
 swarmauri_core = { workspace = true }
 swarmauri_base = { workspace = true }
 swarmauri_standard = { workspace = true }
+autoapi = { workspace = true }
+swarmauri_secret_autogpg = { workspace = true }
+swarmauri_crypto_paramiko = { workspace = true }
 
 [tool.pytest.ini_options]
 norecursedirs = ["combined", "scripts"]

--- a/pkgs/standards/autoapi/autoapi/v2/endpoints/endpoints.py
+++ b/pkgs/standards/autoapi/autoapi/v2/endpoints/endpoints.py
@@ -3,7 +3,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
-from .naming import label_hook_callable
+from ..naming import label_hook_callable
 from ..hooks import Phase
 
 

--- a/pkgs/standards/autoapi/autoapi/v2/impl/_runner.py
+++ b/pkgs/standards/autoapi/autoapi/v2/impl/_runner.py
@@ -28,7 +28,7 @@ except Exception:  # pragma: no cover
     Session = Any  # type: ignore
     AsyncSession = Any  # type: ignore
 
-from .errors import create_standardized_error
+from ..jsonrpc_models import create_standardized_error
 
 logger = logging.getLogger(__name__)
 

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
@@ -94,7 +94,7 @@ def _resource_name(model: type) -> str:
 
 def _pk_name(model: type) -> str:
     table = getattr(model, "__table__", None)
-    if not table or not getattr(table, "primary_key", None):
+    if table is None or not getattr(table, "primary_key", None):
         return "id"
     cols = list(table.primary_key.columns)  # type: ignore[attr-defined]
     if not cols:

--- a/pkgs/standards/autoapi/autoapi/v3/transport/jsonrpc/dispatcher.py
+++ b/pkgs/standards/autoapi/autoapi/v3/transport/jsonrpc/dispatcher.py
@@ -79,7 +79,7 @@ except Exception:  # pragma: no cover
 from ...runtime.errors import (
     ERROR_MESSAGES,
 )
-from ...v2.jsonrpc_models import _http_exc_to_rpc
+from ....v2.jsonrpc_models import _http_exc_to_rpc
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- document how to run Auto KMS
- add missing dependencies and workspace sources for Auto KMS
- fix several AutoAPI import and path issues

## Testing
- `uv run --directory pkgs/standards/auto_kms --package auto_kms ruff format .`
- `uv run --directory pkgs/standards/auto_kms --package auto_kms ruff check . --fix`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `uv run --package auto_kms auto-kms --host 127.0.0.1 --port 8001 --no-reload` *(fails: AttributeError: 'AutoAPI' object has no attribute 'register_hook')*

------
https://chatgpt.com/codex/tasks/task_e_689e99ab9ea083269762d9726ff766ac