### PR TITLE
Use runtime http_exc_to_rpc in JSON-RPC dispatcher

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/transport/jsonrpc/dispatcher.py
+++ b/pkgs/standards/autoapi/autoapi/v3/transport/jsonrpc/dispatcher.py
@@ -78,8 +78,8 @@ except Exception:  # pragma: no cover
 
 from ...runtime.errors import (
     ERROR_MESSAGES,
+    http_exc_to_rpc,
 )
-from ....v2.jsonrpc_models import _http_exc_to_rpc
 
 logger = logging.getLogger(__name__)
 
@@ -165,7 +165,7 @@ async def _dispatch_one(
         try:
             params = _normalize_params(obj.get("params"))
         except HTTPException as exc:
-            code, msg, data = _http_exc_to_rpc(exc)
+            code, msg, data = http_exc_to_rpc(exc)
             return _err(code, msg, rid, data)
 
         # Compose a context; allow middlewares to seed request.state.ctx
@@ -184,7 +184,7 @@ async def _dispatch_one(
         return _ok(result, rid)
 
     except HTTPException as exc:
-        code, msg, data = _http_exc_to_rpc(exc)
+        code, msg, data = http_exc_to_rpc(exc)
         # Notifications still don't produce output
         if rid is None:
             return None


### PR DESCRIPTION
## Summary
- use `http_exc_to_rpc` from runtime errors in JSON-RPC dispatcher

## Testing
- `uv run --directory standards --package autoapi ruff format autoapi/autoapi/v3/transport/jsonrpc/dispatcher.py`
- `uv run --directory standards --package autoapi ruff check autoapi/autoapi/v3/transport/jsonrpc/dispatcher.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_689ea2c42488832686e131885857d8e2