### PR TITLE
feat(autoapi/v3): refresh hook provider and v3 references

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/runtime/errors.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/errors.py
@@ -1,4 +1,4 @@
-# autoapi/v2/impl/runtime/errors.py
+# autoapi/v3/runtime/errors.py
 from __future__ import annotations
 
 from typing import Any, Optional, Iterable, Tuple

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/executor.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/executor.py
@@ -1,4 +1,4 @@
-# autoapi/v2/impl/runtime/executor.py
+# autoapi/v3/runtime/executor.py
 from __future__ import annotations
 
 from typing import (

--- a/pkgs/standards/autoapi/autoapi/v3/types/authn_abc.py
+++ b/pkgs/standards/autoapi/autoapi/v3/types/authn_abc.py
@@ -1,4 +1,4 @@
-# autoapi/v2/authn_abc.py
+# autoapi/v3/types/authn_abc.py
 from __future__ import annotations
 from abc import ABC, abstractmethod
 from fastapi import Request

--- a/pkgs/standards/autoapi/autoapi/v3/types/hook_provider.py
+++ b/pkgs/standards/autoapi/autoapi/v3/types/hook_provider.py
@@ -1,29 +1,32 @@
-# autoapi/v2/types/hook_provider.py  – tiny helper module
-from abc import abstractmethod
-from typing import TYPE_CHECKING
+# autoapi/v3/types/hook_provider.py  – tiny helper module
+from typing import TYPE_CHECKING, Callable
 
 from .table_config_provider import TableConfigProvider
 
 if TYPE_CHECKING:  # forward ref avoids circular import
-    from autoapi.v2 import AutoAPI
+    from autoapi.v3 import AutoAPI
 
 _HOOK_PROVIDERS: set[type] = set()
 
 
 class HookProvider(TableConfigProvider):
-    """
-    Marker-base for mixins / models that attach hooks to an AutoAPI router.
+    """Marker-base for mixins / models that attach hooks to an AutoAPI router."""
 
-    Subclasses **must** implement `__autoapi_register_hooks__`.
-    """
+    __autoapi_hooks__: list[Callable[["AutoAPI"], None]]
 
     @classmethod
-    @abstractmethod
-    def __autoapi_register_hooks__(cls, api: "AutoAPI") -> None: ...
+    def append(cls, hook: Callable[["AutoAPI"], None]) -> None:
+        cls.__autoapi_hooks__.append(hook)
+
+    @classmethod
+    def __autoapi_register_hooks__(cls, api: "AutoAPI") -> None:
+        for hook in cls.__autoapi_hooks__:
+            hook(api)
 
     def __init_subclass__(cls, **kw):
         super().__init_subclass__(**kw)
         _HOOK_PROVIDERS.add(cls)
+        cls.__autoapi_hooks__ = []
 
 
 def list_hook_providers():

--- a/pkgs/standards/autoapi/autoapi/v3/types/op.py
+++ b/pkgs/standards/autoapi/autoapi/v3/types/op.py
@@ -1,5 +1,5 @@
 """
-autoapi/v2/types/_op.py
+autoapi/v3/types/_op.py
 Pure structural helpers (no FastAPI / DB imports).
 """
 


### PR DESCRIPTION
## Summary
- clean up lingering autoapi/v2 references in v3 modules
- allow HookProvider to collect __autoapi_hooks__ and expose an append helper

## Testing
- `uv run --package autoapi --directory . ruff check autoapi/v3 --fix`
- `uv run --package autoapi --directory . pytest` *(fails: ModuleNotFoundError: No module named 'autoapi.v2.impl.errors')*


------
https://chatgpt.com/codex/tasks/task_e_689ea2d394348326baca2405ee086014