### PR TITLE
fix: update runner error import

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/impl/_runner.py
+++ b/pkgs/standards/autoapi/autoapi/v2/impl/_runner.py
@@ -28,7 +28,7 @@ except Exception:  # pragma: no cover
     Session = Any  # type: ignore
     AsyncSession = Any  # type: ignore
 
-from .errors import create_standardized_error
+from ..jsonrpc_models import create_standardized_error
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- fix autoapi runner missing module error by importing from jsonrpc_models

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_689ea4ce2bb083269c66695f49a79900