### PR TITLE
Add AutoAPI v3 regression tests

### DIFF
--- a/pkgs/standards/autoapi/tests/r8n/conftest.py
+++ b/pkgs/standards/autoapi/tests/r8n/conftest.py
@@ -1,0 +1,202 @@
+from typing import AsyncIterator, Iterator
+
+import pytest
+import pytest_asyncio
+from autoapi.v3 import AutoAPI, Base
+from autoapi.v3.mixins import BulkCapable, GUIDPk
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import Column, ForeignKey, String, create_engine
+from sqlalchemy.pool import StaticPool
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+
+def pytest_addoption(parser):
+    """Add command line options for database mode."""
+    group = parser.getgroup("database")
+    group.addoption(
+        "--db-mode",
+        choices=["sync", "async"],
+        help="Database mode to test (sync or async). If not specified, tests both modes.",
+    )
+
+
+def pytest_generate_tests(metafunc):
+    """Generate test parameters for db modes."""
+    if "db_mode" in metafunc.fixturenames:
+        db_mode_option = metafunc.config.getoption("--db-mode")
+        if db_mode_option:
+            # Run only the specified mode
+            metafunc.parametrize("db_mode", [db_mode_option])
+        else:
+            # Run both modes by default
+            metafunc.parametrize("db_mode", ["sync", "async"])
+
+
+@pytest.fixture
+def sync_db_session():
+    """Create a sync database session for testing."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+
+    def get_sync_db() -> Iterator[Session]:
+        with SessionLocal() as session:
+            yield session
+
+    return engine, get_sync_db
+
+
+@pytest_asyncio.fixture
+async def async_db_session():
+    """Create an async database session for testing."""
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+    AsyncSessionLocal = async_sessionmaker(
+        bind=engine, class_=AsyncSession, expire_on_commit=False
+    )
+
+    async def get_async_db() -> AsyncIterator[AsyncSession]:
+        async with AsyncSessionLocal() as session:
+            yield session
+
+    return engine, get_async_db
+
+
+@pytest.fixture
+def create_test_api(sync_db_session):
+    """Factory fixture to create AutoAPI instances for testing individual models."""
+    engine, get_sync_db = sync_db_session
+
+    def _create_api(model_class, base=None):
+        """Create AutoAPI instance with a single model for testing."""
+        if base is None:
+            base = Base
+
+        # Clear metadata to avoid conflicts
+        base.metadata.clear()
+
+        api = AutoAPI(base=base, include={model_class}, get_db=get_sync_db)
+        api.initialize_sync()
+        return api
+
+    return _create_api
+
+
+@pytest_asyncio.fixture
+async def create_test_api_async(async_db_session):
+    """Factory fixture to create async AutoAPI instances for testing individual models."""
+    engine, get_async_db = async_db_session
+
+    def _create_api_async(model_class, base=None):
+        """Create async AutoAPI instance with a single model for testing."""
+        if base is None:
+            base = Base
+
+        # Clear metadata to avoid conflicts
+        base.metadata.clear()
+
+        api = AutoAPI(base=base, include={model_class}, get_async_db=get_async_db)
+        return api
+
+    return _create_api_async
+
+
+@pytest.fixture
+def test_models():
+    """Factory fixture to create test model classes."""
+
+    def _create_model(name, mixins=None, extra_fields=None):
+        """Create a test model class with specified mixins and fields."""
+        if mixins is None:
+            mixins = (GUIDPk,)
+
+        attrs = {
+            "__tablename__": f"test_{name.lower()}",
+            "name": Column(String, nullable=False),
+        }
+
+        if extra_fields:
+            attrs.update(extra_fields)
+
+        # Create the model class dynamically
+        model_class = type(f"Test{name}", (Base,) + mixins, attrs)
+        return model_class
+
+    return _create_model
+
+
+@pytest_asyncio.fixture()
+async def api_client(db_mode):
+    """Main fixture for integration tests with Tenant and Item models."""
+    Base.metadata.clear()
+
+    class Tenant(Base, GUIDPk):
+        __tablename__ = "tenants"
+        name = Column(String, nullable=False)
+
+    class Item(Base, GUIDPk, BulkCapable):
+        __tablename__ = "items"
+        tenant_id = Column(UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False)
+        name = Column(String, nullable=False)
+
+        @classmethod
+        def __autoapi_nested_paths__(cls):
+            return "/tenant/{tenant_id}"
+
+    if db_mode == "async":
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=True)
+
+        AsyncSessionLocal = async_sessionmaker(
+            bind=engine, class_=AsyncSession, expire_on_commit=False
+        )
+
+        async def get_async_db() -> AsyncIterator[AsyncSession]:
+            async with AsyncSessionLocal() as session:
+                yield session
+
+        api = AutoAPI(base=Base, include={Tenant, Item}, get_async_db=get_async_db)
+        await api.initialize_async()
+
+    else:
+        engine = create_engine(
+            "sqlite:///:memory:",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+
+        SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+
+        def get_sync_db() -> Iterator[Session]:
+            with SessionLocal() as session:
+                yield session
+
+        api = AutoAPI(base=Base, include={Tenant, Item}, get_db=get_sync_db)
+        api.initialize_sync()
+
+    app = FastAPI()
+    app.include_router(api.router)
+    transport = ASGITransport(app=app)
+
+    client = AsyncClient(transport=transport, base_url="http://test")
+    return client, api, Item
+
+
+@pytest.fixture
+def sample_tenant_data():
+    """Sample tenant data for testing."""
+    return {"name": "test-tenant"}
+
+
+@pytest.fixture
+def sample_item_data():
+    """Sample item data for testing (requires tenant_id)."""
+
+    def _create_item_data(tenant_id):
+        return {"tenant_id": tenant_id, "name": "test-item"}
+
+    return _create_item_data

--- a/pkgs/standards/autoapi/tests/r8n/test_acronym_route_name.py
+++ b/pkgs/standards/autoapi/tests/r8n/test_acronym_route_name.py
@@ -1,0 +1,16 @@
+import pytest
+from autoapi.v3 import Base
+from autoapi.v3.mixins import GUIDPk
+from sqlalchemy import Column, String
+
+
+@pytest.mark.r8n
+def test_acronym_model_route(create_test_api):
+    class GPGKey(Base, GUIDPk):
+        __tablename__ = "gpg_keys"
+        key = Column(String, nullable=False)
+
+    api = create_test_api(GPGKey)
+    paths = {route.path for route in api.router.routes}
+    assert "/gpg_key" in paths
+    assert all("g_p_g_key" not in p for p in paths)

--- a/pkgs/standards/autoapi/tests/r8n/test_allow_anon.py
+++ b/pkgs/standards/autoapi/tests/r8n/test_allow_anon.py
@@ -1,0 +1,124 @@
+from fastapi import FastAPI, HTTPException, Security
+from fastapi.testclient import TestClient
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy import Column, String, ForeignKey, create_engine
+from sqlalchemy.pool import StaticPool
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import sessionmaker
+
+from autoapi.v3 import AutoAPI, Base
+from autoapi.v3.mixins import GUIDPk
+from autoapi.v3.types import AuthNProvider
+
+
+class DummyAuth(AuthNProvider):
+    async def get_principal(
+        self,
+        creds: HTTPAuthorizationCredentials = Security(HTTPBearer()),
+    ):
+        if creds.credentials != "secret":
+            raise HTTPException(status_code=401)
+        return {"sub": "user"}
+
+    def register_inject_hook(self, api) -> None:
+        return None
+
+
+def _build_client():
+    Base.metadata.clear()
+
+    class Tenant(Base, GUIDPk):
+        __tablename__ = "tenants"
+        name = Column(String, nullable=False)
+
+    class Item(Base, GUIDPk):
+        __tablename__ = "items"
+        tenant_id = Column(UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False)
+        name = Column(String, nullable=False)
+
+        @classmethod
+        def __autoapi_allow_anon__(cls):
+            return {"list", "read"}
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+
+    def get_db():
+        with SessionLocal() as session:
+            yield session
+
+    api = AutoAPI(base=Base, include={Tenant, Item}, get_db=get_db, authn=DummyAuth())
+    app = FastAPI()
+    app.include_router(api.router)
+    api.initialize_sync()
+    return TestClient(app)
+
+
+def _build_client_attr():
+    Base.metadata.clear()
+
+    class Tenant(Base, GUIDPk):
+        __tablename__ = "tenants"
+        name = Column(String, nullable=False)
+
+    class Item(Base, GUIDPk):
+        __tablename__ = "items"
+        tenant_id = Column(UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False)
+        name = Column(String, nullable=False)
+
+        __autoapi_allow_anon__ = {"list", "read"}
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+
+    def get_db():
+        with SessionLocal() as session:
+            yield session
+
+    api = AutoAPI(base=Base, include={Tenant, Item}, get_db=get_db, authn=DummyAuth())
+    app = FastAPI()
+    app.include_router(api.router)
+    api.initialize_sync()
+    return TestClient(app)
+
+
+def test_allow_anon_list_and_read():
+    client = _build_client()
+    assert client.get("/item").status_code == 200
+    tenant = {"name": "acme"}
+    res = client.post(
+        "/tenant", json=tenant, headers={"Authorization": "Bearer secret"}
+    )
+    tid = res.json()["id"]
+    payload = {"tenant_id": tid, "name": "thing"}
+    res = client.post("/item", json=payload, headers={"Authorization": "Bearer secret"})
+    iid = res.json()["id"]
+    assert client.get(f"/item/{iid}").status_code == 200
+    # FastAPI's HTTPBearer returns 403 when the Authorization header is
+    # completely missing (as opposed to a malformed token).  The AutoAPI
+    # endpoint mirrors this behaviour for unauthenticated access to routes
+    # that are not whitelisted via ``__autoapi_allow_anon__``.
+    assert client.post("/item", json=payload).status_code == 403
+
+
+def test_allow_anon_list_and_read_attr():
+    client = _build_client_attr()
+    assert client.get("/item").status_code == 200
+    tenant = {"name": "acme"}
+    res = client.post(
+        "/tenant", json=tenant, headers={"Authorization": "Bearer secret"}
+    )
+    tid = res.json()["id"]
+    payload = {"tenant_id": tid, "name": "thing"}
+    res = client.post("/item", json=payload, headers={"Authorization": "Bearer secret"})
+    iid = res.json()["id"]
+    assert client.get(f"/item/{iid}").status_code == 200
+    assert client.post("/item", json=payload).status_code == 403

--- a/pkgs/standards/autoapi/tests/r8n/test_apikey_generation.py
+++ b/pkgs/standards/autoapi/tests/r8n/test_apikey_generation.py
@@ -1,0 +1,39 @@
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from autoapi.v3 import AutoAPI, Base
+from autoapi.v3.tables import ApiKey
+
+
+class ConcreteApiKey(ApiKey):
+    """Concrete table for testing API key generation."""
+
+    __abstract__ = False
+
+
+# Ensure hooks register under expected model name
+ConcreteApiKey.__name__ = "ApiKey"
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_api_key_creation_returns_raw_key(sync_db_session):
+    """Creating an API key returns the raw key once."""
+    _, get_sync_db = sync_db_session
+    Base.metadata.clear()
+    api = AutoAPI(base=Base, include={ConcreteApiKey}, get_db=get_sync_db)
+    api.initialize_sync()
+
+    app = FastAPI()
+    app.include_router(api.router)
+    transport = ASGITransport(app=app)
+
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        res = await client.post("/api_key", json={"label": "test"})
+
+    assert res.status_code == 201
+    data = res.json()
+    assert data["label"] == "test"
+    assert "api_key" in data and data["api_key"]
+    assert "digest" in data and data["digest"]

--- a/pkgs/standards/autoapi/tests/r8n/test_authn_provider_integration.py
+++ b/pkgs/standards/autoapi/tests/r8n/test_authn_provider_integration.py
@@ -1,0 +1,91 @@
+from fastapi import FastAPI, HTTPException, Security
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from fastapi.testclient import TestClient
+from sqlalchemy import Column, ForeignKey, String, create_engine
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from autoapi.v3 import AutoAPI, Base
+from autoapi.v3.cfgs import AUTH_CONTEXT_KEY
+from autoapi.v3.hooks import Phase
+from autoapi.v3.mixins import GUIDPk
+from autoapi.v3.types import AuthNProvider
+
+
+class HookedAuth(AuthNProvider):
+    """Simple AuthN provider that records context via a hook."""
+
+    def __init__(self) -> None:
+        self.ctx_principal: dict | None = None
+
+    async def get_principal(
+        self,
+        creds: HTTPAuthorizationCredentials = Security(HTTPBearer()),
+    ) -> dict:
+        if creds.credentials != "secret":
+            raise HTTPException(status_code=401)
+        return {"sub": "user", "tid": "tenant"}
+
+    def register_inject_hook(self, api) -> None:  # pragma: no cover - runtime wiring
+        @api.register_hook(Phase.PRE_TX_BEGIN)
+        async def _capture(ctx):  # pragma: no cover - executed in tests
+            self.ctx_principal = ctx.get(AUTH_CONTEXT_KEY)
+
+
+def _build_client_with_auth():
+    Base.metadata.clear()
+
+    class Tenant(Base, GUIDPk):
+        __tablename__ = "tenants"
+        name = Column(String, nullable=False)
+
+    class Item(Base, GUIDPk):
+        __tablename__ = "items"
+        tenant_id = Column(UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False)
+        name = Column(String, nullable=False)
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+
+    def get_db():
+        with SessionLocal() as session:
+            yield session
+
+    auth = HookedAuth()
+    api = AutoAPI(base=Base, include={Tenant, Item}, get_db=get_db, authn=auth)
+    auth.register_inject_hook(api)
+    app = FastAPI()
+    app.include_router(api.router)
+    api.initialize_sync()
+    return TestClient(app), auth
+
+
+def test_authn_hooks_and_context_injection():
+    client, auth = _build_client_with_auth()
+
+    tenant = {"name": "acme"}
+    res = client.post(
+        "/tenant", json=tenant, headers={"Authorization": "Bearer secret"}
+    )
+    tid = res.json()["id"]
+
+    auth.ctx_principal = None
+    payload = {"tenant_id": tid, "name": "widget"}
+    res = client.post("/item", json=payload, headers={"Authorization": "Bearer secret"})
+    assert res.status_code == 201
+    assert auth.ctx_principal == {"sub": "user", "tid": "tenant"}
+
+
+def test_authn_unauthorized_errors():
+    client, _ = _build_client_with_auth()
+
+    assert client.get("/item").status_code == 403
+    assert (
+        client.get("/item", headers={"Authorization": "Bearer wrong"}).status_code
+        == 401
+    )

--- a/pkgs/standards/autoapi/tests/r8n/test_column_metadata_runtime.py
+++ b/pkgs/standards/autoapi/tests/r8n/test_column_metadata_runtime.py
@@ -1,0 +1,163 @@
+"""Runtime behavior tests for column metadata keys."""
+
+from datetime import datetime
+from uuid import UUID
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import Column, DateTime, String
+
+from autoapi.v3 import Base, get_schema
+from autoapi.v3.mixins import GUIDPk
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_write_only_field_runtime_behavior(create_test_api):
+    """Ensure write_only fields are accepted but never returned."""
+
+    class WriteOnlyModel(Base, GUIDPk):
+        __tablename__ = "write_only_model"
+        name = Column(String)
+        secret = Column(String, info={"autoapi": {"write_only": True}})
+
+    api = create_test_api(WriteOnlyModel)
+    app = FastAPI()
+    app.include_router(api.router)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        payload = {"name": "test", "secret": "s3cr3t"}
+        res = await client.post("/write_only_model", json=payload)
+        assert res.status_code == 201
+        item_id = res.json()["id"]
+
+        gen = api.get_db()
+        session = next(gen)
+        try:
+            obj = session.get(WriteOnlyModel, UUID(item_id))
+            assert obj.secret == "s3cr3t"
+        finally:
+            try:
+                next(gen)
+            except StopIteration:
+                pass
+
+        res = await client.get(f"/write_only_model/{item_id}")
+        assert res.status_code == 200
+        assert "secret" not in res.json()
+
+        res = await client.patch(
+            f"/write_only_model/{item_id}", json={"secret": "newsecret"}
+        )
+        assert res.status_code == 200
+        assert "secret" not in res.json()
+
+        gen = api.get_db()
+        session = next(gen)
+        try:
+            obj = session.get(WriteOnlyModel, UUID(item_id))
+            assert obj.secret == "newsecret"
+        finally:
+            try:
+                next(gen)
+            except StopIteration:
+                pass
+
+    create_schema = get_schema(WriteOnlyModel, "create")
+    read_schema = get_schema(WriteOnlyModel, "read")
+    update_schema = get_schema(WriteOnlyModel, "update")
+
+    assert "secret" in create_schema.model_fields
+    assert "secret" in update_schema.model_fields
+    assert "secret" not in read_schema.model_fields
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_read_only_field_runtime_behavior(create_test_api):
+    """Ensure read_only fields are returned but cannot be written."""
+
+    class ReadOnlyModel(Base, GUIDPk):
+        __tablename__ = "read_only_model"
+        name = Column(String)
+        code = Column(String, default="RO", info={"autoapi": {"read_only": True}})
+
+    api = create_test_api(ReadOnlyModel)
+    app = FastAPI()
+    app.include_router(api.router)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        res = await client.post(
+            "/read_only_model", json={"name": "bad", "code": "hack"}
+        )
+        assert res.status_code == 201
+        data = res.json()
+        item_id = data["id"]
+        ro_value = data["code"]
+        assert ro_value == "RO"
+
+        res = await client.patch(f"/read_only_model/{item_id}", json={"code": "hack"})
+        assert res.status_code == 200
+        assert res.json()["code"] == ro_value
+
+        res = await client.patch(f"/read_only_model/{item_id}", json={"name": "new"})
+        assert res.status_code == 200
+        assert res.json()["code"] == ro_value
+
+        res = await client.get(f"/read_only_model/{item_id}")
+        assert res.status_code == 200
+        assert res.json()["code"] == ro_value
+
+    create_schema = get_schema(ReadOnlyModel, "create")
+    read_schema = get_schema(ReadOnlyModel, "read")
+    update_schema = get_schema(ReadOnlyModel, "update")
+
+    assert "code" not in create_schema.model_fields
+    assert "code" in read_schema.model_fields
+    assert "code" not in update_schema.model_fields
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_default_factory_field_runtime_behavior(create_test_api):
+    """Ensure default_factory populates missing values and persists across updates."""
+
+    class FactoryModel(Base, GUIDPk):
+        __tablename__ = "factory_model"
+        name = Column(String)
+        created_at = Column(
+            DateTime, info={"autoapi": {"default_factory": datetime.utcnow}}
+        )
+
+    api = create_test_api(FactoryModel)
+    app = FastAPI()
+    app.include_router(api.router)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        res = await client.post("/factory_model", json={"name": "test"})
+        assert res.status_code == 201
+        data = res.json()
+        item_id = data["id"]
+        created = data["created_at"]
+
+        res = await client.get(f"/factory_model/{item_id}")
+        assert res.status_code == 200
+        assert res.json()["created_at"] == created
+
+        res = await client.patch(f"/factory_model/{item_id}", json={"name": "updated"})
+        assert res.status_code == 200
+        assert res.json()["created_at"] == created
+
+    create_schema = get_schema(FactoryModel, "create")
+    field = create_schema.model_fields["created_at"]
+    assert field.default_factory is not None
+    assert not field.is_required()
+    assert "created_at" in get_schema(FactoryModel, "read").model_fields
+    assert "created_at" in get_schema(FactoryModel, "update").model_fields

--- a/pkgs/standards/autoapi/tests/r8n/test_core_access.py
+++ b/pkgs/standards/autoapi/tests/r8n/test_core_access.py
@@ -1,0 +1,629 @@
+"""
+Test cases for api.core and api.core_raw direct access methods.
+
+Tests cover:
+- Basic CRUD operations with api.core (manual session management)
+- Basic CRUD operations with api.core_raw (automatic session management)
+- Sync vs Async database compatibility
+- Edge cases and error handling
+- Session management edge cases
+"""
+
+import pytest
+import pytest_asyncio
+from autoapi.v3 import AutoAPI, Base
+from autoapi.v3.mixins import GUIDPk
+from sqlalchemy import Column, String, Integer
+from fastapi import HTTPException
+
+
+class CoreTestUser(Base, GUIDPk):
+    __tablename__ = "test_users"
+    name = Column(String(100), nullable=True)  # Allow partial updates
+    email = Column(String(255), unique=True, nullable=True)  # Allow partial updates
+    age = Column(Integer, nullable=True)
+
+
+@pytest.fixture
+def sync_api(sync_db_session):
+    """Create sync AutoAPI instance with TestUser model."""
+    engine, get_sync_db = sync_db_session
+    Base.metadata.clear()
+
+    api = AutoAPI(base=Base, include={CoreTestUser}, get_db=get_sync_db)
+    api.initialize_sync()
+    return api, get_sync_db
+
+
+@pytest_asyncio.fixture
+async def async_api(async_db_session):
+    """Create async AutoAPI instance with TestUser model."""
+    engine, get_async_db = async_db_session
+    Base.metadata.clear()
+
+    api = AutoAPI(base=Base, include={CoreTestUser}, get_async_db=get_async_db)
+    await api.initialize_async()
+    return api, get_async_db
+
+
+def test_schemas_dir_contains_operation_names(sync_api):
+    api, _ = sync_api
+    names = dir(api.schemas)
+    assert "CoreTestUserCreateIn" in names
+    assert "CoreTestUser" not in names
+    assert not hasattr(api.schemas, "CoreTestUser")
+
+
+class TestApiCore:
+    """Test cases for api.core direct access (manual session management)."""
+
+    def test_sync_core_create_success(self, sync_api):
+        """Test successful creation using api.core with schema validation."""
+        api, get_db = sync_api
+
+        # Use api.schemas for proper validation
+        user_schema = api.schemas.CoreTestUserCreateIn(
+            name="John Doe", email="john@example.com", age=30
+        )
+
+        with next(get_db()) as db:
+            with db.begin():
+                user = api.core.CoreTestUser.create(user_schema, db)
+                db.flush()
+
+                assert user.name == "John Doe"
+                assert user.email == "john@example.com"
+                assert user.age == 30
+                assert user.id is not None
+
+    def test_sync_core_read_success(self, sync_api):
+        """Test successful read using api.core with schema validation."""
+        api, get_db = sync_api
+
+        # Use schema for creation
+        user_schema = api.schemas.CoreTestUserCreateIn(
+            name="Jane Doe", email="jane@example.com"
+        )
+
+        # First create a user
+        with next(get_db()) as db:
+            with db.begin():
+                user = api.core.CoreTestUser.create(user_schema, db)
+                db.flush()
+                user_id = user.id
+
+        # Then read it back - core.Read takes ID directly, not schema
+        with next(get_db()) as db:
+            retrieved_user = api.core.CoreTestUser.read(user_id, db)
+            assert retrieved_user.name == "Jane Doe"
+            assert retrieved_user.email == "jane@example.com"
+            assert retrieved_user.id == user_id
+
+    def test_sync_core_update_success(self, sync_api):
+        """Test successful update using api.core with schema validation."""
+        api, get_db = sync_api
+
+        # Create user using schema
+        user_schema = api.schemas.CoreTestUserCreateIn(
+            name="Bob Smith", email="bob@example.com"
+        )
+
+        # Create user
+        with next(get_db()) as db:
+            with db.begin():
+                user = api.core.CoreTestUser.create(user_schema, db)
+                db.flush()
+                user_id = user.id
+
+        # Update user using schema for payload validation
+        update_schema = api.schemas.CoreTestUserUpdateIn(name="Robert Smith", age=25)
+        with next(get_db()) as db:
+            with db.begin():
+                updated_user = api.core.CoreTestUser.update(user_id, update_schema, db)
+                db.flush()
+
+                assert updated_user.name == "Robert Smith"
+                assert updated_user.email == "bob@example.com"  # Unchanged
+                assert updated_user.age == 25
+
+    def test_sync_core_delete_success(self, sync_api):
+        """Test successful deletion using api.core with schema validation."""
+        api, get_db = sync_api
+
+        # Create user using schema
+        user_schema = api.schemas.CoreTestUserCreateIn(
+            name="Delete Me", email="delete@example.com"
+        )
+
+        # Create user
+        with next(get_db()) as db:
+            with db.begin():
+                user = api.core.CoreTestUser.create(user_schema, db)
+                db.flush()
+                user_id = user.id
+
+        # Delete user - core.Delete takes ID directly
+        with next(get_db()) as db:
+            with db.begin():
+                result = api.core.CoreTestUser.delete(user_id, db)
+                db.flush()
+
+                assert result == {"id": user_id}
+
+    def test_sync_core_list_success(self, sync_api):
+        """Test successful listing using api.core with schema validation."""
+        api, get_db = sync_api
+
+        # Create multiple users using schemas
+        user_schemas = [
+            api.schemas.CoreTestUserCreateIn(name="User 1", email="user1@example.com"),
+            api.schemas.CoreTestUserCreateIn(name="User 2", email="user2@example.com"),
+            api.schemas.CoreTestUserCreateIn(name="User 3", email="user3@example.com"),
+        ]
+
+        with next(get_db()) as db:
+            with db.begin():
+                for user_schema in user_schemas:
+                    api.core.CoreTestUser.create(user_schema, db)
+                db.flush()
+
+        # List users using schema
+        with next(get_db()) as db:
+            list_schema = api.schemas.CoreTestUserListIn(skip=0, limit=10)
+            users = api.core.CoreTestUser.list(list_schema, db)
+
+            assert len(users) == 3
+            assert all(user.name.startswith("User") for user in users)
+
+    def test_sync_core_clear_success(self, sync_api):
+        """Test successful clear using api.core with schema validation."""
+        api, get_db = sync_api
+
+        # Create users using schemas
+        with next(get_db()) as db:
+            with db.begin():
+                user1_schema = api.schemas.CoreTestUserCreateIn(
+                    name="User 1", email="user1@example.com"
+                )
+                user2_schema = api.schemas.CoreTestUserCreateIn(
+                    name="User 2", email="user2@example.com"
+                )
+                api.core.CoreTestUser.create(user1_schema, db)
+                api.core.CoreTestUser.create(user2_schema, db)
+                db.flush()
+
+        # Clear all users (clear only takes db parameter)
+        with next(get_db()) as db:
+            with db.begin():
+                result = api.core.CoreTestUser.clear(db)
+                db.flush()
+
+                assert result["deleted"] == 2
+
+        # Verify empty using schema
+        with next(get_db()) as db:
+            list_schema = api.schemas.CoreTestUserListIn()
+            users = api.core.CoreTestUser.list(list_schema, db)
+            assert len(users) == 0
+
+    def test_sync_core_read_not_found(self, sync_api):
+        """Test reading non-existent record raises HTTPException with schema validation."""
+        api, get_db = sync_api
+        fake_id = "00000000-0000-0000-0000-000000000000"
+
+        with pytest.raises(HTTPException) as exc_info:
+            with next(get_db()) as db:
+                api.core.CoreTestUser.read(fake_id, db)
+
+        assert exc_info.value.status_code == 404
+
+    def test_sync_core_update_not_found(self, sync_api):
+        """Test updating non-existent record raises HTTPException with schema validation."""
+        api, get_db = sync_api
+        fake_id = "00000000-0000-0000-0000-000000000000"
+
+        update_schema = api.schemas.CoreTestUserUpdateIn(name="Updated")
+
+        with pytest.raises(HTTPException) as exc_info:
+            with next(get_db()) as db:
+                with db.begin():
+                    api.core.CoreTestUser.update(fake_id, update_schema, db)
+
+        assert exc_info.value.status_code == 404
+
+    def test_sync_core_delete_not_found(self, sync_api):
+        """Test deleting non-existent record raises HTTPException with schema validation."""
+        api, get_db = sync_api
+        fake_id = "00000000-0000-0000-0000-000000000000"
+
+        with pytest.raises(HTTPException) as exc_info:
+            with next(get_db()) as db:
+                with db.begin():
+                    api.core.CoreTestUser.delete(fake_id, db)
+
+        assert exc_info.value.status_code == 404
+
+    def test_sync_core_create_duplicate_email(self, sync_api):
+        """Test creating user with duplicate email raises HTTPException with schema validation."""
+        api, get_db = sync_api
+
+        first_user_schema = api.schemas.CoreTestUserCreateIn(
+            name="First User", email="duplicate@example.com"
+        )
+
+        # Create first user
+        with next(get_db()) as db:
+            with db.begin():
+                api.core.CoreTestUser.create(first_user_schema, db)
+                db.flush()
+
+        # Try to create duplicate using schema
+        duplicate_schema = api.schemas.CoreTestUserCreateIn(
+            name="Second User", email="duplicate@example.com"
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            with next(get_db()) as db:
+                with db.begin():
+                    api.core.CoreTestUser.create(duplicate_schema, db)
+                    db.flush()
+
+        # SQLite returns 422 for constraint violations, PostgreSQL returns 409
+        assert exc_info.value.status_code in (409, 422)
+
+    def test_sync_core_manual_transaction_rollback(self, sync_api):
+        """Test manual transaction rollback with api.core and schema validation."""
+        api, get_db = sync_api
+
+        user_schema = api.schemas.CoreTestUserCreateIn(
+            name="Rollback User", email="rollback@example.com"
+        )
+
+        with next(get_db()) as db:
+            with db.begin():
+                user = api.core.CoreTestUser.create(user_schema, db)
+                db.flush()
+                user_id = user.id
+
+                # Manually rollback
+                db.rollback()
+
+        # Verify user was not persisted
+        with pytest.raises(HTTPException):
+            with next(get_db()) as db:
+                api.core.CoreTestUser.read(user_id, db)
+
+    @pytest.mark.asyncio
+    async def test_async_db_with_core_via_run_sync(self, async_api):
+        """Test using api.core with async database via run_sync and schema validation."""
+        api, get_async_db = async_api
+
+        user_schema = api.schemas.CoreTestUserCreateIn(
+            name="Async User", email="async@example.com"
+        )
+
+        async for db in get_async_db():
+            # Use run_sync to call sync CRUD function with schema
+            result = await db.run_sync(
+                lambda sync_db: api.core.CoreTestUser.create(user_schema, sync_db)
+            )
+            await db.commit()
+
+            assert result.name == "Async User"
+            assert result.email == "async@example.com"
+            break
+
+
+class TestApiCoreRaw:
+    """Test cases for api.core_raw (automatic session management)."""
+
+    @pytest.mark.asyncio
+    async def test_sync_core_raw_create_auto_session(self, sync_api):
+        """Test api.core_raw with automatic session management (sync)."""
+        api, get_db = sync_api
+        user_data = {"name": "Auto Session", "email": "auto@example.com"}
+
+        # No manual session management required
+        user = await api.core_raw.CoreTestUser.create(user_data)
+
+        assert user.name == "Auto Session"
+        assert user.email == "auto@example.com"
+        assert user.id is not None
+
+    @pytest.mark.asyncio
+    async def test_sync_core_raw_create_manual_session(self, sync_api):
+        """Test api.core_raw with manual session (sync)."""
+        api, get_db = sync_api
+        user_data = {"name": "Manual Session", "email": "manual@example.com"}
+
+        with next(get_db()) as db:
+            user = await api.core_raw.CoreTestUser.create(user_data, db=db)
+            db.commit()  # Manual commit required
+
+            assert user.name == "Manual Session"
+            assert user.email == "manual@example.com"
+
+    @pytest.mark.asyncio
+    async def test_sync_core_raw_read_success(self, sync_api):
+        """Test successful read using api.core_raw."""
+        api, get_db = sync_api
+        user_data = {"name": "Read Me", "email": "read@example.com"}
+
+        # Create user with manual session to ensure it's committed
+        with next(get_db()) as db:
+            user = await api.core_raw.CoreTestUser.create(user_data, db=db)
+            db.commit()  # Ensure it's persisted
+            user_id = user.id
+
+        # Read user back
+        retrieved_user = await api.core_raw.CoreTestUser.read({"id": user_id})
+
+        assert retrieved_user.name == "Read Me"
+        assert retrieved_user.email == "read@example.com"
+        assert retrieved_user.id == user_id
+
+    @pytest.mark.asyncio
+    async def test_sync_core_raw_update_success(self, sync_api):
+        """Test successful update using api.core_raw."""
+        api, get_db = sync_api
+        user_data = {"name": "Update Me", "email": "update@example.com"}
+
+        # Create user with manual session to ensure it's committed
+        with next(get_db()) as db:
+            user = await api.core_raw.CoreTestUser.create(user_data, db=db)
+            db.commit()  # Ensure it's persisted
+            user_id = user.id
+
+        # Update user with manual session
+        with next(get_db()) as db:
+            update_data = {"id": user_id, "name": "Updated Name", "age": 35}
+            updated_user = await api.core_raw.CoreTestUser.update(update_data, db=db)
+            db.commit()  # Ensure update is persisted
+
+        assert updated_user.name == "Updated Name"
+        assert updated_user.email == "update@example.com"  # Unchanged
+        assert updated_user.age == 35
+
+    @pytest.mark.asyncio
+    async def test_sync_core_raw_delete_success(self, sync_api):
+        """Test successful deletion using api.core_raw."""
+        api, get_db = sync_api
+        user_data = {"name": "Delete Me Raw", "email": "deleteraw@example.com"}
+
+        # Create user with manual session to ensure it's committed
+        with next(get_db()) as db:
+            user = await api.core_raw.CoreTestUser.create(user_data, db=db)
+            db.commit()  # Ensure it's persisted
+            user_id = user.id
+
+        # Delete user with manual session
+        with next(get_db()) as db:
+            result = await api.core_raw.CoreTestUser.delete({"id": user_id}, db=db)
+            db.commit()  # Ensure deletion is persisted
+
+        assert result == {"id": user_id}
+
+    @pytest.mark.asyncio
+    async def test_sync_core_raw_list_success(self, sync_api):
+        """Test successful listing using api.core_raw."""
+        api, get_db = sync_api
+
+        # Create multiple users with manual session to ensure they're committed
+        with next(get_db()) as db:
+            await api.core_raw.CoreTestUser.create(
+                {"name": "List User 1", "email": "list1@example.com"}, db=db
+            )
+            await api.core_raw.CoreTestUser.create(
+                {"name": "List User 2", "email": "list2@example.com"}, db=db
+            )
+            db.commit()  # Ensure they're persisted
+
+        # List users
+        list_params = {"skip": 0, "limit": 10}
+        users = await api.core_raw.CoreTestUser.list(list_params)
+
+        assert len(users) >= 2
+        user_names = [u.name for u in users]
+        assert "List User 1" in user_names
+        assert "List User 2" in user_names
+
+    @pytest.mark.asyncio
+    async def test_sync_core_raw_clear_success(self, sync_api):
+        """Test successful clear using api.core_raw."""
+        api, get_db = sync_api
+
+        # Create users first with manual session to ensure they're committed
+        with next(get_db()) as db:
+            await api.core_raw.CoreTestUser.create(
+                {"name": "Clear User 1", "email": "clear1@example.com"}, db=db
+            )
+            await api.core_raw.CoreTestUser.create(
+                {"name": "Clear User 2", "email": "clear2@example.com"}, db=db
+            )
+            db.commit()  # Ensure they're persisted
+
+        # Clear all users with manual session
+        with next(get_db()) as db:
+            result = await api.core_raw.CoreTestUser.clear({}, db=db)
+            db.commit()  # Ensure clear is persisted
+
+        assert result["deleted"] >= 2
+
+        # Verify empty
+        users = await api.core_raw.CoreTestUser.list({})
+        assert len(users) == 0
+
+    @pytest.mark.asyncio
+    async def test_async_core_raw_create_auto_session(self, async_api):
+        """Test api.core_raw with async database and manual session (auto-session doesn't work with async-only setup)."""
+        api, get_async_db = async_api
+        user_data = {"name": "Async Auto", "email": "asyncauto@example.com"}
+
+        # Since async-only API doesn't have sync get_db, we need to provide a manual session
+        async for db in get_async_db():
+            user = await api.core_raw.CoreTestUser.create(user_data, db=db)
+            await db.commit()  # Ensure it's persisted
+
+            assert user.name == "Async Auto"
+            assert user.email == "asyncauto@example.com"
+            assert user.id is not None
+            break
+
+    @pytest.mark.asyncio
+    async def test_async_core_raw_create_manual_session(self, async_api):
+        """Test api.core_raw with async database and manual session."""
+        api, get_async_db = async_api
+        user_data = {"name": "Async Manual", "email": "asyncmanual@example.com"}
+
+        async for db in get_async_db():
+            user = await api.core_raw.CoreTestUser.create(user_data, db=db)
+            await db.commit()
+
+            assert user.name == "Async Manual"
+            assert user.email == "asyncmanual@example.com"
+            break
+
+
+class TestCoreRawEdgeCases:
+    """Test edge cases and error conditions for api.core_raw."""
+
+    @pytest.mark.asyncio
+    async def test_core_raw_no_get_db_configured(self, async_db_session):
+        """Test api.core_raw when no get_db is configured."""
+        engine, get_async_db = async_db_session
+        Base.metadata.clear()
+
+        # Create API with only async_db, no sync get_db
+        api = AutoAPI(base=Base, include={CoreTestUser}, get_async_db=get_async_db)
+        await api.initialize_async()
+
+        user_data = {"name": "No GetDB", "email": "nogetdb@example.com"}
+
+        # Should raise TypeError when trying to auto-acquire session
+        with pytest.raises(TypeError, match="core_raw requires a DB"):
+            await api.core_raw.CoreTestUser.create(user_data)
+
+    @pytest.mark.asyncio
+    async def test_core_raw_read_not_found(self, sync_api):
+        """Test api.core_raw reading non-existent record."""
+        api, get_db = sync_api
+        fake_id = "00000000-0000-0000-0000-000000000000"
+
+        with pytest.raises(HTTPException) as exc_info:
+            await api.core_raw.CoreTestUser.read({"id": fake_id})
+
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_core_raw_update_not_found(self, sync_api):
+        """Test api.core_raw updating non-existent record."""
+        api, get_db = sync_api
+        fake_id = "00000000-0000-0000-0000-000000000000"
+        update_data = {"id": fake_id, "name": "Updated"}
+
+        with pytest.raises(HTTPException) as exc_info:
+            await api.core_raw.CoreTestUser.update(update_data)
+
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_core_raw_delete_not_found(self, sync_api):
+        """Test api.core_raw deleting non-existent record."""
+        api, get_db = sync_api
+        fake_id = "00000000-0000-0000-0000-000000000000"
+
+        with pytest.raises(HTTPException) as exc_info:
+            await api.core_raw.CoreTestUser.delete({"id": fake_id})
+
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_core_raw_create_duplicate_email(self, sync_api):
+        """Test api.core_raw creating user with duplicate email."""
+        api, get_db = sync_api
+
+        # Create first user with manual session to ensure it's committed
+        with next(get_db()) as db:
+            await api.core_raw.CoreTestUser.create(
+                {"name": "First", "email": "dup@example.com"}, db=db
+            )
+            db.commit()  # Ensure it's persisted
+
+        # Try to create duplicate with manual session to trigger constraint
+        with pytest.raises(HTTPException) as exc_info:
+            with next(get_db()) as db:
+                await api.core_raw.CoreTestUser.create(
+                    {"name": "Second", "email": "dup@example.com"}, db=db
+                )
+                db.commit()  # This should trigger the constraint violation
+
+        # SQLite returns 422 for constraint violations, PostgreSQL returns 409
+        assert exc_info.value.status_code in (409, 422)
+
+
+class TestCoreVsCoreRawComparison:
+    """Compare behavior between api.core and api.core_raw."""
+
+    def test_core_attributes_exist(self, sync_api):
+        """Test that both core and core_raw attributes exist and have expected methods."""
+        api, get_db = sync_api
+
+        # Check that core exists and exposes resource operations
+        assert hasattr(api, "core")
+        assert hasattr(api.core, "CoreTestUser")
+        assert hasattr(api.core.CoreTestUser, "create")
+        assert hasattr(api.core.CoreTestUser, "read")
+        assert hasattr(api.core.CoreTestUser, "update")
+        assert hasattr(api.core.CoreTestUser, "delete")
+        assert hasattr(api.core.CoreTestUser, "list")
+        assert hasattr(api.core.CoreTestUser, "clear")
+
+        # Check that core_raw exists and exposes resource operations
+        assert hasattr(api, "core_raw")
+        assert hasattr(api.core_raw, "CoreTestUser")
+        assert hasattr(api.core_raw.CoreTestUser, "create")
+        assert hasattr(api.core_raw.CoreTestUser, "read")
+        assert hasattr(api.core_raw.CoreTestUser, "update")
+        assert hasattr(api.core_raw.CoreTestUser, "delete")
+        assert hasattr(api.core_raw.CoreTestUser, "list")
+        assert hasattr(api.core_raw.CoreTestUser, "clear")
+
+    @pytest.mark.asyncio
+    async def test_core_vs_core_raw_consistency(self, sync_api):
+        """Test that core and core_raw produce consistent results."""
+        api, get_db = sync_api
+
+        # Create user with api.core using schema validation
+        user_schema = api.schemas.CoreTestUserCreateIn(
+            name="Consistency Test", email="consistency@example.com"
+        )
+
+        with next(get_db()) as db:
+            with db.begin():
+                core_user = api.core.CoreTestUser.create(user_schema, db)
+                db.flush()
+                core_user_id = core_user.id
+
+        # Create user with api.core_raw using raw dict (no schema validation)
+        user_data2 = {"name": "Consistency Test 2", "email": "consistency2@example.com"}
+        with next(get_db()) as db:
+            raw_user = await api.core_raw.CoreTestUser.create(user_data2, db=db)
+            db.commit()  # Ensure it's persisted
+            raw_user_id = raw_user.id
+
+        # Both should have similar structure
+        assert core_user.name == "Consistency Test"
+        assert raw_user.name == "Consistency Test 2"
+        assert core_user.email == "consistency@example.com"
+        assert raw_user.email == "consistency2@example.com"
+
+        # Read back with both methods - core takes ID directly, core_raw uses dict
+        with next(get_db()) as db:
+            core_read = api.core.CoreTestUser.read(core_user_id, db)
+
+        raw_read = await api.core_raw.CoreTestUser.read({"id": raw_user_id})
+
+        # Results should be structurally similar
+        assert core_read.id == core_user_id
+        assert raw_read.id == raw_user_id
+        assert core_read.name == "Consistency Test"
+        assert raw_read.name == "Consistency Test 2"

--- a/pkgs/standards/autoapi/tests/r8n/test_error_mappings.py
+++ b/pkgs/standards/autoapi/tests/r8n/test_error_mappings.py
@@ -1,0 +1,351 @@
+"""
+Error Mappings and Parity Tests for AutoAPI v2
+
+Tests error mappings between RPC and HTTP, and verifies parity between error responses.
+"""
+
+import pytest
+from autoapi.v3.jsonrpc_models import (
+    _HTTP_TO_RPC,
+    _RPC_TO_HTTP,
+    ERROR_MESSAGES,
+    HTTP_ERROR_MESSAGES,
+    _http_exc_to_rpc,
+    _rpc_error_to_http,
+    create_standardized_error,
+)
+from fastapi import HTTPException
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_http_to_rpc_error_mapping():
+    """Test that HTTP status codes map correctly to RPC error codes."""
+    # Test known mappings from _HTTP_TO_RPC
+    test_cases = [
+        (400, -32602),  # Bad Request -> Invalid params
+        (401, -32001),  # Unauthorized -> Authentication required
+        (403, -32002),  # Forbidden -> Insufficient permissions
+        (404, -32003),  # Not Found -> Resource not found
+        (409, -32004),  # Conflict -> Resource conflict
+        (422, -32602),  # Unprocessable Entity -> Invalid params
+        (500, -32603),  # Internal Server Error -> Internal error
+    ]
+
+    for http_code, expected_rpc_code in test_cases:
+        assert _HTTP_TO_RPC[http_code] == expected_rpc_code
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_rpc_to_http_error_mapping():
+    """Test that RPC error codes map correctly to HTTP status codes."""
+    # Test known mappings from _RPC_TO_HTTP
+    test_cases = [
+        (-32700, 400),  # Parse error -> Bad Request
+        (-32600, 400),  # Invalid Request -> Bad Request
+        (-32601, 404),  # Method not found -> Not Found
+        (-32602, 400),  # Invalid params -> Bad Request
+        (-32603, 500),  # Internal error -> Internal Server Error
+        (-32001, 401),  # Authentication required -> Unauthorized
+        (-32002, 403),  # Insufficient permissions -> Forbidden
+        (-32003, 404),  # Resource not found -> Not Found
+        (-32004, 409),  # Resource conflict -> Conflict
+    ]
+
+    for rpc_code, expected_http_code in test_cases:
+        assert _RPC_TO_HTTP[rpc_code] == expected_http_code
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_error_message_standardization():
+    """Test that error messages are standardized and consistent."""
+    # Test that ERROR_MESSAGES contains expected keys
+    expected_rpc_codes = [
+        -32700,
+        -32600,
+        -32601,
+        -32602,
+        -32603,
+        -32001,
+        -32002,
+        -32003,
+        -32004,
+    ]
+
+    for code in expected_rpc_codes:
+        assert code in ERROR_MESSAGES
+        assert isinstance(ERROR_MESSAGES[code], str)
+        assert len(ERROR_MESSAGES[code]) > 0
+
+    # Test that HTTP_ERROR_MESSAGES contains expected keys
+    expected_http_codes = [400, 401, 403, 404, 409, 422, 500]
+
+    for code in expected_http_codes:
+        assert code in HTTP_ERROR_MESSAGES
+        assert isinstance(HTTP_ERROR_MESSAGES[code], str)
+        assert len(HTTP_ERROR_MESSAGES[code]) > 0
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_http_exc_to_rpc_conversion():
+    """Test conversion from HTTP exceptions to RPC errors."""
+    # Test with standard HTTP exception
+    http_exc = HTTPException(status_code=404, detail="Resource not found")
+    rpc_code, rpc_message, data = _http_exc_to_rpc(http_exc)
+
+    assert rpc_code == -32003  # Resource not found
+    assert rpc_message == "Resource not found"
+    assert data is None
+
+    # Test with HTTP exception that has custom message
+    http_exc = HTTPException(status_code=400, detail="Custom bad request message")
+    rpc_code, rpc_message, data = _http_exc_to_rpc(http_exc)
+
+    assert rpc_code == -32602  # Invalid params
+    assert rpc_message == "Custom bad request message"
+    assert data is None
+
+    # Test with unmapped HTTP status code (should default to internal error)
+    http_exc = HTTPException(status_code=418, detail="I'm a teapot")
+    rpc_code, rpc_message, data = _http_exc_to_rpc(http_exc)
+
+    assert rpc_code == -32603  # Internal error
+    assert rpc_message == "I'm a teapot"
+    assert data is None
+
+    # Detail provided as structured data should be forwarded via data
+    http_exc = HTTPException(
+        status_code=422,
+        detail=[{"loc": ["body", "name"], "msg": "Field required", "type": "missing"}],
+    )
+    rpc_code, rpc_message, data = _http_exc_to_rpc(http_exc)
+    assert rpc_code == -32602
+    assert isinstance(data, list)
+    assert data[0]["loc"] == ["body", "name"]
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_rpc_error_to_http_conversion():
+    """Test conversion from RPC errors to HTTP exceptions."""
+    # Test with standard RPC error
+    http_exc = _rpc_error_to_http(-32003, "Resource not found")
+
+    assert http_exc.status_code == 404
+    assert http_exc.detail == "Resource not found"
+
+    # Test with RPC error without custom message (should use default)
+    http_exc = _rpc_error_to_http(-32001)
+
+    assert http_exc.status_code == 401
+    assert http_exc.detail == HTTP_ERROR_MESSAGES[401]
+
+    # Test with unmapped RPC error code (should default to 500)
+    http_exc = _rpc_error_to_http(-99999, "Unknown error")
+
+    assert http_exc.status_code == 500
+    assert http_exc.detail == "Unknown error"
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_create_standardized_error():
+    """Test creation of standardized errors."""
+    # Test creating error from HTTP status
+    http_exc, rpc_code, rpc_message = create_standardized_error(404, "Custom not found")
+
+    assert http_exc.status_code == 404
+    assert http_exc.detail == "Custom not found"
+    assert rpc_code == -32003
+    assert rpc_message == "Custom not found"
+
+    # Test creating error with explicit RPC code
+    http_exc, rpc_code, rpc_message = create_standardized_error(
+        400, "Bad request", -32602
+    )
+
+    assert http_exc.status_code == 400
+    assert http_exc.detail == "Bad request"
+    assert rpc_code == -32602
+    assert rpc_message == "Bad request"
+
+    # Test creating error with default message
+    http_exc, rpc_code, rpc_message = create_standardized_error(401)
+
+    assert http_exc.status_code == 401
+    assert http_exc.detail == HTTP_ERROR_MESSAGES[401]
+    assert rpc_code == -32001
+    assert rpc_message == ERROR_MESSAGES[-32001]
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_error_parity_crud_vs_rpc(api_client):
+    """Test that CRUD and RPC operations return equivalent errors."""
+    client, api, _ = api_client
+
+    # Test 404 error parity
+    # Try to read non-existent item via REST
+    rest_response = await client.get("/item/00000000-0000-0000-0000-000000000000")
+    assert rest_response.status_code == 404
+    rest_error = rest_response.json()
+
+    # Try to read non-existent item via RPC
+    rpc_response = await client.post(
+        "/rpc",
+        json={
+            "method": "Item.read",
+            "params": {"id": "00000000-0000-0000-0000-000000000000"},
+        },
+    )
+    assert rpc_response.status_code == 200  # RPC always returns 200
+    rpc_data = rpc_response.json()
+    assert "error" in rpc_data
+    rpc_error = rpc_data["error"]
+
+    # Both should indicate the same type of error
+    assert rpc_error["code"] == -32003  # Resource not found
+    # The messages should be equivalent in meaning
+    assert "not found" in rest_error["detail"].lower()
+    assert "not found" in rpc_error["message"].lower()
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_error_parity_validation_errors(api_client):
+    """Test that validation errors are consistent between CRUD and RPC."""
+    client, api, _ = api_client
+
+    # Test validation error - missing required field
+    # Try via REST
+    rest_response = await client.post("/tenant", json={})  # Missing name
+    assert rest_response.status_code == 422
+    rest_error = rest_response.json()
+
+    # Try via RPC
+    rpc_response = await client.post(
+        "/rpc",
+        json={"method": "Tenant.create", "params": {}},  # Missing name
+    )
+    assert rpc_response.status_code == 200
+    rpc_data = rpc_response.json()
+    assert "error" in rpc_data
+    rpc_error = rpc_data["error"]
+
+    # Both should indicate validation error
+    assert rpc_error["code"] == -32602  # Invalid params
+    # Both should mention the validation issue
+    assert "name" in str(rest_error).lower()
+    assert "name" in rpc_error["message"].lower()
+    assert any("name" in str(err["loc"]).lower() for err in rpc_error["data"])
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_error_mapping_bidirectional_consistency():
+    """Test that error mappings are bidirectionally consistent."""
+    # For each HTTP->RPC mapping, verify the reverse RPC->HTTP mapping exists
+    for http_code, rpc_code in _HTTP_TO_RPC.items():
+        assert rpc_code in _RPC_TO_HTTP
+        # The reverse mapping should map back to a reasonable HTTP code
+        reverse_http_code = _RPC_TO_HTTP[rpc_code]
+        # It doesn't have to be exactly the same (e.g., 422 and 400 both map to -32602)
+        # But it should be in the same error class
+        assert reverse_http_code // 100 == http_code // 100 or (
+            http_code in [400, 422] and reverse_http_code in [400, 422]
+        )
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_error_response_structure(api_client):
+    """Test that error responses have consistent structure."""
+    client, api, _ = api_client
+
+    # Test REST error structure
+    rest_response = await client.get("/item/invalid-uuid")
+    rest_error = rest_response.json()
+
+    # REST errors should have detail field
+    assert "detail" in rest_error
+
+    # Test RPC error structure
+    rpc_response = await client.post(
+        "/rpc", json={"method": "Item.read", "params": {"id": "invalid-uuid"}}
+    )
+    rpc_data = rpc_response.json()
+
+    if "error" in rpc_data:
+        rpc_error = rpc_data["error"]
+
+        # RPC errors should have code and message
+        assert "code" in rpc_error
+        assert "message" in rpc_error
+        assert isinstance(rpc_error["code"], int)
+        assert isinstance(rpc_error["message"], str)
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_custom_error_messages_preserved():
+    """Test that custom error messages are preserved through conversions."""
+    custom_message = "This is a custom error message for testing"
+
+    # Test HTTP to RPC conversion preserves message
+    http_exc = HTTPException(status_code=404, detail=custom_message)
+    rpc_code, rpc_message, data = _http_exc_to_rpc(http_exc)
+    assert rpc_message == custom_message
+    assert data is None
+
+    # Test RPC to HTTP conversion preserves message
+    http_exc = _rpc_error_to_http(-32003, custom_message)
+    assert http_exc.detail == custom_message
+
+    # Test standardized error creation preserves message
+    http_exc, rpc_code, rpc_message = create_standardized_error(404, custom_message)
+    assert http_exc.detail == custom_message
+    assert rpc_message == custom_message
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_error_mapping_completeness():
+    """Test that error mappings cover all expected scenarios."""
+    # Common HTTP error codes should be mapped
+    common_http_codes = [400, 401, 403, 404, 409, 422, 500, 503]
+
+    for code in common_http_codes:
+        if code in _HTTP_TO_RPC:
+            # If mapped, should have corresponding RPC code
+            rpc_code = _HTTP_TO_RPC[code]
+            assert rpc_code in _RPC_TO_HTTP
+            assert rpc_code in ERROR_MESSAGES
+
+        # Should have HTTP error message
+        if code in HTTP_ERROR_MESSAGES:
+            assert isinstance(HTTP_ERROR_MESSAGES[code], str)
+            assert len(HTTP_ERROR_MESSAGES[code]) > 0
+
+    # Common RPC error codes should be mapped
+    common_rpc_codes = [
+        -32700,
+        -32600,
+        -32601,
+        -32602,
+        -32603,
+        -32001,
+        -32002,
+        -32003,
+        -32004,
+    ]
+
+    for code in common_rpc_codes:
+        assert code in _RPC_TO_HTTP
+        assert code in ERROR_MESSAGES
+
+        # Should map to valid HTTP code
+        http_code = _RPC_TO_HTTP[code]
+        assert 400 <= http_code <= 599

--- a/pkgs/standards/autoapi/tests/r8n/test_healthz_methodz_hookz.py
+++ b/pkgs/standards/autoapi/tests/r8n/test_healthz_methodz_hookz.py
@@ -1,0 +1,218 @@
+"""
+Healthz, Methodz and Hookz Endpoints Tests for AutoAPI v2
+
+Tests that healthz, methodz and hookz endpoints are properly attached and behave as expected.
+"""
+
+import pytest
+from autoapi.v3 import Phase
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_healthz_endpoint_comprehensive(api_client):
+    """Test healthz endpoint attachment, behavior, and response format."""
+    client, api, _ = api_client
+
+    # Check that healthz endpoint exists in routes
+    routes = [route.path for route in api.router.routes]
+    assert "/healthz" in routes
+
+    # Test healthz response
+    response = await client.get("/healthz")
+    assert response.status_code == 200
+
+    # Check content type
+    assert response.headers["content-type"].startswith("application/json")
+
+    # Should return JSON with health status
+    data = response.json()
+
+    # The actual healthz endpoint returns {'ok': True}
+    assert "ok" in data
+    assert isinstance(data["ok"], bool)
+    assert data["ok"] is True
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_methodz_endpoint_comprehensive(api_client):
+    """Test methodz endpoint attachment, behavior, and response format."""
+    client, api, _ = api_client
+
+    # Check that methodz endpoint exists in routes
+    routes = [route.path for route in api.router.routes]
+    assert "/methodz" in routes
+
+    # Test methodz response
+    response = await client.get("/methodz")
+    assert response.status_code == 200
+
+    # Check content type
+    assert response.headers["content-type"].startswith("application/json")
+
+    # Should return JSON array of method names (strings)
+    data = response.json()
+    assert isinstance(data, list)
+
+    # Each item should be a string (method name)
+    for method_name in data:
+        assert isinstance(method_name, str)
+        assert "." in method_name  # Should follow Model.operation pattern
+
+    # Should have methods for Item and Tenant (from conftest)
+    expected_methods = [
+        "Item.create",
+        "Item.read",
+        "Item.update",
+        "Item.delete",
+        "Item.list",
+        "Tenant.create",
+        "Tenant.read",
+        "Tenant.update",
+        "Tenant.delete",
+        "Tenant.list",
+    ]
+
+    for method in expected_methods:
+        assert method in data
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_hookz_endpoint_comprehensive(api_client):
+    """Test hookz endpoint attachment, behavior, and response format."""
+    client, api, _ = api_client
+
+    @api.register_hook(Phase.POST_RESPONSE)
+    def first_hook(ctx):
+        pass
+
+    @api.register_hook(Phase.POST_RESPONSE)
+    def second_hook(ctx):
+        pass
+
+    @api.register_hook(Phase.POST_RESPONSE, model="Item", op="create")
+    def item_hook(ctx):
+        pass
+
+    routes = [route.path for route in api.router.routes]
+    assert "/hookz" in routes
+
+    response = await client.get("/hookz")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/json")
+
+    data = response.json()
+    assert isinstance(data, dict)
+
+    expected_global_hooks = [
+        f"autoapi.v3.hooks.{first_hook.__qualname__}",
+        f"autoapi.v3.hooks.{second_hook.__qualname__}",
+    ]
+    for method, phases in data.items():
+        assert isinstance(method, str)
+        assert isinstance(phases, dict)
+        assert phases["POST_RESPONSE"][:2] == expected_global_hooks
+
+    assert "Item.create" in data
+    assert data["Item.create"]["POST_RESPONSE"] == expected_global_hooks + [
+        f"autoapi.v3.hooks.{item_hook.__qualname__}",
+    ]
+    assert "Tenant.create" in data
+    assert data["Tenant.create"]["POST_RESPONSE"] == expected_global_hooks
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_methodz_basic_functionality(api_client):
+    """Test that methodz endpoint provides basic method information."""
+    client, api, _ = api_client
+
+    response = await client.get("/methodz")
+    data = response.json()
+
+    # Should contain Item.create method
+    assert "Item.create" in data
+
+    # Should contain basic CRUD operations
+    crud_operations = ["create", "read", "update", "delete", "list"]
+    for operation in crud_operations:
+        assert f"Item.{operation}" in data
+        assert f"Tenant.{operation}" in data
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_healthz_methodz_hookz_in_openapi_schema(api_client):
+    """Test that healthz, methodz and hookz endpoints are included in OpenAPI schema."""
+    client, api, _ = api_client
+
+    # Get OpenAPI schema
+    spec_response = await client.get("/openapi.json")
+    spec = spec_response.json()
+    paths = spec["paths"]
+
+    # healthz, methodz and hookz should be in OpenAPI spec
+    assert "/healthz" in paths
+    assert "/methodz" in paths
+    assert "/hookz" in paths
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_healthz_database_error_handling(api_client):
+    """Test healthz endpoint behavior when database has issues."""
+    client, api, _ = api_client
+
+    # Note: In a real test, we'd mock database connectivity issues
+    # For now, we just verify the endpoint responds and has the right structure
+    response = await client.get("/healthz")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert "ok" in data
+    assert isinstance(data["ok"], bool)
+
+    # The actual values depend on database state
+    # but structure should always be consistent
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_methodz_reflects_dynamic_models(api_client):
+    """Test that methodz reflects dynamically registered models."""
+    client, api, _ = api_client
+
+    # Get initial methods
+    response = await client.get("/methodz")
+    initial_data = response.json()
+
+    # Should include methods for models from conftest
+    assert "Tenant.create" in initial_data
+    assert "Tenant.read" in initial_data
+    assert "Tenant.update" in initial_data
+    assert "Tenant.delete" in initial_data
+    assert "Tenant.list" in initial_data
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_endpoints_are_synchronous(api_client):
+    """Test that healthz, methodz and hookz endpoints work in sync mode."""
+    client, api, _ = api_client
+
+    # These endpoints should work regardless of async/sync context
+    healthz_response = await client.get("/healthz")
+    assert healthz_response.status_code == 200
+
+    methodz_response = await client.get("/methodz")
+    assert methodz_response.status_code == 200
+
+    hookz_response = await client.get("/hookz")
+    assert hookz_response.status_code == 200
+
+    # Responses should be immediate and not require async database operations
+    assert healthz_response.json()
+    assert methodz_response.json()
+    assert isinstance(hookz_response.json(), dict)

--- a/pkgs/standards/autoapi/tests/r8n/test_hook_lifecycle.py
+++ b/pkgs/standards/autoapi/tests/r8n/test_hook_lifecycle.py
@@ -1,0 +1,387 @@
+"""
+Hook Lifecycle Tests for AutoAPI v2
+
+Tests all hook phases and their behavior across CRUD, nested CRUD, and RPC operations.
+"""
+
+import logging
+import pytest
+from autoapi.v3 import Phase
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_hook_phases_execution_order(api_client):
+    """Test that all hook phases execute in the correct order."""
+    client, api, _ = api_client
+    execution_order = []
+
+    # Register hooks for all phases
+    @api.register_hook(Phase.PRE_TX_BEGIN, model="Item", op="create")
+    async def pre_tx_begin(ctx):
+        execution_order.append("PRE_TX_BEGIN")
+        ctx["test_data"] = {"started": True}
+
+    @api.register_hook(Phase.PRE_HANDLER, model="Item", op="create")
+    async def pre_handler(ctx):
+        execution_order.append("PRE_HANDLER")
+        assert ctx["test_data"]["started"] is True
+        ctx["test_data"]["pre_handler_done"] = True
+
+    @api.register_hook(Phase.POST_HANDLER, model="Item", op="create")
+    async def post_handler(ctx):
+        execution_order.append("POST_HANDLER")
+        assert ctx["test_data"]["pre_handler_done"] is True
+        ctx["test_data"]["handler_done"] = True
+
+    @api.register_hook(Phase.PRE_COMMIT, model="Item", op="create")
+    async def pre_commit(ctx):
+        execution_order.append("PRE_COMMIT")
+        assert ctx["test_data"]["handler_done"] is True
+        ctx["test_data"]["pre_commit_done"] = True
+
+    @api.register_hook(Phase.POST_COMMIT, model="Item", op="create")
+    async def post_commit(ctx):
+        execution_order.append("POST_COMMIT")
+        assert ctx["test_data"]["pre_commit_done"] is True
+        ctx["test_data"]["committed"] = True
+
+    @api.register_hook(Phase.POST_RESPONSE, model="Item", op="create")
+    async def post_response(ctx):
+        execution_order.append("POST_RESPONSE")
+        assert ctx["test_data"]["committed"] is True
+        ctx["response"].result["hook_completed"] = True
+
+    # Create a tenant first
+    t = await client.post("/tenant", json={"name": "test-tenant"})
+    tid = t.json()["id"]
+
+    # Create an item via RPC
+    res = await client.post(
+        "/rpc",
+        json={
+            "method": "Item.create",
+            "params": {"tenant_id": tid, "name": "test-item"},
+        },
+    )
+
+    assert res.status_code == 200
+    data = res.json()["result"]
+    assert data["hook_completed"] is True
+
+    # Verify execution order
+    expected_order = [
+        "PRE_TX_BEGIN",
+        "PRE_HANDLER",
+        "POST_HANDLER",
+        "PRE_COMMIT",
+        "POST_COMMIT",
+        "POST_RESPONSE",
+    ]
+    assert execution_order == expected_order
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_hook_parity_crud_vs_rpc(api_client):
+    """Test that hooks execute identically for REST CRUD and RPC calls."""
+    client, api, _ = api_client
+    crud_hooks = []
+    rpc_hooks = []
+
+    @api.register_hook(Phase.PRE_TX_BEGIN, model="Item", op="create")
+    async def track_hooks(ctx):
+        if hasattr(ctx.get("request"), "url") and "/rpc" in str(ctx["request"].url):
+            rpc_hooks.append("PRE_TX_BEGIN")
+        else:
+            crud_hooks.append("PRE_TX_BEGIN")
+
+    @api.register_hook(Phase.POST_COMMIT, model="Item", op="create")
+    async def track_post_commit(ctx):
+        logging.info(f">>>>>>>>>>>>>>>>>POST_COMMIT {ctx}")
+        if hasattr(ctx.get("request"), "url") and "/rpc" in str(ctx["request"].url):
+            rpc_hooks.append("POST_COMMIT")
+        else:
+            crud_hooks.append("POST_COMMIT")
+
+    # Create tenant
+    t = await client.post("/tenant", json={"name": "test-tenant"})
+    tid = t.json()["id"]
+
+    # Test via REST CRUD
+    await client.post("/item", json={"tenant_id": tid, "name": "crud-item"})
+
+    # Test via RPC
+    await client.post(
+        "/rpc",
+        json={
+            "method": "Item.create",
+            "params": {"tenant_id": tid, "name": "rpc-item"},
+        },
+    )
+
+    # Both should have executed the same hooks
+    assert crud_hooks == ["PRE_TX_BEGIN", "POST_COMMIT"]
+    assert rpc_hooks == ["PRE_TX_BEGIN", "POST_COMMIT"]
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_hook_error_handling(api_client):
+    """Test hook behavior during error conditions."""
+    client, api, _ = api_client
+    error_hooks = []
+
+    @api.register_hook(Phase.ON_ERROR)
+    async def error_handler(ctx):
+        error_hooks.append("ERROR_HANDLED")
+        ctx["error_data"] = {"handled": True}
+
+    @api.register_hook(Phase.PRE_TX_BEGIN, model="Item", op="create")
+    async def failing_hook(ctx):
+        raise ValueError("Intentional test error")
+
+    # Create tenant
+    t = await client.post("/tenant", json={"name": "test-tenant"})
+    tid = t.json()["id"]
+
+    # This should trigger the error hook - expect the exception to propagate
+    # but the error hook should still execute
+    try:
+        res = await client.post("/item", json={"tenant_id": tid, "name": "error-item"})
+        # If no exception, should have error status code
+        assert res.status_code >= 400
+    except Exception:
+        # Exception is expected to propagate after error hook runs
+        pass
+
+    # Verify error hook was called
+    assert error_hooks == ["ERROR_HANDLED"]
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_hook_early_termination_and_cleanup(api_client):
+    """Test early termination when a hook raises and ensure cleanup."""
+    client, api, _ = api_client
+    execution_order: list[str] = []
+
+    @api.register_hook(Phase.PRE_TX_BEGIN, model="Item", op="create")
+    async def pre_tx_begin(ctx):
+        execution_order.append("PRE_TX_BEGIN")
+
+    @api.register_hook(Phase.PRE_HANDLER, model="Item", op="create")
+    async def pre_handler(ctx):
+        execution_order.append("PRE_HANDLER")
+
+    @api.register_hook(Phase.POST_HANDLER, model="Item", op="create")
+    async def post_handler(ctx):
+        execution_order.append("POST_HANDLER")
+
+    @api.register_hook(Phase.PRE_COMMIT, model="Item", op="create")
+    async def pre_commit(ctx):
+        execution_order.append("PRE_COMMIT")
+        raise RuntimeError("boom")
+
+    @api.register_hook(Phase.POST_COMMIT, model="Item", op="create")
+    async def post_commit(ctx):
+        execution_order.append("POST_COMMIT")
+
+    @api.register_hook(Phase.POST_RESPONSE, model="Item", op="create")
+    async def post_response(ctx):
+        execution_order.append("POST_RESPONSE")
+
+    # Create tenant
+    t = await client.post("/tenant", json={"name": "test-tenant"})
+    tid = t.json()["id"]
+
+    # Ensure no items exist before the test
+    before = await client.get("/item")
+    assert before.json() == []
+
+    # Trigger the failing hook
+    try:
+        res = await client.post("/item", json={"tenant_id": tid, "name": "fail-item"})
+        assert res.status_code >= 400
+    except RuntimeError:
+        pass
+
+    # Verify no items were created
+    after = await client.get("/item")
+    assert after.json() == []
+
+    # Ensure execution stopped at the failing hook
+    assert execution_order == [
+        "PRE_TX_BEGIN",
+        "PRE_HANDLER",
+        "POST_HANDLER",
+        "PRE_COMMIT",
+    ]
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_hook_context_modification(api_client):
+    """Test that hooks can modify context and affect subsequent hooks."""
+    client, api, _ = api_client
+
+    hook_executions = []
+
+    @api.register_hook(Phase.PRE_TX_BEGIN, model="Item", op="create")
+    async def modify_params(ctx):
+        # Track hook execution and add custom data
+        hook_executions.append("PRE_TX_BEGIN")
+        ctx["custom_data"] = {"modified": True}
+
+    @api.register_hook(Phase.POST_HANDLER, model="Item", op="create")
+    async def verify_modification(ctx):
+        # Verify the modification was applied and add more data
+        hook_executions.append("POST_HANDLER")
+        assert ctx["custom_data"]["modified"] is True
+        ctx["custom_data"]["verified"] = True
+
+    @api.register_hook(Phase.POST_RESPONSE, model="Item", op="create")
+    async def enrich_response(ctx):
+        # Add custom data to response
+        hook_executions.append("POST_RESPONSE")
+        assert ctx["custom_data"]["verified"] is True
+        # Note: ctx["response"].result is a model instance, not a dict
+        # We can't modify it directly, but we can verify it has the expected structure
+        assert hasattr(ctx["response"].result, "name")
+
+    # Create tenant
+    t = await client.post("/tenant", json={"name": "test-tenant"})
+    tid = t.json()["id"]
+
+    # Create item
+    res = await client.post("/item", json={"tenant_id": tid, "name": "test-item"})
+
+    assert res.status_code == 201
+    data = res.json()
+    assert data["name"] == "test-item"
+
+    # Verify all hooks were executed in the correct order
+    assert hook_executions == ["PRE_TX_BEGIN", "POST_HANDLER", "POST_RESPONSE"]
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_catch_all_hooks(api_client):
+    """Test that catch-all hooks (no model/op specified) work correctly."""
+    client, api, _ = api_client
+    catch_all_executions = []
+
+    @api.register_hook(Phase.POST_COMMIT)  # Catch-all hook for most operations
+    async def catch_all_hook(ctx):
+        method = getattr(ctx.get("env"), "method", "unknown")
+        catch_all_executions.append(method)
+
+    @api.register_hook(
+        Phase.POST_HANDLER
+    )  # Fallback for operations that don't reach POST_COMMIT
+    async def post_handler_hook(ctx):
+        method = getattr(ctx.get("env"), "method", "unknown")
+        # Only count delete operations that don't make it to POST_COMMIT
+        if method.endswith(".delete") and method not in catch_all_executions:
+            catch_all_executions.append(method)
+
+    # Create tenant
+    t = await client.post("/tenant", json={"name": "test-tenant"})
+    tid = t.json()["id"]
+
+    # Create item
+    await client.post("/item", json={"tenant_id": tid, "name": "test-item"})
+
+    # Read item
+    items = await client.get("/item")
+    item_id = items.json()[0]["id"]
+    await client.get(f"/item/{item_id}")
+
+    # Update item - need to provide tenant_id as well
+    update_res = await client.patch(
+        f"/item/{item_id}", json={"tenant_id": tid, "name": "updated-item"}
+    )
+    update_succeeded = update_res.status_code < 400
+
+    # Delete item
+    delete_res = await client.delete(f"/item/{item_id}")
+    delete_succeeded = delete_res.status_code < 400
+
+    # Verify catch-all hook was called for successful operations
+    expected_methods = [
+        "Tenant.create",
+        "Item.create",
+        "Item.list",
+        "Item.read",
+    ]
+
+    # Add update and delete to expected methods if they succeeded
+    if update_succeeded:
+        expected_methods.append("Item.update")
+    if delete_succeeded:
+        expected_methods.append("Item.delete")
+
+    # Deduplicate because the fallback POST_HANDLER hook runs before POST_COMMIT
+    unique_methods = list(dict.fromkeys(catch_all_executions))
+
+    assert unique_methods == expected_methods
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_hook_model_object_reference(api_client):
+    """Test that hooks work with both string and object model references."""
+    client, api, Item = api_client
+    string_hooks = []
+    object_hooks = []
+
+    @api.register_hook(Phase.POST_COMMIT, model="Item", op="create")
+    async def string_model_hook(ctx):
+        string_hooks.append("executed")
+
+    @api.register_hook(Phase.POST_COMMIT, model=Item, op="create")
+    async def object_model_hook(ctx):
+        object_hooks.append("executed")
+
+    # Create tenant
+    t = await client.post("/tenant", json={"name": "test-tenant"})
+    tid = t.json()["id"]
+
+    # Create item - both hooks should execute
+    await client.post("/item", json={"tenant_id": tid, "name": "test-item"})
+
+    assert string_hooks == ["executed"]
+    assert object_hooks == ["executed"]
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_multiple_hooks_same_phase(api_client):
+    """Test that multiple hooks for the same phase execute correctly."""
+    client, api, _ = api_client
+    executions = []
+
+    @api.register_hook(Phase.POST_COMMIT, model="Item", op="create")
+    async def first_hook(ctx):
+        executions.append("first")
+
+    @api.register_hook(Phase.POST_COMMIT, model="Item", op="create")
+    async def second_hook(ctx):
+        executions.append("second")
+
+    @api.register_hook(Phase.POST_COMMIT, model="Item", op="create")
+    async def third_hook(ctx):
+        executions.append("third")
+
+    # Create tenant
+    t = await client.post("/tenant", json={"name": "test-tenant"})
+    tid = t.json()["id"]
+
+    # Create item
+    await client.post("/item", json={"tenant_id": tid, "name": "test-item"})
+
+    # All hooks should have executed
+    assert len(executions) == 3
+    assert "first" in executions
+    assert "second" in executions
+    assert "third" in executions

--- a/pkgs/standards/autoapi/tests/r8n/test_info_schema_keys.py
+++ b/pkgs/standards/autoapi/tests/r8n/test_info_schema_keys.py
@@ -1,0 +1,322 @@
+"""
+Info Schema Keys Tests for AutoAPI v2
+
+Tests all 7 info-schema keys: disable_on, write_only, read_only, default_factory, examples, hybrid, py_type
+Each key is tested individually using DummyModel instances.
+"""
+
+import pytest
+from datetime import datetime
+from sqlalchemy import Column, String, Integer, DateTime
+from sqlalchemy.ext.hybrid import hybrid_property
+
+from autoapi.v3.mixins import GUIDPk
+from autoapi.v3 import Base, get_schema
+
+
+class DummyModelDisableOn(Base, GUIDPk):
+    """Test model for disable_on key."""
+
+    __tablename__ = "dummy_disable_on"
+
+    name = Column(String, info=dict(autoapi={"disable_on": ["update", "replace"]}))
+    description = Column(String)
+
+
+class DummyModelWriteOnly(Base, GUIDPk):
+    """Test model for write_only key."""
+
+    __tablename__ = "dummy_write_only"
+
+    name = Column(String)
+    secret = Column(String, info=dict(autoapi={"write_only": True}))
+
+
+class DummyModelReadOnly(Base, GUIDPk):
+    """Test model for read_only key."""
+
+    __tablename__ = "dummy_read_only"
+
+    name = Column(String)
+    computed_field = Column(String, info=dict(autoapi={"read_only": True}))
+
+
+class DummyModelDefaultFactory(Base, GUIDPk):
+    """Test model for default_factory key."""
+
+    __tablename__ = "dummy_default_factory"
+
+    name = Column(String)
+    timestamp = Column(
+        DateTime, info=dict(autoapi={"default_factory": datetime.utcnow})
+    )
+
+
+class DummyModelExamples(Base, GUIDPk):
+    """Test model for examples key."""
+
+    __tablename__ = "dummy_examples"
+
+    name = Column(
+        String, info=dict(autoapi={"examples": ["example1", "example2", "example3"]})
+    )
+    count = Column(Integer, info=dict(autoapi={"examples": [1, 5, 10, 100]}))
+
+
+class DummyModelHybrid(Base, GUIDPk):
+    """Test model for hybrid key."""
+
+    __tablename__ = "dummy_hybrid"
+
+    first_name = Column(String)
+    last_name = Column(String)
+
+    @hybrid_property
+    def full_name(self):
+        return f"{self.first_name} {self.last_name}"
+
+    @full_name.setter
+    def full_name(self, value):
+        parts = value.split(" ", 1)
+        self.first_name = parts[0]
+        self.last_name = parts[1] if len(parts) > 1 else ""
+
+    # Enable hybrid property in schema
+    full_name.info = {"autoapi": {"hybrid": True}}
+
+
+class DummyModelPyType(Base, GUIDPk):
+    """Test model for py_type key."""
+
+    __tablename__ = "dummy_py_type"
+
+    name = Column(String)
+
+    @hybrid_property
+    def computed_value(self):
+        return len(self.name) if self.name else 0
+
+    # Specify Python type for hybrid property
+    computed_value.info = {"autoapi": {"hybrid": True, "py_type": int}}
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_disable_on_key(create_test_api):
+    """Test that disable_on key excludes fields from specified verbs."""
+    create_test_api(DummyModelDisableOn)
+
+    # Get schemas for different verbs
+    create_schema = get_schema(DummyModelDisableOn, "create")
+    update_schema = get_schema(DummyModelDisableOn, "update")
+    read_schema = get_schema(DummyModelDisableOn, "read")
+
+    # name should be in create and read schemas
+    assert "name" in create_schema.model_fields
+    assert "name" in read_schema.model_fields
+
+    # name should NOT be in update schema due to disable_on
+    assert "name" not in update_schema.model_fields
+
+    # description should be in all schemas
+    assert "description" in create_schema.model_fields
+    assert "description" in update_schema.model_fields
+    assert "description" in read_schema.model_fields
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_write_only_key(create_test_api):
+    """Test that write_only key excludes fields from read operations."""
+    create_test_api(DummyModelWriteOnly)
+
+    # Get schemas for different verbs
+    create_schema = get_schema(DummyModelWriteOnly, "create")
+    read_schema = get_schema(DummyModelWriteOnly, "read")
+
+    # secret should be in create schema (write operation)
+    assert "secret" in create_schema.model_fields
+
+    # secret should NOT be in read schema (read operation)
+    assert "secret" not in read_schema.model_fields
+
+    # name should be in both schemas
+    assert "name" in create_schema.model_fields
+    assert "name" in read_schema.model_fields
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_read_only_key(create_test_api):
+    """Test that read_only key excludes fields from write operations."""
+    create_test_api(DummyModelReadOnly)
+
+    # Get schemas for different verbs
+    create_schema = get_schema(DummyModelReadOnly, "create")
+    update_schema = get_schema(DummyModelReadOnly, "update")
+    read_schema = get_schema(DummyModelReadOnly, "read")
+
+    # computed_field should be in read schema
+    assert "computed_field" in read_schema.model_fields
+
+    # computed_field should NOT be in create or update schemas
+    assert "computed_field" not in create_schema.model_fields
+    assert "computed_field" not in update_schema.model_fields
+
+    # name should be in all schemas
+    assert "name" in create_schema.model_fields
+    assert "name" in update_schema.model_fields
+    assert "name" in read_schema.model_fields
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_default_factory_key(create_test_api):
+    """Test that default_factory key provides default values."""
+    create_test_api(DummyModelDefaultFactory)
+
+    # Get create schema
+    create_schema = get_schema(DummyModelDefaultFactory, "create")
+
+    # timestamp field should be present
+    assert "timestamp" in create_schema.model_fields
+
+    # timestamp field should have a default factory
+    timestamp_field = create_schema.model_fields["timestamp"]
+    assert timestamp_field.default_factory is not None
+
+    # Test that we can create an instance without providing timestamp
+    instance_data = {"name": "test"}
+    instance = create_schema(**instance_data)
+
+    # Should be able to create without timestamp due to default_factory
+    assert instance.name == "test"
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_examples_key(create_test_api):
+    """Test that examples key provides example values in schema."""
+    create_test_api(DummyModelExamples)
+
+    # Get create schema
+    create_schema = get_schema(DummyModelExamples, "create")
+
+    # Check that fields have examples
+    name_field = create_schema.model_fields["name"]
+    count_field = create_schema.model_fields["count"]
+
+    # Examples should be accessible through field info
+    # Note: The exact way examples are stored may vary by Pydantic version
+    assert hasattr(name_field, "json_schema_extra") or hasattr(name_field, "examples")
+    assert hasattr(count_field, "json_schema_extra") or hasattr(count_field, "examples")
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_hybrid_key(create_test_api):
+    """Test that hybrid key enables hybrid properties in schemas."""
+    create_test_api(DummyModelHybrid)
+
+    # Get schemas for different verbs
+    create_schema = get_schema(DummyModelHybrid, "create")
+    read_schema = get_schema(DummyModelHybrid, "read")
+
+    # full_name should be in schemas because hybrid=True
+    assert "full_name" in create_schema.model_fields
+    assert "full_name" in read_schema.model_fields
+
+    # Regular fields should also be present
+    assert "first_name" in create_schema.model_fields
+    assert "last_name" in create_schema.model_fields
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_py_type_key(create_test_api):
+    """Test that py_type key specifies Python type for hybrid properties."""
+    create_test_api(DummyModelPyType)
+
+    # Get read schema
+    read_schema = get_schema(DummyModelPyType, "read")
+
+    # computed_value should be present due to hybrid=True
+    assert "computed_value" in read_schema.model_fields
+
+    # The field should have the specified Python type
+    computed_value_field = read_schema.model_fields["computed_value"]
+
+    # Check that the annotation reflects the py_type
+    assert computed_value_field.annotation is int
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_info_schema_validation():
+    """Test that invalid info schema keys raise errors."""
+    from autoapi.v3.info_schema import check
+
+    # Valid metadata should not raise error
+    valid_meta = {"disable_on": ["update"], "write_only": True, "examples": ["test"]}
+    check(valid_meta, "test_field", "TestModel")  # Should not raise
+
+    # Invalid key should raise error
+    invalid_meta = {"invalid_key": True, "disable_on": ["update"]}
+
+    with pytest.raises(RuntimeError, match="bad autoapi keys"):
+        check(invalid_meta, "test_field", "TestModel")
+
+    # Invalid verb should raise error
+    invalid_verb_meta = {"disable_on": ["invalid_verb"]}
+
+    with pytest.raises(RuntimeError, match="invalid verb"):
+        check(invalid_verb_meta, "test_field", "TestModel")
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_combined_info_schema_keys(create_test_api):
+    """Test that multiple info schema keys work together correctly."""
+
+    class DummyModelCombined(Base, GUIDPk):
+        __tablename__ = "dummy_combined"
+
+        name = Column(String)
+        secret = Column(
+            String,
+            info=dict(
+                autoapi={
+                    "write_only": True,
+                    "disable_on": ["update"],
+                    "examples": ["secret123", "password456"],
+                }
+            ),
+        )
+
+        @hybrid_property
+        def computed(self):
+            return f"computed-{self.name}"
+
+        computed.info = {"autoapi": {"hybrid": True, "read_only": True, "py_type": str}}
+
+    create_test_api(DummyModelCombined)
+
+    # Get schemas
+    create_schema = get_schema(DummyModelCombined, "create")
+    update_schema = get_schema(DummyModelCombined, "update")
+    read_schema = get_schema(DummyModelCombined, "read")
+
+    # secret should be in create (write_only=True allows writes, disable_on excludes update)
+    assert "secret" in create_schema.model_fields
+    assert "secret" not in update_schema.model_fields  # disabled on update
+    assert "secret" not in read_schema.model_fields  # write_only=True
+
+    # computed should only be in read (read_only=True, hybrid=True)
+    assert "computed" not in create_schema.model_fields
+    assert "computed" not in update_schema.model_fields
+    assert "computed" in read_schema.model_fields
+
+    # name should be in all schemas
+    assert "name" in create_schema.model_fields
+    assert "name" in update_schema.model_fields
+    assert "name" in read_schema.model_fields

--- a/pkgs/standards/autoapi/tests/r8n/test_mixins.py
+++ b/pkgs/standards/autoapi/tests/r8n/test_mixins.py
@@ -1,0 +1,500 @@
+"""
+Mixins Tests for AutoAPI v2
+
+Tests all mixins and their expected behavior using individual DummyModel instances.
+"""
+
+import pytest
+from datetime import datetime, timedelta
+from sqlalchemy import Column, String
+
+from autoapi.v3.mixins import GUIDPk
+from autoapi.v3.mixins import (
+    Timestamped,
+    Created,
+    LastUsed,
+    ActiveToggle,
+    SoftDelete,
+    Versioned,
+    BulkCapable,
+    Replaceable,
+    AsyncCapable,
+    Audited,
+    Streamable,
+    Slugged,
+    StatusMixin,
+    ValidityWindow,
+    Monetary,
+    ExtRef,
+    MetaJSON,
+    RelationEdge,
+)
+from autoapi.v3 import Base, get_schema
+
+
+class DummyModelTimestamped(Base, GUIDPk, Timestamped):
+    """Test model for Timestamped mixin."""
+
+    __tablename__ = "dummy_timestamped"
+    name = Column(String)
+
+
+class DummyModelCreated(Base, GUIDPk, Created):
+    """Test model for Created mixin."""
+
+    __tablename__ = "dummy_created"
+    name = Column(String)
+
+
+class DummyModelLastUsed(Base, GUIDPk, LastUsed):
+    """Test model for LastUsed mixin."""
+
+    __tablename__ = "dummy_last_used"
+    name = Column(String)
+
+
+class DummyModelActiveToggle(Base, GUIDPk, ActiveToggle):
+    """Test model for ActiveToggle mixin."""
+
+    __tablename__ = "dummy_active_toggle"
+    name = Column(String)
+
+
+class DummyModelSoftDelete(Base, GUIDPk, SoftDelete):
+    """Test model for SoftDelete mixin."""
+
+    __tablename__ = "dummy_soft_delete"
+    name = Column(String)
+
+
+class DummyModelVersioned(Base, GUIDPk, Versioned):
+    """Test model for Versioned mixin."""
+
+    __tablename__ = "dummy_versioned"
+    name = Column(String)
+
+
+class DummyModelBulkCapable(Base, GUIDPk, BulkCapable):
+    """Test model for BulkCapable mixin."""
+
+    __tablename__ = "dummy_bulk_capable"
+    name = Column(String)
+
+
+class DummyModelReplaceable(Base, GUIDPk, Replaceable):
+    """Test model for Replaceable mixin."""
+
+    __tablename__ = "dummy_replaceable"
+    name = Column(String)
+
+
+class DummyModelAsyncCapable(Base, GUIDPk, AsyncCapable):
+    """Test model for AsyncCapable mixin."""
+
+    __tablename__ = "dummy_async_capable"
+    name = Column(String)
+
+
+class DummyModelSlugged(Base, GUIDPk, Slugged):
+    """Test model for Slugged mixin."""
+
+    __tablename__ = "dummy_slugged"
+    name = Column(String)
+
+
+class DummyModelStatusMixin(Base, GUIDPk, StatusMixin):
+    """Test model for StatusMixin."""
+
+    __tablename__ = "dummy_status_mixin"
+    name = Column(String)
+
+
+class DummyModelValidityWindow(Base, GUIDPk, ValidityWindow):
+    """Test model for ValidityWindow mixin."""
+
+    __tablename__ = "dummy_validity_window"
+    name = Column(String)
+
+
+class DummyModelMonetary(Base, GUIDPk, Monetary):
+    """Test model for Monetary mixin."""
+
+    __tablename__ = "dummy_monetary"
+    name = Column(String)
+
+
+class DummyModelExtRef(Base, GUIDPk, ExtRef):
+    """Test model for ExtRef mixin."""
+
+    __tablename__ = "dummy_ext_ref"
+    name = Column(String)
+
+
+class DummyModelMetaJSON(Base, GUIDPk, MetaJSON):
+    """Test model for MetaJSON mixin."""
+
+    __tablename__ = "dummy_meta_json"
+    name = Column(String)
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_timestamped_mixin(create_test_api):
+    """Test that Timestamped mixin adds created_at and updated_at fields."""
+    create_test_api(DummyModelTimestamped)
+
+    # Get schemas
+    create_schema = get_schema(DummyModelTimestamped, "create")
+    read_schema = get_schema(DummyModelTimestamped, "read")
+    update_schema = get_schema(DummyModelTimestamped, "update")
+
+    # created_at and updated_at should be in read schema
+    assert "created_at" in read_schema.model_fields
+    assert "updated_at" in read_schema.model_fields
+
+    # created_at and updated_at should NOT be in create/update schemas (no_create, no_update)
+    assert "created_at" not in create_schema.model_fields
+    assert "updated_at" not in create_schema.model_fields
+    assert "created_at" not in update_schema.model_fields
+    assert "updated_at" not in update_schema.model_fields
+
+    # name should be in all schemas
+    assert "name" in create_schema.model_fields
+    assert "name" in read_schema.model_fields
+    assert "name" in update_schema.model_fields
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_created_mixin(create_test_api):
+    """Test that Created mixin adds created_at field."""
+    create_test_api(DummyModelCreated)
+
+    # Get schemas
+    create_schema = get_schema(DummyModelCreated, "create")
+    read_schema = get_schema(DummyModelCreated, "read")
+
+    # created_at should be in read schema
+    assert "created_at" in read_schema.model_fields
+
+    # created_at should NOT be in create schema (no_create)
+    assert "created_at" not in create_schema.model_fields
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_last_used_mixin(create_test_api):
+    """Test that LastUsed mixin adds last_used_at field and touch method."""
+    create_test_api(DummyModelLastUsed)
+
+    # Get schemas
+    read_schema = get_schema(DummyModelLastUsed, "read")
+
+    # last_used_at should be in read schema
+    assert "last_used_at" in read_schema.model_fields
+
+    # Verify the model has touch method
+    assert hasattr(DummyModelLastUsed, "touch")
+
+    # Test touch method functionality
+    instance = DummyModelLastUsed(name="test")
+    assert instance.last_used_at is None
+
+    instance.touch()
+    assert instance.last_used_at is not None
+    assert isinstance(instance.last_used_at, datetime)
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_active_toggle_mixin(create_test_api):
+    """Test that ActiveToggle mixin adds is_active field."""
+    create_test_api(DummyModelActiveToggle)
+
+    # Get schemas
+    create_schema = get_schema(DummyModelActiveToggle, "create")
+    read_schema = get_schema(DummyModelActiveToggle, "read")
+
+    # is_active should be in schemas
+    assert "is_active" in create_schema.model_fields
+    assert "is_active" in read_schema.model_fields
+
+    # is_active field should be boolean type (default may be None)
+    is_active_field = create_schema.model_fields["is_active"]
+    assert is_active_field.annotation is bool
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_soft_delete_mixin(create_test_api):
+    """Test that SoftDelete mixin adds deleted_at field."""
+    create_test_api(DummyModelSoftDelete)
+
+    # Get schemas
+    read_schema = get_schema(DummyModelSoftDelete, "read")
+
+    # deleted_at should be in read schema
+    assert "deleted_at" in read_schema.model_fields
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_versioned_mixin(create_test_api):
+    """Test that Versioned mixin adds revision and prev_id fields."""
+    create_test_api(DummyModelVersioned)
+
+    # Get schemas
+    create_schema = get_schema(DummyModelVersioned, "create")
+    read_schema = get_schema(DummyModelVersioned, "read")
+
+    # revision and prev_id should be in schemas
+    assert "revision" in read_schema.model_fields
+    assert "prev_id" in read_schema.model_fields
+
+    # revision should have default value of 1
+    revision_field = create_schema.model_fields["revision"]
+    assert revision_field.annotation is int
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_bulk_capable_mixin(create_test_api):
+    """Test that BulkCapable mixin enables bulk operations."""
+    api = create_test_api(DummyModelBulkCapable)
+
+    # Check that bulk routes are available
+    routes = [route.path for route in api.router.routes]
+
+    # Should have bulk create and bulk delete routes
+    assert "/dummy_model_bulk_capable/bulk" in [
+        route for route in routes if "/bulk" in route
+    ]
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_replaceable_mixin(create_test_api):
+    """Test that Replaceable mixin enables replacement operations."""
+    create_test_api(DummyModelReplaceable)
+
+    # Get schemas
+    create_schema = get_schema(DummyModelReplaceable, "create")
+    read_schema = get_schema(DummyModelReplaceable, "read")
+
+    # Should have basic fields
+    assert "name" in create_schema.model_fields
+    assert "name" in read_schema.model_fields
+
+    # Replaceable mixin is a marker mixin - doesn't add fields
+    # but enables replacement functionality
+    expected_fields = {"id", "name"}
+    actual_fields = set(read_schema.model_fields.keys())
+    assert expected_fields.issubset(actual_fields)
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_async_capable_mixin(create_test_api):
+    """Test that AsyncCapable mixin is a marker mixin."""
+    create_test_api(DummyModelAsyncCapable)
+
+    # Get schemas
+    read_schema = get_schema(DummyModelAsyncCapable, "read")
+
+    # AsyncCapable is a marker mixin - doesn't add fields
+    expected_fields = {"id", "name"}
+    actual_fields = set(read_schema.model_fields.keys())
+    assert actual_fields == expected_fields
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_slugged_mixin(create_test_api):
+    """Test that Slugged mixin adds slug field."""
+    create_test_api(DummyModelSlugged)
+
+    # Get schemas
+    create_schema = get_schema(DummyModelSlugged, "create")
+    read_schema = get_schema(DummyModelSlugged, "read")
+
+    # slug should be in schemas
+    assert "slug" in create_schema.model_fields
+    assert "slug" in read_schema.model_fields
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_status_mixin(create_test_api):
+    """Test that StatusMixin adds status field."""
+    create_test_api(DummyModelStatusMixin)
+
+    # Get schemas
+    create_schema = get_schema(DummyModelStatusMixin, "create")
+    read_schema = get_schema(DummyModelStatusMixin, "read")
+
+    # status should be in schemas
+    assert "status" in create_schema.model_fields
+    assert "status" in read_schema.model_fields
+
+    # status field should be string type
+    status_field = create_schema.model_fields["status"]
+    assert status_field.annotation is str
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_validity_window_mixin(create_test_api):
+    """Test that ValidityWindow mixin adds valid_from and valid_until fields."""
+    create_test_api(DummyModelValidityWindow)
+
+    # Get schemas
+    create_schema = get_schema(DummyModelValidityWindow, "create")
+    read_schema = get_schema(DummyModelValidityWindow, "read")
+
+    # validity fields should be in schemas
+    assert "valid_from" in create_schema.model_fields
+    assert "valid_to" in create_schema.model_fields
+    assert "valid_from" in read_schema.model_fields
+    assert "valid_to" in read_schema.model_fields
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_validity_window_default(create_test_api):
+    api = create_test_api(DummyModelValidityWindow)
+    session = next(api.get_db())
+    try:
+        instance = DummyModelValidityWindow(name="x")
+        session.add(instance)
+        session.flush()
+        vf_default = instance.valid_from
+        vt_default = instance.valid_to
+    finally:
+        session.close()
+    assert vf_default is not None
+    assert vt_default is not None
+    assert abs((vt_default - vf_default) - timedelta(days=1)) < timedelta(seconds=1)
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_monetary_mixin(create_test_api):
+    """Test that Monetary mixin adds currency and amount fields."""
+    create_test_api(DummyModelMonetary)
+
+    # Get schemas
+    create_schema = get_schema(DummyModelMonetary, "create")
+    read_schema = get_schema(DummyModelMonetary, "read")
+
+    # monetary fields should be in schemas
+    assert "currency" in create_schema.model_fields
+    assert "amount" in create_schema.model_fields
+    assert "currency" in read_schema.model_fields
+    assert "amount" in read_schema.model_fields
+
+    # currency field should be string type
+    currency_field = create_schema.model_fields["currency"]
+    assert currency_field.annotation is str
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_ext_ref_mixin(create_test_api):
+    """Test that ExtRef mixin adds external_id field."""
+    create_test_api(DummyModelExtRef)
+
+    # Get schemas
+    create_schema = get_schema(DummyModelExtRef, "create")
+    read_schema = get_schema(DummyModelExtRef, "read")
+
+    # external_id should be in schemas
+    assert "external_id" in create_schema.model_fields
+    assert "external_id" in read_schema.model_fields
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+@pytest.mark.skip(reason="JSONB type not supported in SQLite test environment")
+async def test_meta_json_mixin(create_test_api):
+    """Test that MetaJSON mixin adds meta field."""
+    create_test_api(DummyModelMetaJSON)
+
+    # Get schemas
+    create_schema = get_schema(DummyModelMetaJSON, "create")
+    read_schema = get_schema(DummyModelMetaJSON, "read")
+
+    # meta should be in schemas
+    assert "meta" in create_schema.model_fields
+    assert "meta" in read_schema.model_fields
+
+    # meta should default to empty dict
+    meta_field = create_schema.model_fields["meta"]
+    assert meta_field.default == {}
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_marker_mixins(create_test_api):
+    """Test that marker mixins (Audited, Streamable, etc.) don't add fields."""
+
+    # Create dummy models for other marker mixins
+    class DummyAudited(Base, GUIDPk, Audited):
+        __tablename__ = "dummy_audited"
+        name = Column(String)
+
+    class DummyStreamable(Base, GUIDPk, Streamable):
+        __tablename__ = "dummy_streamable"
+        name = Column(String)
+
+    class DummyRelationEdge(Base, GUIDPk, RelationEdge):
+        __tablename__ = "dummy_relation_edge"
+        name = Column(String)
+
+    marker_models = [DummyAudited, DummyStreamable, DummyRelationEdge]
+
+    for model in marker_models:
+        create_test_api(model)
+
+        read_schema = get_schema(model, "read")
+
+        # Should only have id and name fields (no extra fields from marker mixins)
+        expected_fields = {"id", "name"}
+        actual_fields = set(read_schema.model_fields.keys())
+        assert actual_fields == expected_fields
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_multiple_mixins_combination(create_test_api):
+    """Test that multiple mixins can be combined correctly."""
+
+    class DummyMultipleMixins(
+        Base, GUIDPk, Timestamped, ActiveToggle, Slugged, StatusMixin
+    ):
+        __tablename__ = "dummy_multiple_mixins"
+        name = Column(String)
+
+    create_test_api(DummyMultipleMixins)
+
+    # Get schemas
+    create_schema = get_schema(DummyMultipleMixins, "create")
+    read_schema = get_schema(DummyMultipleMixins, "read")
+
+    # Should have fields from all mixins
+    # From ActiveToggle
+    assert "is_active" in create_schema.model_fields
+    assert "is_active" in read_schema.model_fields
+
+    # From Slugged
+    assert "slug" in create_schema.model_fields
+    assert "slug" in read_schema.model_fields
+
+    # From StatusMixin
+    assert "status" in create_schema.model_fields
+    assert "status" in read_schema.model_fields
+
+    # From Timestamped (only in read schema due to no_create, no_update)
+    assert "created_at" not in create_schema.model_fields
+    assert "updated_at" not in create_schema.model_fields
+    assert "created_at" in read_schema.model_fields
+    assert "updated_at" in read_schema.model_fields

--- a/pkgs/standards/autoapi/tests/r8n/test_nested_routing_depth.py
+++ b/pkgs/standards/autoapi/tests/r8n/test_nested_routing_depth.py
@@ -1,0 +1,127 @@
+import pytest
+import pytest_asyncio
+from autoapi.v3 import AutoAPI, Base
+from autoapi.v3.mixins import GUIDPk
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import Column, ForeignKey, String
+
+
+@pytest_asyncio.fixture
+async def three_level_api_client(db_mode, sync_db_session, async_db_session):
+    Base.metadata.clear()
+
+    class Company(Base, GUIDPk):
+        __tablename__ = "companies"
+        name = Column(String, nullable=False)
+
+    class Department(Base, GUIDPk):
+        __tablename__ = "departments"
+        company_id = Column(String, ForeignKey("companies.id"), nullable=False)
+        name = Column(String, nullable=False)
+
+        @classmethod
+        def __autoapi_nested_paths__(cls):
+            return "/company/{company_id}"
+
+    class Employee(Base, GUIDPk):
+        __tablename__ = "employees"
+        company_id = Column(String, ForeignKey("companies.id"), nullable=False)
+        department_id = Column(String, ForeignKey("departments.id"), nullable=False)
+        name = Column(String, nullable=False)
+
+        @classmethod
+        def __autoapi_nested_paths__(cls):
+            return "/company/{company_id}/department/{department_id}"
+
+    if db_mode == "async":
+        _, get_async_db = async_db_session
+        api = AutoAPI(
+            base=Base,
+            include={Company, Department, Employee},
+            get_async_db=get_async_db,
+        )
+        await api.initialize_async()
+    else:
+        _, get_sync_db = sync_db_session
+        api = AutoAPI(
+            base=Base, include={Company, Department, Employee}, get_db=get_sync_db
+        )
+        api.initialize_sync()
+
+    app = FastAPI()
+    app.include_router(api.router)
+    transport = ASGITransport(app=app)
+    client = AsyncClient(transport=transport, base_url="http://test")
+    return client
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_nested_routing_depth(three_level_api_client):
+    client = three_level_api_client
+
+    # Create company
+    res = await client.post("/company", json={"name": "Acme"})
+    assert res.status_code == 201
+    company_id = res.json()["id"]
+
+    # Create department
+    res = await client.post(
+        f"/company/{company_id}",
+        json={"company_id": company_id, "name": "Engineering"},
+    )
+    assert res.status_code == 201
+    department_id = res.json()["id"]
+
+    # Create employee
+    res = await client.post(
+        f"/company/{company_id}/department/{department_id}",
+        json={
+            "company_id": company_id,
+            "department_id": department_id,
+            "name": "Alice",
+        },
+    )
+    assert res.status_code == 201
+    employee_id = res.json()["id"]
+
+    # Verify generated REST paths and HTTP methods
+    paths = (await client.get("/openapi.json")).json()["paths"]
+    expected = {
+        "/company": {"post", "get", "delete"},
+        "/company/{item_id}": {"get", "patch", "delete"},
+        "/company/{company_id}": {"post", "get", "delete"},
+        "/company/{company_id}/{item_id}": {"get", "patch", "delete"},
+        "/company/{company_id}/department/{department_id}": {
+            "post",
+            "get",
+            "delete",
+        },
+        "/company/{company_id}/department/{department_id}/{item_id}": {
+            "get",
+            "patch",
+            "delete",
+        },
+    }
+    for path, verbs in expected.items():
+        assert path in paths
+        for verb in verbs:
+            assert verb in paths[path]
+
+    # Verify RPC methods exist
+    methods = (await client.get("/methodz")).json()
+    for model in ("Company", "Department", "Employee"):
+        for verb in ("create", "list", "clear", "read", "update", "delete"):
+            assert f"{model}.{verb}" in methods
+
+    # Confirm nested routes resolve to correct handlers
+    res = await client.get(f"/company/{company_id}/{department_id}")
+    assert res.status_code == 200
+    assert res.json()["id"] == department_id
+
+    res = await client.get(
+        f"/company/{company_id}/department/{department_id}/{employee_id}"
+    )
+    assert res.status_code == 200
+    assert res.json()["id"] == employee_id

--- a/pkgs/standards/autoapi/tests/r8n/test_owner_tenant_policy.py
+++ b/pkgs/standards/autoapi/tests/r8n/test_owner_tenant_policy.py
@@ -1,0 +1,159 @@
+from fastapi import FastAPI, HTTPException, Security
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from fastapi.testclient import TestClient
+from sqlalchemy import Column, String, create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+import uuid
+
+from autoapi.v3 import AutoAPI, Base
+from autoapi.v3.mixins import GUIDPk
+from autoapi.v3.mixins.ownable import Ownable, OwnerPolicy
+from autoapi.v3.mixins.tenant_bound import TenantBound, TenantPolicy
+from autoapi.v3.types import AuthNProvider
+from autoapi.v3.hooks import Phase
+
+
+class DummyAuth(AuthNProvider):
+    def __init__(self, user_id: uuid.UUID, tenant_id: uuid.UUID):
+        self.user_id = user_id
+        self.tenant_id = tenant_id
+
+    async def get_principal(
+        self, creds: HTTPAuthorizationCredentials = Security(HTTPBearer())
+    ):
+        if creds.credentials != "secret":
+            raise HTTPException(status_code=401)
+        return {"user_id": self.user_id, "tenant_id": self.tenant_id}
+
+    def register_inject_hook(self, api) -> None:
+        @api.register_hook(Phase.PRE_TX_BEGIN)
+        async def _inject(ctx):
+            p = getattr(ctx["request"].state, "principal", None)
+            if not p:
+                return
+            injected = ctx.setdefault("__autoapi_injected_fields__", {})
+            if p.get("tenant_id") is not None:
+                injected["tenant_id"] = p["tenant_id"]
+            if p.get("user_id") is not None:
+                injected["user_id"] = p["user_id"]
+
+
+def _client_for_owner(
+    policy: OwnerPolicy, user_id: uuid.UUID, tenant_id: uuid.UUID
+) -> TestClient:
+    Base.metadata.clear()
+
+    class User(Base, GUIDPk):
+        __tablename__ = "users"
+        __table_args__ = {"schema": "main"}
+        name = Column(String, nullable=False)
+
+    class Item(Base, GUIDPk, Ownable):
+        __tablename__ = "items"
+        __table_args__ = {"schema": "main"}
+        name = Column(String, nullable=False)
+        __autoapi_owner_policy__ = policy
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+    Base.metadata.create_all(bind=engine)
+
+    with SessionLocal() as session:
+        session.execute(User.__table__.insert().values(id=user_id, name="owner"))
+        session.commit()
+
+    def get_db():
+        with SessionLocal() as session:
+            yield session
+
+    authn = DummyAuth(user_id, tenant_id)
+    api = AutoAPI(base=Base, include={User, Item}, get_db=get_db, authn=authn)
+    authn.register_inject_hook(api)
+    app = FastAPI()
+    app.include_router(api.router)
+    api.initialize_sync()
+    return TestClient(app)
+
+
+def test_owner_policy_runtime_switch():
+    user_id = uuid.uuid4()
+    tenant_id = uuid.uuid4()
+    headers = {"Authorization": "Bearer secret"}
+
+    client = _client_for_owner(OwnerPolicy.STRICT_SERVER, user_id, tenant_id)
+    res = client.post("/item", json={"name": "one"}, headers=headers)
+    assert res.status_code == 201
+    assert res.json()["owner_id"] == str(user_id)
+
+    client = _client_for_owner(OwnerPolicy.CLIENT_SET, user_id, tenant_id)
+    supplied = str(uuid.uuid4())
+    res = client.post(
+        "/item", json={"name": "two", "owner_id": supplied}, headers=headers
+    )
+    assert res.status_code == 201
+    assert res.json()["owner_id"] == supplied
+
+
+def _client_for_tenant(
+    policy: TenantPolicy, user_id: uuid.UUID, tenant_id: uuid.UUID
+) -> TestClient:
+    Base.metadata.clear()
+
+    class Tenant(Base, GUIDPk):
+        __tablename__ = "tenants"
+        __table_args__ = {"schema": "main"}
+        name = Column(String, nullable=False)
+
+    class Item(Base, GUIDPk, TenantBound):
+        __tablename__ = "items"
+        __table_args__ = {"schema": "main"}
+        name = Column(String, nullable=False)
+        __autoapi_tenant_policy__ = policy
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+    Base.metadata.create_all(bind=engine)
+
+    with SessionLocal() as session:
+        session.execute(Tenant.__table__.insert().values(id=tenant_id, name="acme"))
+        session.commit()
+
+    def get_db():
+        with SessionLocal() as session:
+            yield session
+
+    authn = DummyAuth(user_id, tenant_id)
+    api = AutoAPI(base=Base, include={Tenant, Item}, get_db=get_db, authn=authn)
+    authn.register_inject_hook(api)
+    app = FastAPI()
+    app.include_router(api.router)
+    api.initialize_sync()
+    return TestClient(app)
+
+
+def test_tenant_policy_runtime_switch():
+    user_id = uuid.uuid4()
+    tenant_id = uuid.uuid4()
+    headers = {"Authorization": "Bearer secret"}
+
+    client = _client_for_tenant(TenantPolicy.STRICT_SERVER, user_id, tenant_id)
+    res = client.post("/item", json={"name": "one"}, headers=headers)
+    assert res.status_code == 201
+    assert res.json()["tenant_id"] == str(tenant_id)
+
+    client = _client_for_tenant(TenantPolicy.CLIENT_SET, user_id, tenant_id)
+    supplied = str(uuid.uuid4())
+    res = client.post(
+        "/item", json={"name": "two", "tenant_id": supplied}, headers=headers
+    )
+    assert res.status_code == 201
+    assert res.json()["tenant_id"] == supplied

--- a/pkgs/standards/autoapi/tests/r8n/test_request_extras.py
+++ b/pkgs/standards/autoapi/tests/r8n/test_request_extras.py
@@ -1,0 +1,91 @@
+import pytest
+import pytest_asyncio
+from autoapi.v3 import AutoAPI, Base, get_schema
+from autoapi.v3.mixins import GUIDPk
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import Column, String, create_engine
+from sqlalchemy.pool import StaticPool
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import Session, sessionmaker
+from pydantic import Field
+
+
+@pytest_asyncio.fixture()
+async def api_client_with_extras(db_mode):
+    Base.metadata.clear()
+
+    class Widget(Base, GUIDPk):
+        __tablename__ = "widgets"
+        name = Column(String, nullable=False)
+        __autoapi_request_extras__ = {
+            "*": {"token": (str | None, Field(default=None, exclude=True))},
+            "create": {"create_note": (str | None, Field(default=None, exclude=True))},
+            "update": {"update_flag": (bool | None, Field(default=None, exclude=True))},
+        }
+
+    if db_mode == "async":
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+        AsyncSessionLocal = async_sessionmaker(
+            bind=engine, class_=AsyncSession, expire_on_commit=False
+        )
+
+        async def get_async_db() -> AsyncSession:
+            async with AsyncSessionLocal() as session:
+                yield session
+
+        api = AutoAPI(base=Base, include={Widget}, get_async_db=get_async_db)
+        await api.initialize_async()
+    else:
+        engine = create_engine(
+            "sqlite:///:memory:",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+
+        def get_sync_db() -> Session:
+            with SessionLocal() as session:
+                yield session
+
+        api = AutoAPI(base=Base, include={Widget}, get_db=get_sync_db)
+        api.initialize_sync()
+
+    app = FastAPI()
+    app.include_router(api.router)
+    transport = ASGITransport(app=app)
+    client = AsyncClient(transport=transport, base_url="http://test")
+    return client, api, Widget
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_request_extras_schema(api_client_with_extras):
+    _, _, Widget = api_client_with_extras
+    create_schema = get_schema(Widget, "create")
+    update_schema = get_schema(Widget, "update")
+    assert {"token", "create_note"} <= set(create_schema.model_fields)
+    assert {"token", "update_flag"} <= set(update_schema.model_fields)
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_request_extras_runtime(api_client_with_extras):
+    client, _, _ = api_client_with_extras
+    res = await client.post(
+        "/widget",
+        json={"name": "w1", "token": "t", "create_note": "note"},
+    )
+    assert res.status_code == 201
+    body = res.json()
+    wid = body["id"]
+    assert "token" not in body and "create_note" not in body
+
+    res = await client.patch(
+        f"/widget/{wid}",
+        json={"name": "w2", "token": "t2", "update_flag": True},
+    )
+    assert res.status_code == 200
+
+    body = res.json()
+    assert "token" not in body and "update_flag" not in body

--- a/pkgs/standards/autoapi/tests/r8n/test_request_extras_provider.py
+++ b/pkgs/standards/autoapi/tests/r8n/test_request_extras_provider.py
@@ -1,0 +1,27 @@
+import pytest
+
+from autoapi.v3 import Base
+from autoapi.v3.types import Column, String, Field, RequestExtrasProvider
+from autoapi.v3.mixins import GUIDPk
+from autoapi.v3.impl.schema import _schema
+from autoapi.v3.types.request_extras_provider import list_request_extras_providers
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_request_extras_provider_in_schema():
+    Base.metadata.clear()
+
+    class Widget(Base, GUIDPk, RequestExtrasProvider):
+        __tablename__ = "widgets"
+        name = Column(String, nullable=False)
+        __autoapi_request_extras__ = {
+            "create": {"extra": (int | None, Field(None, exclude=True))}
+        }
+
+    SCreate = _schema(Widget, verb="create")
+    SRead = _schema(Widget, verb="read")
+
+    assert "extra" in SCreate.model_fields
+    assert "extra" not in SRead.model_fields
+    assert Widget in list_request_extras_providers()

--- a/pkgs/standards/autoapi/tests/r8n/test_response_extras_provider.py
+++ b/pkgs/standards/autoapi/tests/r8n/test_response_extras_provider.py
@@ -1,0 +1,22 @@
+import pytest
+
+from autoapi.v3 import Base
+from autoapi.v3.types import Column, String, Field, ResponseExtrasProvider
+from autoapi.v3.mixins import GUIDPk
+from autoapi.v3.impl.schema import _schema
+from autoapi.v3.types.response_extras_provider import list_response_extras_providers
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_response_extras_provider_in_schema():
+    Base.metadata.clear()
+
+    class Widget(Base, GUIDPk, ResponseExtrasProvider):
+        __tablename__ = "widgets"
+        name = Column(String, nullable=False)
+        __autoapi_response_extras__ = {"read": {"extra": (int | None, Field(None))}}
+
+    SRead = _schema(Widget, verb="read")
+    assert "extra" in SRead.model_fields
+    assert Widget in list_response_extras_providers()

--- a/pkgs/standards/autoapi/tests/r8n/test_schema.py
+++ b/pkgs/standards/autoapi/tests/r8n/test_schema.py
@@ -1,0 +1,34 @@
+import pytest
+from autoapi.v3 import get_schema
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_schema_generation(api_client):
+    client, _, Item = api_client
+
+    create_model = get_schema(Item, "create")
+    read_model = get_schema(Item, "read")
+    update_model = get_schema(Item, "update")
+    delete_model = get_schema(Item, "delete")
+    list_model = get_schema(Item, "list")
+
+    assert create_model.__name__ == "ItemCreate"
+    assert read_model.__name__ == "ItemRead"
+    assert update_model.__name__ == "ItemUpdate"
+    assert delete_model.__name__ == "ItemDelete"
+    assert list_model.__name__ == "ItemListParams"
+
+    spec = (await client.get("/openapi.json")).json()
+    schemas = spec["components"]["schemas"]
+    assert create_model.__name__ in schemas
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_bulk_operation_schema(api_client):
+    client, _, _ = api_client
+    spec = (await client.get("/openapi.json")).json()
+    assert "/item/bulk" in spec["paths"]
+    ops = spec["paths"]["/item/bulk"]
+    assert "post" in ops and "delete" in ops

--- a/pkgs/standards/autoapi/tests/r8n/test_symmetry_parity.py
+++ b/pkgs/standards/autoapi/tests/r8n/test_symmetry_parity.py
@@ -1,0 +1,34 @@
+import pytest
+
+CRUD_MAP = {
+    "create": ("post", "/item"),
+    "list": ("get", "/item"),
+    "clear": ("delete", "/item"),
+    "read": ("get", "/item/{item_id}"),
+    "update": ("patch", "/item/{item_id}"),
+    "delete": ("delete", "/item/{item_id}"),
+}
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_route_and_method_symmetry(api_client):
+    client, _, _ = api_client
+    spec = (await client.get("/openapi.json")).json()
+    paths = spec["paths"]
+    methods = await client.get("/methodz")
+    method_list = methods.json()
+
+    for verb, (http_verb, path) in CRUD_MAP.items():
+        assert path in paths
+        assert http_verb in paths[path]
+        assert f"Item.{verb}" in method_list
+
+    nested_base = "/tenant/{tenant_id}"
+    assert nested_base in paths
+    for verb in ("create", "list", "clear"):
+        assert CRUD_MAP[verb][0] in paths[nested_base]
+    nested_item = "/tenant/{tenant_id}/{item_id}"
+    assert nested_item in paths
+    for verb in ("read", "update", "delete"):
+        assert CRUD_MAP[verb][0] in paths[nested_item]

--- a/pkgs/standards/autoapi/tests/r8n/test_transactional.py
+++ b/pkgs/standards/autoapi/tests/r8n/test_transactional.py
@@ -1,0 +1,45 @@
+import pytest
+import uuid
+from autoapi.v3.transactional import transactional
+
+
+@pytest.mark.r8n
+@pytest.mark.asyncio
+async def test_transaction_decorator(api_client):
+    client, api, Item = api_client
+
+    def fail(params, db):
+        obj = Item(tenant_id=uuid.UUID(params["tenant_id"]), name=params["name"])
+        db.add(obj)
+        db.flush()
+        if params.get("fail"):
+            raise ValueError("boom")
+        return {"id": obj.id}
+
+    fail = transactional(api, fail)
+
+    api.rpc["Item.fail"] = fail
+    api._method_ids["Item.fail"] = None
+
+    t = await client.post("/tenant", json={"name": "tx"})
+    tid = t.json()["id"]
+
+    bad = await client.post(
+        "/rpc",
+        json={
+            "method": "Item.fail",
+            "params": {"tenant_id": tid, "name": "a", "fail": True},
+        },
+    )
+    assert bad.json()["error"] is not None
+
+    lst = await client.get("/item")
+    assert lst.json() == []
+
+    ok = await client.post(
+        "/rpc",
+        json={"method": "Item.fail", "params": {"tenant_id": tid, "name": "b"}},
+    )
+    assert ok.json()["result"]["id"]
+    lst2 = await client.get("/item")
+    assert len(lst2.json()) == 1

--- a/pkgs/standards/autoapi/tests/r8n/test_verb_alias_policy.py
+++ b/pkgs/standards/autoapi/tests/r8n/test_verb_alias_policy.py
@@ -1,0 +1,57 @@
+"""Tests for AutoAPI verb aliasing and policy handling."""
+
+import pytest
+
+from autoapi.v3.mixins import GUIDPk
+from autoapi.v3 import Base
+
+
+@pytest.mark.r8n
+def test_verb_alias_policy_both_routes_same_handler(create_test_api):
+    """Canonical verbs and aliases should map to the same handler when allowed."""
+
+    class AliasModelBoth(Base, GUIDPk):
+        __tablename__ = "alias_model"
+        __autoapi_verb_aliases__ = {"create": "register"}
+        __autoapi_verb_alias_policy__ = "both"
+
+    api = create_test_api(AliasModelBoth)
+
+    # Alias exposed alongside canonical verb
+    assert hasattr(api.core.AliasModelBoth, "register")
+    assert api.core.AliasModelBoth.register is api.core.AliasModelBoth.create
+    assert api.core.AliasModelBothRegister is api.core.AliasModelBothCreate
+
+    m_id_create = f"{AliasModelBoth.__name__}.create"
+    m_id_register = f"{AliasModelBoth.__name__}.register"
+    assert api.rpc[m_id_create] is api.rpc[m_id_register]
+
+
+@pytest.mark.r8n
+def test_verb_alias_policy_canonical_only_blocks_alias(create_test_api):
+    """Alias policy 'canonical_only' should hide aliases from public surface."""
+
+    class AliasModelBlocked(Base, GUIDPk):
+        __tablename__ = "alias_model_blocked"
+        __autoapi_verb_aliases__ = {"create": "register"}
+        __autoapi_verb_alias_policy__ = "canonical_only"
+
+    api = create_test_api(AliasModelBlocked)
+
+    assert not hasattr(api.core, "AliasModelBlockedRegister")
+    assert not hasattr(api.core.AliasModelBlocked, "register")
+    m_id_register = f"{AliasModelBlocked.__name__}.register"
+    with pytest.raises(KeyError):
+        api.rpc[m_id_register]
+
+
+@pytest.mark.r8n
+def test_invalid_alias_raises_error(create_test_api):
+    """Invalid alias names should raise a runtime error during initialization."""
+
+    class BadAliasModel(Base, GUIDPk):
+        __tablename__ = "bad_alias_model"
+        __autoapi_verb_aliases__ = {"create": "Bad-Name"}
+
+    with pytest.raises(RuntimeError):
+        create_test_api(BadAliasModel)


### PR DESCRIPTION
## Summary
- duplicate AutoAPI integration tests into `tests/r8n` for regression coverage
- update new tests to use AutoAPI v3 and `pytest.mark.r8n`

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff check tests/r8n --fix`
- `uv run --package autoapi --directory standards/autoapi pytest` *(fails: ModuleNotFoundError: No module named 'autoapi.v2.impl.errors')*

------
https://chatgpt.com/codex/tasks/task_e_689e526fd44c8326917ae5a550327060