### PR TITLE
fix: handle missing mapper class

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v2/__init__.py
@@ -209,7 +209,9 @@ class AutoAPI:
 
         # generate CRUD + RPC for every mapped SQLAlchemy model
         for m in base.registry.mappers:
-            cls = m.class_
+            cls = getattr(m, "class_", None)
+            if cls is None:
+                continue
             if self._include and cls not in self._include:
                 continue
             self._crud(cls)


### PR DESCRIPTION
## Summary
- skip non-mapper objects when building CRUD ops in AutoAPI

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format autoapi/v2/__init__.py`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check autoapi/v2/__init__.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_689eaf4803ac83268e6a8559ff6842c1