### PR TITLE
Skip placeholder namespaces in AutoAPI mapper iteration

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v2/__init__.py
@@ -208,7 +208,13 @@ class AutoAPI:
         self.router.include_router(build_rpcdispatch(self))
 
         # generate CRUD + RPC for every mapped SQLAlchemy model
+        # ``base.registry.mappers`` may occasionally contain placeholder objects
+        # (e.g., :class:`types.SimpleNamespace`) that lack the ``class_`` attribute
+        # expected on SQLAlchemy ``Mapper`` instances.  Guard against these to
+        # avoid AttributeError during application start-up.
         for m in base.registry.mappers:
+            if isinstance(m, SimpleNamespace):  # skip non-mapper sentinels
+                continue
             cls = getattr(m, "class_", None)
             if cls is None:
                 continue


### PR DESCRIPTION
## Summary
- avoid AttributeError when `base.registry.mappers` yields placeholder `SimpleNamespace`

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_689eb1b3e2188326bd16d3215a758556