### PR TITLE
feat(peagen): migrate orm to autoapi v3

### DIFF
--- a/pkgs/standards/peagen/peagen/orm/__init__.py
+++ b/pkgs/standards/peagen/peagen/orm/__init__.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 
 from typing import FrozenSet
 
-# from autoapi.v2.tables import Role, RoleGrant, RolePerm
-from autoapi.v2.tables import Status, Base
+# from autoapi.v3.tables import Role, RoleGrant, RolePerm
+from autoapi.v3.tables import Status, Base
 
 # Import table classes. Ensure Tenant is imported before Pool so bootstrapping
 # default rows inserts the default tenant prior to default pools.

--- a/pkgs/standards/peagen/peagen/orm/abuse_record.py
+++ b/pkgs/standards/peagen/peagen/orm/abuse_record.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-from sqlalchemy import Column, String, Integer, Boolean
-
-from autoapi.v2.tables import Base, User
-from autoapi.v2.mixins import GUIDPk, Timestamped, Ownable
-from sqlalchemy.orm import relationship
+from autoapi.v3.types import Column, String, Integer, Boolean, relationship
+from autoapi.v3.tables import Base, User
+from autoapi.v3.mixins import GUIDPk, Timestamped, Ownable
 
 
 class AbuseRecord(Base, GUIDPk, Timestamped, Ownable):
@@ -17,7 +15,7 @@ class AbuseRecord(Base, GUIDPk, Timestamped, Ownable):
     """
 
     __tablename__ = "abuse_records"
-    __table_args__= ({"schema": "peagen"},)
+    __table_args__ = ({"schema": "peagen"},)
 
     ip = Column(String, nullable=False, unique=True, index=True)
     count = Column(Integer, nullable=False, default=0)

--- a/pkgs/standards/peagen/peagen/orm/analysis_result.py
+++ b/pkgs/standards/peagen/peagen/orm/analysis_result.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from autoapi.v2.types import Column, Text, JSON, PgUUID, ForeignKey, relationship
-from autoapi.v2.tables import Base
-from autoapi.v2.mixins import GUIDPk, Timestamped, Ownable, TenantBound
+from autoapi.v3.types import Column, Text, JSON, PgUUID, ForeignKey, relationship
+from autoapi.v3.tables import Base
+from autoapi.v3.mixins import GUIDPk, Timestamped, Ownable, TenantBound
 
 
 from .users import User
@@ -10,7 +10,7 @@ from .users import User
 
 class AnalysisResult(Base, GUIDPk, Timestamped, TenantBound, Ownable):
     __tablename__ = "analysis_results"
-    __table_args__= ({"schema": "peagen"},)
+    __table_args__ = ({"schema": "peagen"},)
     eval_result_id = Column(
         PgUUID(as_uuid=True), ForeignKey("peagen.eval_results.id", ondelete="CASCADE")
     )
@@ -21,4 +21,3 @@ class AnalysisResult(Base, GUIDPk, Timestamped, TenantBound, Ownable):
 
 
 __all__ = ["AnalysisResult"]
-    

--- a/pkgs/standards/peagen/peagen/orm/doe_spec.py
+++ b/pkgs/standards/peagen/peagen/orm/doe_spec.py
@@ -1,27 +1,26 @@
 from __future__ import annotations
 
-from autoapi.v2.types import (
+from autoapi.v3.types import (
     Column,
     String,
     Text,
     JSON,
     UniqueConstraint,
-    ForeignKey,
-    PgUUID,
     relationship,
 )
-from autoapi.v2.tables import Base
-from autoapi.v2.mixins import GUIDPk, Timestamped, TenantBound, Ownable
+from autoapi.v3.tables import Base
+from autoapi.v3.mixins import GUIDPk, Timestamped, TenantBound, Ownable
 
-from .tenants import Tenant
 from .users import User
 
 
 class DoeSpec(Base, GUIDPk, Timestamped, TenantBound, Ownable):
     __tablename__ = "doe_specs"
-    __table_args__= (UniqueConstraint("tenant_id", "name"), {"schema": "peagen"},)
+    __table_args__ = (
+        UniqueConstraint("tenant_id", "name"),
+        {"schema": "peagen"},
+    )
 
- 
     name = Column(String, nullable=False)
     schema_version = Column(String, nullable=False, default="1.1.0")
     description = Column(Text, nullable=True)

--- a/pkgs/standards/peagen/peagen/orm/eval_result.py
+++ b/pkgs/standards/peagen/peagen/orm/eval_result.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
-from autoapi.v2.types import Column, String, JSON, PgUUID, ForeignKey, relationship
-from autoapi.v2.tables import Base
-from autoapi.v2.mixins import GUIDPk, Timestamped, Ownable, TenantBound
+from autoapi.v3.types import Column, String, JSON, PgUUID, ForeignKey, relationship
+from autoapi.v3.tables import Base
+from autoapi.v3.mixins import GUIDPk, Timestamped, Ownable, TenantBound
 
 from .users import User
 
 
 class EvalResult(Base, GUIDPk, Timestamped, TenantBound, Ownable):
     __tablename__ = "eval_results"
-    __table_args__= ({"schema": "peagen"},)
-    work_id = Column(PgUUID(as_uuid=True), ForeignKey("peagen.works.id", ondelete="CASCADE"))
+    __table_args__ = ({"schema": "peagen"},)
+    work_id = Column(
+        PgUUID(as_uuid=True), ForeignKey("peagen.works.id", ondelete="CASCADE")
+    )
     label = Column(String)
     metrics = Column(JSON, nullable=False)
     owner = relationship(User, lazy="selectin")

--- a/pkgs/standards/peagen/peagen/orm/evolve_spec.py
+++ b/pkgs/standards/peagen/peagen/orm/evolve_spec.py
@@ -1,25 +1,25 @@
 from __future__ import annotations
 
-from autoapi.v2.types import (
+from autoapi.v3.types import (
     Column,
     String,
     Text,
     JSON,
     UniqueConstraint,
-    ForeignKey,
-    PgUUID,
     relationship,
 )
-from autoapi.v2.tables import Base
-from autoapi.v2.mixins import GUIDPk, Timestamped, TenantBound, Ownable
+from autoapi.v3.tables import Base
+from autoapi.v3.mixins import GUIDPk, Timestamped, TenantBound, Ownable
 
-from .tenants import Tenant
 from .users import User
 
 
 class EvolveSpec(Base, GUIDPk, Timestamped, TenantBound, Ownable):
     __tablename__ = "evolve_specs"
-    __table_args__= (UniqueConstraint("tenant_id", "name"),{"schema": "peagen"},)
+    __table_args__ = (
+        UniqueConstraint("tenant_id", "name"),
+        {"schema": "peagen"},
+    )
     name = Column(String, nullable=False)
     schema_version = Column(String, nullable=False, default="1.0.0")
     description = Column(Text, nullable=True)

--- a/pkgs/standards/peagen/peagen/orm/keys.py
+++ b/pkgs/standards/peagen/peagen/orm/keys.py
@@ -2,16 +2,16 @@ from __future__ import annotations
 
 import uuid
 
-from autoapi.v2.types import (
+from autoapi.v3.types import (
     Boolean,
     Column,
     String,
     UniqueConstraint,
     HookProvider,
+    relationship,
 )
-from autoapi.v2.types import relationship
-from autoapi.v2.tables import Base
-from autoapi.v2.mixins import GUIDPk, Timestamped, UserMixin
+from autoapi.v3.tables import Base
+from autoapi.v3.mixins import GUIDPk, Timestamped, UserMixin
 from peagen.orm.mixins import RepositoryRefMixin
 
 
@@ -98,26 +98,24 @@ class DeployKey(Base, GUIDPk, RepositoryRefMixin, Timestamped, HookProvider):
 
     @classmethod
     def __autoapi_register_hooks__(cls, api) -> None:
-        from autoapi.v2 import Phase, get_schema
+        from autoapi.v3 import _schema
 
-        cls._SCreate = get_schema(cls, "create")
-        cls._SRead = get_schema(cls, "read")
-        cls._SDelete = get_schema(cls, "delete")
-        api.register_hook(Phase.PRE_TX_BEGIN, model="DeployKey", op="create")(
+        cls._SCreate = _schema(cls, verb="create")
+        cls._SRead = _schema(cls, verb="read")
+        cls._SDelete = _schema(cls, verb="delete")
+        api.register_hook("PRE_TX_BEGIN", model="DeployKey", op="create")(
             cls._pre_create
         )
-        api.register_hook(Phase.PRE_TX_BEGIN, model="DeployKey", op="delete")(
+        api.register_hook("PRE_TX_BEGIN", model="DeployKey", op="delete")(
             cls._pre_delete
         )
-        api.register_hook(Phase.POST_COMMIT, model="DeployKey", op="create")(
+        api.register_hook("POST_COMMIT", model="DeployKey", op="create")(
             cls._post_create
         )
-        api.register_hook(Phase.POST_COMMIT, model="DeployKey", op="delete")(
+        api.register_hook("POST_COMMIT", model="DeployKey", op="delete")(
             cls._post_delete
         )
-        api.register_hook(Phase.POST_HANDLER, model="DeployKey", op="read")(
-            cls._post_read
-        )
+        api.register_hook("POST_HANDLER", model="DeployKey", op="read")(cls._post_read)
 
 
 __all__ = ["PublicKey", "GPGKey", "DeployKey"]

--- a/pkgs/standards/peagen/peagen/orm/mixins.py
+++ b/pkgs/standards/peagen/peagen/orm/mixins.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from autoapi.v2.types import (
+from autoapi.v3.types import (
     Column,
     ForeignKey,
     PgUUID,

--- a/pkgs/standards/peagen/peagen/orm/orgs.py
+++ b/pkgs/standards/peagen/peagen/orm/orgs.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
-from autoapi.v2.tables import Org as OrgBase
+from autoapi.v3.tables import Org as OrgBase
+
 
 class Org(OrgBase):
     # __mapper_args__ = {"concrete": True}
-    __table_args__ = ({
-        "extend_existing": True,
-        "schema": "peagen",
-    },)
+    __table_args__ = (
+        {
+            "extend_existing": True,
+            "schema": "peagen",
+        },
+    )
 
 
 __all__ = ["Org"]

--- a/pkgs/standards/peagen/peagen/orm/peagen_toml_spec.py
+++ b/pkgs/standards/peagen/peagen/orm/peagen_toml_spec.py
@@ -1,26 +1,26 @@
 from __future__ import annotations
 
-from autoapi.v2.types import (
+from autoapi.v3.types import (
     Column,
     String,
     Text,
     JSON,
     UniqueConstraint,
-    ForeignKey,
-    PgUUID,
     relationship,
 )
-from autoapi.v2.tables import Base
-from autoapi.v2.mixins import GUIDPk, Timestamped, TenantBound, Ownable
+from autoapi.v3.tables import Base
+from autoapi.v3.mixins import GUIDPk, Timestamped, TenantBound, Ownable
 
-from .tenants import Tenant
 from .users import User
 
 
 class PeagenTomlSpec(Base, GUIDPk, Timestamped, TenantBound, Ownable):
     __tablename__ = "peagen_toml_specs"
-    __table_args__= (UniqueConstraint("tenant_id", "name"),{"schema": "peagen"},)
-      
+    __table_args__ = (
+        UniqueConstraint("tenant_id", "name"),
+        {"schema": "peagen"},
+    )
+
     name = Column(String, nullable=False)
     schema_version = Column(String, nullable=False, default="1.0.0")
     raw_toml = Column(Text, nullable=False)

--- a/pkgs/standards/peagen/peagen/orm/pools.py
+++ b/pkgs/standards/peagen/peagen/orm/pools.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from autoapi.v2.types import (
+from autoapi.v3.types import (
     JSON,
     Column,
     String,
@@ -8,8 +8,8 @@ from autoapi.v2.types import (
     MutableDict,
     HookProvider,
 )
-from autoapi.v2.tables import Base
-from autoapi.v2.mixins import GUIDPk, Bootstrappable, Timestamped, TenantBound
+from autoapi.v3.tables import Base
+from autoapi.v3.mixins import GUIDPk, Bootstrappable, Timestamped, TenantBound
 from peagen.defaults import DEFAULT_POOL_NAME, DEFAULT_POOL_ID, DEFAULT_TENANT_ID
 
 
@@ -45,10 +45,10 @@ class Pool(Base, GUIDPk, Bootstrappable, Timestamped, TenantBound, HookProvider)
 
     @classmethod
     def __autoapi_register_hooks__(cls, api) -> None:
-        from autoapi.v2 import Phase, get_schema
+        from autoapi.v3 import _schema
 
-        cls._SRead = get_schema(cls, "read")
-        api.register_hook(Phase.POST_COMMIT, model="Pool", op="create")(
+        cls._SRead = _schema(cls, verb="read")
+        api.register_hook("POST_COMMIT", model="Pool", op="create")(
             cls._post_create_register
         )
 

--- a/pkgs/standards/peagen/peagen/orm/project_payload.py
+++ b/pkgs/standards/peagen/peagen/orm/project_payload.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from autoapi.v2.types import (
+from autoapi.v3.types import (
     Column,
     String,
     Text,
@@ -10,18 +10,20 @@ from autoapi.v2.types import (
     PgUUID,
     relationship,
 )
-from autoapi.v2.tables import Base
-from autoapi.v2.mixins import GUIDPk, Timestamped, TenantBound, Ownable
+from autoapi.v3.tables import Base
+from autoapi.v3.mixins import GUIDPk, Timestamped, TenantBound, Ownable
 
-from .tenants import Tenant
 from .users import User
 
 
 class ProjectPayload(Base, GUIDPk, Timestamped, TenantBound, Ownable):
     __tablename__ = "project_payloads"
 
-    __table_args__= (UniqueConstraint("tenant_id", "name"),{"schema": "peagen"},)
-    
+    __table_args__ = (
+        UniqueConstraint("tenant_id", "name"),
+        {"schema": "peagen"},
+    )
+
     doe_spec_id = Column(
         PgUUID(as_uuid=True),
         ForeignKey("peagen.doe_specs.id", ondelete="SET NULL"),

--- a/pkgs/standards/peagen/peagen/orm/raw_blobs.py
+++ b/pkgs/standards/peagen/peagen/orm/raw_blobs.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-from autoapi.v2.tables import Base
-from autoapi.v2.types import Column, String, Integer
-from autoapi.v2.mixins import GUIDPk, Timestamped, BlobRef
+from autoapi.v3.tables import Base
+from autoapi.v3.types import Column, String, Integer
+from autoapi.v3.mixins import GUIDPk, Timestamped, BlobRef
 
 
 class RawBlob(Base, GUIDPk, Timestamped, BlobRef):
     __tablename__ = "raw_blobs"
-    __table_args__= ({"schema": "peagen"},)
+    __table_args__ = ({"schema": "peagen"},)
     mime_type = Column(String, nullable=False)
     size = Column(Integer, nullable=False)
 

--- a/pkgs/standards/peagen/peagen/orm/secrets.py
+++ b/pkgs/standards/peagen/peagen/orm/secrets.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from autoapi.v2.types import (
+from autoapi.v3.types import (
     Column,
     String,
     UniqueConstraint,
@@ -8,8 +8,8 @@ from autoapi.v2.types import (
     HookProvider,
     relationship,
 )
-from autoapi.v2.tables import Base
-from autoapi.v2.mixins import GUIDPk, OrgMixin, Timestamped, UserMixin
+from autoapi.v3.tables import Base
+from autoapi.v3.mixins import GUIDPk, OrgMixin, Timestamped, UserMixin
 from peagen.orm.mixins import RepositoryMixin
 
 
@@ -68,13 +68,13 @@ class RepoSecret(
 
     @classmethod
     def __autoapi_register_hooks__(cls, api) -> None:
-        from autoapi.v2 import Phase, get_schema
+        from autoapi.v3 import _schema
 
-        cls._SRead = get_schema(cls, "read")
-        api.register_hook(Phase.POST_COMMIT, model="RepoSecret", op="create")(
+        cls._SRead = _schema(cls, verb="read")
+        api.register_hook("POST_COMMIT", model="RepoSecret", op="create")(
             cls._post_create
         )
-        api.register_hook(Phase.POST_COMMIT, model="RepoSecret", op="delete")(
+        api.register_hook("POST_COMMIT", model="RepoSecret", op="delete")(
             cls._post_delete
         )
 

--- a/pkgs/standards/peagen/peagen/orm/tasks.py
+++ b/pkgs/standards/peagen/peagen/orm/tasks.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from enum import Enum, auto
 
-from autoapi.v2.types import (
+from autoapi.v3.types import (
     JSON,
     Column,
     String,
@@ -14,8 +14,8 @@ from autoapi.v2.types import (
     relationship,
     HookProvider,
 )
-from autoapi.v2.tables import Base
-from autoapi.v2.mixins import (
+from autoapi.v3.tables import Base
+from autoapi.v3.mixins import (
     GUIDPk,
     Timestamped,
     TenantBound,
@@ -186,26 +186,26 @@ class Task(
 
     @classmethod
     def __autoapi_register_hooks__(cls, api) -> None:
-        from autoapi.v2 import Phase, get_schema
+        from autoapi.v3 import _schema
 
-        cls._SCreate = get_schema(cls, "create")
-        cls._SRead = get_schema(cls, "read")
-        cls._SUpdate = get_schema(cls, "update")
+        cls._SCreate = _schema(cls, verb="create")
+        cls._SRead = _schema(cls, verb="read")
+        cls._SUpdate = _schema(cls, verb="update")
         model_name = cls.__name__
-        api.register_hook(Phase.PRE_TX_BEGIN, model=model_name, op="create")(
+        api.register_hook("PRE_TX_BEGIN", model=model_name, op="create")(
             cls._pre_create
         )
-        api.register_hook(Phase.PRE_TX_BEGIN, model=model_name, op="update")(
+        api.register_hook("PRE_TX_BEGIN", model=model_name, op="update")(
             cls._pre_update
         )
-        api.register_hook(Phase.PRE_TX_BEGIN, model=model_name, op="read")(cls._pre_read)
-        api.register_hook(Phase.POST_COMMIT, model=model_name, op="create")(
+        api.register_hook("PRE_TX_BEGIN", model=model_name, op="read")(cls._pre_read)
+        api.register_hook("POST_COMMIT", model=model_name, op="create")(
             cls._post_create
         )
-        api.register_hook(Phase.POST_COMMIT, model=model_name, op="update")(
+        api.register_hook("POST_COMMIT", model=model_name, op="update")(
             cls._post_update
         )
-        api.register_hook(Phase.POST_HANDLER, model=model_name, op="read")(cls._post_read)
+        api.register_hook("POST_HANDLER", model=model_name, op="read")(cls._post_read)
 
 
 __all__ = ["Action", "SpecKind", "Task"]

--- a/pkgs/standards/peagen/peagen/orm/tenants.py
+++ b/pkgs/standards/peagen/peagen/orm/tenants.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from autoapi.v2.tables import Tenant as TenantBase
-from autoapi.v2.mixins import Bootstrappable
-from autoapi.v2.mixins.upsertable import Upsertable
+from autoapi.v3.tables import Tenant as TenantBase
+from autoapi.v3.mixins import Bootstrappable, Upsertable
 from peagen.defaults import (
     DEFAULT_TENANT_ID,
     DEFAULT_TENANT_SLUG,
@@ -11,10 +10,12 @@ from peagen.defaults import (
 
 class Tenant(TenantBase, Bootstrappable, Upsertable):
     # __mapper_args__ = {"concrete": True}
-    __table_args__ = ({
-        "extend_existing": True,
-        "schema": "peagen",
-    },)
+    __table_args__ = (
+        {
+            "extend_existing": True,
+            "schema": "peagen",
+        },
+    )
     DEFAULT_ROWS = [
         {
             "id": DEFAULT_TENANT_ID,
@@ -23,5 +24,6 @@ class Tenant(TenantBase, Bootstrappable, Upsertable):
     ]
 
     __upsert_keys__ = ("slug",)
+
 
 __all__ = ["Tenant"]

--- a/pkgs/standards/peagen/peagen/orm/user_repositories.py
+++ b/pkgs/standards/peagen/peagen/orm/user_repositories.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from autoapi.v2.tables import Base
-from autoapi.v2.mixins import GUIDPk, UserMixin
+from autoapi.v3.tables import Base
+from autoapi.v3.mixins import GUIDPk, UserMixin
 
 from .mixins import RepositoryMixin
 
@@ -10,6 +10,7 @@ class UserRepository(Base, GUIDPk, RepositoryMixin, UserMixin):
     """Edge capturing any per-repository permission or ownership the user may have."""
 
     __tablename__ = "user_repositories"
-    __table_args__= ({"schema": "peagen"},)
+    __table_args__ = ({"schema": "peagen"},)
+
 
 __all__ = ["UserRepository"]

--- a/pkgs/standards/peagen/peagen/orm/users.py
+++ b/pkgs/standards/peagen/peagen/orm/users.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from autoapi.v2.tables import User as UserBase
-from autoapi.v2.mixins import Bootstrappable, Upsertable, uuid_example
-from autoapi.v2.types import Column, PgUUID, uuid4
+from autoapi.v3.tables import User as UserBase
+from autoapi.v3.mixins import Bootstrappable, Upsertable, uuid_example
+from autoapi.v3.types import Column, PgUUID, uuid4
+
 
 class User(UserBase, Bootstrappable, Upsertable):
     __table_args__ = ({"extend_existing": True, "schema": "peagen"},)
@@ -18,5 +19,6 @@ class User(UserBase, Bootstrappable, Upsertable):
             }
         ),
     )
+
 
 __all__ = ["User"]

--- a/pkgs/standards/peagen/peagen/orm/workers.py
+++ b/pkgs/standards/peagen/peagen/orm/workers.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 
-from autoapi.v2.types import (
+from autoapi.v3.types import (
     JSON,
     Column,
     ForeignKey,
@@ -13,9 +13,9 @@ from autoapi.v2.types import (
     HookProvider,
     AllowAnonProvider,
 )
-from autoapi.v2.tables import Base
+from autoapi.v3.tables import Base
 
-from autoapi.v2.mixins import GUIDPk, Timestamped
+from autoapi.v3.mixins import GUIDPk, Timestamped
 from peagen.defaults import DEFAULT_POOL_ID, WORKER_KEY, WORKER_TTL
 
 from .pools import Pool
@@ -301,40 +301,36 @@ class Worker(Base, GUIDPk, Timestamped, HookProvider, AllowAnonProvider):
 
     @classmethod
     def __autoapi_register_hooks__(cls, api) -> None:
-        from autoapi.v2 import Phase, get_schema
+        from autoapi.v3 import _schema
 
-        cls._SRead = get_schema(cls, "read")
-        api.register_hook(Phase.PRE_TX_BEGIN, model="Worker", op="create")(
+        cls._SRead = _schema(cls, verb="read")
+        api.register_hook("PRE_TX_BEGIN", model="Worker", op="create")(
             cls._pre_create_policy_gate
         )
-        api.register_hook(Phase.POST_RESPONSE, model="Worker", op="create")(
+        api.register_hook("POST_RESPONSE", model="Worker", op="create")(
             cls._post_create_cache_pool
         )
-        api.register_hook(Phase.POST_RESPONSE, model="Worker", op="create")(
+        api.register_hook("POST_RESPONSE", model="Worker", op="create")(
             cls._post_create_cache_worker
         )
-        api.register_hook(Phase.POST_COMMIT, model="Worker", op="create")(
+        api.register_hook("POST_COMMIT", model="Worker", op="create")(
             cls._post_create_auto_register
         )
-        api.register_hook(Phase.POST_RESPONSE, model="Worker", op="create")(
+        api.register_hook("POST_RESPONSE", model="Worker", op="create")(
             cls._post_create_inject_key
         )
-        api.register_hook(Phase.PRE_TX_BEGIN, model="Worker", op="update")(
+        api.register_hook("PRE_TX_BEGIN", model="Worker", op="update")(
             cls._pre_update_policy_gate
         )
-        api.register_hook(Phase.PRE_TX_BEGIN, model="Worker", op="update")(
-            cls._pre_update
-        )
-        api.register_hook(Phase.POST_RESPONSE, model="Worker", op="update")(
+        api.register_hook("PRE_TX_BEGIN", model="Worker", op="update")(cls._pre_update)
+        api.register_hook("POST_RESPONSE", model="Worker", op="update")(
             cls._post_update_cache_pool
         )
-        api.register_hook(Phase.POST_RESPONSE, model="Worker", op="update")(
+        api.register_hook("POST_RESPONSE", model="Worker", op="update")(
             cls._post_update_cache_worker
         )
-        api.register_hook(Phase.POST_HANDLER, model="Worker", op="list")(cls._post_list)
-        api.register_hook(Phase.POST_HANDLER, model="Worker", op="delete")(
-            cls._post_delete
-        )
+        api.register_hook("POST_HANDLER", model="Worker", op="list")(cls._post_list)
+        api.register_hook("POST_HANDLER", model="Worker", op="delete")(cls._post_delete)
 
 
 __all__ = ["Worker"]

--- a/pkgs/standards/peagen/peagen/orm/works.py
+++ b/pkgs/standards/peagen/peagen/orm/works.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from autoapi.v2.types import (
+from autoapi.v3.types import (
     JSON,
     Column,
     PgUUID,
@@ -9,8 +9,8 @@ from autoapi.v2.types import (
     relationship,
     HookProvider,
 )
-from autoapi.v2.tables import Base
-from autoapi.v2.mixins import GUIDPk, Timestamped, StatusMixin
+from autoapi.v3.tables import Base
+from autoapi.v3.mixins import GUIDPk, Timestamped, StatusMixin
 
 from .tasks import Task
 
@@ -65,12 +65,10 @@ class Work(Base, GUIDPk, Timestamped, StatusMixin, HookProvider):
 
     @classmethod
     def __autoapi_register_hooks__(cls, api) -> None:
-        from autoapi.v2 import Phase, get_schema
+        from autoapi.v3 import _schema
 
-        cls._SRead = get_schema(cls, "read")
-        api.register_hook(Phase.POST_COMMIT, model="Work", op="update")(
-            cls._post_update
-        )
+        cls._SRead = _schema(cls, verb="read")
+        api.register_hook("POST_COMMIT", model="Work", op="update")(cls._post_update)
 
 
 __all__ = ["Work"]


### PR DESCRIPTION
## Summary
- migrate peagen ORM models to AutoAPI v3
- adopt v3 schema helper and string-based phase registration

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format peagen/orm`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/orm --fix`


------
https://chatgpt.com/codex/tasks/task_e_689ebef512548326b3a8c504cb069ced