### PR TITLE
refactor(peagen): migrate handlers to autoapi v3

### DIFF
--- a/pkgs/standards/peagen/peagen/handlers/analysis_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/analysis_handler.py
@@ -18,7 +18,7 @@ from contextlib import suppress
 from pathlib import Path
 from typing import Any, Dict, List
 
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.orm import Task
 from peagen.core.analysis_core import analyze_runs
 from peagen._utils.config_loader import resolve_cfg

--- a/pkgs/standards/peagen/peagen/handlers/control_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/control_handler.py
@@ -16,8 +16,8 @@ from __future__ import annotations
 
 from typing import Iterable
 
-from autoapi.v2 import get_schema
-from autoapi.v2.tables.task import Task  # SQLAlchemy model row
+from autoapi.v3 import get_schema
+from autoapi.v3.tables.task import Task  # SQLAlchemy model row
 
 from peagen.core import control_core
 from peagen.plugins.queues import QueueBase

--- a/pkgs/standards/peagen/peagen/handlers/doe_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/doe_handler.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 import yaml
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.orm import Task, Status, Action
 
 from peagen.core.git_repo_core import (

--- a/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 import yaml
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.orm import Task, Status, Action
 
 from peagen.defaults import ROOT_DIR

--- a/pkgs/standards/peagen/peagen/handlers/eval_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/eval_handler.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Any, Dict, Optional
 
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.orm import Task
 
 from peagen.core.eval_core import evaluate_workspace

--- a/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
@@ -20,7 +20,7 @@ import yaml
 from pathlib import Path
 from typing import Any, Dict, List
 
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.orm import Task, Status, Action
 from peagen.core.git_repo_core import (
     repo_lock,

--- a/pkgs/standards/peagen/peagen/handlers/extras_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/extras_handler.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, List
 
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.orm import Task
 from peagen.core.extras_core import generate_schemas
 

--- a/pkgs/standards/peagen/peagen/handlers/fetch_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/fetch_handler.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.orm import Task
 from peagen.core.fetch_core import fetch_many
 

--- a/pkgs/standards/peagen/peagen/handlers/init_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/init_handler.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict
 
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.orm import Task
 from peagen.core import init_core
 

--- a/pkgs/standards/peagen/peagen/handlers/keys_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/keys_handler.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 import anyio
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.core import keys_core
 from peagen.defaults import DEFAULT_GATEWAY
 from peagen.orm import Task

--- a/pkgs/standards/peagen/peagen/handlers/migrate_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/migrate_handler.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict
 
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.orm import Task
 
 from peagen.core.migrate_core import (

--- a/pkgs/standards/peagen/peagen/handlers/mutate_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/mutate_handler.py
@@ -19,7 +19,7 @@ from contextlib import suppress
 from pathlib import Path
 from typing import Any, Dict
 
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.orm import Task
 from peagen.core.mutate_core import mutate_workspace
 from peagen._utils.config_loader import resolve_cfg

--- a/pkgs/standards/peagen/peagen/handlers/process_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/process_handler.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict
 
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.orm import Task
 
 from peagen._utils.config_loader import resolve_cfg

--- a/pkgs/standards/peagen/peagen/handlers/secrets_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/secrets_handler.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict
 
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.orm import Task
 
 from peagen.core import secrets_core

--- a/pkgs/standards/peagen/peagen/handlers/sort_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/sort_handler.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict
 
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.orm import Task
 
 from peagen._utils.config_loader import resolve_cfg

--- a/pkgs/standards/peagen/peagen/handlers/templates_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/templates_handler.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.orm import Task
 
 from peagen._utils import maybe_clone_repo

--- a/pkgs/standards/peagen/peagen/handlers/validate_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/validate_handler.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Dict, Any
 
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.orm import Task
 from peagen.core.validate_core import validate_artifact
 


### PR DESCRIPTION
## Summary
- update peagen handlers to import autoapi.v3 instead of autoapi.v2
- switch Task model import to autoapi.v3.tables.task in control handler

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format peagen/handlers`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/handlers --fix`


------
https://chatgpt.com/codex/tasks/task_e_689ebf5ab4d483268e08609b655e8459