### PR TITLE
fix: align REST route summary/description in autoapi v3

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
@@ -393,11 +393,14 @@ def _build_router(model: type, specs: Sequence[OpSpec]) -> APIRouter:
         )
 
         # Attach route
+        label = f"{model.__name__} - {sp.alias}"
         router.add_api_route(
             path,
             endpoint,
             methods=methods,
             name=f"{model.__name__}.{sp.alias}",
+            summary=label,
+            description=label,
             response_model=response_model,
             status_code=status_code,
             tags=list(sp.tags) if sp.tags else None,


### PR DESCRIPTION
## Summary
- ensure REST routes in autoapi v3 expose consistent summary and description like autoapi v2

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `uv run --package autoapi --directory pkgs/standards/autoapi pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fdb689e788326a94f937bbbe607e6