### PR TITLE
fix: avoid duplicated resource segments

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/api.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/api.py
@@ -271,11 +271,14 @@ def include_models(
 ) -> Dict[str, Any]:
     """
     Convenience helper to include multiple models.
-    Each model is mounted at `{base_prefix}/{resource}` when base_prefix is provided.
+
+    If ``base_prefix`` is provided, each model's router is mounted under that
+    prefix.  The router already includes its own ``/{resource}`` segment, so we
+    avoid appending it again here.
     """
     results: Dict[str, Any] = {}
     for mdl in models:
-        px = (base_prefix.rstrip("/") if base_prefix else "") + _default_prefix(mdl)
+        px = base_prefix.rstrip("/") if base_prefix else None
         _, router = include_model(
             api, mdl, app=app, prefix=px, mount_router=mount_router
         )

--- a/pkgs/standards/autoapi/tests/unit/test_include_models_base_prefix.py
+++ b/pkgs/standards/autoapi/tests/unit/test_include_models_base_prefix.py
@@ -1,0 +1,28 @@
+from fastapi import FastAPI
+
+from autoapi.v3.autoapi import AutoAPI
+from autoapi.v3.tables import Base
+from autoapi.v3.mixins import GUIDPk
+from autoapi.v3.types import Column, String
+
+
+def test_include_models_base_prefix_avoids_duplicate_segments():
+    app = FastAPI()
+
+    class Key(Base, GUIDPk):
+        __tablename__ = "Key"
+        name = Column(String, nullable=False)
+
+    class KeyVersion(Base, GUIDPk):
+        __tablename__ = "key_versions"
+        name = Column(String, nullable=False)
+
+    api = AutoAPI(app=app)
+    api.include_models([Key, KeyVersion], base_prefix="/kms")
+
+    paths = {r.path for r in app.router.routes}
+
+    assert "/kms/Key" in paths
+    assert "/kms/key_versions" in paths
+    assert "/kms/Key/Key" not in paths
+    assert "/kms/key_versions/key_versions" not in paths


### PR DESCRIPTION
## Summary
- avoid appending resource name twice when using `include_models` with a base prefix
- add regression test ensuring routers mount under the base prefix once

## Testing
- `uv run --package autoapi --directory . ruff format .`
- `uv run --package autoapi --directory . ruff check . --fix`
- `uv run --package autoapi --directory . pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fdb603fac8326bc9550cb1244a669