### PR TITLE
fix: restore default tags in autoapi v3

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
@@ -403,7 +403,7 @@ def _build_router(model: type, specs: Sequence[OpSpec]) -> APIRouter:
             description=label,
             response_model=response_model,
             status_code=status_code,
-            tags=list(sp.tags) if sp.tags else None,
+            tags=list(sp.tags or (resource,)),
         )
 
         logger.debug(

--- a/pkgs/standards/autoapi/autoapi/v3/system/diagnostics.py
+++ b/pkgs/standards/autoapi/autoapi/v3/system/diagnostics.py
@@ -152,7 +152,7 @@ def _build_methodz_endpoint(api: Any):
                         "returns": sp.returns,
                         "routes": bool(getattr(sp, "expose_routes", True)),
                         "rpc": bool(getattr(sp, "expose_rpc", True)),
-                        "tags": list(getattr(sp, "tags", ()) or ()),
+                        "tags": list(getattr(sp, "tags", ()) or (mname,)),
                     }
                 )
         methods.sort(key=lambda x: (x["model"], x["alias"]))

--- a/pkgs/standards/autoapi/tests/unit/test_default_tags.py
+++ b/pkgs/standards/autoapi/tests/unit/test_default_tags.py
@@ -1,0 +1,17 @@
+from autoapi.v3.bindings.rest import _build_router
+from autoapi.v3.opspec import OpSpec
+from autoapi.v3.tables import Base
+from autoapi.v3.mixins import GUIDPk
+from autoapi.v3.types import Column, String
+
+
+class Widget(Base, GUIDPk):
+    __tablename__ = "widgets"
+    name = Column(String, nullable=False)
+
+
+def test_router_default_tag():
+    sp = OpSpec(alias="list", target="list")
+    router = _build_router(Widget, [sp])
+    route = router.routes[0]
+    assert route.tags == ["widgets"]


### PR DESCRIPTION
## Summary
- default to resource name when no tags provided for v3 routes
- diagnostics include default tags
- add unit test for default tagging

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `uv run --directory pkgs/standards/autoapi --package autoapi pytest`
- `cd pkgs && uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_default_tags.py`


------
https://chatgpt.com/codex/tasks/task_e_689fe7d3ecbc8326a4080f121f6bbac0