### PR TITLE
Tag JSON-RPC route in AutoAPI v3

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/transport/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/transport/__init__.py
@@ -24,7 +24,7 @@ Quick usage:
 
 from __future__ import annotations
 
-from typing import Any, Awaitable, Callable, Optional
+from typing import Any, Awaitable, Callable, Optional, Sequence
 
 # JSON-RPC transport
 from .jsonrpc import build_jsonrpc_router
@@ -40,14 +40,23 @@ def mount_jsonrpc(
     prefix: str = "/rpc",
     get_db: Optional[Callable[..., Any]] = None,
     get_async_db: Optional[Callable[..., Awaitable[Any]]] = None,
+    tags: Sequence[str] | None = ("system",),
 ):
     """
     Build a JSON-RPC router for `api` and include it on the given FastAPI `app`
     (or any object exposing `include_router`).
 
     Returns the created router so you can keep a reference if desired.
+
+    Parameters
+    ----------
+    tags:
+        Optional tags applied to the mounted "/rpc" endpoint. Defaults to
+        ``("system",)``.
     """
-    router = build_jsonrpc_router(api, get_db=get_db, get_async_db=get_async_db)
+    router = build_jsonrpc_router(
+        api, get_db=get_db, get_async_db=get_async_db, tags=tags
+    )
     include_router = getattr(app, "include_router", None)
     if callable(include_router):
         include_router(router, prefix=prefix)

--- a/pkgs/standards/autoapi/autoapi/v3/transport/jsonrpc/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/transport/jsonrpc/__init__.py
@@ -3,7 +3,9 @@
 AutoAPI v3 – JSON-RPC transport.
 
 Public helper:
-  - build_jsonrpc_router(api, *, get_db=None, get_async_db=None) -> APIRouter
+  - build_jsonrpc_router(
+        api, *, get_db=None, get_async_db=None, tags=("system",)
+    ) -> APIRouter
 
 Usage:
     from autoapi.v3.transport.jsonrpc import build_jsonrpc_router

--- a/pkgs/standards/autoapi/autoapi/v3/transport/jsonrpc/dispatcher.py
+++ b/pkgs/standards/autoapi/autoapi/v3/transport/jsonrpc/dispatcher.py
@@ -269,6 +269,7 @@ def build_jsonrpc_router(
     *,
     get_db: Optional[Callable[..., Any]] = None,
     get_async_db: Optional[Callable[..., Awaitable[Any]]] = None,
+    tags: Sequence[str] | None = ("system",),
 ) -> APIRouter:
     """
     Build and return an APIRouter that serves a single POST endpoint at "/".
@@ -283,6 +284,9 @@ def build_jsonrpc_router(
           so it runs before dispatch. It may set `request.state.user` and/or raise 401.
         • If `api._authorize` is set, we call it before executing the op; False/exception → 403.
         • Additional router-level dependencies can be provided via `api.rpc_dependencies`.
+
+    The generated endpoint is tagged as "system" by default. Supply a custom
+    sequence via ``tags`` to override or set ``None`` to omit tags.
     """
     # Extra router-level deps (e.g., tracing, IP allowlist)
     extra_router_deps = _normalize_deps(getattr(api, "rpc_dependencies", None))
@@ -405,6 +409,7 @@ def build_jsonrpc_router(
         endpoint=_endpoint,
         methods=["POST"],
         name="autoapi.jsonrpc",
+        tags=list(tags) if tags else None,
         # extra router deps already applied via APIRouter(dependencies=...)
     )
     return router

--- a/pkgs/standards/autoapi/tests/unit/test_jsonrpc_router_default_tag.py
+++ b/pkgs/standards/autoapi/tests/unit/test_jsonrpc_router_default_tag.py
@@ -1,0 +1,10 @@
+from types import SimpleNamespace
+
+from autoapi.v3.transport import build_jsonrpc_router
+
+
+def test_jsonrpc_router_default_tag():
+    api = SimpleNamespace()
+    router = build_jsonrpc_router(api)
+    route = router.routes[0]
+    assert route.tags == ["system"]


### PR DESCRIPTION
## Summary
- allow specifying tags for JSON-RPC router and default to `system`
- expose tag control through `mount_jsonrpc`
- document JSON-RPC router tag parameter and add regression test

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff check autoapi/v3/transport/__init__.py autoapi/v3/transport/jsonrpc/__init__.py autoapi/v3/transport/jsonrpc/dispatcher.py tests/unit/test_jsonrpc_router_default_tag.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_689fe9b16f108326868a514dd29e977f