### PR TITLE
Tag system diagnostics and clarify summaries

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/system/diagnostics.py
+++ b/pkgs/standards/autoapi/autoapi/v3/system/diagnostics.py
@@ -215,7 +215,7 @@ def mount_diagnostics(
         "/healthz",
         _build_healthz_endpoint(dep),
         methods=["GET"],
-        name="autoapi.healthz",
+        name="healthz",
         tags=["system"],
         summary="Health",
     )
@@ -223,7 +223,7 @@ def mount_diagnostics(
         "/methodz",
         _build_methodz_endpoint(api),
         methods=["GET"],
-        name="autoapi.methodz",
+        name="methodz",
         tags=["system"],
         summary="Methods",
     )
@@ -231,7 +231,7 @@ def mount_diagnostics(
         "/hookz",
         _build_hookz_endpoint(api),
         methods=["GET"],
-        name="autoapi.hookz",
+        name="hookz",
         tags=["system"],
         summary="Hooks",
     )

--- a/pkgs/standards/autoapi/autoapi/v3/system/diagnostics.py
+++ b/pkgs/standards/autoapi/autoapi/v3/system/diagnostics.py
@@ -216,15 +216,24 @@ def mount_diagnostics(
         _build_healthz_endpoint(dep),
         methods=["GET"],
         name="autoapi.healthz",
+        tags=["system"],
+        summary="Health",
     )
     router.add_api_route(
         "/methodz",
         _build_methodz_endpoint(api),
         methods=["GET"],
         name="autoapi.methodz",
+        tags=["system"],
+        summary="Methods",
     )
     router.add_api_route(
-        "/hookz", _build_hookz_endpoint(api), methods=["GET"], name="autoapi.hookz"
+        "/hookz",
+        _build_hookz_endpoint(api),
+        methods=["GET"],
+        name="autoapi.hookz",
+        tags=["system"],
+        summary="Hooks",
     )
 
     return router


### PR DESCRIPTION
## Summary
- tag AutoAPI v3 diagnostics routes with `system`
- simplify diagnostics route summaries to `Health`, `Methods`, and `Hooks`

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_689febc3beb083269e2f6ddff1c24509