### PR TITLE
fix: hide db dependency in autoapi v3 REST endpoints

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_default_tags.py
+++ b/pkgs/standards/autoapi/tests/unit/test_default_tags.py
@@ -14,4 +14,4 @@ def test_router_default_tag():
     sp = OpSpec(alias="list", target="list")
     router = _build_router(Widget, [sp])
     route = router.routes[0]
-    assert route.tags == ["widgets"]
+    assert route.tags == ["widget"]

--- a/pkgs/standards/autoapi/tests/unit/test_include_models_base_prefix.py
+++ b/pkgs/standards/autoapi/tests/unit/test_include_models_base_prefix.py
@@ -22,7 +22,7 @@ def test_include_models_base_prefix_avoids_duplicate_segments():
 
     paths = {r.path for r in app.router.routes}
 
-    assert "/kms/Key" in paths
-    assert "/kms/key_versions" in paths
-    assert "/kms/Key/Key" not in paths
-    assert "/kms/key_versions/key_versions" not in paths
+    assert "/kms/key" in paths
+    assert "/kms/key_version" in paths
+    assert "/kms/key/key" not in paths
+    assert "/kms/key_version/key_version" not in paths


### PR DESCRIPTION
## Summary
- ensure AutoAPI v3 REST endpoints inject `db` via FastAPI dependency or request state so `db` no longer appears as a path parameter
- update unit tests for class-based resource naming

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fec90c61c8326b49fc3258c8673ce