### PR TITLE
fix: hide db param in autoapi v3 routes

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_db_dependency.py
+++ b/pkgs/standards/autoapi/tests/unit/test_db_dependency.py
@@ -1,0 +1,19 @@
+from autoapi.v3.bindings.rest import _build_router
+from autoapi.v3.opspec import OpSpec
+from autoapi.v3.tables import Base
+from autoapi.v3.mixins import GUIDPk
+from autoapi.v3.types import Column, String
+
+
+class Widget(Base, GUIDPk):
+    __tablename__ = "widgets_db_dep"
+    name = Column(String, nullable=False)
+
+
+def test_db_injected_via_dependency():
+    sp = OpSpec(alias="list", target="list")
+    router = _build_router(Widget, [sp])
+    route = router.routes[0]
+    assert "db" not in {p.name for p in route.dependant.path_params}
+    assert "db" not in {p.name for p in route.dependant.query_params}
+    assert any(d.name == "db" for d in route.dependant.dependencies)


### PR DESCRIPTION
## Summary
- ensure REST endpoints obtain `db` via FastAPI dependencies instead of path params
- default to request.state.db when no provider is configured
- add regression test for db dependency injection

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fec9209588326afbec5a82f09167a