### PR TITLE
fix: adjust jsonrpc router default tag

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/transport/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/transport/__init__.py
@@ -52,10 +52,13 @@ def mount_jsonrpc(
     ----------
     tags:
         Optional tags applied to the mounted "/rpc" endpoint. Defaults to
-        ``("system",)``.
+        ``("rpc",)``.
     """
     router = build_jsonrpc_router(
-        api, get_db=get_db, get_async_db=get_async_db, tags=tags,
+        api,
+        get_db=get_db,
+        get_async_db=get_async_db,
+        tags=tags,
     )
     include_router = getattr(app, "include_router", None)
     if callable(include_router):

--- a/pkgs/standards/autoapi/autoapi/v3/transport/jsonrpc/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/transport/jsonrpc/__init__.py
@@ -4,7 +4,7 @@ AutoAPI v3 – JSON-RPC transport.
 
 Public helper:
   - build_jsonrpc_router(
-        api, *, get_db=None, get_async_db=None, tags=("system",)
+        api, *, get_db=None, get_async_db=None, tags=("rpc",)
     ) -> APIRouter
 
 Usage:

--- a/pkgs/standards/autoapi/autoapi/v3/transport/jsonrpc/dispatcher.py
+++ b/pkgs/standards/autoapi/autoapi/v3/transport/jsonrpc/dispatcher.py
@@ -285,7 +285,7 @@ def build_jsonrpc_router(
         • If `api._authorize` is set, we call it before executing the op; False/exception → 403.
         • Additional router-level dependencies can be provided via `api.rpc_dependencies`.
 
-    The generated endpoint is tagged as "system" by default. Supply a custom
+    The generated endpoint is tagged as "rpc" by default. Supply a custom
     sequence via ``tags`` to override or set ``None`` to omit tags.
     """
     # Extra router-level deps (e.g., tracing, IP allowlist)
@@ -410,7 +410,7 @@ def build_jsonrpc_router(
         methods=["POST"],
         name="jsonrpc",
         tags=list(tags) if tags else None,
-        summary="JSONRPC"
+        summary="JSONRPC",
         # extra router deps already applied via APIRouter(dependencies=...)
     )
     return router

--- a/pkgs/standards/autoapi/tests/unit/test_jsonrpc_router_default_tag.py
+++ b/pkgs/standards/autoapi/tests/unit/test_jsonrpc_router_default_tag.py
@@ -7,4 +7,4 @@ def test_jsonrpc_router_default_tag():
     api = SimpleNamespace()
     router = build_jsonrpc_router(api)
     route = router.routes[0]
-    assert route.tags == ["system"]
+    assert route.tags == ["rpc"]


### PR DESCRIPTION
## Summary
- align JSON-RPC router default tag with implementation
- update documentation and tests for "rpc" tag

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ffa799f188326bc84fdf7294966c0