### PR TITLE
fix: expose request models in autoapi v3 docs

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_request_body_schema.py
+++ b/pkgs/standards/autoapi/tests/unit/test_request_body_schema.py
@@ -1,0 +1,29 @@
+from fastapi import FastAPI
+
+from autoapi.v3.bindings.rest import _build_router
+from autoapi.v3.opspec import OpSpec
+from autoapi.v3.tables import Base
+from autoapi.v3.mixins import GUIDPk
+from autoapi.v3.types import Column, String
+
+
+class Widget(Base, GUIDPk):
+    __tablename__ = "widgets_req_schema"
+    name = Column(String, nullable=False)
+
+
+def test_request_body_uses_schema_model():
+    sp = OpSpec(alias="create", target="create")
+    router = _build_router(Widget, [sp])
+    app = FastAPI()
+    app.include_router(router)
+    spec = app.openapi()
+
+    request_schema = spec["paths"]["/widgets_req_schema"]["post"]["requestBody"][
+        "content"
+    ]["application/json"]["schema"]
+    any_of = request_schema.get("anyOf")
+    assert any_of and any_of[0]["$ref"] == "#/components/schemas/WidgetCreate"
+
+    widget_schema = spec["components"]["schemas"]["WidgetCreate"]
+    assert "name" in widget_schema.get("properties", {})


### PR DESCRIPTION
## Summary
- ensure FastAPI request bodies use AutoAPI-generated schemas
- normalize request body validation to accept Pydantic models
- add regression test for request schema generation

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `uv run --directory pkgs/standards/autoapi --package autoapi pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0069edd1883268b26811ad7e82827