### PR TITLE
fix: bind schemas only when present

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/schemas.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/schemas.py
@@ -227,13 +227,16 @@ def build_and_attach(
         ns = _ensure_alias_namespace(model, sp.alias)
         shapes = _schemas_for_spec(model, sp)
 
-        # Attach; allow None to signal "no body" or "raw" response
-        if "in_" in shapes:
-            setattr(ns, "in_", shapes["in_"])
-        if "out" in shapes:
-            setattr(ns, "out", shapes["out"])
-        if "list" in shapes:
-            setattr(ns, "list", shapes["list"])
+        # Attach only non-null schemas so the namespace reflects available shapes
+        in_schema = shapes.get("in_")
+        if in_schema is not None:
+            setattr(ns, "in_", in_schema)
+        out_schema = shapes.get("out")
+        if out_schema is not None:
+            setattr(ns, "out", out_schema)
+        list_schema = shapes.get("list")
+        if list_schema is not None:
+            setattr(ns, "list", list_schema)
 
         logger.debug(
             "schemas: %s.%s -> in=%s out=%s list=%s",

--- a/pkgs/standards/autoapi/tests/unit/test_schemas_binding.py
+++ b/pkgs/standards/autoapi/tests/unit/test_schemas_binding.py
@@ -1,0 +1,28 @@
+from autoapi.v3.bindings.model import bind
+from autoapi.v3.tables import Base
+from autoapi.v3.mixins import GUIDPk
+from autoapi.v3.types import Column, String
+
+
+class Gadget(Base, GUIDPk):
+    __tablename__ = "gadgets"
+    name = Column(String, nullable=False)
+
+
+def test_bind_generates_request_and_response_schemas():
+    bind(Gadget)
+
+    # create/update/replace/delete should have request and response schemas
+    for alias in ("create", "update", "replace", "delete"):
+        ns = getattr(Gadget.schemas, alias)
+        assert getattr(ns, "in_", None) is not None
+        assert getattr(ns, "out", None) is not None
+
+    # list should expose list params and response schema
+    list_ns = Gadget.schemas.list
+    assert getattr(list_ns, "list", None) is not None
+    assert getattr(list_ns, "out", None) is not None
+
+    # read should expose a response schema
+    read_ns = Gadget.schemas.read
+    assert getattr(read_ns, "out", None) is not None


### PR DESCRIPTION
## Summary
- bind non-null request/response models when attaching schemas
- add regression test ensuring canonical ops expose schemas

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a006e0d4488326854eb829acb7e1bf