### PR TITLE
fix: build request/response schemas

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/__init__.py
@@ -39,7 +39,7 @@ from .bindings import (
 from .runtime.executor import _invoke
 
 # ── Schemas ────────────────────────────────────────────────────────────────────
-from .schema import _schema, create_list_schema
+from .schema import _build_schema, _build_list_params
 
 # ── Transport & Diagnostics (optional) ─────────────────────────────────────────
 from .transport.jsonrpc import build_jsonrpc_router
@@ -80,8 +80,8 @@ __all__ += [
     # Runtime
     "_invoke",
     # Schemas
-    "_schema",
-    "create_list_schema",
+    "_build_schema",
+    "_build_list_params",
     # Transport / Diagnostics
     "build_jsonrpc_router",
     "mount_diagnostics",

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/schemas.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/schemas.py
@@ -8,8 +8,7 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, Type
 from pydantic import BaseModel, Field, create_model
 
 from ..opspec import OpSpec
-from ..schema import _schema as _build_schema
-from ..schema import create_list_schema as _build_list_params
+from ..schema import _build_schema, _build_list_params
 
 logger = logging.getLogger(__name__)
 
@@ -118,99 +117,73 @@ def _schemas_for_spec(model: type, sp: OpSpec) -> Dict[str, Optional[Type[BaseMo
     # Canonical targets
     if target == "create":
         result["in_"] = result["in_"] or _build_schema(model, verb="create")
-        # If caller wants "model" return, supply read schema; otherwise keep None (raw)
-        if sp.returns == "model":
-            result["out"] = result["out"] or read_schema
+        result["out"] = result["out"] or read_schema
 
     elif target == "read":
-        # Require PK in body for RPC; OUT uses the read schema
         pk_name, pk_type = _pk_info(model)
         result["in_"] = result["in_"] or _make_pk_model(model, "read", pk_name, pk_type)
-        if sp.returns == "model":
-            result["out"] = result["out"] or read_schema
+        result["out"] = result["out"] or read_schema
 
     elif target == "update":
         result["in_"] = result["in_"] or _build_schema(model, verb="update")
-        if sp.returns == "model":
-            result["out"] = result["out"] or read_schema
+        result["out"] = result["out"] or read_schema
 
     elif target == "replace":
         result["in_"] = result["in_"] or _build_schema(model, verb="replace")
-        if sp.returns == "model":
-            result["out"] = result["out"] or read_schema
+        result["out"] = result["out"] or read_schema
 
     elif target == "delete":
-        # Require PK in body for RPC shape; REST may pass it as a path param.
         result["in_"] = result["in_"] or _build_schema(model, verb="delete")
-        if sp.returns == "model":
-            result["out"] = result["out"] or read_schema
-        else:
-            # default raw (e.g., {"deleted": 1})
-            result["out"] = result["out"] or None
+        result["out"] = result["out"] or read_schema
 
     elif target == "list":
-        # Filters/paging in request; element OUT is the read schema
         params = _build_list_params(model)
         result["in_"] = result["in_"] or params
         result["list"] = params
-        if sp.returns == "model":
-            result["out"] = result["out"] or read_schema
+        result["out"] = result["out"] or read_schema
 
     elif target == "clear":
-        # Same filters as list; OUT is raw by default ({"deleted": N})
         params = _build_list_params(model)
         result["in_"] = result["in_"] or params
         result["list"] = params
-        if sp.returns == "model":
-            result["out"] = result["out"] or read_schema
-        else:
-            result["out"] = result["out"] or None
+        result["out"] = result["out"] or read_schema
 
-    # Bulk variants
     elif target == "bulk_create":
         item_in = _build_schema(model, verb="create")
         result["in_"] = result["in_"] or _make_bulk_rows_model(
             model, "bulk_create", item_in
         )
-        if sp.returns == "model":
-            result["out"] = result["out"] or read_schema
+        result["out"] = result["out"] or read_schema
 
     elif target == "bulk_update":
         item_in = _build_schema(model, verb="update")
         result["in_"] = result["in_"] or _make_bulk_rows_model(
             model, "bulk_update", item_in
         )
-        if sp.returns == "model":
-            result["out"] = result["out"] or read_schema
+        result["out"] = result["out"] or read_schema
 
     elif target == "bulk_replace":
         item_in = _build_schema(model, verb="replace")
         result["in_"] = result["in_"] or _make_bulk_rows_model(
             model, "bulk_replace", item_in
         )
-        if sp.returns == "model":
-            result["out"] = result["out"] or read_schema
+        result["out"] = result["out"] or read_schema
 
     elif target == "bulk_delete":
         pk_name, pk_type = _pk_info(model)
         result["in_"] = result["in_"] or _make_bulk_ids_model(
             model, "bulk_delete", pk_type
         )
-        # OUT defaults to raw ({"deleted": N}); only supply model if explicitly requested
-        if sp.returns == "model":
-            result["out"] = result["out"] or read_schema
-        else:
-            result["out"] = result["out"] or None
+        result["out"] = result["out"] or read_schema
 
-    # Custom ops: use overrides if present; otherwise
     elif target == "custom":
-        # No default IN unless provided; OUT uses read schema when returns="model"
-        if sp.returns == "model":
-            result["out"] = result["out"] or read_schema
+        result["out"] = result["out"] or read_schema
 
     else:
-        # Unknown targets – leave as provided
-        pass
+        result["out"] = result["out"] or read_schema
+
+    result["in_"] = result["in_"] or _build_schema(model, verb="create")
+    result["out"] = result["out"] or read_schema
 
     return result
 

--- a/pkgs/standards/autoapi/autoapi/v3/schema/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/__init__.py
@@ -1,5 +1,5 @@
 # autoapi/v3/schema/__init__.py
-from .builder import _schema, create_list_schema
+from .builder import _build_schema, _build_list_params
 from .col_info import (
     VALID_KEYS,
     VALID_VERBS,
@@ -11,8 +11,8 @@ from .col_info import (
 )
 
 __all__ = [
-    "_schema",
-    "create_list_schema",
+    "_build_schema",
+    "_build_list_params",
     "VALID_KEYS",
     "VALID_VERBS",
     "WRITE_VERBS",

--- a/pkgs/standards/autoapi/autoapi/v3/schema/builder.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/builder.py
@@ -212,7 +212,7 @@ def _is_required(col: Any, verb: str) -> bool:
 # ───────────────────────────────────────────────────────────────────────────────
 
 
-def _schema(
+def _build_schema(
     orm_cls: type,
     *,
     name: str | None = None,
@@ -370,13 +370,13 @@ def _schema(
     return schema_cls
 
 
-def create_list_schema(model: type) -> Type[BaseModel]:
+def _build_list_params(model: type) -> Type[BaseModel]:
     """
     Create a list/filter schema for the given model (forbid extra keys).
     Includes: skip>=0, limit>=10, plus nullable scalar filters for non-PK columns.
     """
     tab = model.__name__
-    logger.debug("schema: create_list_schema for %s", tab)
+    logger.debug("schema: build_list_params for %s", tab)
 
     base = dict(
         skip=(int | None, Field(None, ge=0)),
@@ -392,7 +392,7 @@ def create_list_schema(model: type) -> Type[BaseModel]:
             f"{tab}ListParams", __config__=ConfigDict(extra="forbid"), **base
         )  # type: ignore[arg-type]
         logger.debug(
-            "schema: create_list_schema generated %s (no columns)", schema.__name__
+            "schema: build_list_params generated %s (no columns)", schema.__name__
         )
         return schema
 
@@ -416,7 +416,7 @@ def create_list_schema(model: type) -> Type[BaseModel]:
         **base,  # type: ignore[arg-type]
         **cols,  # type: ignore[arg-type]
     )
-    logger.debug("schema: create_list_schema generated %s", schema.__name__)
+    logger.debug("schema: build_list_params generated %s", schema.__name__)
     return schema
 
 
@@ -450,8 +450,8 @@ def _strip_parent_fields(base: Type[BaseModel], *, drop: Set[str]) -> Type[BaseM
 
 
 __all__ = [
-    "_schema",
-    "create_list_schema",
+    "_build_schema",
+    "_build_list_params",
     "_strip_parent_fields",
     "_merge_request_extras",
     "_merge_response_extras",


### PR DESCRIPTION
## Summary
- ensure autoapi v3 builds request/response schemas for every operation
- rename schema helpers to `_build_schema` and `_build_list_params`

## Testing
- `uv run --directory . --package autoapi ruff format .`
- `uv run --directory . --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68a00a770d188326900f04cdd109522c