### PR TITLE
Ensure all AutoAPI v3 operations expose request/response schemas

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_schemas_binding.py
+++ b/pkgs/standards/autoapi/tests/unit/test_schemas_binding.py
@@ -23,6 +23,11 @@ def test_bind_generates_request_and_response_schemas():
     assert getattr(list_ns, "list", None) is not None
     assert getattr(list_ns, "out", None) is not None
 
+    # clear should expose request params and a response schema
+    clear_ns = Gadget.schemas.clear
+    assert getattr(clear_ns, "in_", None) is not None
+    assert getattr(clear_ns, "out", None) is not None
+
     # read should expose a response schema
     read_ns = Gadget.schemas.read
     assert getattr(read_ns, "out", None) is not None


### PR DESCRIPTION
## Summary
- build default response schemas for raw operations (delete, clear, bulk delete)
- provide generic response fallbacks for any op lacking an explicit model
- test that `clear` now exposes both request params and a response schema

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a00c76db588326a0c9c1bf1510f149