### PR TITLE
feat(autoapi): add named schema helpers

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/schemas.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/schemas.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, Type
 from pydantic import BaseModel, Field, create_model
 
 from ..opspec import OpSpec
-from ..schema import _build_schema, _build_list_params
+from ..schema import _build_schema, _build_list_params, namely_model
 
 logger = logging.getLogger(__name__)
 
@@ -58,9 +58,14 @@ def _make_bulk_rows_model(
     Build a wrapper schema with a `rows: List[item_schema]` field.
     """
     name = f"{model.__name__}{_camel(verb)}Request"
-    return create_model(  # type: ignore[call-arg]
+    schema = create_model(  # type: ignore[call-arg]
         name,
         rows=(List[item_schema], Field(...)),  # type: ignore[name-defined]
+    )
+    return namely_model(
+        schema,
+        name=name,
+        doc=f"{verb} request schema for {model.__name__}",
     )
 
 
@@ -71,9 +76,14 @@ def _make_bulk_ids_model(
     Build a wrapper schema with an `ids: List[pk_type]` field.
     """
     name = f"{model.__name__}{_camel(verb)}Request"
-    return create_model(  # type: ignore[call-arg]
+    schema = create_model(  # type: ignore[call-arg]
         name,
         ids=(List[pk_type], Field(...)),  # type: ignore[name-defined]
+    )
+    return namely_model(
+        schema,
+        name=name,
+        doc=f"{verb} request schema for {model.__name__}",
     )
 
 
@@ -82,9 +92,14 @@ def _make_pk_model(
 ) -> Type[BaseModel]:
     """Build a wrapper schema with a single primary-key field."""
     name = f"{model.__name__}{_camel(verb)}Request"
-    return create_model(  # type: ignore[call-arg]
+    schema = create_model(  # type: ignore[call-arg]
         name,
         **{pk_name: (pk_type, Field(...))},  # type: ignore[name-defined]
+    )
+    return namely_model(
+        schema,
+        name=name,
+        doc=f"{verb} request schema for {model.__name__}",
     )
 
 

--- a/pkgs/standards/autoapi/autoapi/v3/schema/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/__init__.py
@@ -1,5 +1,6 @@
 # autoapi/v3/schema/__init__.py
 from .builder import _build_schema, _build_list_params
+from .utils import namely_model
 from .col_info import (
     VALID_KEYS,
     VALID_VERBS,
@@ -13,6 +14,7 @@ from .col_info import (
 __all__ = [
     "_build_schema",
     "_build_list_params",
+    "namely_model",
     "VALID_KEYS",
     "VALID_VERBS",
     "WRITE_VERBS",

--- a/pkgs/standards/autoapi/autoapi/v3/schema/builder.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/builder.py
@@ -30,6 +30,8 @@ from typing import (
 
 from pydantic import BaseModel, ConfigDict, Field, create_model
 
+from .utils import namely_model
+
 try:
     # Optional: validate column meta (if available in your tree)
     from ..info_schema import check as _info_check  # type: ignore
@@ -365,6 +367,11 @@ def _build_schema(
 
     schema_cls = create_model(model_name, __config__=cfg, **fields)  # type: ignore[arg-type]
     schema_cls.model_rebuild(force=True)
+    schema_cls = namely_model(
+        schema_cls,
+        name=model_name,
+        doc=f"AutoAPI v3 {orm_cls.__name__} {verb} schema",
+    )
     _SchemaCache[cache_key] = schema_cls
     logger.debug("schema: created %s with %d fields", model_name, len(fields))
     return schema_cls
@@ -391,6 +398,11 @@ def _build_list_params(model: type) -> Type[BaseModel]:
         schema = create_model(
             f"{tab}ListParams", __config__=ConfigDict(extra="forbid"), **base
         )  # type: ignore[arg-type]
+        schema = namely_model(
+            schema,
+            name=f"{tab}ListParams",
+            doc=f"List parameters for {tab}",
+        )
         logger.debug(
             "schema: build_list_params generated %s (no columns)", schema.__name__
         )
@@ -415,6 +427,11 @@ def _build_list_params(model: type) -> Type[BaseModel]:
         __config__=ConfigDict(extra="forbid"),
         **base,  # type: ignore[arg-type]
         **cols,  # type: ignore[arg-type]
+    )
+    schema = namely_model(
+        schema,
+        name=f"{tab}ListParams",
+        doc=f"List parameters for {tab}",
     )
     logger.debug("schema: build_list_params generated %s", schema.__name__)
     return schema

--- a/pkgs/standards/autoapi/autoapi/v3/schema/utils.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/utils.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import Type
+
+from pydantic import BaseModel
+
+
+def namely_model(model: Type[BaseModel], *, name: str, doc: str) -> Type[BaseModel]:
+    """Assign a unique name and docstring to a Pydantic model class."""
+    model.__name__ = name
+    model.__doc__ = doc
+    return model
+
+
+__all__ = ["namely_model"]


### PR DESCRIPTION
## Summary
- add `namely_model` helper to give schemas unique names and docstrings
- apply helper in schema builder and binding models so every op exposes `in_` and `out` schemas with clear docs

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff format .`
- `uv run --directory standards/autoapi --package autoapi ruff check . --fix`
- `uv run --directory standards/autoapi --package autoapi pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a00f92be788326b69f74dc995d393e