### PR TITLE
refactor: remove redundant list schema namespace

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/model.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/model.py
@@ -63,7 +63,7 @@ def _ensure_model_namespaces(model: type) -> None:
     # opspec indexes & metadata
     if not hasattr(model, "opspecs"):
         model.opspecs = SimpleNamespace(all=(), by_key={}, by_alias={})
-    # pydantic schemas: .<alias>.in_ / .<alias>.out / .<alias>.list
+    # pydantic schemas: .<alias>.in_ / .<alias>.out
     if not hasattr(model, "schemas"):
         model.schemas = SimpleNamespace()
     # hooks: phase chains & raw hook descriptors if you want to expose them
@@ -165,7 +165,7 @@ def bind(model: type, *, only_keys: Optional[Set[_Key]] = None) -> Tuple[OpSpec,
       3) Optionally drop old entries for a targeted set of (alias,target) keys.
       4) Merge ctx-only hooks (@hook_ctx) into model.__autoapi_hooks__ (alias-aware).
       5) Rebuild & attach:
-         • schemas (in_/out/list)
+         • schemas (in_/out)
          • hooks (phase chains, with auto START_TX/END_TX defaults)
          • handlers (raw & handler entrypoint for HANDLER)
          • rpc (register callables under model.rpc.<alias>)

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
@@ -168,11 +168,7 @@ def _validate_body(
     alias_ns = getattr(schemas_root, alias, None)
     if not alias_ns:
         return dict(body)
-
     in_model = getattr(alias_ns, "in_", None)
-    if target in {"list", "clear"}:
-        # List/clear use query params primarily; body rarely used
-        in_model = getattr(alias_ns, "list", in_model)
 
     if in_model and inspect.isclass(in_model) and issubclass(in_model, BaseModel):
         try:
@@ -198,12 +194,7 @@ def _validate_query(
     alias_ns = getattr(schemas_root, alias, None)
     if not alias_ns:
         return dict(query)
-    # For list/clear, prefer .list
-    in_model = getattr(
-        alias_ns,
-        "list",
-        None if target not in {"list", "clear"} else getattr(alias_ns, "list", None),
-    )
+    in_model = getattr(alias_ns, "in_", None)
     if in_model and inspect.isclass(in_model) and issubclass(in_model, BaseModel):
         try:
             inst = in_model.model_validate(dict(query))  # type: ignore[arg-type]
@@ -287,10 +278,7 @@ def _request_model_for(sp: OpSpec, model: type) -> Any | None:
     alias_ns = getattr(
         getattr(model, "schemas", None) or SimpleNamespace(), sp.alias, None
     )
-    in_model = getattr(alias_ns, "in_", None)
-    if sp.target in {"list", "clear"}:
-        in_model = getattr(alias_ns, "list", in_model)
-    return in_model
+    return getattr(alias_ns, "in_", None)
 
 
 # ───────────────────────────────────────────────────────────────────────────────

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rpc.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rpc.py
@@ -76,11 +76,7 @@ def _coerce_payload(payload: Any) -> Mapping[str, Any]:
 def _validate_input(
     model: type, alias: str, target: str, payload: Mapping[str, Any]
 ) -> Mapping[str, Any]:
-    """
-    Choose the appropriate request schema (if any) and validate/normalize payload.
-    • Use .schemas.<alias>.in_ when present.
-    • For list/clear, prefer .schemas.<alias>.list.
-    """
+    """Choose the appropriate request schema (if any) and validate/normalize payload."""
     schemas_root = getattr(model, "schemas", None)
     if not schemas_root:
         return payload
@@ -89,8 +85,6 @@ def _validate_input(
         return payload
 
     in_model = getattr(alias_ns, "in_", None)
-    if target in {"list", "clear"}:
-        in_model = getattr(alias_ns, "list", in_model)
 
     if in_model and inspect.isclass(in_model) and issubclass(in_model, BaseModel):
         try:

--- a/pkgs/standards/autoapi/tests/unit/test_schemas_binding.py
+++ b/pkgs/standards/autoapi/tests/unit/test_schemas_binding.py
@@ -18,10 +18,11 @@ def test_bind_generates_request_and_response_schemas():
         assert getattr(ns, "in_", None) is not None
         assert getattr(ns, "out", None) is not None
 
-    # list should expose list params and response schema
+    # list should expose request and response schemas
     list_ns = Gadget.schemas.list
-    assert getattr(list_ns, "list", None) is not None
+    assert getattr(list_ns, "in_", None) is not None
     assert getattr(list_ns, "out", None) is not None
+    assert not hasattr(list_ns, "list")
 
     # read should expose a response schema
     read_ns = Gadget.schemas.read


### PR DESCRIPTION
## Summary
- stop generating `.schemas.list.list`
- validate list and clear operations using `in_` schemas
- update tests for new schema layout

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68a013ccf9308326b95be88492cc04f5