### PR TITLE
fix: await db.begin in start_tx

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_start_tx_async_begin.py
+++ b/pkgs/standards/autoapi/tests/unit/test_start_tx_async_begin.py
@@ -1,0 +1,27 @@
+import pytest
+from autoapi.v3.bindings import hooks
+
+
+class _AsyncBeginSyncCommitDB:
+    def __init__(self) -> None:
+        self.started = False
+        self.committed = False
+
+    async def begin(self) -> None:  # pragma: no cover - executed via await
+        self.started = True
+
+    def commit(self) -> None:  # pragma: no cover - executed if tx began
+        if self.started:
+            self.committed = True
+
+    def in_transaction(self) -> bool:
+        return self.started
+
+
+@pytest.mark.asyncio
+async def test_start_tx_handles_async_begin_sync_commit() -> None:
+    db = _AsyncBeginSyncCommitDB()
+    ctx = {"db": db}
+    await hooks._default_start_tx()(ctx)
+    await hooks._default_end_tx()(ctx)
+    assert db.started and db.committed


### PR DESCRIPTION
## Summary
- ensure default start_tx awaits databases with async begin and handles async commit
- detect async db methods in runtime executor
- test async begin with sync commit

## Testing
- `uv run --directory . --package autoapi ruff format .`
- `uv run --directory . --package autoapi ruff check . --fix`
- `uv run --package autoapi --directory . pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0188d65d48326a756fbae808648a7