### PR TITLE
fix: ensure transaction detection for async sessions

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/runtime/executor.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/executor.py
@@ -106,11 +106,13 @@ def _bool_call(meth: Any) -> bool:
 
 def _in_tx(db: Any) -> bool:
     for name in ("in_transaction", "in_nested_transaction"):
-        meth = getattr(db, name, None)
-        if callable(meth) and _bool_call(meth):
+        attr = getattr(db, name, None)
+        if callable(attr):
+            if _bool_call(attr):
+                return True
+        elif attr:
             return True
-    val = getattr(db, "in_transaction", False)
-    return bool(val)
+    return False
 
 
 async def _maybe_await(v: Any) -> Any:

--- a/pkgs/standards/autoapi/tests/unit/test_in_tx.py
+++ b/pkgs/standards/autoapi/tests/unit/test_in_tx.py
@@ -1,0 +1,16 @@
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from autoapi.v3.runtime.executor import _in_tx
+
+
+@pytest.mark.asyncio
+async def test_in_tx_detects_async_session_transaction():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    SessionLocal = async_sessionmaker(
+        engine, expire_on_commit=False, class_=AsyncSession
+    )
+    async with SessionLocal() as session:
+        assert _in_tx(session) is False
+        await session.begin()
+        assert _in_tx(session) is True


### PR DESCRIPTION
## Summary
- fix transaction detection in `_in_tx` for async DB sessions
- add regression test covering async transaction start

## Testing
- `uv run --package autoapi --directory pkgs/standards/autoapi pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0188b20c88326b737087155203c1f