### PR TITLE
Ensure handler steps keep original qualnames

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/handlers.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/handlers.py
@@ -183,6 +183,11 @@ def _wrap_core(model: type, target: str) -> StepFn:
         # Unknown canonical target – return payload to avoid hard failure
         return payload
 
+    fn = getattr(_core, target, None)
+    step.__name__ = getattr(fn, "__name__", step.__name__)
+    step.__qualname__ = getattr(fn, "__qualname__", step.__name__)
+    step.__module__ = getattr(fn, "__module__", step.__module__)
+
     return step
 
 
@@ -234,6 +239,10 @@ def _wrap_custom(model: type, sp: OpSpec, user_handler: Callable[..., Any]) -> S
         if inspect.isawaitable(rv):
             return await rv
         return rv
+
+    step.__name__ = getattr(user_handler, "__name__", step.__name__)
+    step.__qualname__ = getattr(user_handler, "__qualname__", step.__name__)
+    step.__module__ = getattr(user_handler, "__module__", step.__module__)
 
     return step
 

--- a/pkgs/standards/autoapi/tests/unit/test_handler_step_qualname.py
+++ b/pkgs/standards/autoapi/tests/unit/test_handler_step_qualname.py
@@ -1,0 +1,30 @@
+from autoapi.v3.bindings.handlers import build_and_attach
+from autoapi.v3.opspec import OpSpec
+from autoapi.v3 import core as _core
+
+
+def test_wrap_core_preserves_qualname_and_module():
+    class Model:
+        pass
+
+    sp = OpSpec(alias="create", target="create")
+    build_and_attach(Model, [sp])
+
+    step = Model.hooks.create.HANDLER[0]
+    assert step.__qualname__ == _core.create.__qualname__
+    assert step.__module__ == _core.create.__module__
+
+
+def test_wrap_custom_preserves_qualname_and_module():
+    class Model:
+        pass
+
+    def custom_handler(ctx):
+        return None
+
+    sp = OpSpec(alias="custom", target="custom", handler=custom_handler)
+    build_and_attach(Model, [sp])
+
+    step = Model.hooks.custom.HANDLER[0]
+    assert step.__qualname__ == custom_handler.__qualname__
+    assert step.__module__ == custom_handler.__module__


### PR DESCRIPTION
## Summary
- preserve underlying function name, qualname, and module when wrapping core and custom handlers
- add tests confirming wrapped handler qualname and module are retained

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff check autoapi/v3/bindings/handlers.py tests/unit/test_handler_step_qualname.py`
- `uv run --package autoapi --directory standards/autoapi pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a01874f8748326b72c8df51e3f6ccf