### PR TITLE
fix(autoapi): exclude pk from replace body

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/schemas.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/schemas.py
@@ -136,11 +136,17 @@ def _schemas_for_spec(model: type, sp: OpSpec) -> Dict[str, Optional[Type[BaseMo
         result["out"] = result["out"] or read_schema
 
     elif target == "update":
-        result["in_"] = result["in_"] or _build_schema(model, verb="update")
+        pk_name, _ = _pk_info(model)
+        result["in_"] = result["in_"] or _build_schema(
+            model, verb="update", exclude={pk_name}
+        )
         result["out"] = result["out"] or read_schema
 
     elif target == "replace":
-        result["in_"] = result["in_"] or _build_schema(model, verb="replace")
+        pk_name, _ = _pk_info(model)
+        result["in_"] = result["in_"] or _build_schema(
+            model, verb="replace", exclude={pk_name}
+        )
         result["out"] = result["out"] or read_schema
 
     elif target == "delete":

--- a/pkgs/standards/autoapi/tests/unit/test_request_body_schema.py
+++ b/pkgs/standards/autoapi/tests/unit/test_request_body_schema.py
@@ -27,3 +27,19 @@ def test_request_body_uses_schema_model():
 
     widget_schema = spec["components"]["schemas"]["WidgetCreate"]
     assert "name" in widget_schema.get("properties", {})
+
+
+def test_replace_request_body_excludes_pk():
+    class Gadget(Base, GUIDPk):
+        __tablename__ = "gadget_replace_schema"
+        name = Column(String, nullable=False)
+
+    sp = OpSpec(alias="replace", target="replace")
+    router = _build_router(Gadget, [sp])
+    app = FastAPI()
+    app.include_router(router)
+    spec = app.openapi()
+
+    gadget_schema = spec["components"]["schemas"]["GadgetReplace"]
+    assert "id" not in gadget_schema.get("properties", {})
+    assert "id" not in gadget_schema.get("required", [])


### PR DESCRIPTION
## Summary
- ensure autoapi v3 update/replace request bodies exclude primary key fields
- add regression test for replace body schema

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff check autoapi/v3/bindings/schemas.py tests/unit/test_request_body_schema.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0248d9d708326b428076b05b55632