### PR TITLE
Ensure AutoAPI v3 list filters are optional

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
@@ -391,14 +391,6 @@ def _request_model_for(sp: OpSpec, model: type) -> Any | None:
 # Query param dependency (so OpenAPI shows list filters)
 # ───────────────────────────────────────────────────────────────────────────────
 
-def _strip_optional(t: Any) -> Any:
-    """If annotation is Optional[T] (i.e., Union[T, None]), return T; else return the input."""
-    origin = _get_origin(t)
-    if origin is _typing.Union:
-        args = tuple(a for a in _get_args(t) if a is not type(None))
-        return args[0] if len(args) == 1 else Any
-    return t
-
 
 def _make_list_query_dep(model: type, alias: str):
     """
@@ -406,13 +398,17 @@ def _make_list_query_dep(model: type, alias: str):
     schemas.<alias>.in_ fields, so FastAPI documents them in OpenAPI. The dep
     returns raw user-supplied values; we validate later in _validate_query().
     """
-    alias_ns = getattr(getattr(model, "schemas", None) or SimpleNamespace(), alias, None)
+    alias_ns = getattr(
+        getattr(model, "schemas", None) or SimpleNamespace(), alias, None
+    )
     in_model = getattr(alias_ns, "in_", None)
 
     # If no model, return raw query as-is
     if not (in_model and inspect.isclass(in_model) and issubclass(in_model, BaseModel)):
+
         async def _dep(request: Request) -> Dict[str, Any]:
             return dict(request.query_params)
+
         _dep.__name__ = f"list_params_{model.__name__}_{alias}"
         return _dep
 
@@ -441,15 +437,13 @@ def _make_list_query_dep(model: type, alias: str):
     for name, f in fields.items():
         key = getattr(f, "alias", None) or name
         ann = getattr(f, "annotation", Any)
-        base = _strip_optional(ann)
-        origin = _get_origin(base)
+        origin = _get_origin(ann)
         if origin in (list, tuple, set):
-            inner = (_get_args(base) or (str,))[0]
+            inner = (_get_args(ann) or (str,))[0]
             annotation = list[inner]  # type: ignore[index]
-            default_q = Query(None, description=getattr(f, "description", None))
         else:
-            annotation = base
-            default_q = Query(None, description=getattr(f, "description", None))
+            annotation = ann
+        default_q = Query(None, description=getattr(f, "description", None))
         params.append(
             inspect.Parameter(
                 name=key,
@@ -469,6 +463,7 @@ def _make_list_query_dep(model: type, alias: str):
 # ───────────────────────────────────────────────────────────────────────────────
 # Optionalize list.in_ model (hardening against bad defaults)
 # ───────────────────────────────────────────────────────────────────────────────
+
 
 def _optionalize_list_in_model(in_model: type[BaseModel]) -> type[BaseModel]:
     """
@@ -519,7 +514,6 @@ def _make_collection_endpoint(
 
     # --- No body on GET list / DELETE clear ---
     if target in {"list", "clear"}:
-
         if target == "list":
             list_dep = _make_list_query_dep(model, alias)
 
@@ -547,6 +541,7 @@ def _make_collection_endpoint(
                 )
                 return _serialize_output(model, alias, target, sp, result)
         else:
+
             async def _endpoint(
                 request: Request,
                 db: Any = Depends(db_dep),


### PR DESCRIPTION
## Summary
- stop stripping optional types from list filter annotations so all AutoAPI v3 list query parameters are optional

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format autoapi/v3/bindings/rest.py`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check autoapi/v3/bindings/rest.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_68a0be492018832682be4454e398635a