### PR TITLE
fix: make v3 list filters optional

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
@@ -391,6 +391,7 @@ def _request_model_for(sp: OpSpec, model: type) -> Any | None:
 # Query param dependency (so OpenAPI shows list filters)
 # ───────────────────────────────────────────────────────────────────────────────
 
+
 def _strip_optional(t: Any) -> Any:
     """If annotation is Optional[T] (i.e., Union[T, None]), return T; else return the input."""
     origin = _get_origin(t)
@@ -406,20 +407,24 @@ def _make_list_query_dep(model: type, alias: str):
     schemas.<alias>.in_ fields, so FastAPI documents them in OpenAPI. The dep
     returns raw user-supplied values; we validate later in _validate_query().
     """
-    alias_ns = getattr(getattr(model, "schemas", None) or SimpleNamespace(), alias, None)
+    alias_ns = getattr(
+        getattr(model, "schemas", None) or SimpleNamespace(), alias, None
+    )
     in_model = getattr(alias_ns, "in_", None)
 
     # If no model, return raw query as-is
     if not (in_model and inspect.isclass(in_model) and issubclass(in_model, BaseModel)):
-        async def _dep(request: Request) -> Dict[str, Any]:
+
+        def _dep(request: Request) -> Dict[str, Any]:
             return dict(request.query_params)
+
         _dep.__name__ = f"list_params_{model.__name__}_{alias}"
         return _dep
 
     fields = getattr(in_model, "model_fields", {})
 
-    async def _dep(**raw) -> Dict[str, Any]:
-        # Collect only user-supplied values; never apply schema defaults here
+    def _dep(**raw: Any) -> Dict[str, Any]:
+        """Collect only user-supplied values; never apply schema defaults here."""
         data: Dict[str, Any] = {}
         for name, f in fields.items():
             key = getattr(f, "alias", None) or name
@@ -445,11 +450,10 @@ def _make_list_query_dep(model: type, alias: str):
         origin = _get_origin(base)
         if origin in (list, tuple, set):
             inner = (_get_args(base) or (str,))[0]
-            annotation = list[inner]  # type: ignore[index]
-            default_q = Query(None, description=getattr(f, "description", None))
+            annotation = list[inner] | None  # type: ignore[index]
         else:
-            annotation = base
-            default_q = Query(None, description=getattr(f, "description", None))
+            annotation = base | None
+        default_q = Query(None, description=getattr(f, "description", None))
         params.append(
             inspect.Parameter(
                 name=key,
@@ -469,6 +473,7 @@ def _make_list_query_dep(model: type, alias: str):
 # ───────────────────────────────────────────────────────────────────────────────
 # Optionalize list.in_ model (hardening against bad defaults)
 # ───────────────────────────────────────────────────────────────────────────────
+
 
 def _optionalize_list_in_model(in_model: type[BaseModel]) -> type[BaseModel]:
     """
@@ -519,7 +524,6 @@ def _make_collection_endpoint(
 
     # --- No body on GET list / DELETE clear ---
     if target in {"list", "clear"}:
-
         if target == "list":
             list_dep = _make_list_query_dep(model, alias)
 
@@ -547,6 +551,7 @@ def _make_collection_endpoint(
                 )
                 return _serialize_output(model, alias, target, sp, result)
         else:
+
             async def _endpoint(
                 request: Request,
                 db: Any = Depends(db_dep),

--- a/pkgs/standards/autoapi/tests/i9n/test_list_filters_optional.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_list_filters_optional.py
@@ -1,0 +1,20 @@
+import pytest
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_list_filters_optional(api_client):
+    client, _, _ = api_client
+
+    spec = (await client.get("/openapi.json")).json()
+    params = spec["paths"]["/tenant"]["get"].get("parameters", [])
+    name_param = next(p for p in params if p["name"] == "name")
+    assert name_param["required"] is False
+
+    r = await client.get("/tenant")
+    assert r.status_code == 200
+    assert r.json() == []
+
+    r2 = await client.get("/tenant", params={"name": "foo"})
+    assert r2.status_code == 200
+    assert r2.json() == []


### PR DESCRIPTION
## Summary
- ensure REST list filter parameters are optional and allow null
- add regression test to validate optional list filters

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `uv run --directory pkgs/standards/autoapi --package autoapi pytest tests/i9n/test_list_filters_optional.py`
- `uv run --directory pkgs/standards/autoapi --package autoapi pytest` *(fails: test_router_default_tag, test_include_models_base_prefix_avoids_duplicate_segments, test_request_body_uses_schema_model, test_rest_serialization_with_and_without_out_schema)*

------
https://chatgpt.com/codex/tasks/task_e_68a0bf04585c832699351bd5d871e1cd