### PR TITLE
fix: ensure autoapi v3 docs show schemas

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_request_body_schema.py
+++ b/pkgs/standards/autoapi/tests/unit/test_request_body_schema.py
@@ -22,8 +22,7 @@ def test_request_body_uses_schema_model():
     request_schema = spec["paths"]["/widgets_req_schema"]["post"]["requestBody"][
         "content"
     ]["application/json"]["schema"]
-    any_of = request_schema.get("anyOf")
-    assert any_of and any_of[0]["$ref"] == "#/components/schemas/WidgetCreate"
+    assert request_schema["$ref"] == "#/components/schemas/WidgetCreate"
 
     widget_schema = spec["components"]["schemas"]["WidgetCreate"]
     assert "name" in widget_schema.get("properties", {})


### PR DESCRIPTION
## Summary
- ensure REST endpoints in autoapi v3 expose request schemas in OpenAPI docs by requiring body payloads
- update request body schema test for new OpenAPI shape

## Testing
- `uv run --directory autoapi --package autoapi ruff format v3/bindings/rest.py ../tests/unit/test_request_body_schema.py`
- `uv run --directory autoapi --package autoapi ruff check v3/bindings/rest.py ../tests/unit/test_request_body_schema.py --fix`
- `uv run --directory autoapi --package autoapi ruff format .` *(fails: Failed to parse v3/runtime/plan.py:233:24: f-string: unterminated string)*
- `uv run --directory autoapi --package autoapi ruff check . --fix` *(fails: E402 Module level import not at top of file ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a5252c512c8326beeeaa4872023711