### PR TITLE
test: add acol vcol binding coverage

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_acol_vcol_knobs.py
+++ b/pkgs/standards/autoapi/tests/unit/test_acol_vcol_knobs.py
@@ -1,0 +1,84 @@
+from datetime import datetime
+from types import SimpleNamespace
+
+
+from autoapi.v3.bindings.model import bind
+from autoapi.v3.runtime.atoms.schema import collect_in, collect_out
+from autoapi.v3.specs import ColumnSpec, F, IO, S, acol, vcol
+from autoapi.v3.tables import Base
+from sqlalchemy import DateTime, Integer, String
+from sqlalchemy.orm import Mapped
+
+
+class Thing(Base):
+    __tablename__ = "things"
+    __allow_unmapped__ = True
+
+    id: Mapped[int] = acol(
+        storage=S(type_=Integer, primary_key=True, autoincrement=True),
+        io=IO(out_verbs=("read", "list")),
+    )
+
+    name: Mapped[str] = acol(
+        storage=S(type_=String, nullable=False),
+        field=F(constraints={"max_length": 50}, required_in=("create",)),
+        io=IO(in_verbs=("create", "update"), out_verbs=("read", "list")),
+    )
+
+    created_at: Mapped[datetime] = acol(
+        storage=S(type_=DateTime, nullable=False),
+        io=IO(out_verbs=("read",)),
+        default_factory=lambda ctx: datetime(2020, 1, 1),
+    )
+
+    nickname: str = vcol(
+        field=F(py_type=str),
+        io=IO(in_verbs=("create",), out_verbs=("read",)),
+        default_factory=lambda ctx: "anon",
+    )
+
+    slug: str = vcol(
+        field=F(py_type=str),
+        io=IO(out_verbs=("read",)),
+        read_producer=lambda obj, ctx: obj.name.lower(),
+    )
+
+
+def test_acol_vcol_knobs_affect_bindings_and_schemas():
+    bind(Thing)
+
+    specs = Thing.__autoapi_cols__
+
+    # openapi request schema via collect_in
+    ctx_in = SimpleNamespace(specs=specs, op="create", temp={})
+    collect_in.run(None, ctx_in)
+    schema_in = ctx_in.temp["schema_in"]
+    assert schema_in["by_field"]["name"]["required"] is True
+    assert schema_in["by_field"]["nickname"]["required"] is False
+    assert schema_in["by_field"]["nickname"]["virtual"] is True
+
+    # openapi response schema via collect_out
+    ctx_out = SimpleNamespace(specs=specs, op="read", temp={})
+    collect_out.run(None, ctx_out)
+    schema_out = ctx_out.temp["schema_out"]
+    for field in ("name", "created_at", "nickname", "slug"):
+        assert field in schema_out["by_field"]
+    assert schema_out["by_field"]["slug"]["virtual"] is True
+
+    # binding of schemas on model
+    assert hasattr(Thing.schemas, "create") and hasattr(Thing.schemas, "read")
+
+    # binding of columns on model: persisted becomes SQLAlchemy Column, virtual remains ColumnSpec
+    from sqlalchemy import Column
+
+    assert isinstance(Thing.__table__.c.name, Column)
+    assert isinstance(Thing.__dict__["slug"], ColumnSpec)
+    assert "name" in Thing.__autoapi_cols__ and "slug" in Thing.__autoapi_cols__
+
+    # read_producer works on virtual column
+    obj = SimpleNamespace(name="TeSt")
+    assert Thing.__autoapi_cols__["slug"].read_producer(obj, {}) == "test"
+
+    # binding of ops on model
+    assert "create" in Thing.opspecs.by_alias
+    assert "read" in Thing.opspecs.by_alias


### PR DESCRIPTION
## Summary
- cover acol and vcol knobs across request and response schemas
- assert bindings for schemas, columns, and ops on a model

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_acol_vcol_knobs.py::test_acol_vcol_knobs_affect_bindings_and_schemas -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5261d00108326b31e46cf57abaef0