### PR TITLE
fix: omit primary key from create schema

### DIFF
--- a/pkgs/standards/auto_kms/tests/unit/test_key_create_schema.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_key_create_schema.py
@@ -1,0 +1,10 @@
+from autoapi.v3.bindings import bind
+from auto_kms.tables.key import Key
+
+
+def test_key_create_schema_excludes_id():
+    bind(Key)
+    fields = set(Key.schemas.create.in_.model_fields.keys())
+    assert "id" not in fields
+    assert "name" in fields and "algorithm" in fields
+    assert "status" not in fields


### PR DESCRIPTION
## Summary
- skip primary key columns with no inbound verbs when collecting input schema
- treat storage defaults as server-supplied values
- respect `in_verbs` when building request schemas so PKs stay out of `create`
- add regression test for `Key` create schema
- bind `Key` model directly in regression test to avoid `AutoAPI` dependency

## Testing
- `uv run --package auto_kms --directory pkgs/standards/auto_kms ruff check . --fix` *(fails: F821 Undefined name `KeyVersion`)*
- `uv run --package auto_kms --directory pkgs/standards/auto_kms ruff format tests/unit/test_key_create_schema.py`
- `uv run --package auto_kms --directory pkgs/standards/auto_kms ruff check tests/unit/test_key_create_schema.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_68a52d1c3bbc83268bf0d4474a18d4dc