### PR TITLE
fix: restore default delete and clear CRUD behaviour

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/handlers.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/handlers.py
@@ -29,6 +29,7 @@ _Key = Tuple[str, str]  # (alias, target)
 # Helpers: model.hooks / model.handlers alias namespaces
 # ───────────────────────────────────────────────────────────────────────────────
 
+
 def _ensure_alias_hooks_ns(model: type, alias: str) -> SimpleNamespace:
     hooks_root = getattr(model, "hooks", None)
     if hooks_root is None:
@@ -64,9 +65,11 @@ def _append_handler_step(model: type, alias: str, step: StepFn) -> None:
     chain: list[StepFn] = getattr(ns, "HANDLER")
     chain.append(step)
 
+
 # ───────────────────────────────────────────────────────────────────────────────
 # Payload/ctx helpers
 # ───────────────────────────────────────────────────────────────────────────────
+
 
 def _ctx_get(ctx: Mapping[str, Any], key: str, default: Any = None) -> Any:
     try:
@@ -74,24 +77,30 @@ def _ctx_get(ctx: Mapping[str, Any], key: str, default: Any = None) -> Any:
     except Exception:
         return getattr(ctx, key, default)
 
+
 def _ctx_payload(ctx: Mapping[str, Any]) -> Mapping[str, Any]:
     v = _ctx_get(ctx, "payload", None)
     # Never let non-mapping (incl. SQLA ClauseElement) flow as payload
     return v if isinstance(v, Mapping) else {}
 
+
 def _ctx_db(ctx: Mapping[str, Any]) -> Any:
     return _ctx_get(ctx, "db")
 
+
 def _ctx_request(ctx: Mapping[str, Any]) -> Any:
     return _ctx_get(ctx, "request")
+
 
 def _ctx_path_params(ctx: Mapping[str, Any]) -> Mapping[str, Any]:
     v = _ctx_get(ctx, "path_params", None)
     return v if isinstance(v, Mapping) else {}
 
+
 # ───────────────────────────────────────────────────────────────────────────────
 # PK discovery & identifier coercion
 # ───────────────────────────────────────────────────────────────────────────────
+
 
 def _pk_name(model: type) -> str:
     """
@@ -129,6 +138,7 @@ def _pk_name(model: type) -> str:
             pass
 
     return "id"
+
 
 def _pk_type_info(model: type) -> tuple[Optional[type], Optional[Any]]:
     """
@@ -172,6 +182,7 @@ def _pk_type_info(model: type) -> tuple[Optional[type], Optional[Any]]:
 
     return (py_t, coltype)
 
+
 def _looks_like_uuid_string(s: str) -> bool:
     if not isinstance(s, str):
         return False
@@ -180,6 +191,7 @@ def _looks_like_uuid_string(s: str) -> bool:
         return True
     except Exception:
         return False
+
 
 def _is_uuid_type(py_t: Optional[type], sa_type: Optional[Any]) -> bool:
     if py_t is uuid.UUID:
@@ -197,6 +209,7 @@ def _is_uuid_type(py_t: Optional[type], sa_type: Optional[Any]) -> bool:
     except Exception:
         pass
     return False
+
 
 def _coerce_ident_to_pk_type(model: type, value: Any) -> Any:
     """
@@ -240,8 +253,10 @@ def _coerce_ident_to_pk_type(model: type, value: Any) -> Any:
     # No known target type → leave as is
     return value
 
+
 def _is_clause(x: Any) -> bool:
     return SAClause is not None and isinstance(x, SAClause)  # type: ignore[truthy-bool]
+
 
 def _resolve_ident(model: type, ctx: Mapping[str, Any]) -> Any:
     """
@@ -263,6 +278,12 @@ def _resolve_ident(model: type, ctx: Mapping[str, Any]) -> Any:
     path = _ctx_path_params(ctx)
     pk = _pk_name(model)
 
+    specs: Mapping[str, Any] = getattr(model, "__autoapi_cols__", {}) or {}
+    alias = None
+    spec = specs.get(pk)
+    if spec is not None:
+        alias = getattr(getattr(spec, "io", None), "alias_in", None)
+
     candidates_keys = [
         (path, pk),
         (payload, pk),
@@ -272,10 +293,14 @@ def _resolve_ident(model: type, ctx: Mapping[str, Any]) -> Any:
         (payload, "item_id"),
     ]
     if pk != "id":
-        candidates_keys.extend([
-            (path, f"{pk}_id"),
-            (payload, f"{pk}_id"),
-        ])
+        candidates_keys.extend(
+            [
+                (path, f"{pk}_id"),
+                (payload, f"{pk}_id"),
+            ]
+        )
+    if isinstance(alias, str) and alias:
+        candidates_keys.extend([(path, alias), (payload, alias)])
     candidates_keys.append((payload, "ident"))
 
     for source, key in candidates_keys:
@@ -297,9 +322,11 @@ def _resolve_ident(model: type, ctx: Mapping[str, Any]) -> Any:
 
     raise TypeError(f"Missing identifier '{pk}' in path or payload")
 
+
 # ───────────────────────────────────────────────────────────────────────────────
 # Core → StepFn adapters
 # ───────────────────────────────────────────────────────────────────────────────
+
 
 async def _call_list_core(
     fn: Callable[..., Any],
@@ -327,7 +354,9 @@ async def _call_list_core(
 
     candidates: list[tuple[tuple, dict]] = []
 
-    def add_candidate(use_pos_filters: bool, use_pos_db: bool, with_req: bool, with_pag: bool):
+    def add_candidate(
+        use_pos_filters: bool, use_pos_db: bool, with_req: bool, with_pag: bool
+    ):
         args: tuple = ()
         kwargs: dict = {}
         if use_pos_filters:
@@ -349,20 +378,20 @@ async def _call_list_core(
 
     # Richest → minimal, always passing db
     add_candidate(False, False, True, True)
-    add_candidate(True,  False, True, True)
-    add_candidate(True,  True,  True, True)
+    add_candidate(True, False, True, True)
+    add_candidate(True, True, True, True)
 
     add_candidate(False, False, False, True)
-    add_candidate(True,  False, False, True)
-    add_candidate(True,  True,  False, True)
+    add_candidate(True, False, False, True)
+    add_candidate(True, True, False, True)
 
     add_candidate(False, False, True, False)
-    add_candidate(True,  False, True, False)
-    add_candidate(True,  True,  True, False)
+    add_candidate(True, False, True, False)
+    add_candidate(True, True, True, False)
 
     add_candidate(False, False, False, False)
-    add_candidate(True,  False, False, False)
-    add_candidate(True,  True,  False, False)
+    add_candidate(True, False, False, False)
+    add_candidate(True, True, False, False)
 
     last_err: Optional[BaseException] = None
     for args, kwargs in candidates:
@@ -378,6 +407,7 @@ async def _call_list_core(
         raise last_err
     raise RuntimeError("list() call resolution failed unexpectedly")
 
+
 def _accepted_kw(handler: Callable[..., Any]) -> set[str]:
     try:
         sig = inspect.signature(handler)
@@ -391,6 +421,7 @@ def _accepted_kw(handler: Callable[..., Any]) -> set[str]:
             return {"ctx", "db", "payload", "request", "model", "op", "spec", "alias"}
         names.add(p.name)
     return names
+
 
 def _wrap_custom(model: type, sp: OpSpec, user_handler: Callable[..., Any]) -> StepFn:
     """
@@ -408,14 +439,22 @@ def _wrap_custom(model: type, sp: OpSpec, user_handler: Callable[..., Any]) -> S
         bound = getattr(model, getattr(user_handler, "__name__", ""), user_handler)
 
         kw = {}
-        if "ctx" in wanted:     kw["ctx"] = ctx
-        if "db" in wanted:      kw["db"] = db
-        if "payload" in wanted: kw["payload"] = payload
-        if "request" in wanted: kw["request"] = request
-        if "model" in wanted:   kw["model"] = model
-        if "op" in wanted:      kw["op"] = sp
-        if "spec" in wanted:    kw["spec"] = sp
-        if "alias" in wanted:   kw["alias"] = sp.alias
+        if "ctx" in wanted:
+            kw["ctx"] = ctx
+        if "db" in wanted:
+            kw["db"] = db
+        if "payload" in wanted:
+            kw["payload"] = payload
+        if "request" in wanted:
+            kw["request"] = request
+        if "model" in wanted:
+            kw["model"] = model
+        if "op" in wanted:
+            kw["op"] = sp
+        if "spec" in wanted:
+            kw["spec"] = sp
+        if "alias" in wanted:
+            kw["alias"] = sp.alias
 
         rv = bound(**kw)  # type: ignore[misc]
         if inspect.isawaitable(rv):
@@ -427,10 +466,12 @@ def _wrap_custom(model: type, sp: OpSpec, user_handler: Callable[..., Any]) -> S
     step.__module__ = getattr(user_handler, "__module__", step.__module__)
     return step
 
+
 def _wrap_core(model: type, target: str) -> StepFn:
     """
     Turn a canonical core function into a StepFn(ctx) → Any.
     """
+
     async def step(ctx: Any) -> Any:
         db = _ctx_db(ctx)
         payload = _ctx_payload(ctx)
@@ -458,8 +499,7 @@ def _wrap_core(model: type, target: str) -> StepFn:
             return await _call_list_core(_core.list, model, payload, ctx)
 
         if target == "clear":
-            # No request body for clear; align with REST semantics.
-            return await _core.clear(model, {}, db=db)
+            return await _call_list_core(_core.clear, model, payload, ctx)
 
         if target == "bulk_create":
             rows = payload.get("rows") if isinstance(payload, Mapping) else None
@@ -500,15 +540,18 @@ def _wrap_core(model: type, target: str) -> StepFn:
     step.__module__ = getattr(fn, "__module__", step.__module__)
     return step
 
+
 # ───────────────────────────────────────────────────────────────────────────────
 # Builder
 # ───────────────────────────────────────────────────────────────────────────────
+
 
 def _build_raw_step(model: type, sp: OpSpec) -> StepFn:
     if sp.target == "custom" and sp.handler is not None:
         return _wrap_custom(model, sp, sp.handler)  # user function
     # Canonical/default core
     return _wrap_core(model, sp.target)
+
 
 def _attach_one(model: type, sp: OpSpec) -> None:
     alias = sp.alias
@@ -540,9 +583,11 @@ def _attach_one(model: type, sp: OpSpec) -> None:
         alias,
     )
 
+
 # ───────────────────────────────────────────────────────────────────────────────
 # Public API
 # ───────────────────────────────────────────────────────────────────────────────
+
 
 def build_and_attach(
     model: type, specs: Sequence[OpSpec], *, only_keys: Optional[Sequence[_Key]] = None
@@ -562,5 +607,6 @@ def build_and_attach(
         if wanted and key not in wanted:
             continue
         _attach_one(model, sp)
+
 
 __all__ = ["build_and_attach"]

--- a/pkgs/standards/autoapi/autoapi/v3/core/crud.py
+++ b/pkgs/standards/autoapi/autoapi/v3/core/crud.py
@@ -16,13 +16,13 @@ from typing import (
 import builtins as _builtins
 
 try:
-    from sqlalchemy import select, delete, and_, asc, desc, Enum as SAEnum
+    from sqlalchemy import select, delete as sa_delete, and_, asc, desc, Enum as SAEnum
     from sqlalchemy.orm import Session
     from sqlalchemy.ext.asyncio import AsyncSession
     from sqlalchemy.orm.exc import NoResultFound  # type: ignore
 except Exception:  # pragma: no cover
     # Minimal shims so type-checkers don't explode if SQLAlchemy isn't present at import
-    select = delete = and_ = asc = desc = None  # type: ignore
+    select = sa_delete = and_ = asc = desc = None  # type: ignore
     SAEnum = None  # type: ignore
     Session = object  # type: ignore
     AsyncSession = object  # type: ignore
@@ -66,11 +66,33 @@ def _model_columns(model: type) -> Tuple[str, ...]:
     return tuple(c.name for c in table.columns)
 
 
-def _coerce_filters(model: type, filters: Optional[Mapping[str, Any]]) -> Dict[str, Any]:
-    """Keep only valid column names, drop paging keys."""
-    cols = set(_model_columns(model))
+def _coerce_filters(
+    model: type,
+    filters: Optional[Mapping[str, Any]],
+    *,
+    verb: str = "list",
+) -> Dict[str, Any]:
+    """Keep only valid column names, honoring alias_in and filter_ops."""
     raw = dict(filters or {})
-    return {k: v for k, v in raw.items() if k in cols}
+    table_cols = set(_model_columns(model))
+    specs: Mapping[str, Any] = getattr(model, "__autoapi_cols__", {}) or {}
+    alias_map: Dict[str, str] = {}
+    for name, spec in specs.items():
+        alias = getattr(getattr(spec, "io", None), "alias_in", None)
+        if isinstance(alias, str) and alias:
+            alias_map[alias] = name
+    out: Dict[str, Any] = {}
+    for key, value in raw.items():
+        col = alias_map.get(key, key)
+        spec = specs.get(col)
+        allowed = True
+        if spec is not None:
+            ops = getattr(getattr(spec, "io", None), "filter_ops", ())
+            if ops and verb not in ops:
+                allowed = False
+        if allowed and col in table_cols:
+            out[col] = value
+    return out
 
 
 def _apply_equality_filters(model: type, filters: Mapping[str, Any]) -> Any:
@@ -197,6 +219,7 @@ def _set_attrs(
 # Enum validation on writes
 # ───────────────────────────────────────────────────────────────────────────────
 
+
 def _validate_enum_values(model: type, values: Mapping[str, Any]) -> None:
     """
     Reject any assignment to Enum-typed columns that isn't one of the allowed labels.
@@ -277,7 +300,9 @@ def _pop_bound_self(args: list[Any]) -> None:
         args.pop(0)
 
 
-def _extract_db(args: list[Any], kwargs: dict[str, Any]) -> Union[Session, AsyncSession]:
+def _extract_db(
+    args: list[Any], kwargs: dict[str, Any]
+) -> Union[Session, AsyncSession]:
     db = kwargs.pop("db", None)
     if db is not None:
         return db
@@ -299,7 +324,9 @@ def _as_pos_int(x: Any) -> Optional[int]:
         return None
 
 
-def _normalize_list_call(_args: tuple[Any, ...], _kwargs: dict[str, Any]) -> tuple[type, Dict[str, Any]]:
+def _normalize_list_call(
+    _args: tuple[Any, ...], _kwargs: dict[str, Any]
+) -> tuple[type, Dict[str, Any]]:
     """
     Accept:
       list(model, filters, *, db, skip, limit, sort)
@@ -311,7 +338,6 @@ def _normalize_list_call(_args: tuple[Any, ...], _kwargs: dict[str, Any]) -> tup
     """
     args = _builtins.list(_args)
     kwargs = dict(_kwargs)
-    print('here')
 
     _pop_bound_self(args)
 
@@ -353,7 +379,13 @@ def _normalize_list_call(_args: tuple[Any, ...], _kwargs: dict[str, Any]) -> tup
         filters = {}
 
     # Ignore any other stray args/kwargs (request, ctx, etc.)
-    return model, {"filters": filters, "skip": skip, "limit": limit, "db": db, "sort": sort}
+    return model, {
+        "filters": filters,
+        "skip": skip,
+        "limit": limit,
+        "db": db,
+        "sort": sort,
+    }
 
 
 # ───────────────────────────────────────────────────────────────────────────────
@@ -378,16 +410,10 @@ async def create(
 
 
 async def read(model: type, ident: Any, db: Union[Session, AsyncSession]) -> Any:
-    """
-    Load a single row by primary key. Raises NoResultFound if not found.
-    """
-    print('read1')
+    """Load a single row by primary key. Raises NoResultFound if not found."""
     obj = await _maybe_get(db, model, ident)
-    print('read2')
     if obj is None:
-        print('read3')
         raise NoResultFound(f"{model.__name__}({ident!r}) not found")
-    print('read4')
     return obj
 
 
@@ -423,16 +449,14 @@ async def replace(
 
 async def delete(
     model: type, ident: Any, db: Union[Session, AsyncSession]
-) -> Dict[str, int]:
-    """
-    Delete by primary key. Returns {"deleted": 1} if removed, else raises NoResultFound.
-    Flush-only.
-    """
+) -> Dict[str, Any]:
+    """Delete by primary key. Returns {<pk_name>: ident} if removed."""
     obj = await read(model, ident, db)
     if hasattr(db, "delete"):
         db.delete(obj)  # type: ignore[attr-defined]
     await _maybe_flush(db)
-    return {"deleted": 1}
+    pk_name = _single_pk_name(model)
+    return {pk_name: ident}
 
 
 # NOTE: tolerant signature: accepts positional/keyword and ignores stray args
@@ -447,7 +471,7 @@ async def list(*_args: Any, **_kwargs: Any) -> List[Any]:  # noqa: A001  (shadow
     """
     model, params = _normalize_list_call(_args, _kwargs)
 
-    filters: Mapping[str, Any] = _coerce_filters(model, params["filters"])
+    filters: Mapping[str, Any] = _coerce_filters(model, params["filters"], verb="list")
     skip: Optional[int] = params["skip"]
     limit: Optional[int] = params["limit"]
     db: Union[Session, AsyncSession] = params["db"]
@@ -484,7 +508,8 @@ async def list(*_args: Any, **_kwargs: Any) -> List[Any]:  # noqa: A001  (shadow
 
 
 async def clear(
-    *args: Any, **kwargs: Any,
+    *args: Any,
+    **kwargs: Any,
 ) -> Dict[str, int]:
     """
     Delete many rows matching equality filters. Returns {"deleted": N}.
@@ -495,7 +520,7 @@ async def clear(
     raw_filters: Mapping[str, Any] = params["filters"]
     db: Union[Session, AsyncSession] = params["db"]
 
-    if delete is None:  # pragma: no cover
+    if sa_delete is None:  # pragma: no cover
         # Fallback path: manual iteration
         items = await list(model, raw_filters, db=db)
         n = 0
@@ -505,9 +530,9 @@ async def clear(
         await _maybe_flush(db)
         return {"deleted": n}
 
-    filt = _coerce_filters(model, raw_filters)
+    filt = _coerce_filters(model, raw_filters, verb="clear")
     where = _apply_equality_filters(model, filt)
-    stmt = delete(model)
+    stmt = sa_delete(model)
     if where is not None:
         stmt = stmt.where(where)
 
@@ -607,9 +632,9 @@ async def bulk_delete(
         return {"deleted": 0}
 
     # Prefer DELETE ... WHERE pk IN (...)
-    if delete is not None:
+    if sa_delete is not None:
         col = getattr(model, pk_name)
-        stmt = delete(model).where(col.in_(id_seq))  # type: ignore[attr-defined]
+        stmt = sa_delete(model).where(col.in_(id_seq))  # type: ignore[attr-defined]
         res = await _maybe_execute(db, stmt)
         await _maybe_flush(db)
         n = int(getattr(res, "rowcount", 0) or 0)

--- a/pkgs/standards/autoapi/tests/unit/test_v3_delete_clear.py
+++ b/pkgs/standards/autoapi/tests/unit/test_v3_delete_clear.py
@@ -1,0 +1,53 @@
+import pytest
+from sqlalchemy import Integer, String, create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from autoapi.v3.bindings import handlers
+from autoapi.v3.tables._base import Base
+from autoapi.v3.specs.shortcuts import acol, F, IO, S
+
+
+class Item(Base):
+    id = acol(
+        storage=S(type_=Integer, primary_key=True),
+        field=F(py_type=int),
+        io=IO(alias_in="item_id"),
+    )
+    name = acol(
+        storage=S(type_=String),
+        field=F(py_type=str),
+        io=IO(alias_in="n", filter_ops=("list", "clear")),
+    )
+
+
+def _session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+@pytest.mark.asyncio
+async def test_delete_uses_pk_alias():
+    db = _session()
+    db.add(Item(id=1, name="a"))
+    db.commit()
+
+    step = handlers._wrap_core(Item, "delete")
+    ctx = {"path_params": {"item_id": "1"}, "db": db}
+    result = await step(ctx)
+    assert result == {"id": 1}
+    assert db.get(Item, 1) is None
+
+
+@pytest.mark.asyncio
+async def test_clear_respects_filters_with_alias():
+    db = _session()
+    db.add_all([Item(id=1, name="a"), Item(id=2, name="b")])
+    db.commit()
+
+    step = handlers._wrap_core(Item, "clear")
+    ctx = {"payload": {"n": "b"}, "db": db}
+    result = await step(ctx)
+    assert result == {"deleted": 1}
+    remaining = db.execute(select(Item)).scalars().all()
+    assert [r.name for r in remaining] == ["a"]


### PR DESCRIPTION
## Summary
- support column spec aliases for primary key resolution and filter mapping
- wire clear handler to pass filters
- return primary key from delete and add regression tests

## Testing
- `uv run --package autoapi --directory . ruff format autoapi/v3/core/crud.py autoapi/v3/bindings/handlers.py tests/unit/test_v3_delete_clear.py`
- `uv run --package autoapi --directory . ruff check autoapi/v3/core/crud.py autoapi/v3/bindings/handlers.py tests/unit/test_v3_delete_clear.py --fix`
- `uv run --package autoapi --directory . pytest tests/unit/test_v3_delete_clear.py`


------
https://chatgpt.com/codex/tasks/task_e_68a548b9533c8326bd5e8797a626e5fc