### PR TITLE
Add resource prefix tests

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_rest_rpc_prefixes.py
+++ b/pkgs/standards/autoapi/tests/unit/test_rest_rpc_prefixes.py
@@ -1,0 +1,40 @@
+from autoapi.v3.autoapi import AutoAPI
+from autoapi.v3.tables import Base
+from autoapi.v3.mixins import GUIDPk
+from autoapi.v3.types import Column, String
+
+
+def _router_paths(api, name: str) -> set[str]:
+    router = api.routers.get(name)
+    return {r.path for r in getattr(router, "routes", [])}
+
+
+def test_default_resource_and_rpc_prefixes():
+    Base.metadata.clear()
+
+    class Item(Base, GUIDPk):
+        __tablename__ = "items"
+        name = Column(String, nullable=False)
+
+    api = AutoAPI()
+    api.include_model(Item, mount_router=False)
+
+    paths = {p.lower() for p in _router_paths(api, "Item")}
+    assert "/item" in paths
+    assert hasattr(api.rpc, "Item")
+
+
+def test_resource_override_affects_prefixes():
+    Base.metadata.clear()
+
+    class Item(Base, GUIDPk):
+        __tablename__ = "items"
+        __resource__ = "test"
+        name = Column(String, nullable=False)
+
+    api = AutoAPI()
+    api.include_model(Item, mount_router=False)
+
+    paths = {p.lower() for p in _router_paths(api, "Item")}
+    assert "/test" in paths
+    assert hasattr(api.rpc, "Test")


### PR DESCRIPTION
## Summary
- add unit tests for REST path and RPC prefix naming

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff format .` *(fails: Failed to parse autoapi/v3/runtime/plan.py:233:24: f-string: unterminated string)*
- `uv run --directory standards/autoapi --package autoapi ruff check . --fix` *(fails: Found 44 errors (21 fixed, 23 remaining))*
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_rest_rpc_prefixes.py` *(fails: assert hasattr(api.rpc, "Test"))*

------
https://chatgpt.com/codex/tasks/task_e_68a549ac69e0832692c7b7885573c913