### PR TITLE
feat: add sort option for list params

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/schema/builder.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/builder.py
@@ -386,9 +386,12 @@ def _build_schema(
 
 
 def _build_list_params(model: type) -> Type[BaseModel]:
-    """
-    Create a list/filter schema for the given model (forbid extra keys).
-    Includes: skip>=0, limit>=10, plus nullable scalar filters for non-PK columns.
+    """Create a list/filter schema for *model*.
+
+    The schema forbids unknown keys and provides fields for ``skip`` (>=0),
+    ``limit`` (>=10), ``sort`` (string or list of strings) and nullable scalar
+    filters for each non-PK column. This mirrors AutoAPI v2 behaviour with the
+    added ability to request ascending/descending sorting via ``sort`` tokens.
     """
     tab = model.__name__
     logger.debug("schema: build_list_params for %s", tab)
@@ -396,6 +399,7 @@ def _build_list_params(model: type) -> Type[BaseModel]:
     base = dict(
         skip=(int | None, Field(None, ge=0)),
         limit=(int | None, Field(None, ge=10)),
+        sort=(str | list[str] | None, Field(None)),
     )
     _scalars = {str, int, float, bool, bytes, uuid.UUID}
     cols: dict[str, tuple[type, Field]] = {}

--- a/pkgs/standards/autoapi/tests/unit/test_core_crud_default_ops.py
+++ b/pkgs/standards/autoapi/tests/unit/test_core_crud_default_ops.py
@@ -129,3 +129,18 @@ async def test_list_ignores_non_sortable_columns(session):
         sort="immutable",
     )
     assert [r.name for r in unsorted] == ["b", "a"]
+
+
+@pytest.mark.asyncio
+async def test_list_supports_descending_sort(session):
+    await crud.create(Widget, {"name": "a", "immutable": "x"}, session)
+    await crud.create(Widget, {"name": "b", "immutable": "y"}, session)
+    rows = await crud.list(
+        Widget,
+        filters=None,
+        db=session,
+        skip=0,
+        limit=None,
+        sort="name:desc",
+    )
+    assert [r.name for r in rows] == ["b", "a"]


### PR DESCRIPTION
## Summary
- include `sort` field in AutoAPI v3 ListParams
- validate descending sort order in CRUD tests

## Testing
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff format autoapi/v3/schema/builder.py tests/unit/test_core_crud_default_ops.py`
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff check autoapi/v3/schema/builder.py tests/unit/test_core_crud_default_ops.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_68a55112c9d48326ac0cefef39aa879b