### PR TITLE
Fix ListParams spec lookup for spec-only models

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/schema/builder.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/builder.py
@@ -453,7 +453,10 @@ def _build_list_params(model: type) -> Type[BaseModel]:
             continue
         py_t = getattr(c.type, "python_type", Any)
         if py_t in _scalars:
-            spec = getattr(model, "__autoapi_colspecs__", {}).get(c.name)
+            spec_map = getattr(model, "__autoapi_colspecs__", None) or getattr(
+                model, "__autoapi_cols__", {}
+            )
+            spec = spec_map.get(c.name) if isinstance(spec_map, Mapping) else None
             io = getattr(spec, "io", None)
             ops_raw = set(getattr(io, "filter_ops", ()) or [])
             ops = {_canon.get(op, op) for op in ops_raw}

--- a/pkgs/standards/autoapi/tests/unit/test_build_list_params_spec_model.py
+++ b/pkgs/standards/autoapi/tests/unit/test_build_list_params_spec_model.py
@@ -1,0 +1,33 @@
+from autoapi.v3.tables._base import _materialize_colspecs_to_sqla
+from autoapi.v3.specs import acol, S, F, IO
+from autoapi.v3.types import Integer, String
+from autoapi.v3.schema import _build_list_params
+from sqlalchemy.orm import Mapped, DeclarativeBase
+
+
+class LocalBase(DeclarativeBase):
+    def __init_subclass__(cls, **kw):  # pragma: no cover - simple mapper hook
+        _materialize_colspecs_to_sqla(cls)
+        super().__init_subclass__(**kw)
+
+
+class Thing(LocalBase):
+    __tablename__ = "spec_things"
+
+    id: Mapped[int] = acol(
+        storage=S(type_=Integer, primary_key=True),
+        field=F(py_type=int),
+        io=IO(out_verbs=("read", "list")),
+    )
+    name: Mapped[str] = acol(
+        storage=S(type_=String),
+        field=F(py_type=str),
+        io=IO(out_verbs=("read", "list"), filter_ops=("eq", "like")),
+    )
+
+
+def test_build_list_params_with_spec_only_model():
+    params = _build_list_params(Thing)
+    fields = set(params.model_fields.keys())
+    assert "name" in fields
+    assert "name__like" in fields


### PR DESCRIPTION
## Summary
- ensure ListParams builder checks `__autoapi_cols__` so models defined with ColumnSpec entries expose filter ops
- add regression test verifying ListParams fields for spec-only models

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .` *(fails: Failed to parse autoapi/v3/runtime/plan.py)*
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix` *(fails: multiple lint errors in unrelated files)*
- `uv run --package autoapi --directory standards/autoapi ruff check autoapi/v3/schema/builder.py tests/unit/test_build_list_params_spec_model.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_build_list_params_spec_model.py`
- `uv run --package auto_kms --directory standards/auto_kms pytest` *(fails: AttributeError in test_model_bindings_before_mount.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a5649e01588326ba2633db9fa72362