### PR TITLE
test: add hook_ctx attribute tests

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_hook_ctx_attributes.py
+++ b/pkgs/standards/autoapi/tests/unit/test_hook_ctx_attributes.py
@@ -1,0 +1,32 @@
+from autoapi.v3.decorators import hook_ctx, _HookDecl
+
+
+def test_hook_ctx_marks_ctx_only():
+    class Table:
+        @hook_ctx(ops="create", phase="PRE_HANDLER")
+        def before_create(cls, ctx):
+            pass
+
+    assert getattr(Table.before_create.__func__, "__autoapi_ctx_only__") is True
+
+
+def test_hook_ctx_records_ops():
+    class Table:
+        @hook_ctx(ops=("create", "delete"), phase="PRE_HANDLER")
+        def hook(cls, ctx):
+            pass
+
+    decls = getattr(Table.hook.__func__, "__autoapi_hook_decls__")
+    assert isinstance(decls[0], _HookDecl)
+    assert decls[0].ops == ("create", "delete")
+
+
+def test_hook_ctx_records_phase():
+    class Table:
+        @hook_ctx(ops="*", phase="POST_COMMIT")
+        def hook(cls, ctx):
+            pass
+
+    decls = getattr(Table.hook.__func__, "__autoapi_hook_decls__")
+    assert isinstance(decls[0], _HookDecl)
+    assert decls[0].phase == "POST_COMMIT"


### PR DESCRIPTION
## Summary
- add unit tests exercising hook_ctx decorator attributes

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check tests/unit/test_hook_ctx_attributes.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_hook_ctx_attributes.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5651f411c8326bb18194befbf25a1