### PR TITLE
test: add op_ctx attribute coverage

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_v3_op_ctx_attributes.py
+++ b/pkgs/standards/autoapi/tests/unit/test_v3_op_ctx_attributes.py
@@ -1,0 +1,72 @@
+from autoapi.v3 import op_ctx
+from autoapi.v3.decorators import collect_decorated_ops
+
+
+def test_op_ctx_alias_sets_alias():
+    class Model:
+        @op_ctx(alias="custom_alias")
+        def do(cls, ctx):
+            return None
+
+    spec = collect_decorated_ops(Model)[0]
+    assert spec.alias == "custom_alias"
+
+
+def test_op_ctx_target_sets_target():
+    class Model:
+        @op_ctx(target="create")
+        def do(cls, ctx):
+            return None
+
+    spec = collect_decorated_ops(Model)[0]
+    assert spec.target == "create"
+
+
+def test_op_ctx_arity_sets_arity():
+    class Model:
+        @op_ctx(arity="collection")
+        def do(cls, ctx):
+            return None
+
+    spec = collect_decorated_ops(Model)[0]
+    assert spec.arity == "collection"
+
+
+def test_op_ctx_rest_controls_exposure():
+    class Model:
+        @op_ctx(rest=False)
+        def do(cls, ctx):
+            return None
+
+    spec = collect_decorated_ops(Model)[0]
+    assert spec.expose_routes is False
+
+
+def test_op_ctx_request_schema_attached():
+    class Model:
+        @op_ctx(request_schema="InputSchema")
+        def do(cls, ctx):
+            return None
+
+    spec = collect_decorated_ops(Model)[0]
+    assert spec.request_model == "InputSchema"
+
+
+def test_op_ctx_response_schema_attached():
+    class Model:
+        @op_ctx(response_schema="OutputSchema")
+        def do(cls, ctx):
+            return None
+
+    spec = collect_decorated_ops(Model)[0]
+    assert spec.response_model == "OutputSchema"
+
+
+def test_op_ctx_persist_policy_override():
+    class Model:
+        @op_ctx(persist="skip")
+        def do(cls, ctx):
+            return None
+
+    spec = collect_decorated_ops(Model)[0]
+    assert spec.persist == "skip"


### PR DESCRIPTION
## Summary
- add tests for op_ctx attributes in autoapi v3

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format tests/unit/test_v3_op_ctx_attributes.py`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check tests/unit/test_v3_op_ctx_attributes.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_68a5656b58848326ac00cc56f4b4cc6b