### PR TITLE
test: cover field spec attributes

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/schema/collect_in.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/schema/collect_in.py
@@ -82,6 +82,12 @@ def run(obj: Optional[object], ctx: Any) -> None:
 
         is_virtual = storage is None
         nullable = getattr(storage, "nullable", None) if storage is not None else None
+        if op:
+            for obj in (f, col, io):
+                allow = getattr(obj, "allow_null_in", ())
+                if allow and op in allow:
+                    nullable = True
+                    break
         alias_in = _infer_in_alias(field, col)
         py_type = _py_type_str(f)
 

--- a/pkgs/standards/autoapi/tests/unit/test_field_spec_attrs.py
+++ b/pkgs/standards/autoapi/tests/unit/test_field_spec_attrs.py
@@ -1,0 +1,91 @@
+from types import SimpleNamespace
+
+from autoapi.v3.bindings.model import bind
+from autoapi.v3.runtime.atoms.schema import collect_in, collect_out
+from autoapi.v3.specs import F, IO, S, acol, vcol
+from autoapi.v3.tables import Base
+from sqlalchemy import Integer, String
+from sqlalchemy.orm import Mapped
+
+
+def test_field_spec_py_type_overrides_annotation():
+    class Thing(Base):
+        __tablename__ = "things_py_type"
+        __allow_unmapped__ = True
+
+        id: Mapped[int] = acol(
+            storage=S(type_=Integer, primary_key=True, autoincrement=True),
+            io=IO(),
+        )
+        nickname: int = vcol(
+            field=F(py_type=str),
+            io=IO(out_verbs=("read",)),
+        )
+
+    bind(Thing)
+    specs = Thing.__autoapi_cols__
+    ctx = SimpleNamespace(specs=specs, op="read", temp={})
+    collect_out.run(None, ctx)
+    schema_out = ctx.temp["schema_out"]
+    assert schema_out["by_field"]["nickname"]["py_type"] == "str"
+
+
+def test_field_spec_constraints_affect_sqla_column():
+    class Item(Base):
+        __tablename__ = "items_constraints"
+        __allow_unmapped__ = True
+
+        id: Mapped[int] = acol(
+            storage=S(type_=Integer, primary_key=True, autoincrement=True),
+        )
+        name: Mapped[str] = acol(
+            storage=S(type_=String, nullable=False),
+            field=F(constraints={"max_length": 10}),
+        )
+
+    bind(Item)
+    assert Item.__table__.c.name.type.length == 10
+
+
+def test_field_spec_required_in_marks_field_required():
+    class Product(Base):
+        __tablename__ = "products_required_in"
+        __allow_unmapped__ = True
+
+        id: Mapped[int] = acol(
+            storage=S(type_=Integer, primary_key=True, autoincrement=True),
+        )
+        name: Mapped[str] = acol(
+            storage=S(type_=String, nullable=False),
+            field=F(required_in=("create",)),
+            io=IO(in_verbs=("create",)),
+        )
+
+    bind(Product)
+    specs = Product.__autoapi_cols__
+    ctx = SimpleNamespace(specs=specs, op="create", temp={})
+    collect_in.run(None, ctx)
+    schema_in = ctx.temp["schema_in"]
+    assert schema_in["by_field"]["name"]["required"] is True
+
+
+def test_field_spec_allow_null_in_overrides_nullable():
+    class Profile(Base):
+        __tablename__ = "profiles_allow_null"
+        __allow_unmapped__ = True
+
+        id: Mapped[int] = acol(
+            storage=S(type_=Integer, primary_key=True, autoincrement=True),
+        )
+        bio: Mapped[str] = acol(
+            storage=S(type_=String, nullable=False),
+            field=F(allow_null_in=("update",)),
+            io=IO(in_verbs=("create", "update")),
+        )
+
+    bind(Profile)
+    specs = Profile.__autoapi_cols__
+    ctx = SimpleNamespace(specs=specs, op="update", temp={})
+    collect_in.run(None, ctx)
+    schema_in = ctx.temp["schema_in"]
+    assert schema_in["by_field"]["bio"]["nullable"] is True


### PR DESCRIPTION
## Summary
- add tests for `FieldSpec` attributes: `py_type`, `constraints`, `required_in`, and `allow_null_in`
- allow `allow_null_in` to flag fields as nullable for specific operations

## Testing
- ⚠️ `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .` (failed: f-string: unterminated string in `autoapi/v3/runtime/plan.py`)
- ⚠️ `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix` (failed: lint errors in untouched files)
- ✅ `uv run --directory pkgs/standards/autoapi --package autoapi ruff format autoapi/v3/runtime/atoms/schema/collect_in.py tests/unit/test_field_spec_attrs.py`
- ✅ `uv run --directory pkgs/standards/autoapi --package autoapi ruff check autoapi/v3/runtime/atoms/schema/collect_in.py tests/unit/test_field_spec_attrs.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_68a565a4c5708326a7189c82bf931e58