### PR TITLE
fix(autoapi): restore healthz endpoint

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_healthz_exec_driver_sql.py
+++ b/pkgs/standards/autoapi/tests/unit/test_healthz_exec_driver_sql.py
@@ -1,0 +1,17 @@
+import pytest
+from types import SimpleNamespace
+from sqlalchemy import create_engine
+
+from autoapi.v3.system.diagnostics import _build_healthz_endpoint
+
+
+@pytest.mark.asyncio
+async def test_healthz_exec_driver_sql():
+    engine = create_engine(
+        "sqlite:///:memory:", connect_args={"check_same_thread": False}
+    )
+    with engine.connect() as conn:
+        request = SimpleNamespace(state=SimpleNamespace(db=conn))
+        healthz = _build_healthz_endpoint(None)
+        resp = await healthz(request)
+    assert resp == {"ok": True}


### PR DESCRIPTION
## Summary
- ensure health checks use exec_driver_sql when available
- add regression test for healthz endpoint

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest` *(fails: tests/unit/test_default_tags.py::test_router_default_tag, tests/unit/test_include_models_base_prefix.py::test_include_models_base_prefix_avoids_duplicate_segments, tests/unit/test_request_body_schema.py::test_request_body_uses_schema_model, tests/unit/test_rest_rpc_prefixes.py::test_resource_override_affects_prefixes, tests/unit/test_v3_schemas_and_decorators.py::test_rest_serialization_with_and_without_out_schema)*

------
https://chatgpt.com/codex/tasks/task_e_68a5660f57cc8326887b426c910428e9