### PR TITLE
fix v3 health endpoint

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/system/diagnostics.py
+++ b/pkgs/standards/autoapi/autoapi/v3/system/diagnostics.py
@@ -53,6 +53,7 @@ except Exception:  # pragma: no cover
             super().__init__(content=content, status_code=status_code)
 
 
+from sqlalchemy import text
 from ..opspec.types import PHASES
 
 logger = logging.getLogger(__name__)
@@ -79,15 +80,15 @@ def _label_callable(fn: Any) -> str:
     return f"{m}.{n}" if m else n
 
 
-async def _maybe_execute(db: Any, stmt: Any):
+async def _maybe_execute(db: Any, stmt: str):
     try:
-        rv = db.execute(stmt)  # type: ignore[attr-defined]
+        rv = db.execute(text(stmt))  # type: ignore[attr-defined]
         if inspect.isawaitable(rv):
             return await rv
         return rv
-    except TypeError:
+    except Exception:
         # Some drivers prefer lowercase 'select 1'
-        rv = db.execute("select 1")  # type: ignore[attr-defined]
+        rv = db.execute(text("select 1"))  # type: ignore[attr-defined]
         if inspect.isawaitable(rv):
             return await rv
         return rv


### PR DESCRIPTION
## Summary
- ensure SQL dialect compatibility for v3 health check

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format autoapi/v3/system/diagnostics.py`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check autoapi/v3/system/diagnostics.py --fix`
- `uv run --directory pkgs/standards/autoapi --package autoapi python - <<'PY'
from autoapi.v3.system.diagnostics import _build_healthz_endpoint
from sqlalchemy.orm import sessionmaker
from sqlalchemy import create_engine
import asyncio

engine=create_engine('sqlite:///:memory:')
Session=sessionmaker(bind=engine)

async def main():
    endpoint=_build_healthz_endpoint(lambda: Session())
    res=await endpoint(db=Session())
    print(res)

asyncio.run(main())
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a56607223083268ab0b3057d54a550