### PR TITLE
test: add hook_ctx binding tests

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_hook_ctx_binding.py
+++ b/pkgs/standards/autoapi/tests/unit/test_hook_ctx_binding.py
@@ -1,0 +1,52 @@
+from autoapi.v3.decorators import hook_ctx
+from autoapi.v3.bindings.model import bind
+from autoapi.v3.tables import Base
+from autoapi.v3.mixins import GUIDPk
+from autoapi.v3.types import Column, String
+
+
+class Widget(Base, GUIDPk):
+    __tablename__ = "widgets"
+    name = Column(String, nullable=False)
+
+    @hook_ctx(ops="create", phase="PRE_HANDLER")
+    async def flag(cls, ctx):
+        pass
+
+
+def test_hook_ctx_binds_to_create_pre_handler():
+    bind(Widget)
+    hooks = Widget.hooks.create.PRE_HANDLER
+    assert any(callable(h) for h in hooks)
+
+
+class Gadget(Base, GUIDPk):
+    __tablename__ = "gadgets"
+    name = Column(String, nullable=False)
+
+    @hook_ctx(ops=("create", "delete"), phase="PRE_HANDLER")
+    async def counter(cls, ctx):
+        pass
+
+
+def test_hook_ctx_binds_hook_to_multiple_ops():
+    bind(Gadget)
+    for alias in ("create", "delete"):
+        hooks = getattr(getattr(Gadget.hooks, alias), "PRE_HANDLER")
+        assert any(callable(h) for h in hooks)
+
+
+class Gizmo(Base, GUIDPk):
+    __tablename__ = "gizmos"
+    name = Column(String, nullable=False)
+
+    @hook_ctx(ops="*", phase="POST_COMMIT")
+    async def tally(cls, ctx):
+        pass
+
+
+def test_hook_ctx_wildcard_binds_to_all_ops():
+    bind(Gizmo)
+    for alias in ("create", "delete"):
+        hooks = getattr(getattr(Gizmo.hooks, alias), "POST_COMMIT")
+        assert any(callable(h) for h in hooks)


### PR DESCRIPTION
## Summary
- add tests ensuring `hook_ctx` decorators bind hooks to model phases and ops

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff format tests/unit/test_hook_ctx_binding.py`
- `uv run --directory standards/autoapi --package autoapi ruff check tests/unit/test_hook_ctx_binding.py --fix`
- `uv run --package autoapi --directory standards pytest autoapi/tests/unit/test_hook_ctx_binding.py autoapi/tests/unit/test_hook_ctx_attributes.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5683348a08326aa4479b458487540