### PR TITLE
test: verify alias_ctx op attributes

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_alias_ctx_op_attributes.py
+++ b/pkgs/standards/autoapi/tests/unit/test_alias_ctx_op_attributes.py
@@ -1,0 +1,61 @@
+from autoapi.v3 import alias_ctx, alias
+from autoapi.v3.opspec import resolve
+
+
+def _spec_for(model: type, target: str):
+    """Return OpSpec for canonical verb `target`."""
+    return next(sp for sp in resolve(model) if sp.target == target)
+
+
+def test_alias_ctx_renames_canonical_verb():
+    @alias_ctx(read="get")
+    class M:
+        pass
+
+    spec = _spec_for(M, "read")
+    assert spec.alias == "get"
+
+
+def test_alias_ctx_overrides_request_schema():
+    @alias_ctx(read=alias("get", request_schema="Search.in"))
+    class M:
+        pass
+
+    spec = _spec_for(M, "read")
+    assert spec.request_model == "Search.in"
+
+
+def test_alias_ctx_overrides_response_schema():
+    @alias_ctx(read=alias("get", response_schema="Search.out"))
+    class M:
+        pass
+
+    spec = _spec_for(M, "read")
+    assert spec.response_model == "Search.out"
+
+
+def test_alias_ctx_overrides_persist():
+    @alias_ctx(read=alias("get", persist="skip"))
+    class M:
+        pass
+
+    spec = _spec_for(M, "read")
+    assert spec.persist == "skip"
+
+
+def test_alias_ctx_overrides_arity():
+    @alias_ctx(delete=alias("remove", arity="collection"))
+    class M:
+        pass
+
+    spec = _spec_for(M, "delete")
+    assert spec.arity == "collection"
+
+
+def test_alias_ctx_overrides_rest_exposure():
+    @alias_ctx(read=alias("get", rest=False))
+    class M:
+        pass
+
+    spec = _spec_for(M, "read")
+    assert spec.expose_routes is False


### PR DESCRIPTION
## Summary
- add tests exercising alias_ctx overrides for v3 OpSpec aliasing

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format tests/unit/test_alias_ctx_op_attributes.py`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check tests/unit/test_alias_ctx_op_attributes.py --fix`
- `uv run --package autoapi --directory pkgs/standards/autoapi pytest tests/unit/test_alias_ctx_op_attributes.py`


------
https://chatgpt.com/codex/tasks/task_e_68a568799ca88326a65067bcd50527fc