### PR TITLE
test: cover alias_ctx overrides

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_v3_op_alias.py
+++ b/pkgs/standards/autoapi/tests/unit/test_v3_op_alias.py
@@ -1,0 +1,88 @@
+import pytest
+import autoapi.v3.core as core
+from pydantic import BaseModel
+
+from autoapi.v3 import alias_ctx, alias, schema_ctx
+from autoapi.v3.opspec import resolve
+from autoapi.v3.bindings import build_schemas, build_handlers
+
+
+@pytest.mark.asyncio
+async def test_alias_ctx_renames_canon_and_uses_core_handler(monkeypatch):
+    called = {}
+
+    async def fake_read(model, ident, db=None):
+        called["args"] = (model, ident, db)
+        return {"id": ident}
+
+    monkeypatch.setattr(core, "read", fake_read)
+
+    @alias_ctx(read="get")
+    class Widget:
+        pass
+
+    specs = resolve(Widget)
+    sp = next(sp for sp in specs if sp.alias == "get")
+    assert sp.target == "read"
+
+    build_handlers(Widget, specs)
+
+    ctx = {"path_params": {"id": 7}}
+    result = await Widget.handlers.get.raw(ctx)
+    assert result == {"id": 7}
+    assert called["args"] == (Widget, 7, None)
+    assert Widget.handlers.get.raw.__name__ == fake_read.__name__
+
+
+def test_alias_ctx_request_schema_override():
+    @alias_ctx(create=alias("add", request_schema="Payload.in"))
+    class Widget:
+        @schema_ctx(alias="Payload", kind="in")
+        class Payload(BaseModel):
+            x: int
+
+    specs = resolve(Widget)
+    build_schemas(Widget, specs)
+    assert Widget.schemas.add.in_ is Widget.Payload
+
+
+def test_alias_ctx_response_schema_override():
+    @alias_ctx(read=alias("fetch", response_schema="Result.out"))
+    class Widget:
+        @schema_ctx(alias="Result", kind="out")
+        class Result(BaseModel):
+            id: int
+
+    specs = resolve(Widget)
+    build_schemas(Widget, specs)
+    assert Widget.schemas.fetch.out is Widget.Result
+
+
+def test_alias_ctx_persist_override():
+    @alias_ctx(update=alias("modify", persist="skip"))
+    class Widget:
+        pass
+
+    specs = resolve(Widget)
+    sp = next(sp for sp in specs if sp.alias == "modify")
+    assert sp.persist == "skip"
+
+
+def test_alias_ctx_arity_override():
+    @alias_ctx(list=alias("ls", arity="member"))
+    class Widget:
+        pass
+
+    specs = resolve(Widget)
+    sp = next(sp for sp in specs if sp.alias == "ls")
+    assert sp.arity == "member"
+
+
+def test_alias_ctx_rest_override():
+    @alias_ctx(delete=alias("remove", rest=False))
+    class Widget:
+        pass
+
+    specs = resolve(Widget)
+    sp = next(sp for sp in specs if sp.alias == "remove")
+    assert sp.expose_routes is False


### PR DESCRIPTION
## Summary
- add unit tests covering alias_ctx overrides for canonical operations
- demonstrate request/response schema, persist, arity, and REST flag aliasing
- ensure aliasing a canonical op still invokes the core CRUD handler

## Testing
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff format tests/unit/test_v3_op_alias.py`
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff check tests/unit/test_v3_op_alias.py --fix`
- `uv run --package autoapi --directory pkgs/standards/autoapi pytest tests/unit/test_v3_op_alias.py`


------
https://chatgpt.com/codex/tasks/task_e_68a568fc35548326a0762dc095a35ae8