### PR TITLE
fix: add returns attribute for AutoAPI v3 OpSpec

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/opspec/types.py
+++ b/pkgs/standards/autoapi/autoapi/v3/opspec/types.py
@@ -18,13 +18,21 @@ from typing import (
 # Core aliases & enums
 # ───────────────────────────────────────────────────────────────────────────────
 
-PersistPolicy = Literal["default", "skip", "override"]          # TX policy
-Arity = Literal["collection", "member"]                          # HTTP path shape
+PersistPolicy = Literal["default", "skip", "override"]  # TX policy
+Arity = Literal["collection", "member"]  # HTTP path shape
 
 TargetOp = Literal[
-    "create", "read", "update", "replace", "delete",
-    "list", "clear",
-    "bulk_create", "bulk_update", "bulk_replace", "bulk_delete",
+    "create",
+    "read",
+    "update",
+    "replace",
+    "delete",
+    "list",
+    "clear",
+    "bulk_create",
+    "bulk_update",
+    "bulk_replace",
+    "bulk_delete",
     "custom",
 ]
 
@@ -35,21 +43,49 @@ VerbAliasPolicy = Literal["both", "alias_only", "canonical_only"]  # legacy expo
 # ───────────────────────────────────────────────────────────────────────────────
 
 HookPhase = Literal[
-    "PRE_TX_BEGIN", "START_TX", "PRE_HANDLER", "HANDLER", "POST_HANDLER",
-    "PRE_COMMIT", "END_TX", "POST_COMMIT", "POST_RESPONSE",
-    "ON_ERROR", "ON_PRE_TX_BEGIN_ERROR", "ON_START_TX_ERROR",
-    "ON_PRE_HANDLER_ERROR", "ON_HANDLER_ERROR", "ON_POST_HANDLER_ERROR",
-    "ON_PRE_COMMIT_ERROR", "ON_END_TX_ERROR", "ON_POST_COMMIT_ERROR",
-    "ON_POST_RESPONSE_ERROR", "ON_ROLLBACK",
+    "PRE_TX_BEGIN",
+    "START_TX",
+    "PRE_HANDLER",
+    "HANDLER",
+    "POST_HANDLER",
+    "PRE_COMMIT",
+    "END_TX",
+    "POST_COMMIT",
+    "POST_RESPONSE",
+    "ON_ERROR",
+    "ON_PRE_TX_BEGIN_ERROR",
+    "ON_START_TX_ERROR",
+    "ON_PRE_HANDLER_ERROR",
+    "ON_HANDLER_ERROR",
+    "ON_POST_HANDLER_ERROR",
+    "ON_PRE_COMMIT_ERROR",
+    "ON_END_TX_ERROR",
+    "ON_POST_COMMIT_ERROR",
+    "ON_POST_RESPONSE_ERROR",
+    "ON_ROLLBACK",
 ]
 
 PHASES: Tuple[HookPhase, ...] = (
-    "PRE_TX_BEGIN", "START_TX", "PRE_HANDLER", "HANDLER", "POST_HANDLER",
-    "PRE_COMMIT", "END_TX", "POST_COMMIT", "POST_RESPONSE",
-    "ON_ERROR", "ON_PRE_TX_BEGIN_ERROR", "ON_START_TX_ERROR",
-    "ON_PRE_HANDLER_ERROR", "ON_HANDLER_ERROR", "ON_POST_HANDLER_ERROR",
-    "ON_PRE_COMMIT_ERROR", "ON_END_TX_ERROR", "ON_POST_COMMIT_ERROR",
-    "ON_POST_RESPONSE_ERROR", "ON_ROLLBACK",
+    "PRE_TX_BEGIN",
+    "START_TX",
+    "PRE_HANDLER",
+    "HANDLER",
+    "POST_HANDLER",
+    "PRE_COMMIT",
+    "END_TX",
+    "POST_COMMIT",
+    "POST_RESPONSE",
+    "ON_ERROR",
+    "ON_PRE_TX_BEGIN_ERROR",
+    "ON_START_TX_ERROR",
+    "ON_PRE_HANDLER_ERROR",
+    "ON_HANDLER_ERROR",
+    "ON_POST_HANDLER_ERROR",
+    "ON_PRE_COMMIT_ERROR",
+    "ON_END_TX_ERROR",
+    "ON_POST_COMMIT_ERROR",
+    "ON_POST_RESPONSE_ERROR",
+    "ON_ROLLBACK",
 )
 
 # ───────────────────────────────────────────────────────────────────────────────
@@ -67,27 +103,33 @@ HookPredicate = Callable[[Any], bool]
 try:  # pragma: no cover
     from pydantic import BaseModel  # type: ignore
 except Exception:  # pragma: no cover
+
     class BaseModel:  # minimal stub for typing only
         pass
 
+
 SchemaKind = Literal["in", "out"]
+
 
 @dataclass(frozen=True, slots=True)
 class SchemaRef:
     """Lazy reference to `model.schemas.<alias>.(in_|out)`."""
+
     alias: str
     kind: SchemaKind = "in"
 
+
 SchemaArg = Union[
-    Type[BaseModel],                  # direct Pydantic model
-    SchemaRef,                        # cross-op reference
-    str,                              # "alias.in" | "alias.out"
-    Callable[[type], Type[BaseModel]] # lambda cls: cls.schemas.create.in_
+    Type[BaseModel],  # direct Pydantic model
+    SchemaRef,  # cross-op reference
+    str,  # "alias.in" | "alias.out"
+    Callable[[type], Type[BaseModel]],  # lambda cls: cls.schemas.create.in_
 ]
 
 # ───────────────────────────────────────────────────────────────────────────────
 # Hook & Spec dataclasses
 # ───────────────────────────────────────────────────────────────────────────────
+
 
 @dataclass(frozen=True, slots=True)
 class OpHook:
@@ -97,6 +139,7 @@ class OpHook:
     when: Optional[HookPredicate] = None
     name: Optional[str] = None
     description: Optional[str] = None
+
 
 @dataclass(frozen=True, slots=True)
 class OpSpec:
@@ -110,6 +153,7 @@ class OpSpec:
       - if model.schemas.<alias>.out exists → serialize
       - otherwise → raw pass-through
     """
+
     # Identity & exposure
     alias: str
     target: TargetOp
@@ -131,6 +175,9 @@ class OpSpec:
     request_model: Optional[SchemaArg] = None
     response_model: Optional[SchemaArg] = None
 
+    # Return shaping: "raw" passthrough vs "model" serialization
+    returns: Literal["raw", "model"] = "raw"
+
     # Handler & hooks
     handler: Optional[StepFn] = None
     hooks: Tuple[OpHook, ...] = field(default_factory=tuple)
@@ -141,11 +188,20 @@ class OpSpec:
     core_raw: Optional[StepFn] = None
     extra: Mapping[str, Any] = field(default_factory=dict)
 
+
 # Canonical verb set
 CANON: Tuple[TargetOp, ...] = (
-    "create", "read", "update", "replace", "delete",
-    "list", "clear",
-    "bulk_create", "bulk_update", "bulk_replace", "bulk_delete",
+    "create",
+    "read",
+    "update",
+    "replace",
+    "delete",
+    "list",
+    "clear",
+    "bulk_create",
+    "bulk_update",
+    "bulk_replace",
+    "bulk_delete",
     "custom",
 )
 


### PR DESCRIPTION
## Summary
- add missing `returns` field to `OpSpec` so diagnostics `/methodz` can inspect specs without crashing
- format opspec types module

## Testing
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff format autoapi/v3/opspec/types.py`
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff check autoapi/v3/opspec/types.py --fix`
- `python` (manual request to `/methodz`)


------
https://chatgpt.com/codex/tasks/task_e_68a569a09afc8326982ae66e82ecdbba