### PR TITLE
feat(autoapi): expand iospec utilities and tests

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/specs/io_spec.py
+++ b/pkgs/standards/autoapi/autoapi/v3/specs/io_spec.py
@@ -2,36 +2,42 @@
 from dataclasses import dataclass, replace
 from typing import Callable, Tuple, Literal
 from .field_spec import FieldSpec as F
-1
+
+
 @dataclass(frozen=True)
 class _PairedCfg:
-    gen: Callable[[dict], object]                 # ctx -> raw
-    store: Callable[[object, dict], object]       # (raw, ctx) -> stored
+    gen: Callable[[dict], object]  # ctx -> raw
+    store: Callable[[object, dict], object]  # (raw, ctx) -> stored
     alias: str
     verbs: Tuple[str, ...]
-    emit: str                                     # "pre_flush" | "post_refresh" | "readtime"
+    emit: str  # "pre_flush" | "post_refresh" | "readtime"
     alias_field: F
     mask_last: int | None
+
 
 @dataclass(frozen=True)
 class _AssembleCfg:
     sources: Tuple[str, ...]
-    fn: Callable[[dict, dict], object]            # (payload, ctx) -> stored
+    fn: Callable[[dict, dict], object]  # (payload, ctx) -> stored
+
 
 @dataclass(frozen=True)
 class _ReadtimeAlias:
     name: str
-    fn: Callable[[object, dict], object]          # (obj, ctx) -> alias value
+    fn: Callable[[object, dict], object]  # (obj, ctx) -> alias value
     verbs: Tuple[str, ...]
     alias_field: F
     mask_last: int | None
 
-EmitPoint = Literal["pre_flush","post_refresh","pre_response","readtime"]
+
+EmitPoint = Literal["pre_flush", "post_refresh", "pre_response", "readtime"]
+
 
 @dataclass(frozen=True)
 class Pair:
     raw: object
     stored: object
+
 
 @dataclass(frozen=True)
 class IOSpec:
@@ -50,10 +56,56 @@ class IOSpec:
     _assemble: _AssembleCfg | None = None
     _readtime_aliases: Tuple[_ReadtimeAlias, ...] = ()
 
-    def assemble(self, sources, fn): ...
-    def paired(self, make, *, alias, verbs=("create",), emit: EmitPoint="pre_flush",
-               alias_field: F=F(py_type=str), mask_last: int | None=None): ...
-    def alias_readtime(self, name, fn, *, verbs=("read","list"),
-                       alias_field: F=F(py_type=str), mask_last: int | None=None): ...
+    def assemble(self, sources, fn):
+        """Return a new spec that derives a value from ``sources`` using ``fn``."""
+        cfg = _AssembleCfg(sources=tuple(sources), fn=fn)
+        return replace(self, _assemble=cfg)
 
+    def paired(
+        self,
+        make,
+        *,
+        alias,
+        verbs=("create",),
+        emit: EmitPoint = "pre_flush",
+        alias_field: F = F(py_type=str),
+        mask_last: int | None = None,
+    ):
+        """Return a new spec with a paired field configuration."""
 
+        def gen(ctx):
+            return make(ctx).raw
+
+        def store(raw, ctx):
+            return make(ctx).stored
+
+        cfg = _PairedCfg(
+            gen=gen,
+            store=store,
+            alias=alias,
+            verbs=tuple(verbs),
+            emit=emit,
+            alias_field=alias_field,
+            mask_last=mask_last,
+        )
+        return replace(self, _paired=cfg)
+
+    def alias_readtime(
+        self,
+        name,
+        fn,
+        *,
+        verbs=("read", "list"),
+        alias_field: F = F(py_type=str),
+        mask_last: int | None = None,
+    ):
+        """Return a new spec with an additional read-time alias."""
+
+        alias_cfg = _ReadtimeAlias(
+            name=name,
+            fn=fn,
+            verbs=tuple(verbs),
+            alias_field=alias_field,
+            mask_last=mask_last,
+        )
+        return replace(self, _readtime_aliases=self._readtime_aliases + (alias_cfg,))


### PR DESCRIPTION
## Summary
- implement IOSpec.assemble, .paired and .alias_readtime helpers
- cover each IOSpec attribute with dedicated tests

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff format autoapi/v3/specs/io_spec.py tests/unit/test_iospec_attributes.py`
- `uv run --directory standards/autoapi --package autoapi ruff check autoapi/v3/specs/io_spec.py tests/unit/test_iospec_attributes.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_iospec_attributes.py`


------
https://chatgpt.com/codex/tasks/task_e_68a56b15bcdc8326a510b823b76a77a4