### PR TITLE
fix v3 health endpoint

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/system/diagnostics.py
+++ b/pkgs/standards/autoapi/autoapi/v3/system/diagnostics.py
@@ -53,6 +53,7 @@ except Exception:  # pragma: no cover
             super().__init__(content=content, status_code=status_code)
 
 
+from sqlalchemy import text
 from ..opspec.types import PHASES
 
 logger = logging.getLogger(__name__)
@@ -79,15 +80,15 @@ def _label_callable(fn: Any) -> str:
     return f"{m}.{n}" if m else n
 
 
-async def _maybe_execute(db: Any, stmt: Any):
+async def _maybe_execute(db: Any, stmt: str):
     try:
-        rv = db.execute(stmt)  # type: ignore[attr-defined]
+        rv = db.execute(text(stmt))  # type: ignore[attr-defined]
         if inspect.isawaitable(rv):
             return await rv
         return rv
-    except TypeError:
+    except Exception:
         # Some drivers prefer lowercase 'select 1'
-        rv = db.execute("select 1")  # type: ignore[attr-defined]
+        rv = db.execute(text("select 1"))  # type: ignore[attr-defined]
         if inspect.isawaitable(rv):
             return await rv
         return rv

--- a/pkgs/standards/autoapi/tests/unit/test_v3_healthz_endpoint.py
+++ b/pkgs/standards/autoapi/tests/unit/test_v3_healthz_endpoint.py
@@ -1,0 +1,39 @@
+import pytest
+from types import SimpleNamespace
+from fastapi import FastAPI
+from httpx import AsyncClient, ASGITransport
+
+from autoapi.v3.system.diagnostics import mount_diagnostics
+
+
+class DummyDB:
+    def __init__(self):
+        self.calls = []
+
+    def execute(self, stmt):
+        text = str(stmt)
+        self.calls.append(text)
+        if text == "SELECT 1":
+            raise RuntimeError("uppercase not supported")
+        return 1
+
+
+@pytest.mark.asyncio
+async def test_healthz_endpoint_select_case_fallback():
+    db = DummyDB()
+
+    def get_db():
+        return db
+
+    api = SimpleNamespace(models={})
+    app = FastAPI()
+    app.include_router(mount_diagnostics(api, get_db=get_db), prefix="/system")
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        res = await client.get("/system/healthz")
+
+    assert res.status_code == 200
+    assert res.json() == {"ok": True}
+    assert db.calls == ["SELECT 1", "select 1"]


### PR DESCRIPTION
## Summary
- ensure SQL dialect compatibility for v3 health check
- test /system/healthz fallback to lowercase `select 1`

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .` *(fails: Failed to parse autoapi/v3/runtime/plan.py)*
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format autoapi/v3/system/diagnostics.py tests/unit/test_v3_healthz_endpoint.py`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check autoapi/v3/system/diagnostics.py tests/unit/test_v3_healthz_endpoint.py --fix`
- `uv run --directory pkgs/standards/autoapi --package autoapi pytest tests/unit/test_v3_healthz_endpoint.py`


------
https://chatgpt.com/codex/tasks/task_e_68a56607223083268ab0b3057d54a550