### PR TITLE
Infer OpSpec return mode from response schema

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/compat/transactional.py
+++ b/pkgs/standards/autoapi/autoapi/v3/compat/transactional.py
@@ -5,7 +5,7 @@ from typing import Any, Callable
 
 from ..bindings.api import include_model
 from ..bindings.model import bind as bind_model
-from ..opspec import OpSpec, get_registry
+from ..opspec import OpSpec, SchemaArg, get_registry
 from ..config.constants import AUTOAPI_TX_MODELS_ATTR
 
 
@@ -72,9 +72,10 @@ def transactional(  # noqa: D401 (compat docstring in v2)
     rest_path: str | None = None,
     rest_method: str = "POST",
     tags: tuple[str, ...] = ("txn",),
-    returns: str = "raw",  # v3: 'raw' or 'model'
     expose_rpc: bool = True,
     expose_routes: bool = True,
+    request_model: SchemaArg | None = None,
+    response_model: SchemaArg | None = None,
 ) -> Callable[..., Any]:
     """
     v3-compatible replacement for the v2 @api.transactional decorator.
@@ -109,8 +110,9 @@ def transactional(  # noqa: D401 (compat docstring in v2)
                 rest_path, name or user_fn.__name__, alias
             ),
             tags=tags,
-            returns=returns,  # 'raw' by default; set 'model' if you want schema-shaped responses
             persist="always",  # ensure START_TX/END_TX are injected
+            request_model=request_model,
+            response_model=response_model,
         )
 
         # Register on the model's registry and (re)bind the model

--- a/pkgs/standards/autoapi/autoapi/v3/opspec/types.py
+++ b/pkgs/standards/autoapi/autoapi/v3/opspec/types.py
@@ -18,13 +18,21 @@ from typing import (
 # Core aliases & enums
 # ───────────────────────────────────────────────────────────────────────────────
 
-PersistPolicy = Literal["default", "skip", "override"]          # TX policy
-Arity = Literal["collection", "member"]                          # HTTP path shape
+PersistPolicy = Literal["default", "skip", "override"]  # TX policy
+Arity = Literal["collection", "member"]  # HTTP path shape
 
 TargetOp = Literal[
-    "create", "read", "update", "replace", "delete",
-    "list", "clear",
-    "bulk_create", "bulk_update", "bulk_replace", "bulk_delete",
+    "create",
+    "read",
+    "update",
+    "replace",
+    "delete",
+    "list",
+    "clear",
+    "bulk_create",
+    "bulk_update",
+    "bulk_replace",
+    "bulk_delete",
     "custom",
 ]
 
@@ -35,21 +43,49 @@ VerbAliasPolicy = Literal["both", "alias_only", "canonical_only"]  # legacy expo
 # ───────────────────────────────────────────────────────────────────────────────
 
 HookPhase = Literal[
-    "PRE_TX_BEGIN", "START_TX", "PRE_HANDLER", "HANDLER", "POST_HANDLER",
-    "PRE_COMMIT", "END_TX", "POST_COMMIT", "POST_RESPONSE",
-    "ON_ERROR", "ON_PRE_TX_BEGIN_ERROR", "ON_START_TX_ERROR",
-    "ON_PRE_HANDLER_ERROR", "ON_HANDLER_ERROR", "ON_POST_HANDLER_ERROR",
-    "ON_PRE_COMMIT_ERROR", "ON_END_TX_ERROR", "ON_POST_COMMIT_ERROR",
-    "ON_POST_RESPONSE_ERROR", "ON_ROLLBACK",
+    "PRE_TX_BEGIN",
+    "START_TX",
+    "PRE_HANDLER",
+    "HANDLER",
+    "POST_HANDLER",
+    "PRE_COMMIT",
+    "END_TX",
+    "POST_COMMIT",
+    "POST_RESPONSE",
+    "ON_ERROR",
+    "ON_PRE_TX_BEGIN_ERROR",
+    "ON_START_TX_ERROR",
+    "ON_PRE_HANDLER_ERROR",
+    "ON_HANDLER_ERROR",
+    "ON_POST_HANDLER_ERROR",
+    "ON_PRE_COMMIT_ERROR",
+    "ON_END_TX_ERROR",
+    "ON_POST_COMMIT_ERROR",
+    "ON_POST_RESPONSE_ERROR",
+    "ON_ROLLBACK",
 ]
 
 PHASES: Tuple[HookPhase, ...] = (
-    "PRE_TX_BEGIN", "START_TX", "PRE_HANDLER", "HANDLER", "POST_HANDLER",
-    "PRE_COMMIT", "END_TX", "POST_COMMIT", "POST_RESPONSE",
-    "ON_ERROR", "ON_PRE_TX_BEGIN_ERROR", "ON_START_TX_ERROR",
-    "ON_PRE_HANDLER_ERROR", "ON_HANDLER_ERROR", "ON_POST_HANDLER_ERROR",
-    "ON_PRE_COMMIT_ERROR", "ON_END_TX_ERROR", "ON_POST_COMMIT_ERROR",
-    "ON_POST_RESPONSE_ERROR", "ON_ROLLBACK",
+    "PRE_TX_BEGIN",
+    "START_TX",
+    "PRE_HANDLER",
+    "HANDLER",
+    "POST_HANDLER",
+    "PRE_COMMIT",
+    "END_TX",
+    "POST_COMMIT",
+    "POST_RESPONSE",
+    "ON_ERROR",
+    "ON_PRE_TX_BEGIN_ERROR",
+    "ON_START_TX_ERROR",
+    "ON_PRE_HANDLER_ERROR",
+    "ON_HANDLER_ERROR",
+    "ON_POST_HANDLER_ERROR",
+    "ON_PRE_COMMIT_ERROR",
+    "ON_END_TX_ERROR",
+    "ON_POST_COMMIT_ERROR",
+    "ON_POST_RESPONSE_ERROR",
+    "ON_ROLLBACK",
 )
 
 # ───────────────────────────────────────────────────────────────────────────────
@@ -67,27 +103,33 @@ HookPredicate = Callable[[Any], bool]
 try:  # pragma: no cover
     from pydantic import BaseModel  # type: ignore
 except Exception:  # pragma: no cover
+
     class BaseModel:  # minimal stub for typing only
         pass
 
+
 SchemaKind = Literal["in", "out"]
+
 
 @dataclass(frozen=True, slots=True)
 class SchemaRef:
     """Lazy reference to `model.schemas.<alias>.(in_|out)`."""
+
     alias: str
     kind: SchemaKind = "in"
 
+
 SchemaArg = Union[
-    Type[BaseModel],                  # direct Pydantic model
-    SchemaRef,                        # cross-op reference
-    str,                              # "alias.in" | "alias.out"
-    Callable[[type], Type[BaseModel]] # lambda cls: cls.schemas.create.in_
+    Type[BaseModel],  # direct Pydantic model
+    SchemaRef,  # cross-op reference
+    str,  # "alias.in" | "alias.out"
+    Callable[[type], Type[BaseModel]],  # lambda cls: cls.schemas.create.in_
 ]
 
 # ───────────────────────────────────────────────────────────────────────────────
 # Hook & Spec dataclasses
 # ───────────────────────────────────────────────────────────────────────────────
+
 
 @dataclass(frozen=True, slots=True)
 class OpHook:
@@ -97,6 +139,7 @@ class OpHook:
     when: Optional[HookPredicate] = None
     name: Optional[str] = None
     description: Optional[str] = None
+
 
 @dataclass(frozen=True, slots=True)
 class OpSpec:
@@ -110,6 +153,7 @@ class OpSpec:
       - if model.schemas.<alias>.out exists → serialize
       - otherwise → raw pass-through
     """
+
     # Identity & exposure
     alias: str
     target: TargetOp
@@ -141,11 +185,20 @@ class OpSpec:
     core_raw: Optional[StepFn] = None
     extra: Mapping[str, Any] = field(default_factory=dict)
 
+
 # Canonical verb set
 CANON: Tuple[TargetOp, ...] = (
-    "create", "read", "update", "replace", "delete",
-    "list", "clear",
-    "bulk_create", "bulk_update", "bulk_replace", "bulk_delete",
+    "create",
+    "read",
+    "update",
+    "replace",
+    "delete",
+    "list",
+    "clear",
+    "bulk_create",
+    "bulk_update",
+    "bulk_replace",
+    "bulk_delete",
     "custom",
 )
 

--- a/pkgs/standards/autoapi/autoapi/v3/system/diagnostics.py
+++ b/pkgs/standards/autoapi/autoapi/v3/system/diagnostics.py
@@ -148,7 +148,9 @@ def _build_methodz_endpoint(api: Any):
                         "target": sp.target,
                         "arity": sp.arity,
                         "persist": sp.persist,
-                        "returns": sp.returns,
+                        "request_model": getattr(sp, "request_model", None) is not None,
+                        "response_model": getattr(sp, "response_model", None)
+                        is not None,
                         "routes": bool(getattr(sp, "expose_routes", True)),
                         "rpc": bool(getattr(sp, "expose_rpc", True)),
                         "tags": list(getattr(sp, "tags", ()) or (mname,)),


### PR DESCRIPTION
## Summary
- drop derived `returns` field from `OpSpec` and rely on response schema presence
- expose `request_model` and `response_model` flags from `/system/methodz`
- allow transactional decorator to declare request and response schemas

## Testing
- `uv run --directory pkgs/standards --package autoapi ruff format autoapi/autoapi/v3/opspec/types.py autoapi/autoapi/v3/system/diagnostics.py autoapi/autoapi/v3/compat/transactional.py`
- `uv run --directory pkgs/standards --package autoapi ruff check autoapi/autoapi/v3/opspec/types.py autoapi/autoapi/v3/system/diagnostics.py autoapi/autoapi/v3/compat/transactional.py --fix`
- `python - <<'PY'
from fastapi import FastAPI
from autoapi.v3.system.diagnostics import mount_diagnostics
from autoapi.v3.opspec import OpSpec

class Model:
    __name__ = "Item"
    class opspecs:
        all = [OpSpec(alias="test", target="custom")]

class API:
    models = {"Item": Model}

app = FastAPI()
app.include_router(mount_diagnostics(API()), prefix="/system")

from fastapi.testclient import TestClient
client = TestClient(app)
res = client.get('/system/methodz')
print('status', res.status_code)
print('json', res.json())
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a5660b3a6883268d3fd4d71a647bfd