### PR TITLE
feat: add v3 opspec integration tests

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_v3_opspec_attributes.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_v3_opspec_attributes.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import String, create_engine
+from sqlalchemy.orm import sessionmaker
+
+from autoapi.v3.bindings.model import bind
+from autoapi.v3.decorators import hook_ctx
+from autoapi.v3.opspec.types import PHASES
+from autoapi.v3.runtime import system as runtime_system
+from autoapi.v3.runtime.kernel import build_phase_chains
+from autoapi.v3.specs import IO, S, acol
+from autoapi.v3.tables import Base
+from autoapi.v3.mixins import GUIDPk
+from autoapi.v3 import core as _core
+
+
+def _fresh_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+@pytest.mark.i9n
+def test_request_and_response_schemas():
+    Base.metadata.clear()
+
+    class Gadget(Base, GUIDPk):
+        __tablename__ = "gadgets_schema"
+        __allow_unmapped__ = True
+
+        name = acol(
+            storage=S(type_=String, nullable=False),
+            io=IO(in_verbs=("create",), out_verbs=("read",)),
+        )
+
+    bind(Gadget)
+    assert hasattr(Gadget.schemas, "create")
+    assert hasattr(Gadget.schemas.create, "in_")
+    assert hasattr(Gadget.schemas, "read")
+    assert hasattr(Gadget.schemas.read, "out")
+
+
+@pytest.mark.i9n
+def test_columns_bound():
+    Base.metadata.clear()
+
+    class Gadget(Base, GUIDPk):
+        __tablename__ = "gadgets_columns"
+        __allow_unmapped__ = True
+
+        name = acol(
+            storage=S(type_=String, nullable=False),
+            io=IO(in_verbs=("create",), out_verbs=("read",)),
+        )
+
+    bind(Gadget)
+    assert "name" in Gadget.__table__.c
+    assert "name" in Gadget.__autoapi_cols__
+
+
+@pytest.mark.i9n
+def test_defaults_value_resolution():
+    Base.metadata.clear()
+
+    class Gadget(Base, GUIDPk):
+        __tablename__ = "gadgets_defaults"
+        __allow_unmapped__ = True
+
+        name = acol(
+            storage=S(type_=String, nullable=False, default="anon"),
+            io=IO(in_verbs=("create",), out_verbs=("read",)),
+        )
+
+    bind(Gadget)
+    db = _fresh_session()
+    obj = asyncio.run(_core.create(Gadget, db=db, data={}))
+    assert obj.name == "anon"
+
+
+@pytest.mark.i9n
+def test_internal_model_opspec_binding():
+    Base.metadata.clear()
+
+    class Gadget(Base, GUIDPk):
+        __tablename__ = "gadgets_internal"
+        __allow_unmapped__ = True
+
+        name = acol(
+            storage=S(type_=String, nullable=False),
+            io=IO(in_verbs=("create",), out_verbs=("read",)),
+        )
+
+    bind(Gadget)
+    sp = Gadget.opspecs.by_alias["create"][0]
+    assert sp.table is Gadget
+
+
+@pytest.mark.i9n
+def test_openapi_includes_path():
+    Base.metadata.clear()
+
+    class Gadget(Base, GUIDPk):
+        __tablename__ = "gadgets_openapi"
+        __allow_unmapped__ = True
+
+        name = acol(
+            storage=S(type_=String, nullable=False),
+            io=IO(in_verbs=("create",), out_verbs=("read",)),
+        )
+
+    bind(Gadget)
+    app = FastAPI()
+    app.include_router(Gadget.rest.router)
+    schema = app.openapi()
+    assert "/Gadget" in schema["paths"]
+
+
+@pytest.mark.i9n
+def test_storage_and_sqlalchemy_persist():
+    Base.metadata.clear()
+
+    class Gadget(Base, GUIDPk):
+        __tablename__ = "gadgets_storage"
+        __allow_unmapped__ = True
+
+        name = acol(
+            storage=S(type_=String, nullable=False),
+            io=IO(in_verbs=("create",), out_verbs=("read",)),
+        )
+
+    bind(Gadget)
+    db = _fresh_session()
+    asyncio.run(_core.create(Gadget, db=db, data={"name": "stored"}))
+    fetched = db.query(Gadget).one()
+    assert fetched.name == "stored"
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_rest_routes_bound():
+    Base.metadata.clear()
+
+    class Gadget(Base, GUIDPk):
+        __tablename__ = "gadgets_rest"
+        __allow_unmapped__ = True
+
+        name = acol(
+            storage=S(type_=String, nullable=False),
+            io=IO(in_verbs=("create",), out_verbs=("read",)),
+        )
+
+    session = _fresh_session()
+
+    def get_db():
+        return session
+
+    Gadget.__autoapi_get_db__ = staticmethod(get_db)  # type: ignore[attr-defined]
+    bind(Gadget)
+    app = FastAPI()
+    app.include_router(Gadget.rest.router)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        res = await client.get("/Gadget")
+        assert res.status_code in {200, 404}
+
+
+@pytest.mark.i9n
+def test_rpc_method_bound():
+    Base.metadata.clear()
+
+    class Gadget(Base, GUIDPk):
+        __tablename__ = "gadgets_rpc"
+        __allow_unmapped__ = True
+
+        name = acol(
+            storage=S(type_=String, nullable=False),
+            io=IO(in_verbs=("create",), out_verbs=("read",)),
+        )
+
+    bind(Gadget)
+    assert hasattr(Gadget.rpc, "create")
+
+
+@pytest.mark.i9n
+def test_core_crud_handler_used():
+    Base.metadata.clear()
+
+    class Gadget(Base, GUIDPk):
+        __tablename__ = "gadgets_crud"
+        __allow_unmapped__ = True
+
+        name = acol(
+            storage=S(type_=String, nullable=False),
+            io=IO(in_verbs=("create",), out_verbs=("read",)),
+        )
+
+    bind(Gadget)
+    step = Gadget.hooks.create.HANDLER[0]
+    assert step.__qualname__ == _core.create.__qualname__
+
+
+@pytest.mark.i9n
+def test_hook_execution():
+    Base.metadata.clear()
+
+    class Hooked(Base, GUIDPk):
+        __tablename__ = "hooked_model"
+        __allow_unmapped__ = True
+
+        name = acol(
+            storage=S(type_=String, nullable=False),
+            io=IO(in_verbs=("create",), out_verbs=("read",)),
+        )
+
+        @hook_ctx(ops="create", phase="PRE_HANDLER")
+        def inject_name(cls, ctx):
+            payload = dict(ctx.get("payload") or {})
+            payload.setdefault("name", "hooked")
+            ctx["payload"] = payload
+
+    bind(Hooked)
+    assert Hooked.hooks.create.PRE_HANDLER
+
+
+@pytest.mark.i9n
+def test_atom_injection():
+    Base.metadata.clear()
+
+    class Gadget(Base, GUIDPk):
+        __tablename__ = "gadgets_atoms"
+        __allow_unmapped__ = True
+
+        name = acol(
+            storage=S(type_=String, nullable=False),
+            io=IO(in_verbs=("create",), out_verbs=("read",)),
+        )
+
+    bind(Gadget)
+    chains = build_phase_chains(Gadget, "create")
+    non_handler = [ph for ph in PHASES if ph != "HANDLER" and chains.get(ph)]
+    assert non_handler
+
+
+@pytest.mark.i9n
+def test_system_step_registry():
+    subjects = runtime_system.subjects()
+    assert ("txn", "begin") in subjects
+    assert ("handler", "crud") in subjects
+    assert ("txn", "commit") in subjects


### PR DESCRIPTION
## Summary
- add integration tests for autoapi v3 op spec attributes

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_v3_opspec_attributes.py`


------
https://chatgpt.com/codex/tasks/task_e_68a571dcaa4083268dd46e481a869a31