### PR TITLE
test: add storage spec integration tests

### DIFF
--- a/pkgs/standards/autoapi/tests/conftest.py
+++ b/pkgs/standards/autoapi/tests/conftest.py
@@ -4,13 +4,17 @@ import pytest
 import pytest_asyncio
 from autoapi.v2 import AutoAPI, Base
 from autoapi.v2.mixins import BulkCapable, GUIDPk
+from autoapi.v3.autoapi import AutoAPI as AutoAPIv3
+from autoapi.v3.tables import Base as Base3
+from autoapi.v3.specs import IO, S, F, acol
+from autoapi.v3.specs.storage_spec import StorageTransform
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
-from sqlalchemy import Column, ForeignKey, String, create_engine
+from sqlalchemy import Column, ForeignKey, Integer, String, create_engine
 from sqlalchemy.pool import StaticPool
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.orm import Mapped, Session, sessionmaker
 
 
 def pytest_addoption(parser):
@@ -200,3 +204,67 @@ def sample_item_data():
         return {"tenant_id": tenant_id, "name": "test-item"}
 
     return _create_item_data
+
+
+@pytest_asyncio.fixture()
+async def api_client_v3():
+    Base3.metadata.clear()
+
+    class Widget(Base3):
+        __tablename__ = "widgets"
+        __allow_unmapped__ = True
+
+        id: Mapped[int] = acol(
+            storage=S(type_=Integer, primary_key=True, autoincrement=True)
+        )
+        name: Mapped[str] = acol(
+            storage=S(type_=String, nullable=False, index=True),
+            field=F(required_in=("create",)),
+            io=IO(
+                in_verbs=("create", "update"),
+                out_verbs=("read", "list"),
+            ),
+        )
+        age: Mapped[int] = acol(
+            storage=S(type_=Integer, nullable=False, default=5),
+            io=IO(
+                in_verbs=("create", "update"),
+                out_verbs=("read", "list"),
+            ),
+        )
+        secret: Mapped[str] = acol(
+            storage=S(
+                type_=String,
+                nullable=False,
+                transform=StorageTransform(to_stored=lambda v, ctx: v.upper()),
+            ),
+            field=F(required_in=("create",)),
+            io=IO(in_verbs=("create",), out_verbs=("read",)),
+        )
+
+        __autoapi_cols__ = {
+            "id": id,
+            "name": name,
+            "age": age,
+            "secret": secret,
+        }
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base3.metadata.create_all)
+    AsyncSessionLocal = async_sessionmaker(
+        bind=engine, class_=AsyncSession, expire_on_commit=False
+    )
+
+    async def get_async_db():
+        async with AsyncSessionLocal() as session:
+            yield session
+
+    app = FastAPI()
+    api = AutoAPIv3(app=app, get_async_db=get_async_db)
+    api.include_model(Widget, prefix="")
+    api.mount_jsonrpc()
+    api.attach_diagnostics()
+    transport = ASGITransport(app=app)
+    client = AsyncClient(transport=transport, base_url="http://test")
+    return client, api, Widget, AsyncSessionLocal

--- a/pkgs/standards/autoapi/tests/i9n/test_storage_spec_integration.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_storage_spec_integration.py
@@ -1,0 +1,126 @@
+import pytest
+from autoapi.v3.core import crud
+from sqlalchemy import String
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_storage_spec_request_response_schema(api_client_v3):
+    client, api, Widget, _ = api_client_v3
+    create_schema = api.schemas.Widget.create.in_
+    read_schema = api.schemas.Widget.read.out
+    assert create_schema.model_fields["name"].is_required()
+    assert not create_schema.model_fields["age"].is_required()
+    assert "secret" in read_schema.model_fields
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_storage_spec_columns(api_client_v3):
+    _, _, Widget, _ = api_client_v3
+    table = Widget.__table__
+    assert table.c.name.nullable is False
+    assert table.c.age.default.arg == 5
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_storage_spec_default_resolution(api_client_v3):
+    client, _, _, _ = api_client_v3
+    resp = await client.post("/Widget", json={"name": "A", "secret": "s"})
+    assert resp.status_code == 201
+    assert resp.json()["age"] == 5
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_storage_spec_internal_orm(api_client_v3):
+    _, api, Widget, _ = api_client_v3
+    assert api.models["Widget"] is Widget
+    assert "age" in api.columns["Widget"]
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_storage_spec_openapi(api_client_v3):
+    client, _, _, _ = api_client_v3
+    spec = (await client.get("/openapi.json")).json()
+    schema = spec["components"]["schemas"]["WidgetCreate"]
+    assert "name" in schema["required"]
+    assert "age" not in schema["required"]
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_storage_spec_storage_sqlalchemy(api_client_v3):
+    client, _, Widget, session_maker = api_client_v3
+    resp = await client.post("/Widget", json={"name": "B", "secret": "abc"})
+    item_id = resp.json()["id"]
+    async with session_maker() as session:
+        await session.get(Widget, item_id)
+        assert isinstance(Widget.__table__.c.name.type, String)
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_storage_spec_rest_calls(api_client_v3):
+    client, _, _, _ = api_client_v3
+    resp = await client.post("/Widget", json={"name": "C", "secret": "xyz"})
+    item_id = resp.json()["id"]
+    read = await client.get(f"/Widget/{item_id}")
+    assert read.status_code == 200
+    assert read.json()["id"] == item_id
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_storage_spec_rpc_methods(api_client_v3):
+    client, _, _, _ = api_client_v3
+    payload = {"name": "rpc", "secret": "mno"}
+    resp = await client.post(
+        "/rpc/",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "Widget.create",
+            "params": payload,
+        },
+    )
+    assert resp.json()["result"]["name"] == "rpc"
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_storage_spec_core_crud(api_client_v3):
+    _, api, Widget, session_maker = api_client_v3
+    async with session_maker() as session:
+        obj = await crud.create(Widget, {"name": "core", "secret": "def"}, db=session)
+        await session.commit()
+    assert obj.age == 5
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_storage_spec_hookz(api_client_v3):
+    client, _, _, _ = api_client_v3
+    hooks = (await client.get("/system/hookz")).json()
+    assert "Widget" in hooks
+    assert "create" in hooks["Widget"]
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_storage_spec_atomz(api_client_v3):
+    client, _, _, _ = api_client_v3
+    planz = (await client.get("/system/planz")).json()
+    steps = planz["Widget"]["create"]
+    assert "autoapi.v3.core.crud.create" in steps
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_storage_spec_system_steps(api_client_v3):
+    client, _, _, _ = api_client_v3
+    planz = (await client.get("/system/planz")).json()
+    assert "Widget" in planz
+    assert "create" in planz["Widget"]


### PR DESCRIPTION
## Summary
- add AutoAPI v3 storage spec integration tests covering schemas, columns, defaults, ORM registration, OpenAPI output, storage, REST and RPC calls, core CRUD, hook diagnostics, runtime atoms, and system plan steps
- add reusable `api_client_v3` fixture for testing AutoAPI v3 models

## Testing
- `uv run --package autoapi --directory . pytest tests/i9n/test_storage_spec_integration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a571ec33388326b6d40b2b2e860d3b