### PR TITLE
test: add schema_ctx op_ctx integration

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/decorators.py
+++ b/pkgs/standards/autoapi/autoapi/v3/decorators.py
@@ -371,13 +371,9 @@ def _wrap_ctx_core(table: type, func: Callable[..., Any]) -> Callable[..., Any]:
     """
 
     async def core(p=None, *, db=None, request=None, ctx: Dict[str, Any] | None = None):
-        ctx = _Ctx.ensure(ctx)
+        ctx = _Ctx.ensure(request=request, db=db, seed=ctx)
         if p is not None:
             ctx["payload"] = p
-        if db is not None:
-            ctx["db"] = db
-        if request is not None:
-            ctx["request"] = request
         bound = func.__get__(table, table)
         res = await _maybe_await(bound(ctx))
         return res if res is not None else ctx.get("result")
@@ -396,11 +392,7 @@ def _wrap_ctx_hook(
     async def hook(
         value=None, *, db=None, request=None, ctx: Dict[str, Any] | None = None
     ):
-        ctx = _Ctx.ensure(ctx)
-        if db is not None:
-            ctx["db"] = db
-        if request is not None:
-            ctx["request"] = request
+        ctx = _Ctx.ensure(request=request, db=db, seed=ctx)
         if io_key is not None and value is not None:
             ctx[io_key] = value
         bound = func.__get__(table, table)

--- a/pkgs/standards/autoapi/tests/i9n/test_schema_ctx_op_ctx_integration.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_schema_ctx_op_ctx_integration.py
@@ -1,0 +1,94 @@
+import pytest
+import pytest_asyncio
+from pydantic import BaseModel
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import Column, String
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from autoapi.v3 import AutoAPI, Base, op_ctx, schema_ctx
+from autoapi.v3.mixins import GUIDPk
+
+
+@pytest_asyncio.fixture
+async def widget_client():
+    Base.metadata.clear()
+
+    class Widget(Base, GUIDPk):
+        __tablename__ = "widgets"
+        name = Column(String, nullable=False)
+
+        @schema_ctx(alias="Echo", kind="in")
+        class EchoIn(BaseModel):
+            name: str
+
+        @schema_ctx(alias="Echo", kind="out")
+        class EchoOut(BaseModel):
+            name: str
+
+        @op_ctx(
+            alias="echo",
+            arity="collection",
+            request_schema="Echo.in",
+            response_schema="Echo.out",
+        )
+        async def echo(cls, ctx):
+            return ctx["payload"]
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    sessionmaker = async_sessionmaker(
+        bind=engine, class_=AsyncSession, expire_on_commit=False
+    )
+
+    async def get_async_db():
+        async with sessionmaker() as session:
+            yield session
+
+    app = FastAPI()
+    api = AutoAPI(app=app, get_async_db=get_async_db)
+    api.include_model(Widget, prefix="")
+    api.mount_jsonrpc()
+    await api.initialize_async()
+
+    client = AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+    return client, api, Widget
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_schema_ctx_binding(widget_client):
+    _, _, Widget = widget_client
+    assert hasattr(Widget.schemas, "Echo")
+    assert Widget.schemas.Echo.in_ is Widget.EchoIn
+    assert Widget.schemas.Echo.out is Widget.EchoOut
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_schema_ctx_openapi(widget_client):
+    client, _, _ = widget_client
+    spec = (await client.get("/openapi.json")).json()
+    paths = spec["paths"]
+    assert "/Widget/echo" in paths
+    schemas = spec["components"]["schemas"]
+    assert "EchoIn" in schemas
+    assert "EchoOut" in schemas
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_schema_ctx_rest_and_rpc(widget_client):
+    client, _, _ = widget_client
+    res = await client.post("/Widget/echo", json={"name": "foo"})
+    assert res.status_code == 200
+    assert res.json() == {"name": "foo"}
+
+    rpc_payload = {
+        "jsonrpc": "2.0",
+        "method": "Widget.echo",
+        "params": {"name": "bar"},
+        "id": 1,
+    }
+    res_rpc = await client.post("/rpc/", json=rpc_payload)
+    assert res_rpc.status_code == 200
+    assert res_rpc.json()["result"] == {"name": "bar"}


### PR DESCRIPTION
## Summary
- fix ctx wrapper seeding of request and db for ctx-only ops and hooks
- add integration tests for schema_ctx with op_ctx alias exposing REST and RPC

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff check autoapi/v3/decorators.py tests/i9n/test_schema_ctx_op_ctx_integration.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_schema_ctx_op_ctx_integration.py`

------
https://chatgpt.com/codex/tasks/task_e_68a5724b27d88326aab1b87cfb403f9b