### PR TITLE
Add tests for runtime atoms

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_emit_paired_post.py
+++ b/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_emit_paired_post.py
@@ -1,0 +1,27 @@
+from types import SimpleNamespace
+
+from autoapi.v3.runtime.atoms.emit import paired_post
+
+
+def test_paired_post_emits_and_scrubs() -> None:
+    temp = {
+        "emit_aliases": {
+            "pre": [
+                {
+                    "field": "token",
+                    "alias": "t",
+                    "source": ("paired_values", "token", "raw"),
+                    "meta": {},
+                }
+            ],
+            "post": [],
+            "read": [],
+        },
+        "paired_values": {"token": {"raw": "abc"}},
+        "response_extras": {},
+    }
+    ctx = SimpleNamespace(persist=True, temp=temp)
+    paired_post.run(None, ctx)
+    assert ctx.temp["response_extras"]["t"] == "abc"
+    assert "raw" not in ctx.temp["paired_values"]["token"]
+    assert ctx.temp["emit_aliases"]["pre"] == []

--- a/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_emit_paired_pre.py
+++ b/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_emit_paired_pre.py
@@ -1,0 +1,12 @@
+from types import SimpleNamespace
+
+from autoapi.v3.runtime.atoms.emit import paired_pre
+
+
+def test_paired_pre_records_descriptor() -> None:
+    temp = {"paired_values": {"token": {"raw": "abc", "alias": "t"}}}
+    ctx = SimpleNamespace(persist=True, specs={}, temp=temp)
+    paired_pre.run(None, ctx)
+    pre = ctx.temp["emit_aliases"]["pre"]
+    assert pre[0]["field"] == "token"
+    assert pre[0]["alias"] == "t"

--- a/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_emit_readtime_alias.py
+++ b/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_emit_readtime_alias.py
@@ -1,0 +1,17 @@
+from types import SimpleNamespace
+
+from autoapi.v3.runtime.atoms.emit import readtime_alias
+
+
+class Col:
+    emit_alias = "hint"
+    sensitive = True
+
+
+def test_readtime_alias_masks_sensitive_value() -> None:
+    specs = {"secret": Col()}
+    temp = {"response_extras": {}, "emit_aliases": {"pre": [], "post": [], "read": []}}
+    ctx = SimpleNamespace(specs=specs, temp=temp)
+    obj = SimpleNamespace(secret="abcd1234")
+    readtime_alias.run(obj, ctx)
+    assert ctx.temp["response_extras"]["hint"] == "••••1234"

--- a/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_out_masking.py
+++ b/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_out_masking.py
@@ -1,0 +1,23 @@
+from types import SimpleNamespace
+
+from autoapi.v3.runtime.atoms.out import masking
+
+
+class SensitiveCol:
+    sensitive = True
+
+
+class PlainCol:
+    sensitive = False
+
+
+def test_out_masking_applies_to_sensitive_fields() -> None:
+    specs = {"secret": SensitiveCol(), "public": PlainCol()}
+    temp = {
+        "response_payload": {"secret": "abcd1234", "token": "abc", "public": "x"},
+        "emit_aliases": {"pre": [], "post": [{"alias": "token"}], "read": []},
+    }
+    ctx = SimpleNamespace(specs=specs, temp=temp)
+    masking.run(None, ctx)
+    assert ctx.temp["response_payload"]["secret"] == "••••1234"
+    assert ctx.temp["response_payload"]["token"] == "abc"

--- a/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_refresh_demand.py
+++ b/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_refresh_demand.py
@@ -1,0 +1,24 @@
+from types import SimpleNamespace
+
+from autoapi.v3.runtime.atoms.refresh import demand
+
+
+class Storage:
+    def __init__(self) -> None:
+        self.server_default = True
+        self.autoincrement = False
+        self.primary_key = False
+
+
+class Col:
+    def __init__(self) -> None:
+        self.storage = Storage()
+
+
+def test_refresh_demand_marks_need() -> None:
+    ctx = SimpleNamespace(
+        persist=True, specs={"id": Col()}, temp={}, cfg=SimpleNamespace()
+    )
+    demand.run(None, ctx)
+    assert ctx.temp["refresh_demand"] is True
+    assert ctx.temp["refresh_fields"] == ("id",)

--- a/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_resolve_assemble.py
+++ b/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_resolve_assemble.py
@@ -1,0 +1,22 @@
+from types import SimpleNamespace
+
+from autoapi.v3.runtime.atoms.resolve import assemble
+
+
+class PersistCol:
+    def __init__(self) -> None:
+        self.storage = object()
+
+
+class VirtualCol:
+    storage = None
+
+
+def test_assemble_separates_virtual_and_persisted() -> None:
+    specs = {"name": PersistCol(), "v": VirtualCol()}
+    ctx = SimpleNamespace(
+        persist=True, specs=specs, temp={"in_values": {"name": "Alice", "v": "x"}}
+    )
+    assemble.run(None, ctx)
+    assert ctx.temp["assembled_values"] == {"name": "Alice"}
+    assert ctx.temp["virtual_in"] == {"v": "x"}

--- a/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_resolve_paired_gen.py
+++ b/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_resolve_paired_gen.py
@@ -1,0 +1,17 @@
+from types import SimpleNamespace
+
+from autoapi.v3.runtime.atoms.resolve import paired_gen
+
+
+class Col:
+    def __init__(self) -> None:
+        self.paired = True
+
+
+def test_generate_paired_value() -> None:
+    ctx = SimpleNamespace(persist=True, specs={"secret": Col()}, temp={})
+    paired_gen.run(None, ctx)
+    pv = ctx.temp["paired_values"]
+    pf = ctx.temp["persist_from_paired"]
+    assert "secret" in pv and "raw" in pv["secret"]
+    assert pf["secret"]["source"] == ("paired_values", "secret", "raw")

--- a/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_schema_collect_in.py
+++ b/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_schema_collect_in.py
@@ -1,0 +1,28 @@
+from types import SimpleNamespace
+
+from autoapi.v3.runtime.atoms.schema import collect_in
+
+
+class Storage:
+    def __init__(self) -> None:
+        self.nullable = False
+
+
+class Col:
+    def __init__(self) -> None:
+        self.storage = Storage()
+        self.alias_in = "alias"
+
+
+class VirtCol:
+    storage = None
+
+
+def test_collect_in_builds_schema() -> None:
+    specs = {"name": Col(), "v": VirtCol()}
+    ctx = SimpleNamespace(specs=specs, op="create", temp={})
+    collect_in.run(None, ctx)
+    schema = ctx.temp["schema_in"]
+    assert schema["by_field"]["name"]["alias_in"] == "alias"
+    assert "name" in schema["required"]
+    assert schema["by_field"]["v"]["virtual"] is True

--- a/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_schema_collect_out.py
+++ b/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_schema_collect_out.py
@@ -1,0 +1,25 @@
+from types import SimpleNamespace
+
+from autoapi.v3.runtime.atoms.schema import collect_out
+
+
+class Storage:
+    def __init__(self) -> None:
+        self.nullable = True
+
+
+class Col:
+    def __init__(self) -> None:
+        self.storage = Storage()
+        self.alias_out = "alias"
+        self.sensitive = True
+
+
+def test_collect_out_registers_alias_and_sensitivity() -> None:
+    specs = {"name": Col()}
+    ctx = SimpleNamespace(specs=specs, temp={})
+    collect_out.run(None, ctx)
+    schema = ctx.temp["schema_out"]
+    assert schema["aliases"]["name"] == "alias"
+    assert schema["by_field"]["name"]["sensitive"] is True
+    assert "name" in schema["expose"]

--- a/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_storage_to_stored.py
+++ b/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_storage_to_stored.py
@@ -1,0 +1,22 @@
+from types import SimpleNamespace
+
+from autoapi.v3.runtime.atoms.storage import to_stored
+
+
+class Col:
+    def derive_from_raw(
+        self, raw: str, ctx: object
+    ) -> str:  # pragma: no cover - simple
+        return raw.upper()
+
+
+def test_to_stored_derives_from_paired_raw() -> None:
+    temp = {
+        "paired_values": {"token": {"raw": "abc"}},
+        "persist_from_paired": {"token": {"source": ("paired_values", "token", "raw")}},
+        "assembled_values": {},
+    }
+    ctx = SimpleNamespace(persist=True, specs={"token": Col()}, temp=temp)
+    to_stored.run(None, ctx)
+    assert ctx.temp["assembled_values"]["token"] == "ABC"
+    assert ctx.temp["storage_log"][0]["action"] == "derived_from_paired"

--- a/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_wire_build_in.py
+++ b/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_wire_build_in.py
@@ -1,0 +1,13 @@
+from types import SimpleNamespace
+
+from autoapi.v3.runtime.atoms.wire import build_in
+
+
+def test_build_in_maps_alias_and_tracks_unknown() -> None:
+    schema_in = {"by_field": {"name": {"alias_in": "n"}}}
+    ctx = SimpleNamespace(
+        temp={"schema_in": schema_in}, in_data={"n": "Bob", "extra": 1}
+    )
+    build_in.run(None, ctx)
+    assert ctx.temp["in_values"] == {"name": "Bob"}
+    assert ctx.temp["in_unknown"] == ("extra",)

--- a/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_wire_build_out.py
+++ b/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_wire_build_out.py
@@ -1,0 +1,26 @@
+from types import SimpleNamespace
+
+from autoapi.v3.runtime.atoms.wire import build_out
+
+
+class PersistCol:
+    def __init__(self) -> None:
+        self.storage = object()
+
+
+class VirtualCol:
+    storage = None
+
+    def read_producer(
+        self, obj: object, ctx: object
+    ) -> str:  # pragma: no cover - simple
+        return "v"
+
+
+def test_build_out_reads_and_produces() -> None:
+    specs = {"id": PersistCol(), "virtual": VirtualCol()}
+    schema_out = {"by_field": {"id": {}, "virtual": {}}, "expose": ("id", "virtual")}
+    ctx = SimpleNamespace(temp={"schema_out": schema_out}, specs=specs)
+    obj = SimpleNamespace(id=1)
+    build_out.run(obj, ctx)
+    assert ctx.temp["out_values"] == {"id": 1, "virtual": "v"}

--- a/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_wire_dump.py
+++ b/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_wire_dump.py
@@ -1,0 +1,14 @@
+from types import SimpleNamespace
+
+from autoapi.v3.runtime.atoms.wire import dump
+
+
+def test_dump_applies_alias_and_omits_nulls() -> None:
+    temp = {
+        "out_values": {"a": None, "b": 1},
+        "schema_out": {"aliases": {"b": "B"}},
+        "response_extras": {"extra": 2},
+    }
+    ctx = SimpleNamespace(temp=temp, cfg=SimpleNamespace(exclude_none=True))
+    dump.run(None, ctx)
+    assert ctx.temp["response_payload"] == {"B": 1, "extra": 2}

--- a/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_wire_validate_in.py
+++ b/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_wire_validate_in.py
@@ -1,0 +1,31 @@
+from types import SimpleNamespace
+
+import pytest
+
+from autoapi.v3.runtime.atoms.wire import validate_in
+
+
+def test_validate_in_missing_required() -> None:
+    schema_in = {"by_field": {}, "required": ("name",)}
+    ctx = SimpleNamespace(temp={"schema_in": schema_in, "in_values": {}}, specs={})
+    with pytest.raises(ValueError):
+        validate_in.run(None, ctx)
+    assert ctx.temp["in_invalid"] is True
+
+
+class Field:
+    py_type = int
+
+
+class Col:
+    field = Field()
+
+
+def test_validate_in_coerces_types() -> None:
+    schema_in = {"by_field": {"age": {}}, "required": ()}
+    ctx = SimpleNamespace(
+        temp={"schema_in": schema_in, "in_values": {"age": "5"}}, specs={"age": Col()}
+    )
+    validate_in.run(None, ctx)
+    assert ctx.temp["in_values"]["age"] == 5
+    assert ctx.temp["in_coerced"] == ("age",)


### PR DESCRIPTION
## Summary
- add unit tests for autoapi runtime atoms
- verify refresh demand, paired generation, inbound/outbound wiring, storage derivation, and masking behaviors

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check tests/unit/runtime/atoms --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/runtime/atoms`


------
https://chatgpt.com/codex/tasks/task_e_68a57324006c83268902d35dfa680ef9