### PR TITLE
test: add schema_ctx integration tests

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_schema_ctx_spec_integration.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_schema_ctx_spec_integration.py
@@ -1,0 +1,216 @@
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from pydantic import BaseModel
+from sqlalchemy import Integer, String
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import Mapped
+
+from autoapi.v3.autoapi import AutoAPI as AutoAPIv3
+from autoapi.v3.tables import Base as Base3
+from autoapi.v3.specs import F, IO, S, acol
+from autoapi.v3.specs.storage_spec import StorageTransform
+from autoapi.v3.decorators import schema_ctx
+from autoapi.v3.core import crud
+
+
+@pytest_asyncio.fixture
+async def schema_ctx_client():
+    Base3.metadata.clear()
+
+    class Widget(Base3):
+        __tablename__ = "widgets"
+        __allow_unmapped__ = True
+
+        id: Mapped[int] = acol(
+            storage=S(type_=Integer, primary_key=True, autoincrement=True)
+        )
+        name: Mapped[str] = acol(
+            storage=S(type_=String, nullable=False),
+            field=F(required_in=("create",)),
+            io=IO(in_verbs=("create", "update"), out_verbs=("read", "list")),
+        )
+        age: Mapped[int] = acol(
+            storage=S(type_=Integer, nullable=False, default=5),
+            io=IO(in_verbs=("create", "update"), out_verbs=("read", "list")),
+        )
+        secret: Mapped[str] = acol(
+            storage=S(
+                type_=String,
+                nullable=False,
+                transform=StorageTransform(to_stored=lambda v, ctx: v.upper()),
+            ),
+            field=F(required_in=("create",)),
+            io=IO(in_verbs=("create",), out_verbs=("read",)),
+        )
+
+        @schema_ctx(alias="create", kind="in")
+        class Create(BaseModel):
+            name: str
+            secret: str
+
+        @schema_ctx(alias="read", kind="out")
+        class Read(BaseModel):
+            id: int
+            name: str
+            age: int
+            secret: str
+
+        __autoapi_cols__ = {
+            "id": id,
+            "name": name,
+            "age": age,
+            "secret": secret,
+        }
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base3.metadata.create_all)
+    SessionLocal = async_sessionmaker(
+        bind=engine, class_=AsyncSession, expire_on_commit=False
+    )
+
+    async def get_async_db():
+        async with SessionLocal() as session:
+            yield session
+
+    app = FastAPI()
+    api = AutoAPIv3(app=app, get_async_db=get_async_db)
+    api.include_model(Widget, prefix="")
+    api.mount_jsonrpc()
+    api.attach_diagnostics()
+    await api.initialize_async()
+    client = AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+    return client, api, Widget, SessionLocal
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_schema_ctx_binding(schema_ctx_client):
+    _, api, Widget, _ = schema_ctx_client
+    assert api.schemas.Widget.create.in_ is Widget.Create
+    assert api.schemas.Widget.read.out is Widget.Read
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_schema_ctx_request_response_schema(schema_ctx_client):
+    _, api, _, _ = schema_ctx_client
+    create_schema = api.schemas.Widget.create.in_
+    read_schema = api.schemas.Widget.read.out
+    assert "secret" in create_schema.model_fields
+    assert "age" in read_schema.model_fields
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_schema_ctx_columns(schema_ctx_client):
+    _, _, Widget, _ = schema_ctx_client
+    table = Widget.__table__
+    assert table.c.name.nullable is False
+    assert table.c.age.default.arg == 5
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_schema_ctx_default_resolution(schema_ctx_client):
+    client, _, _, _ = schema_ctx_client
+    resp = await client.post("/Widget", json={"name": "A", "secret": "s"})
+    assert resp.status_code == 201
+    assert resp.json()["age"] == 5
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_schema_ctx_internal_orm(schema_ctx_client):
+    _, api, Widget, _ = schema_ctx_client
+    assert api.models["Widget"] is Widget
+    assert "age" in api.columns["Widget"]
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_schema_ctx_openapi(schema_ctx_client):
+    client, _, _, _ = schema_ctx_client
+    spec = (await client.get("/openapi.json")).json()
+    components = spec["components"]["schemas"]
+    assert "Create" in components
+    assert "Read" in components
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_schema_ctx_storage_sqlalchemy(schema_ctx_client):
+    client, _, Widget, SessionLocal = schema_ctx_client
+    resp = await client.post("/Widget", json={"name": "B", "secret": "abc"})
+    item_id = resp.json()["id"]
+    async with SessionLocal() as session:
+        obj = await session.get(Widget, item_id)
+        assert obj is not None
+        assert isinstance(Widget.__table__.c.name.type, String)
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_schema_ctx_rest_calls(schema_ctx_client):
+    client, _, _, _ = schema_ctx_client
+    resp = await client.post("/Widget", json={"name": "C", "secret": "xyz"})
+    item_id = resp.json()["id"]
+    read = await client.get(f"/Widget/{item_id}")
+    assert read.status_code == 200
+    assert read.json()["id"] == item_id
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_schema_ctx_rpc_methods(schema_ctx_client):
+    client, _, _, _ = schema_ctx_client
+    payload = {"name": "rpc", "secret": "mno"}
+    res = await client.post(
+        "/rpc/",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "Widget.create",
+            "params": payload,
+        },
+    )
+    assert res.json()["result"]["name"] == "rpc"
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_schema_ctx_core_crud(schema_ctx_client):
+    _, api, Widget, SessionLocal = schema_ctx_client
+    async with SessionLocal() as session:
+        obj = await crud.create(Widget, {"name": "core", "secret": "def"}, db=session)
+        await session.commit()
+    assert obj.age == 5
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_schema_ctx_hookz(schema_ctx_client):
+    client, _, _, _ = schema_ctx_client
+    hooks = (await client.get("/system/hookz")).json()
+    assert "Widget" in hooks
+    assert "create" in hooks["Widget"]
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_schema_ctx_atomz(schema_ctx_client):
+    client, _, _, _ = schema_ctx_client
+    planz = (await client.get("/system/planz")).json()
+    steps = planz["Widget"]["create"]
+    assert "autoapi.v3.core.crud.create" in steps
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_schema_ctx_system_steps(schema_ctx_client):
+    client, _, _, _ = schema_ctx_client
+    planz = (await client.get("/system/planz")).json()
+    assert "Widget" in planz
+    assert "create" in planz["Widget"]


### PR DESCRIPTION
## Summary
- add integration tests covering schema_ctx with AutoAPI v3

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_schema_ctx_spec_integration.py`

------
https://chatgpt.com/codex/tasks/task_e_68a57657266883268d5ae62d86c0b3f5