### PR TITLE
test: add schema_ctx integration coverage

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_schema_ctx_attributes_integration.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_schema_ctx_attributes_integration.py
@@ -1,0 +1,184 @@
+import pytest
+import pytest_asyncio
+from pydantic import BaseModel
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import Column, Integer, String
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from autoapi.v3 import AutoAPI, Base, schema_ctx
+from autoapi.v3.core import crud
+
+
+@pytest_asyncio.fixture
+async def schema_ctx_client():
+    Base.metadata.clear()
+
+    class Widget(Base):
+        __tablename__ = "widgets"
+        id = Column(Integer, primary_key=True, autoincrement=True)
+        name = Column(String, nullable=False)
+        age = Column(Integer, nullable=False, default=5)
+
+        @schema_ctx(alias="create", kind="in")
+        class CreateSchema(BaseModel):
+            name: str
+
+        @schema_ctx(alias="read", kind="out")
+        class ReadSchema(BaseModel):
+            id: int
+            name: str
+            age: int
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    sessionmaker = async_sessionmaker(
+        bind=engine, class_=AsyncSession, expire_on_commit=False
+    )
+
+    async def get_async_db():
+        async with sessionmaker() as session:
+            yield session
+
+    app = FastAPI()
+    api = AutoAPI(app=app, get_async_db=get_async_db)
+    api.include_model(Widget, prefix="")
+    api.mount_jsonrpc()
+    api.attach_diagnostics()
+    await api.initialize_async()
+
+    client = AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+    return client, api, Widget, sessionmaker
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_schema_ctx_bindings(schema_ctx_client):
+    _, _, Widget, _ = schema_ctx_client
+    assert hasattr(Widget.schemas, "create")
+    assert Widget.schemas.create.in_ is Widget.CreateSchema
+    assert Widget.schemas.read.out is Widget.ReadSchema
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_schema_ctx_request_response_schema(schema_ctx_client):
+    _, api, _, _ = schema_ctx_client
+    create_schema = api.schemas.Widget.create.in_
+    read_schema = api.schemas.Widget.read.out
+    assert create_schema.model_fields["name"].is_required()
+    assert "age" in read_schema.model_fields
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_schema_ctx_columns(schema_ctx_client):
+    _, _, Widget, _ = schema_ctx_client
+    table = Widget.__table__
+    assert table.c.name.nullable is False
+    assert table.c.age.default.arg == 5
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_schema_ctx_default_resolution(schema_ctx_client):
+    client, _, _, _ = schema_ctx_client
+    resp = await client.post("/Widget", json={"name": "A"})
+    assert resp.status_code == 201
+    assert resp.json()["age"] == 5
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_schema_ctx_internal_orm(schema_ctx_client):
+    _, api, Widget, _ = schema_ctx_client
+    assert api.models["Widget"] is Widget
+    assert "age" in api.columns["Widget"]
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_schema_ctx_openapi(schema_ctx_client):
+    client, _, _, _ = schema_ctx_client
+    spec = (await client.get("/openapi.json")).json()
+    schemas = spec["components"]["schemas"]
+    assert "CreateSchema" in schemas
+    assert "ReadSchema" in schemas
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_schema_ctx_storage_sqlalchemy(schema_ctx_client):
+    client, _, Widget, sessionmaker = schema_ctx_client
+    resp = await client.post("/Widget", json={"name": "B"})
+    item_id = resp.json()["id"]
+    async with sessionmaker() as session:
+        obj = await session.get(Widget, item_id)
+        assert obj is not None
+        assert isinstance(Widget.__table__.c.name.type, String)
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_schema_ctx_rest_calls(schema_ctx_client):
+    client, _, _, _ = schema_ctx_client
+    resp = await client.post("/Widget", json={"name": "C"})
+    item_id = resp.json()["id"]
+    read = await client.get(f"/Widget/{item_id}")
+    assert read.status_code == 200
+    assert read.json()["id"] == item_id
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_schema_ctx_rpc_methods(schema_ctx_client):
+    client, _, _, _ = schema_ctx_client
+    payload = {"name": "rpc"}
+    resp = await client.post(
+        "/rpc/",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "Widget.create",
+            "params": payload,
+        },
+    )
+    assert resp.json()["result"]["name"] == "rpc"
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_schema_ctx_core_crud(schema_ctx_client):
+    _, _, Widget, sessionmaker = schema_ctx_client
+    async with sessionmaker() as session:
+        obj = await crud.create(Widget, {"name": "core"}, db=session)
+        await session.commit()
+    assert obj.age == 5
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_schema_ctx_hookz(schema_ctx_client):
+    client, _, _, _ = schema_ctx_client
+    hooks = (await client.get("/system/hookz")).json()
+    assert "Widget" in hooks
+    assert "create" in hooks["Widget"]
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_schema_ctx_atomz(schema_ctx_client):
+    client, _, _, _ = schema_ctx_client
+    planz = (await client.get("/system/planz")).json()
+    steps = planz["Widget"]["create"]
+    assert "autoapi.v3.core.crud.create" in steps
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_schema_ctx_system_steps(schema_ctx_client):
+    client, _, _, _ = schema_ctx_client
+    planz = (await client.get("/system/planz")).json()
+    assert "Widget" in planz
+    assert "create" in planz["Widget"]


### PR DESCRIPTION
## Summary
- add integration tests for schema_ctx covering bindings, schemas, storage, and diagnostics

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format tests/i9n/test_schema_ctx_attributes_integration.py`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check tests/i9n/test_schema_ctx_attributes_integration.py --fix`
- `uv run --package autoapi --directory pkgs/standards/autoapi pytest tests/i9n/test_schema_ctx_attributes_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5762996a08326bdc3045381781fcd