### PR TITLE
test: cover system steps in runtime

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_sys_handler_crud.py
+++ b/pkgs/standards/autoapi/tests/unit/test_sys_handler_crud.py
@@ -1,0 +1,86 @@
+from types import SimpleNamespace
+
+import pytest
+
+from autoapi.v3.runtime import system
+from autoapi.v3.runtime.errors import SystemStepError
+
+
+def test_registry_handler_crud_step() -> None:
+    anchor, runner = system.get("handler", "crud")
+    assert anchor == system.HANDLER
+    assert runner is system._sys_handler_crud
+
+
+def test_handler_calls_installed(monkeypatch: pytest.MonkeyPatch) -> None:
+    called = {}
+
+    def installed(obj: object | None, ctx: SimpleNamespace) -> None:
+        called["obj"] = obj
+
+    monkeypatch.setattr(system.INSTALLED, "handler", installed)
+    ctx = SimpleNamespace(temp={})
+    runner = system.get("handler", "crud")[1]
+    runner("payload", ctx)
+    assert called["obj"] == "payload"
+
+
+def test_handler_uses_temp_handler(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(system.INSTALLED, "handler", None)
+
+    def temp_handler(obj: object | None, ctx: SimpleNamespace) -> None:
+        ctx.temp["hit"] = True
+
+    ctx = SimpleNamespace(temp={"handler": temp_handler})
+    runner = system.get("handler", "crud")[1]
+    runner(None, ctx)
+    assert ctx.temp["hit"] is True
+
+
+def test_handler_uses_ctx_handler(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(system.INSTALLED, "handler", None)
+
+    def ctx_handler(obj: object | None, ctx: SimpleNamespace) -> None:
+        ctx.called = True
+
+    ctx = SimpleNamespace(temp={}, handler=ctx_handler)
+    runner = system.get("handler", "crud")[1]
+    runner(None, ctx)
+    assert ctx.called is True
+
+
+def test_handler_uses_model_runtime_handler(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(system.INSTALLED, "handler", None)
+
+    class ModelRuntime:
+        def handler(self, obj: object | None, ctx: SimpleNamespace) -> None:
+            ctx.called = "runtime"
+
+    class Model:
+        runtime = ModelRuntime()
+
+    ctx = SimpleNamespace(temp={}, model=Model())
+    runner = system.get("handler", "crud")[1]
+    runner(None, ctx)
+    assert ctx.called == "runtime"
+
+
+def test_handler_uses_model_handler(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(system.INSTALLED, "handler", None)
+
+    class Model:
+        def handler(self, obj: object | None, ctx: SimpleNamespace) -> None:
+            ctx.called = "model"
+
+    ctx = SimpleNamespace(temp={}, model=Model())
+    runner = system.get("handler", "crud")[1]
+    runner(None, ctx)
+    assert ctx.called == "model"
+
+
+def test_handler_raises_when_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(system.INSTALLED, "handler", None)
+    ctx = SimpleNamespace(temp={})
+    runner = system.get("handler", "crud")[1]
+    with pytest.raises(SystemStepError):
+        runner(None, ctx)

--- a/pkgs/standards/autoapi/tests/unit/test_sys_run_rollback.py
+++ b/pkgs/standards/autoapi/tests/unit/test_sys_run_rollback.py
@@ -1,0 +1,42 @@
+from types import SimpleNamespace
+
+from autoapi.v3.runtime import system
+
+
+def test_run_rollback_calls_installed(monkeypatch) -> None:
+    called = {}
+
+    def fake_rb(ctx: SimpleNamespace, err: BaseException | None) -> None:
+        called["err"] = err
+
+    monkeypatch.setattr(system.INSTALLED, "rollback", fake_rb)
+    ctx = SimpleNamespace()
+    err = RuntimeError("boom")
+    system.run_rollback(ctx, err)
+    assert called.get("err") is err
+
+
+def test_run_rollback_falls_back_to_ctx_session(monkeypatch) -> None:
+    monkeypatch.setattr(system.INSTALLED, "rollback", None)
+
+    class Session:
+        def __init__(self) -> None:
+            self.rolled_back = False
+
+        def rollback(
+            self,
+        ) -> None:  # pragma: no cover - executed via system.run_rollback
+            self.rolled_back = True
+
+    ctx = SimpleNamespace(session=Session())
+    system.run_rollback(ctx, None)
+    assert ctx.session.rolled_back is True
+
+
+def test_run_rollback_swallows_exceptions(monkeypatch) -> None:
+    def bad_rb(ctx: SimpleNamespace, err: BaseException | None) -> None:
+        raise ValueError("fail")
+
+    monkeypatch.setattr(system.INSTALLED, "rollback", bad_rb)
+    ctx = SimpleNamespace()
+    system.run_rollback(ctx, None)  # should not raise

--- a/pkgs/standards/autoapi/tests/unit/test_sys_tx_begin.py
+++ b/pkgs/standards/autoapi/tests/unit/test_sys_tx_begin.py
@@ -1,0 +1,49 @@
+from types import SimpleNamespace
+
+import pytest
+
+from autoapi.v3.runtime import system
+from autoapi.v3.runtime.errors import SystemStepError
+
+
+def test_registry_tx_begin_step() -> None:
+    anchor, runner = system.get("txn", "begin")
+    assert anchor == system.START_TX
+    assert runner is system._sys_tx_begin
+
+
+def test_tx_begin_calls_installed_runner_and_sets_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called = {}
+
+    def fake_begin(ctx: SimpleNamespace) -> None:
+        called["ran"] = True
+
+    monkeypatch.setattr(system.INSTALLED, "begin", fake_begin)
+    ctx = SimpleNamespace(temp={})
+    runner = system.get("txn", "begin")[1]
+    runner(None, ctx)
+    assert called.get("ran") is True
+    assert ctx.temp["__sys_tx_open__"] is True
+
+
+def test_tx_begin_noop_without_installed_runner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(system.INSTALLED, "begin", None)
+    ctx = SimpleNamespace(temp={})
+    runner = system.get("txn", "begin")[1]
+    runner(None, ctx)
+    assert ctx.temp["__sys_tx_open__"] is False
+
+
+def test_tx_begin_wraps_exceptions(monkeypatch: pytest.MonkeyPatch) -> None:
+    def bad_begin(ctx: SimpleNamespace) -> None:
+        raise ValueError("boom")
+
+    monkeypatch.setattr(system.INSTALLED, "begin", bad_begin)
+    ctx = SimpleNamespace(temp={})
+    runner = system.get("txn", "begin")[1]
+    with pytest.raises(SystemStepError):
+        runner(None, ctx)

--- a/pkgs/standards/autoapi/tests/unit/test_sys_tx_commit.py
+++ b/pkgs/standards/autoapi/tests/unit/test_sys_tx_commit.py
@@ -1,0 +1,54 @@
+from types import SimpleNamespace
+
+import pytest
+
+from autoapi.v3.runtime import system
+from autoapi.v3.runtime.errors import SystemStepError
+
+
+def test_registry_tx_commit_step() -> None:
+    anchor, runner = system.get("txn", "commit")
+    assert anchor == system.END_TX
+    assert runner is system._sys_tx_commit
+
+
+def test_tx_commit_calls_installed_when_flag_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called = {}
+
+    def fake_commit(ctx: SimpleNamespace) -> None:
+        called["ran"] = True
+
+    monkeypatch.setattr(system.INSTALLED, "commit", fake_commit)
+    ctx = SimpleNamespace(temp={"__sys_tx_open__": True})
+    runner = system.get("txn", "commit")[1]
+    runner(None, ctx)
+    assert called.get("ran") is True
+    assert ctx.temp["__sys_tx_open__"] is False
+
+
+def test_tx_commit_noop_when_flag_not_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    called = {}
+
+    def fake_commit(ctx: SimpleNamespace) -> None:  # pragma: no cover - should not run
+        called["ran"] = True
+
+    monkeypatch.setattr(system.INSTALLED, "commit", fake_commit)
+    ctx = SimpleNamespace(temp={"__sys_tx_open__": False})
+    runner = system.get("txn", "commit")[1]
+    runner(None, ctx)
+    assert called == {}
+    assert ctx.temp["__sys_tx_open__"] is False
+
+
+def test_tx_commit_wraps_exceptions(monkeypatch: pytest.MonkeyPatch) -> None:
+    def bad_commit(ctx: SimpleNamespace) -> None:
+        raise ValueError("boom")
+
+    monkeypatch.setattr(system.INSTALLED, "commit", bad_commit)
+    ctx = SimpleNamespace(temp={"__sys_tx_open__": True})
+    runner = system.get("txn", "commit")[1]
+    with pytest.raises(SystemStepError):
+        runner(None, ctx)
+    assert ctx.temp["__sys_tx_open__"] is False


### PR DESCRIPTION
## Summary
- add tests for transaction begin step
- add tests for handler resolution order
- add tests for transaction commit step
- add tests for rollback behavior

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff check tests/unit/test_sys_tx_begin.py tests/unit/test_sys_handler_crud.py tests/unit/test_sys_tx_commit.py tests/unit/test_sys_run_rollback.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_sys_tx_begin.py tests/unit/test_sys_handler_crud.py tests/unit/test_sys_tx_commit.py tests/unit/test_sys_run_rollback.py`


------
https://chatgpt.com/codex/tasks/task_e_68a577219bc88326b1c9c2c52daafc79