### PR TITLE
Add runtime plan tests verifying atom behaviors

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/runtime/plan.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/plan.py
@@ -10,7 +10,6 @@ from typing import (
     Iterable,
     List,
     Mapping,
-    MutableMapping,
     Optional,
     Sequence,
     Tuple,
@@ -25,13 +24,15 @@ from . import ordering as _ord
 # Public datatypes
 # ──────────────────────────────────────────────────────────────────────────────
 
+
 @dataclass(frozen=True)
 class AtomNode:
     """
     A single executable atom instance bound to a (model, anchor[, field]).
     """
-    label: _lbl.Label            # atom:domain:subject@anchor[#field]
-    run: Callable[..., Any]      # (obj|None, ctx) -> None/Mutation
+
+    label: _lbl.Label  # atom:domain:subject@anchor[#field]
+    run: Callable[..., Any]  # (obj|None, ctx) -> None/Mutation
     domain: str
     subject: str
     anchor: str
@@ -45,6 +46,7 @@ class Plan:
     System steps (txn begin/commit/handler) are executor-owned; we only inject
     their labels at render/flatten time for diagnostics.
     """
+
     model_name: str
     atoms_by_anchor: Dict[str, Tuple[AtomNode, ...]]
     # Optional pre-phase deps/secdeps (router-level). Only labels are kept here.
@@ -62,6 +64,7 @@ class Plan:
 # ──────────────────────────────────────────────────────────────────────────────
 # Entry points
 # ──────────────────────────────────────────────────────────────────────────────
+
 
 def attach_atoms_for_model(
     model: Any,
@@ -118,8 +121,8 @@ def build_plan(
     per_field_subjects = {
         # wire (contract → wire)
         ("wire", "build_in"),
-        ("wire", "validate"),       # canonical subject (alias of validate_in)
-        ("wire", "validate_in"),    # accept old name if registrar exports it
+        ("wire", "validate"),  # canonical subject (alias of validate_in)
+        ("wire", "validate_in"),  # accept old name if registrar exports it
         ("wire", "build_out"),
         ("wire", "dump"),
         # storage / out
@@ -128,7 +131,9 @@ def build_plan(
     }
     # The rest of the registered atoms are treated as per-model.
 
-    atoms_by_anchor: Dict[str, List[AtomNode]] = {a: [] for a in _ev.all_events_ordered()}
+    atoms_by_anchor: Dict[str, List[AtomNode]] = {
+        a: [] for a in _ev.all_events_ordered()
+    }
 
     # 1) Per-model atoms (single instance)
     for (domain, subject), (anchor, runner) in _ATOM_REGISTRY.items():
@@ -196,16 +201,18 @@ def flattened_order(
 
     # 2) Optional deps/secdeps
     secdep_labels = [_ensure_label(x, kind="secdep") for x in secdeps]
-    dep_labels    = [_ensure_label(x, kind="dep") for x in deps]
+    dep_labels = [_ensure_label(x, kind="dep") for x in deps]
 
     # 3) Optional system steps (labels only; executor owns behavior)
     sys_labels: List[_lbl.Label] = []
     if include_system_steps and persist:
-        sys_labels.extend([
-            _lbl.make_sys("txn:begin", "START_TX"),
-            _lbl.make_sys("handler:crud", "HANDLER"),
-            _lbl.make_sys("txn:commit", "END_TX"),
-        ])
+        sys_labels.extend(
+            [
+                _lbl.make_sys("txn:begin", "START_TX"),
+                _lbl.make_sys("handler:crud", "HANDLER"),
+                _lbl.make_sys("txn:commit", "END_TX"),
+            ]
+        )
 
     # 4) Flatten using canonical ordering
     return _ord.flatten(
@@ -219,9 +226,13 @@ def flattened_order(
 # Internals
 # ──────────────────────────────────────────────────────────────────────────────
 
+
 def _ensure_known_anchor(anchor: str, domain: str, subject: str) -> None:
     if not _ev.is_valid_event(anchor):
-        raise ValueError(f"Atom ({domain}:{subject}) declares unknown anchor {anchor!r}")
+        raise ValueError(
+            f"Atom ({domain}:{subject}) declares unknown anchor {anchor!r}"
+        )
+
 
 def _ensure_label(x: str | _lbl.Label, *, kind: str) -> _lbl.Label:
     if isinstance(x, _lbl.Label):
@@ -230,4 +241,15 @@ def _ensure_label(x: str | _lbl.Label, *, kind: str) -> _lbl.Label:
         return _lbl.make_secdep(x)
     if kind == "dep":
         return _lbl.make_dep(x)
-    raise ValueError(f"Unsupporte
+    raise ValueError(f"Unsupported label kind {kind!r}")
+
+
+def _should_instantiate(
+    domain: str,
+    subject: str,
+    anchor: str,
+    field: str,
+    col: Any,
+) -> bool:
+    """Placeholder predicate for atom instantiation decisions."""
+    return True

--- a/pkgs/standards/autoapi/tests/unit/test_runtime_plan.py
+++ b/pkgs/standards/autoapi/tests/unit/test_runtime_plan.py
@@ -1,0 +1,125 @@
+from autoapi.v3.runtime import plan as runtime_plan
+from autoapi.v3.runtime import labels as _lbl
+from autoapi.v3.runtime import events as _ev
+from autoapi.v3.runtime import atoms as runtime_atoms
+
+
+def test_plan_labels_collects_all_atom_labels():
+    """Plan.labels returns every atom label across all anchors."""
+    node1 = runtime_plan.AtomNode(
+        label=_lbl.make_atom("schema", "collect_in", _ev.SCHEMA_COLLECT_IN),
+        run=lambda *_: None,
+        domain="schema",
+        subject="collect_in",
+        anchor=_ev.SCHEMA_COLLECT_IN,
+    )
+    node2 = runtime_plan.AtomNode(
+        label=_lbl.make_atom("out", "build", _ev.OUT_BUILD, field="field"),
+        run=lambda *_: None,
+        domain="out",
+        subject="build",
+        anchor=_ev.OUT_BUILD,
+        field="field",
+    )
+    plan = runtime_plan.Plan(
+        model_name="M",
+        atoms_by_anchor={
+            _ev.SCHEMA_COLLECT_IN: (node1,),
+            _ev.OUT_BUILD: (node2,),
+        },
+    )
+    assert set(plan.labels()) == {node1.label, node2.label}
+
+
+def test_attach_atoms_for_model_sets_plan_and_runtime(monkeypatch):
+    """attach_atoms_for_model sets the plan and runtime namespace on the model."""
+    dummy_plan = runtime_plan.Plan(model_name="X", atoms_by_anchor={})
+
+    class Model:
+        pass
+
+    monkeypatch.setattr(runtime_plan, "build_plan", lambda *a, **k: dummy_plan)
+    runtime_plan.attach_atoms_for_model(Model, {})
+
+    assert getattr(Model, "_autoapi_plan") is dummy_plan
+    assert hasattr(Model, "runtime")
+    assert Model.runtime.plan is dummy_plan
+
+
+def test_build_plan_creates_per_model_and_per_field_atoms(monkeypatch):
+    """build_plan instantiates per-model and per-field atoms based on registry."""
+    fake_registry = {
+        ("emit", "paired_pre"): (_ev.EMIT_ALIASES_PRE, lambda *_: None),
+        ("wire", "build_in"): (_ev.IN_VALIDATE, lambda *_: None),
+    }
+    monkeypatch.setattr(runtime_atoms, "REGISTRY", fake_registry, raising=False)
+    monkeypatch.setattr(
+        runtime_plan, "_should_instantiate", lambda *a, **k: True, raising=False
+    )
+
+    specs = {"f1": object(), "f2": object()}
+
+    class Model:
+        pass
+
+    plan = runtime_plan.build_plan(Model, specs)
+
+    assert plan.model_name == "Model"
+    assert set(plan.atoms_by_anchor) == {
+        _ev.EMIT_ALIASES_PRE,
+        _ev.IN_VALIDATE,
+    }
+    assert len(plan.atoms_by_anchor[_ev.EMIT_ALIASES_PRE]) == 1
+    assert len(plan.atoms_by_anchor[_ev.IN_VALIDATE]) == 2
+    assert {n.field for n in plan.atoms_by_anchor[_ev.IN_VALIDATE]} == {"f1", "f2"}
+
+
+def test_flattened_order_includes_deps_and_system_steps():
+    """flattened_order adds dep/secdep and system labels in order."""
+    node = runtime_plan.AtomNode(
+        label=_lbl.make_atom("schema", "collect_in", _ev.SCHEMA_COLLECT_IN),
+        run=lambda *_: None,
+        domain="schema",
+        subject="collect_in",
+        anchor=_ev.SCHEMA_COLLECT_IN,
+    )
+    plan = runtime_plan.Plan(
+        model_name="M",
+        atoms_by_anchor={_ev.SCHEMA_COLLECT_IN: (node,)},
+    )
+    labels = runtime_plan.flattened_order(
+        plan,
+        persist=True,
+        include_system_steps=True,
+        secdeps=("a",),
+        deps=("b",),
+    )
+    rendered = [lbl.render() for lbl in labels]
+    assert rendered[:2] == ["secdep:a", "dep:b"]
+    assert rendered[2] == node.label.render()
+    assert rendered[3:] == [
+        "sys:txn:begin@START_TX",
+        "sys:handler:crud@HANDLER",
+        "sys:txn:commit@END_TX",
+    ]
+
+
+def test_flattened_order_omits_system_steps_when_not_persist():
+    """System step labels are skipped when persist is False."""
+    node = runtime_plan.AtomNode(
+        label=_lbl.make_atom("schema", "collect_in", _ev.SCHEMA_COLLECT_IN),
+        run=lambda *_: None,
+        domain="schema",
+        subject="collect_in",
+        anchor=_ev.SCHEMA_COLLECT_IN,
+    )
+    plan = runtime_plan.Plan(
+        model_name="M",
+        atoms_by_anchor={_ev.SCHEMA_COLLECT_IN: (node,)},
+    )
+    labels = runtime_plan.flattened_order(
+        plan,
+        persist=False,
+        include_system_steps=True,
+    )
+    assert all(lbl.kind != "sys" for lbl in labels)


### PR DESCRIPTION
## Summary
- extend runtime plan helper to guard unsupported label kinds and provide instantiation hook
- add comprehensive unit tests for runtime plan atom labeling, model attachment, build logic, and label ordering

## Testing
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff check autoapi/v3/runtime/plan.py tests/unit/test_runtime_plan.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_runtime_plan.py`


------
https://chatgpt.com/codex/tasks/task_e_68a57743434c8326bd9ef7923d08ddee