### PR TITLE
test(autoapi): cover default REST verb endpoints

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_rest_default_op_verbs.py
+++ b/pkgs/standards/autoapi/tests/unit/test_rest_default_op_verbs.py
@@ -1,0 +1,56 @@
+import pytest
+from autoapi.v3.bindings.rest import build_router_and_attach
+from autoapi.v3.mixins import GUIDPk
+from autoapi.v3.opspec import OpSpec
+from autoapi.v3.tables import Base
+from autoapi.v3.types import Column, String
+
+
+def _route_map(router) -> dict[str, tuple[str, set[str]]]:
+    out: dict[str, tuple[str, set[str]]] = {}
+    for r in getattr(router, "routes", []):
+        if hasattr(r, "name"):
+            name = getattr(r, "name")
+            path = getattr(r, "path")
+            methods = set(getattr(r, "methods", []) or [])
+        else:  # pragma: no cover - fallback when FastAPI is missing
+            path, methods, _, opts = r
+            name = opts.get("name")
+            methods = set(methods)
+        if name and "." in name:
+            alias = name.split(".", 1)[1]
+            out[alias] = (path, methods)
+    return out
+
+
+@pytest.mark.parametrize(
+    "alias,target,path,methods",
+    [
+        ("create", "create", "/Item", {"POST"}),
+        ("read", "read", "/Item/{item_id}", {"GET"}),
+        ("update", "update", "/Item/{item_id}", {"PATCH"}),
+        ("replace", "replace", "/Item/{item_id}", {"PUT"}),
+        ("delete", "delete", "/Item/{item_id}", {"DELETE"}),
+        ("list", "list", "/Item", {"GET"}),
+        ("clear", "clear", "/Item", {"DELETE"}),
+        ("bulk_create", "bulk_create", "/Item/bulk", {"POST"}),
+        ("bulk_update", "bulk_update", "/Item/bulk", {"PATCH"}),
+        ("bulk_replace", "bulk_replace", "/Item/bulk", {"PUT"}),
+        ("bulk_delete", "bulk_delete", "/Item/bulk", {"DELETE"}),
+        ("custom_op", "custom", "/Item/custom_op", {"POST"}),
+    ],
+)
+def test_rest_default_op_verbs(alias, target, path, methods):
+    Base.metadata.clear()
+
+    class Item(Base, GUIDPk):
+        __tablename__ = "items"
+        name = Column(String, nullable=False)
+
+    build_router_and_attach(Item, [OpSpec(alias=alias, target=target)])
+
+    routes = _route_map(Item.rest.router)
+    assert alias in routes
+    got_path, got_methods = routes[alias]
+    assert got_path.lower() == path.lower()
+    assert got_methods == methods


### PR DESCRIPTION
## Summary
- add parameterized tests covering default REST verbs in AutoAPI v3

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff format .`
- `uv run --directory standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68a57aabf8308326a2c8b7c0794bab18