### PR TITLE
test: ensure parity between REST and RPC ops in autoapi v3

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_rest_rpc_parity_v3.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_rest_rpc_parity_v3.py
@@ -1,0 +1,143 @@
+import pytest
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_create_parity(api_client_v3):
+    client, _, _, _ = api_client_v3
+    payload = {"name": "gadget", "secret": "sec"}
+
+    rest_resp = await client.post("/Widget", json=payload)
+    rpc_resp = await client.post(
+        "/rpc/",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "Widget.create",
+            "params": payload,
+        },
+    )
+
+    rest_data = rest_resp.json()
+    rpc_data = rpc_resp.json()["result"]
+
+    rest_filtered = {k: v for k, v in rest_data.items() if k != "id"}
+    rpc_filtered = {k: v for k, v in rpc_data.items() if k != "id"}
+    assert rest_filtered == rpc_filtered
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_read_parity(api_client_v3):
+    client, _, _, _ = api_client_v3
+    create_payload = {"name": "reader", "secret": "s1"}
+    created = await client.post("/Widget", json=create_payload)
+    wid = created.json()["id"]
+
+    rest_resp = await client.get(f"/Widget/{wid}")
+    rpc_resp = await client.post(
+        "/rpc/",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "Widget.read",
+            "params": {"id": wid},
+        },
+    )
+
+    assert rest_resp.json() == rpc_resp.json()["result"]
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_delete_parity(api_client_v3):
+    client, _, _, _ = api_client_v3
+    w1 = (await client.post("/Widget", json={"name": "a", "secret": "s"})).json()
+    w2 = (await client.post("/Widget", json={"name": "b", "secret": "s"})).json()
+
+    rest_del = await client.delete(f"/Widget/{w1['id']}")
+    assert rest_del.status_code == 204
+    rpc_read = await client.post(
+        "/rpc/",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "Widget.read",
+            "params": {"id": w1["id"]},
+        },
+    )
+    err = rpc_read.json()["error"]
+    assert err["code"] == -32003
+
+    rpc_del = await client.post(
+        "/rpc/",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "Widget.delete",
+            "params": {"id": w2["id"]},
+        },
+    )
+    assert rpc_del.json()["result"]["deleted"] == 1
+    rest_read = await client.get(f"/Widget/{w2['id']}")
+    assert rest_read.status_code == 404
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_list_parity(api_client_v3):
+    client, _, _, _ = api_client_v3
+    await client.post("/Widget", json={"name": "a", "secret": "s"})
+    await client.post("/Widget", json={"name": "b", "secret": "s"})
+
+    rest_resp = await client.get("/Widget")
+    rpc_resp = await client.post(
+        "/rpc/",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "Widget.list",
+            "params": {"filters": {}},
+        },
+    )
+
+    rest_names = sorted([w["name"] for w in rest_resp.json()])
+    rpc_names = sorted([w["name"] for w in rpc_resp.json()["result"]])
+    assert rest_names == rpc_names == ["a", "b"]
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_clear_parity(api_client_v3):
+    client, _, _, _ = api_client_v3
+    await client.post("/Widget", json={"name": "a", "secret": "s"})
+    await client.post("/Widget", json={"name": "b", "secret": "s"})
+
+    rest_clear = await client.delete("/Widget")
+    assert rest_clear.status_code == 204
+    rpc_list = await client.post(
+        "/rpc/",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "Widget.list",
+            "params": {"filters": {}},
+        },
+    )
+    assert rpc_list.json()["result"] == []
+
+    await client.post("/Widget", json={"name": "c", "secret": "s"})
+    await client.post("/Widget", json={"name": "d", "secret": "s"})
+
+    rpc_clear = await client.post(
+        "/rpc/",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "Widget.clear",
+            "params": {"filters": {}},
+        },
+    )
+    assert rpc_clear.json()["result"]["deleted"] == 2
+    rest_list = await client.get("/Widget")
+    assert rest_list.json() == []


### PR DESCRIPTION
## Summary
- add integration tests checking REST and JSON-RPC parity for default AutoAPI v3 verbs

## Testing
- `uv run --directory pkgs/standards --package autoapi pytest autoapi/tests/i9n/test_rest_rpc_parity_v3.py`

------
https://chatgpt.com/codex/tasks/task_e_68a57ad813d48326acb931409041b08a