### PR TITLE
Add comprehensive tests for runtime plan module

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_runtime_plan.py
+++ b/pkgs/standards/autoapi/tests/unit/test_runtime_plan.py
@@ -1,7 +1,9 @@
-from autoapi.v3.runtime import plan as runtime_plan
-from autoapi.v3.runtime import labels as _lbl
-from autoapi.v3.runtime import events as _ev
+import pytest
+
 from autoapi.v3.runtime import atoms as runtime_atoms
+from autoapi.v3.runtime import events as _ev
+from autoapi.v3.runtime import labels as _lbl
+from autoapi.v3.runtime import plan as runtime_plan
 
 
 def test_plan_labels_collects_all_atom_labels():
@@ -123,3 +125,89 @@ def test_flattened_order_omits_system_steps_when_not_persist():
         include_system_steps=True,
     )
     assert all(lbl.kind != "sys" for lbl in labels)
+
+
+def test_flattened_order_skips_system_steps_when_disabled():
+    """System step labels are omitted when include_system_steps=False."""
+    node = runtime_plan.AtomNode(
+        label=_lbl.make_atom("schema", "collect_in", _ev.SCHEMA_COLLECT_IN),
+        run=lambda *_: None,
+        domain="schema",
+        subject="collect_in",
+        anchor=_ev.SCHEMA_COLLECT_IN,
+    )
+    plan = runtime_plan.Plan(
+        model_name="M",
+        atoms_by_anchor={_ev.SCHEMA_COLLECT_IN: (node,)},
+    )
+    labels = runtime_plan.flattened_order(
+        plan,
+        persist=True,
+        include_system_steps=False,
+    )
+    assert all(lbl.kind != "sys" for lbl in labels)
+
+
+def test_build_plan_respects_only_keys(monkeypatch):
+    """build_plan filters per-field atoms using only_keys."""
+    fake_registry = {("wire", "build_in"): (_ev.IN_VALIDATE, lambda *_: None)}
+    monkeypatch.setattr(runtime_atoms, "REGISTRY", fake_registry, raising=False)
+    monkeypatch.setattr(
+        runtime_plan, "_should_instantiate", lambda *a, **k: True, raising=False
+    )
+
+    specs = {"f1": object(), "f2": object()}
+
+    class Model:
+        pass
+
+    plan = runtime_plan.build_plan(Model, specs, only_keys=["f1"])
+    fields = [n.field for n in plan.atoms_by_anchor[_ev.IN_VALIDATE]]
+    assert fields == ["f1"]
+
+
+@pytest.mark.parametrize(
+    "domain,subject,anchor,field,col",
+    [
+        ("wire", "build_in", "anchor1", "f1", object()),
+        ("out", "masking", "anchor2", "f2", object()),
+    ],
+)
+def test_should_instantiate_always_true(domain, subject, anchor, field, col):
+    """_should_instantiate returns True for any inputs."""
+    assert runtime_plan._should_instantiate(domain, subject, anchor, field, col)
+
+
+def test_ensure_known_anchor_accepts_valid_event():
+    """_ensure_known_anchor passes for known event names."""
+    runtime_plan._ensure_known_anchor(_ev.SCHEMA_COLLECT_IN, "schema", "collect_in")
+
+
+def test_ensure_known_anchor_rejects_unknown_event():
+    """_ensure_known_anchor raises for unknown event names."""
+    with pytest.raises(ValueError):
+        runtime_plan._ensure_known_anchor("bogus", "schema", "collect_in")
+
+
+@pytest.mark.parametrize(
+    "raw,kind,maker",
+    [
+        ("a", "secdep", _lbl.make_secdep),
+        ("b", "dep", _lbl.make_dep),
+    ],
+)
+def test_ensure_label_wraps_strings(raw, kind, maker):
+    """_ensure_label wraps strings into the appropriate label types."""
+    assert runtime_plan._ensure_label(raw, kind=kind) == maker(raw)
+
+
+def test_ensure_label_returns_existing_label():
+    """_ensure_label returns Label instances unchanged."""
+    label = _lbl.make_atom("schema", "collect_in", _ev.SCHEMA_COLLECT_IN)
+    assert runtime_plan._ensure_label(label, kind="dep") is label
+
+
+def test_ensure_label_invalid_kind_raises():
+    """_ensure_label errors on unsupported kinds."""
+    with pytest.raises(ValueError):
+        runtime_plan._ensure_label("x", kind="other")


### PR DESCRIPTION
## Summary
- extend runtime plan tests for system-step control and field filtering
- validate _should_instantiate, _ensure_known_anchor, and _ensure_label helpers

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_runtime_plan.py`

------
https://chatgpt.com/codex/tasks/task_e_68a57b48565c832691b28d1bcd212721