### PR TITLE
Fix missing import in swarmauri performance test

### DIFF
--- a/pkgs/swarmauri/tests/test_performance.py
+++ b/pkgs/swarmauri/tests/test_performance.py
@@ -8,6 +8,7 @@ import types
 from importlib.metadata import EntryPoint
 
 from swarmauri.plugin_citizenship_registry import PluginCitizenshipRegistry
+from swarmauri.plugin_manager import invalidate_entry_point_cache
 
 
 def test_startup_and_first_class_registration_performance() -> None:


### PR DESCRIPTION
## Summary
- ensure `invalidate_entry_point_cache` is imported in performance tests

## Testing
- `uv run --package swarmauri --directory swarmauri ruff format .`
- `uv run --package swarmauri --directory swarmauri ruff check . --fix`
- `uv run --package swarmauri --directory swarmauri pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a57c5e53cc8326af971b510ea48367