### PR TITLE
feat: preserve quotes during JAML loading

### DIFF
--- a/pkgs/jaml/jaml/_config.py
+++ b/pkgs/jaml/jaml/_config.py
@@ -332,7 +332,7 @@ class Config(MutableMapping):
     dump = staticmethod(lambda obj, fp: fp.write(Config.dumps(obj)))  # type: ignore
 
     # ───────────────────────────────────────────────────────── resolution
-    def resolve(self) -> Dict[str, Any]:
+    def resolve(self, strip_quotes: bool = True) -> Dict[str, Any]:
         logger.debug("\n\n\n\n⮕ [resolve] entered...")
         from ._eval import safe_eval
         from ._fstring import _eval_fstrings
@@ -464,7 +464,7 @@ class Config(MutableMapping):
                 final[k] = v
             else:
                 final[k] = _expand(v, collapsed)
-        return _strip_quotes(final)
+        return _strip_quotes(final) if strip_quotes else final
 
     def render(self, context: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """

--- a/pkgs/jaml/jaml/api.py
+++ b/pkgs/jaml/jaml/api.py
@@ -80,7 +80,8 @@ def loads(s: str) -> Dict[str, Any]:
     transformer = ConfigTransformer()
     transformer._context = type("Context", (), {"text": s})
     config = transformer.transform(parse_tree)
-    return config.resolve()  # Resolve and return plain dictionary
+    # Preserve surrounding quotes during load to match specification tests
+    return config.resolve(strip_quotes=False)
 
 
 def load(fp: IO[str]) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- allow optional retention of quotes in `Config.resolve`
- preserve string quoting when using `jaml.loads`

## Testing
- `uv run --package jaml --directory jaml ruff check . --fix`
- `uv run --package jaml --directory jaml pytest 'tests/spec/(MEP-0006) whitespace_test.py::test_trailing_whitespace_after_value_ignored' -q`


------
https://chatgpt.com/codex/tasks/task_e_68a57c5e53cc8326af971b510ea48367