### PR TITLE
Fix autoapi bindings tests and col_info frozenset handling

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/schema/col_info.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/col_info.py
@@ -131,7 +131,7 @@ def _normalize_read_only(ro: Any, *, model: str, attr: str):
 def _normalize_disable_on(disable_on: Any, *, model: str, attr: str) -> frozenset[str]:
     if disable_on is None:
         return frozenset()
-    if not isinstance(disable_on, (set, list, tuple)):
+    if not isinstance(disable_on, (set, list, tuple, frozenset)):
         raise _err_ctx(
             model,
             attr,

--- a/pkgs/standards/autoapi/tests/i9n/test_bindings_modules.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_bindings_modules.py
@@ -3,7 +3,8 @@ from types import SimpleNamespace
 
 import pytest
 from sqlalchemy import Integer, String
-from sqlalchemy.orm import declarative_base
+from sqlalchemy.orm.attributes import InstrumentedAttribute
+from autoapi.v3.tables import Base
 
 from autoapi.v3.bindings import (
     api as api_binding,
@@ -21,10 +22,9 @@ from autoapi.v3.runtime import executor as _executor
 from autoapi.v3.specs import shortcuts as sc
 
 
-Base = declarative_base()
-
-
 def _make_model():
+    Base.metadata.clear()
+
     class Item(Base):  # type: ignore[misc]
         __tablename__ = "items"
 
@@ -60,9 +60,7 @@ def test_columns_build_and_attach(model_cls):
     columns_binding.build_and_attach(model_cls)
     assert hasattr(model_cls, "__autoapi_cols__")
     assert "name" in model_cls.__autoapi_cols__
-    from sqlalchemy import Column
-
-    assert isinstance(model_cls.__dict__["name"], Column)
+    assert isinstance(model_cls.__dict__["name"], InstrumentedAttribute)
 
 
 @pytest.mark.i9n


### PR DESCRIPTION
## Summary
- handle `frozenset` in `col_info._normalize_disable_on`
- update bindings integration tests to use AutoAPI Base and reset metadata

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_bindings_modules.py`


------
https://chatgpt.com/codex/tasks/task_e_68a57c7c51048326bc849e34f4663841