### PR TITLE
Fix autoapi core CRUD test to expect dict response

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_field_spec_effects.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_field_spec_effects.py
@@ -104,7 +104,7 @@ async def test_field_spec_core_crud_create(fs_app):
     _, api, SessionLocal, FSItem = fs_app
     with SessionLocal() as session:
         obj = await api.core.FSItem.create({"name": "hi"}, db=session)
-        assert obj.name == "hi"
+        assert obj["name"] == "hi"
 
 
 @pytest.mark.i9n


### PR DESCRIPTION
## Summary
- fix field spec integration test to expect dict output from `api.core` create helper

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_field_spec_effects.py`


------
https://chatgpt.com/codex/tasks/task_e_68a57c833e8c832694121511adb2f0e7