### PR TITLE
fix: return raw models from core helpers

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/api.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/api.py
@@ -15,6 +15,7 @@ from typing import (
 )
 
 from . import model as _binder  # bind(model) → builds/attaches namespaces
+from .rpc import _coerce_payload, _get_phase_chains, _validate_input
 from ..config.constants import (
     AUTOAPI_AUTH_DEP_ATTR,
     AUTOAPI_AUTHORIZE_ATTR,
@@ -23,6 +24,7 @@ from ..config.constants import (
     AUTOAPI_REST_DEPENDENCIES_ATTR,
     AUTOAPI_RPC_DEPENDENCIES_ATTR,
 )
+from ..runtime import executor as _executor
 
 logger = logging.getLogger(__name__)
 
@@ -95,24 +97,21 @@ def _ensure_api_ns(api: ApiLike) -> None:
 
 
 class _ResourceProxy:
-    """
-    Lightweight dynamic proxy that forwards calls to model.rpc.<alias>.
-    We resolve methods lazily so new/changed ops after rebinds are visible.
-    """
+    """Dynamic proxy that executes core operations without output serialization."""
 
     __slots__ = ("_model",)
 
-    def __init__(self, model: type) -> None:
+    def __init__(self, model: type) -> None:  # pragma: no cover - trivial
         self._model = model
 
-    def __repr__(self) -> str:
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
         return f"<ResourceProxy {self._model.__name__}>"
 
     def __getattr__(self, alias: str) -> Callable[..., Awaitable[Any]]:
-        rpc_ns = getattr(self._model, "rpc", None)
-        target = getattr(rpc_ns, alias, None)
-        if target is None:
-            raise AttributeError(f"{self._model.__name__} has no RPC method '{alias}'")
+        handlers_root = getattr(self._model, "handlers", None)
+        h_alias = getattr(handlers_root, alias, None) if handlers_root else None
+        if h_alias is None or not hasattr(h_alias, "core"):
+            raise AttributeError(f"{self._model.__name__} has no core method '{alias}'")
 
         async def _call(
             payload: Any = None,
@@ -121,11 +120,30 @@ class _ResourceProxy:
             request: Any = None,
             ctx: Optional[Dict[str, Any]] = None,
         ) -> Any:
-            return await target(payload, db=db, request=request, ctx=ctx)
+            raw_payload = _coerce_payload(payload)
+            norm_payload = _validate_input(self._model, alias, alias, raw_payload)
+            base_ctx: Dict[str, Any] = dict(ctx or {})
+            base_ctx.setdefault("payload", norm_payload)
+            base_ctx.setdefault("db", db)
+            if request is not None:
+                base_ctx.setdefault("request", request)
+            base_ctx.setdefault(
+                "env",
+                SimpleNamespace(
+                    method=alias, params=norm_payload, target=alias, model=self._model
+                ),
+            )
+            phases = _get_phase_chains(self._model, alias)
+            return await _executor._invoke(
+                request=request,
+                db=db,
+                phases=phases,
+                ctx=base_ctx,
+            )
 
         _call.__name__ = f"{self._model.__name__}.{alias}"
         _call.__qualname__ = _call.__name__
-        _call.__doc__ = f"Helper for RPC call {self._model.__name__}.{alias}"
+        _call.__doc__ = f"Helper for core call {self._model.__name__}.{alias}"
         return _call
 
 


### PR DESCRIPTION
## Summary
- ensure `api.core` helpers return raw ORM models instead of serialized dicts

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_field_spec_effects.py`


------
https://chatgpt.com/codex/tasks/task_e_68a57c833e8c832694121511adb2f0e7