### PR TITLE
fix autoapi hook ctx behavior

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/api.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/api.py
@@ -47,8 +47,19 @@ def _resource_name(model: type) -> str:
 
 
 def _default_prefix(model: type) -> str:
-    # Router prefix will be '/<ModelClassName>' unless __resource__ overrides it.
-    return f"/{_resource_name(model)}"
+    """Default mount prefix for a model router.
+
+    The router paths produced by :mod:`bindings.rest` already include the
+    resource name (e.g. ``/Item``). Mounting again at ``/{resource}`` results in
+    duplicated segments such as ``/Item/Item`` and ultimately 404 responses for
+    requests like ``POST /Item``.  Returning an empty string ensures the router
+    is mounted at the API root unless the caller explicitly provides a prefix.
+    """
+
+    # Historically AutoAPI v3 mounted routers at ``/{ModelClassName}``.  The
+    # v3 router now emits fully-qualified paths, so the default mount prefix
+    # must be empty to avoid double prefixes.
+    return ""
 
 
 def _has_include_router(obj: Any) -> bool:

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rpc.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rpc.py
@@ -197,8 +197,10 @@ def _build_rpc_callable(model: type, sp: OpSpec) -> Callable[..., Awaitable[Any]
         )
 
         phases = _get_phase_chains(model, alias)
-
-        # 3) run executor + shape output
+        base_ctx["response_serializer"] = lambda r: _serialize_output(
+            model, alias, target, r
+        )
+        # 3) run executor
         result = await _executor._invoke(
             request=request,
             db=db,
@@ -206,7 +208,7 @@ def _build_rpc_callable(model: type, sp: OpSpec) -> Callable[..., Awaitable[Any]
             ctx=base_ctx,
         )
 
-        return _serialize_output(model, alias, target, result)
+        return result
 
     # Give the callable a nice name for introspection/logging
     _rpc_method.__name__ = f"rpc_{model.__name__}_{alias}"

--- a/pkgs/standards/autoapi/autoapi/v3/decorators.py
+++ b/pkgs/standards/autoapi/autoapi/v3/decorators.py
@@ -401,6 +401,8 @@ def _wrap_ctx_hook(
             return None
         return ctx.get(io_key, value)
 
+    hook.__name__ = getattr(func, "__name__", "hook")
+    hook.__qualname__ = getattr(func, "__qualname__", hook.__name__)
     return hook
 
 


### PR DESCRIPTION
## Summary
- avoid double mount prefixes and widen schema verb inclusion
- ensure hooks receive serialized responses and proper context
- relax JSON-RPC input/path handling for `/rpc`

## Testing
- `uv run --package autoapi --directory standards ruff check autoapi/v3/bindings/rest.py autoapi/v3/runtime/executor.py autoapi/v3/bindings/hooks.py autoapi/v3/schema/builder.py autoapi/v3/bindings/api.py --fix`
- `uv run --package autoapi --directory standards pytest autoapi/tests/i9n/test_hook_ctx_v3_i9n.py`


------
https://chatgpt.com/codex/tasks/task_e_68a57c8ae0ec8326a3757c497e7f1f54