### PR TITLE
Deprecate autoapi v3 col_info

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/col_info.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/col_info.py
@@ -8,6 +8,8 @@ This will be fully deprecated in place of ColumnSpecs.
 
 from __future__ import annotations
 
+import warnings
+
 from ..schema.col_info import (
     VALID_KEYS,
     VALID_VERBS,
@@ -16,6 +18,13 @@ from ..schema.col_info import (
     check,
     should_include_in_input,
     should_include_in_output,
+)
+
+warnings.warn(
+    "autoapi.v3.bindings.col_info is deprecated; Column.info['autoapi'] will be removed. "
+    "Use ColumnSpecs instead.",
+    DeprecationWarning,
+    stacklevel=2,
 )
 
 __all__ = [

--- a/pkgs/standards/autoapi/autoapi/v3/schema/col_info.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/col_info.py
@@ -19,9 +19,18 @@ Typical usage in the schema builder:
 
 from __future__ import annotations
 
+import warnings
+
 from typing import Any, Mapping
 
 from ..opspec.types import CANON
+
+warnings.warn(
+    "autoapi.v3.schema.col_info is deprecated; Column.info['autoapi'] will be removed. "
+    "Use ColumnSpecs instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 # ───────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add deprecation warnings for autoapi v3 col_info to steer away from Column.info['autoapi'] toward ColumnSpecs

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest` *(fails: Table 'widgets' is already defined for this MetaData instance)*

------
https://chatgpt.com/codex/tasks/task_e_68a5885d6c588326b1e9832ae08ed82a