### PR TITLE
fix: use json_schema_extra for pydantic literal

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/jsonrpc_models.py
+++ b/pkgs/standards/autoapi/autoapi/v2/jsonrpc_models.py
@@ -134,14 +134,14 @@ def create_standardized_error(
 
 
 class _RPCReq(BaseModel):
-    jsonrpc: str = Field(default="2.0", Literal=True)
+    jsonrpc: str = Field(default="2.0", json_schema_extra={"Literal": True})
     method: str
     params: dict = {}
     id: str | int | None = str(uuid.uuid4())
 
 
 class _RPCRes(BaseModel):
-    jsonrpc: str = Field(default="2.0", Literal=True)
+    jsonrpc: str = Field(default="2.0", json_schema_extra={"Literal": True})
     result: Any | None = None
     error: dict | None = None
     id: str | int | None = None

--- a/pkgs/standards/peagen/peagen/handlers/keys_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/keys_handler.py
@@ -21,26 +21,26 @@ class _Base(BaseModel):
 
 
 class _Create(_Base):
-    action: str = Field("create", Literal=True)
+    action: str = Field("create", json_schema_extra={"Literal": True})
     key_dir: Path | None = None
     passphrase: str | None = None
 
 
 class _Upload(_Base):
-    action: str = Field("upload", Literal=True)
+    action: str = Field("upload", json_schema_extra={"Literal": True})
     key_dir: Path | None = None
     passphrase: str | None = None
     gateway_url: str = DEFAULT_GATEWAY
 
 
 class _Remove(_Base):
-    action: str = Field("remove", Literal=True)
+    action: str = Field("remove", json_schema_extra={"Literal": True})
     fingerprint: str
     gateway_url: str = DEFAULT_GATEWAY
 
 
 class _Fetch(_Base):
-    action: str = Field("fetch-server", Literal=True)
+    action: str = Field("fetch-server", json_schema_extra={"Literal": True})
     gateway_url: str = DEFAULT_GATEWAY
 
 


### PR DESCRIPTION
## Summary
- address PydanticDeprecatedSince20 warnings by moving custom `Literal` metadata into `json_schema_extra`

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff check autoapi/v2/jsonrpc_models.py --fix`
- `uv run --package peagen --directory standards/peagen ruff check peagen/handlers/keys_handler.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_68a58a9359488326b83830bd8d7422c3