### PR TITLE
feat(autoapi): show system steps in planz

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_iospec_integration.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_iospec_integration.py
@@ -177,4 +177,4 @@ async def test_planz_lists_atoms_and_steps(widget_setup):
     data = (await client.get("/system/planz")).json()
     steps = data["Widget"]["create"]
     assert any("crud.create" in s for s in steps)
-    assert any("start_tx" in s for s in steps)
+    assert any("sys:txn:begin@START_TX" in s for s in steps)


### PR DESCRIPTION
## Summary
- include system step labels in `/planz` diagnostics output
- adjust diagnostics tests for new system labels

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_planz_endpoint.py tests/i9n/test_iospec_integration.py::test_planz_lists_atoms_and_steps`


------
https://chatgpt.com/codex/tasks/task_e_68a58b2f32dc8326ad9fc1127672db35