### PR TITLE
Use UUID for JSON-RPC ids

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v2/jsonrpc_models.py
+++ b/pkgs/standards/autoapi/autoapi/v2/jsonrpc_models.py
@@ -3,7 +3,7 @@ from typing import (
 )
 from fastapi import HTTPException
 from pydantic import BaseModel, Field
-import uuid
+from uuid import UUID, uuid4
 
 # ───────────────────── Centralized Error Mappings ────────────────────────────
 
@@ -137,14 +137,20 @@ class _RPCReq(BaseModel):
     jsonrpc: str = Field(default="2.0", json_schema_extra={"Literal": True})
     method: str
     params: dict = {}
-    id: str | int | None = str(uuid.uuid4())
+    id: UUID | None = Field(
+        default_factory=uuid4,
+        examples=[uuid4()],
+    )
 
 
 class _RPCRes(BaseModel):
     jsonrpc: str = Field(default="2.0", json_schema_extra={"Literal": True})
     result: Any | None = None
     error: dict | None = None
-    id: str | int | None = None
+    id: UUID | None = Field(
+        default=None,
+        examples=[uuid4()],
+    )
 
 
 def _ok(x: Any, q: _RPCReq) -> _RPCRes:

--- a/pkgs/standards/autoapi/autoapi/v3/transport/jsonrpc/models.py
+++ b/pkgs/standards/autoapi/autoapi/v3/transport/jsonrpc/models.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from typing import Any, Literal
-import uuid
+from uuid import UUID, uuid4
+
 from pydantic import BaseModel, Field
 
 
@@ -11,7 +12,10 @@ class RPCRequest(BaseModel):
     jsonrpc: Literal["2.0"] = "2.0"
     method: str
     params: dict[str, Any] = Field(default_factory=dict)
-    id: str | int | None = Field(default_factory=lambda: str(uuid.uuid4()))
+    id: UUID | None = Field(
+        default_factory=uuid4,
+        examples=[uuid4()],
+    )
 
 
 class RPCError(BaseModel):
@@ -26,4 +30,7 @@ class RPCResponse(BaseModel):
     jsonrpc: Literal["2.0"] = "2.0"
     result: Any | None = None
     error: RPCError | None = None
-    id: str | int | None = None
+    id: UUID | None = Field(
+        default=None,
+        examples=[uuid4()],
+    )


### PR DESCRIPTION
## Summary
- switch JSON-RPC request/response id to UUID
- add UUID examples for request/response ids

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68a58fe534e4832699c37c2374666c8c