### PR TITLE
fix: return 409 on unique constraint errors

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/runtime/errors.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/errors.py
@@ -365,10 +365,10 @@ def _classify_exception(
         return status.HTTP_404_NOT_FOUND, "Resource not found", None
 
     if _is_asyncpg_constraint_error(exc):
-        return status.HTTP_422_UNPROCESSABLE_ENTITY, _stringify_exc(exc), None
+        return status.HTTP_409_CONFLICT, _stringify_exc(exc), None
 
     if (IntegrityError is not None) and isinstance(exc, IntegrityError):
-        return status.HTTP_422_UNPROCESSABLE_ENTITY, _stringify_exc(exc), None
+        return status.HTTP_409_CONFLICT, _stringify_exc(exc), None
 
     if (OperationalError is not None) and isinstance(exc, OperationalError):
         return status.HTTP_503_SERVICE_UNAVAILABLE, _stringify_exc(exc), None

--- a/pkgs/standards/autoapi/tests/i9n/test_core_access.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_core_access.py
@@ -267,8 +267,8 @@ class TestApiCore:
                     api.core.CoreTestUser.create(duplicate_schema, db)
                     db.flush()
 
-        # SQLite returns 422 for constraint violations, PostgreSQL returns 409
-        assert exc_info.value.status_code in (409, 422)
+        # Constraint violations should surface as HTTP 409
+        assert exc_info.value.status_code == 409
 
     def test_sync_core_manual_transaction_rollback(self, sync_api):
         """Test manual transaction rollback with api.core and schema validation."""
@@ -556,8 +556,8 @@ class TestCoreRawEdgeCases:
                 )
                 db.commit()  # This should trigger the constraint violation
 
-        # SQLite returns 422 for constraint violations, PostgreSQL returns 409
-        assert exc_info.value.status_code in (409, 422)
+        # Constraint violations should surface as HTTP 409
+        assert exc_info.value.status_code == 409
 
 
 class TestCoreVsCoreRawComparison:


### PR DESCRIPTION
## Summary
- map DB constraint violations to HTTP 409 in AutoAPI v3
- update integration tests to expect 409 on duplicates

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff format .`
- `uv run --directory standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68a59121047c8326ab17eb965fb5fc76