### PR TITLE
Generate new JSON-RPC id example for each Swagger call

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/transport/jsonrpc/models.py
+++ b/pkgs/standards/autoapi/autoapi/v3/transport/jsonrpc/models.py
@@ -6,6 +6,11 @@ from uuid import UUID, uuid4
 from pydantic import BaseModel, Field
 
 
+def _uuid_examples(schema: dict[str, Any]) -> None:
+    """Populate schema examples with a random UUID."""
+    schema["examples"] = [str(uuid4())]
+
+
 class RPCRequest(BaseModel):
     """JSON-RPC 2.0 request envelope."""
 
@@ -14,7 +19,7 @@ class RPCRequest(BaseModel):
     params: dict[str, Any] = Field(default_factory=dict)
     id: UUID | None = Field(
         default_factory=uuid4,
-        examples=[uuid4()],
+        json_schema_extra=_uuid_examples,
     )
 
 
@@ -32,5 +37,5 @@ class RPCResponse(BaseModel):
     error: RPCError | None = None
     id: UUID | None = Field(
         default=None,
-        examples=[uuid4()],
+        json_schema_extra=_uuid_examples,
     )

--- a/pkgs/standards/autoapi/tests/unit/test_jsonrpc_id_example.py
+++ b/pkgs/standards/autoapi/tests/unit/test_jsonrpc_id_example.py
@@ -1,0 +1,9 @@
+from autoapi.v3.transport.jsonrpc.models import RPCRequest
+
+
+def test_rpc_request_id_example_changes():
+    schema1 = RPCRequest.model_json_schema()
+    schema2 = RPCRequest.model_json_schema()
+    example1 = schema1["properties"]["id"]["examples"][0]
+    example2 = schema2["properties"]["id"]["examples"][0]
+    assert example1 != example2


### PR DESCRIPTION
## Summary
- ensure JSON-RPC request and response models populate UUID id example dynamically
- add unit test verifying JSON-RPC id example changes between schema generations

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_jsonrpc_id_example.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5946e562c8326b0b099eb1771e23c