### PR TITLE
fix: normalize autoapi REST resource paths

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/api.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/api.py
@@ -15,7 +15,7 @@ from typing import (
 )
 
 from . import model as _binder  # bind(model) → builds/attaches namespaces
-from .rpc import _coerce_payload, _get_phase_chains, _validate_input
+from .rpc import _coerce_payload, _get_phase_chains, _validate_input, _serialize_output
 from ..config.constants import (
     AUTOAPI_AUTH_DEP_ATTR,
     AUTOAPI_AUTHORIZE_ATTR,
@@ -143,6 +143,10 @@ class _ResourceProxy:
                 SimpleNamespace(
                     method=alias, params=norm_payload, target=alias, model=self._model
                 ),
+            )
+            base_ctx.setdefault(
+                "response_serializer",
+                lambda r: _serialize_output(self._model, alias, alias, r),
             )
             phases = _get_phase_chains(self._model, alias)
             return await _executor._invoke(

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
@@ -107,7 +107,7 @@ def _resource_name(model: type) -> str:
     override or fall back to the model class name.
     """
     override = getattr(model, "__resource__", None)
-    return override or model.__name__
+    return override or model.__name__.lower()
 
 
 def _pk_name(model: type) -> str:


### PR DESCRIPTION
## Summary
- ensure autoapi REST resource names default to lowercase
- serialize core CRUD responses so hooks can mutate results

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff format .`
- `uv run --directory standards/autoapi --package autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_hook_ctx_v3_i9n.py`


------
https://chatgpt.com/codex/tasks/task_e_68a59a10241c83268670588166a70bdc