### PR TITLE
fix: expose handler phase chain in handlers namespace

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/handlers.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/handlers.py
@@ -57,6 +57,10 @@ def _ensure_alias_handlers_ns(model: type, alias: str) -> SimpleNamespace:
     if ns is None:
         ns = SimpleNamespace()
         setattr(handlers_root, alias, ns)
+    # Mirror the HANDLER phase chain from hooks namespace for back-compat
+    hooks_ns = _ensure_alias_hooks_ns(model, alias)
+    if not hasattr(ns, "HANDLER"):
+        setattr(ns, "HANDLER", getattr(hooks_ns, "HANDLER"))
     return ns
 
 


### PR DESCRIPTION
## Summary
- ensure autoapi exposes handler phase chain on `model.handlers.<alias>.HANDLER`
- verify handler alias support via tests

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_alias_ctx_op_alias_attributes.py`


------
https://chatgpt.com/codex/tasks/task_e_68a59a6c4f0883269f446e9525e8fc9b