### PR TITLE
fix(auto_kms): normalize algorithm before encrypt/decrypt

### DIFF
--- a/pkgs/standards/auto_kms/tests/unit/test_algorithm_mapping.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_algorithm_mapping.py
@@ -1,0 +1,76 @@
+import base64
+import importlib
+import asyncio
+import types
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+from autoapi.v3.tables import Base
+
+
+def _create_key(client, name="k1"):
+    payload = {"name": name, "algorithm": "AES256_GCM"}
+    res = client.post("/kms/Key", json=payload)
+    assert res.status_code == 200
+    return res.json()
+
+
+@pytest.fixture
+def client_kid(tmp_path, monkeypatch):
+    mod1 = types.ModuleType("swarmauri_secret_autogpg")
+
+    class DummySecretDrive: ...
+
+    mod1.AutoGpgSecretDrive = DummySecretDrive
+    sys.modules["swarmauri_secret_autogpg"] = mod1
+
+    mod2 = types.ModuleType("swarmauri_crypto_paramiko")
+
+    class DummyParamikoCrypto: ...
+
+    mod2.ParamikoCrypto = DummyParamikoCrypto
+    sys.modules["swarmauri_crypto_paramiko"] = mod2
+
+    db_path = tmp_path / "kms.db"
+    monkeypatch.setenv("KMS_DATABASE_URL", f"sqlite+aiosqlite:///{db_path}")
+
+    app = importlib.reload(importlib.import_module("auto_kms.app"))
+
+    class DummyCrypto:
+        async def encrypt(self, *, kid, plaintext, alg, aad=None, nonce=None):
+            assert alg == "AES-256-GCM"
+            from types import SimpleNamespace
+
+            return SimpleNamespace(
+                version=1, alg=alg, nonce=b"n" * 12, ct=plaintext, tag=b"t"
+            )
+
+        async def decrypt(self, *, kid, ciphertext, nonce, tag, aad=None, alg=None):
+            assert alg == "AES-256-GCM"
+            return ciphertext
+
+    app.SECRETS = DummySecretDrive()
+    app.CRYPTO = DummyCrypto()
+
+    async def init_db():
+        async with app.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+    asyncio.run(init_db())
+    with TestClient(app.app) as c:
+        yield c
+    if hasattr(app, "SECRETS"):
+        delattr(app, "SECRETS")
+    if hasattr(app, "CRYPTO"):
+        delattr(app, "CRYPTO")
+    sys.modules.pop("swarmauri_secret_autogpg", None)
+    sys.modules.pop("swarmauri_crypto_paramiko", None)
+
+
+def test_encrypt_passes_provider_algorithm_string(client_kid):
+    key = _create_key(client_kid)
+    payload = {"plaintext_b64": base64.b64encode(b"hello").decode()}
+    res = client_kid.post(f"/kms/Key/{key['id']}/encrypt", json=payload)
+    assert res.status_code == 200
+    assert res.json()["alg"] == "AES256_GCM"

--- a/pkgs/standards/auto_kms/tests/unit/test_ctx_providers.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_ctx_providers.py
@@ -43,8 +43,10 @@ def test_ctx_has_secrets_provider(app_module):
 
 
 def test_ctx_has_crypto_provider(app_module):
+    from auto_kms.crypto import ParamikoCryptoAdapter
+
     app, _, DummyCrypto = app_module
     ctx: dict = {}
     asyncio.run(app._stash_ctx(ctx))
     assert "crypto" in ctx
-    assert isinstance(ctx["crypto"], DummyCrypto)
+    assert isinstance(ctx["crypto"], ParamikoCryptoAdapter)

--- a/pkgs/standards/auto_kms/tests/unit/test_paramiko_integration.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_paramiko_integration.py
@@ -21,7 +21,23 @@ def _create_key(client, name="k1"):
 def client_paramiko(tmp_path, monkeypatch):
     mod1 = types.ModuleType("swarmauri_secret_autogpg")
 
-    class DummySecretDrive: ...
+    from swarmauri_core.crypto.types import (
+        ExportPolicy,
+        KeyRef,
+        KeyType,
+        KeyUse,
+    )
+
+    class DummySecretDrive:
+        async def load_key(self, *, kid, require_private=False, **_):
+            return KeyRef(
+                kid=str(kid),
+                version=1,
+                type=KeyType.SYMMETRIC,
+                uses=(KeyUse.ENCRYPT, KeyUse.DECRYPT),
+                export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+                material=b"\x11" * 32,
+            )
 
     mod1.AutoGpgSecretDrive = DummySecretDrive
     sys.modules["swarmauri_secret_autogpg"] = mod1

--- a/pkgs/standards/auto_kms/tests/unit/test_rest_calls.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_rest_calls.py
@@ -124,6 +124,7 @@ def test_key_clear(client):
 def test_key_encrypt_decrypt_with_paramiko_crypto_interface(client):
     """Encryption should succeed using a Paramiko-style crypto provider."""
     key = _create_key(client)
+    _create_key_version(client, key["id"])
     pt = b"hello"
     payload = {"plaintext_b64": base64.b64encode(pt).decode()}
     enc = client.post(f"/kms/Key/{key['id']}/encrypt", json=payload)


### PR DESCRIPTION
## Summary
- normalize `KeyAlg` values to provider strings when encrypting/decrypting
- add tests ensuring AES256_GCM keys encrypt using expected algorithm
- adjust test fixtures for paramiko and REST integrations

## Testing
- `uv run --package auto_kms --directory standards/auto_kms pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a59b2ae2a883269aaa177d395b7930