### PR TITLE
fix(autoapi): remove duplicated mount segment

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/api.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/api.py
@@ -51,13 +51,12 @@ def _resource_name(model: type) -> str:
 def _default_prefix(model: type) -> str:
     """Default mount prefix for a model router.
 
-    By default we mount each router under ``/{resource}``, where ``resource`` is
-    the model's lowercased class name (or ``__resource__`` override).  This
-    mirrors the REST transport's own resource segment so legacy clients
-    continue to work with paths like ``/fsitem/fsitem``.
+    Historically routers were mounted under ``/{resource}``, resulting in
+    duplicated path segments such as ``/item/item``.  To expose REST endpoints
+    under ``/item`` we now mount routers at the application root by default.
     """
 
-    return f"/{_resource_name(model)}"
+    return ""
 
 
 def _has_include_router(obj: Any) -> bool:


### PR DESCRIPTION
## Summary
- mount autoapi routers at root by default to avoid /item/item paths

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_hook_ctx_v3_i9n.py`


------
https://chatgpt.com/codex/tasks/task_e_68a59ec6518c8326bc4e5013c1d31f95