### PR TITLE
fix: update request body schema test

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_request_body_schema.py
+++ b/pkgs/standards/autoapi/tests/unit/test_request_body_schema.py
@@ -18,10 +18,10 @@ def test_request_body_uses_schema_model():
     app = FastAPI()
     app.include_router(router)
     spec = app.openapi()
-
-    request_schema = spec["paths"]["/widgets_req_schema"]["post"]["requestBody"][
-        "content"
-    ]["application/json"]["schema"]
+    path = f"/{Widget.__name__.lower()}"
+    request_schema = spec["paths"][path]["post"]["requestBody"]["content"][
+        "application/json"
+    ]["schema"]
     assert request_schema["$ref"] == "#/components/schemas/WidgetCreate"
 
     widget_schema = spec["components"]["schemas"]["WidgetCreate"]


### PR DESCRIPTION
## Summary
- align request body schema test with resource naming

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_request_body_schema.py`


------
https://chatgpt.com/codex/tasks/task_e_68a59f18c1d48326ba9d5ba336121ca4