### PR TITLE
Fix op_ctx arity path test expectations for lowercase routes

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_op_ctx_arity_paths.py
+++ b/pkgs/standards/autoapi/tests/unit/test_op_ctx_arity_paths.py
@@ -21,7 +21,7 @@ def test_member_arity_rest_path_includes_pk():
     spec = collect_decorated_ops(MemberModel)[0]
     router = _build_router(MemberModel, [spec])
     paths = {route.path for route in router.routes}
-    assert f"/{MemberModel.__name__}/{{item_id}}/do" in paths
+    assert f"/{MemberModel.__name__.lower()}/{{item_id}}/do" in paths
 
 
 def test_collection_arity_rest_path_excludes_pk():
@@ -38,7 +38,7 @@ def test_collection_arity_rest_path_excludes_pk():
     spec = collect_decorated_ops(CollectionModel)[0]
     router = _build_router(CollectionModel, [spec])
     paths = {route.path for route in router.routes}
-    assert f"/{CollectionModel.__name__}/do" in paths
+    assert f"/{CollectionModel.__name__.lower()}/do" in paths
 
 
 def test_member_arity_openapi_has_path_param():
@@ -56,9 +56,9 @@ def test_member_arity_openapi_has_path_param():
     router = _build_router(MemberModel, [spec])
     app = FastAPI()
     app.include_router(router)
-    params = app.openapi()["paths"][f"/{MemberModel.__name__}/{{item_id}}/do"]["post"][
-        "parameters"
-    ]
+    params = app.openapi()["paths"][f"/{MemberModel.__name__.lower()}/{{item_id}}/do"][
+        "post"
+    ]["parameters"]
     assert any(p["name"] == "item_id" for p in params)
 
 
@@ -77,5 +77,7 @@ def test_collection_arity_openapi_has_no_path_param():
     router = _build_router(CollectionModel, [spec])
     app = FastAPI()
     app.include_router(router)
-    operation = app.openapi()["paths"][f"/{CollectionModel.__name__}/do"]["post"]
+    operation = app.openapi()["paths"][f"/{CollectionModel.__name__.lower()}/do"][
+        "post"
+    ]
     assert "parameters" not in operation


### PR DESCRIPTION
## Summary
- update op_ctx arity path unit tests to expect lowercase resource names

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff check tests/unit/test_op_ctx_arity_paths.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_op_ctx_arity_paths.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a59f109df48326a2c2af1c1ffb013a