### PR TITLE
fix autoapi schema coercion in REST endpoints

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
@@ -609,7 +609,9 @@ def _make_collection_endpoint(
     # --- Body-based collection endpoints: create / bulk_* ---
 
     body_model = _request_model_for(sp, model)
-    body_annotation = body_model if body_model is not None else Mapping[str, Any]
+    body_annotation = (
+        body_model | Mapping[str, Any] if body_model is not None else Mapping[str, Any]
+    )
 
     async def _endpoint(
         request: Request,
@@ -702,7 +704,9 @@ def _make_member_endpoint(
     # --- Body-based member endpoints: PATCH update / PUT replace (and custom member) ---
 
     body_model = _request_model_for(sp, model)
-    body_annotation = body_model if body_model is not None else Mapping[str, Any]
+    body_annotation = (
+        body_model | Mapping[str, Any] if body_model is not None else Mapping[str, Any]
+    )
 
     async def _endpoint(
         item_id: Any,


### PR DESCRIPTION
## Summary
- allow request body union with Mapping for autoapi REST endpoints
- this prevents FastAPI from rejecting bodies that don't strictly match schema

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_v3_schemas_and_decorators.py`


------
https://chatgpt.com/codex/tasks/task_e_68a59f247a5483269f07f3ef0e4cafc1