### PR TITLE
Fix AutoAPI io spec aliasing and REST create status

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/api.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/api.py
@@ -51,13 +51,15 @@ def _resource_name(model: type) -> str:
 def _default_prefix(model: type) -> str:
     """Default mount prefix for a model router.
 
-    By default we mount each router under ``/{resource}``, where ``resource`` is
-    the model's lowercased class name (or ``__resource__`` override).  This
-    mirrors the REST transport's own resource segment so legacy clients
-    continue to work with paths like ``/fsitem/fsitem``.
+    Historically the router was mounted under ``/{resource}`` while individual
+    routes also included that resource segment, yielding paths like
+    ``/thing/thing``.  This no longer matches expected behaviour for modern
+    clients and breaks tests that call the endpoint at ``/thing``.  Mount the
+    router with an empty prefix so the paths defined on the router become the
+    final API paths.
     """
 
-    return f"/{_resource_name(model)}"
+    return ""
 
 
 def _has_include_router(obj: Any) -> bool:

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
@@ -191,10 +191,12 @@ def _serialize_output(
     try:
         if target == "list" and isinstance(result, (list, tuple)):
             return [
-                out_model.model_validate(x).model_dump(exclude_none=True)
+                out_model.model_validate(x).model_dump(exclude_none=True, by_alias=True)
                 for x in result
             ]
-        return out_model.model_validate(result).model_dump(exclude_none=True)
+        return out_model.model_validate(result).model_dump(
+            exclude_none=True, by_alias=True
+        )
     except Exception:
         logger.debug(
             "rest output serialization failed for %s.%s",
@@ -314,10 +316,7 @@ def _normalize_deps(deps: Optional[Sequence[Any]]) -> list[Any]:
 
 def _status_for(target: str) -> int:
     if target == "create":
-        # Historically AutoAPI returned 200 for create operations.  The v3 router
-        # switched to 201 (Created), which broke backward-compat expectations and
-        # existing tests.  Align with legacy behaviour by defaulting to 200.
-        return _status.HTTP_200_OK
+        return _status.HTTP_201_CREATED
     if target in ("delete", "clear"):
         return _status.HTTP_204_NO_CONTENT
     return _status.HTTP_200_OK


### PR DESCRIPTION
## Summary
- ensure routers mount without duplicate prefixes
- support iospec field aliases in RPC and REST schemas
- return 201 for REST create operations

## Testing
- `uv run --package autoapi --directory standards ruff check autoapi/autoapi/v3/bindings/api.py autoapi/autoapi/v3/bindings/rpc.py autoapi/autoapi/v3/schema/builder.py autoapi/autoapi/v3/bindings/rest.py --fix`
- `uv run --package autoapi --directory standards pytest autoapi/tests/i9n/test_iospec_attributes.py -q`
- `uv run --package autoapi --directory standards pytest autoapi/tests/i9n/test_op_ctx_behavior.py -q`
- `uv run --package autoapi --directory standards pytest autoapi/tests/i9n/test_opspec_effects_i9n_test.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a59ed5c7e08326bdba64e22b318c82