### PR TITLE
fix: default to 200 for create operations

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
@@ -313,13 +313,9 @@ def _normalize_deps(deps: Optional[Sequence[Any]]) -> list[Any]:
 
 
 def _status_for(target: str) -> int:
-    if target == "create":
-        # Creating resources should use HTTP 201 (Created).
-        # Earlier revisions defaulted to 200 for backward compatibility, but
-        # the integration tests rely on the standard 201 code.
-        return _status.HTTP_201_CREATED
     if target in ("delete", "clear"):
         return _status.HTTP_204_NO_CONTENT
+    # Default to HTTP 200 OK for create and all other operations.
     return _status.HTTP_200_OK
 
 


### PR DESCRIPTION
## Summary
- return HTTP 200 by default for create operations

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_hook_ctx_v3_i9n.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5a34c1dc88326a26f4ced20b015eb