### PR TITLE
fix: return body for delete ops

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
@@ -319,7 +319,10 @@ def _status_for(target: str) -> int:
         # the integration tests rely on the standard 201 code.
         return _status.HTTP_201_CREATED
     if target in ("delete", "clear"):
-        return _status.HTTP_204_NO_CONTENT
+        # DELETE operations return a confirmation payload (e.g. number of
+        # deleted rows). Returning 204 would discard this body, so default to
+        # 200 to surface the response content to clients.
+        return _status.HTTP_200_OK
     return _status.HTTP_200_OK
 
 


### PR DESCRIPTION
## Summary
- ensure delete and clear REST operations return a body

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_v3_default_rest_ops.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5a35c37048326a107ff8ce428ed39