### PR TITLE
Fix IOSpec alias handling for AutoAPI

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
@@ -191,10 +191,12 @@ def _serialize_output(
     try:
         if target == "list" and isinstance(result, (list, tuple)):
             return [
-                out_model.model_validate(x).model_dump(exclude_none=True)
+                out_model.model_validate(x).model_dump(exclude_none=True, by_alias=True)
                 for x in result
             ]
-        return out_model.model_validate(result).model_dump(exclude_none=True)
+        return out_model.model_validate(result).model_dump(
+            exclude_none=True, by_alias=True
+        )
     except Exception:
         logger.debug(
             "rest output serialization failed for %s.%s",

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rpc.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rpc.py
@@ -136,11 +136,13 @@ def _serialize_output(model: type, alias: str, target: str, result: Any) -> Any:
     try:
         if target == "list" and isinstance(result, (list, tuple)):
             return [
-                out_model.model_validate(x).model_dump(exclude_none=True)
+                out_model.model_validate(x).model_dump(exclude_none=True, by_alias=True)
                 for x in result
             ]
         # Single object case
-        return out_model.model_validate(result).model_dump(exclude_none=True)
+        return out_model.model_validate(result).model_dump(
+            exclude_none=True, by_alias=True
+        )
     except Exception as e:
         # If serialization fails, let raw result through rather than failing the call
         logger.debug(

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/wire/dump.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/wire/dump.py
@@ -66,20 +66,22 @@ def run(obj: Optional[object], ctx: Any) -> None:
             if conflicts:
                 temp["dump_conflicts"] = tuple(sorted(set(conflicts)))
         temp["response_payload"] = payload
-        return
+        return payload
 
     # List/tuple of objects (already expanded by executor)
     if isinstance(out_values, (list, tuple)) and all(
         isinstance(x, Mapping) for x in out_values
     ):
-        temp["response_payload"] = [
+        payload_list = [
             _dump_one(item, aliases, omit_nulls)
             for item in out_values  # type: ignore[arg-type]
         ]
-        return
+        temp["response_payload"] = payload_list
+        return payload_list
 
     # Unknown shape — stash as-is to avoid surprises (transport may serialize).
     temp["response_payload"] = out_values
+    return out_values
 
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/executor.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/executor.py
@@ -429,6 +429,9 @@ async def _invoke(
         in_tx=False,
         nonfatal=True,
     )
+    # If POST_RESPONSE steps produced a new result, expose it.
+    if ctx.get("result") is not None:
+        ctx.response.result = ctx.get("result")
     # Defensive: ensure the session is not left in a transactional state. Some
     # backends may implicitly begin a new transaction during commit/flush cycles.
     if db is not None and _in_tx(db):


### PR DESCRIPTION
## Summary
- ensure IOSpec alias_in and alias_out are respected by Pydantic schemas
- propagate alias-based payloads through runtime dumping and post-response handling
- serialize REST and RPC responses using aliases

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff format .`
- `uv run --directory standards/autoapi --package autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_iospec_attributes.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5a34f7e008326822251d56e8c1477