### PR TITLE
Enable bulk RPC operations in AutoAPI v3

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rpc.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rpc.py
@@ -134,7 +134,12 @@ def _serialize_output(model: type, alias: str, target: str, result: Any) -> Any:
         return result
 
     try:
-        if target == "list" and isinstance(result, (list, tuple)):
+        if target in {
+            "list",
+            "bulk_create",
+            "bulk_update",
+            "bulk_replace",
+        } and isinstance(result, (list, tuple)):
             return [
                 out_model.model_validate(x).model_dump(exclude_none=True)
                 for x in result
@@ -181,10 +186,25 @@ def _build_rpc_callable(model: type, sp: OpSpec) -> Callable[..., Awaitable[Any]
         # 1) normalize + validate input
         raw_payload = _coerce_payload(payload)
         norm_payload = _validate_input(model, alias, target, raw_payload)
+        merged_payload: Dict[str, Any] = dict(raw_payload)
+        for key, value in norm_payload.items():
+            if (
+                key == "rows"
+                and isinstance(value, list)
+                and isinstance(raw_payload.get("rows"), list)
+            ):
+                raw_rows = raw_payload.get("rows", [])
+                merged_rows = []
+                for idx, nv in enumerate(value):
+                    base = raw_rows[idx] if idx < len(raw_rows) else {}
+                    merged_rows.append({**base, **nv})
+                merged_payload["rows"] = merged_rows
+            else:
+                merged_payload[key] = value
 
         # 2) build executor context & phases
         base_ctx: Dict[str, Any] = dict(ctx or {})
-        base_ctx.setdefault("payload", norm_payload)
+        base_ctx.setdefault("payload", merged_payload)
         base_ctx.setdefault("db", db)
         if request is not None:
             base_ctx.setdefault("request", request)
@@ -192,7 +212,7 @@ def _build_rpc_callable(model: type, sp: OpSpec) -> Callable[..., Awaitable[Any]
         base_ctx.setdefault(
             "env",
             SimpleNamespace(
-                method=alias, params=norm_payload, target=target, model=model
+                method=alias, params=merged_payload, target=target, model=model
             ),
         )
 

--- a/pkgs/standards/autoapi/autoapi/v3/opspec/collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/opspec/collect.py
@@ -122,8 +122,7 @@ def _collect_registry(model: type) -> List[OpSpec]:
 
 def _generate_canonical(model: type) -> List[OpSpec]:
     """
-    Provide a baseline set of canonical specs for CRUD, list, clear.
-    Bulk verbs can be added later by registry if supported.
+    Provide a baseline set of canonical specs for CRUD, list, clear, and bulk ops.
 
     NOTE: We do not wire any `returns` preference here. Serialization mode is
     inferred later from the presence/absence of a response schema during binding.
@@ -136,6 +135,10 @@ def _generate_canonical(model: type) -> List[OpSpec]:
         "delete",
         "list",
         "clear",
+        "bulk_create",
+        "bulk_update",
+        "bulk_replace",
+        "bulk_delete",
     )
     out: List[OpSpec] = []
     for target in canon_targets:


### PR DESCRIPTION
## Summary
- include bulk_* verbs in default OpSpecs so RPC routes are registered
- preserve primary key fields during RPC validation and serialize bulk results

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff format .`
- `uv run --directory standards/autoapi --package autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_v3_default_rpc_ops.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5a361b83c8326a946f2b82386c2f0