### PR TITLE
test(autoapi): expect 201 Created in hook context tests

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_hook_ctx_v3_i9n.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_hook_ctx_v3_i9n.py
@@ -83,7 +83,7 @@ async def test_hook_ctx_request_response_schema_i9n():
 
     client, _, _ = create_client(Item)
     res = await client.post("/item", json={"name": "a"})
-    assert res.status_code == 200
+    assert res.status_code == 201
     assert res.json()["hook"] is True
     await client.aclose()
 
@@ -137,7 +137,7 @@ async def test_hook_ctx_defaults_resolution_i9n():
 
     client, _, _ = create_client(Item)
     res = await client.post("/item", json={})
-    assert res.status_code == 200
+    assert res.status_code == 201
     assert res.json()["name"] == "default"
     await client.aclose()
 


### PR DESCRIPTION
## Summary
- update v3 hook context integration tests to expect HTTP 201 for create ops

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_hook_ctx_v3_i9n.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5a405fbf88326a8633e5a0229d509