### PR TITLE
Store symmetric key material for AutoKMS AEAD operations

### DIFF
--- a/pkgs/standards/auto_kms/tests/unit/test_memoryview_material.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_memoryview_material.py
@@ -13,7 +13,7 @@ from autoapi.v3.tables import Base
 def _create_key(client, name="k1"):
     payload = {"name": name, "algorithm": "AES256_GCM"}
     res = client.post("/kms/key", json=payload)
-    assert res.status_code == 200
+    assert res.status_code == 201
     return res.json()
 
 

--- a/pkgs/standards/auto_kms/tests/unit/test_rest_calls.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_rest_calls.py
@@ -64,8 +64,8 @@ def client(tmp_path, monkeypatch):
 
 def _create_key(client, name="k1"):
     payload = {"name": name, "algorithm": "AES256_GCM"}
-    res = client.post("/kms/Key", json=payload)
-    assert res.status_code == 200
+    res = client.post("/kms/key", json=payload)
+    assert res.status_code == 201
     return res.json()
 
 
@@ -77,14 +77,14 @@ def test_key_create(client):
 def test_key_list(client):
     _create_key(client, "k1")
     _create_key(client, "k2")
-    res = client.get("/kms/Key")
+    res = client.get("/kms/key")
     assert res.status_code == 200
     assert len(res.json()) == 2
 
 
 def test_key_read(client):
     key = _create_key(client)
-    res = client.get(f"/kms/Key/{key['id']}")
+    res = client.get(f"/kms/key/{key['id']}")
     assert res.status_code == 200
     assert res.json()["id"] == key["id"]
 
@@ -92,7 +92,7 @@ def test_key_read(client):
 def test_key_update(client):
     key = _create_key(client)
     res = client.patch(
-        f"/kms/Key/{key['id']}", json={"name": key["name"], "status": "disabled"}
+        f"/kms/key/{key['id']}", json={"name": key["name"], "status": "disabled"}
     )
     assert res.status_code == 200
     assert res.json()["status"] == "disabled"
@@ -101,23 +101,23 @@ def test_key_update(client):
 def test_key_replace(client):
     key = _create_key(client)
     payload = {"name": key["name"]}
-    res = client.put(f"/kms/Key/{key['id']}", json=payload)
+    res = client.put(f"/kms/key/{key['id']}", json=payload)
     assert res.status_code == 409
 
 
 def test_key_delete(client):
     key = _create_key(client)
-    res = client.delete(f"/kms/Key/{key['id']}")
+    res = client.delete(f"/kms/key/{key['id']}")
     assert res.status_code == 204
-    res = client.get(f"/kms/Key/{key['id']}")
+    res = client.get(f"/kms/key/{key['id']}")
     assert res.status_code == 404
 
 
 def test_key_clear(client):
     _create_key(client)
-    res = client.delete("/kms/Key")
+    res = client.delete("/kms/key")
     assert res.status_code == 204
-    res = client.get("/kms/Key")
+    res = client.get("/kms/key")
     assert res.json() == []
 
 
@@ -127,7 +127,7 @@ def test_key_encrypt_decrypt_with_paramiko_crypto_interface(client):
     _create_key_version(client, key["id"])
     pt = b"hello"
     payload = {"plaintext_b64": base64.b64encode(pt).decode()}
-    enc = client.post(f"/kms/Key/{key['id']}/encrypt", json=payload)
+    enc = client.post(f"/kms/key/{key['id']}/encrypt", json=payload)
     assert enc.status_code == 200
     ct = enc.json()["ciphertext_b64"]
     dec_payload = {
@@ -135,15 +135,15 @@ def test_key_encrypt_decrypt_with_paramiko_crypto_interface(client):
         "nonce_b64": enc.json()["nonce_b64"],
         "tag_b64": enc.json()["tag_b64"],
     }
-    dec = client.post(f"/kms/Key/{key['id']}/decrypt", json=dec_payload)
+    dec = client.post(f"/kms/key/{key['id']}/decrypt", json=dec_payload)
     assert dec.status_code == 200
     assert base64.b64decode(dec.json()["plaintext_b64"]) == pt
 
 
 def _create_key_version(client, key_id, version=1):
     payload = {"key_id": key_id, "version": version, "status": "active"}
-    res = client.post("/kms/key_version", json=payload)
-    assert res.status_code == 200
+    res = client.post("/kms/key_versions", json=payload)
+    assert res.status_code == 201
     return res.json()
 
 
@@ -157,7 +157,7 @@ def test_key_version_list(client):
     key = _create_key(client)
     _create_key_version(client, key["id"], 1)
     _create_key_version(client, key["id"], 2)
-    res = client.get("/kms/key_version")
+    res = client.get("/kms/key_versions")
     assert res.status_code == 200
     assert len(res.json()) == 2
 
@@ -165,7 +165,7 @@ def test_key_version_list(client):
 def test_key_version_read(client):
     key = _create_key(client)
     kv = _create_key_version(client, key["id"])
-    res = client.get(f"/kms/key_version/{kv['id']}")
+    res = client.get(f"/kms/key_versions/{kv['id']}")
     assert res.status_code == 200
     assert res.json()["id"] == kv["id"]
 
@@ -174,7 +174,7 @@ def test_key_version_update(client):
     key = _create_key(client)
     kv = _create_key_version(client, key["id"])
     res = client.patch(
-        f"/kms/key_version/{kv['id']}",
+        f"/kms/key_versions/{kv['id']}",
         json={"key_id": key["id"], "version": kv["version"], "status": "active"},
     )
     assert res.status_code == 200
@@ -185,23 +185,23 @@ def test_key_version_replace(client):
     key = _create_key(client)
     kv = _create_key_version(client, key["id"])
     payload = {"key_id": key["id"], "version": 1, "status": "active"}
-    res = client.put(f"/kms/key_version/{kv['id']}", json=payload)
+    res = client.put(f"/kms/key_versions/{kv['id']}", json=payload)
     assert res.status_code == 409
 
 
 def test_key_version_delete(client):
     key = _create_key(client)
     kv = _create_key_version(client, key["id"])
-    res = client.delete(f"/kms/key_version/{kv['id']}")
+    res = client.delete(f"/kms/key_versions/{kv['id']}")
     assert res.status_code == 204
-    res = client.get(f"/kms/key_version/{kv['id']}")
+    res = client.get(f"/kms/key_versions/{kv['id']}")
     assert res.status_code == 404
 
 
 def test_key_version_clear(client):
     key = _create_key(client)
     _create_key_version(client, key["id"])
-    res = client.delete("/kms/key_version")
+    res = client.delete("/kms/key_versions")
     assert res.status_code == 204
-    res = client.get("/kms/key_version")
+    res = client.get("/kms/key_versions")
     assert res.json() == []


### PR DESCRIPTION
## Summary
- ensure AutoKMS seeds the secret drive with key material when using AEAD providers
- add regression test using real swarmauri plugins
- align AutoKMS tests with lowercase REST paths

## Testing
- `uv run --package auto_kms --directory standards/auto_kms ruff format tests/unit/test_algorithm_mapping.py tests/unit/test_paramiko_integration.py tests/unit/test_rest_calls.py tests/unit/test_memoryview_material.py tests/unit/test_secret_drive_fallback.py auto_kms/tables/key.py`
- `uv run --package auto_kms --directory standards/auto_kms ruff check tests/unit/test_algorithm_mapping.py tests/unit/test_secret_drive_fallback.py auto_kms/tables/key.py tests/unit/test_paramiko_integration.py tests/unit/test_rest_calls.py tests/unit/test_memoryview_material.py --fix`
- `uv run --package auto_kms --directory standards/auto_kms pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5a2e417b0832688755c0c485cf803