### PR TITLE
Fix IO spec alias handling for requests and responses

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
@@ -191,10 +191,12 @@ def _serialize_output(
     try:
         if target == "list" and isinstance(result, (list, tuple)):
             return [
-                out_model.model_validate(x).model_dump(exclude_none=True)
+                out_model.model_validate(x).model_dump(exclude_none=True, by_alias=True)
                 for x in result
             ]
-        return out_model.model_validate(result).model_dump(exclude_none=True)
+        return out_model.model_validate(result).model_dump(
+            exclude_none=True, by_alias=True
+        )
     except Exception:
         logger.debug(
             "rest output serialization failed for %s.%s",

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rpc.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rpc.py
@@ -136,11 +136,13 @@ def _serialize_output(model: type, alias: str, target: str, result: Any) -> Any:
     try:
         if target == "list" and isinstance(result, (list, tuple)):
             return [
-                out_model.model_validate(x).model_dump(exclude_none=True)
+                out_model.model_validate(x).model_dump(exclude_none=True, by_alias=True)
                 for x in result
             ]
         # Single object case
-        return out_model.model_validate(result).model_dump(exclude_none=True)
+        return out_model.model_validate(result).model_dump(
+            exclude_none=True, by_alias=True
+        )
     except Exception as e:
         # If serialization fails, let raw result through rather than failing the call
         logger.debug(


### PR DESCRIPTION
## Summary
- ensure autoapi schemas include alias-based validation and serialization
- serialize responses using field aliases for REST and RPC bindings

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_iospec_attributes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5a409d2588326b5dbc0b93dcbacd9