### PR TITLE
fix: ensure CRUD colspec compatibility

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/core/crud.py
+++ b/pkgs/standards/autoapi/autoapi/v3/core/crud.py
@@ -97,6 +97,9 @@ def _colspecs(model: type) -> Mapping[str, Any]:
     specs = getattr(model, "__autoapi_colspecs__", None)
     if isinstance(specs, Mapping):
         return specs
+    specs = getattr(model, "__autoapi_cols__", None)
+    if isinstance(specs, Mapping):
+        return specs
     return {}
 
 


### PR DESCRIPTION
## Summary
- fix `_colspecs` to handle `__autoapi_cols__` fallback

## Testing
- `uv run --directory standards --package autoapi ruff format autoapi`
- `uv run --directory standards --package autoapi ruff check autoapi --fix`
- `uv run --package autoapi --directory standards pytest autoapi/tests/i9n/test_iospec_attributes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5a5e74fc0832692c9bcf8c9c46fab