### PR TITLE
Fix base64 padding in auto_kms and enforce resource names

### DIFF
--- a/pkgs/standards/auto_kms/auto_kms/tables/key.py
+++ b/pkgs/standards/auto_kms/auto_kms/tables/key.py
@@ -176,6 +176,7 @@ class Key(Base):
     )
     async def encrypt(cls, ctx):
         import base64
+        from ..utils import b64d, b64d_optional
 
         p = ctx.get("payload") or {}
         crypto = getattr(
@@ -184,9 +185,9 @@ class Key(Base):
         if crypto is None:
             raise HTTPException(status_code=500, detail="Crypto provider missing")
 
-        aad = base64.b64decode(p["aad_b64"]) if p.get("aad_b64") else None
-        nonce = base64.b64decode(p["nonce_b64"]) if p.get("nonce_b64") else None
-        pt = base64.b64decode(p["plaintext_b64"])
+        aad = b64d_optional(p.get("aad_b64"))
+        nonce = b64d_optional(p.get("nonce_b64"))
+        pt = b64d(p["plaintext_b64"])
         kid = str(ctx["key"].id)
         alg_in = p.get("alg") or ctx["key"].algorithm
         alg_enum = alg_in if isinstance(alg_in, KeyAlg) else KeyAlg(alg_in)
@@ -254,6 +255,7 @@ class Key(Base):
     )
     async def decrypt(cls, ctx):
         import base64
+        from ..utils import b64d, b64d_optional
 
         p = ctx.get("payload") or {}
         crypto = getattr(
@@ -262,10 +264,10 @@ class Key(Base):
         if crypto is None:
             raise HTTPException(status_code=500, detail="Crypto provider missing")
 
-        aad = base64.b64decode(p["aad_b64"]) if p.get("aad_b64") else None
-        nonce = base64.b64decode(p["nonce_b64"])
-        ct = base64.b64decode(p["ciphertext_b64"])
-        tag = base64.b64decode(p["tag_b64"]) if p.get("tag_b64") else None
+        aad = b64d_optional(p.get("aad_b64"))
+        nonce = b64d(p["nonce_b64"])
+        ct = b64d(p["ciphertext_b64"])
+        tag = b64d_optional(p.get("tag_b64"))
         kid = str(ctx["key"].id)
         alg_in = p.get("alg") or ctx["key"].algorithm
         alg_enum = alg_in if isinstance(alg_in, KeyAlg) else KeyAlg(alg_in)

--- a/pkgs/standards/auto_kms/auto_kms/tables/key_version.py
+++ b/pkgs/standards/auto_kms/auto_kms/tables/key_version.py
@@ -16,7 +16,7 @@ from autoapi.v3.mixins import GUIDPk, Timestamped
 
 class KeyVersion(Base, GUIDPk, Timestamped):
     __tablename__ = "key_versions"
-    __resource__ = "key_versions"
+    __resource__ = "key_version"
     __table_args__ = (UniqueConstraint("key_id", "version"),)
 
     key_id = Column(

--- a/pkgs/standards/auto_kms/auto_kms/utils.py
+++ b/pkgs/standards/auto_kms/auto_kms/utils.py
@@ -12,12 +12,17 @@ def b64e(data: bytes) -> str:
     return base64.b64encode(data).decode()
 
 
+def _add_padding(data_b64: str) -> str:
+    """Pad ``data_b64`` so its length is a multiple of four."""
+    return data_b64 + "=" * (-len(data_b64) % 4)
+
+
 def b64d(data_b64: str) -> bytes:
-    return base64.b64decode(data_b64)
+    return base64.b64decode(_add_padding(data_b64))
 
 
 def b64d_optional(data_b64: Optional[str]) -> Optional[bytes]:
-    return base64.b64decode(data_b64) if data_b64 else None
+    return base64.b64decode(_add_padding(data_b64)) if data_b64 else None
 
 
 def params(ctx) -> Mapping[str, Any]:

--- a/pkgs/standards/auto_kms/tests/unit/test_paramiko_integration.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_paramiko_integration.py
@@ -72,3 +72,37 @@ def test_key_encrypt_decrypt_with_paramiko_crypto(client_paramiko):
     dec = client.post(f"/kms/key/{key['id']}/decrypt", json=dec_payload)
     assert dec.status_code == 200
     assert base64.b64decode(dec.json()["plaintext_b64"]) == pt
+
+
+def test_encrypt_accepts_unpadded_base64(client_paramiko):
+    client, AsyncSessionLocal = client_paramiko
+    from auto_kms.tables.key_version import KeyVersion
+
+    key = _create_key(client, name="k2")
+
+    async def seed():
+        async with AsyncSessionLocal() as s:
+            kv = KeyVersion(
+                key_id=UUID(key["id"]),
+                version=1,
+                status="active",
+                public_material=b"\x11" * 32,
+            )
+            s.add(kv)
+            await s.commit()
+
+    asyncio.run(seed())
+
+    pt = b"world"
+    pt_b64 = base64.b64encode(pt).decode().rstrip("=")
+    payload = {"plaintext_b64": pt_b64}
+    enc = client.post(f"/kms/key/{key['id']}/encrypt", json=payload)
+    assert enc.status_code == 200
+    dec_payload = {
+        "ciphertext_b64": enc.json()["ciphertext_b64"],
+        "nonce_b64": enc.json()["nonce_b64"],
+        "tag_b64": enc.json()["tag_b64"],
+    }
+    dec = client.post(f"/kms/key/{key['id']}/decrypt", json=dec_payload)
+    assert dec.status_code == 200
+    assert base64.b64decode(dec.json()["plaintext_b64"]) == pt

--- a/pkgs/standards/auto_kms/tests/unit/test_resource_names.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_resource_names.py
@@ -1,0 +1,7 @@
+from auto_kms.tables.key import Key
+from auto_kms.tables.key_version import KeyVersion
+
+
+def test_resource_names():
+    assert Key.__resource__ == "key"
+    assert KeyVersion.__resource__ == "key_version"


### PR DESCRIPTION
## Summary
- handle missing base64 padding during encryption and decryption
- ensure KeyVersion table uses singular resource name
- add tests for unpadded base64 and table resource names

## Testing
- `uv run --package auto_kms --directory pkgs/standards/auto_kms pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5a7638db083269e48749aca114c0e