### PR TITLE
fix: handle invalid base64 in auto kms

### DIFF
--- a/pkgs/standards/auto_kms/auto_kms/tables/key_version.py
+++ b/pkgs/standards/auto_kms/auto_kms/tables/key_version.py
@@ -16,7 +16,7 @@ from autoapi.v3.mixins import GUIDPk, Timestamped
 
 class KeyVersion(Base, GUIDPk, Timestamped):
     __tablename__ = "key_versions"
-    __resource__ = "key_versions"
+    __resource__ = "key_version"
     __table_args__ = (UniqueConstraint("key_id", "version"),)
 
     key_id = Column(


### PR DESCRIPTION
## Summary
- validate base64 input in auto_kms encrypt/decrypt to return 400 on invalid data
- rename KeyVersion resource to `key_version`
- add regression test for invalid base64

## Testing
- `uv run --directory pkgs/standards/auto_kms --package auto_kms ruff format .`
- `uv run --directory pkgs/standards/auto_kms --package auto_kms ruff check . --fix`
- `uv run --package auto_kms --directory pkgs/standards/auto_kms pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5a781fe4c8326acbee045a4fd3e39