### PR TITLE
Store key version material for encryption

### DIFF
--- a/pkgs/standards/auto_kms/auto_kms/tables/key.py
+++ b/pkgs/standards/auto_kms/auto_kms/tables/key.py
@@ -318,6 +318,7 @@ class Key(Base):
     )
     async def decrypt(cls, ctx):
         import base64
+        from ..utils import b64d, b64d_optional
 
         p = ctx.get("payload") or {}
         crypto = getattr(

--- a/pkgs/standards/auto_kms/auto_kms/tables/key_version.py
+++ b/pkgs/standards/auto_kms/auto_kms/tables/key_version.py
@@ -85,4 +85,19 @@ class KeyVersion(Base, GUIDPk, Timestamped):
             material=material,
             export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
         )
-        payload["public_material"] = None
+        # Persist the generated key material on the version so that downstream
+        # crypto providers that require direct material access can operate.
+        # This mirrors the behavior during initial key creation where the
+        # material is stored with the primary version. Without this assignment
+        # the database row ends up with ``public_material`` as ``NULL``,
+        # triggering "Key material missing" errors during encrypt/decrypt
+        # operations when the provider expects the material to be present on the
+        # key version record.
+        payload["public_material"] = material
+
+    @hook_ctx(ops="create", phase="POST_HANDLER")
+    async def _scrub_material(cls, ctx):
+        """Remove raw key material from the response payload."""
+        obj = ctx.get("result")
+        if obj is not None:
+            obj.public_material = None

--- a/pkgs/standards/auto_kms/tests/unit/test_encrypt_invalid_base64.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_encrypt_invalid_base64.py
@@ -43,7 +43,9 @@ def client(tmp_path, monkeypatch):
 
 def test_encrypt_invalid_base64(client):
     key = _create_key(client)
-    kv_payload = {"key_id": key["id"], "version": 1, "status": "active"}
+    # The primary version (1) is seeded automatically during key creation.
+    # Create a new secondary version to exercise the key version endpoint.
+    kv_payload = {"key_id": key["id"], "version": 2, "status": "active"}
     res = client.post("/kms/key_version", json=kv_payload)
     assert res.status_code == 201
     payload = {

--- a/pkgs/standards/auto_kms/tests/unit/test_paramiko_integration.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_paramiko_integration.py
@@ -5,7 +5,6 @@ import asyncio
 
 import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy import select
 from autoapi.v3.tables import Base
 from swarmauri_secret_autogpg import AutoGpgSecretDrive
 
@@ -48,7 +47,7 @@ def test_key_encrypt_decrypt_with_paramiko_crypto(client_paramiko):
     client, secret_dir = client_paramiko
 
     key = _create_key(client)
-    kv_payload = {"key_id": key["id"], "version": 1, "status": "active"}
+    kv_payload = {"key_id": key["id"], "version": 2, "status": "active"}
     res = client.post("/kms/key_version", json=kv_payload)
     assert res.status_code == 201
 
@@ -70,7 +69,7 @@ def test_encrypt_accepts_unpadded_base64(client_paramiko):
     client, secret_dir = client_paramiko
 
     key = _create_key(client, name="k2")
-    kv_payload = {"key_id": key["id"], "version": 1, "status": "active"}
+    kv_payload = {"key_id": key["id"], "version": 2, "status": "active"}
     res = client.post("/kms/key_version", json=kv_payload)
     assert res.status_code == 201
 
@@ -92,7 +91,7 @@ def test_encrypt_accepts_unpadded_base64(client_paramiko):
 def test_key_version_creation_writes_secret_file(client_paramiko):
     client, secret_dir = client_paramiko
     key = _create_key(client, name="k3")
-    kv_payload = {"key_id": key["id"], "version": 1, "status": "active"}
+    kv_payload = {"key_id": key["id"], "version": 2, "status": "active"}
     res = client.post("/kms/key_version", json=kv_payload)
     assert res.status_code == 201
     assert (secret_dir / key["id"] / "private.asc").exists()


### PR DESCRIPTION
## Summary
- persist generated key material on new key versions
- hide key material from responses to avoid serialization errors
- exercise secondary key-version creation in tests

## Testing
- `uv run --directory pkgs/standards/auto_kms --package auto_kms ruff format .`
- `uv run --directory pkgs/standards/auto_kms --package auto_kms ruff check . --fix`
- `uv run --package auto_kms --directory standards/auto_kms pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5bdfbdc148326bc5d0d2c259757c1