### PR TITLE
test: verify key lifecycle

### DIFF
--- a/pkgs/standards/auto_kms/tests/unit/test_key_lifecycle.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_key_lifecycle.py
@@ -1,0 +1,69 @@
+import importlib
+import asyncio
+from uuid import UUID
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+from autoapi.v3.tables import Base
+from swarmauri_secret_autogpg import AutoGpgSecretDrive
+from auto_kms.tables.key_version import KeyVersion
+
+
+@pytest.fixture
+def client_app(tmp_path, monkeypatch):
+    secret_dir = tmp_path / "keys"
+    db_path = tmp_path / "kms.db"
+    monkeypatch.setenv("KMS_DATABASE_URL", f"sqlite+aiosqlite:///{db_path}")
+    app = importlib.reload(importlib.import_module("auto_kms.app"))
+    monkeypatch.setattr(
+        app, "AutoGpgSecretDrive", lambda: AutoGpgSecretDrive(path=secret_dir)
+    )
+
+    async def init_db():
+        async with app.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+    asyncio.run(init_db())
+    try:
+        with TestClient(app.app) as client:
+            yield client, app
+    finally:
+        if hasattr(app, "SECRETS"):
+            delattr(app, "SECRETS")
+        if hasattr(app, "CRYPTO"):
+            delattr(app, "CRYPTO")
+
+
+def _fetch_versions(app, key_id):
+    async def _inner():
+        async with app.AsyncSessionLocal() as session:
+            result = await session.execute(
+                select(KeyVersion.version).where(KeyVersion.key_id == UUID(str(key_id)))
+            )
+            return sorted(result.scalars().all())
+
+    return asyncio.run(_inner())
+
+
+def test_key_full_lifecycle(client_app):
+    client, app = client_app
+    payload = {"name": "k1", "algorithm": "AES256_GCM"}
+    res = client.post("/kms/key", json=payload)
+    assert res.status_code == 201
+    key = res.json()
+
+    assert _fetch_versions(app, key["id"]) == [1]
+
+    kv_payload = {"key_id": key["id"], "version": 2, "status": "active"}
+    res = client.post("/kms/key_version", json=kv_payload)
+    assert res.status_code == 201
+    assert _fetch_versions(app, key["id"]) == [1, 2]
+
+    res = client.delete(f"/kms/key/{key['id']}")
+    assert res.status_code == 200
+    assert res.json()["deleted"] == 1
+
+    assert _fetch_versions(app, key["id"]) == []
+    res = client.get(f"/kms/key/{key['id']}")
+    assert res.status_code == 404


### PR DESCRIPTION
## Summary
- test full key lifecycle in auto_kms

## Testing
- `uv run --package auto_kms --directory standards/auto_kms pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5c7bfcb248326b91466d8ac5e2dec