### PR TITLE
test(auto_kms): cover key creation and version tracking

### DIFF
--- a/pkgs/standards/auto_kms/tests/unit/test_key_creation_versions.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_key_creation_versions.py
@@ -1,0 +1,67 @@
+import asyncio
+import importlib
+from uuid import UUID
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from autoapi.v3.tables import Base
+from swarmauri_secret_autogpg import AutoGpgSecretDrive
+
+from auto_kms.tables.key_version import KeyVersion
+
+
+def _create_key(client, name: str = "k1"):
+    payload = {"name": name, "algorithm": "AES256_GCM"}
+    res = client.post("/kms/key", json=payload)
+    assert res.status_code == 201
+    return res.json()
+
+
+@pytest.fixture
+def client_app(tmp_path, monkeypatch):
+    secret_dir = tmp_path / "keys"
+    db_path = tmp_path / "kms.db"
+    monkeypatch.setenv("KMS_DATABASE_URL", f"sqlite+aiosqlite:///{db_path}")
+    app = importlib.reload(importlib.import_module("auto_kms.app"))
+    monkeypatch.setattr(
+        app, "AutoGpgSecretDrive", lambda: AutoGpgSecretDrive(path=secret_dir)
+    )
+
+    async def init_db():
+        async with app.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+    asyncio.run(init_db())
+    try:
+        with TestClient(app.app) as c:
+            yield c, app
+    finally:
+        if hasattr(app, "SECRETS"):
+            delattr(app, "SECRETS")
+        if hasattr(app, "CRYPTO"):
+            delattr(app, "CRYPTO")
+
+
+def test_key_creation_seeded_version(client_app):
+    client, app = client_app
+    key = _create_key(client)
+    key_id = key["id"]
+
+    read = client.get(f"/kms/key/{key_id}")
+    assert read.status_code == 200
+    data = read.json()
+    assert data["id"] == key_id
+    assert data["primary_version"] == 1
+
+    async def fetch_versions():
+        async with app.engine.begin() as conn:
+            res = await conn.execute(
+                select(KeyVersion.version).where(KeyVersion.key_id == UUID(key_id))
+            )
+            return [row[0] for row in res.all()]
+
+    versions = asyncio.run(fetch_versions())
+    assert 1 in versions
+    assert max(versions) == data["primary_version"]


### PR DESCRIPTION
## Summary
- add unit test ensuring key creation seeds version 1
- verify key read exposes primary_version and matches latest version

## Testing
- `uv run --package auto_kms --directory standards/auto_kms ruff format .`
- `uv run --package auto_kms --directory standards/auto_kms ruff check . --fix`
- `cd pkgs && uv run --package auto_kms --directory standards/auto_kms pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5c815e6ac832689e72c5a2101f061