### PR TITLE
test(auto_kms): add encryption round-trip example

### DIFF
--- a/pkgs/standards/auto_kms/tests/unit/test_encrypt_decrypt_roundtrip.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_encrypt_decrypt_roundtrip.py
@@ -1,0 +1,59 @@
+import base64
+import importlib
+import asyncio
+
+import pytest
+from fastapi.testclient import TestClient
+from autoapi.v3.tables import Base
+from swarmauri_secret_autogpg import AutoGpgSecretDrive
+
+
+def _create_key(client, name: str = "k1"):
+    payload = {"name": name, "algorithm": "AES256_GCM"}
+    res = client.post("/kms/key", json=payload)
+    assert res.status_code == 201
+    return res.json()
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    secret_dir = tmp_path / "keys"
+    db_path = tmp_path / "kms.db"
+    monkeypatch.setenv("KMS_DATABASE_URL", f"sqlite+aiosqlite:///{db_path}")
+    app = importlib.reload(importlib.import_module("auto_kms.app"))
+    monkeypatch.setattr(
+        app,
+        "AutoGpgSecretDrive",
+        lambda: AutoGpgSecretDrive(path=secret_dir),
+    )
+
+    async def init_db():
+        async with app.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+    asyncio.run(init_db())
+    try:
+        with TestClient(app.app) as c:
+            yield c
+    finally:
+        if hasattr(app, "SECRETS"):
+            delattr(app, "SECRETS")
+        if hasattr(app, "CRYPTO"):
+            delattr(app, "CRYPTO")
+
+
+def test_key_creation_encrypt_decrypt(client):
+    """Document key creation followed by encrypt/decrypt roundtrip."""
+    key = _create_key(client)
+    plaintext = b"hello"
+    payload = {"plaintext_b64": base64.b64encode(plaintext).decode()}
+    enc = client.post(f"/kms/key/{key['id']}/encrypt", json=payload)
+    assert enc.status_code == 200
+    dec_payload = {
+        "ciphertext_b64": enc.json()["ciphertext_b64"],
+        "nonce_b64": enc.json()["nonce_b64"],
+        "tag_b64": enc.json()["tag_b64"],
+    }
+    dec = client.post(f"/kms/key/{key['id']}/decrypt", json=dec_payload)
+    assert dec.status_code == 200
+    assert base64.b64decode(dec.json()["plaintext_b64"]) == plaintext


### PR DESCRIPTION
## Summary
- add unit test showing key creation, encryption, and decryption

## Testing
- `uv run --package auto_kms --directory standards/auto_kms ruff format .`
- `uv run --package auto_kms --directory standards/auto_kms ruff check . --fix`
- `uv run --package auto_kms --directory standards/auto_kms pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5c82de62c8326ae4418e9bb871a18