### PR TITLE
feat(auto_kms): add key rotation op

### DIFF
--- a/pkgs/standards/auto_kms/auto_kms/tables/key.py
+++ b/pkgs/standards/auto_kms/auto_kms/tables/key.py
@@ -182,7 +182,7 @@ class Key(Base):
             db.add(kv)
 
     # ---- Hook: ensure key exists & enabled ----
-    @hook_ctx(ops=("encrypt", "decrypt"), phase="PRE_HANDLER")
+    @hook_ctx(ops=("encrypt", "decrypt", "rotate"), phase="PRE_HANDLER")
     async def _ensure_key_enabled(cls, ctx):
         pp = ctx.get("path_params") or {}
         ident = pp.get("id") or pp.get("item_id")
@@ -401,3 +401,33 @@ class Key(Base):
             )
 
         return {"plaintext_b64": base64.b64encode(pt).decode()}
+
+    @op_ctx(
+        alias="rotate",
+        target="custom",
+        arity="member",  # /key/{item_id}/rotate
+    )
+    async def rotate(cls, ctx):
+        import secrets
+        from .key_version import KeyVersion
+
+        db = ctx.get("db")
+        secrets_drv = ctx.get("secrets")
+        key_obj = ctx.get("key")
+        if db is None or secrets_drv is None or key_obj is None:
+            raise HTTPException(status_code=500, detail="Required context missing")
+        if key_obj.algorithm != KeyAlg.AES256_GCM:
+            raise HTTPException(status_code=400, detail="Unsupported algorithm")
+
+        new_version = key_obj.primary_version + 1
+        material = secrets.token_bytes(32)
+        await secrets_drv.rotate(kid=str(key_obj.id), material=material)
+        kv = KeyVersion(
+            key_id=key_obj.id,
+            version=new_version,
+            status="active",
+            public_material=material,
+        )
+        key_obj.primary_version = new_version
+        db.add(kv)
+        return {"id": str(key_obj.id), "primary_version": key_obj.primary_version}

--- a/pkgs/standards/auto_kms/tests/unit/test_key_rotate.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_key_rotate.py
@@ -1,0 +1,62 @@
+import asyncio
+import importlib
+from uuid import UUID
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from autoapi.v3.tables import Base
+from swarmauri_secret_autogpg import AutoGpgSecretDrive
+from auto_kms.tables.key_version import KeyVersion
+
+
+@pytest.fixture
+def client_app(tmp_path, monkeypatch):
+    secret_dir = tmp_path / "keys"
+    db_path = tmp_path / "kms.db"
+    monkeypatch.setenv("KMS_DATABASE_URL", f"sqlite+aiosqlite:///{db_path}")
+    app = importlib.reload(importlib.import_module("auto_kms.app"))
+    monkeypatch.setattr(
+        app, "AutoGpgSecretDrive", lambda: AutoGpgSecretDrive(path=secret_dir)
+    )
+
+    async def init_db():
+        async with app.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+    asyncio.run(init_db())
+    try:
+        with TestClient(app.app) as client:
+            yield client, app
+    finally:
+        if hasattr(app, "SECRETS"):
+            delattr(app, "SECRETS")
+        if hasattr(app, "CRYPTO"):
+            delattr(app, "CRYPTO")
+
+
+def test_key_rotate_creates_new_version(client_app):
+    client, app = client_app
+    payload = {"name": "k1", "algorithm": "AES256_GCM"}
+    res = client.post("/kms/key", json=payload)
+    assert res.status_code == 201
+    key = res.json()
+    assert key["primary_version"] == 1
+
+    res = client.post(f"/kms/key/{key['id']}/rotate", json={})
+    assert res.status_code == 200
+    data = res.json()
+    assert data["primary_version"] == 2
+
+    async def fetch_versions():
+        async with app.AsyncSessionLocal() as session:
+            result = await session.execute(
+                select(KeyVersion.version).where(
+                    KeyVersion.key_id == UUID(str(key["id"]))
+                )
+            )
+            return sorted(result.scalars().all())
+
+    versions = asyncio.run(fetch_versions())
+    assert versions == [1, 2]


### PR DESCRIPTION
## Summary
- add rotate op_ctx to generate new key versions
- ensure rotate checks key existence and status
- test key rotation behaviour

## Testing
- `uv run --package auto_kms --directory standards/auto_kms ruff check . --fix`
- `uv run --package auto_kms --directory standards/auto_kms pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5cb17f240832693f466ce40103c92