### PR TITLE
Add tests for default op verbs in auto_kms

### DIFF
--- a/pkgs/standards/auto_kms/tests/unit/test_key_default_op_verbs.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_key_default_op_verbs.py
@@ -1,0 +1,43 @@
+import importlib
+import pytest
+
+
+def _route_map(app, resource: str) -> dict[str, tuple[str, set[str]]]:
+    out: dict[str, tuple[str, set[str]]] = {}
+    for r in getattr(app, "routes", []):
+        name = getattr(r, "name", "")
+        if name.startswith(f"{resource}."):
+            alias = name.split(".", 1)[1]
+            out[alias] = (r.path, set(getattr(r, "methods", []) or []))
+    return out
+
+
+@pytest.fixture
+def key_routes(tmp_path, monkeypatch):
+    db_path = tmp_path / "kms.db"
+    monkeypatch.setenv("KMS_DATABASE_URL", f"sqlite+aiosqlite:///{db_path}")
+    app_mod = importlib.reload(importlib.import_module("auto_kms.app"))
+    return _route_map(app_mod.app, "Key")
+
+
+@pytest.mark.parametrize(
+    "alias,path,methods",
+    [
+        ("create", "/kms/key", {"POST"}),
+        ("read", "/kms/key/{item_id}", {"GET"}),
+        ("update", "/kms/key/{item_id}", {"PATCH"}),
+        ("replace", "/kms/key/{item_id}", {"PUT"}),
+        ("delete", "/kms/key/{item_id}", {"DELETE"}),
+        ("list", "/kms/key", {"GET"}),
+        ("clear", "/kms/key", {"DELETE"}),
+        ("bulk_create", "/kms/key/bulk", {"POST"}),
+        ("bulk_update", "/kms/key/bulk", {"PATCH"}),
+        ("bulk_replace", "/kms/key/bulk", {"PUT"}),
+        ("bulk_delete", "/kms/key/bulk", {"DELETE"}),
+    ],
+)
+def test_key_default_op_verbs(key_routes, alias, path, methods):
+    assert alias in key_routes
+    got_path, got_methods = key_routes[alias]
+    assert got_path.lower() == path.lower()
+    assert got_methods == methods

--- a/pkgs/standards/auto_kms/tests/unit/test_key_version_default_op_verbs.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_key_version_default_op_verbs.py
@@ -1,0 +1,43 @@
+import importlib
+import pytest
+
+
+def _route_map(app, resource: str) -> dict[str, tuple[str, set[str]]]:
+    out: dict[str, tuple[str, set[str]]] = {}
+    for r in getattr(app, "routes", []):
+        name = getattr(r, "name", "")
+        if name.startswith(f"{resource}."):
+            alias = name.split(".", 1)[1]
+            out[alias] = (r.path, set(getattr(r, "methods", []) or []))
+    return out
+
+
+@pytest.fixture
+def key_version_routes(tmp_path, monkeypatch):
+    db_path = tmp_path / "kms.db"
+    monkeypatch.setenv("KMS_DATABASE_URL", f"sqlite+aiosqlite:///{db_path}")
+    app_mod = importlib.reload(importlib.import_module("auto_kms.app"))
+    return _route_map(app_mod.app, "KeyVersion")
+
+
+@pytest.mark.parametrize(
+    "alias,path,methods",
+    [
+        ("create", "/kms/key_version", {"POST"}),
+        ("read", "/kms/key_version/{item_id}", {"GET"}),
+        ("update", "/kms/key_version/{item_id}", {"PATCH"}),
+        ("replace", "/kms/key_version/{item_id}", {"PUT"}),
+        ("delete", "/kms/key_version/{item_id}", {"DELETE"}),
+        ("list", "/kms/key_version", {"GET"}),
+        ("clear", "/kms/key_version", {"DELETE"}),
+        ("bulk_create", "/kms/key_version/bulk", {"POST"}),
+        ("bulk_update", "/kms/key_version/bulk", {"PATCH"}),
+        ("bulk_replace", "/kms/key_version/bulk", {"PUT"}),
+        ("bulk_delete", "/kms/key_version/bulk", {"DELETE"}),
+    ],
+)
+def test_key_version_default_op_verbs(key_version_routes, alias, path, methods):
+    assert alias in key_version_routes
+    got_path, got_methods = key_version_routes[alias]
+    assert got_path.lower() == path.lower()
+    assert got_methods == methods


### PR DESCRIPTION
## Summary
- test key resource exposes all default operation verbs
- test key_version resource exposes all default operation verbs

## Testing
- `uv run --directory pkgs/standards/auto_kms --package auto_kms ruff format .`
- `uv run --directory pkgs/standards/auto_kms --package auto_kms ruff check . --fix`
- `cd pkgs && uv run --package auto_kms --directory standards/auto_kms pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5ccbb76a08326ae878390f7a024bf