### PR TITLE
fix(standards.autoapi): show atoms in planz diagnostics

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/system/diagnostics.py
+++ b/pkgs/standards/autoapi/autoapi/v3/system/diagnostics.py
@@ -213,6 +213,15 @@ def _build_planz_endpoint(api: Any):
             compiled_plan = getattr(
                 getattr(model, "runtime", SimpleNamespace()), "plan", None
             )
+            if compiled_plan is None:
+                specs = getattr(model, "__autoapi_colspecs__", None) or getattr(
+                    model, "__autoapi_cols__", None
+                )
+                if specs is not None:
+                    try:
+                        compiled_plan = _plan.attach_atoms_for_model(model, specs)
+                    except Exception:
+                        compiled_plan = None
             for sp in _opspecs(model):
                 seq: List[str] = []
                 if compiled_plan is not None:


### PR DESCRIPTION
## Summary
- ensure /planz diagnostics builds a plan when one is missing so atom labels appear

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format autoapi/v3/system/diagnostics.py`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check autoapi/v3/system/diagnostics.py --fix`
- `python - <<'PY'
from autoapi.v3.system.diagnostics import _build_planz_endpoint
from autoapi.v3.opspec import OpSpec
from types import SimpleNamespace

class API: pass
class Model:
    __name__='Widget'
    __autoapi_cols__={}

async def handler(ctx): pass
Model.opspecs=SimpleNamespace(all=(OpSpec(alias='create', target='create', table=Model, persist='default', handler=handler),))
api=API(); api.models={'Widget':Model}
planz_fn=_build_planz_endpoint(api)
import asyncio
print(asyncio.run(planz_fn()))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a5cd8c7b8c8326ba61296787f6f304