### PR TITLE
Add default operation tests for auto_kms resources

### DIFF
--- a/pkgs/standards/auto_kms/tests/unit/test_default_ops.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_default_ops.py
@@ -1,0 +1,28 @@
+import auto_kms.app  # noqa: F401 ensures models are bound
+from auto_kms.tables.key import Key
+from auto_kms.tables.key_version import KeyVersion
+import pytest
+
+DEFAULT_OPS = {
+    "create",
+    "read",
+    "update",
+    "replace",
+    "delete",
+    "list",
+    "clear",
+    "bulk_create",
+    "bulk_update",
+    "bulk_replace",
+    "bulk_delete",
+}
+
+RESOURCES = [("key", Key), ("key_version", KeyVersion)]
+
+
+@pytest.mark.parametrize("resource, model", RESOURCES)
+@pytest.mark.parametrize("verb", sorted(DEFAULT_OPS))
+def test_default_op_registered(resource, model, verb):
+    specs = model.opspecs.by_alias.get(verb) or []
+    assert specs, f"{verb} not registered for {resource}"
+    assert any(sp.target == verb for sp in specs)


### PR DESCRIPTION
## Summary
- verify presence of canonical CRUD and bulk operations on key and key_version resources

## Testing
- `uv run --package auto_kms --directory standards/auto_kms pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5ccbdad608326aba1a997b928aafb