### PR TITLE
fix: expose vcol schemas for custom ops

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/schemas.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/schemas.py
@@ -264,9 +264,8 @@ def _default_schemas_for_spec(
         result["out"] = read_schema
 
     elif target == "custom":
-        # No defaults for custom: leave raw unless explicitly overridden
-        result["in_"] = None
-        result["out"] = None
+        result["in_"] = _build_schema(model, verb=f"in:{sp.alias}")
+        result["out"] = _build_schema(model, verb=f"out:{sp.alias}")
 
     else:
         # Defensive default: treat unknown like custom (raw)


### PR DESCRIPTION
## Summary
- include virtual columns when building schema models
- generate request/response schemas for custom operations

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `uv run --directory pkgs/standards/auto_kms --package auto_kms -- python - <<'PY'
from auto_kms.app import app
schema = app.openapi()
print(schema['components']['schemas']['KeyEncrypt-Input']['properties'])
print(schema['components']['schemas']['KeyEncrypt-Output']['properties'])
print(schema['components']['schemas']['KeyDecrypt-Input']['properties'])
print(schema['components']['schemas']['KeyDecrypt-Output']['properties'])
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a5d51757bc83268d63aa47fa10c31b