### PR TITLE
Return 201 with empty body for key rotation

### DIFF
--- a/pkgs/standards/auto_kms/auto_kms/tables/key.py
+++ b/pkgs/standards/auto_kms/auto_kms/tables/key.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Mapped, relationship
 from autoapi.v3.tables import Base
 from autoapi.v3.specs import acol, vcol, S, F, IO
 from autoapi.v3.decorators import hook_ctx, op_ctx
-from fastapi import HTTPException
+from fastapi import HTTPException, Response
 
 if TYPE_CHECKING:
     from .key_version import KeyVersion
@@ -143,7 +143,6 @@ class Key(Base):
     @hook_ctx(ops="create", phase="POST_HANDLER")
     async def _seed_primary_version(cls, ctx):
         import secrets
-        from sqlalchemy import select
         from swarmauri_core.crypto.types import (
             ExportPolicy,
             KeyType,
@@ -232,7 +231,6 @@ class Key(Base):
         persist="skip",
     )
     async def encrypt(cls, ctx):
-        import base64
         from ..utils import b64d, b64d_optional
 
         p = ctx.get("payload") or {}
@@ -326,7 +324,6 @@ class Key(Base):
         persist="skip",
     )
     async def decrypt(cls, ctx):
-        import base64
         from ..utils import b64d, b64d_optional
 
         p = ctx.get("payload") or {}
@@ -439,4 +436,4 @@ class Key(Base):
         )
         key_obj.primary_version = new_version
         db.add(kv)
-        return {"id": str(key_obj.id), "primary_version": key_obj.primary_version}
+        return Response(status_code=201)

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
@@ -665,15 +665,17 @@ def _make_member_endpoint(
     real_pk = _pk_name(model)
     pk_names = _pk_names(model)
 
-    # --- No body on GET read / DELETE delete ---
-    if target in {"read", "delete"}:
+    body_model = _request_model_for(sp, model)
+
+    # --- No body on GET read / DELETE delete or when no request model ---
+    if target in {"read", "delete"} or body_model is None:
 
         async def _endpoint(
             item_id: Any,
             request: Request,
             db: Any = Depends(db_dep),
         ):
-            payload: Mapping[str, Any] = {}  # no body
+            payload: Mapping[str, Any] = {}
             ctx: Dict[str, Any] = {
                 "request": request,
                 "db": db,
@@ -706,7 +708,6 @@ def _make_member_endpoint(
 
     # --- Body-based member endpoints: PATCH update / PUT replace (and custom member) ---
 
-    body_model = _request_model_for(sp, model)
     body_annotation = body_model if body_model is not None else Mapping[str, Any]
 
     async def _endpoint(


### PR DESCRIPTION
## Summary
- allow custom member operations without a request model to omit a body
- return a 201 with no body from `/kms/key/{id}/rotate`
- test key rotation to ensure the 201 response and version update

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff format .`
- `uv run --directory standards/autoapi --package autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_v3_op_ctx_attributes.py`
- `uv run --directory standards/auto_kms --package auto_kms ruff format .`
- `uv run --directory standards/auto_kms --package auto_kms ruff check . --fix`
- `uv run --package auto_kms --directory standards/auto_kms pytest tests/unit/test_key_rotate.py::test_key_rotate_creates_new_version`


------
https://chatgpt.com/codex/tasks/task_e_68a5ded71dec832685dba0f0e5fe6831