### PR TITLE
Return 201 status for key rotation

### DIFF
--- a/pkgs/standards/auto_kms/auto_kms/tables/key.py
+++ b/pkgs/standards/auto_kms/auto_kms/tables/key.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Mapped, relationship
 from autoapi.v3.tables import Base
 from autoapi.v3.specs import acol, vcol, S, F, IO
 from autoapi.v3.decorators import hook_ctx, op_ctx
-from fastapi import HTTPException
+from fastapi import HTTPException, Response
 
 if TYPE_CHECKING:
     from .key_version import KeyVersion
@@ -143,7 +143,6 @@ class Key(Base):
     @hook_ctx(ops="create", phase="POST_HANDLER")
     async def _seed_primary_version(cls, ctx):
         import secrets
-        from sqlalchemy import select
         from swarmauri_core.crypto.types import (
             ExportPolicy,
             KeyType,
@@ -232,7 +231,6 @@ class Key(Base):
         persist="skip",
     )
     async def encrypt(cls, ctx):
-        import base64
         from ..utils import b64d, b64d_optional
 
         p = ctx.get("payload") or {}
@@ -326,7 +324,6 @@ class Key(Base):
         persist="skip",
     )
     async def decrypt(cls, ctx):
-        import base64
         from ..utils import b64d, b64d_optional
 
         p = ctx.get("payload") or {}
@@ -439,4 +436,4 @@ class Key(Base):
         )
         key_obj.primary_version = new_version
         db.add(kv)
-        return {"id": str(key_obj.id), "primary_version": key_obj.primary_version}
+        return Response(status_code=201)

--- a/pkgs/standards/auto_kms/tests/unit/test_key_rotate.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_key_rotate.py
@@ -9,6 +9,7 @@ from sqlalchemy import select
 from autoapi.v3.tables import Base
 from swarmauri_secret_autogpg import AutoGpgSecretDrive
 from auto_kms.tables.key_version import KeyVersion
+from auto_kms.tables.key import Key
 
 
 @pytest.fixture
@@ -45,18 +46,19 @@ def test_key_rotate_creates_new_version(client_app):
     assert key["primary_version"] == 1
 
     res = client.post(f"/kms/key/{key['id']}/rotate", json={})
-    assert res.status_code == 200
-    data = res.json()
-    assert data["primary_version"] == 2
+    assert res.status_code == 201
 
-    async def fetch_versions():
+    async def fetch_key_and_versions():
         async with app.AsyncSessionLocal() as session:
+            key_obj = await session.get(Key, UUID(str(key["id"])))
             result = await session.execute(
                 select(KeyVersion.version).where(
                     KeyVersion.key_id == UUID(str(key["id"]))
                 )
             )
-            return sorted(result.scalars().all())
+            versions = sorted(row[0] for row in result.all())
+            return key_obj, versions
 
-    versions = asyncio.run(fetch_versions())
+    key_obj, versions = asyncio.run(fetch_key_and_versions())
+    assert key_obj.primary_version == 2
     assert versions == [1, 2]


### PR DESCRIPTION
## Summary
- return 201 status for key rotation and remove response body
- update key creation and rotation tests to verify primary version from DB

## Testing
- `uv run --directory pkgs/standards/auto_kms --package auto_kms pytest tests/unit/test_key_creation_versions.py tests/unit/test_key_rotate.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5df36495c8326a669c2b8d0aaeb56