### PR TITLE
fix: scrub key version material in read responses

### DIFF
--- a/pkgs/standards/auto_kms/auto_kms/app.py
+++ b/pkgs/standards/auto_kms/auto_kms/app.py
@@ -56,6 +56,7 @@ api.include_models([Key, KeyVersion], base_prefix="/kms")
 api.mount_jsonrpc(prefix="/kms/rpc")
 api.attach_diagnostics(prefix="/system")
 
+
 @app.on_event("startup")
 async def startup_event():
     await api.initialize_async()

--- a/pkgs/standards/auto_kms/auto_kms/tables/key.py
+++ b/pkgs/standards/auto_kms/auto_kms/tables/key.py
@@ -193,6 +193,18 @@ class Key(Base):
                 }
             )
 
+    @hook_ctx(ops=("read", "list"), phase="POST_RESPONSE")
+    async def _scrub_version_material(cls, ctx):
+        obj = ctx.get("result")
+        if obj is None:
+            return
+        if isinstance(obj, dict):
+            obj.pop("versions", None)
+        else:
+            data = {k: v for k, v in vars(obj).items() if not k.startswith("_")}
+            data.pop("versions", None)
+            ctx["result"] = data
+
     # ---- Hook: ensure key exists & enabled ----
     @hook_ctx(ops=("encrypt", "decrypt", "rotate"), phase="PRE_HANDLER")
     async def _ensure_key_enabled(cls, ctx):


### PR DESCRIPTION
## Summary
- scrub key version material from key read/list responses to avoid returning raw bytes and leaking data
- tidy auto_kms app formatting

## Testing
- `uv run --directory standards/auto_kms --package auto_kms ruff format .`
- `uv run --directory standards/auto_kms --package auto_kms ruff check . --fix`
- `uv run --package auto_kms --directory standards/auto_kms pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5e2c03e9c83268552a023565ebce0