### PR TITLE
Align autoapi tests with new plan step names

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_hook_ctx_v3_i9n.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_hook_ctx_v3_i9n.py
@@ -374,5 +374,5 @@ async def test_hook_ctx_system_steps_i9n():
     res = await client.get("/system/planz")
     data = res.json()
     steps = data["Item"]["create"]
-    assert any("marker" in s for s in steps)
+    assert "sys:handler:crud@HANDLER" in steps
     await client.aclose()

--- a/pkgs/standards/autoapi/tests/i9n/test_iospec_integration.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_iospec_integration.py
@@ -179,5 +179,5 @@ async def test_planz_lists_atoms_and_steps(widget_setup):
     client, _, _ = widget_setup
     data = (await client.get("/system/planz")).json()
     steps = data["Widget"]["create"]
-    assert any("crud.create" in s for s in steps)
-    assert any("sys:txn:begin@START_TX" in s for s in steps)
+    assert "sys:handler:crud@HANDLER" in steps
+    assert "sys:txn:begin@START_TX" in steps

--- a/pkgs/standards/autoapi/tests/i9n/test_schema_ctx_attributes_integration.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_schema_ctx_attributes_integration.py
@@ -172,7 +172,7 @@ async def test_schema_ctx_atomz(schema_ctx_client):
     client, _, _, _ = schema_ctx_client
     planz = (await client.get("/system/planz")).json()
     steps = planz["Widget"]["create"]
-    assert "autoapi.v3.core.crud.create" in steps
+    assert "sys:handler:crud@HANDLER" in steps
 
 
 @pytest.mark.i9n

--- a/pkgs/standards/autoapi/tests/i9n/test_schema_ctx_spec_integration.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_schema_ctx_spec_integration.py
@@ -204,7 +204,7 @@ async def test_schema_ctx_atomz(schema_ctx_client):
     client, _, _, _ = schema_ctx_client
     planz = (await client.get("/system/planz")).json()
     steps = planz["Widget"]["create"]
-    assert "autoapi.v3.core.crud.create" in steps
+    assert "sys:handler:crud@HANDLER" in steps
 
 
 @pytest.mark.i9n

--- a/pkgs/standards/autoapi/tests/i9n/test_storage_spec_integration.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_storage_spec_integration.py
@@ -114,7 +114,7 @@ async def test_storage_spec_atomz(api_client_v3):
     client, _, _, _ = api_client_v3
     planz = (await client.get("/system/planz")).json()
     steps = planz["Widget"]["create"]
-    assert "autoapi.v3.core.crud.create" in steps
+    assert "sys:handler:crud@HANDLER" in steps
 
 
 @pytest.mark.i9n

--- a/pkgs/standards/autoapi_client/autoapi_client/_rpc.py
+++ b/pkgs/standards/autoapi_client/autoapi_client/_rpc.py
@@ -90,7 +90,9 @@ class RPCMixin:
         """
         # ----- payload build ------------------------------------------------
         if isinstance(params, _Schema):  # pydantic in → dump to dict
-            params_dict = json.loads(params.model_dump_json(exclude_none=True, exclude=None))
+            params_dict = json.loads(
+                params.model_dump_json(exclude_none=True, exclude=None)
+            )
         else:
             # ensure plain dicts contain only JSON-serializable values
             params_dict = json.loads(json.dumps(params or {}, default=str))


### PR DESCRIPTION
## Summary
- adjust autoapi integration tests to expect `sys:handler:crud@HANDLER` step
- split long RPC payload line to satisfy ruff formatting

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi_client --directory standards/autoapi_client ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_hook_ctx_v3_i9n.py::test_hook_ctx_system_steps_i9n tests/i9n/test_iospec_integration.py::test_planz_lists_atoms_and_steps tests/i9n/test_schema_ctx_attributes_integration.py::test_schema_ctx_atomz tests/i9n/test_schema_ctx_spec_integration.py::test_schema_ctx_atomz tests/i9n/test_storage_spec_integration.py::test_storage_spec_atomz -q`
- `uv run --package autoapi_client --directory standards/autoapi_client pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5e2b043b08326b521632f5614de99