### PR TITLE
fix: set wrapper function name in ctx core adapter

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/decorators.py
+++ b/pkgs/standards/autoapi/autoapi/v3/decorators.py
@@ -381,6 +381,8 @@ def _wrap_ctx_core(table: type, func: Callable[..., Any]) -> Callable[..., Any]:
         res = await _maybe_await(bound(ctx))
         return res if res is not None else ctx.get("result")
 
+    core.__name__ = getattr(func, "__name__", "core")
+    core.__qualname__ = getattr(func, "__qualname__", core.__name__)
     return core
 
 


### PR DESCRIPTION
## Summary
- ensure ctx-only core wrappers inherit original function names

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest` *(failed: KeyboardInterrupt, 146 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ebb0da008326859cf6aaf0cf7ab4