### PR TITLE
test(autoapi): cover invalid dep names in plan

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/runtime/test_plan.py
+++ b/pkgs/standards/autoapi/tests/unit/runtime/test_plan.py
@@ -235,3 +235,9 @@ def test_ensure_label_returns_label() -> None:
 def test_ensure_label_raises_on_unknown_kind() -> None:
     with pytest.raises(ValueError):
         plan_mod._ensure_label("x", kind="unknown")
+
+
+def test_ensure_label_raises_on_invalid_dep_name() -> None:
+    bad = "autoapi.v3.decorators._wrap_ctx_core.<locals>.core"
+    with pytest.raises(ValueError, match="Invalid dep name"):
+        plan_mod._ensure_label(bad, kind="dep")

--- a/pkgs/standards/autoapi/tests/unit/test_runtime_plan.py
+++ b/pkgs/standards/autoapi/tests/unit/test_runtime_plan.py
@@ -211,3 +211,10 @@ def test_ensure_label_invalid_kind_raises():
     """_ensure_label errors on unsupported kinds."""
     with pytest.raises(ValueError):
         runtime_plan._ensure_label("x", kind="other")
+
+
+def test_ensure_label_invalid_dep_name_rejected():
+    """_ensure_label rejects dep names with invalid characters."""
+    bad = "autoapi.v3.decorators._wrap_ctx_core.<locals>.core"
+    with pytest.raises(ValueError, match="Invalid dep name"):
+        runtime_plan._ensure_label(bad, kind="dep")


### PR DESCRIPTION
## Summary
- add tests ensuring `_ensure_label` rejects invalid dep names such as `autoapi.v3.decorators._wrap_ctx_core.<locals>.core`

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff format .`
- `uv run --directory standards/autoapi --package autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest` *(fails: tests/unit/test_v3_schemas_and_decorators.py::test_rest_serialization_with_and_without_out_schema)*

------
https://chatgpt.com/codex/tasks/task_e_68a5edafdc7083269c95c931be687d97