### PR TITLE
Fix vcol filtering in AutoAPI schema builder

### DIFF
--- a/pkgs/standards/auto_kms/tests/unit/test_key_create_schema.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_key_create_schema.py
@@ -8,3 +8,27 @@ def test_key_create_schema_excludes_id():
     assert "id" not in fields
     assert "name" in fields and "algorithm" in fields
     assert "status" not in fields
+    vcols = {
+        "kid",
+        "plaintext_b64",
+        "aad_b64",
+        "nonce_b64",
+        "alg",
+        "ciphertext_b64",
+        "tag_b64",
+        "version",
+    }
+    assert fields.isdisjoint(vcols)
+
+
+def test_key_encrypt_decrypt_schemas():
+    bind(Key)
+    encrypt_in = set(Key.schemas.encrypt.in_.model_fields.keys())
+    encrypt_out = set(Key.schemas.encrypt.out.model_fields.keys())
+    decrypt_in = set(Key.schemas.decrypt.in_.model_fields.keys())
+    decrypt_out = set(Key.schemas.decrypt.out.model_fields.keys())
+
+    assert {"plaintext_b64", "aad_b64", "nonce_b64", "alg"}.issubset(encrypt_in)
+    assert {"kid", "ciphertext_b64", "tag_b64", "version"}.issubset(encrypt_out)
+    assert {"ciphertext_b64", "nonce_b64"}.issubset(decrypt_in)
+    assert {"plaintext_b64"}.issubset(decrypt_out)

--- a/pkgs/standards/autoapi/autoapi/v3/schema/builder.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/builder.py
@@ -375,6 +375,17 @@ def _build_schema(
         if exclude and attr_name in exclude:
             continue
 
+        io = getattr(spec, "io", None)
+        if include is None:
+            if verb in {"create", "update", "replace", "delete"}:
+                allowed = getattr(io, "in_verbs", None) if io is not None else None
+                if allowed is not None and verb not in set(allowed):
+                    continue
+            else:
+                allowed = getattr(io, "out_verbs", None) if io is not None else None
+                if allowed is not None and verb not in set(allowed):
+                    continue
+
         fs = getattr(spec, "field", None)
         py_t = getattr(fs, "py_type", Any) if fs is not None else Any
         required = bool(fs and verb in getattr(fs, "required_in", ()))

--- a/pkgs/standards/autoapi/tests/unit/test_acol_vcol_knobs.py
+++ b/pkgs/standards/autoapi/tests/unit/test_acol_vcol_knobs.py
@@ -57,6 +57,9 @@ def test_acol_vcol_knobs_affect_bindings_and_schemas():
     assert schema_in["by_field"]["nickname"]["required"] is False
     assert schema_in["by_field"]["nickname"]["virtual"] is True
 
+    create_fields = set(Thing.schemas.create.in_.model_fields.keys())
+    assert "slug" not in create_fields
+
     # openapi response schema via collect_out
     ctx_out = SimpleNamespace(specs=specs, op="read", temp={})
     collect_out.run(None, ctx_out)

--- a/pkgs/standards/autoapi/tests/unit/test_v3_schemas_and_decorators.py
+++ b/pkgs/standards/autoapi/tests/unit/test_v3_schemas_and_decorators.py
@@ -13,6 +13,7 @@ from autoapi.v3.bindings import build_schemas, build_hooks, build_handlers, buil
 
 # REST test client
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 
 
@@ -50,7 +51,7 @@ class Widget:
         response_schema="raw",  # explicit raw → no serialization
     )
     def ping(cls, ctx):
-        return {"id": "5", "name": "x"}
+        return JSONResponse({"id": "5", "name": "x"})
 
 
 def _build_all(model):


### PR DESCRIPTION
## Summary
- ensure virtual columns respect IO verbs when building schemas
- add regression tests for auto_kms key schemas
- clarify test helpers for raw responses

## Testing
- `uv run --package autoapi --directory pkgs/standards/autoapi pytest -q | tail -n 20`
- `uv run --package auto_kms --directory pkgs/standards/auto_kms pytest tests/unit/test_key_create_schema.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5edffa62c83268381c9789a3067a1