### PR TITLE
fix: respect custom handler signatures

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/handlers.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/handlers.py
@@ -424,7 +424,6 @@ def _wrap_custom(model: type, sp: OpSpec, user_handler: Callable[..., Any]) -> S
     Wrap a user-supplied handler so it can be executed as StepFn(ctx).
     We pass keyword args selectively (ctx, db, payload, request, model, op/spec/alias).
     """
-    wanted = _accepted_kw(user_handler)
 
     async def step(ctx: Any) -> Any:
         db = _ctx_db(ctx)
@@ -433,6 +432,7 @@ def _wrap_custom(model: type, sp: OpSpec, user_handler: Callable[..., Any]) -> S
 
         # Try to resolve a *bound* attribute from the class if available
         bound = getattr(model, getattr(user_handler, "__name__", ""), user_handler)
+        wanted = _accepted_kw(bound)
 
         kw = {}
         if "ctx" in wanted:


### PR DESCRIPTION
## Summary
- ensure custom operation handlers only receive supported keyword arguments

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff format autoapi/v3/bindings/handlers.py`
- `uv run --directory standards/autoapi --package autoapi ruff check autoapi/v3/bindings/handlers.py --fix`
- `uv run --directory standards/autoapi --package autoapi pytest tests/unit/test_op_ctx_core_crud_integration.py::test_op_ctx_alias_read_overrides_core tests/unit/test_op_ctx_core_crud_integration.py::test_op_ctx_alias_create_overrides_core tests/unit/test_op_ctx_core_crud_integration.py::test_op_ctx_alias_update_overrides_core tests/unit/test_op_ctx_core_crud_integration.py::test_op_ctx_alias_replace_overrides_core tests/unit/test_op_ctx_core_crud_integration.py::test_op_ctx_alias_delete_overrides_core`


------
https://chatgpt.com/codex/tasks/task_e_68a5ee6fc0e483269ca2abd99c28984f