### PR TITLE
Restrict virtual column schemas to declared verbs

### DIFF
--- a/pkgs/standards/auto_kms/tests/unit/test_key_create_schema.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_key_create_schema.py
@@ -8,3 +8,14 @@ def test_key_create_schema_excludes_id():
     assert "id" not in fields
     assert "name" in fields and "algorithm" in fields
     assert "status" not in fields
+    for vcol in (
+        "kid",
+        "plaintext_b64",
+        "aad_b64",
+        "nonce_b64",
+        "alg",
+        "ciphertext_b64",
+        "tag_b64",
+        "version",
+    ):
+        assert vcol not in fields

--- a/pkgs/standards/auto_kms/tests/unit/test_key_encrypt_decrypt_schema.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_key_encrypt_decrypt_schema.py
@@ -1,0 +1,23 @@
+from autoapi.v3.bindings import bind
+from auto_kms.tables.key import Key
+
+
+def test_key_encrypt_decrypt_schemas():
+    bind(Key)
+    enc_in = set(Key.schemas.encrypt.in_.model_fields.keys())
+    enc_out = set(Key.schemas.encrypt.out.model_fields.keys())
+    dec_in = set(Key.schemas.decrypt.in_.model_fields.keys())
+    dec_out = set(Key.schemas.decrypt.out.model_fields.keys())
+
+    assert {"plaintext_b64", "aad_b64", "nonce_b64", "alg"} <= enc_in
+    assert {
+        "kid",
+        "aad_b64",
+        "nonce_b64",
+        "alg",
+        "ciphertext_b64",
+        "tag_b64",
+        "version",
+    } <= enc_out
+    assert {"aad_b64", "nonce_b64", "alg", "ciphertext_b64", "tag_b64"} <= dec_in
+    assert {"plaintext_b64"} <= dec_out

--- a/pkgs/standards/autoapi/autoapi/v3/schema/builder.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/builder.py
@@ -375,6 +375,13 @@ def _build_schema(
         if exclude and attr_name in exclude:
             continue
 
+        io = getattr(spec, "io", None)
+        allowed_verbs = set(getattr(io, "in_verbs", ()) or ()) | set(
+            getattr(io, "out_verbs", ()) or ()
+        )
+        if allowed_verbs and verb not in allowed_verbs:
+            continue
+
         fs = getattr(spec, "field", None)
         py_t = getattr(fs, "py_type", Any) if fs is not None else Any
         required = bool(fs and verb in getattr(fs, "required_in", ()))


### PR DESCRIPTION
## Summary
- honor IOSpec verb restrictions when building schemas so vcols only appear for allowed operations
- test key schemas to ensure vcols excluded from create and included for encrypt/decrypt operations

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `uv run --directory pkgs/standards/auto_kms --package auto_kms ruff format .`
- `uv run --directory pkgs/standards/auto_kms --package auto_kms ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68a5f00a4b0c8326bdeedc81bfcd1edf