### PR TITLE
Fix vcol schema exposure for custom KMS operations

### DIFF
--- a/pkgs/standards/auto_kms/tests/unit/test_key_create_schema.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_key_create_schema.py
@@ -2,9 +2,20 @@ from autoapi.v3.bindings import bind
 from auto_kms.tables.key import Key
 
 
-def test_key_create_schema_excludes_id():
+def test_key_create_schema_excludes_id_and_vcols():
     bind(Key)
     fields = set(Key.schemas.create.in_.model_fields.keys())
     assert "id" not in fields
     assert "name" in fields and "algorithm" in fields
     assert "status" not in fields
+    vcols = {
+        "kid",
+        "plaintext_b64",
+        "aad_b64",
+        "nonce_b64",
+        "alg",
+        "ciphertext_b64",
+        "tag_b64",
+        "version",
+    }
+    assert vcols.isdisjoint(fields)

--- a/pkgs/standards/auto_kms/tests/unit/test_key_encrypt_decrypt_schemas.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_key_encrypt_decrypt_schemas.py
@@ -1,0 +1,40 @@
+from autoapi.v3.bindings import bind
+from auto_kms.tables.key import Key
+
+
+def test_key_encrypt_decrypt_vcols():
+    bind(Key)
+    enc_in = set(Key.schemas.encrypt.in_.model_fields.keys())
+    assert {"plaintext_b64", "aad_b64", "nonce_b64", "alg"} <= enc_in
+    assert "ciphertext_b64" not in enc_in
+
+    enc_out = set(Key.schemas.encrypt.out.model_fields.keys())
+    assert {
+        "kid",
+        "nonce_b64",
+        "ciphertext_b64",
+        "tag_b64",
+        "alg",
+        "version",
+    } <= enc_out
+    assert "plaintext_b64" not in enc_out
+
+    dec_in = set(Key.schemas.decrypt.in_.model_fields.keys())
+    assert {"ciphertext_b64", "aad_b64", "nonce_b64", "tag_b64", "alg"} <= dec_in
+    assert "plaintext_b64" not in dec_in
+
+    dec_out = set(Key.schemas.decrypt.out.model_fields.keys())
+    assert {"plaintext_b64"} <= dec_out
+    assert "ciphertext_b64" not in dec_out
+
+    read_out = set(Key.schemas.read.out.model_fields.keys())
+    for fld in [
+        "plaintext_b64",
+        "ciphertext_b64",
+        "tag_b64",
+        "nonce_b64",
+        "alg",
+        "version",
+    ]:
+        assert fld not in read_out
+    assert "kid" in read_out

--- a/pkgs/standards/autoapi/autoapi/v3/schema/builder.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/builder.py
@@ -375,6 +375,16 @@ def _build_schema(
         if exclude and attr_name in exclude:
             continue
 
+        io = getattr(spec, "io", None)
+        allowed_in = set(getattr(io, "in_verbs", []) or [])
+        allowed_out = set(getattr(io, "out_verbs", []) or [])
+        if (
+            (allowed_in or allowed_out)
+            and verb not in allowed_in
+            and verb not in allowed_out
+        ):
+            continue
+
         fs = getattr(spec, "field", None)
         py_t = getattr(fs, "py_type", Any) if fs is not None else Any
         required = bool(fs and verb in getattr(fs, "required_in", ()))
@@ -382,7 +392,7 @@ def _build_schema(
         field_kwargs: Dict[str, Any] = dict(getattr(fs, "constraints", {}) or {})
 
         default_factory = getattr(spec, "default_factory", None)
-        if default_factory and verb in set(getattr(spec.io, "in_verbs", []) or []):
+        if default_factory and verb in allowed_in:
             field_kwargs["default_factory"] = default_factory
             required = False
         else:


### PR DESCRIPTION
## Summary
- respect IOSpec verbs when building schemas for virtual columns
- add coverage ensuring AutoKMS virtual fields appear only in encrypt/decrypt operations

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_acol_vcol_knobs.py::test_acol_vcol_knobs_affect_bindings_and_schemas -q`
- `uv run --package auto_kms --directory standards/auto_kms pytest tests/unit/test_key_create_schema.py tests/unit/test_key_encrypt_decrypt_schemas.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a5f00a4b0c8326bdeedc81bfcd1edf