### PR TITLE
feat: add NaCl PKCS11 crypto provider

### DIFF
--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -78,7 +78,8 @@ members = [
     "standards/auto_kms",
     "standards/swarmauri_crypto_paramiko",
     "standards/swarmauri_crypto_pgp",
-    "standards/swarmauri_secret_autogpg",    
+    "standards/swarmauri_crypto_nacl_pkcs11",
+    "standards/swarmauri_secret_autogpg",
     "community/swarmauri_middleware_circuitbreaker",
     "community/swarmauri_middleware_ratepolicy",
     "community/swarmauri_vectorstore_redis",
@@ -201,6 +202,7 @@ auto_kms = { workspace = true }
 swarmauri_secret_autogpg = { workspace = true }
 swarmauri_crypto_paramiko = { workspace = true }
 swarmauri_crypto_pgp = { workspace = true }
+swarmauri_crypto_nacl_pkcs11 = { workspace = true }
 
 swarmauri_vectorstore_redis = { workspace = true }
 swarmauri_vectorstore_qdrant = { workspace = true }

--- a/pkgs/standards/swarmauri_crypto_nacl_pkcs11/LICENSE
+++ b/pkgs/standards/swarmauri_crypto_nacl_pkcs11/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/standards/swarmauri_crypto_nacl_pkcs11/README.md
+++ b/pkgs/standards/swarmauri_crypto_nacl_pkcs11/README.md
@@ -1,0 +1,56 @@
+![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_crypto_nacl_pkcs11/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_crypto_nacl_pkcs11" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_crypto_nacl_pkcs11/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_crypto_nacl_pkcs11.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_crypto_nacl_pkcs11/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_crypto_nacl_pkcs11" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_crypto_nacl_pkcs11/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_crypto_nacl_pkcs11" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_crypto_nacl_pkcs11/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_crypto_nacl_pkcs11?label=swarmauri_crypto_nacl_pkcs11&color=green" alt="PyPI - swarmauri_crypto_nacl_pkcs11"/></a>
+</p>
+
+---
+
+## Swarmauri Crypto NaCl PKCS#11
+
+Hybrid crypto provider using PyNaCl for Ed25519/X25519 operations and `python-pkcs11` for AES-KW key wrapping. Implements the `ICrypto` contract via `CryptoBase`.
+
+- AES-GCM symmetric encrypt/decrypt
+- Ed25519 sign/verify
+- AES-KW wrap/unwrap using PKCS#11
+- X25519 sealed boxes for single and multi-recipient encryption
+
+## Installation
+
+```bash
+pip install swarmauri_crypto_nacl_pkcs11
+```
+
+## Usage
+
+```python
+from swarmauri_crypto_nacl_pkcs11 import NaClPkcs11Crypto
+from swarmauri_core.crypto.types import KeyRef, KeyType, KeyUse, ExportPolicy
+
+crypto = NaClPkcs11Crypto()
+
+sym = KeyRef(
+    kid="sym1",
+    version=1,
+    type=KeyType.SYMMETRIC,
+    uses=(KeyUse.ENCRYPT, KeyUse.DECRYPT),
+    export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+    material=b"\x00" * 32,
+)
+
+ct = await crypto.encrypt(sym, b"hello")
+pt = await crypto.decrypt(sym, ct)
+```
+
+## Entry point
+
+The provider is registered under the `swarmauri.cryptos` entry-point as `NaClPkcs11Crypto`.

--- a/pkgs/standards/swarmauri_crypto_nacl_pkcs11/pyproject.toml
+++ b/pkgs/standards/swarmauri_crypto_nacl_pkcs11/pyproject.toml
@@ -1,0 +1,68 @@
+[project]
+name = "swarmauri_crypto_nacl_pkcs11"
+version = "0.1.0"
+description = "NaCl + PKCS#11 crypto provider for Swarmauri"
+license = "Apache-2.0"
+readme = "README.md"
+requires-python = ">=3.10,<3.13"
+authors = [{ name = "Swarmauri", email = "opensource@swarmauri.com" }]
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Development Status :: 3 - Alpha",
+    "Topic :: Security :: Cryptography",
+    "Intended Audience :: Developers",
+]
+dependencies = [
+    "swarmauri_core",
+    "swarmauri_base",
+    "PyNaCl>=1.5",
+    "cryptography>=41",
+    "python-pkcs11>=0.7.0",
+]
+
+[tool.uv.sources]
+swarmauri_core = { workspace = true }
+swarmauri_base = { workspace = true }
+
+[tool.pytest.ini_options]
+norecursedirs = ["combined", "scripts"]
+markers = [
+    "test: standard test",
+    "unit: Unit tests",
+    "i9n: Integration tests",
+    "r8n: Regression tests",
+    "acceptance: Acceptance tests",
+    "perf: Performance tests",
+]
+timeout = 300
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "flake8>=7.0",
+    "ruff>=0.9.9",
+    "pytest-timeout>=2.3.1",
+]
+
+[project.entry-points.'swarmauri.cryptos']
+NaClPkcs11Crypto = "swarmauri_crypto_nacl_pkcs11:NaClPkcs11Crypto"
+
+[project.entry-points."peagen.plugins.cryptos"]
+nacl_pkcs11 = "swarmauri_crypto_nacl_pkcs11:NaClPkcs11Crypto"

--- a/pkgs/standards/swarmauri_crypto_nacl_pkcs11/swarmauri_crypto_nacl_pkcs11/NaClPkcs11Crypto.py
+++ b/pkgs/standards/swarmauri_crypto_nacl_pkcs11/swarmauri_crypto_nacl_pkcs11/NaClPkcs11Crypto.py
@@ -1,0 +1,307 @@
+"""NaCl + PKCS#11 backed crypto provider with sealing support."""
+
+from __future__ import annotations
+
+import json
+import os
+import base64
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Optional, Tuple, Literal
+
+from nacl.public import PublicKey, PrivateKey, SealedBox
+from nacl.signing import SigningKey, VerifyKey
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+import pkcs11
+from pkcs11 import Attribute, KeyType as PKKeyType, Mechanism
+
+from swarmauri_core.crypto.types import (
+    AEADCiphertext,
+    Alg,
+    KeyRef,
+    MultiRecipientEnvelope,
+    RecipientInfo,
+    Signature,
+    WrappedKey,
+    UnsupportedAlgorithm,
+)
+from swarmauri_core.crypto.types import KeyType
+from swarmauri_base.crypto.CryptoBase import CryptoBase
+from swarmauri_base.ComponentBase import ComponentBase
+
+
+@dataclass
+class _Resolved:
+    kind: str
+    material: bytes | Any
+
+
+def _resolve_keyref_for_aead(key: KeyRef) -> _Resolved:
+    if key.type == KeyType.SYMMETRIC and key.material:
+        kb = key.material
+        if len(kb) not in (16, 24, 32):
+            raise ValueError("AES key must be 128/192/256 bits")
+        return _Resolved(kind="aes", material=kb)
+    raise ValueError("Unsupported KeyRef for AEAD")
+
+
+def _resolve_keyref_for_sign(key: KeyRef, for_verify: bool = False) -> _Resolved:
+    if for_verify:
+        if key.type == KeyType.ED25519 and key.public:
+            return _Resolved(kind="ed25519_verify", material=key.public)
+    else:
+        if key.type == KeyType.ED25519 and key.material:
+            return _Resolved(kind="ed25519_sign", material=key.material)
+    raise ValueError("Unsupported KeyRef for sign/verify")
+
+
+def _resolve_keyref_for_sealed_box(key: KeyRef, private: bool = False) -> _Resolved:
+    if not private:
+        if key.type == KeyType.X25519 and key.public:
+            return _Resolved(kind="x25519_pub", material=key.public)
+    else:
+        if key.type == KeyType.X25519 and key.material:
+            return _Resolved(kind="x25519_priv", material=key.material)
+    raise ValueError("Unsupported KeyRef for sealed-box")
+
+
+def _resolve_keyref_for_hsm_kek(kek: KeyRef) -> Tuple[pkcs11.Session, pkcs11.SecretKey]:
+    tags = kek.tags or {}
+    module_path = tags.get("module") or os.environ.get("PKCS11_MODULE")
+    slot_label = tags.get("slot_label") or os.environ.get("PKCS11_SLOT_LABEL")
+    user_pin = tags.get("user_pin") or os.environ.get("PKCS11_USER_PIN")
+    kek_label = tags.get("label") or os.environ.get("PKCS11_KEK_LABEL", "autokms-kek")
+
+    lib = pkcs11.lib(module_path)
+    token = next(t for t in lib.get_tokens() if t.label == slot_label)
+    sess = token.open(user_pin=user_pin)
+    keys = list(
+        sess.get_objects(
+            {
+                Attribute.LABEL: kek_label,
+                Attribute.CLASS: pkcs11.constants.ObjectClass.SECRET_KEY,
+            }
+        )
+    )
+    if not keys:
+        raise RuntimeError(f"KEK '{kek_label}' not found in slot {slot_label}")
+    return sess, keys[0]
+
+
+_SEAL_ALG = "X25519-SEALEDBOX"
+_AEAD_ALG = "AES-GCM"
+_WRAP_ALG = "AES-KW"
+
+
+@ComponentBase.register_type(CryptoBase, "NaClPkcs11Crypto")
+class NaClPkcs11Crypto(CryptoBase):
+    """Concrete implementation of the ICrypto contract using PyNaCl and PKCS#11."""
+
+    type: Literal["NaClPkcs11Crypto"] = "NaClPkcs11Crypto"
+
+    def supports(self) -> Dict[str, Iterable[Alg]]:
+        return {
+            "encrypt": (_AEAD_ALG,),
+            "decrypt": (_AEAD_ALG,),
+            "wrap": (_WRAP_ALG,),
+            "unwrap": (_WRAP_ALG,),
+            "sign": ("ED25519",),
+            "verify": ("ED25519",),
+            "seal": (_SEAL_ALG,),
+            "unseal": (_SEAL_ALG,),
+            "for_many": (_SEAL_ALG,),
+        }
+
+    # ────────────────────────── AEAD ──────────────────────────
+    async def encrypt(
+        self,
+        key: KeyRef,
+        pt: bytes,
+        *,
+        alg: Optional[Alg] = None,
+        aad: Optional[bytes] = None,
+        nonce: Optional[bytes] = None,
+    ) -> AEADCiphertext:
+        alg = alg or _AEAD_ALG
+        if alg != _AEAD_ALG:
+            raise UnsupportedAlgorithm(f"Unsupported AEAD algorithm: {alg}")
+        r = _resolve_keyref_for_aead(key)
+        n = nonce or os.urandom(12)
+        aead = AESGCM(r.material)
+        ct_with_tag = aead.encrypt(n, pt, aad)
+        ct, tag = ct_with_tag[:-16], ct_with_tag[-16:]
+        return AEADCiphertext(
+            kid=key.kid,
+            version=key.version,
+            alg=alg,
+            nonce=n,
+            ct=ct,
+            tag=tag,
+            aad=aad,
+        )
+
+    async def decrypt(
+        self,
+        key: KeyRef,
+        ct: AEADCiphertext,
+        *,
+        aad: Optional[bytes] = None,
+    ) -> bytes:
+        if ct.alg != _AEAD_ALG:
+            raise UnsupportedAlgorithm(f"Unsupported AEAD algorithm: {ct.alg}")
+        r = _resolve_keyref_for_aead(key)
+        aead = AESGCM(r.material)
+        blob = ct.ct + ct.tag
+        return aead.decrypt(ct.nonce, blob, aad or ct.aad)
+
+    # ────────────────────────── Sign / Verify ──────────────────────────
+    async def sign(
+        self,
+        key: KeyRef,
+        msg: bytes,
+        *,
+        alg: Optional[Alg] = None,
+    ) -> Signature:
+        alg = alg or "ED25519"
+        if alg != "ED25519":
+            raise UnsupportedAlgorithm(f"Unsupported sign algorithm: {alg}")
+        r = _resolve_keyref_for_sign(key, for_verify=False)
+        sig = SigningKey(r.material).sign(msg).signature
+        return Signature(kid=key.kid, version=key.version, alg=alg, sig=sig)
+
+    async def verify(
+        self,
+        key: KeyRef,
+        msg: bytes,
+        sig: Signature,
+    ) -> bool:
+        if sig.alg != "ED25519":
+            return False
+        r = _resolve_keyref_for_sign(key, for_verify=True)
+        try:
+            VerifyKey(r.material).verify(msg, sig.sig)
+            return True
+        except Exception:
+            return False
+
+    # ────────────────────────── Wrap / Unwrap ──────────────────────────
+    async def wrap(
+        self,
+        kek: KeyRef,
+        *,
+        dek: Optional[bytes] = None,
+        wrap_alg: Optional[Alg] = None,
+        nonce: Optional[bytes] = None,
+    ) -> WrappedKey:
+        alg = wrap_alg or _WRAP_ALG
+        if alg != _WRAP_ALG:
+            raise UnsupportedAlgorithm(f"Unsupported wrap algorithm: {alg}")
+        if not dek:
+            raise ValueError("wrap requires a DEK")
+        sess, kek_obj = _resolve_keyref_for_hsm_kek(kek)
+        tmp = sess.create_secret_key(PKKeyType.AES, len(dek) * 8, value=dek)
+        wrapped = kek_obj.wrap_key(tmp, mechanism=Mechanism.AES_KEY_WRAP_PAD)
+        tmp.destroy()
+        return WrappedKey(
+            kek_kid=kek.kid, kek_version=kek.version, wrap_alg=alg, wrapped=wrapped
+        )
+
+    async def unwrap(self, kek: KeyRef, wrapped: WrappedKey) -> bytes:
+        if wrapped.wrap_alg != _WRAP_ALG:
+            raise UnsupportedAlgorithm(
+                f"Unsupported wrapped key algorithm: {wrapped.wrap_alg}"
+            )
+        sess, kek_obj = _resolve_keyref_for_hsm_kek(kek)
+        key = kek_obj.unwrap_key(
+            wrapped.wrapped,
+            mechanism=Mechanism.AES_KEY_WRAP_PAD,
+            template={
+                Attribute.CLASS: pkcs11.ObjectClass.SECRET_KEY,
+                Attribute.KEY_TYPE: PKKeyType.AES,
+            },
+        )
+        return key[Attribute.VALUE]
+
+    # ────────────────── Multi-recipient (Sealed Box) ──────────────────
+    async def encrypt_for_many(
+        self,
+        recipients: Iterable[KeyRef],
+        pt: bytes,
+        *,
+        enc_alg: Optional[Alg] = None,
+        recipient_wrap_alg: Optional[Alg] = None,
+        aad: Optional[bytes] = None,
+        nonce: Optional[bytes] = None,
+    ) -> MultiRecipientEnvelope:
+        alg = enc_alg or _SEAL_ALG
+        if alg != _SEAL_ALG:
+            raise UnsupportedAlgorithm(f"Unsupported multi-recipient alg: {alg}")
+
+        infos = []
+        for ref in recipients:
+            r = _resolve_keyref_for_sealed_box(ref, private=False)
+            c = SealedBox(PublicKey(r.material)).encrypt(pt)
+            infos.append(
+                RecipientInfo(
+                    kid=ref.kid,
+                    version=ref.version,
+                    wrap_alg=_SEAL_ALG,
+                    wrapped_key=c,
+                )
+            )
+
+        # optional AAD binding by wrapping whole envelope
+        if aad:
+            dek = AESGCM.generate_key(bit_length=256)
+            aead = AESGCM(dek)
+            n = os.urandom(12)
+            packed = json.dumps(
+                {i.kid: base64.b64encode(i.wrapped_key).decode("ascii") for i in infos}
+            ).encode("utf-8")
+            ct_with_tag = aead.encrypt(n, packed, aad)
+            ct, tag = ct_with_tag[:-16], ct_with_tag[-16:]
+            # The DEK is not returned; caller should wrap it separately if needed.
+            return MultiRecipientEnvelope(
+                enc_alg=_AEAD_ALG,
+                nonce=n,
+                ct=ct,
+                tag=tag,
+                recipients=tuple(infos),
+                aad=aad,
+            )
+
+        return MultiRecipientEnvelope(
+            enc_alg=_SEAL_ALG,
+            nonce=b"",
+            ct=b"",
+            tag=b"",
+            recipients=tuple(infos),
+            aad=None,
+        )
+
+    # ───────────────────────────── seal / unseal ─────────────────────────────
+    async def seal(
+        self,
+        recipient: KeyRef,
+        pt: bytes,
+        *,
+        alg: Optional[Alg] = None,
+    ) -> bytes:
+        alg = alg or _SEAL_ALG
+        if alg != _SEAL_ALG:
+            raise UnsupportedAlgorithm(f"Unsupported seal algorithm: {alg}")
+        r = _resolve_keyref_for_sealed_box(recipient, private=False)
+        return SealedBox(PublicKey(r.material)).encrypt(pt)
+
+    async def unseal(
+        self,
+        recipient_priv: KeyRef,
+        sealed: bytes,
+        *,
+        alg: Optional[Alg] = None,
+    ) -> bytes:
+        alg = alg or _SEAL_ALG
+        if alg != _SEAL_ALG:
+            raise UnsupportedAlgorithm(f"Unsupported seal algorithm: {alg}")
+        r = _resolve_keyref_for_sealed_box(recipient_priv, private=True)
+        return SealedBox(PrivateKey(r.material)).decrypt(sealed)

--- a/pkgs/standards/swarmauri_crypto_nacl_pkcs11/swarmauri_crypto_nacl_pkcs11/__init__.py
+++ b/pkgs/standards/swarmauri_crypto_nacl_pkcs11/swarmauri_crypto_nacl_pkcs11/__init__.py
@@ -1,0 +1,3 @@
+from .NaClPkcs11Crypto import NaClPkcs11Crypto
+
+__all__ = ["NaClPkcs11Crypto"]

--- a/pkgs/standards/swarmauri_crypto_nacl_pkcs11/tests/unit/test_NaClPkcs11Crypto.py
+++ b/pkgs/standards/swarmauri_crypto_nacl_pkcs11/tests/unit/test_NaClPkcs11Crypto.py
@@ -1,0 +1,105 @@
+import pytest
+from nacl.signing import SigningKey
+from nacl.public import PrivateKey
+
+from swarmauri_crypto_nacl_pkcs11 import NaClPkcs11Crypto
+from swarmauri_core.crypto.types import ExportPolicy, KeyRef, KeyType, KeyUse
+
+
+@pytest.fixture
+def crypto():
+    return NaClPkcs11Crypto()
+
+
+@pytest.mark.unit
+def test_resource_and_type(crypto):
+    assert crypto.resource == "Crypto"
+    assert crypto.type == "NaClPkcs11Crypto"
+
+
+@pytest.mark.asyncio
+async def test_aead_encrypt_decrypt_roundtrip(crypto):
+    key = KeyRef(
+        kid="sym1",
+        version=1,
+        type=KeyType.SYMMETRIC,
+        uses=(KeyUse.ENCRYPT, KeyUse.DECRYPT),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+        material=b"\x11" * 32,
+    )
+    pt = b"hello world"
+    ct = await crypto.encrypt(key, pt)
+    rt = await crypto.decrypt(key, ct)
+    assert rt == pt
+
+
+@pytest.mark.asyncio
+async def test_sign_verify_roundtrip(crypto):
+    sk = SigningKey.generate()
+    vk = sk.verify_key
+    sign_ref = KeyRef(
+        kid="ed1",
+        version=1,
+        type=KeyType.ED25519,
+        uses=(KeyUse.SIGN,),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+        material=sk.encode(),
+    )
+    verify_ref = KeyRef(
+        kid="ed1",
+        version=1,
+        type=KeyType.ED25519,
+        uses=(KeyUse.VERIFY,),
+        export_policy=ExportPolicy.PUBLIC_ONLY,
+        public=vk.encode(),
+    )
+    msg = b"sign me"
+    sig = await crypto.sign(sign_ref, msg)
+    assert await crypto.verify(verify_ref, msg, sig)
+
+
+@pytest.mark.asyncio
+async def test_seal_unseal(crypto):
+    priv = PrivateKey.generate()
+    pub_ref = KeyRef(
+        kid="x1",
+        version=1,
+        type=KeyType.X25519,
+        uses=(KeyUse.ENCRYPT,),
+        export_policy=ExportPolicy.PUBLIC_ONLY,
+        public=priv.public_key.encode(),
+    )
+    priv_ref = KeyRef(
+        kid="x1",
+        version=1,
+        type=KeyType.X25519,
+        uses=(KeyUse.DECRYPT,),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+        material=priv.encode(),
+        public=priv.public_key.encode(),
+    )
+    pt = b"sealed secret"
+    sealed = await crypto.seal(pub_ref, pt)
+    opened = await crypto.unseal(priv_ref, sealed)
+    assert opened == pt
+
+
+@pytest.mark.asyncio
+async def test_encrypt_for_many(crypto):
+    priv = PrivateKey.generate()
+    pub_ref = KeyRef(
+        kid="x1",
+        version=1,
+        type=KeyType.X25519,
+        uses=(KeyUse.ENCRYPT,),
+        export_policy=ExportPolicy.PUBLIC_ONLY,
+        public=priv.public_key.encode(),
+    )
+    env = await crypto.encrypt_for_many([pub_ref], b"hi")
+    assert env.enc_alg == "X25519-SEALEDBOX"
+    assert env.nonce == env.ct == env.tag == b""
+    assert len(env.recipients) == 1
+    info = env.recipients[0]
+    assert info.kid == "x1"
+    assert info.wrap_alg == "X25519-SEALEDBOX"
+    assert info.wrapped_key


### PR DESCRIPTION
## Summary
- add NaClPkcs11Crypto plugin with AES-GCM, Ed25519, AES-KW and X25519 sealed box support
- register plugin with entry points and workspace configuration
- cover core features with unit tests

## Testing
- `uv run --package swarmauri_crypto_nacl_pkcs11 --directory standards/swarmauri_crypto_nacl_pkcs11 ruff format .`
- `uv run --package swarmauri_crypto_nacl_pkcs11 --directory standards/swarmauri_crypto_nacl_pkcs11 ruff check . --fix`
- `uv run --package swarmauri_crypto_nacl_pkcs11 --directory standards/swarmauri_crypto_nacl_pkcs11 pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6a114328c8326812311f4e881732a