### PR TITLE
feat: add libsodium crypto plugin

### DIFF
--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -78,6 +78,7 @@ members = [
     "standards/auto_kms",
     "standards/swarmauri_crypto_paramiko",
     "standards/swarmauri_crypto_pgp",
+    "standards/swarmauri_crypto_sodium",
     "standards/swarmauri_secret_autogpg",    
     "community/swarmauri_middleware_circuitbreaker",
     "community/swarmauri_middleware_ratepolicy",

--- a/pkgs/standards/swarmauri_crypto_sodium/LICENSE
+++ b/pkgs/standards/swarmauri_crypto_sodium/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/standards/swarmauri_crypto_sodium/README.md
+++ b/pkgs/standards/swarmauri_crypto_sodium/README.md
@@ -1,0 +1,56 @@
+![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_crypto_sodium/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_crypto_sodium" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_crypto_sodium/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_crypto_sodium.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_crypto_sodium/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_crypto_sodium" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_crypto_sodium/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_crypto_sodium" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_crypto_sodium/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_crypto_sodium?label=swarmauri_crypto_sodium&color=green" alt="PyPI - swarmauri_crypto_sodium"/></a>
+</p>
+
+---
+
+## Swarmauri Crypto Sodium
+
+Libsodium-backed crypto provider implementing the `ICrypto` contract via `CryptoBase`.
+
+- XChaCha20-Poly1305 symmetric encrypt/decrypt
+- Ed25519 sign/verify
+- X25519 sealed boxes for data sealing and key wrapping
+- Multi-recipient envelopes using XChaCha20-Poly1305 + X25519 sealed wrap
+
+## Installation
+
+```bash
+pip install swarmauri_crypto_sodium
+```
+
+## Usage
+
+```python
+from swarmauri_crypto_sodium import SodiumCrypto
+from swarmauri_core.crypto.types import KeyRef, KeyType, KeyUse, ExportPolicy
+
+crypto = SodiumCrypto()
+
+sym = KeyRef(
+    kid="sym1",
+    version=1,
+    type=KeyType.SYMMETRIC,
+    uses=(KeyUse.ENCRYPT, KeyUse.DECRYPT),
+    export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+    material=b"\x00" * 32,
+)
+
+ct = await crypto.encrypt(sym, b"hello")
+pt = await crypto.decrypt(sym, ct)
+```
+
+## Entry point
+
+The provider is registered under the `swarmauri.cryptos` entry-point as `SodiumCrypto`.

--- a/pkgs/standards/swarmauri_crypto_sodium/pyproject.toml
+++ b/pkgs/standards/swarmauri_crypto_sodium/pyproject.toml
@@ -1,0 +1,65 @@
+[project]
+name = "swarmauri_crypto_sodium"
+version = "0.1.0"
+description = "Libsodium-backed crypto provider for Swarmauri"
+license = "Apache-2.0"
+readme = "README.md"
+requires-python = ">=3.10,<3.13"
+authors = [{ name = "Swarmauri", email = "opensource@swarmauri.com" }]
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Development Status :: 3 - Alpha",
+    "Topic :: Security :: Cryptography",
+    "Intended Audience :: Developers",
+]
+dependencies = [
+    "swarmauri_core",
+    "swarmauri_base",
+]
+
+[tool.uv.sources]
+swarmauri_core = { workspace = true }
+swarmauri_base = { workspace = true }
+
+[tool.pytest.ini_options]
+norecursedirs = ["combined", "scripts"]
+markers = [
+    "test: standard test",
+    "unit: Unit tests",
+    "i9n: Integration tests",
+    "r8n: Regression tests",
+    "acceptance: Acceptance tests",
+    "perf: Performance tests",
+]
+timeout = 300
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "flake8>=7.0",
+    "ruff>=0.9.9",
+    "pytest-timeout>=2.3.1",
+]
+
+[project.entry-points.'swarmauri.cryptos']
+SodiumCrypto = "swarmauri_crypto_sodium:SodiumCrypto"
+
+[project.entry-points."peagen.plugins.cryptos"]
+sodium = "swarmauri_crypto_sodium:SodiumCrypto"

--- a/pkgs/standards/swarmauri_crypto_sodium/swarmauri_crypto_sodium/SodiumCrypto.py
+++ b/pkgs/standards/swarmauri_crypto_sodium/swarmauri_crypto_sodium/SodiumCrypto.py
@@ -1,0 +1,561 @@
+"""Libsodium-backed crypto provider (no PyNaCl).
+
+Implements the ICrypto contract using:
+- XChaCha20-Poly1305-IETF for symmetric AEAD
+- Ed25519 for sign/verify
+- X25519 sealed boxes for:
+    • sealing/unsealing data (X25519-SEALEDBOX)
+    • wrapping/unwrapping DEKs (X25519-SEAL-WRAP)
+- encrypt_for_many:
+    • sealed-style (enc_alg="X25519-SEALEDBOX")
+    • KEM+AEAD (enc_alg="XCHACHA20-POLY1305", recipient_wrap_alg="X25519-SEAL-WRAP")
+
+This implementation calls libsodium via ctypes and does not depend on PyNaCl.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import sys
+from ctypes import (
+    CDLL,
+    POINTER,
+    byref,
+    c_int,
+    c_ubyte,
+    c_ulonglong,
+)
+from functools import lru_cache
+from typing import Any, Dict, Iterable, Literal, Optional
+
+from swarmauri_core.crypto.types import (
+    AEADCiphertext,
+    Alg,
+    IntegrityError,
+    KeyRef,
+    MultiRecipientEnvelope,
+    RecipientInfo,
+    Signature,
+    UnsupportedAlgorithm,
+    WrappedKey,
+)
+from swarmauri_core.crypto.types import (
+    KeyType,
+    KeyUse,
+    ExportPolicy,
+)  # re-export for tests
+from swarmauri_base.crypto.CryptoBase import CryptoBase
+
+# ---------- libsodium constants ----------
+_XCHACHA_KEYBYTES = 32
+_XCHACHA_NPUBBYTES = 24
+_XCHACHA_ABYTES = 16
+
+_CRYPTO_BOX_PUBLICKEYBYTES = 32
+_CRYPTO_BOX_SECRETKEYBYTES = 32
+_CRYPTO_BOX_SEALBYTES = 48  # 32 (pk) + 16 (mac)
+
+_CRYPTO_SIGN_PUBLICKEYBYTES = 32
+_CRYPTO_SIGN_SECRETKEYBYTES = 64
+_CRYPTO_SIGN_BYTES = 64
+
+_AEAD_DEFAULT = "XCHACHA20-POLY1305"
+_SEAL_ALG = "X25519-SEALEDBOX"
+_WRAP_ALG = "X25519-SEAL-WRAP"
+_SIGN_ALG = "ED25519"
+
+
+# ---------- libsodium loader ----------
+def _load_libsodium() -> CDLL:
+    env = os.environ.get("LIBSODIUM_PATH")
+    if env and os.path.exists(env):
+        return CDLL(env)
+
+    names: list[str]
+    if sys.platform.startswith("linux"):
+        names = ["libsodium.so.23", "libsodium.so"]
+    elif sys.platform == "darwin":
+        names = ["libsodium.23.dylib", "libsodium.dylib", "lib/libsodium.dylib"]
+    elif sys.platform.startswith("win"):
+        names = ["libsodium.dll", "sodium.dll"]
+    else:
+        names = []
+    for n in names:
+        try:
+            return CDLL(n)
+        except OSError:
+            continue
+    raise RuntimeError(
+        "Could not load libsodium. Set LIBSODIUM_PATH or install libsodium."
+    )
+
+
+@lru_cache(maxsize=1)
+def _sodium() -> CDLL:
+    lib = _load_libsodium()
+
+    lib.sodium_init.restype = c_int
+    if lib.sodium_init() < 0:
+        raise RuntimeError("sodium_init failed")
+
+    # AEAD
+    lib.crypto_aead_xchacha20poly1305_ietf_encrypt.restype = c_int
+    lib.crypto_aead_xchacha20poly1305_ietf_encrypt.argtypes = [
+        POINTER(c_ubyte),
+        POINTER(c_ulonglong),
+        POINTER(c_ubyte),
+        c_ulonglong,
+        POINTER(c_ubyte),
+        c_ulonglong,
+        POINTER(c_ubyte),
+        POINTER(c_ubyte),
+        POINTER(c_ubyte),
+    ]
+
+    lib.crypto_aead_xchacha20poly1305_ietf_decrypt.restype = c_int
+    lib.crypto_aead_xchacha20poly1305_ietf_decrypt.argtypes = [
+        POINTER(c_ubyte),
+        POINTER(c_ulonglong),
+        POINTER(c_ubyte),
+        POINTER(c_ubyte),
+        c_ulonglong,
+        POINTER(c_ubyte),
+        c_ulonglong,
+        POINTER(c_ubyte),
+        POINTER(c_ubyte),
+    ]
+
+    # Sealed boxes
+    lib.crypto_box_seal.restype = c_int
+    lib.crypto_box_seal.argtypes = [
+        POINTER(c_ubyte),
+        POINTER(c_ubyte),
+        c_ulonglong,
+        POINTER(c_ubyte),
+    ]
+
+    lib.crypto_box_seal_open.restype = c_int
+    lib.crypto_box_seal_open.argtypes = [
+        POINTER(c_ubyte),
+        POINTER(c_ubyte),
+        c_ulonglong,
+        POINTER(c_ubyte),
+        POINTER(c_ubyte),
+    ]
+
+    # Ed25519 sign/verify
+    lib.crypto_sign_ed25519_detached.restype = c_int
+    lib.crypto_sign_ed25519_detached.argtypes = [
+        POINTER(c_ubyte),
+        POINTER(c_ulonglong),
+        POINTER(c_ubyte),
+        c_ulonglong,
+        POINTER(c_ubyte),
+    ]
+
+    lib.crypto_sign_ed25519_verify_detached.restype = c_int
+    lib.crypto_sign_ed25519_verify_detached.argtypes = [
+        POINTER(c_ubyte),
+        POINTER(c_ubyte),
+        c_ulonglong,
+        POINTER(c_ubyte),
+    ]
+
+    # keypair generation helpers
+    lib.crypto_box_keypair.restype = c_int
+    lib.crypto_box_keypair.argtypes = [POINTER(c_ubyte), POINTER(c_ubyte)]
+
+    lib.crypto_sign_ed25519_keypair.restype = c_int
+    lib.crypto_sign_ed25519_keypair.argtypes = [POINTER(c_ubyte), POINTER(c_ubyte)]
+
+    return lib
+
+
+# ---------- helpers ----------
+def _as_ubytes(b: bytes) -> POINTER(c_ubyte):
+    return (c_ubyte * len(b)).from_buffer_copy(b)
+
+
+def _ensure_len(name: str, b: Optional[bytes], *sizes: int) -> bytes:
+    if b is None:
+        raise ValueError(f"{name} is required")
+    if sizes and len(b) not in sizes:
+        raise IntegrityError(f"{name} must be one of lengths {sizes}, got {len(b)}")
+    return b
+
+
+def _normalize_aead_alg(alg: Any) -> Alg:
+    a = (alg.value if hasattr(alg, "value") else alg) or _AEAD_DEFAULT
+    if a.upper() in ("XCHACHA20_POLY1305", "XCHACHA20-POLY1305"):
+        return _AEAD_DEFAULT
+    return a
+
+
+# =========================== Provider ===========================
+
+
+class SodiumCrypto(CryptoBase):
+    """Libsodium-backed provider (no PyNaCl)."""
+
+    type: Literal["SodiumCrypto"] = "SodiumCrypto"
+
+    # ---------------- capabilities ----------------
+    def supports(self) -> Dict[str, Iterable[Alg]]:
+        return {
+            "encrypt": (_AEAD_DEFAULT,),
+            "decrypt": (_AEAD_DEFAULT,),
+            "wrap": (_WRAP_ALG,),
+            "unwrap": (_WRAP_ALG,),
+            "sign": (_SIGN_ALG,),
+            "verify": (_SIGN_ALG,),
+            "seal": (_SEAL_ALG,),
+            "unseal": (_SEAL_ALG,),
+        }
+
+    # ---------------- AEAD: XChaCha20-Poly1305 ----------------
+    async def encrypt(
+        self,
+        key: KeyRef,
+        pt: bytes,
+        *,
+        alg: Optional[Alg] = None,
+        aad: Optional[bytes] = None,
+        nonce: Optional[bytes] = None,
+    ) -> AEADCiphertext:
+        alg = _normalize_aead_alg(alg)
+        if alg != _AEAD_DEFAULT:
+            raise UnsupportedAlgorithm(f"Unsupported AEAD algorithm: {alg}")
+
+        k = _ensure_len("AEAD key.material", key.material, _XCHACHA_KEYBYTES)
+        npub = nonce or secrets.token_bytes(_XCHACHA_NPUBBYTES)
+        if len(npub) != _XCHACHA_NPUBBYTES:
+            raise IntegrityError(f"nonce must be {_XCHACHA_NPUBBYTES} bytes")
+
+        ad = aad or b""
+        m = pt
+
+        c_len = len(m) + _XCHACHA_ABYTES
+        c_buf = (c_ubyte * (c_len))()
+        c_len_out = c_ulonglong(0)
+
+        rc = _sodium().crypto_aead_xchacha20poly1305_ietf_encrypt(
+            c_buf,
+            byref(c_len_out),
+            _as_ubytes(m),
+            c_ulonglong(len(m)),
+            _as_ubytes(ad),
+            c_ulonglong(len(ad)),
+            None,
+            _as_ubytes(npub),
+            _as_ubytes(k),
+        )
+        if rc != 0:
+            raise IntegrityError("AEAD encrypt failed")
+
+        c = bytes(c_buf)[: c_len_out.value]
+        ct, tag = c[:-_XCHACHA_ABYTES], c[-_XCHACHA_ABYTES:]
+
+        return AEADCiphertext(
+            kid=key.kid,
+            version=key.version,
+            alg=_AEAD_DEFAULT,
+            nonce=npub,
+            ct=ct,
+            tag=tag,
+            aad=ad if ad else None,
+        )
+
+    async def decrypt(
+        self,
+        key: KeyRef,
+        ct: AEADCiphertext,
+        *,
+        aad: Optional[bytes] = None,
+    ) -> bytes:
+        if _normalize_aead_alg(ct.alg) != _AEAD_DEFAULT:
+            raise UnsupportedAlgorithm(f"Unsupported AEAD algorithm: {ct.alg}")
+
+        k = _ensure_len("AEAD key.material", key.material, _XCHACHA_KEYBYTES)
+        if len(ct.nonce) != _XCHACHA_NPUBBYTES:
+            raise IntegrityError(f"nonce must be {_XCHACHA_NPUBBYTES} bytes")
+
+        ad = aad if aad is not None else (ct.aad or b"")
+        blob = ct.ct + ct.tag
+
+        m_buf = (c_ubyte * len(blob))()
+        m_len_out = c_ulonglong(0)
+
+        rc = _sodium().crypto_aead_xchacha20poly1305_ietf_decrypt(
+            m_buf,
+            byref(m_len_out),
+            None,
+            _as_ubytes(blob),
+            c_ulonglong(len(blob)),
+            _as_ubytes(ad),
+            c_ulonglong(len(ad)),
+            _as_ubytes(ct.nonce),
+            _as_ubytes(k),
+        )
+        if rc != 0:
+            raise IntegrityError("AEAD decrypt failed (auth?)")
+
+        return bytes(m_buf)[: m_len_out.value]
+
+    # ---------------- sign / verify (Ed25519) ----------------
+    async def sign(
+        self,
+        key: KeyRef,
+        msg: bytes,
+        *,
+        alg: Optional[Alg] = None,
+    ) -> Signature:
+        alg = (alg or _SIGN_ALG).upper()
+        if alg != _SIGN_ALG:
+            raise UnsupportedAlgorithm(f"Unsupported sign alg: {alg}")
+        sk = _ensure_len(
+            "Ed25519 key.material",
+            key.material,
+            _CRYPTO_SIGN_SECRETKEYBYTES,
+        )
+
+        sig_buf = (c_ubyte * (_CRYPTO_SIGN_BYTES))()
+        sig_len = c_ulonglong(0)
+        rc = _sodium().crypto_sign_ed25519_detached(
+            sig_buf,
+            byref(sig_len),
+            _as_ubytes(msg),
+            c_ulonglong(len(msg)),
+            _as_ubytes(sk),
+        )
+        if rc != 0 or sig_len.value != _CRYPTO_SIGN_BYTES:
+            raise IntegrityError("sign failed")
+        return Signature(
+            kid=key.kid,
+            version=key.version,
+            alg=_SIGN_ALG,
+            sig=bytes(sig_buf)[: sig_len.value],
+        )
+
+    async def verify(
+        self,
+        key: KeyRef,
+        msg: bytes,
+        sig: Signature,
+    ) -> bool:
+        alg = (sig.alg or _SIGN_ALG).upper()
+        if alg != _SIGN_ALG:
+            raise UnsupportedAlgorithm(f"Unsupported verify alg: {alg}")
+        pk = _ensure_len(
+            "Ed25519 key.public",
+            key.public,
+            _CRYPTO_SIGN_PUBLICKEYBYTES,
+        )
+        rc = _sodium().crypto_sign_ed25519_verify_detached(
+            _as_ubytes(sig.sig),
+            _as_ubytes(msg),
+            c_ulonglong(len(msg)),
+            _as_ubytes(pk),
+        )
+        if rc != 0:
+            raise IntegrityError("signature verify failed")
+        return True
+
+    # ---------------- wrap / unwrap using sealed box ----------------
+    async def wrap(
+        self,
+        kek: KeyRef,
+        *,
+        dek: Optional[bytes] = None,
+        wrap_alg: Optional[Alg] = None,
+        nonce: Optional[bytes] = None,
+    ) -> WrappedKey:
+        wrap_alg = (wrap_alg or _WRAP_ALG).upper()
+        if wrap_alg != _WRAP_ALG:
+            raise UnsupportedAlgorithm(f"Unsupported wrap_alg: {wrap_alg}")
+        pk = _ensure_len(
+            "X25519 key.public",
+            kek.public,
+            _CRYPTO_BOX_PUBLICKEYBYTES,
+        )
+        dek = dek or secrets.token_bytes(_XCHACHA_KEYBYTES)
+        c_buf = (c_ubyte * (len(dek) + _CRYPTO_BOX_SEALBYTES))()
+        rc = _sodium().crypto_box_seal(
+            c_buf,
+            _as_ubytes(dek),
+            c_ulonglong(len(dek)),
+            _as_ubytes(pk),
+        )
+        if rc != 0:
+            raise IntegrityError("wrap failed")
+        return WrappedKey(
+            kek_kid=kek.kid,
+            kek_version=kek.version,
+            wrap_alg=_WRAP_ALG,
+            wrapped=bytes(c_buf),
+        )
+
+    async def unwrap(self, kek: KeyRef, wrapped: WrappedKey) -> bytes:
+        if wrapped.wrap_alg != _WRAP_ALG:
+            raise UnsupportedAlgorithm(f"Unsupported wrap_alg: {wrapped.wrap_alg}")
+        pk = _ensure_len(
+            "X25519 key.public",
+            kek.public,
+            _CRYPTO_BOX_PUBLICKEYBYTES,
+        )
+        sk = _ensure_len(
+            "X25519 key.material",
+            kek.material,
+            _CRYPTO_BOX_SECRETKEYBYTES,
+        )
+        m_len = len(wrapped.wrapped) - _CRYPTO_BOX_SEALBYTES
+        m_buf = (c_ubyte * (m_len))()
+        rc = _sodium().crypto_box_seal_open(
+            m_buf,
+            _as_ubytes(wrapped.wrapped),
+            c_ulonglong(len(wrapped.wrapped)),
+            _as_ubytes(pk),
+            _as_ubytes(sk),
+        )
+        if rc != 0:
+            raise IntegrityError("unwrap failed")
+        return bytes(m_buf)[:m_len]
+
+    # ---------------- seal / unseal data using sealed boxes ----------------
+    async def seal(
+        self,
+        recipient: KeyRef,
+        pt: bytes,
+        *,
+        alg: Optional[Alg] = _SEAL_ALG,
+    ) -> bytes:
+        if alg != _SEAL_ALG:
+            raise UnsupportedAlgorithm(f"Unsupported seal alg: {alg}")
+        pk = _ensure_len(
+            "X25519 key.public",
+            recipient.public,
+            _CRYPTO_BOX_PUBLICKEYBYTES,
+        )
+        c_buf = (c_ubyte * (len(pt) + _CRYPTO_BOX_SEALBYTES))()
+        rc = _sodium().crypto_box_seal(
+            c_buf,
+            _as_ubytes(pt),
+            c_ulonglong(len(pt)),
+            _as_ubytes(pk),
+        )
+        if rc != 0:
+            raise IntegrityError("seal failed")
+        return bytes(c_buf)
+
+    async def unseal(
+        self,
+        recipient_priv: KeyRef,
+        sealed: bytes,
+        *,
+        alg: Optional[Alg] = _SEAL_ALG,
+    ) -> bytes:
+        if alg != _SEAL_ALG:
+            raise UnsupportedAlgorithm(f"Unsupported seal alg: {alg}")
+        pk = _ensure_len(
+            "X25519 key.public",
+            recipient_priv.public,
+            _CRYPTO_BOX_PUBLICKEYBYTES,
+        )
+        sk = _ensure_len(
+            "X25519 key.material",
+            recipient_priv.material,
+            _CRYPTO_BOX_SECRETKEYBYTES,
+        )
+        m_len = len(sealed) - _CRYPTO_BOX_SEALBYTES
+        m_buf = (c_ubyte * (m_len))()
+        rc = _sodium().crypto_box_seal_open(
+            m_buf,
+            _as_ubytes(sealed),
+            c_ulonglong(len(sealed)),
+            _as_ubytes(pk),
+            _as_ubytes(sk),
+        )
+        if rc != 0:
+            raise IntegrityError("unseal failed")
+        return bytes(m_buf)[:m_len]
+
+    # ---------------- hybrid encrypt-for-many ----------------
+    async def encrypt_for_many(
+        self,
+        recipients: Iterable[KeyRef],
+        pt: bytes,
+        *,
+        enc_alg: Optional[Alg] = None,
+        recipient_wrap_alg: Optional[Alg] = None,
+        aad: Optional[bytes] = None,
+        nonce: Optional[bytes] = None,
+    ) -> MultiRecipientEnvelope:
+        # sealed-style variant
+        if enc_alg == _SEAL_ALG:
+            infos: list[RecipientInfo] = []
+            for r in recipients:
+                sealed = await self.seal(r, pt)
+                infos.append(
+                    RecipientInfo(
+                        kid=r.kid,
+                        version=r.version,
+                        wrap_alg=_SEAL_ALG,
+                        wrapped_key=sealed,
+                        nonce=None,
+                    )
+                )
+            return MultiRecipientEnvelope(
+                enc_alg=_SEAL_ALG,
+                nonce=b"",
+                ct=b"",
+                tag=b"",
+                recipients=tuple(infos),
+                aad=None,
+            )
+
+        # KEM+AEAD variant
+        enc_alg = _normalize_aead_alg(enc_alg)
+        if enc_alg != _AEAD_DEFAULT:
+            raise UnsupportedAlgorithm(f"Unsupported enc_alg: {enc_alg}")
+        wrap_alg = (recipient_wrap_alg or _WRAP_ALG).upper()
+        if wrap_alg != _WRAP_ALG:
+            raise UnsupportedAlgorithm(f"Unsupported wrap_alg: {wrap_alg}")
+
+        k = secrets.token_bytes(_XCHACHA_KEYBYTES)
+        npub = nonce or secrets.token_bytes(_XCHACHA_NPUBBYTES)
+        aead_ct = await self.encrypt(
+            KeyRef(
+                kid="cek",
+                version=1,
+                type=KeyType.SYMMETRIC,
+                uses=(KeyUse.ENCRYPT, KeyUse.DECRYPT),
+                export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+                material=k,
+            ),
+            pt,
+            alg=_AEAD_DEFAULT,
+            aad=aad,
+            nonce=npub,
+        )
+
+        infos = []
+        for r in recipients:
+            wrapped = await self.wrap(r, dek=k, wrap_alg=_WRAP_ALG)
+            infos.append(
+                RecipientInfo(
+                    kid=r.kid,
+                    version=r.version,
+                    wrap_alg=_WRAP_ALG,
+                    wrapped_key=wrapped.wrapped,
+                    nonce=None,
+                )
+            )
+
+        return MultiRecipientEnvelope(
+            enc_alg=_AEAD_DEFAULT,
+            nonce=aead_ct.nonce,
+            ct=aead_ct.ct,
+            tag=aead_ct.tag,
+            recipients=tuple(infos),
+            aad=aad,
+        )

--- a/pkgs/standards/swarmauri_crypto_sodium/swarmauri_crypto_sodium/__init__.py
+++ b/pkgs/standards/swarmauri_crypto_sodium/swarmauri_crypto_sodium/__init__.py
@@ -1,0 +1,3 @@
+from .SodiumCrypto import SodiumCrypto
+
+__all__ = ["SodiumCrypto"]

--- a/pkgs/standards/swarmauri_crypto_sodium/tests/unit/test_SodiumCrypto.py
+++ b/pkgs/standards/swarmauri_crypto_sodium/tests/unit/test_SodiumCrypto.py
@@ -1,0 +1,191 @@
+import ctypes
+import pytest
+from swarmauri_core.crypto.types import (
+    ExportPolicy,
+    KeyRef,
+    KeyType,
+    KeyUse,
+    AEADCiphertext,
+    WrappedKey,
+)
+
+from swarmauri_crypto_sodium import SodiumCrypto
+from swarmauri_crypto_sodium.SodiumCrypto import (
+    _CRYPTO_BOX_PUBLICKEYBYTES,
+    _CRYPTO_BOX_SECRETKEYBYTES,
+    _CRYPTO_SIGN_PUBLICKEYBYTES,
+    _CRYPTO_SIGN_SECRETKEYBYTES,
+    _sodium,
+)
+
+
+@pytest.fixture
+def sodium_crypto():
+    return SodiumCrypto()
+
+
+@pytest.fixture
+def ed25519_keys():
+    pk = (ctypes.c_ubyte * _CRYPTO_SIGN_PUBLICKEYBYTES)()
+    sk = (ctypes.c_ubyte * _CRYPTO_SIGN_SECRETKEYBYTES)()
+    rc = _sodium().crypto_sign_ed25519_keypair(pk, sk)
+    assert rc == 0
+    return bytes(pk), bytes(sk)
+
+
+@pytest.fixture
+def x25519_keys():
+    pk = (ctypes.c_ubyte * _CRYPTO_BOX_PUBLICKEYBYTES)()
+    sk = (ctypes.c_ubyte * _CRYPTO_BOX_SECRETKEYBYTES)()
+    rc = _sodium().crypto_box_keypair(pk, sk)
+    assert rc == 0
+    return bytes(pk), bytes(sk)
+
+
+@pytest.mark.unit
+def test_ubc_resource(sodium_crypto):
+    assert sodium_crypto.resource == "Crypto"
+
+
+@pytest.mark.unit
+def test_ubc_type(sodium_crypto):
+    assert sodium_crypto.type == "SodiumCrypto"
+
+
+@pytest.mark.unit
+def test_serialization(sodium_crypto):
+    assert (
+        sodium_crypto.id
+        == SodiumCrypto.model_validate_json(sodium_crypto.model_dump_json()).id
+    )
+
+
+@pytest.mark.asyncio
+async def test_aead_encrypt_decrypt_roundtrip(sodium_crypto):
+    sym = KeyRef(
+        kid="sym1",
+        version=1,
+        type=KeyType.SYMMETRIC,
+        uses=(KeyUse.ENCRYPT, KeyUse.DECRYPT),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+        material=b"\x11" * 32,
+    )
+    pt = b"hello world"
+    ct = await sodium_crypto.encrypt(sym, pt)
+    rt = await sodium_crypto.decrypt(sym, ct)
+    assert rt == pt
+
+
+@pytest.mark.asyncio
+async def test_sign_verify(sodium_crypto, ed25519_keys):
+    pk, sk = ed25519_keys
+    signer = KeyRef(
+        kid="sig1",
+        version=1,
+        type=KeyType.ED25519,
+        uses=(KeyUse.SIGN,),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+        material=sk,
+    )
+    verifier = KeyRef(
+        kid="sig1",
+        version=1,
+        type=KeyType.ED25519,
+        uses=(KeyUse.VERIFY,),
+        export_policy=ExportPolicy.PUBLIC_ONLY,
+        public=pk,
+    )
+    msg = b"sign me"
+    sig = await sodium_crypto.sign(signer, msg)
+    assert await sodium_crypto.verify(verifier, msg, sig)
+
+
+@pytest.mark.asyncio
+async def test_wrap_unwrap(sodium_crypto, x25519_keys):
+    pk, sk = x25519_keys
+    kek = KeyRef(
+        kid="x1",
+        version=1,
+        type=KeyType.X25519,
+        uses=(KeyUse.WRAP, KeyUse.UNWRAP),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+        public=pk,
+        material=sk,
+    )
+    dek = b"\x01" * 32
+    wrapped = await sodium_crypto.wrap(kek, dek=dek)
+    unwrapped = await sodium_crypto.unwrap(kek, wrapped)
+    assert unwrapped == dek
+
+
+@pytest.mark.asyncio
+async def test_seal_unseal(sodium_crypto, x25519_keys):
+    pk, sk = x25519_keys
+    recipient_pub = KeyRef(
+        kid="r1",
+        version=1,
+        type=KeyType.X25519,
+        uses=(KeyUse.WRAP,),
+        export_policy=ExportPolicy.PUBLIC_ONLY,
+        public=pk,
+    )
+    recipient_priv = KeyRef(
+        kid="r1",
+        version=1,
+        type=KeyType.X25519,
+        uses=(KeyUse.UNWRAP,),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+        public=pk,
+        material=sk,
+    )
+    sealed = await sodium_crypto.seal(recipient_pub, b"top secret")
+    opened = await sodium_crypto.unseal(recipient_priv, sealed)
+    assert opened == b"top secret"
+
+
+@pytest.mark.asyncio
+async def test_encrypt_for_many_kem_aead(sodium_crypto, x25519_keys):
+    pk, sk = x25519_keys
+    recipient = KeyRef(
+        kid="r1",
+        version=1,
+        type=KeyType.X25519,
+        uses=(KeyUse.WRAP, KeyUse.UNWRAP),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+        public=pk,
+        material=sk,
+    )
+    env = await sodium_crypto.encrypt_for_many([recipient], b"secret data")
+    assert env.enc_alg == "XCHACHA20-POLY1305"
+    assert env.ct and env.tag
+    assert len(env.recipients) == 1
+    cek = await sodium_crypto.unwrap(
+        recipient,
+        WrappedKey(
+            kek_kid=recipient.kid,
+            kek_version=recipient.version,
+            wrap_alg="X25519-SEAL-WRAP",
+            wrapped=env.recipients[0].wrapped_key,
+        ),
+    )
+    sym = KeyRef(
+        kid="cek",
+        version=1,
+        type=KeyType.SYMMETRIC,
+        uses=(KeyUse.DECRYPT,),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+        material=cek,
+    )
+    pt = await sodium_crypto.decrypt(
+        sym,
+        AEADCiphertext(
+            kid="cek",
+            version=1,
+            alg=env.enc_alg,
+            nonce=env.nonce,
+            ct=env.ct,
+            tag=env.tag,
+            aad=env.aad,
+        ),
+    )
+    assert pt == b"secret data"


### PR DESCRIPTION
## Summary
- add sodium-based crypto provider implementing XChaCha20-Poly1305, Ed25519, and X25519 sealed box operations
- document plugin usage and register entry points
- verify AEAD, signature, wrapping, sealing, and multi-recipient encryption

## Testing
- `uv run --directory standards/swarmauri_crypto_sodium --package swarmauri_crypto_sodium ruff format .`
- `uv run --directory standards/swarmauri_crypto_sodium --package swarmauri_crypto_sodium ruff check . --fix`
- `uv run --package swarmauri_crypto_sodium --directory standards/swarmauri_crypto_sodium pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6a4cb73f48326bd58a4268090e6f8