### PR TITLE
feat: add constant time timing evaluator

### DIFF
--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -49,6 +49,7 @@ members = [
     "standards/swarmauri_evaluator_abstractmethods",
     "standards/swarmauri_evaluator_anyusage",
     "standards/swarmauri_evaluator_externalimports",
+    "standards/swarmauri_evaluator_constanttime",
     "standards/swarmauri_evaluator_subprocess",
     "standards/swarmauri_evaluatorpool_accessibility",
     "standards/swarmauri_publisher_rabbitmq",

--- a/pkgs/standards/swarmauri_evaluator_constanttime/LICENSE
+++ b/pkgs/standards/swarmauri_evaluator_constanttime/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/standards/swarmauri_evaluator_constanttime/README.md
+++ b/pkgs/standards/swarmauri_evaluator_constanttime/README.md
@@ -1,0 +1,3 @@
+# swarmauri_evaluator_constanttime
+
+Evaluator that detects timing side channels using a simple fixed-vs-random test.

--- a/pkgs/standards/swarmauri_evaluator_constanttime/pyproject.toml
+++ b/pkgs/standards/swarmauri_evaluator_constanttime/pyproject.toml
@@ -1,0 +1,75 @@
+[project]
+name = "swarmauri_evaluator_constanttime"
+version = "0.1.0.dev0"
+description = "Evaluator that detects timing side channels using fixed-vs-random test"
+license = "Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/swarmauri/swarmauri-sdk/pkgs/standards/swarmauri_evaluator_constanttime/"
+requires-python = ">=3.10,<3.13"
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Development Status :: 3 - Alpha",
+]
+authors = [
+    {name = "SwarmAuri Team", email = "info@swarmauri.com"},
+]
+keywords = [
+    "swarmauri",
+    "evaluator",
+    "constant time",
+    "side channel",
+    "timing",
+]
+dependencies = [
+    "swarmauri_core",
+    "swarmauri_base",
+]
+
+[project.entry-points.'swarmauri.evaluators']
+ConstantTimeEvaluator = "swarmauri_evaluator_constanttime:ConstantTimeEvaluator"
+
+[tool.uv.sources]
+swarmauri_core = { workspace = true }
+swarmauri_base = { workspace = true }
+
+[tool.pytest.ini_options]
+norecursedirs = ["combined", "scripts"]
+markers = [
+    "test: standard test",
+    "unit: Unit tests",
+    "i9n: Integration tests",
+    "r8n: Regression tests",
+    "timeout: mark test to timeout after X seconds",
+    "xpass: Expected passes",
+    "xfail: Expected failures",
+    "acceptance: Acceptance tests",
+    "perf: Performance tests that measure execution time and resource usage",
+]
+timeout = 300
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "python-dotenv",
+    "requests>=2.32.3",
+    "flake8>=7.0",
+    "pytest-timeout>=2.3.1",
+    "ruff>=0.9.9",
+    "pytest-benchmark>=4.0.0",
+]

--- a/pkgs/standards/swarmauri_evaluator_constanttime/swarmauri_evaluator_constanttime/ConstantTimeEvaluator.py
+++ b/pkgs/standards/swarmauri_evaluator_constanttime/swarmauri_evaluator_constanttime/ConstantTimeEvaluator.py
@@ -1,0 +1,170 @@
+"""Evaluator that checks for constant-time behavior."""
+
+from __future__ import annotations
+
+import gc
+import os
+import random
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, ClassVar, Dict, List, Literal, Sequence, Tuple
+
+from swarmauri_base.evaluators.EvaluatorBase import EvaluatorBase
+from swarmauri_core.programs.IProgram import IProgram as Program
+
+
+@dataclass
+class TvlaResult:
+    t_stat: float
+    df: float
+    mean_fixed: float
+    mean_random: float
+    n_fixed: int
+    n_random: int
+
+
+@dataclass
+class CliffResult:
+    delta: float
+
+
+def welchs_t(fixed: Sequence[float], rnd: Sequence[float]) -> TvlaResult:
+    n1 = len(fixed)
+    n2 = len(rnd)
+    m1 = sum(fixed) / n1 if n1 else 0.0
+    m2 = sum(rnd) / n2 if n2 else 0.0
+    v1 = (sum((x - m1) ** 2 for x in fixed) / n1) if n1 else 0.0
+    v2 = (sum((x - m2) ** 2 for x in rnd) / n2) if n2 else 0.0
+    num = m1 - m2
+    den = ((v1 / n1) + (v2 / n2)) ** 0.5 if n1 and n2 else float("inf")
+    t = num / den if den else float("inf")
+    df_num = (v1 / n1 + v2 / n2) ** 2
+    df_den = (v1**2 / (n1**2 * (n1 - 1) if n1 > 1 else float("inf"))) + (
+        v2**2 / (n2**2 * (n2 - 1) if n2 > 1 else float("inf"))
+    )
+    df = df_num / df_den if df_den else float("inf")
+    return TvlaResult(
+        t_stat=t, df=df, mean_fixed=m1, mean_random=m2, n_fixed=n1, n_random=n2
+    )
+
+
+def cliffs_delta(a: Sequence[float], b: Sequence[float]) -> CliffResult:
+    gt = lt = 0
+    for x in a:
+        for y in b:
+            if x > y:
+                gt += 1
+            elif x < y:
+                lt += 1
+    denom = len(a) * len(b)
+    delta = (gt - lt) / denom if denom else 0.0
+    return CliffResult(delta=delta)
+
+
+def _prepare_env():
+    gc.disable()
+    try:
+        if hasattr(os, "sched_setaffinity"):
+            cpus = os.sched_getaffinity(0)
+            if len(cpus) > 1:
+                one = {sorted(list(cpus))[0]}
+                os.sched_setaffinity(0, one)
+    except Exception:  # pragma: no cover
+        pass
+    _busywait(50_000)
+
+
+def _restore_env():
+    gc.enable()
+
+
+def _busywait(iters: int):
+    x = 0
+    for _ in range(iters):
+        x ^= 1
+    return x
+
+
+def _now_ns() -> int:
+    return time.perf_counter_ns()
+
+
+def measure_timings(
+    fn: Callable[..., Any],
+    inputs: Sequence[Tuple[tuple, dict]],
+    *,
+    iters_per_input: int = 50,
+    rounds: int = 1,
+    shuffle_each_round: bool = True,
+) -> List[float]:
+    timings: List[float] = []
+    _prepare_env()
+    try:
+        for _ in range(10_000):
+            _busywait(10)
+        for _ in range(rounds):
+            seq = list(inputs)
+            if shuffle_each_round:
+                random.shuffle(seq)
+            for args, kwargs in seq:
+                for _ in range(iters_per_input):
+                    t0 = _now_ns()
+                    fn(*args, **kwargs)
+                    t1 = _now_ns()
+                    timings.append(t1 - t0)
+    finally:
+        _restore_env()
+    return timings
+
+
+def _mk_inputs_fixed_vs_random(
+    make_input_pair: Callable[[], Tuple[bytes, bytes]],
+    fixed_pair: Tuple[bytes, bytes],
+    n_samples: int,
+) -> Tuple[List[Tuple[tuple, dict]], List[Tuple[tuple, dict]]]:
+    fixed_inputs = [((fixed_pair[0], fixed_pair[1]), {}) for _ in range(n_samples)]
+    random_inputs = [make_input_pair() for _ in range(n_samples)]
+    rnd_inputs = [((a, b), {}) for (a, b) in random_inputs]
+    return fixed_inputs, rnd_inputs
+
+
+class ConstantTimeEvaluator(EvaluatorBase):
+    """Check whether a function exhibits constant-time behavior."""
+
+    type: Literal["ConstantTimeEvaluator"] = "ConstantTimeEvaluator"
+
+    TVLA_T_THRESHOLD: ClassVar[float] = 4.5
+    CLIFF_ALERT: ClassVar[float] = 0.147
+
+    def _compute_score(
+        self,
+        program: Program,
+        *,
+        fn: Callable[[bytes, bytes], Any],
+        make_input_pair: Callable[[], Tuple[bytes, bytes]],
+        fixed_pair: Tuple[bytes, bytes],
+        n_samples: int = 50,
+        iters_per: int = 20,
+    ) -> Tuple[float, Dict[str, Any]]:
+        fixed_inputs, rnd_inputs = _mk_inputs_fixed_vs_random(
+            make_input_pair, fixed_pair, n_samples
+        )
+        t_fixed = measure_timings(fn, fixed_inputs, iters_per_input=iters_per)
+        t_random = measure_timings(fn, rnd_inputs, iters_per_input=iters_per)
+        tvla = welchs_t(t_fixed, t_random)
+        cliff = cliffs_delta(t_fixed, t_random)
+        constant_time = (
+            abs(tvla.t_stat) <= self.TVLA_T_THRESHOLD
+            and abs(cliff.delta) <= self.CLIFF_ALERT
+        )
+        score = 1.0 if constant_time else 0.0
+        metadata: Dict[str, Any] = {
+            "t_stat": tvla.t_stat,
+            "cliff_delta": cliff.delta,
+            "mean_fixed": tvla.mean_fixed,
+            "mean_random": tvla.mean_random,
+            "n_fixed": tvla.n_fixed,
+            "n_random": tvla.n_random,
+            "constant_time": constant_time,
+        }
+        return score, metadata

--- a/pkgs/standards/swarmauri_evaluator_constanttime/swarmauri_evaluator_constanttime/__init__.py
+++ b/pkgs/standards/swarmauri_evaluator_constanttime/swarmauri_evaluator_constanttime/__init__.py
@@ -1,0 +1,13 @@
+from .ConstantTimeEvaluator import ConstantTimeEvaluator
+
+__all__ = ["ConstantTimeEvaluator"]
+
+try:
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError:  # pragma: no cover
+    from importlib_metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("swarmauri_evaluator_constanttime")
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "0.0.0"

--- a/pkgs/standards/swarmauri_evaluator_constanttime/tests/unit/test_ConstantTimeEvaluator.py
+++ b/pkgs/standards/swarmauri_evaluator_constanttime/tests/unit/test_ConstantTimeEvaluator.py
@@ -1,0 +1,104 @@
+import os
+import random
+import tempfile
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from swarmauri_evaluator_constanttime import ConstantTimeEvaluator
+from swarmauri_core.programs.IProgram import IProgram
+
+
+@pytest.mark.unit
+def test_ubc_resource() -> None:
+    assert ConstantTimeEvaluator().resource == "Evaluator"
+
+
+@pytest.mark.unit
+def test_ubc_type() -> None:
+    assert ConstantTimeEvaluator().type == "ConstantTimeEvaluator"
+
+
+@pytest.mark.unit
+def test_initialization() -> None:
+    assert isinstance(ConstantTimeEvaluator().id, str)
+
+
+@pytest.mark.unit
+def test_serialization() -> None:
+    evaluator = ConstantTimeEvaluator()
+    assert (
+        evaluator.id
+        == ConstantTimeEvaluator.model_validate_json(evaluator.model_dump_json()).id
+    )
+
+
+def _leaky_compare(a: bytes, b: bytes) -> bool:
+    if a[0] != b[0]:
+        time.sleep(0.005)
+    return True
+
+
+def _constant_delay(a: bytes, b: bytes) -> bool:
+    for _ in range(100000):
+        pass
+    return True
+
+
+def _gen_pair_random_same_len(n: int = 32):
+    a = os.urandom(n)
+    b = bytearray(a)
+    b[0] ^= 0xFF
+    return a, bytes(b)
+
+
+def _fixed_pair(n: int = 32):
+    a = b"x" * n
+    return a, a
+
+
+@pytest.fixture
+def evaluator():
+    return ConstantTimeEvaluator()
+
+
+@pytest.fixture
+def mock_program():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        program = MagicMock(spec=IProgram)
+        program.path = temp_dir
+        yield program
+
+
+@pytest.mark.unit
+def test_leaky_function_shows_timing_difference(evaluator, mock_program):
+    random.seed(1337)
+    score, meta = evaluator.evaluate(
+        mock_program,
+        fn=_leaky_compare,
+        make_input_pair=_gen_pair_random_same_len,
+        fixed_pair=_fixed_pair(),
+        n_samples=20,
+        iters_per=5,
+    )
+    assert meta["mean_random"] > meta["mean_fixed"]
+    assert isinstance(score, float)
+    assert {"t_stat", "cliff_delta", "constant_time"} <= meta.keys()
+
+
+@pytest.mark.unit
+def test_constant_function_has_similar_means(evaluator, mock_program):
+    random.seed(1337)
+    score, meta = evaluator.evaluate(
+        mock_program,
+        fn=_constant_delay,
+        make_input_pair=_gen_pair_random_same_len,
+        fixed_pair=_fixed_pair(),
+        n_samples=20,
+        iters_per=5,
+    )
+    diff = abs(meta["mean_fixed"] - meta["mean_random"])
+    assert diff < 0.5 * meta["mean_fixed"]
+    assert isinstance(score, float)
+    assert {"t_stat", "cliff_delta", "constant_time"} <= meta.keys()


### PR DESCRIPTION
## Summary
- add ConstantTimeEvaluator to statistically compare fixed and random inputs
- register package in workspace and add unit tests
- include standardized plugin tests for resource, type, initialization, and serialization

## Testing
- `uv run --directory pkgs/standards/swarmauri_evaluator_constanttime --package swarmauri_evaluator_constanttime ruff format .`
- `uv run --directory pkgs/standards/swarmauri_evaluator_constanttime --package swarmauri_evaluator_constanttime ruff check . --fix`
- `uv run --package swarmauri_evaluator_constanttime --directory pkgs/standards/swarmauri_evaluator_constanttime pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6c0286edc832682d20ed64e4169f1