### PR TITLE
Add composite crypto plugin

### DIFF
--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -76,6 +76,7 @@ members = [
     "standards/peagen",
     "standards/auto_authn",
     "standards/auto_kms",
+    "standards/swarmauri_crypto_composite",
     "standards/swarmauri_crypto_paramiko",
     "standards/swarmauri_crypto_pgp",
     "standards/swarmauri_crypto_sodium",
@@ -201,6 +202,7 @@ peagen = { workspace = true }
 auto_kms = { workspace = true }
 
 swarmauri_secret_autogpg = { workspace = true }
+swarmauri_crypto_composite = { workspace = true }
 swarmauri_crypto_paramiko = { workspace = true }
 swarmauri_crypto_pgp = { workspace = true }
 swarmauri_crypto_nacl_pkcs11 = { workspace = true }

--- a/pkgs/standards/swarmauri_crypto_composite/LICENSE
+++ b/pkgs/standards/swarmauri_crypto_composite/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/standards/swarmauri_crypto_composite/README.md
+++ b/pkgs/standards/swarmauri_crypto_composite/README.md
@@ -1,0 +1,39 @@
+![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_crypto_composite/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_crypto_composite" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_crypto_composite/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_crypto_composite.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_crypto_composite/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_crypto_composite" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_crypto_composite/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_crypto_composite" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_crypto_composite/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_crypto_composite?label=swarmauri_crypto_composite&color=green" alt="PyPI - swarmauri_crypto_composite"/></a>
+</p>
+
+---
+
+## Swarmauri Crypto Composite
+
+Algorithm-routing crypto provider implementing the `ICrypto` contract and delegating operations to the first child provider supporting the requested algorithm.
+
+## Installation
+
+```bash
+pip install swarmauri_crypto_composite
+```
+
+## Usage
+
+```python
+from swarmauri_crypto_composite import CompositeCrypto
+from swarmauri_crypto_sodium import SodiumCrypto
+
+crypto = CompositeCrypto([SodiumCrypto()])
+```
+
+## Entry point
+
+The provider is registered under the `swarmauri.cryptos` entry-point as `CompositeCrypto`.

--- a/pkgs/standards/swarmauri_crypto_composite/pyproject.toml
+++ b/pkgs/standards/swarmauri_crypto_composite/pyproject.toml
@@ -1,0 +1,65 @@
+[project]
+name = "swarmauri_crypto_composite"
+version = "0.1.0"
+description = "Algorithm-routing crypto provider for Swarmauri"
+license = "Apache-2.0"
+readme = "README.md"
+requires-python = ">=3.10,<3.13"
+authors = [{ name = "Swarmauri", email = "opensource@swarmauri.com" }]
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Development Status :: 3 - Alpha",
+    "Topic :: Security :: Cryptography",
+    "Intended Audience :: Developers",
+]
+dependencies = [
+    "swarmauri_core",
+    "swarmauri_base",
+]
+
+[tool.uv.sources]
+swarmauri_core = { workspace = true }
+swarmauri_base = { workspace = true }
+
+[tool.pytest.ini_options]
+norecursedirs = ["combined", "scripts"]
+markers = [
+    "test: standard test",
+    "unit: Unit tests",
+    "i9n: Integration tests",
+    "r8n: Regression tests",
+    "acceptance: Acceptance tests",
+    "perf: Performance tests",
+]
+timeout = 300
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "flake8>=7.0",
+    "ruff>=0.9.9",
+    "pytest-timeout>=2.3.1",
+]
+
+[project.entry-points.'swarmauri.cryptos']
+CompositeCrypto = "swarmauri_crypto_composite:CompositeCrypto"
+
+[project.entry-points."peagen.plugins.cryptos"]
+composite = "swarmauri_crypto_composite:CompositeCrypto"

--- a/pkgs/standards/swarmauri_crypto_composite/swarmauri_crypto_composite/CompositeCrypto.py
+++ b/pkgs/standards/swarmauri_crypto_composite/swarmauri_crypto_composite/CompositeCrypto.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+from swarmauri_core.crypto.ICrypto import ICrypto
+from swarmauri_core.crypto.types import (
+    AEADCiphertext,
+    Alg,
+    KeyRef,
+    MultiRecipientEnvelope,
+    Signature,
+    WrappedKey,
+    UnsupportedAlgorithm,
+)
+from swarmauri_base.ComponentBase import ComponentBase
+
+
+def _norm_alg(a: Optional[Alg]) -> Optional[Alg]:
+    if a is None:
+        return None
+    # keep it stable but insensitive to simple stylistic variants
+    return str(a).strip()
+
+
+class CompositeCrypto(ICrypto, ComponentBase):
+    """
+    Algorithm-routing crypto provider.
+    Delegates to the first child that advertises support for the requested algorithm.
+    """
+
+    def __init__(self, providers: Sequence[ICrypto]) -> None:
+        super().__init__()
+        self._providers: Tuple[ICrypto, ...] = tuple(providers)
+        if not self._providers:
+            raise ValueError("CompositeCrypto requires at least one provider")
+
+    # -------- capability surfacing --------
+    def supports(self) -> Dict[str, Iterable[Alg]]:
+        agg: Dict[str, List[Alg]] = {}
+        for p in self._providers:
+            for k, v in p.supports().items():
+                agg.setdefault(k, [])
+                for a in v:
+                    if a not in agg[k]:
+                        agg[k].append(a)
+        return {k: tuple(v) for k, v in agg.items()}
+
+    # -------- routing helpers --------
+    def _pick(self, area: str, alg: Optional[Alg]) -> ICrypto:
+        alg_n = _norm_alg(alg)
+        # If caller passed None for enc/sign alg, we let providers apply their own default;
+        # pick the first provider advertising *any* alg for that area.
+        for p in self._providers:
+            caps = p.supports()
+            if area not in caps:
+                continue
+            if alg_n is None:
+                # any alg for this area is fine
+                if caps[area]:
+                    return p
+            else:
+                if any(_norm_alg(a) == alg_n for a in caps[area]):
+                    return p
+        raise UnsupportedAlgorithm(f"No provider supports {area} with alg={alg_n!r}")
+
+    # -------- AEAD --------
+    async def encrypt(
+        self,
+        key: KeyRef,
+        pt: bytes,
+        *,
+        alg: Optional[Alg] = None,
+        aad: Optional[bytes] = None,
+        nonce: Optional[bytes] = None,
+    ) -> AEADCiphertext:
+        return await self._pick("encrypt", alg).encrypt(
+            key, pt, alg=alg, aad=aad, nonce=nonce
+        )
+
+    async def decrypt(
+        self,
+        key: KeyRef,
+        ct: AEADCiphertext,
+        *,
+        aad: Optional[bytes] = None,
+    ) -> bytes:
+        return await self._pick("decrypt", ct.alg).decrypt(key, ct, aad=aad)
+
+    # -------- sign / verify --------
+    async def sign(
+        self,
+        key: KeyRef,
+        msg: bytes,
+        *,
+        alg: Optional[Alg] = None,
+    ) -> Signature:
+        return await self._pick("sign", alg).sign(key, msg, alg=alg)
+
+    async def verify(
+        self,
+        key: KeyRef,
+        msg: bytes,
+        sig: Signature,
+    ) -> bool:
+        return await self._pick("verify", sig.alg).verify(key, msg, sig)
+
+    # -------- wrap / unwrap --------
+    async def wrap(
+        self,
+        kek: KeyRef,
+        *,
+        dek: Optional[bytes] = None,
+        wrap_alg: Optional[Alg] = None,
+        nonce: Optional[bytes] = None,
+    ) -> WrappedKey:
+        return await self._pick("wrap", wrap_alg).wrap(
+            kek, dek=dek, wrap_alg=wrap_alg, nonce=nonce
+        )
+
+    async def unwrap(self, kek: KeyRef, wrapped: WrappedKey) -> bytes:
+        return await self._pick("unwrap", wrapped.wrap_alg).unwrap(kek, wrapped)
+
+    # -------- for-many --------
+    async def encrypt_for_many(
+        self,
+        recipients: Iterable[KeyRef],
+        pt: bytes,
+        *,
+        enc_alg: Optional[Alg] = None,
+        recipient_wrap_alg: Optional[Alg] = None,
+        aad: Optional[bytes] = None,
+        nonce: Optional[bytes] = None,
+    ) -> MultiRecipientEnvelope:
+        # Route primarily by enc_alg; if None, pick a provider that supports "encrypt" and has for_many.
+        return await self._pick("encrypt", enc_alg).encrypt_for_many(
+            recipients,
+            pt,
+            enc_alg=enc_alg,
+            recipient_wrap_alg=recipient_wrap_alg,
+            aad=aad,
+            nonce=nonce,
+        )
+
+    # -------- seal / unseal (explicit) --------
+    async def seal(
+        self, recipient: KeyRef, pt: bytes, *, alg: Optional[Alg] = None
+    ) -> bytes:
+        return await self._pick("seal", alg).seal(recipient, pt, alg=alg)
+
+    async def unseal(
+        self, recipient_priv: KeyRef, sealed: bytes, *, alg: Optional[Alg] = None
+    ) -> bytes:
+        # Some providers embed alg tag in sealed blob; we still require alg for routing clarity.
+        return await self._pick("unseal", alg).unseal(recipient_priv, sealed, alg=alg)

--- a/pkgs/standards/swarmauri_crypto_composite/swarmauri_crypto_composite/__init__.py
+++ b/pkgs/standards/swarmauri_crypto_composite/swarmauri_crypto_composite/__init__.py
@@ -1,0 +1,13 @@
+from .CompositeCrypto import CompositeCrypto
+
+__all__ = ["CompositeCrypto"]
+
+try:  # pragma: no cover - simply version shim
+    from importlib.metadata import PackageNotFoundError, version
+except ImportError:  # pragma: no cover
+    from importlib_metadata import PackageNotFoundError, version
+
+try:  # pragma: no cover - environment dependent
+    __version__ = version("swarmauri_crypto_composite")
+except PackageNotFoundError:  # pragma: no cover - local dev fallback
+    __version__ = "0.0.0"

--- a/pkgs/standards/swarmauri_crypto_composite/tests/i9n/test_i9n__init__.py
+++ b/pkgs/standards/swarmauri_crypto_composite/tests/i9n/test_i9n__init__.py
@@ -1,0 +1,29 @@
+import importlib
+import logging
+
+import pytest
+
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.i9n
+class TestInit:
+    """Integration tests for package initialization."""
+
+    def test_module_import(self):
+        """Module can be imported."""
+        module = importlib.import_module("swarmauri_crypto_composite")
+        assert module is not None
+
+    def test_version(self):
+        """__version__ is exposed and non-empty."""
+        module = importlib.import_module("swarmauri_crypto_composite")
+        assert isinstance(module.__version__, str)
+        assert module.__version__
+
+    def test_all_and_class(self):
+        """__all__ lists CompositeCrypto and it is exposed."""
+        module = importlib.import_module("swarmauri_crypto_composite")
+        assert "CompositeCrypto" in module.__all__
+        assert hasattr(module, "CompositeCrypto")

--- a/pkgs/standards/swarmauri_crypto_composite/tests/unit/test_composite_crypto.py
+++ b/pkgs/standards/swarmauri_crypto_composite/tests/unit/test_composite_crypto.py
@@ -1,0 +1,47 @@
+import pytest
+from swarmauri_core.crypto.types import (
+    KeyRef,
+    KeyType,
+    KeyUse,
+    ExportPolicy,
+    AEADCiphertext,
+)
+from swarmauri_crypto_composite import CompositeCrypto
+
+
+class DummyCrypto:
+    def __init__(self, alg: str) -> None:
+        self.alg = alg
+        self.called = False
+
+    def supports(self):
+        return {"encrypt": (self.alg,)}
+
+    async def encrypt(
+        self,
+        key: KeyRef,
+        pt: bytes,
+        *,
+        alg: str | None = None,
+        aad: bytes | None = None,
+        nonce: bytes | None = None,
+    ):
+        self.called = True
+        return AEADCiphertext(key.kid, key.version, self.alg, b"", b"", b"")
+
+
+@pytest.mark.asyncio
+async def test_encrypt_routes_by_alg():
+    key = KeyRef(
+        kid="sym1",
+        version=1,
+        type=KeyType.SYMMETRIC,
+        uses=(KeyUse.ENCRYPT,),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+        material=b"\x00" * 32,
+    )
+    a = DummyCrypto("AALG")
+    b = DummyCrypto("BALG")
+    cc = CompositeCrypto([a, b])
+    await cc.encrypt(key, b"data", alg="BALG")
+    assert b.called and not a.called


### PR DESCRIPTION
## Summary
- add CompositeCrypto provider delegating to child crypto implementations
- document and expose composite provider via entry points
- test algorithm routing with dummy providers
- cover standard initialization checks verifying module metadata

## Testing
- `uv run --directory pkgs/standards/swarmauri_crypto_composite --package swarmauri_crypto_composite ruff format .`
- `uv run --directory pkgs/standards/swarmauri_crypto_composite --package swarmauri_crypto_composite ruff check . --fix`
- `uv run --package swarmauri_crypto_composite --directory pkgs/standards/swarmauri_crypto_composite pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6a902fde8832690b0d6ca12206da9