### PR TITLE
refactor: add signing and MRE interfaces

### DIFF
--- a/pkgs/base/swarmauri_base/crypto/CryptoBase.py
+++ b/pkgs/base/swarmauri_base/crypto/CryptoBase.py
@@ -15,8 +15,6 @@ from swarmauri_core.crypto.ICrypto import (
     AEADCiphertext,
     Alg,
     KeyRef,
-    MultiRecipientEnvelope,
-    Signature,
     WrappedKey,
 )
 from swarmauri_base.ComponentBase import ComponentBase, ResourceTypes
@@ -52,24 +50,6 @@ class CryptoBase(ICrypto, ComponentBase):
     ) -> bytes:
         raise NotImplementedError("decrypt() must be implemented by subclass")
 
-    # ─────────────────────────── sign / verify ──────────────────────────
-    async def sign(
-        self,
-        key: KeyRef,
-        msg: bytes,
-        *,
-        alg: Optional[Alg] = None,
-    ) -> Signature:
-        raise NotImplementedError("sign() must be implemented by subclass")
-
-    async def verify(
-        self,
-        key: KeyRef,
-        msg: bytes,
-        sig: Signature,
-    ) -> bool:
-        raise NotImplementedError("verify() must be implemented by subclass")
-
     # ─────────────────────────── wrap / unwrap ──────────────────────────
     async def wrap(
         self,
@@ -83,19 +63,6 @@ class CryptoBase(ICrypto, ComponentBase):
 
     async def unwrap(self, kek: KeyRef, wrapped: WrappedKey) -> bytes:
         raise NotImplementedError("unwrap() must be implemented by subclass")
-
-    # ──────────────── hybrid encrypt-for-many (KEM/AEAD or sealed) ───────
-    async def encrypt_for_many(
-        self,
-        recipients: Iterable[KeyRef],
-        pt: bytes,
-        *,
-        enc_alg: Optional[Alg] = None,
-        recipient_wrap_alg: Optional[Alg] = None,
-        aad: Optional[bytes] = None,
-        nonce: Optional[bytes] = None,
-    ) -> MultiRecipientEnvelope:
-        raise NotImplementedError("encrypt_for_many() must be implemented by subclass")
 
     # ─────────────────────────── seal / unseal ──────────────────────────
     async def seal(

--- a/pkgs/base/swarmauri_base/mre_crypto/MreCryptoBase.py
+++ b/pkgs/base/swarmauri_base/mre_crypto/MreCryptoBase.py
@@ -1,0 +1,77 @@
+"""Base class for multi-recipient encryption providers."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, Mapping, Optional, Sequence
+
+from pydantic import Field
+
+from swarmauri_core.mre_crypto.IMreCrypto import (
+    IMreCrypto,
+    MreMode,
+    MultiRecipientEnvelope,
+    RecipientId,
+)
+from swarmauri_core.crypto.types import Alg, KeyRef
+from swarmauri_base.ComponentBase import ComponentBase, ResourceTypes
+
+
+@ComponentBase.register_model()
+class MreCryptoBase(IMreCrypto, ComponentBase):
+    """Default NotImplemented implementations for :class:`IMreCrypto`."""
+
+    resource: Optional[str] = Field(default=ResourceTypes.CRYPTO.value, frozen=True)
+    type: str = "MreCryptoBase"
+
+    # ------------------------------------------------------------------
+    def supports(self) -> Dict[str, Iterable[str | MreMode]]:
+        raise NotImplementedError("supports() must be implemented by subclass")
+
+    # ------------------------------------------------------------------
+    async def encrypt_for_many(
+        self,
+        recipients: Sequence[KeyRef],
+        pt: bytes,
+        *,
+        payload_alg: Optional[Alg] = None,
+        recipient_alg: Optional[Alg] = None,
+        mode: Optional[MreMode | str] = None,
+        aad: Optional[bytes] = None,
+        shared: Optional[Mapping[str, bytes]] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> MultiRecipientEnvelope:
+        raise NotImplementedError("encrypt_for_many() must be implemented by subclass")
+
+    # ------------------------------------------------------------------
+    async def open_for(
+        self,
+        my_identity: KeyRef,
+        env: MultiRecipientEnvelope,
+        *,
+        aad: Optional[bytes] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bytes:
+        raise NotImplementedError("open_for() must be implemented by subclass")
+
+    # ------------------------------------------------------------------
+    async def open_for_many(
+        self,
+        my_identities: Sequence[KeyRef],
+        env: MultiRecipientEnvelope,
+        *,
+        aad: Optional[bytes] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bytes:
+        raise NotImplementedError("open_for_many() must be implemented by subclass")
+
+    # ------------------------------------------------------------------
+    async def rewrap(
+        self,
+        env: MultiRecipientEnvelope,
+        *,
+        add: Optional[Sequence[KeyRef]] = None,
+        remove: Optional[Sequence[RecipientId]] = None,
+        recipient_alg: Optional[Alg] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> MultiRecipientEnvelope:
+        raise NotImplementedError("rewrap() must be implemented by subclass")

--- a/pkgs/base/swarmauri_base/mre_crypto/__init__.py
+++ b/pkgs/base/swarmauri_base/mre_crypto/__init__.py
@@ -1,0 +1,5 @@
+"""Base helpers for MRE providers."""
+
+from .MreCryptoBase import MreCryptoBase
+
+__all__ = ["MreCryptoBase"]

--- a/pkgs/base/swarmauri_base/signing/SigningBase.py
+++ b/pkgs/base/swarmauri_base/signing/SigningBase.py
@@ -1,0 +1,82 @@
+"""Base class for detached signing providers."""
+
+from __future__ import annotations
+
+from typing import Iterable, Mapping, Optional, Sequence
+
+from pydantic import Field
+
+from swarmauri_core.signing.ISigning import ISigning, Canon, Envelope
+from swarmauri_core.signing.types import Signature
+from swarmauri_core.crypto.types import Alg, KeyRef
+from swarmauri_base.ComponentBase import ComponentBase, ResourceTypes
+
+
+@ComponentBase.register_model()
+class SigningBase(ISigning, ComponentBase):
+    """Default NotImplemented implementations for :class:`ISigning`."""
+
+    resource: Optional[str] = Field(default=ResourceTypes.CRYPTO.value, frozen=True)
+    type: str = "SigningBase"
+
+    # ------------------------------------------------------------------
+    def supports(self) -> Mapping[str, Iterable[str]]:
+        raise NotImplementedError("supports() must be implemented by subclass")
+
+    # ------------------------------------------------------------------
+    async def sign_bytes(
+        self,
+        key: KeyRef,
+        payload: bytes,
+        *,
+        alg: Optional[Alg] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> Sequence[Signature]:
+        raise NotImplementedError("sign_bytes() must be implemented by subclass")
+
+    # ------------------------------------------------------------------
+    async def verify_bytes(
+        self,
+        payload: bytes,
+        signatures: Sequence[Signature],
+        *,
+        require: Optional[Mapping[str, object]] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bool:
+        raise NotImplementedError("verify_bytes() must be implemented by subclass")
+
+    # ------------------------------------------------------------------
+    async def canonicalize_envelope(
+        self,
+        env: Envelope,
+        *,
+        canon: Optional[Canon] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bytes:
+        raise NotImplementedError(
+            "canonicalize_envelope() must be implemented by subclass"
+        )
+
+    # ------------------------------------------------------------------
+    async def sign_envelope(
+        self,
+        key: KeyRef,
+        env: Envelope,
+        *,
+        alg: Optional[Alg] = None,
+        canon: Optional[Canon] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> Sequence[Signature]:
+        raise NotImplementedError("sign_envelope() must be implemented by subclass")
+
+    # ------------------------------------------------------------------
+    async def verify_envelope(
+        self,
+        env: Envelope,
+        signatures: Sequence[Signature],
+        *,
+        canon: Optional[Canon] = None,
+        require: Optional[Mapping[str, object]] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bool:
+        raise NotImplementedError("verify_envelope() must be implemented by subclass")

--- a/pkgs/base/swarmauri_base/signing/__init__.py
+++ b/pkgs/base/swarmauri_base/signing/__init__.py
@@ -1,0 +1,5 @@
+"""Base helpers for signing providers."""
+
+from .SigningBase import SigningBase
+
+__all__ = ["SigningBase"]

--- a/pkgs/core/swarmauri_core/crypto/ICrypto.py
+++ b/pkgs/core/swarmauri_core/crypto/ICrypto.py
@@ -16,12 +16,20 @@ Intentionally out of scope
 
 Capability discovery
 --------------------
-Implementations advertise supported algorithms via supports(), e.g.:
+Implementations advertise supported algorithms via ``supports()``, using
+keys for any operation they handle.  Providers MAY separate advertise
+algorithms by direction (e.g., ``encrypt`` vs ``decrypt``) when they only
+support one side.
+
+Example capability map::
 
   {
-    "aead": ("AES-256-GCM", "XCHACHA20-POLY1305"),
+    "encrypt": ("AES-256-GCM", "XCHACHA20-POLY1305"),
+    "decrypt": ("AES-256-GCM",),
     "wrap": ("AES-KW", "RSA-OAEP-SHA256", "OpenPGP"),
-    "seal": ("OpenPGP-SEAL", "X25519-SEALEDBOX", "RSA-OAEP-SHA256-SEAL"),
+    "unwrap": ("AES-KW", "RSA-OAEP-SHA256", "OpenPGP"),
+    "seal": ("OpenPGP-SEAL", "X25519-SEALEDBOX"),
+    "unseal": ("OpenPGP-SEAL", "X25519-SEALEDBOX"),
   }
 
 Notes
@@ -50,15 +58,19 @@ class ICrypto(ABC):
         Return a capability map describing supported algorithms.
 
         Expected keys (all optional; omit if unsupported):
-          - "aead": iterable of AEAD algorithm identifiers
-          - "wrap": iterable of key-wrapping algorithm identifiers
-          - "seal": iterable of sealing algorithm identifiers
+          - "encrypt" / "decrypt": AEAD algorithms for each direction
+          - "wrap" / "unwrap": key-wrapping algorithms
+          - "seal" / "unseal": sealed-box style algorithms
 
-        Example:
+        Example::
+
             return {
-                "aead": ("AES-256-GCM", "XCHACHA20-POLY1305"),
+                "encrypt": ("AES-256-GCM", "XCHACHA20-POLY1305"),
+                "decrypt": ("AES-256-GCM",),
                 "wrap": ("AES-KW", "RSA-OAEP-SHA256"),
+                "unwrap": ("AES-KW", "RSA-OAEP-SHA256"),
                 "seal": ("X25519-SEALEDBOX",),
+                "unseal": ("X25519-SEALEDBOX",),
             }
         """
         ...

--- a/pkgs/core/swarmauri_core/mre_crypto/IMreCrypto.py
+++ b/pkgs/core/swarmauri_core/mre_crypto/IMreCrypto.py
@@ -1,0 +1,191 @@
+"""
+IMreCrypto: Multi‑Recipient Encryption (MRE) provider interface.
+
+Design (agreed)
+---------------
+- ONE interface with pluggable *modes* (e.g., KEM+AEAD headers, sealed-per-recipient,
+  sealed-CEK+AEAD). Providers implement only the subset they support and advertise
+  via `supports()`.
+- Signing/verification is OUT-OF-SCOPE here (use swarmauri_core.signing.IEnvelopeSign).
+- Header-only batch DEK distribution (no payload) is OUT-OF-SCOPE here; if needed,
+  use the optional mix‑in `swarmauri_core.mre_crypto.IMreWrap`.
+
+Key concepts
+------------
+- payload_alg: AEAD used for the content (if the chosen mode uses a shared AEAD).
+- recipient_alg: algorithm used for each recipient’s header (wrap/seal).
+- mode: a value from MreMode (see swarmauri_core.mre_crypto.types.MreMode).
+- envelope: a structured MultiRecipientEnvelope (see .types) holding the payload
+  (or per‑recipient sealed payloads) and recipient headers.
+
+Typical non‑sealed flow (KEM+AEAD):
+  1) Generate CEK
+  2) AEAD‑encrypt plaintext once
+  3) Per‑recipient: protect CEK via recipient_alg
+  4) Emit one shared ciphertext + N recipient headers
+
+Typical sealed flow:
+  - Either seal the payload per‑recipient (no shared AEAD), or seal a CEK per‑recipient
+    and use an outer AEAD for the payload (sealed‑CEK+AEAD).
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Dict, Iterable, Mapping, Optional, Sequence
+
+from ..crypto.types import Alg, KeyRef
+from .types import (
+    MultiRecipientEnvelope,
+    RecipientId,
+    MreMode,
+)
+
+
+class IMreCrypto(ABC):
+    @abstractmethod
+    def supports(self) -> Dict[str, Iterable[str | MreMode]]:
+        """
+        Return a capability map describing supported algorithms, modes, and features.
+        Providers SHOULD list only what they actually implement.
+
+        Keys (omit any you do not support):
+          - "payload": iterable[str] of AEAD algorithms usable for the shared payload.
+                       (Only relevant for modes that use a shared AEAD.)
+          - "recipient": iterable[str] of recipient protection algorithms
+                         (e.g., "OpenPGP", "X25519-SEAL", "RSA-OAEP-SHA256", "AES-KW").
+          - "modes": iterable[MreMode|str] of supported composition modes.
+          - "features": iterable[str] of optional features (e.g., "aad",
+                        "threshold", "rewrap_without_reencrypt").
+
+        Example:
+            return {
+              "payload": ("AES-256-GCM", "XCHACHA20-POLY1305"),
+              "recipient": ("OpenPGP", "X25519-SEAL"),
+              "modes": (MreMode.ENC_ONCE_HEADERS, MreMode.SEALED_CEK_AEAD),
+              "features": ("aad", "rewrap_without_reencrypt"),
+            }
+        """
+        ...
+
+    # ─────────────────── Encrypt (N recipients) ───────────────────
+
+    @abstractmethod
+    async def encrypt_for_many(
+        self,
+        recipients: Sequence[KeyRef],
+        pt: bytes,
+        *,
+        payload_alg: Optional[Alg] = None,
+        recipient_alg: Optional[Alg] = None,
+        mode: Optional[MreMode | str] = None,
+        aad: Optional[bytes] = None,
+        shared: Optional[Mapping[str, bytes]] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> MultiRecipientEnvelope:
+        """
+        Encrypt 'pt' for all 'recipients' and return a single MultiRecipientEnvelope.
+
+        Parameters:
+          recipients     : public-key KeyRefs (or handles) for each recipient.
+          pt             : plaintext bytes.
+          payload_alg    : AEAD for the shared payload (if required by the mode).
+          recipient_alg  : per‑recipient protection algorithm (wrap/seal).
+          mode           : MRE composition mode (see supports()["modes"]).
+          aad            : Additional Authenticated Data (supported only by AEAD modes).
+          shared         : optional map of app-defined fields to bind/version with envelope.
+          opts           : provider hints (e.g., {"threshold_k": 2}).
+
+        Returns:
+          MultiRecipientEnvelope with:
+            - top-level metadata (mode, payload_alg, recipient_alg, etc.),
+            - either a shared AEAD payload or per‑recipient sealed payloads,
+            - recipient header list with the material needed to open.
+        """
+        ...
+
+    # ───────────────── Open (single / many IDs) ─────────────────
+
+    @abstractmethod
+    async def open_for(
+        self,
+        my_identity: KeyRef,
+        env: MultiRecipientEnvelope,
+        *,
+        aad: Optional[bytes] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bytes:
+        """
+        Open 'env' using a single private identity.
+
+        Parameters:
+          my_identity : private-key KeyRef (or HSM handle) corresponding to one recipient.
+          env         : envelope produced by encrypt_for_many.
+          aad         : AAD value (must match for AEAD modes).
+          opts        : optional hints (e.g., {"prefer_handle": True}).
+
+        Returns:
+          plaintext bytes.
+
+        Raises on authentication failure, unsupported mode/alg, or identity mismatch.
+        """
+        ...
+
+    @abstractmethod
+    async def open_for_many(
+        self,
+        my_identities: Sequence[KeyRef],
+        env: MultiRecipientEnvelope,
+        *,
+        aad: Optional[bytes] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bytes:
+        """
+        Attempt to open 'env' with any of the provided identities. Useful when a service
+        has multiple keys/slots or when a scheme requires multiple partial openings.
+
+        Parameters:
+          my_identities : sequence of private-key KeyRefs / handles.
+          env           : envelope to open.
+          aad           : AAD (if required by the mode).
+          opts          : optional hints (e.g., {"threshold_parts": {...}}).
+
+        Returns:
+          plaintext bytes on success.
+
+        Raises on failure to satisfy the scheme (e.g., threshold unmet).
+        """
+        ...
+
+    # ───────────────── Recipient‑set management ─────────────────
+
+    @abstractmethod
+    async def rewrap(
+        self,
+        env: MultiRecipientEnvelope,
+        *,
+        add: Optional[Sequence[KeyRef]] = None,
+        remove: Optional[Sequence[RecipientId]] = None,
+        recipient_alg: Optional[Alg] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> MultiRecipientEnvelope:
+        """
+        Modify the recipient set, re‑wrapping headers without re‑encrypting the payload
+        when the mode permits.
+
+        Parameters:
+          env            : existing envelope.
+          add            : recipients to grant (append headers).
+          remove         : recipient IDs to revoke (drop headers).
+          recipient_alg  : optionally switch the per‑recipient protection algorithm.
+          opts           : hints (e.g., {"rotate_payload_on_revoke": True}).
+
+        Returns:
+          Updated MultiRecipientEnvelope.
+
+        Notes:
+          - If safe header removal is not possible for the mode (e.g., sealed-per-recipient
+            payload), providers SHOULD rotate the payload key and re‑encrypt.
+          - Providers SHOULD document complexity: header‑only O(1) vs payload re‑encrypt O(N).
+        """
+        ...

--- a/pkgs/core/swarmauri_core/mre_crypto/__init__.py
+++ b/pkgs/core/swarmauri_core/mre_crypto/__init__.py
@@ -1,0 +1,12 @@
+"""Multi-Recipient Encryption interfaces and types."""
+
+from .IMreCrypto import IMreCrypto
+from .types import MultiRecipientEnvelope, RecipientInfo, RecipientId, MreMode
+
+__all__ = [
+    "IMreCrypto",
+    "MultiRecipientEnvelope",
+    "RecipientInfo",
+    "RecipientId",
+    "MreMode",
+]

--- a/pkgs/core/swarmauri_core/mre_crypto/types.py
+++ b/pkgs/core/swarmauri_core/mre_crypto/types.py
@@ -1,0 +1,50 @@
+"""Types for Multi-Recipient Encryption (MRE)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional, Tuple
+
+# Local scalar aliases to avoid circular imports
+KeyId = str
+KeyVersion = int
+Alg = str
+
+RecipientId = str
+
+
+class MreMode(str, Enum):
+    ENC_ONCE_HEADERS = "enc_once_headers"
+    SEALED_PER_RECIPIENT = "sealed_per_recipient"
+    SEALED_CEK_AEAD = "sealed_cek_aead"
+
+
+@dataclass(frozen=True)
+class RecipientInfo:
+    kid: KeyId
+    version: KeyVersion
+    wrap_alg: Alg
+    wrapped_key: bytes
+    nonce: Optional[bytes] = None
+
+
+@dataclass(frozen=True)
+class MultiRecipientEnvelope:
+    enc_alg: Alg
+    nonce: bytes
+    ct: bytes
+    tag: bytes
+    recipients: Tuple[RecipientInfo, ...]
+    aad: Optional[bytes] = None
+
+
+__all__ = [
+    "RecipientInfo",
+    "MultiRecipientEnvelope",
+    "RecipientId",
+    "MreMode",
+    "KeyId",
+    "KeyVersion",
+    "Alg",
+]

--- a/pkgs/core/swarmauri_core/signing/ISigning.py
+++ b/pkgs/core/swarmauri_core/signing/ISigning.py
@@ -1,0 +1,160 @@
+"""
+ISigning: Detached signing / verification interface (envelope‑agnostic).
+
+Design goals
+------------
+- One interface that cleanly supports:
+  • Signing/verification of raw bytes.
+  • Signing/verification of structured envelopes (AEAD or MRE) via canonicalization.
+- No encryption here (kept in ICrypto/IMreCrypto).
+- Multi‑signer friendly: return one or more detached signatures; verification
+  can accept N signatures and enforce policy (e.g., m‑of‑n) at the caller.
+
+Conventions
+-----------
+- "alg" describes the signature scheme (e.g., "Ed25519", "RSA-PSS-SHA256", "OpenPGP").
+- Canonicalization MUST be deterministic. Implementations should document which
+  canonical form(s) they support (e.g., JSON‑canonical, CBOR‑canonical).
+- Key material is referenced via KeyRef (HSM handle, KMS id, in‑memory key, etc.).
+
+Typical flows
+-------------
+- Bytes:
+    sigs = await signer.sign_bytes(my_key, b"payload", alg="Ed25519")
+    ok = await signer.verify_bytes(b"payload", sigs)
+
+- Envelopes (AEAD or MRE):
+    sigs = await signer.sign_envelope(my_key, env, alg="Ed25519", canon="json")
+    ok = await signer.verify_envelope(env, sigs, canon="json")
+
+Notes
+-----
+- This ABC is intentionally minimal. Providers may expose additional methods,
+  but must implement the surface below.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Iterable, Mapping, Optional, Sequence, Union
+
+from ..crypto.types import Alg, KeyRef
+from ..crypto.types import AEADCiphertext  # single‑recipient envelope
+from ..mre_crypto.types import MultiRecipientEnvelope  # multi‑recipient envelope
+from .types import Signature
+
+
+# --------- Canonicalization tokens (stringly‑typed to avoid a hard dep) ---------
+# Examples: "json", "json-c14n", "cbor", "dag-json", "raw" (no canonicalization)
+Canon = str
+
+Envelope = Union[AEADCiphertext, MultiRecipientEnvelope, Mapping[str, object]]
+
+
+class ISigning(ABC):
+    @abstractmethod
+    def supports(self) -> Mapping[str, Iterable[str]]:
+        """
+        Return capability information.
+
+        Keys (omit if unsupported):
+          - "algs": iterable of signature algorithms (e.g., "Ed25519", "RSA-PSS-SHA256", "OpenPGP").
+          - "canons": iterable of canonicalization identifiers (e.g., "json", "cbor", "json-c14n").
+          - "features": optional iterable of flags, e.g.:
+                • "multi"          → optimized for multi‑signature sets
+                • "detached_only"  → only detached signatures (default)
+                • "attest"         → can include attestation chains in Signature["chain"]
+        """
+        ...
+
+    # ────────────────────────────────── Bytes ──────────────────────────────────
+
+    @abstractmethod
+    async def sign_bytes(
+        self,
+        key: KeyRef,
+        payload: bytes,
+        *,
+        alg: Optional[Alg] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> Sequence[Signature]:
+        """
+        Produce one or more detached signatures over raw bytes.
+
+        Returns:
+          Sequence[Signature] (typically length 1). Multiple signatures MAY be
+          returned if the provider is configured to co‑sign (e.g., hardware + software).
+        """
+        ...
+
+    @abstractmethod
+    async def verify_bytes(
+        self,
+        payload: bytes,
+        signatures: Sequence[Signature],
+        *,
+        require: Optional[Mapping[str, object]] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bool:
+        """
+        Verify detached signatures over raw bytes.
+
+        Parameters:
+          signatures : sequence of Signature mappings.
+          require    : optional policy hints, e.g. {"min_signers": 1, "algs": ["Ed25519"]}
+
+        Returns:
+          True if the verification criteria are met, False otherwise.
+        """
+        ...
+
+    # ────────────────────────────────── Envelopes ──────────────────────────────────
+
+    @abstractmethod
+    async def canonicalize_envelope(
+        self,
+        env: Envelope,
+        *,
+        canon: Optional[Canon] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bytes:
+        """
+        Deterministically canonicalize an envelope to bytes prior to signing/verifying.
+
+        Implementations MUST document the exact canonicalization performed for each
+        'canon' token and ensure stable byte output for semantically identical envelopes.
+        """
+        ...
+
+    @abstractmethod
+    async def sign_envelope(
+        self,
+        key: KeyRef,
+        env: Envelope,
+        *,
+        alg: Optional[Alg] = None,
+        canon: Optional[Canon] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> Sequence[Signature]:
+        """
+        Produce one or more detached signatures over a canonicalized envelope.
+        """
+        ...
+
+    @abstractmethod
+    async def verify_envelope(
+        self,
+        env: Envelope,
+        signatures: Sequence[Signature],
+        *,
+        canon: Optional[Canon] = None,
+        require: Optional[Mapping[str, object]] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bool:
+        """
+        Verify detached signatures against the canonicalized envelope.
+
+        'require' can express policy such as:
+          {"min_signers": 2, "algs": ["Ed25519", "RSA-PSS-SHA256"], "kids": ["..."]}
+        """
+        ...

--- a/pkgs/core/swarmauri_core/signing/__init__.py
+++ b/pkgs/core/swarmauri_core/signing/__init__.py
@@ -1,0 +1,6 @@
+"""Signing interfaces and types."""
+
+from .ISigning import ISigning, Canon, Envelope
+from .types import Signature
+
+__all__ = ["ISigning", "Canon", "Envelope", "Signature"]

--- a/pkgs/core/swarmauri_core/signing/types.py
+++ b/pkgs/core/swarmauri_core/signing/types.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from collections.abc import Mapping, Iterator
+from typing import Optional, Dict, Any
+
+# Local scalar aliases to avoid circular imports
+KeyId = str
+KeyVersion = int
+Alg = str
+
+
+@dataclass(frozen=True)
+class Signature(Mapping[str, object]):
+    """Simple signature record used by signing providers."""
+
+    kid: KeyId
+    version: KeyVersion
+    alg: Alg
+    sig: bytes
+    ts: Optional[int] = None
+    chain: Optional[bytes] = None
+    meta: Optional[Dict[str, Any]] = None
+
+    def __getitem__(self, k: str) -> object:  # type: ignore[override]
+        return getattr(self, k)
+
+    def __iter__(self) -> Iterator[str]:  # type: ignore[override]
+        return iter(
+            (
+                "kid",
+                "version",
+                "alg",
+                "sig",
+                "ts",
+                "chain",
+                "meta",
+            )
+        )
+
+    def __len__(self) -> int:  # type: ignore[override]
+        return 7
+
+
+__all__ = ["Signature", "KeyId", "KeyVersion", "Alg"]


### PR DESCRIPTION
## Summary
- clarify capability advertisement in ICrypto
- add dedicated signing and multi-recipient encryption interfaces with base classes
- streamline CryptoBase to match ICrypto scope

## Testing
- `uv run --directory core --package swarmauri-core ruff format .`
- `uv run --directory core --package swarmauri-core ruff check . --fix`
- `uv run --directory base --package swarmauri-base ruff format .`
- `uv run --directory base --package swarmauri-base ruff check . --fix`
- `uv run --package swarmauri-core --directory core pytest`
- `uv run --package swarmauri-base --directory base pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6ee9a1fe083269218095ca1fc6e1a