### PR TITLE
refactor: align crypto providers with new ICrypto

### DIFF
--- a/pkgs/base/swarmauri_base/crypto/CryptoBase.py
+++ b/pkgs/base/swarmauri_base/crypto/CryptoBase.py
@@ -10,13 +10,8 @@ from typing import Dict, Iterable, Literal, Optional
 
 from pydantic import Field
 
-from swarmauri_core.crypto.ICrypto import (
-    ICrypto,
-    AEADCiphertext,
-    Alg,
-    KeyRef,
-    WrappedKey,
-)
+from swarmauri_core.crypto.ICrypto import ICrypto
+from swarmauri_core.crypto.types import AEADCiphertext, Alg, KeyRef, WrappedKey
 from swarmauri_base.ComponentBase import ComponentBase, ResourceTypes
 
 

--- a/pkgs/standards/swarmauri_crypto_composite/swarmauri_crypto_composite/CompositeCrypto.py
+++ b/pkgs/standards/swarmauri_crypto_composite/swarmauri_crypto_composite/CompositeCrypto.py
@@ -8,7 +8,6 @@ from swarmauri_core.crypto.types import (
     Alg,
     KeyRef,
     MultiRecipientEnvelope,
-    Signature,
     WrappedKey,
     UnsupportedAlgorithm,
 )
@@ -48,7 +47,7 @@ class CompositeCrypto(ICrypto, ComponentBase):
     # -------- routing helpers --------
     def _pick(self, area: str, alg: Optional[Alg]) -> ICrypto:
         alg_n = _norm_alg(alg)
-        # If caller passed None for enc/sign alg, we let providers apply their own default;
+        # If caller passed None for the algorithm, we let providers apply their own default;
         # pick the first provider advertising *any* alg for that area.
         for p in self._providers:
             caps = p.supports()
@@ -85,24 +84,6 @@ class CompositeCrypto(ICrypto, ComponentBase):
         aad: Optional[bytes] = None,
     ) -> bytes:
         return await self._pick("decrypt", ct.alg).decrypt(key, ct, aad=aad)
-
-    # -------- sign / verify --------
-    async def sign(
-        self,
-        key: KeyRef,
-        msg: bytes,
-        *,
-        alg: Optional[Alg] = None,
-    ) -> Signature:
-        return await self._pick("sign", alg).sign(key, msg, alg=alg)
-
-    async def verify(
-        self,
-        key: KeyRef,
-        msg: bytes,
-        sig: Signature,
-    ) -> bool:
-        return await self._pick("verify", sig.alg).verify(key, msg, sig)
 
     # -------- wrap / unwrap --------
     async def wrap(

--- a/pkgs/standards/swarmauri_crypto_composite/tests/test_composite_crypto.py
+++ b/pkgs/standards/swarmauri_crypto_composite/tests/test_composite_crypto.py
@@ -32,12 +32,6 @@ class DummyCrypto(ICrypto):
     async def decrypt(self, key, ct, *, aad=None):  # pragma: no cover - unused
         raise NotImplementedError
 
-    async def sign(self, key, msg, *, alg=None):  # pragma: no cover - unused
-        raise NotImplementedError
-
-    async def verify(self, key, msg, sig):  # pragma: no cover - unused
-        raise NotImplementedError
-
     async def wrap(
         self, kek, *, dek=None, wrap_alg=None, nonce=None
     ):  # pragma: no cover - unused

--- a/pkgs/standards/swarmauri_crypto_nacl_pkcs11/README.md
+++ b/pkgs/standards/swarmauri_crypto_nacl_pkcs11/README.md
@@ -20,7 +20,6 @@
 Hybrid crypto provider using PyNaCl for Ed25519/X25519 operations and `python-pkcs11` for AES-KW key wrapping. Implements the `ICrypto` contract via `CryptoBase`.
 
 - AES-GCM symmetric encrypt/decrypt
-- Ed25519 sign/verify
 - AES-KW wrap/unwrap using PKCS#11
 - X25519 sealed boxes for single and multi-recipient encryption
 

--- a/pkgs/standards/swarmauri_crypto_nacl_pkcs11/tests/unit/test_NaClPkcs11Crypto.py
+++ b/pkgs/standards/swarmauri_crypto_nacl_pkcs11/tests/unit/test_NaClPkcs11Crypto.py
@@ -1,5 +1,4 @@
 import pytest
-from nacl.signing import SigningKey
 from nacl.public import PrivateKey
 
 from swarmauri_crypto_nacl_pkcs11 import NaClPkcs11Crypto
@@ -31,31 +30,6 @@ async def test_aead_encrypt_decrypt_roundtrip(crypto):
     ct = await crypto.encrypt(key, pt)
     rt = await crypto.decrypt(key, ct)
     assert rt == pt
-
-
-@pytest.mark.asyncio
-async def test_sign_verify_roundtrip(crypto):
-    sk = SigningKey.generate()
-    vk = sk.verify_key
-    sign_ref = KeyRef(
-        kid="ed1",
-        version=1,
-        type=KeyType.ED25519,
-        uses=(KeyUse.SIGN,),
-        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
-        material=sk.encode(),
-    )
-    verify_ref = KeyRef(
-        kid="ed1",
-        version=1,
-        type=KeyType.ED25519,
-        uses=(KeyUse.VERIFY,),
-        export_policy=ExportPolicy.PUBLIC_ONLY,
-        public=vk.encode(),
-    )
-    msg = b"sign me"
-    sig = await crypto.sign(sign_ref, msg)
-    assert await crypto.verify(verify_ref, msg, sig)
 
 
 @pytest.mark.asyncio

--- a/pkgs/standards/swarmauri_crypto_paramiko/swarmauri_crypto_paramiko/ParamikoCrypto.py
+++ b/pkgs/standards/swarmauri_crypto_paramiko/swarmauri_crypto_paramiko/ParamikoCrypto.py
@@ -56,8 +56,6 @@ class ParamikoCrypto(CryptoBase):
             "decrypt": (_AEAD_DEFAULT,),
             "wrap": (_WRAP_ALG,),
             "unwrap": (_WRAP_ALG,),
-            "sign": (),
-            "verify": (),
             # NEW:
             "seal": (_SEAL_ALG,),
             "unseal": (_SEAL_ALG,),
@@ -111,7 +109,9 @@ class ParamikoCrypto(CryptoBase):
             raise UnsupportedAlgorithm(f"Unsupported AEAD algorithm: {alg}")
 
         if key.material is None:
-            raise ValueError("KeyRef.material must contain symmetric key bytes for AEAD")
+            raise ValueError(
+                "KeyRef.material must contain symmetric key bytes for AEAD"
+            )
         if len(key.material) not in (16, 24, 32):
             raise ValueError("KeyRef.material must be 16/24/32 bytes for AES-GCM")
 
@@ -139,7 +139,9 @@ class ParamikoCrypto(CryptoBase):
         if self._normalize_aead_alg(ct.alg) != _AEAD_DEFAULT:
             raise UnsupportedAlgorithm(f"Unsupported AEAD algorithm: {ct.alg}")
         if key.material is None:
-            raise ValueError("KeyRef.material must contain symmetric key bytes for AEAD")
+            raise ValueError(
+                "KeyRef.material must contain symmetric key bytes for AEAD"
+            )
 
         aead = AESGCM(key.material)
         blob = ct.ct + ct.tag
@@ -183,7 +185,9 @@ class ParamikoCrypto(CryptoBase):
         if alg != _SEAL_ALG:
             raise UnsupportedAlgorithm(f"Unsupported seal alg: {alg}")
         if recipient_priv.material is None:
-            raise ValueError("KeyRef.material must contain PEM-encoded RSA private key bytes")
+            raise ValueError(
+                "KeyRef.material must contain PEM-encoded RSA private key bytes"
+            )
 
         priv = self._load_rsa_priv_pem(recipient_priv.material)
         return priv.decrypt(
@@ -212,7 +216,9 @@ class ParamikoCrypto(CryptoBase):
             recip_infos: list[RecipientInfo] = []
             for r in recipients:
                 if r.public is None:
-                    raise ValueError("Recipient KeyRef.public must contain OpenSSH RSA public key bytes")
+                    raise ValueError(
+                        "Recipient KeyRef.public must contain OpenSSH RSA public key bytes"
+                    )
                 rsa_pub = self._load_rsa_pub_ssh(r.public)
                 self._seal_size_check(rsa_pub, len(pt))
                 sealed = rsa_pub.encrypt(
@@ -260,7 +266,9 @@ class ParamikoCrypto(CryptoBase):
         recip_infos: list[RecipientInfo] = []
         for r in recipients:
             if r.public is None:
-                raise ValueError("Recipient KeyRef.public must contain OpenSSH RSA public key bytes")
+                raise ValueError(
+                    "Recipient KeyRef.public must contain OpenSSH RSA public key bytes"
+                )
             rsa_pub = self._load_rsa_pub_ssh(r.public)
             enc_k = rsa_pub.encrypt(
                 k,
@@ -326,7 +334,9 @@ class ParamikoCrypto(CryptoBase):
         if wrapped.wrap_alg != _WRAP_ALG:
             raise UnsupportedAlgorithm(f"Unsupported wrap_alg: {wrapped.wrap_alg}")
         if kek.material is None:
-            raise ValueError("KeyRef.material must contain PEM-encoded RSA private key bytes")
+            raise ValueError(
+                "KeyRef.material must contain PEM-encoded RSA private key bytes"
+            )
 
         priv = self._load_rsa_priv_pem(kek.material)
         return priv.decrypt(
@@ -337,22 +347,3 @@ class ParamikoCrypto(CryptoBase):
                 label=None,
             ),
         )
-
-    # ───────────────────────── signing (not supported) ──────────────────
-
-    async def sign(
-        self,
-        key: KeyRef,
-        msg: bytes,
-        *,
-        alg: Optional[Alg] = None,
-    ):
-        raise UnsupportedAlgorithm("sign not supported by ParamikoCrypto")
-
-    async def verify(
-        self,
-        key: KeyRef,
-        msg: bytes,
-        sig,
-    ) -> bool:
-        raise UnsupportedAlgorithm("verify not supported by ParamikoCrypto")

--- a/pkgs/standards/swarmauri_crypto_sodium/README.md
+++ b/pkgs/standards/swarmauri_crypto_sodium/README.md
@@ -20,7 +20,6 @@
 Libsodium-backed crypto provider implementing the `ICrypto` contract via `CryptoBase`.
 
 - XChaCha20-Poly1305 symmetric encrypt/decrypt
-- Ed25519 sign/verify
 - X25519 sealed boxes for data sealing and key wrapping
 - Multi-recipient envelopes using XChaCha20-Poly1305 + X25519 sealed wrap
 


### PR DESCRIPTION
## Summary
- switch CryptoBase to new ICrypto type exports
- drop sign/verify capabilities from crypto providers and docs
- update composite crypto routing after removing signing

## Testing
- `uv run --directory pkgs/base/swarmauri_base --package swarmauri_base ruff format .`
- `uv run --directory pkgs/base/swarmauri_base --package swarmauri_base ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_crypto_paramiko --package swarmauri_crypto_paramiko ruff format .`
- `uv run --directory pkgs/standards/swarmauri_crypto_paramiko --package swarmauri_crypto_paramiko ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_crypto_pgp --package swarmauri_crypto_pgp ruff format .`
- `uv run --directory pkgs/standards/swarmauri_crypto_pgp --package swarmauri_crypto_pgp ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_crypto_sodium --package swarmauri_crypto_sodium ruff format .`
- `uv run --directory pkgs/standards/swarmauri_crypto_sodium --package swarmauri_crypto_sodium ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_crypto_nacl_pkcs11 --package swarmauri_crypto_nacl_pkcs11 ruff format .`
- `uv run --directory pkgs/standards/swarmauri_crypto_nacl_pkcs11 --package swarmauri_crypto_nacl_pkcs11 ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_crypto_composite --package swarmauri_crypto_composite ruff format .`
- `uv run --directory pkgs/standards/swarmauri_crypto_composite --package swarmauri_crypto_composite ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68a6f24c9fd88326955c3430c95ff162