### PR TITLE
feat: add OpenPGP sealed MRE provider

### DIFF
--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -79,6 +79,7 @@ members = [
     "standards/auto_kms",
     "standards/swarmauri_crypto_paramiko",
     "standards/swarmauri_crypto_pgp",
+    "standards/swarmauri_mre_crypto_pgpseal",
     "standards/swarmauri_crypto_sodium",
     "standards/swarmauri_crypto_nacl_pkcs11",
     "standards/swarmauri_crypto_composite",
@@ -207,6 +208,7 @@ auto_kms = { workspace = true }
 swarmauri_secret_autogpg = { workspace = true }
 swarmauri_crypto_paramiko = { workspace = true }
 swarmauri_crypto_pgp = { workspace = true }
+swarmauri_mre_crypto_pgpseal = { workspace = true }
 swarmauri_crypto_nacl_pkcs11 = { workspace = true }
 swarmauri_crypto_composite = { workspace = true }
 swarmauri_signing_ed25519 = { workspace = true }

--- a/pkgs/standards/swarmauri_mre_crypto_pgpseal/LICENSE
+++ b/pkgs/standards/swarmauri_mre_crypto_pgpseal/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/standards/swarmauri_mre_crypto_pgpseal/README.md
+++ b/pkgs/standards/swarmauri_mre_crypto_pgpseal/README.md
@@ -1,0 +1,30 @@
+# swarmauri_mre_crypto_pgpseal
+
+OpenPGP sealed-per-recipient Multi-Recipient Encryption (MRE) provider for the Swarmauri framework.
+
+## Features
+
+- Implements `IMreCrypto` with sealed-per-recipient mode only.
+- Each recipient receives a PGP-encrypted copy of the plaintext.
+- Optional CBOR canonicalization via the `cbor` extra.
+
+## Installation
+
+```bash
+pip install swarmauri_mre_crypto_pgpseal
+```
+
+To enable optional CBOR support:
+
+```bash
+pip install swarmauri_mre_crypto_pgpseal[cbor]
+```
+
+## Usage
+
+```python
+from swarmauri_mre_crypto_pgpseal import PGPSealMreCrypto
+
+crypto = PGPSealMreCrypto()
+# ... load KeyRefs and encrypt
+```

--- a/pkgs/standards/swarmauri_mre_crypto_pgpseal/pyproject.toml
+++ b/pkgs/standards/swarmauri_mre_crypto_pgpseal/pyproject.toml
@@ -1,0 +1,70 @@
+[project]
+name = "swarmauri_mre_crypto_pgpseal"
+version = "0.1.0"
+description = "OpenPGP sealed-per-recipient MRE crypto provider for Swarmauri"
+license = "Apache-2.0"
+readme = "README.md"
+requires-python = ">=3.10,<3.13"
+authors = [{ name = "Swarmauri", email = "opensource@swarmauri.com" }]
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Development Status :: 3 - Alpha",
+    "Topic :: Security :: Cryptography",
+    "Intended Audience :: Developers",
+]
+dependencies = [
+    "swarmauri_core",
+    "swarmauri_base",
+    "pgpy>=0.6.0",
+]
+
+[project.optional-dependencies]
+cbor = ["cbor2>=5.4.6"]
+
+[tool.uv.sources]
+swarmauri_core = { workspace = true }
+swarmauri_base = { workspace = true }
+
+[tool.pytest.ini_options]
+norecursedirs = ["combined", "scripts"]
+markers = [
+    "test: standard test",
+    "unit: Unit tests",
+    "i9n: Integration tests",
+    "r8n: Regression tests",
+    "acceptance: Acceptance tests",
+    "perf: Performance tests",
+]
+timeout = 300
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "flake8>=7.0",
+    "ruff>=0.9.9",
+    "pytest-timeout>=2.3.1",
+    "pytest-benchmark>=4.0.0",
+]
+
+[project.entry-points.'swarmauri.mre_cryptos']
+PGPSealMreCrypto = "swarmauri_mre_crypto_pgpseal:PGPSealMreCrypto"
+
+[project.entry-points."peagen.plugins.mre_cryptos"]
+pgpseal = "swarmauri_mre_crypto_pgpseal:PGPSealMreCrypto"

--- a/pkgs/standards/swarmauri_mre_crypto_pgpseal/swarmauri_mre_crypto_pgpseal/PGPSealMreCrypto.py
+++ b/pkgs/standards/swarmauri_mre_crypto_pgpseal/swarmauri_mre_crypto_pgpseal/PGPSealMreCrypto.py
@@ -1,0 +1,283 @@
+"""PGPSealMreCrypto: IMreCrypto provider (sealed-per-recipient, OpenPGP).
+Mode
+----
+- sealed_per_recipient (ONLY)
+  For each recipient:
+    • PGP-encrypt the *payload itself* (sealed payload per recipient)
+  There is NO shared AEAD payload and NO AAD binding in this mode.
+Out of scope
+------------
+- Signing: use swarmauri_core.signing.ISigning implementations.
+- Header-only “wrap DEK for many”: use IMreWrap mix-in if you need it.
+
+KeyRef expectations
+-------------------
+Public recipients (encrypt):
+  - {"kind":"pgpy_pub", "pub": pgpy.PGPKey}
+  - {"kind":"pgpy_pub_armored", "pub": "<ASCII armored PUBLIC key>"}
+
+Private identities (open/rewrap):
+  - {"kind":"pgpy_priv", "priv": pgpy.PGPKey}    (unlocked or unlockable via opts["passphrase"])
+  - {"kind":"pgpy_priv_armored", "priv": "<ASCII armored PRIVATE key>"}
+
+Options (opts)
+--------------
+- For private keys locked with a passphrase: opts["passphrase"] = str|bytes
+- For rewrap(add=...): requires the *plaintext* via opts["plaintext"] = bytes
+  (because payload is sealed per recipient; we must reseal the plaintext)
+
+Dependencies
+------------
+- PGP: pip install pgpy
+"""
+
+from __future__ import annotations
+
+import base64
+from swarmauri_base.mre_crypto.MreCryptoBase import MreCryptoBase
+from typing import Dict, Iterable, Mapping, Optional, Sequence, Any, List, Literal
+
+from swarmauri_core.mre_crypto.types import MultiRecipientEnvelope, RecipientId, MreMode
+from swarmauri_core.crypto.types import Alg, KeyRef
+
+# ----- external deps -----
+try:
+    import pgpy
+
+    _PGP_OK = True
+except Exception:  # pragma: no cover - dependency check
+    _PGP_OK = False
+
+
+def _ensure_pgpy() -> None:
+    if not _PGP_OK:  # pragma: no cover - simple guard
+        raise RuntimeError(
+            "PGPSealMreCrypto requires 'PGPy'. Install with: pip install pgpy"
+        )
+
+
+# ============================== Helpers (PGP) ==============================
+
+
+def _load_pubkey(ref: KeyRef) -> "pgpy.PGPKey":
+    _ensure_pgpy()
+    if isinstance(ref, dict):
+        kind = ref.get("kind")
+        if kind == "pgpy_pub" and isinstance(ref.get("pub"), pgpy.PGPKey):
+            return ref["pub"]
+        if kind == "pgpy_pub_armored" and isinstance(ref.get("pub"), str):
+            k, _ = pgpy.PGPKey.from_blob(ref["pub"])
+            return k
+    raise TypeError("Unsupported recipient KeyRef for PGP public key.")
+
+
+def _load_privkey(ref: KeyRef, passphrase: Optional[bytes | str]) -> "pgpy.PGPKey":
+    _ensure_pgpy()
+    if isinstance(ref, dict):
+        kind = ref.get("kind")
+        if kind == "pgpy_priv" and isinstance(ref.get("priv"), pgpy.PGPKey):
+            k: pgpy.PGPKey = ref["priv"]
+        elif kind == "pgpy_priv_armored" and isinstance(ref.get("priv"), str):
+            k, _ = pgpy.PGPKey.from_blob(ref["priv"])
+        else:
+            raise TypeError("Unsupported identity KeyRef for PGP private key.")
+        if not k.is_unlocked:
+            if passphrase is None:
+                raise RuntimeError(
+                    "PGP private key is locked; supply opts['passphrase']."
+                )
+            k.unlock(passphrase)
+        return k
+    raise TypeError("Unsupported identity KeyRef for PGP private key.")
+
+
+def _fingerprint_pub(k: "pgpy.PGPKey") -> str:
+    return str(k.fingerprint)
+
+
+def _pgp_encrypt_bytes_for(pub: "pgpy.PGPKey", data: bytes) -> bytes:
+    """
+    PGPy often treats message payloads as text. To ensure byte fidelity, base64-encode
+    before encrypting, and decode after decrypting.
+    """
+    _ensure_pgpy()
+    msg = pgpy.PGPMessage.new(base64.b64encode(data), file=False)
+    enc = pub.encrypt(msg)
+    return bytes(enc.__bytes__())
+
+
+def _pgp_decrypt_bytes_with(priv: "pgpy.PGPKey", blob: bytes) -> bytes:
+    _ensure_pgpy()
+    msg = pgpy.PGPMessage.from_blob(blob)
+    dec = priv.decrypt(msg)
+    if isinstance(dec.message, str):
+        return base64.b64decode(dec.message.encode("utf-8"))
+    return base64.b64decode(dec.message)
+
+
+# ============================== Envelope shapers ==============================
+
+
+def _make_sealed_recipient(rid: str, sealed_payload: bytes) -> Dict[str, Any]:
+    return {"id": rid, "sealed": sealed_payload}
+
+
+# ============================== Provider ==============================
+
+
+class PGPSealMreCrypto(MreCryptoBase):
+    type: Literal["PGPSealMreCrypto"] = "PGPSealMreCrypto"
+    """
+    OpenPGP sealed-per-recipient MRE provider.
+
+    - Supports:
+        • MreMode.SEALED_PER_RECIPIENT (ONLY)
+    - Recipient protection: OpenPGP-SEAL
+    - No shared AEAD payload; no AAD.
+    """
+
+    def supports(self) -> Dict[str, Iterable[str | MreMode]]:
+        return {
+            "recipient": ("OpenPGP-SEAL",),
+            "modes": (MreMode.SEALED_PER_RECIPIENT,),
+            "features": (),
+        }
+
+    # ————— Encrypt (N) —————
+    async def encrypt_for_many(
+        self,
+        recipients: Sequence[KeyRef],
+        pt: bytes,
+        *,
+        payload_alg: Optional[Alg] = None,
+        recipient_alg: Optional[Alg] = None,
+        mode: Optional[MreMode | str] = None,
+        aad: Optional[bytes] = None,
+        shared: Optional[Mapping[str, bytes]] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> MultiRecipientEnvelope:
+        _ensure_pgpy()
+
+        m = (
+            MreMode(mode)
+            if isinstance(mode, str)
+            else (mode or MreMode.SEALED_PER_RECIPIENT)
+        )
+        if m != MreMode.SEALED_PER_RECIPIENT:
+            raise ValueError(
+                f"PGPSealMreCrypto supports only mode={MreMode.SEALED_PER_RECIPIENT.value}."
+            )
+        if aad is not None:
+            raise ValueError("AAD is not supported in sealed_per_recipient mode.")
+
+        pubs = [_load_pubkey(r) for r in recipients]
+        rids = [_fingerprint_pub(pk) for pk in pubs]
+
+        sealed_entries = [
+            _make_sealed_recipient(rid, _pgp_encrypt_bytes_for(pk, pt))
+            for rid, pk in zip(rids, pubs)
+        ]
+        env: MultiRecipientEnvelope = {
+            "mode": MreMode.SEALED_PER_RECIPIENT.value,
+            "recipient_alg": "OpenPGP-SEAL",
+            "payload": {"kind": "sealed_per_recipient"},
+            "recipients": sealed_entries,
+        }
+        if shared:
+            env["shared"] = dict(shared)
+        return env
+
+    # ————— Open (single) —————
+    async def open_for(
+        self,
+        my_identity: KeyRef,
+        env: MultiRecipientEnvelope,
+        *,
+        aad: Optional[bytes] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bytes:
+        _ensure_pgpy()
+        if env.get("mode") != MreMode.SEALED_PER_RECIPIENT.value:
+            raise ValueError("Envelope mode mismatch; expected sealed_per_recipient.")
+        if aad is not None:
+            raise ValueError("AAD is not supported in sealed_per_recipient mode.")
+
+        priv = _load_privkey(my_identity, (opts or {}).get("passphrase"))
+        my_id = str(priv.fingerprint)
+
+        entries: List[Dict[str, Any]] = env.get("recipients", [])
+        target = next((e for e in entries if e.get("id") == my_id), None)
+        if target:
+            return _pgp_decrypt_bytes_with(priv, target["sealed"])
+
+        for e in entries:
+            try:
+                return _pgp_decrypt_bytes_with(priv, e["sealed"])
+            except Exception:
+                continue
+        raise PermissionError("This identity cannot open the sealed envelope.")
+
+    # ————— Open (many) —————
+    async def open_for_many(
+        self,
+        my_identities: Sequence[KeyRef],
+        env: MultiRecipientEnvelope,
+        *,
+        aad: Optional[bytes] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bytes:
+        last_err: Optional[Exception] = None
+        for ident in my_identities:
+            try:
+                return await self.open_for(ident, env, aad=aad, opts=opts)
+            except Exception as e:
+                last_err = e
+                continue
+        raise last_err or PermissionError(
+            "None of the provided identities could open the envelope."
+        )
+
+    # ————— Rewrap —————
+    async def rewrap(
+        self,
+        env: MultiRecipientEnvelope,
+        *,
+        add: Optional[Sequence[KeyRef]] = None,
+        remove: Optional[Sequence[RecipientId]] = None,
+        recipient_alg: Optional[Alg] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> MultiRecipientEnvelope:
+        _ensure_pgpy()
+        if env.get("mode") != MreMode.SEALED_PER_RECIPIENT.value:
+            raise ValueError("Envelope mode mismatch; expected sealed_per_recipient.")
+
+        add = add or ()
+        remove_ids = set(remove or ())
+
+        new_env: MultiRecipientEnvelope = {k: v for k, v in env.items()}
+        current_entries: List[Dict[str, Any]] = list(new_env.get("recipients", []))
+
+        if remove_ids:
+            current_entries = [
+                e for e in current_entries if e.get("id") not in remove_ids
+            ]
+
+        if add:
+            pt_bytes = (opts or {}).get("plaintext")
+            if not isinstance(pt_bytes, (bytes, bytearray)):
+                raise RuntimeError(
+                    "Rewrap(add=...) in sealed_per_recipient mode requires opts['plaintext'] (bytes)."
+                )
+            pubs = [_load_pubkey(r) for r in add]
+            rids = [_fingerprint_pub(pk) for pk in pubs]
+            new_entries = [
+                _make_sealed_recipient(rid, _pgp_encrypt_bytes_for(pk, pt_bytes))
+                for rid, pk in zip(rids, pubs)
+            ]
+            remaining = [
+                e for e in current_entries if e["id"] not in {rid for rid in rids}
+            ]
+            current_entries = remaining + new_entries
+
+        new_env["recipients"] = current_entries
+        return new_env

--- a/pkgs/standards/swarmauri_mre_crypto_pgpseal/swarmauri_mre_crypto_pgpseal/__init__.py
+++ b/pkgs/standards/swarmauri_mre_crypto_pgpseal/swarmauri_mre_crypto_pgpseal/__init__.py
@@ -1,0 +1,3 @@
+from .PGPSealMreCrypto import PGPSealMreCrypto
+
+__all__ = ["PGPSealMreCrypto"]

--- a/pkgs/standards/swarmauri_mre_crypto_pgpseal/tests/functional/test_pgpseal_functional.py
+++ b/pkgs/standards/swarmauri_mre_crypto_pgpseal/tests/functional/test_pgpseal_functional.py
@@ -1,0 +1,11 @@
+import pytest
+from swarmauri.plugin_citizenship_registry import PluginCitizenshipRegistry
+
+
+@pytest.mark.acceptance
+@pytest.mark.test
+def test_plugin_discovery():
+    entry = PluginCitizenshipRegistry.FIRST_CLASS_REGISTRY.get(
+        "swarmauri.mre_cryptos.PGPSealMreCrypto"
+    )
+    assert entry == "swarmauri_mre_crypto_pgpseal.PGPSealMreCrypto"

--- a/pkgs/standards/swarmauri_mre_crypto_pgpseal/tests/performance/test_pgpseal_perf.py
+++ b/pkgs/standards/swarmauri_mre_crypto_pgpseal/tests/performance/test_pgpseal_perf.py
@@ -1,0 +1,39 @@
+import asyncio
+import pytest
+from pgpy import PGPKey, PGPUID
+from pgpy.constants import (
+    PubKeyAlgorithm,
+    KeyFlags,
+    HashAlgorithm,
+    SymmetricKeyAlgorithm,
+    CompressionAlgorithm,
+)
+
+from swarmauri_mre_crypto_pgpseal import PGPSealMreCrypto
+
+
+def _generate_key() -> PGPKey:
+    key = PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 2048)
+    uid = PGPUID.new("Perf", email="perf@example.com")
+    key.add_uid(
+        uid,
+        usage={KeyFlags.EncryptCommunications},
+        hashes=[HashAlgorithm.SHA256],
+        ciphers=[SymmetricKeyAlgorithm.AES256],
+        compression=[CompressionAlgorithm.ZLIB],
+    )
+    return key
+
+
+@pytest.mark.perf
+@pytest.mark.test
+def test_encrypt_perf(benchmark):
+    key = _generate_key()
+    crypto = PGPSealMreCrypto()
+    recipients = [{"kind": "pgpy_pub", "pub": key.pubkey}]
+    pt = b"x" * 32
+
+    def run():
+        return asyncio.run(crypto.encrypt_for_many(recipients, pt))
+
+    benchmark(run)

--- a/pkgs/standards/swarmauri_mre_crypto_pgpseal/tests/unit/test_PGPSealMreCrypto.py
+++ b/pkgs/standards/swarmauri_mre_crypto_pgpseal/tests/unit/test_PGPSealMreCrypto.py
@@ -1,0 +1,36 @@
+import pytest
+from pgpy import PGPKey, PGPUID
+from pgpy.constants import (
+    PubKeyAlgorithm,
+    KeyFlags,
+    HashAlgorithm,
+    SymmetricKeyAlgorithm,
+    CompressionAlgorithm,
+)
+
+from swarmauri_mre_crypto_pgpseal import PGPSealMreCrypto
+
+
+def _generate_key() -> PGPKey:
+    key = PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 2048)
+    uid = PGPUID.new("Test", email="test@example.com")
+    key.add_uid(
+        uid,
+        usage={KeyFlags.EncryptCommunications},
+        hashes=[HashAlgorithm.SHA256],
+        ciphers=[SymmetricKeyAlgorithm.AES256],
+        compression=[CompressionAlgorithm.ZLIB],
+    )
+    return key
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+@pytest.mark.test
+async def test_encrypt_and_open_roundtrip():
+    key = _generate_key()
+    crypto = PGPSealMreCrypto()
+    recipients = [{"kind": "pgpy_pub", "pub": key.pubkey}]
+    env = await crypto.encrypt_for_many(recipients, b"hello")
+    pt = await crypto.open_for({"kind": "pgpy_priv", "priv": key}, env)
+    assert pt == b"hello"

--- a/pkgs/swarmauri/swarmauri/interface_registry.py
+++ b/pkgs/swarmauri/swarmauri/interface_registry.py
@@ -20,6 +20,7 @@ from swarmauri_base.dataconnectors.DataConnectorBase import DataConnectorBase
 from swarmauri_base.crypto.CryptoBase import CryptoBase
 from swarmauri_base.secrets.SecretDriveBase import SecretDriveBase
 from swarmauri_base.signing.SigningBase import SigningBase
+from swarmauri_base.mre_crypto.MreCryptoBase import MreCryptoBase
 from swarmauri_base.distances.DistanceBase import DistanceBase
 from swarmauri_base.documents.DocumentBase import DocumentBase
 from swarmauri_base.embeddings.EmbeddingBase import EmbeddingBase
@@ -116,6 +117,7 @@ class InterfaceRegistry:
         "swarmauri.utils": None,
         "swarmauri.vector_stores": VectorStoreBase,
         "swarmauri.vectors": VectorBase,
+        "swarmauri.mre_cryptos": MreCryptoBase,
         "swarmauri.crypto": CryptoBase,
         "swarmauri.secrets": SecretDriveBase,
         "swarmauri.signings": SigningBase,

--- a/pkgs/swarmauri/swarmauri/plugin_citizenship_registry.py
+++ b/pkgs/swarmauri/swarmauri/plugin_citizenship_registry.py
@@ -53,6 +53,7 @@ class PluginCitizenshipRegistry:
         "swarmauri.signing.ISigning": "swarmauri_core.signing.ISigning",
         "swarmauri.signing.SigningBase": "swarmauri_base.signing.SigningBase",
         "swarmauri.signings.PgpEnvelopeSigner": "swarmauri_signing_pgp.PgpEnvelopeSigner",
+        "swarmauri.mre_cryptos.PGPSealMreCrypto": "swarmauri_mre_crypto_pgpseal.PGPSealMreCrypto",
         "swarmauri.agents.ExampleAgent": "swm_example_package.ExampleAgent",
         "swarmauri.agents.QAAgent": "swarmauri_standard.agents.QAAgent",
         "swarmauri.agents.RagAgent": "swarmauri_standard.agents.RagAgent",


### PR DESCRIPTION
## Summary
- add `swarmauri_mre_crypto_pgpseal` plugin implementing sealed-per-recipient OpenPGP MRE
- expose plugin via namespace registries and workspace config
- cover unit, functional, and performance tests for new provider

## Testing
- `uv run --package swarmauri_mre_crypto_pgpseal --directory standards/swarmauri_mre_crypto_pgpseal ruff format .`
- `uv run --package swarmauri_mre_crypto_pgpseal --directory standards/swarmauri_mre_crypto_pgpseal ruff check . --fix`
- `uv run --package swarmauri --directory swarmauri ruff format .`
- `uv run --package swarmauri --directory swarmauri ruff check . --fix`
- `uv run --package swarmauri_mre_crypto_pgpseal --directory standards/swarmauri_mre_crypto_pgpseal pytest`
- `uv run --package swarmauri --directory swarmauri pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6fa1ef1048326a8e47ad9bac6d16f