### PR TITLE
Add PGP sealed-per-recipient MRE crypto plugin

### DIFF
--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -82,6 +82,7 @@ members = [
     "standards/swarmauri_crypto_sodium",
     "standards/swarmauri_crypto_nacl_pkcs11",
     "standards/swarmauri_crypto_composite",
+    "standards/swarmauri_mre_crypto_pgp",
     "standards/swarmauri_signing_ed25519",
     "standards/swarmauri_secret_autogpg",
     "standards/swarmauri_signing_pgp",
@@ -209,6 +210,7 @@ swarmauri_crypto_paramiko = { workspace = true }
 swarmauri_crypto_pgp = { workspace = true }
 swarmauri_crypto_nacl_pkcs11 = { workspace = true }
 swarmauri_crypto_composite = { workspace = true }
+swarmauri_mre_crypto_pgp = { workspace = true }
 swarmauri_signing_ed25519 = { workspace = true }
 swarmauri_signing_pgp = { workspace = true }
 

--- a/pkgs/standards/swarmauri_mre_crypto_pgp/LICENSE
+++ b/pkgs/standards/swarmauri_mre_crypto_pgp/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/standards/swarmauri_mre_crypto_pgp/README.md
+++ b/pkgs/standards/swarmauri_mre_crypto_pgp/README.md
@@ -1,0 +1,42 @@
+![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_mre_crypto_pgp/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_mre_crypto_pgp" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_mre_crypto_pgp/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_mre_crypto_pgp.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_mre_crypto_pgp/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_mre_crypto_pgp" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_mre_crypto_pgp/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_mre_crypto_pgp" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_mre_crypto_pgp/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_mre_crypto_pgp?label=swarmauri_mre_crypto_pgp&color=green" alt="PyPI - swarmauri_mre_crypto_pgp"/></a>
+</p>
+
+---
+
+## Swarmauri MRE Crypto PGP
+
+OpenPGP sealed-per-recipient multi-recipient encryption provider implementing the `IMreCrypto` contract.
+
+- Mode: `sealed_per_recipient`
+- Recipient protection: OpenPGP public key encryption (PGPy)
+
+### Installation
+
+```bash
+pip install swarmauri_mre_crypto_pgp
+```
+
+### Usage
+
+```python
+from swarmauri_mre_crypto_pgp import PGPSealMreCrypto
+
+mre = PGPSealMreCrypto()
+```
+
+## Entry point
+
+The provider is registered under the `swarmauri.mre_cryptos` entry-point as `PGPSealMreCrypto`.
+

--- a/pkgs/standards/swarmauri_mre_crypto_pgp/pyproject.toml
+++ b/pkgs/standards/swarmauri_mre_crypto_pgp/pyproject.toml
@@ -1,0 +1,70 @@
+[project]
+name = "swarmauri_mre_crypto_pgp"
+version = "0.1.0"
+description = "OpenPGP sealed-per-recipient MRE provider for Swarmauri"
+license = "Apache-2.0"
+readme = "README.md"
+requires-python = ">=3.10,<3.13"
+authors = [{ name = "Swarmauri", email = "opensource@swarmauri.com" }]
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Development Status :: 3 - Alpha",
+    "Topic :: Security :: Cryptography",
+    "Intended Audience :: Developers",
+]
+dependencies = [
+    "swarmauri_core",
+    "swarmauri_base",
+    "pgpy>=0.6.0",
+]
+
+[project.optional-dependencies]
+cbor = ["cbor2>=5.4.6"]
+
+[tool.uv.sources]
+swarmauri_core = { workspace = true }
+swarmauri_base = { workspace = true }
+
+[tool.pytest.ini_options]
+norecursedirs = ["combined", "scripts"]
+markers = [
+    "test: standard test",
+    "unit: Unit tests",
+    "i9n: Integration tests",
+    "r8n: Regression tests",
+    "acceptance: Acceptance tests",
+    "perf: Performance tests",
+]
+timeout = 300
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "flake8>=7.0",
+    "ruff>=0.9.9",
+    "pytest-timeout>=2.3.1",
+    "pytest-benchmark>=4.0.0",
+]
+
+[project.entry-points.'swarmauri.mre_cryptos']
+PGPSealMreCrypto = "swarmauri_mre_crypto_pgp:PGPSealMreCrypto"
+
+[project.entry-points."peagen.plugins.mre_cryptos"]
+pgp_seal = "swarmauri_mre_crypto_pgp:PGPSealMreCrypto"

--- a/pkgs/standards/swarmauri_mre_crypto_pgp/swarmauri_mre_crypto_pgp/PGPSealMreCrypto.py
+++ b/pkgs/standards/swarmauri_mre_crypto_pgp/swarmauri_mre_crypto_pgp/PGPSealMreCrypto.py
@@ -1,0 +1,223 @@
+"""OpenPGP sealed-per-recipient MRE provider."""
+
+from __future__ import annotations
+
+import base64
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence
+
+from swarmauri_core.mre_crypto.types import MultiRecipientEnvelope, RecipientId, MreMode
+from swarmauri_core.crypto.types import Alg, KeyRef
+from swarmauri_base.mre_crypto.MreCryptoBase import MreCryptoBase
+from swarmauri_base.ComponentBase import ComponentBase
+
+try:  # pragma: no cover - dependency optional at runtime
+    import pgpy  # type: ignore
+
+    _PGP_OK = True
+except Exception:  # pragma: no cover
+    _PGP_OK = False
+
+
+def _ensure_pgpy() -> None:
+    if not _PGP_OK:  # pragma: no cover - env dependent
+        raise RuntimeError(
+            "PGPSealMreCrypto requires 'PGPy'. Install with: pip install pgpy"
+        )
+
+
+def _load_pubkey(ref: KeyRef) -> "pgpy.PGPKey":
+    _ensure_pgpy()
+    if isinstance(ref, dict):
+        kind = ref.get("kind")
+        if kind == "pgpy_pub" and isinstance(ref.get("pub"), pgpy.PGPKey):
+            return ref["pub"]
+        if kind == "pgpy_pub_armored" and isinstance(ref.get("pub"), str):
+            k, _ = pgpy.PGPKey.from_blob(ref["pub"])
+            return k
+    raise TypeError("Unsupported recipient KeyRef for PGP public key.")
+
+
+def _load_privkey(ref: KeyRef, passphrase: Optional[bytes | str]) -> "pgpy.PGPKey":
+    _ensure_pgpy()
+    if isinstance(ref, dict):
+        kind = ref.get("kind")
+        if kind == "pgpy_priv" and isinstance(ref.get("priv"), pgpy.PGPKey):
+            k: pgpy.PGPKey = ref["priv"]
+        elif kind == "pgpy_priv_armored" and isinstance(ref.get("priv"), str):
+            k, _ = pgpy.PGPKey.from_blob(ref["priv"])
+        else:
+            raise TypeError("Unsupported identity KeyRef for PGP private key.")
+        if not k.is_unlocked:
+            if passphrase is None:
+                raise RuntimeError(
+                    "PGP private key is locked; supply opts['passphrase']."
+                )
+            k.unlock(passphrase)
+        return k
+    raise TypeError("Unsupported identity KeyRef for PGP private key.")
+
+
+def _fingerprint_pub(k: "pgpy.PGPKey") -> str:
+    return str(k.fingerprint)
+
+
+def _pgp_encrypt_bytes_for(pub: "pgpy.PGPKey", data: bytes) -> bytes:
+    """Encrypt bytes for a recipient using OpenPGP."""
+    _ensure_pgpy()
+    msg = pgpy.PGPMessage.new(base64.b64encode(data), file=False)
+    enc = pub.encrypt(msg)
+    return bytes(enc.__bytes__())
+
+
+def _pgp_decrypt_bytes_with(priv: "pgpy.PGPKey", blob: bytes) -> bytes:
+    _ensure_pgpy()
+    msg = pgpy.PGPMessage.from_blob(blob)
+    dec = priv.decrypt(msg)
+    if isinstance(dec.message, str):
+        return base64.b64decode(dec.message.encode("utf-8"))
+    return base64.b64decode(dec.message)
+
+
+def _make_sealed_recipient(rid: str, sealed_payload: bytes) -> Dict[str, Any]:
+    return {"id": rid, "sealed": sealed_payload}
+
+
+@ComponentBase.register_type(MreCryptoBase, "PGPSealMreCrypto")
+class PGPSealMreCrypto(MreCryptoBase):
+    """OpenPGP sealed-per-recipient MRE provider."""
+
+    type: str = "PGPSealMreCrypto"
+
+    def supports(self) -> Dict[str, Iterable[str | MreMode]]:
+        return {
+            "recipient": ("OpenPGP-SEAL",),
+            "modes": (MreMode.SEALED_PER_RECIPIENT,),
+            "features": (),
+        }
+
+    async def encrypt_for_many(
+        self,
+        recipients: Sequence[KeyRef],
+        pt: bytes,
+        *,
+        payload_alg: Optional[Alg] = None,
+        recipient_alg: Optional[Alg] = None,
+        mode: Optional[MreMode | str] = None,
+        aad: Optional[bytes] = None,
+        shared: Optional[Mapping[str, bytes]] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> MultiRecipientEnvelope:
+        _ensure_pgpy()
+        m = (
+            MreMode(mode)
+            if isinstance(mode, str)
+            else (mode or MreMode.SEALED_PER_RECIPIENT)
+        )
+        if m != MreMode.SEALED_PER_RECIPIENT:
+            raise ValueError(
+                f"PGPSealMreCrypto supports only mode={MreMode.SEALED_PER_RECIPIENT.value}."
+            )
+        if aad is not None:
+            raise ValueError("AAD is not supported in sealed_per_recipient mode.")
+
+        pubs = [_load_pubkey(r) for r in recipients]
+        rids = [_fingerprint_pub(pk) for pk in pubs]
+        sealed_entries = [
+            _make_sealed_recipient(rid, _pgp_encrypt_bytes_for(pk, pt))
+            for rid, pk in zip(rids, pubs)
+        ]
+        env: MultiRecipientEnvelope = {
+            "mode": MreMode.SEALED_PER_RECIPIENT.value,
+            "recipient_alg": "OpenPGP-SEAL",
+            "payload": {"kind": "sealed_per_recipient"},
+            "recipients": sealed_entries,
+        }
+        if shared:
+            env["shared"] = dict(shared)
+        return env
+
+    async def open_for(
+        self,
+        my_identity: KeyRef,
+        env: MultiRecipientEnvelope,
+        *,
+        aad: Optional[bytes] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bytes:
+        _ensure_pgpy()
+        if env.get("mode") != MreMode.SEALED_PER_RECIPIENT.value:
+            raise ValueError("Envelope mode mismatch; expected sealed_per_recipient.")
+        if aad is not None:
+            raise ValueError("AAD is not supported in sealed_per_recipient mode.")
+
+        priv = _load_privkey(my_identity, (opts or {}).get("passphrase"))
+        my_id = str(priv.fingerprint)
+        entries: List[Dict[str, Any]] = env.get("recipients", [])
+        target = next((e for e in entries if e.get("id") == my_id), None)
+        if target:
+            return _pgp_decrypt_bytes_with(priv, target["sealed"])
+        for e in entries:
+            try:
+                return _pgp_decrypt_bytes_with(priv, e["sealed"])
+            except Exception:
+                continue
+        raise PermissionError("This identity cannot open the sealed envelope.")
+
+    async def open_for_many(
+        self,
+        my_identities: Sequence[KeyRef],
+        env: MultiRecipientEnvelope,
+        *,
+        aad: Optional[bytes] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bytes:
+        last_err: Optional[Exception] = None
+        for ident in my_identities:
+            try:
+                return await self.open_for(ident, env, aad=aad, opts=opts)
+            except Exception as e:  # pragma: no cover - best effort
+                last_err = e
+                continue
+        raise last_err or PermissionError(
+            "None of the provided identities could open the envelope."
+        )
+
+    async def rewrap(
+        self,
+        env: MultiRecipientEnvelope,
+        *,
+        add: Optional[Sequence[KeyRef]] = None,
+        remove: Optional[Sequence[RecipientId]] = None,
+        recipient_alg: Optional[Alg] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> MultiRecipientEnvelope:
+        _ensure_pgpy()
+        if env.get("mode") != MreMode.SEALED_PER_RECIPIENT.value:
+            raise ValueError("Envelope mode mismatch; expected sealed_per_recipient.")
+
+        add = add or ()
+        remove_ids = set(remove or ())
+        new_env: MultiRecipientEnvelope = {k: v for k, v in env.items()}
+        current_entries: List[Dict[str, Any]] = list(new_env.get("recipients", []))
+        if remove_ids:
+            current_entries = [
+                e for e in current_entries if e.get("id") not in remove_ids
+            ]
+        if add:
+            pt_bytes = (opts or {}).get("plaintext")
+            if not isinstance(pt_bytes, (bytes, bytearray)):
+                raise RuntimeError(
+                    "Rewrap(add=...) in sealed_per_recipient mode requires opts['plaintext'] (bytes)."
+                )
+            pubs = [_load_pubkey(r) for r in add]
+            rids = [_fingerprint_pub(pk) for pk in pubs]
+            new_entries = [
+                _make_sealed_recipient(rid, _pgp_encrypt_bytes_for(pk, pt_bytes))
+                for rid, pk in zip(rids, pubs)
+            ]
+            remaining = [
+                e for e in current_entries if e["id"] not in {rid for rid in rids}
+            ]
+            current_entries = remaining + new_entries
+        new_env["recipients"] = current_entries
+        return new_env

--- a/pkgs/standards/swarmauri_mre_crypto_pgp/swarmauri_mre_crypto_pgp/__init__.py
+++ b/pkgs/standards/swarmauri_mre_crypto_pgp/swarmauri_mre_crypto_pgp/__init__.py
@@ -1,0 +1,3 @@
+from .PGPSealMreCrypto import PGPSealMreCrypto
+
+__all__ = ["PGPSealMreCrypto"]

--- a/pkgs/standards/swarmauri_mre_crypto_pgp/tests/i9n/test_rewrap_integration.py
+++ b/pkgs/standards/swarmauri_mre_crypto_pgp/tests/i9n/test_rewrap_integration.py
@@ -1,0 +1,49 @@
+import pytest
+from pgpy import PGPKey, PGPUID
+from pgpy.constants import (
+    CompressionAlgorithm,
+    HashAlgorithm,
+    KeyFlags,
+    PubKeyAlgorithm,
+    SymmetricKeyAlgorithm,
+)
+
+from swarmauri_mre_crypto_pgp import PGPSealMreCrypto
+
+
+def make_key(email: str) -> PGPKey:
+    key = PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 2048)
+    uid = PGPUID.new("User", email=email)
+    key.add_uid(
+        uid,
+        usage={KeyFlags.EncryptCommunications},
+        hashes=[HashAlgorithm.SHA256],
+        ciphers=[SymmetricKeyAlgorithm.AES256],
+        compression=[CompressionAlgorithm.ZLIB],
+    )
+    return key
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_rewrap_add_and_remove():
+    crypto = PGPSealMreCrypto()
+    key1 = make_key("a@example.com")
+    key2 = make_key("b@example.com")
+    pub1 = {"kind": "pgpy_pub", "pub": key1.pubkey}
+    priv1 = {"kind": "pgpy_priv", "priv": key1}
+    pub2 = {"kind": "pgpy_pub", "pub": key2.pubkey}
+    priv2 = {"kind": "pgpy_priv", "priv": key2}
+    pt = b"integration"
+
+    env = await crypto.encrypt_for_many([pub1], pt)
+    env = await crypto.rewrap(env, add=[pub2], opts={"plaintext": pt})
+    assert len(env["recipients"]) == 2
+    env = await crypto.rewrap(env, remove=[str(key1.fingerprint)])
+    assert len(env["recipients"]) == 1
+
+    rt = await crypto.open_for(priv2, env)
+    assert rt == pt
+
+    with pytest.raises(PermissionError):
+        await crypto.open_for(priv1, env)

--- a/pkgs/standards/swarmauri_mre_crypto_pgp/tests/perf/test_encrypt_perf.py
+++ b/pkgs/standards/swarmauri_mre_crypto_pgp/tests/perf/test_encrypt_perf.py
@@ -1,0 +1,43 @@
+import asyncio
+
+import pytest
+from pgpy import PGPKey, PGPUID
+from pgpy.constants import (
+    CompressionAlgorithm,
+    HashAlgorithm,
+    KeyFlags,
+    PubKeyAlgorithm,
+    SymmetricKeyAlgorithm,
+)
+
+from swarmauri_mre_crypto_pgp import PGPSealMreCrypto
+
+
+def gen_key() -> PGPKey:
+    key = PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 2048)
+    uid = PGPUID.new("Perf", email="perf@example.com")
+    key.add_uid(
+        uid,
+        usage={KeyFlags.EncryptCommunications},
+        hashes=[HashAlgorithm.SHA256],
+        ciphers=[SymmetricKeyAlgorithm.AES256],
+        compression=[CompressionAlgorithm.ZLIB],
+    )
+    return key
+
+
+@pytest.mark.perf
+@pytest.mark.test
+def test_encrypt_open_perf(benchmark):
+    crypto = PGPSealMreCrypto()
+    key = gen_key()
+    pub_ref = {"kind": "pgpy_pub", "pub": key.pubkey}
+    priv_ref = {"kind": "pgpy_priv", "priv": key}
+    pt = b"performance"
+
+    async def run():
+        env = await crypto.encrypt_for_many([pub_ref], pt)
+        return await crypto.open_for(priv_ref, env)
+
+    result = benchmark(lambda: asyncio.run(run()))
+    assert result == pt

--- a/pkgs/standards/swarmauri_mre_crypto_pgp/tests/unit/test_PGPSealMreCrypto.py
+++ b/pkgs/standards/swarmauri_mre_crypto_pgp/tests/unit/test_PGPSealMreCrypto.py
@@ -1,0 +1,58 @@
+
+import pytest
+from pgpy import PGPKey, PGPUID
+from pgpy.constants import (
+    CompressionAlgorithm,
+    HashAlgorithm,
+    KeyFlags,
+    PubKeyAlgorithm,
+    SymmetricKeyAlgorithm,
+)
+
+from swarmauri_mre_crypto_pgp import PGPSealMreCrypto
+
+
+def generate_key() -> PGPKey:
+    key = PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 2048)
+    uid = PGPUID.new("Test User", email="test@example.com")
+    key.add_uid(
+        uid,
+        usage={KeyFlags.EncryptCommunications},
+        hashes=[HashAlgorithm.SHA256],
+        ciphers=[SymmetricKeyAlgorithm.AES256],
+        compression=[CompressionAlgorithm.ZLIB],
+    )
+    return key
+
+
+@pytest.fixture
+def pgp_keys():
+    key = generate_key()
+    return {"kind": "pgpy_pub", "pub": key.pubkey}, {"kind": "pgpy_priv", "priv": key}
+
+
+@pytest.fixture
+def crypto():
+    return PGPSealMreCrypto()
+
+
+@pytest.mark.unit
+def test_resource_and_type(crypto):
+    assert crypto.resource == "Crypto"
+    assert crypto.type == "PGPSealMreCrypto"
+
+
+@pytest.mark.unit
+def test_serialization(crypto):
+    assert (
+        crypto.id == PGPSealMreCrypto.model_validate_json(crypto.model_dump_json()).id
+    )
+
+
+@pytest.mark.asyncio
+async def test_encrypt_open_roundtrip(crypto, pgp_keys):
+    pub_ref, priv_ref = pgp_keys
+    pt = b"hello"
+    env = await crypto.encrypt_for_many([pub_ref], pt)
+    rt = await crypto.open_for(priv_ref, env)
+    assert rt == pt

--- a/pkgs/swarmauri/swarmauri/interface_registry.py
+++ b/pkgs/swarmauri/swarmauri/interface_registry.py
@@ -54,6 +54,7 @@ from swarmauri_base.loggers.LoggerBase import LoggerBase
 from swarmauri_base.logger_handlers.HandlerBase import HandlerBase
 from swarmauri_base.rate_limits.RateLimitBase import RateLimitBase
 from swarmauri_base.middlewares.MiddlewareBase import MiddlewareBase
+from swarmauri_base.mre_crypto.MreCryptoBase import MreCryptoBase
 
 try:
     from swarmauri_base.signing.SigningBase import SigningBase
@@ -123,6 +124,7 @@ class InterfaceRegistry:
         "swarmauri.loggers": LoggerBase,
         "swarmauri.logger_handlers": HandlerBase,
         "swarmauri.rate_limits": RateLimitBase,
+        "swarmauri.mre_crypto": MreCryptoBase,
     }
 
     @classmethod

--- a/pkgs/swarmauri/swarmauri/plugin_citizenship_registry.py
+++ b/pkgs/swarmauri/swarmauri/plugin_citizenship_registry.py
@@ -299,6 +299,7 @@ class PluginCitizenshipRegistry:
         "swarmauri.rate_limits.TokenBucketRateLimit": "swarmauri_standard.rate_limits.TokenBucketRateLimit",
         "swarmauri.crypto.ParamikoCrypto": "swarmauri_crypto_paramiko.ParamikoCrypto",
         "swarmauri.crypto.PGPCrypto": "swarmauri_crypto_pgp.PGPCrypto",
+        "swarmauri.mre_crypto.PGPSealMreCrypto": "swarmauri_mre_crypto_pgp.PGPSealMreCrypto",
         "swarmauri.secret.AutoGpgSecretDrive": "swarmauri_secret_autogpg.AutoGpgSecretDrive",
     }
     SECOND_CLASS_REGISTRY: Dict[str, str] = {}


### PR DESCRIPTION
## Summary
- add `PGPSealMreCrypto` OpenPGP sealed-per-recipient MRE provider
- register new provider in Swarmauri first-class and interface registries
- wire new package into monorepo workspace

## Testing
- `uv run --package swarmauri --directory swarmauri ruff check . --fix`
- `uv run --package swarmauri_mre_crypto_pgp --directory standards/swarmauri_mre_crypto_pgp ruff check . --fix`
- `uv run --package swarmauri --directory swarmauri pytest`
- `uv run --package swarmauri_mre_crypto_pgp --directory standards/swarmauri_mre_crypto_pgp pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6fa1ef1048326a8e47ad9bac6d16f