### PR TITLE
feat: add PGP-based MRE crypto plugin

### DIFF
--- a/pkgs/core/swarmauri_core/mre_crypto/__init__.py
+++ b/pkgs/core/swarmauri_core/mre_crypto/__init__.py
@@ -1,6 +1,5 @@
 """Multi-Recipient Encryption interfaces and types."""
 
-from .IMreCrypto import IMreCrypto
 from .types import MultiRecipientEnvelope, RecipientInfo, RecipientId, MreMode
 
 __all__ = [
@@ -10,3 +9,11 @@ __all__ = [
     "RecipientId",
     "MreMode",
 ]
+
+
+def __getattr__(name: str):
+    if name == "IMreCrypto":
+        from .IMreCrypto import IMreCrypto
+
+        return IMreCrypto
+    raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/pkgs/core/swarmauri_core/signing/__init__.py
+++ b/pkgs/core/swarmauri_core/signing/__init__.py
@@ -1,6 +1,13 @@
 """Signing interfaces and types."""
 
-from .ISigning import ISigning, Canon, Envelope
 from .types import Signature
 
 __all__ = ["ISigning", "Canon", "Envelope", "Signature"]
+
+
+def __getattr__(name: str):
+    if name in {"ISigning", "Canon", "Envelope"}:
+        from .ISigning import ISigning, Canon, Envelope
+
+        return {"ISigning": ISigning, "Canon": Canon, "Envelope": Envelope}[name]
+    raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -79,6 +79,7 @@ members = [
     "standards/auto_kms",
     "standards/swarmauri_crypto_paramiko",
     "standards/swarmauri_crypto_pgp",
+    "standards/swarmauri_mre_crypto_pgp",
     "standards/swarmauri_crypto_sodium",
     "standards/swarmauri_crypto_nacl_pkcs11",
     "standards/swarmauri_crypto_composite",

--- a/pkgs/standards/swarmauri_mre_crypto_pgp/LICENSE
+++ b/pkgs/standards/swarmauri_mre_crypto_pgp/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/standards/swarmauri_mre_crypto_pgp/README.md
+++ b/pkgs/standards/swarmauri_mre_crypto_pgp/README.md
@@ -1,0 +1,34 @@
+![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_mre_crypto_pgp/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_mre_crypto_pgp" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_mre_crypto_pgp/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_mre_crypto_pgp.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_mre_crypto_pgp/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_mre_crypto_pgp" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_mre_crypto_pgp/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_mre_crypto_pgp" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_mre_crypto_pgp/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_mre_crypto_pgp?label=swarmauri_mre_crypto_pgp&color=green" alt="PyPI - swarmauri_mre_crypto_pgp"/></a>
+</p>
+
+---
+
+## Swarmauri MRE Crypto PGP
+
+OpenPGP-backed multi-recipient encryption provider implementing the `IMreCrypto` contract.
+
+- Shared payload via AES-256-GCM or per-recipient sealed payloads
+- Recipient protection via OpenPGP public-key encryption
+- Supports rewrap operations
+
+### Installation
+
+```bash
+pip install swarmauri_mre_crypto_pgp
+```
+
+## Entry point
+
+The provider is registered under the `swarmauri.mre_crypto` entry-point as `PGPMreCrypto`.

--- a/pkgs/standards/swarmauri_mre_crypto_pgp/pyproject.toml
+++ b/pkgs/standards/swarmauri_mre_crypto_pgp/pyproject.toml
@@ -1,0 +1,72 @@
+[project]
+name = "swarmauri_mre_crypto_pgp"
+version = "0.1.0"
+description = "OpenPGP-backed multi-recipient encryption provider for Swarmauri"
+license = "Apache-2.0"
+readme = "README.md"
+requires-python = ">=3.10,<3.13"
+authors = [{ name = "Swarmauri", email = "opensource@swarmauri.com" }]
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Development Status :: 3 - Alpha",
+    "Topic :: Security :: Cryptography",
+    "Intended Audience :: Developers",
+]
+dependencies = [
+    "swarmauri_core",
+    "swarmauri_base",
+    "cryptography>=41",
+    "pgpy>=0.6.0",
+]
+
+[project.optional-dependencies]
+canon-json = ["orjson>=3.10"]
+canon-cbor = ["cbor2>=5.6"]
+
+[tool.uv.sources]
+swarmauri_core = { workspace = true }
+swarmauri_base = { workspace = true }
+
+[tool.pytest.ini_options]
+norecursedirs = ["combined", "scripts"]
+markers = [
+    "test: standard test",
+    "unit: Unit tests",
+    "i9n: Integration tests",
+    "r8n: Regression tests",
+    "acceptance: Acceptance tests",
+    "perf: Performance tests",
+]
+timeout = 300
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "flake8>=7.0",
+    "ruff>=0.9.9",
+    "pytest-timeout>=2.3.1",
+    "pytest-benchmark>=4.0.0",
+]
+
+[project.entry-points.'swarmauri.mre_crypto']
+PGPMreCrypto = "swarmauri_mre_crypto_pgp:PGPMreCrypto"
+
+[project.entry-points."peagen.plugins.mre_crypto"]
+pgp = "swarmauri_mre_crypto_pgp:PGPMreCrypto"

--- a/pkgs/standards/swarmauri_mre_crypto_pgp/swarmauri_mre_crypto_pgp/PGPMreCrypto.py
+++ b/pkgs/standards/swarmauri_mre_crypto_pgp/swarmauri_mre_crypto_pgp/PGPMreCrypto.py
@@ -1,0 +1,518 @@
+"""
+PGPMreCrypto: IMreCrypto provider using OpenPGP for recipient protection.
+
+Supported modes
+---------------
+1) enc_once+per_recipient_header  (default)
+   - Generate a random CEK
+   - AEAD-encrypt the payload once (AES-256-GCM by default)
+   - For each recipient, PGP-encrypt the CEK and store as a per-recipient header
+
+2) sealed_per_recipient  (optional)
+   - For each recipient, PGP-encrypt the *payload itself* (sealed payload)
+   - No shared AEAD payload
+
+Out of scope
+------------
+- Signing: use swarmauri_core.signing.ISigning implementations.
+- Header-only “wrap DEK for many”: use IMreWrap mix-in if you need it.
+
+KeyRef expectations
+-------------------
+Public recipients (encrypt):
+  - {"kind":"pgpy_pub", "pub": pgpy.PGPKey}
+  - {"kind":"pgpy_pub_armored", "pub": "<ASCII armored PUBLIC key>"}
+
+Private identities (open/rewrap):
+  - {"kind":"pgpy_priv", "priv": pgpy.PGPKey}    (unlocked or unlockable via opts["passphrase"])
+  - {"kind":"pgpy_priv_armored", "priv": "<ASCII armored PRIVATE key>"}
+
+Options (opts)
+--------------
+- For private keys locked with a passphrase: opts["passphrase"] = str|bytes
+- For rewrap(add=...):
+    • Provide CEK via opts["cek"] = bytes
+      OR a management key via opts["manage_key"] = KeyRef (must be one of recipients)
+- For rewrap(remove=...):
+    • Optional rotation: opts["rotate_payload_on_revoke"] = True (default: False)
+
+Dependencies
+------------
+- PGP: pip install pgpy
+- AEAD: pip install cryptography
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+from typing import (
+    Dict,
+    Iterable,
+    Mapping,
+    Optional,
+    Sequence,
+    Any,
+    Tuple,
+    List,
+    Literal,
+)
+
+from swarmauri_core.mre_crypto.types import MultiRecipientEnvelope, RecipientId, MreMode
+from swarmauri_core.crypto.types import Alg, KeyRef
+from swarmauri_base.mre_crypto.MreCryptoBase import MreCryptoBase
+from swarmauri_base.ComponentBase import ComponentBase
+
+# ----- external deps -----
+try:
+    from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+    _CRYPTOGRAPHY_OK = True
+except Exception:  # pragma: no cover - dependency issue
+    _CRYPTOGRAPHY_OK = False
+
+try:
+    import pgpy
+
+    _PGP_OK = True
+except Exception:  # pragma: no cover - dependency issue
+    _PGP_OK = False
+
+
+def _ensure_crypto() -> None:
+    if not _CRYPTOGRAPHY_OK:
+        raise RuntimeError(
+            "PGPMreCrypto requires 'cryptography'. Install with: pip install cryptography"
+        )
+
+
+def _ensure_pgpy() -> None:
+    if not _PGP_OK:
+        raise RuntimeError(
+            "PGPMreCrypto requires 'PGPy'. Install with: pip install pgpy"
+        )
+
+
+# ============================== Helpers (PGP) ==============================
+
+
+def _load_pubkey(ref: KeyRef) -> "pgpy.PGPKey":
+    _ensure_pgpy()
+    if isinstance(ref, dict):
+        kind = ref.get("kind")
+        if kind == "pgpy_pub" and isinstance(ref.get("pub"), pgpy.PGPKey):
+            return ref["pub"]
+        if kind == "pgpy_pub_armored" and isinstance(ref.get("pub"), str):
+            k, _ = pgpy.PGPKey.from_blob(ref["pub"])
+            return k
+    raise TypeError("Unsupported recipient KeyRef for PGP public key.")
+
+
+def _load_privkey(ref: KeyRef, passphrase: Optional[bytes | str]) -> "pgpy.PGPKey":
+    _ensure_pgpy()
+    if isinstance(ref, dict):
+        kind = ref.get("kind")
+        if kind == "pgpy_priv" and isinstance(ref.get("priv"), pgpy.PGPKey):
+            k: pgpy.PGPKey = ref["priv"]
+        elif kind == "pgpy_priv_armored" and isinstance(ref.get("priv"), str):
+            k, _ = pgpy.PGPKey.from_blob(ref["priv"])
+        else:
+            raise TypeError("Unsupported identity KeyRef for PGP private key.")
+        if not k.is_unlocked:
+            if passphrase is None:
+                raise RuntimeError(
+                    "PGP private key is locked; supply opts['passphrase']."
+                )
+            k.unlock(passphrase)
+        return k
+    raise TypeError("Unsupported identity KeyRef for PGP private key.")
+
+
+def _fingerprint_pub(k: "pgpy.PGPKey") -> str:
+    return str(k.fingerprint)
+
+
+def _pgp_encrypt_bytes_for(pub: "pgpy.PGPKey", data: bytes) -> bytes:
+    """
+    PGPy deals more naturally with text; to ensure byte fidelity, encode with base64
+    before encrypting, and decode after decrypting.
+    """
+    _ensure_pgpy()
+    msg = pgpy.PGPMessage.new(base64.b64encode(data), file=False)
+    enc = pub.encrypt(msg)
+    return bytes(enc.__bytes__())
+
+
+def _pgp_decrypt_bytes_with(priv: "pgpy.PGPKey", blob: bytes) -> bytes:
+    _ensure_pgpy()
+    msg = pgpy.PGPMessage.from_blob(blob)
+    dec = priv.decrypt(msg)
+    if isinstance(dec.message, str):
+        return base64.b64decode(dec.message.encode("utf-8"))
+    return base64.b64decode(dec.message)
+
+
+# ============================== Helpers (AEAD) ==============================
+
+
+def _aead_encrypt_gcm(
+    cek: bytes, pt: bytes, *, aad: Optional[bytes]
+) -> Tuple[bytes, bytes, bytes]:
+    """
+    Returns (nonce, ct, tag). cryptography's AESGCM returns ct||tag combined; we split 16-byte tag.
+    """
+    _ensure_crypto()
+    if len(cek) != 32:
+        raise ValueError("AES-256-GCM requires a 32-byte CEK.")
+    aead = AESGCM(cek)
+    nonce = os.urandom(12)
+    cttag = aead.encrypt(nonce, pt, aad)
+    return nonce, cttag[:-16], cttag[-16:]
+
+
+def _aead_decrypt_gcm(
+    cek: bytes, nonce: bytes, ct: bytes, tag: bytes, *, aad: Optional[bytes]
+) -> bytes:
+    _ensure_crypto()
+    aead = AESGCM(cek)
+    return aead.decrypt(nonce, ct + tag, aad)
+
+
+# ============================== Envelope shapers ==============================
+
+
+def _make_aead_payload(
+    payload_alg: str, nonce: bytes, ct: bytes, tag: bytes, aad: Optional[bytes]
+) -> Dict[str, Any]:
+    return {
+        "kind": "aead",
+        "alg": payload_alg,
+        "nonce": nonce,
+        "ct": ct,
+        "tag": tag,
+        "aad": aad,
+    }
+
+
+def _make_recipient_header(rid: str, header: bytes) -> Dict[str, Any]:
+    return {"id": rid, "header": header}
+
+
+def _make_sealed_recipient(rid: str, sealed_payload: bytes) -> Dict[str, Any]:
+    return {"id": rid, "sealed": sealed_payload}
+
+
+# ============================== Provider ==============================
+
+
+@ComponentBase.register_type(MreCryptoBase, "PGPMreCrypto")
+class PGPMreCrypto(MreCryptoBase):
+    """
+    OpenPGP-backed MRE provider.
+
+    - Supports:
+        • MreMode.ENC_ONCE_HEADERS  (default): shared AEAD payload + per-recipient PGP headers
+        • MreMode.SEALED_PER_RECIPIENT (optional): per-recipient sealed payloads via PGP
+    - Payload AEAD: AES-256-GCM (default/only)
+    - Recipient protection: OpenPGP
+    """
+
+    type: Literal["PGPMreCrypto"] = "PGPMreCrypto"
+    default_payload_alg: str = "AES-256-GCM"
+    default_recipient_alg: str = "OpenPGP"
+
+    def supports(self) -> Dict[str, Iterable[str | MreMode]]:
+        modes: Tuple[str | MreMode, ...] = (
+            MreMode.ENC_ONCE_HEADERS,
+            MreMode.SEALED_PER_RECIPIENT,
+        )
+        return {
+            "payload": (self.default_payload_alg,),
+            "recipient": ("OpenPGP", "OpenPGP-SEAL"),
+            "modes": modes,
+            "features": ("aad", "rewrap_without_reencrypt"),
+        }
+
+    async def encrypt_for_many(
+        self,
+        recipients: Sequence[KeyRef],
+        pt: bytes,
+        *,
+        payload_alg: Optional[Alg] = None,
+        recipient_alg: Optional[Alg] = None,
+        mode: Optional[MreMode | str] = None,
+        aad: Optional[bytes] = None,
+        shared: Optional[Mapping[str, bytes]] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> MultiRecipientEnvelope:
+        _ensure_pgpy()
+
+        m = (
+            MreMode(mode)
+            if isinstance(mode, str)
+            else (mode or MreMode.ENC_ONCE_HEADERS)
+        )
+        payload_alg = payload_alg or self.default_payload_alg
+        recipient_alg = recipient_alg or self.default_recipient_alg
+
+        pubs = [_load_pubkey(r) for r in recipients]
+        rids = [_fingerprint_pub(pk) for pk in pubs]
+
+        if m == MreMode.ENC_ONCE_HEADERS:
+            if payload_alg != "AES-256-GCM":
+                raise ValueError(
+                    "PGPMreCrypto currently supports only AES-256-GCM for shared payload."
+                )
+            cek = os.urandom(32)
+            nonce, ct, tag = _aead_encrypt_gcm(cek, pt, aad=aad)
+            headers = [
+                _make_recipient_header(rid, _pgp_encrypt_bytes_for(pk, cek))
+                for rid, pk in zip(rids, pubs)
+            ]
+            env: MultiRecipientEnvelope = {
+                "mode": MreMode.ENC_ONCE_HEADERS.value,
+                "payload_alg": payload_alg,
+                "recipient_alg": "OpenPGP",
+                "payload": _make_aead_payload(payload_alg, nonce, ct, tag, aad),
+                "recipients": headers,
+            }
+            if shared:
+                env["shared"] = dict(shared)
+            return env
+
+        elif m == MreMode.SEALED_PER_RECIPIENT:
+            sealed_entries = [
+                _make_sealed_recipient(rid, _pgp_encrypt_bytes_for(pk, pt))
+                for rid, pk in zip(rids, pubs)
+            ]
+            env = {
+                "mode": MreMode.SEALED_PER_RECIPIENT.value,
+                "recipient_alg": "OpenPGP-SEAL",
+                "payload": {"kind": "sealed_per_recipient"},
+                "recipients": sealed_entries,
+            }
+            if shared:
+                env["shared"] = dict(shared)
+            return env
+
+        else:
+            raise ValueError(f"Unsupported mode: {mode}")
+
+    async def open_for(
+        self,
+        my_identity: KeyRef,
+        env: MultiRecipientEnvelope,
+        *,
+        aad: Optional[bytes] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bytes:
+        _ensure_pgpy()
+        mode_str = env.get("mode")
+        m = MreMode(mode_str) if isinstance(mode_str, str) else mode_str
+        priv = _load_privkey(my_identity, (opts or {}).get("passphrase"))
+
+        if m == MreMode.ENC_ONCE_HEADERS:
+            my_id = str(priv.fingerprint)
+            headers: List[Dict[str, Any]] = env.get("recipients", [])
+            target = next((h for h in headers if h.get("id") == my_id), None)
+
+            cek: Optional[bytes] = None
+            if target:
+                cek = _pgp_decrypt_bytes_with(priv, target["header"])
+            else:
+                for h in headers:
+                    try:
+                        cek = _pgp_decrypt_bytes_with(priv, h["header"])
+                        break
+                    except Exception:
+                        continue
+            if cek is None:
+                raise PermissionError("This identity cannot open the envelope.")
+
+            payload = env["payload"]
+            if payload.get("alg") != "AES-256-GCM":
+                raise ValueError("Unsupported payload_alg for PGPMreCrypto open.")
+            nonce, ct, tag = payload["nonce"], payload["ct"], payload["tag"]
+            bound_aad = payload.get("aad", None)
+            if aad is not None and bound_aad is not None and aad != bound_aad:
+                raise ValueError("AAD mismatch.")
+            return _aead_decrypt_gcm(cek, nonce, ct, tag, aad=bound_aad)
+
+        elif m == MreMode.SEALED_PER_RECIPIENT:
+            my_id = str(priv.fingerprint)
+            entries: List[Dict[str, Any]] = env.get("recipients", [])
+            target = next((e for e in entries if e.get("id") == my_id), None)
+            if not target:
+                for e in entries:
+                    try:
+                        return _pgp_decrypt_bytes_with(priv, e["sealed"])
+                    except Exception:
+                        continue
+                raise PermissionError("This identity cannot open the sealed envelope.")
+            return _pgp_decrypt_bytes_with(priv, target["sealed"])
+
+        else:
+            raise ValueError(f"Unsupported mode: {mode_str}")
+
+    async def open_for_many(
+        self,
+        my_identities: Sequence[KeyRef],
+        env: MultiRecipientEnvelope,
+        *,
+        aad: Optional[bytes] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bytes:
+        last_err: Optional[Exception] = None
+        for ident in my_identities:
+            try:
+                return await self.open_for(ident, env, aad=aad, opts=opts)
+            except Exception as e:  # pragma: no cover
+                last_err = e
+                continue
+        raise last_err or PermissionError(
+            "None of the provided identities could open the envelope."
+        )
+
+    async def rewrap(
+        self,
+        env: MultiRecipientEnvelope,
+        *,
+        add: Optional[Sequence[KeyRef]] = None,
+        remove: Optional[Sequence[RecipientId]] = None,
+        recipient_alg: Optional[Alg] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> MultiRecipientEnvelope:
+        _ensure_pgpy()
+        mode_str = env.get("mode")
+        m = MreMode(mode_str) if isinstance(mode_str, str) else mode_str
+
+        add = add or ()
+        remove_ids = set(remove or ())
+
+        new_env: MultiRecipientEnvelope = {k: v for k, v in env.items()}
+
+        if m == MreMode.ENC_ONCE_HEADERS:
+            current_headers: List[Dict[str, Any]] = list(new_env.get("recipients", []))
+            if remove_ids:
+                current_headers = [
+                    h for h in current_headers if h.get("id") not in remove_ids
+                ]
+
+            cek: Optional[bytes] = None
+            if add:
+                if opts and isinstance(opts.get("cek"), (bytes, bytearray)):
+                    cek = bytes(opts["cek"])
+                elif opts and opts.get("manage_key"):
+                    manage_key = _load_privkey(
+                        opts["manage_key"], (opts or {}).get("passphrase")
+                    )
+                    candidate_headers = current_headers or list(
+                        env.get("recipients", [])
+                    )
+                    for h in candidate_headers:
+                        try:
+                            cek = _pgp_decrypt_bytes_with(manage_key, h["header"])
+                            break
+                        except Exception:
+                            continue
+                else:
+                    raise RuntimeError(
+                        "Rewrap(add=...) requires opts['cek'] or opts['manage_key']."
+                    )
+
+            if add and cek is not None:
+                pubs = [_load_pubkey(r) for r in add]
+                rids = [_fingerprint_pub(pk) for pk in pubs]
+                new_headers = [
+                    _make_recipient_header(rid, _pgp_encrypt_bytes_for(pk, cek))
+                    for rid, pk in zip(rids, pubs)
+                ]
+                merged: List[Dict[str, Any]] = []
+                for h in current_headers:
+                    if h["id"] not in {rid for rid, _ in zip(rids, pubs)}:
+                        merged.append(h)
+                merged.extend(new_headers)
+                current_headers = merged
+
+            rotate = bool(opts.get("rotate_payload_on_revoke")) if opts else False
+            if remove_ids and rotate:
+                if not cek:
+                    if opts and opts.get("manage_key"):
+                        manage_key = _load_privkey(
+                            opts["manage_key"], (opts or {}).get("passphrase")
+                        )
+                        for h in env.get("recipients", []):
+                            try:
+                                cek = _pgp_decrypt_bytes_with(manage_key, h["header"])
+                                break
+                            except Exception:
+                                continue
+                    if not cek:
+                        raise RuntimeError(
+                            "rotate_payload_on_revoke requires CEK via opts['manage_key'] or opts['cek']."
+                        )
+
+                new_cek = os.urandom(32)
+                payload = env["payload"]
+                old_pt = _aead_decrypt_gcm(
+                    cek,
+                    payload["nonce"],
+                    payload["ct"],
+                    payload["tag"],
+                    aad=payload.get("aad"),
+                )
+                nonce, ct, tag = _aead_encrypt_gcm(
+                    new_cek, old_pt, aad=payload.get("aad")
+                )
+                new_env["payload"] = _make_aead_payload(
+                    env.get("payload_alg", self.default_payload_alg),
+                    nonce,
+                    ct,
+                    tag,
+                    payload.get("aad"),
+                )
+
+                add_pubkeys = (opts or {}).get("add_pubkeys")
+                if not isinstance(add_pubkeys, (list, tuple)) or not add_pubkeys:
+                    raise RuntimeError(
+                        "After rotation, provide opts['add_pubkeys'] = [KeyRef(pub=...), ...] for remaining recipients."
+                    )
+                pubs = [_load_pubkey(r) for r in add_pubkeys]
+                rids = [_fingerprint_pub(pk) for pk in pubs]
+                new_headers = [
+                    _make_recipient_header(rid, _pgp_encrypt_bytes_for(pk, new_cek))
+                    for rid, pk in zip(rids, pubs)
+                ]
+                current_headers = new_headers
+
+            new_env["recipients"] = current_headers
+            return new_env
+
+        elif m == MreMode.SEALED_PER_RECIPIENT:
+            current_entries: List[Dict[str, Any]] = list(new_env.get("recipients", []))
+            if remove_ids:
+                current_entries = [
+                    e for e in current_entries if e.get("id") not in remove_ids
+                ]
+            if add:
+                pt_bytes = (opts or {}).get("plaintext")
+                if not isinstance(pt_bytes, (bytes, bytearray)):
+                    raise RuntimeError(
+                        "Rewrap(add=...) in sealed_per_recipient mode requires opts['plaintext']."
+                    )
+                pubs = [_load_pubkey(r) for r in add]
+                rids = [_fingerprint_pub(pk) for pk in pubs]
+                new_entries = [
+                    _make_sealed_recipient(rid, _pgp_encrypt_bytes_for(pk, pt_bytes))
+                    for rid, pk in zip(rids, pubs)
+                ]
+                remaining = [
+                    e for e in current_entries if e["id"] not in {rid for rid in rids}
+                ]
+                current_entries = remaining + new_entries
+
+            new_env["recipients"] = current_entries
+            return new_env
+
+        else:
+            raise ValueError(f"Unsupported mode for rewrap: {mode_str}")

--- a/pkgs/standards/swarmauri_mre_crypto_pgp/swarmauri_mre_crypto_pgp/__init__.py
+++ b/pkgs/standards/swarmauri_mre_crypto_pgp/swarmauri_mre_crypto_pgp/__init__.py
@@ -1,0 +1,3 @@
+from .PGPMreCrypto import PGPMreCrypto
+
+__all__ = ["PGPMreCrypto"]

--- a/pkgs/standards/swarmauri_mre_crypto_pgp/tests/i9n/PGPMreCrypto_i9n_test.py
+++ b/pkgs/standards/swarmauri_mre_crypto_pgp/tests/i9n/PGPMreCrypto_i9n_test.py
@@ -1,0 +1,26 @@
+import pgpy
+import pytest
+from swarmauri_mre_crypto_pgp import PGPMreCrypto
+
+
+def _generate_keypair():
+    key = pgpy.PGPKey.new(pgpy.constants.PubKeyAlgorithm.RSAEncryptOrSign, 1024)
+    uid = pgpy.PGPUID.new("Test", email="test@example.com")
+    key.add_uid(
+        uid,
+        usage={pgpy.constants.KeyFlags.EncryptCommunications},
+        hashes=[pgpy.constants.HashAlgorithm.SHA256],
+        ciphers=[pgpy.constants.SymmetricKeyAlgorithm.AES256],
+        compression=[pgpy.constants.CompressionAlgorithm.Uncompressed],
+    )
+    return {"kind": "pgpy_pub", "pub": key.pubkey}, {"kind": "pgpy_priv", "priv": key}
+
+
+@pytest.mark.asyncio
+@pytest.mark.i9n
+async def test_encrypt_open_roundtrip():
+    pub, priv = _generate_keypair()
+    crypto = PGPMreCrypto()
+    env = await crypto.encrypt_for_many([pub], b"hello")
+    pt = await crypto.open_for(priv, env)
+    assert pt == b"hello"

--- a/pkgs/standards/swarmauri_mre_crypto_pgp/tests/perf/PGPMreCrypto_perf_test.py
+++ b/pkgs/standards/swarmauri_mre_crypto_pgp/tests/perf/PGPMreCrypto_perf_test.py
@@ -1,0 +1,28 @@
+import asyncio
+import pgpy
+import pytest
+from swarmauri_mre_crypto_pgp import PGPMreCrypto
+
+
+def _keypair():
+    key = pgpy.PGPKey.new(pgpy.constants.PubKeyAlgorithm.RSAEncryptOrSign, 1024)
+    uid = pgpy.PGPUID.new("Perf", email="perf@example.com")
+    key.add_uid(
+        uid,
+        usage={pgpy.constants.KeyFlags.EncryptCommunications},
+        hashes=[pgpy.constants.HashAlgorithm.SHA256],
+        ciphers=[pgpy.constants.SymmetricKeyAlgorithm.AES256],
+        compression=[pgpy.constants.CompressionAlgorithm.Uncompressed],
+    )
+    return {"kind": "pgpy_pub", "pub": key.pubkey}
+
+
+@pytest.mark.perf
+def test_encrypt_perf(benchmark):
+    pub = _keypair()
+    crypto = PGPMreCrypto()
+
+    async def run():
+        await crypto.encrypt_for_many([pub], b"bench")
+
+    benchmark(lambda: asyncio.run(run()))

--- a/pkgs/standards/swarmauri_mre_crypto_pgp/tests/unit/PGPMreCrypto_unit_test.py
+++ b/pkgs/standards/swarmauri_mre_crypto_pgp/tests/unit/PGPMreCrypto_unit_test.py
@@ -1,0 +1,24 @@
+import pytest
+from swarmauri_mre_crypto_pgp import PGPMreCrypto
+
+
+@pytest.fixture
+def pgp_mre_crypto():
+    return PGPMreCrypto()
+
+
+@pytest.mark.unit
+def test_resource(pgp_mre_crypto):
+    assert pgp_mre_crypto.resource == "Crypto"
+
+
+@pytest.mark.unit
+def test_type(pgp_mre_crypto):
+    assert pgp_mre_crypto.type == "PGPMreCrypto"
+
+
+@pytest.mark.unit
+def test_serialization(pgp_mre_crypto):
+    dumped = pgp_mre_crypto.model_dump_json()
+    restored = PGPMreCrypto.model_validate_json(dumped)
+    assert restored.type == pgp_mre_crypto.type

--- a/pkgs/swarmauri/pyproject.toml
+++ b/pkgs/swarmauri/pyproject.toml
@@ -34,6 +34,7 @@ default = [
     "swarmauri_parser_beautifulsoupelement",
     #"swarmauri_vectorstore_tfidf",
     "swarmauri_distance_minkowski",
+    "swarmauri_mre_crypto_pgp",
 ]
 
 full = [
@@ -46,6 +47,7 @@ full = [
     "swarmauri_embedding_nmf",
     "swarmauri_distance_minkowski",
     "swarmauri_tool_matplotlib",
+    "swarmauri_mre_crypto_pgp",
 ]
 
 [tool.uv.sources]
@@ -61,6 +63,7 @@ swarmauri_parser_keywordextractor = { workspace = true }
 swarmauri_parser_beautifulsoupelement = { workspace = true }
 #swarmauri_vectorstore_tfidf = { workspace = true }
 swarmauri_distance_minkowski = { workspace = true }
+swarmauri_mre_crypto_pgp = { workspace = true }
 
 [tool.pytest.ini_options]
 norecursedirs = ["combined", "scripts"]

--- a/pkgs/swarmauri/swarmauri/interface_registry.py
+++ b/pkgs/swarmauri/swarmauri/interface_registry.py
@@ -18,6 +18,7 @@ from swarmauri_base.control_panels.ControlPanelBase import ControlPanelBase
 from swarmauri_base.conversations.ConversationBase import ConversationBase
 from swarmauri_base.dataconnectors.DataConnectorBase import DataConnectorBase
 from swarmauri_base.crypto.CryptoBase import CryptoBase
+from swarmauri_base.mre_crypto.MreCryptoBase import MreCryptoBase
 from swarmauri_base.secrets.SecretDriveBase import SecretDriveBase
 from swarmauri_base.distances.DistanceBase import DistanceBase
 from swarmauri_base.documents.DocumentBase import DocumentBase
@@ -108,6 +109,7 @@ class InterfaceRegistry:
         "swarmauri.vector_stores": VectorStoreBase,
         "swarmauri.vectors": VectorBase,
         "swarmauri.crypto": CryptoBase,
+        "swarmauri.mre_crypto": MreCryptoBase,
         "swarmauri.secrets": SecretDriveBase,
         "swarmauri.logger_formatters": FormatterBase,
         "swarmauri.loggers": LoggerBase,

--- a/pkgs/swarmauri/swarmauri/plugin_citizenship_registry.py
+++ b/pkgs/swarmauri/swarmauri/plugin_citizenship_registry.py
@@ -295,6 +295,7 @@ class PluginCitizenshipRegistry:
         "swarmauri.rate_limits.TokenBucketRateLimit": "swarmauri_standard.rate_limits.TokenBucketRateLimit",
         "swarmauri.crypto.ParamikoCrypto": "swarmauri_crypto_paramiko.ParamikoCrypto",
         "swarmauri.crypto.PGPCrypto": "swarmauri_crypto_pgp.PGPCrypto",
+        "swarmauri.mre_crypto.PGPMreCrypto": "swarmauri_mre_crypto_pgp.PGPMreCrypto",
         "swarmauri.secret.AutoGpgSecretDrive": "swarmauri_secret_autogpg.AutoGpgSecretDrive",
     }
     SECOND_CLASS_REGISTRY: Dict[str, str] = {}


### PR DESCRIPTION
## Summary
- add OpenPGP-backed multi-recipient encryption provider plugin
- register PGPMreCrypto in Swarmauri registries and workspace
- fix circular imports in `swarmauri_core` signing and MRE modules

## Testing
- `uv run --directory pkgs/core --package swarmauri-core ruff format .`
- `uv run --directory pkgs/core --package swarmauri-core ruff check . --fix`
- `uv run --package swarmauri-core --directory core pytest`
- `uv run --directory pkgs/standards/swarmauri_mre_crypto_pgp --package swarmauri_mre_crypto_pgp ruff format .`
- `uv run --directory pkgs/standards/swarmauri_mre_crypto_pgp --package swarmauri_mre_crypto_pgp ruff check . --fix`
- `uv run --package swarmauri_mre_crypto_pgp --directory standards/swarmauri_mre_crypto_pgp pytest`
- `uv run --directory pkgs/swarmauri --package swarmauri ruff format .`
- `uv run --directory pkgs/swarmauri --package swarmauri ruff check . --fix`
- `uv run --package swarmauri --directory swarmauri pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6f6edaf088326baf0a2ff95c3c7ac