### PR TITLE
feat(signing): add RSA envelope signer plugin

### DIFF
--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -88,6 +88,7 @@ members = [
     "standards/swarmauri_signing_ed25519",
     "standards/swarmauri_secret_autogpg",
     "standards/swarmauri_signing_pgp",
+    "standards/swarmauri_signing_rsa",
     "community/swarmauri_middleware_circuitbreaker",
     "community/swarmauri_middleware_ratepolicy",
     "community/swarmauri_vectorstore_redis",
@@ -217,6 +218,7 @@ swarmauri_crypto_age_mre = { workspace = true }
 swarmauri_mre_crypto_pgp = { workspace = true }
 swarmauri_signing_ed25519 = { workspace = true }
 swarmauri_signing_pgp = { workspace = true }
+swarmauri_signing_rsa = { workspace = true }
 
 swarmauri_vectorstore_redis = { workspace = true }
 swarmauri_vectorstore_qdrant = { workspace = true }

--- a/pkgs/standards/swarmauri_signing_rsa/LICENSE
+++ b/pkgs/standards/swarmauri_signing_rsa/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/standards/swarmauri_signing_rsa/README.md
+++ b/pkgs/standards/swarmauri_signing_rsa/README.md
@@ -1,0 +1,31 @@
+![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+
+# Swarmauri Signing RSA
+
+An RSA-based signer implementing the `ISigning` interface for detached
+signatures over raw bytes and canonicalized envelopes.
+
+Features:
+- JSON canonicalization (always available)
+- Optional CBOR canonicalization via `cbor2`
+- Detached signatures using `cryptography`'s RSA primitives
+- Supports `RSA-PSS-SHA256` (recommended) and `RS256`
+
+## Installation
+
+```bash
+pip install swarmauri_signing_rsa
+```
+
+## Usage
+
+```python
+from swarmauri_signing_rsa import RSAEnvelopeSigner
+
+signer = RSAEnvelopeSigner()
+# create a KeyRef for an RSA private key; see swarmauri_core for details
+```
+
+## Entry Point
+
+The signer registers under the `swarmauri.signings` entry point as `RSAEnvelopeSigner`.

--- a/pkgs/standards/swarmauri_signing_rsa/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_rsa/pyproject.toml
@@ -1,0 +1,70 @@
+[project]
+name = "swarmauri_signing_rsa"
+version = "0.1.0"
+description = "RSA-based signer for Swarmauri"
+license = "Apache-2.0"
+readme = "README.md"
+requires-python = ">=3.10,<3.13"
+authors = [{ name = "Swarmauri", email = "opensource@swarmauri.com" }]
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Development Status :: 3 - Alpha",
+    "Topic :: Security :: Cryptography",
+    "Intended Audience :: Developers",
+]
+dependencies = [
+    "swarmauri_core",
+    "swarmauri_base",
+    "cryptography",
+]
+
+[project.optional-dependencies]
+cbor = ["cbor2"]
+
+[tool.uv.sources]
+swarmauri_core = { workspace = true }
+swarmauri_base = { workspace = true }
+
+[tool.pytest.ini_options]
+norecursedirs = ["combined", "scripts"]
+markers = [
+    "test: standard test",
+    "unit: Unit tests",
+    "i9n: Integration tests",
+    "r8n: Regression tests",
+    "acceptance: Acceptance tests",
+    "perf: Performance tests",
+]
+timeout = 300
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "pytest-timeout>=2.3.1",
+    "pytest-benchmark>=4.0.0",
+    "flake8>=7.0",
+    "ruff>=0.9.9",
+]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[project.entry-points.'swarmauri.signings']
+RSAEnvelopeSigner = "swarmauri_signing_rsa:RSAEnvelopeSigner"
+
+[project.entry-points."peagen.plugins.signings"]
+rsa = "swarmauri_signing_rsa:RSAEnvelopeSigner"

--- a/pkgs/standards/swarmauri_signing_rsa/swarmauri_signing_rsa/RSAEnvelopeSigner.py
+++ b/pkgs/standards/swarmauri_signing_rsa/swarmauri_signing_rsa/RSAEnvelopeSigner.py
@@ -1,0 +1,379 @@
+from __future__ import annotations
+
+import json
+import hashlib
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Mapping, Optional, Sequence, Union
+
+from swarmauri_base.signing.SigningBase import SigningBase
+from swarmauri_core.signing.ISigning import Canon, Envelope
+from swarmauri_core.signing.types import Signature
+from swarmauri_core.crypto.types import KeyRef, Alg
+
+try:  # pragma: no cover - optional dependency
+    from cryptography.hazmat.primitives.asymmetric import rsa, padding
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.serialization import (
+        load_pem_private_key,
+        load_pem_public_key,
+    )
+    from cryptography.exceptions import InvalidSignature
+
+    _CRYPTO_OK = True
+except Exception:  # pragma: no cover - runtime check
+    _CRYPTO_OK = False
+
+try:  # pragma: no cover - optional dependency
+    import cbor2
+
+    _CBOR_OK = True
+except Exception:  # pragma: no cover - runtime check
+    _CBOR_OK = False
+
+
+# ---------------------------------------------------------------------------
+# helpers: canonicalization
+# ---------------------------------------------------------------------------
+
+
+def _canon_json(obj: Any) -> bytes:
+    return json.dumps(
+        obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
+
+
+def _canon_cbor(obj: Any) -> bytes:
+    if not _CBOR_OK:
+        raise RuntimeError("CBOR canonicalization requires 'cbor2' to be installed.")
+    return cbor2.dumps(obj)
+
+
+# ---------------------------------------------------------------------------
+# helpers: JWK <-> ints/bytes
+# ---------------------------------------------------------------------------
+
+
+def _b64u_to_int(s: str) -> int:
+    import base64
+
+    pad = "=" * ((4 - len(s) % 4) % 4)
+    return int.from_bytes(base64.urlsafe_b64decode((s + pad).encode("ascii")), "big")
+
+
+def _int_to_b64u(i: int) -> str:  # pragma: no cover - convenience
+    import base64
+
+    if i == 0:
+        raw = b"\x00"
+    else:
+        length = (i.bit_length() + 7) // 8
+        raw = i.to_bytes(length, "big")
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _jwk_thumbprint_sha256(jwk: Mapping[str, Any]) -> str:
+    if jwk.get("kty") != "RSA":
+        raise ValueError("JWK kty must be 'RSA' for thumbprint.")
+    obj = {"e": jwk["e"], "kty": "RSA", "n": jwk["n"]}
+    data = json.dumps(
+        obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
+    return hashlib.sha256(data).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# helpers: key loading (PEM/JWK)
+# ---------------------------------------------------------------------------
+
+
+def _ensure_crypto() -> None:
+    if not _CRYPTO_OK:
+        raise RuntimeError(
+            "RSAEnvelopeSigner requires 'cryptography'. Install with: pip install cryptography"
+        )
+
+
+def _load_private_from_pem(
+    pem_bytes: bytes, passphrase: Optional[Union[str, bytes]]
+) -> rsa.RSAPrivateKey:
+    _ensure_crypto()
+    pw = None
+    if isinstance(passphrase, str):
+        pw = passphrase.encode("utf-8")
+    elif isinstance(passphrase, (bytes, bytearray)):
+        pw = bytes(passphrase)
+    return load_pem_private_key(pem_bytes, password=pw)
+
+
+def _load_public_from_pem(pem_bytes: bytes) -> rsa.RSAPublicKey:
+    _ensure_crypto()
+    pub = load_pem_public_key(pem_bytes)
+    if not isinstance(pub, rsa.RSAPublicKey):
+        raise TypeError("PEM public key is not RSA.")
+    return pub
+
+
+def _private_from_jwk(jwk: Mapping[str, Any]) -> rsa.RSAPrivateKey:
+    _ensure_crypto()
+    if jwk.get("kty") != "RSA":
+        raise ValueError("JWK kty must be 'RSA' for RSA signing.")
+    n = _b64u_to_int(jwk["n"])
+    e = _b64u_to_int(jwk["e"])
+    d = _b64u_to_int(jwk["d"])
+    p = _b64u_to_int(jwk["p"]) if "p" in jwk else None
+    q = _b64u_to_int(jwk["q"]) if "q" in jwk else None
+    dp = _b64u_to_int(jwk["dp"]) if "dp" in jwk else None
+    dq = _b64u_to_int(jwk["dq"]) if "dq" in jwk else None
+    qi = _b64u_to_int(jwk["qi"]) if "qi" in jwk else None
+
+    pub_numbers = rsa.RSAPublicNumbers(e=e, n=n)
+    if all(v is not None for v in (p, q, dp, dq, qi)):
+        priv_numbers = rsa.RSAPrivateNumbers(
+            p=p, q=q, d=d, dmp1=dp, dmq1=dq, iqmp=qi, public_numbers=pub_numbers
+        )
+    else:
+        raise ValueError("RSA private JWK must include CRT params: p,q,dp,dq,qi")
+    return priv_numbers.private_key()
+
+
+def _public_from_jwk(jwk: Mapping[str, Any]) -> rsa.RSAPublicKey:
+    _ensure_crypto()
+    if jwk.get("kty") != "RSA":
+        raise ValueError("JWK kty must be 'RSA'.")
+    n = _b64u_to_int(jwk["n"])
+    e = _b64u_to_int(jwk["e"])
+    return rsa.RSAPublicNumbers(e=e, n=n).public_key()
+
+
+def _keyref_to_private(
+    key: KeyRef, passphrase: Optional[Union[str, bytes]]
+) -> rsa.RSAPrivateKey:
+    _ensure_crypto()
+    if isinstance(key, dict):
+        k = key.get("kind")
+        if k == "cryptography_obj" and isinstance(key.get("obj"), rsa.RSAPrivateKey):
+            return key["obj"]  # type: ignore[return-value]
+        if k == "pem_priv":
+            data = key.get("data")
+            if isinstance(data, str):
+                data = data.encode("utf-8")
+            if not isinstance(data, (bytes, bytearray)):
+                raise TypeError("pem_priv KeyRef requires 'data' as bytes/str.")
+            return _load_private_from_pem(bytes(data), passphrase)
+        if k == "pem_priv_path":
+            path = key.get("path")
+            if not isinstance(path, str):
+                raise TypeError("pem_priv_path KeyRef requires 'path' string.")
+            with open(path, "rb") as f:
+                return _load_private_from_pem(f.read(), passphrase)
+        if k == "jwk_priv":
+            jwk = key.get("jwk")
+            if not isinstance(jwk, Mapping):
+                raise TypeError("jwk_priv KeyRef requires 'jwk' mapping.")
+            return _private_from_jwk(jwk)
+    raise TypeError("Unsupported KeyRef for RSA private key.")
+
+
+def _keyref_to_public(key: Any) -> rsa.RSAPublicKey:
+    _ensure_crypto()
+    if isinstance(key, dict):
+        k = key.get("kind")
+        if k == "cryptography_obj" and isinstance(key.get("obj"), rsa.RSAPublicKey):
+            return key["obj"]  # type: ignore[return-value]
+        if k == "pem_pub":
+            data = key.get("data")
+            if isinstance(data, str):
+                data = data.encode("utf-8")
+            return _load_public_from_pem(bytes(data))
+        if k == "pem_pub_path":
+            path = key.get("path")
+            with open(path, "rb") as f:
+                return _load_public_from_pem(f.read())
+        if k == "jwk_pub":
+            jwk = key.get("jwk")
+            if not isinstance(jwk, Mapping):
+                raise TypeError("jwk_pub requires 'jwk' mapping.")
+            return _public_from_jwk(jwk)
+        if key.get("kty") == "RSA" and "n" in key and "e" in key:
+            return _public_from_jwk(key)
+    elif isinstance(key, (bytes, bytearray, str)):
+        data = key.encode("utf-8") if isinstance(key, str) else bytes(key)
+        try:
+            return _load_public_from_pem(data)
+        except Exception as e:  # pragma: no cover - invalid format
+            raise TypeError(
+                "bytes/str given to _keyref_to_public is not a valid PEM public key."
+            ) from e
+    raise TypeError("Unsupported verification key format for RSA.")
+
+
+def _kid_from_public(
+    pk: rsa.RSAPublicKey, jwk_hint: Optional[Mapping[str, Any]] = None
+) -> str:
+    try:
+        if jwk_hint and jwk_hint.get("kty") == "RSA":
+            return _jwk_thumbprint_sha256(jwk_hint)
+    except Exception:  # pragma: no cover - thumbprint failure
+        pass
+    spki = pk.public_bytes(
+        serialization.Encoding.DER, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    return hashlib.sha256(spki).hexdigest()
+
+
+@dataclass(frozen=True)
+class _Sig:  # pragma: no cover - mapping proxy
+    data: Dict[str, Any]
+
+    def __getitem__(self, k: str) -> object:
+        return self.data[k]
+
+    def __iter__(self):  # pragma: no cover - trivial
+        return iter(self.data)
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self.data)
+
+    def get(self, k: str, default: Any = None) -> Any:
+        return self.data.get(k, default)
+
+
+class RSAEnvelopeSigner(SigningBase):
+    """RSA detached signer for bytes and canonicalized envelopes."""
+
+    def supports(self) -> Mapping[str, Iterable[str]]:
+        algs = ("RSA-PSS-SHA256", "RS256")
+        canons = ("json", "cbor") if _CBOR_OK else ("json",)
+        return {"algs": algs, "canons": canons, "features": ("multi", "detached_only")}
+
+    async def sign_bytes(
+        self,
+        key: KeyRef,
+        payload: bytes,
+        *,
+        alg: Optional[Alg] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> Sequence[Signature]:
+        _ensure_crypto()
+        alg = alg or "RSA-PSS-SHA256"
+        sk = _keyref_to_private(key, passphrase=(opts or {}).get("passphrase"))
+        pk = sk.public_key()
+        if alg == "RSA-PSS-SHA256":
+            sig = sk.sign(
+                payload,
+                padding.PSS(
+                    mgf=padding.MGF1(hashes.SHA256()),
+                    salt_length=padding.PSS.MAX_LENGTH,
+                ),
+                hashes.SHA256(),
+            )
+        elif alg == "RS256":
+            sig = sk.sign(payload, padding.PKCS1v15(), hashes.SHA256())
+        else:
+            raise ValueError(
+                "Unsupported alg for RSAEnvelopeSigner. Use 'RSA-PSS-SHA256' or 'RS256'."
+            )
+
+        jwk_hint = (
+            (opts or {}).get("kid_jwk_hint") if isinstance(opts, Mapping) else None
+        )
+        kid = _kid_from_public(pk, jwk_hint if isinstance(jwk_hint, Mapping) else None)
+        return [_Sig({"alg": str(alg), "kid": kid, "sig": sig})]
+
+    async def verify_bytes(
+        self,
+        payload: bytes,
+        signatures: Sequence[Signature],
+        *,
+        require: Optional[Mapping[str, object]] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bool:
+        _ensure_crypto()
+        min_signers = int((require or {}).get("min_signers", 1))
+        allowed_algs = set((require or {}).get("algs", ("RSA-PSS-SHA256", "RS256")))
+
+        pubs: list[rsa.RSAPublicKey] = []
+        if opts and "pubkeys" in opts:
+            for entry in opts["pubkeys"]:  # type: ignore[index]
+                pubs.append(_keyref_to_public(entry))
+        else:
+            raise ValueError(
+                "RSAEnvelopeSigner.verify_bytes requires opts['pubkeys'] with one or more RSA public keys."
+            )
+
+        accepted = 0
+        for sig in signatures:
+            alg = sig.get("alg")
+            if not isinstance(alg, str) or alg not in allowed_algs:
+                continue
+            sig_bytes = sig.get("sig")
+            if not isinstance(sig_bytes, (bytes, bytearray)):
+                continue
+
+            verified = False
+            for pk in pubs:
+                try:
+                    if alg == "RSA-PSS-SHA256":
+                        pk.verify(
+                            sig_bytes,
+                            payload,
+                            padding.PSS(
+                                mgf=padding.MGF1(hashes.SHA256()),
+                                salt_length=padding.PSS.MAX_LENGTH,
+                            ),
+                            hashes.SHA256(),
+                        )
+                    else:  # RS256
+                        pk.verify(
+                            sig_bytes, payload, padding.PKCS1v15(), hashes.SHA256()
+                        )
+                    verified = True
+                    break
+                except InvalidSignature:
+                    continue
+
+            if verified:
+                accepted += 1
+                if accepted >= min_signers:
+                    return True
+
+        return False
+
+    async def canonicalize_envelope(
+        self,
+        env: Envelope,
+        *,
+        canon: Optional[Canon] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bytes:
+        if canon in (None, "json"):
+            return _canon_json(env)  # type: ignore[arg-type]
+        if canon == "cbor":
+            return _canon_cbor(env)  # type: ignore[arg-type]
+        raise ValueError(f"Unsupported canon: {canon}")
+
+    async def sign_envelope(
+        self,
+        key: KeyRef,
+        env: Envelope,
+        *,
+        alg: Optional[Alg] = None,
+        canon: Optional[Canon] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> Sequence[Signature]:
+        payload = await self.canonicalize_envelope(env, canon=canon, opts=opts)
+        return await self.sign_bytes(
+            key, payload, alg=alg or "RSA-PSS-SHA256", opts=opts
+        )
+
+    async def verify_envelope(
+        self,
+        env: Envelope,
+        signatures: Sequence[Signature],
+        *,
+        canon: Optional[Canon] = None,
+        require: Optional[Mapping[str, object]] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bool:
+        payload = await self.canonicalize_envelope(env, canon=canon, opts=opts)
+        return await self.verify_bytes(payload, signatures, require=require, opts=opts)

--- a/pkgs/standards/swarmauri_signing_rsa/swarmauri_signing_rsa/__init__.py
+++ b/pkgs/standards/swarmauri_signing_rsa/swarmauri_signing_rsa/__init__.py
@@ -1,0 +1,3 @@
+from .RSAEnvelopeSigner import RSAEnvelopeSigner
+
+__all__ = ["RSAEnvelopeSigner"]

--- a/pkgs/standards/swarmauri_signing_rsa/tests/functional/test_signer_functional.py
+++ b/pkgs/standards/swarmauri_signing_rsa/tests/functional/test_signer_functional.py
@@ -1,0 +1,29 @@
+import asyncio
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from swarmauri_signing_rsa import RSAEnvelopeSigner
+
+
+def create_env(message: str):
+    return {"msg": message}
+
+
+async def _run() -> bool:
+    signer = RSAEnvelopeSigner()
+    sk = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    key = {"kind": "cryptography_obj", "obj": sk}
+    env = create_env("hello")
+    sigs = await signer.sign_envelope(key, env, canon="json")
+    pk = sk.public_key()
+    pub = {"kind": "cryptography_obj", "obj": pk}
+    good = await signer.verify_envelope(
+        env, sigs, canon="json", opts={"pubkeys": [pub]}
+    )
+    bad = await signer.verify_envelope(
+        {"msg": "tampered"}, sigs, canon="json", opts={"pubkeys": [pub]}
+    )
+    return good and not bad
+
+
+def test_sign_and_verify_envelope_functional():
+    assert asyncio.run(_run())

--- a/pkgs/standards/swarmauri_signing_rsa/tests/perf/test_signer_perf.py
+++ b/pkgs/standards/swarmauri_signing_rsa/tests/perf/test_signer_perf.py
@@ -1,0 +1,18 @@
+import asyncio
+from cryptography.hazmat.primitives.asymmetric import rsa
+import pytest
+
+from swarmauri_signing_rsa import RSAEnvelopeSigner
+
+
+@pytest.mark.perf
+def test_sign_bytes_perf(benchmark):
+    signer = RSAEnvelopeSigner()
+    sk = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    key = {"kind": "cryptography_obj", "obj": sk}
+    payload = b"perf-test"
+
+    async def _sign():
+        await signer.sign_bytes(key, payload)
+
+    benchmark(lambda: asyncio.run(_sign()))

--- a/pkgs/standards/swarmauri_signing_rsa/tests/unit/test_signer_unit.py
+++ b/pkgs/standards/swarmauri_signing_rsa/tests/unit/test_signer_unit.py
@@ -1,0 +1,21 @@
+import asyncio
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from swarmauri_signing_rsa import RSAEnvelopeSigner
+
+
+async def _sign_and_verify() -> bool:
+    signer = RSAEnvelopeSigner()
+    sk = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    key = {"kind": "cryptography_obj", "obj": sk}
+    payload = b"unit-test"
+    sigs = await signer.sign_bytes(key, payload)
+    pk = sk.public_key()
+    ok = await signer.verify_bytes(
+        payload, sigs, opts={"pubkeys": [{"kind": "cryptography_obj", "obj": pk}]}
+    )
+    return ok
+
+
+def test_sign_and_verify_unit():
+    assert asyncio.run(_sign_and_verify())

--- a/pkgs/swarmauri/swarmauri/interface_registry.py
+++ b/pkgs/swarmauri/swarmauri/interface_registry.py
@@ -55,7 +55,6 @@ from swarmauri_base.loggers.LoggerBase import LoggerBase
 from swarmauri_base.logger_handlers.HandlerBase import HandlerBase
 from swarmauri_base.rate_limits.RateLimitBase import RateLimitBase
 from swarmauri_base.middlewares.MiddlewareBase import MiddlewareBase
-from swarmauri_base.mre_crypto.MreCryptoBase import MreCryptoBase
 
 try:
     from swarmauri_base.signing.SigningBase import SigningBase
@@ -122,6 +121,7 @@ class InterfaceRegistry:
         "swarmauri.mre_cryptos": MreCryptoBase,
         "swarmauri.secrets": SecretDriveBase,
         "swarmauri.signings": SigningBase,
+        "swarmauri.signings.RSAEnvelopeSigner": SigningBase,
         "swarmauri.logger_formatters": FormatterBase,
         "swarmauri.loggers": LoggerBase,
         "swarmauri.logger_handlers": HandlerBase,

--- a/pkgs/swarmauri/swarmauri/plugin_citizenship_registry.py
+++ b/pkgs/swarmauri/swarmauri/plugin_citizenship_registry.py
@@ -53,6 +53,7 @@ class PluginCitizenshipRegistry:
         "swarmauri.signing.ISigning": "swarmauri_core.signing.ISigning",
         "swarmauri.signing.SigningBase": "swarmauri_base.signing.SigningBase",
         "swarmauri.signings.PgpEnvelopeSigner": "swarmauri_signing_pgp.PgpEnvelopeSigner",
+        "swarmauri.signings.RSAEnvelopeSigner": "swarmauri_signing_rsa.RSAEnvelopeSigner",
         "swarmauri.agents.ExampleAgent": "swm_example_package.ExampleAgent",
         "swarmauri.agents.QAAgent": "swarmauri_standard.agents.QAAgent",
         "swarmauri.agents.RagAgent": "swarmauri_standard.agents.RagAgent",


### PR DESCRIPTION
## Summary
- add RSAEnvelopeSigner plugin with RSA-PSS and RS256 support
- register RSAEnvelopeSigner in first-class and interface registries
- include plugin in workspace configuration

## Testing
- `uv run --directory pkgs/standards/swarmauri_signing_rsa --package swarmauri_signing_rsa ruff format .`
- `uv run --directory pkgs/standards/swarmauri_signing_rsa --package swarmauri_signing_rsa ruff check . --fix`
- `uv run --directory pkgs/swarmauri --package swarmauri ruff format .`
- `uv run --directory pkgs/swarmauri --package swarmauri ruff check . --fix`
- `uv run --package swarmauri_signing_rsa --directory pkgs/standards/swarmauri_signing_rsa pytest`
- `uv run --package swarmauri --directory pkgs/swarmauri pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a700cf01ec8326a1a9d6bb7cbe78c7