### PR TITLE
feat: add Shamir-based MRE crypto plugin

### DIFF
--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -82,6 +82,7 @@ members = [
     "standards/swarmauri_crypto_sodium",
     "standards/swarmauri_crypto_nacl_pkcs11",
     "standards/swarmauri_crypto_composite",
+    "standards/swarmauri_crypto_shamir",
     "standards/swarmauri_signing_ed25519",
     "standards/swarmauri_secret_autogpg",
     "standards/swarmauri_signing_pgp",
@@ -209,6 +210,7 @@ swarmauri_crypto_paramiko = { workspace = true }
 swarmauri_crypto_pgp = { workspace = true }
 swarmauri_crypto_nacl_pkcs11 = { workspace = true }
 swarmauri_crypto_composite = { workspace = true }
+swarmauri_crypto_shamir = { workspace = true }
 swarmauri_signing_ed25519 = { workspace = true }
 swarmauri_signing_pgp = { workspace = true }
 

--- a/pkgs/standards/swarmauri_crypto_shamir/LICENSE
+++ b/pkgs/standards/swarmauri_crypto_shamir/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/standards/swarmauri_crypto_shamir/README.md
+++ b/pkgs/standards/swarmauri_crypto_shamir/README.md
@@ -1,0 +1,18 @@
+# swarmauri_crypto_shamir
+
+Shamir Secret Sharing based multi-recipient encryption (MRE) provider for the Swarmauri framework. The provider splits an AES-256-GCM content encryption key using Shamir's threshold scheme and distributes shares to recipients.
+
+## Features
+- AES-256-GCM payload encryption
+- Threshold k-of-n key sharing via Shamir secret sharing
+- Envelope rewrapping with optional payload rotation
+
+## Extras
+The plugin supports optional canonicalization extras:
+- `cbor` – enables CBOR canonicalization via `cbor2`
+
+## Installation
+This package is part of the Swarmauri standards collection and is typically installed as part of the `swarmauri-sdk` workspace.
+
+## License
+Apache-2.0

--- a/pkgs/standards/swarmauri_crypto_shamir/pyproject.toml
+++ b/pkgs/standards/swarmauri_crypto_shamir/pyproject.toml
@@ -1,0 +1,70 @@
+[project]
+name = "swarmauri_crypto_shamir"
+version = "0.1.0"
+description = "Shamir secret sharing based MRE crypto provider for Swarmauri"
+license = "Apache-2.0"
+readme = "README.md"
+requires-python = ">=3.10,<3.13"
+authors = [{ name = "Swarmauri", email = "opensource@swarmauri.com" }]
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Development Status :: 3 - Alpha",
+    "Topic :: Security :: Cryptography",
+    "Intended Audience :: Developers",
+]
+dependencies = [
+    "swarmauri_core",
+    "swarmauri_base",
+    "cryptography",
+]
+
+[project.optional-dependencies]
+cbor = ["cbor2"]
+
+[tool.uv.sources]
+swarmauri_core = { workspace = true }
+swarmauri_base = { workspace = true }
+
+[tool.pytest.ini_options]
+norecursedirs = ["combined", "scripts"]
+markers = [
+    "test: standard test",
+    "unit: Unit tests",
+    "i9n: Integration tests",
+    "r8n: Regression tests",
+    "acceptance: Acceptance tests",
+    "perf: Performance tests",
+]
+timeout = 300
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "pytest-timeout>=2.3.1",
+    "pytest-benchmark>=4.0.0",
+    "flake8>=7.0",
+    "ruff>=0.9.9",
+]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[project.entry-points.'swarmauri.mre_cryptos']
+ShamirMreCrypto = "swarmauri_crypto_shamir:ShamirMreCrypto"
+
+[project.entry-points."peagen.plugins.mre_cryptos"]
+shamir = "swarmauri_crypto_shamir:ShamirMreCrypto"

--- a/pkgs/standards/swarmauri_crypto_shamir/swarmauri_crypto_shamir/ShamirMreCrypto.py
+++ b/pkgs/standards/swarmauri_crypto_shamir/swarmauri_crypto_shamir/ShamirMreCrypto.py
@@ -1,0 +1,510 @@
+"""Shamir-based Multi-Recipient Encryption provider."""
+
+from __future__ import annotations
+
+import os
+import json
+import hashlib
+from typing import Any, Dict, Iterable, Mapping, Optional, Sequence, Tuple, List, Union
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from swarmauri_core.crypto.types import Alg, KeyRef
+from swarmauri_core.mre_crypto.types import MultiRecipientEnvelope, RecipientId
+from swarmauri_base.mre_crypto.MreCryptoBase import MreCryptoBase
+from swarmauri_base.ComponentBase import ComponentBase
+
+
+# ======================== Field and envelope constants ========================
+
+# Prime field for Shamir (Mersenne prime > 2^521)
+_P = (1 << 521) - 1
+_ZERO = 0
+_ONE = 1
+
+# CEK size for AES-256-GCM
+_CEK_LEN = 32
+_NONCE_LEN = 12
+_TAG_LEN = 16
+
+# Envelope tokens
+_MODE = "sealed_cek+aead"
+_RECIP_ALG = "SHAMIR-KOFN"
+_PAYLOAD_AEAD_DEFAULT = "AES-256-GCM"
+
+# Header (per-recipient share) binary format
+_HDR_MAGIC = b"SHAMIR-KOFN\x00"
+_HDR_VER = b"\x01"
+
+
+# ================================ utils ======================================
+
+
+def _int_to_bytes(x: int) -> bytes:
+    if x == 0:
+        return b"\x00"
+    length = (x.bit_length() + 7) // 8
+    return x.to_bytes(length, "big")
+
+
+def _bytes_to_int(b: bytes) -> int:
+    return int.from_bytes(b, "big")
+
+
+def _mod_inv(a: int, p: int) -> int:
+    # Modular inverse via Fermat's little theorem; p is prime
+    if a % p == 0:
+        raise ZeroDivisionError("division by zero in modular inverse")
+    return pow(a, p - 2, p)
+
+
+def _poly_eval_at(x: int, coeffs: Sequence[int], p: int = _P) -> int:
+    """
+    Evaluate polynomial a0 + a1*x + a2*x^2 + ... at x (mod p).
+    coeffs[0] is the secret (a0).
+    """
+    acc = 0
+    power = 1
+    for a in coeffs:
+        acc = (acc + (a * power)) % p
+        power = (power * x) % p
+    return acc
+
+
+def _lagrange_interpolate_at(
+    x: int, points: Sequence[Tuple[int, int]], p: int = _P
+) -> int:
+    """
+    Compute f(x) from k points (x_i, y_i) on a degree-(k-1) polynomial over GF(p).
+    Works for x == 0 (reconstruct secret) or any other x (evaluate at new x).
+    """
+    k = len(points)
+    xs = [xi for (xi, _) in points]
+    ys = [yi for (_, yi) in points]
+    total = 0
+    for i in range(k):
+        xi, yi = xs[i], ys[i]
+        num = 1
+        den = 1
+        for j in range(k):
+            if i == j:
+                continue
+            xj = xs[j]
+            num = (num * (x - xj)) % p
+            den = (den * (xi - xj)) % p
+        li = (num * _mod_inv(den % p, p)) % p
+        total = (total + (yi * li)) % p
+    return total
+
+
+def _encode_share(x: int, y: int) -> bytes:
+    xb = _int_to_bytes(x)
+    yb = _int_to_bytes(y)
+    return b"".join(
+        [
+            _HDR_MAGIC,
+            _HDR_VER,
+            len(xb).to_bytes(2, "big"),
+            xb,
+            len(yb).to_bytes(2, "big"),
+            yb,
+        ]
+    )
+
+
+def _decode_share(b: bytes) -> Tuple[int, int]:
+    if not b.startswith(_HDR_MAGIC):
+        raise ValueError("Malformed Shamir header (magic).")
+    off = len(_HDR_MAGIC)
+    ver = b[off : off + 1]
+    off += 1
+    if ver != _HDR_VER:
+        raise ValueError("Unsupported Shamir header version.")
+    xlen = int.from_bytes(b[off : off + 2], "big")
+    off += 2
+    xb = b[off : off + xlen]
+    off += xlen
+    ylen = int.from_bytes(b[off : off + 2], "big")
+    off += 2
+    yb = b[off : off + ylen]
+    if len(xb) != xlen or len(yb) != ylen:
+        raise ValueError("Malformed Shamir header (length).")
+    return (_bytes_to_int(xb), _bytes_to_int(yb))
+
+
+def _sha256(data: bytes) -> bytes:
+    return hashlib.sha256(data).digest()
+
+
+def _stable_recipient_id(ref: KeyRef) -> str:
+    """
+    Produce a stable recipient id from a KeyRef without assuming key type.
+    Preference:
+      - explicit 'kid' or 'id' in dict
+      - raw public bytes if available
+      - canonicalized JSON of the dict
+      - repr fallback
+    """
+    if isinstance(ref, dict):
+        if "kid" in ref and isinstance(ref["kid"], (str, bytes)):
+            v = ref["kid"]
+            if isinstance(v, bytes):
+                v = v.decode("utf-8", "ignore")
+            return v
+        if "id" in ref and isinstance(ref["id"], (str, bytes)):
+            v = ref["id"]
+            if isinstance(v, bytes):
+                v = v.decode("utf-8", "ignore")
+            return v
+        obj = ref.get("obj")
+        if hasattr(obj, "public_bytes"):
+            try:
+                pb = obj.public_bytes(encoding=None, format=None)  # type: ignore[arg-type]
+                return hashlib.sha256(pb).hexdigest()
+            except Exception:
+                pass
+        try:
+            canon = json.dumps(
+                ref, sort_keys=True, separators=(",", ":"), default=str
+            ).encode("utf-8")
+        except Exception:
+            canon = repr(ref).encode("utf-8")
+        return hashlib.sha256(canon).hexdigest()
+    return hashlib.sha256(repr(ref).encode("utf-8")).hexdigest()
+
+
+def _x_from_recipient_id(rid: str, used: set[int]) -> int:
+    base = (
+        int.from_bytes(_sha256(("SHAMIR-X|" + rid).encode("utf-8")), "big") % (_P - 1)
+    ) + 1
+    x = base
+    while x in used:
+        x = (x + 1) % _P
+        if x == 0:
+            x = 1
+    used.add(x)
+    return x
+
+
+def _aes_gcm_encrypt(
+    cek: bytes, pt: bytes, aad: Optional[bytes]
+) -> Tuple[bytes, bytes, bytes]:
+    nonce = os.urandom(_NONCE_LEN)
+    enc = AESGCM(cek).encrypt(nonce, pt, aad)
+    ct, tag = enc[:-_TAG_LEN], enc[-_TAG_LEN:]
+    return nonce, ct, tag
+
+
+def _aes_gcm_decrypt(
+    cek: bytes, nonce: bytes, ct: bytes, tag: bytes, aad: Optional[bytes]
+) -> bytes:
+    return AESGCM(cek).decrypt(nonce, ct + tag, aad)
+
+
+# ============================== implementation ===============================
+
+
+@ComponentBase.register_type(MreCryptoBase, "ShamirMreCrypto")
+class ShamirMreCrypto(MreCryptoBase):
+    """Shamir secret sharing based MRE crypto provider."""
+
+    type: str = "ShamirMreCrypto"
+
+    def supports(self) -> Dict[str, Iterable[str]]:
+        return {
+            "payload": (_PAYLOAD_AEAD_DEFAULT,),
+            "recipient": (_RECIP_ALG,),
+            "modes": (_MODE,),
+            "features": ("aad", "threshold", "rewrap_without_reencrypt"),
+        }
+
+    # ----------------------------- encrypt_for_many -----------------------------
+    async def encrypt_for_many(
+        self,
+        recipients: Sequence[KeyRef],
+        pt: bytes,
+        *,
+        payload_alg: Optional[Alg] = None,
+        recipient_alg: Optional[Alg] = None,
+        mode: Optional[Union[str, Any]] = None,
+        aad: Optional[bytes] = None,
+        shared: Optional[Mapping[str, bytes]] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> MultiRecipientEnvelope:
+        m = str(mode or _MODE)
+        if m != _MODE:
+            raise ValueError("ShamirMreCrypto supports only mode='sealed_cek+aead'.")
+        if recipient_alg not in (None, _RECIP_ALG):
+            raise ValueError(
+                "ShamirMreCrypto supports only recipient_alg='SHAMIR-KOFN'."
+            )
+        palg = str(payload_alg or _PAYLOAD_AEAD_DEFAULT)
+        if palg != _PAYLOAD_AEAD_DEFAULT:
+            raise ValueError("ShamirMreCrypto supports only AES-256-GCM for now.")
+        if not recipients:
+            raise ValueError("At least one recipient is required.")
+        n = len(recipients)
+        k = int((opts or {}).get("threshold_k", (n // 2) + 1))
+        k = max(1, min(k, n))
+        cek = os.urandom(_CEK_LEN)
+        nonce, ct, tag = _aes_gcm_encrypt(cek, pt, aad)
+        secret = _bytes_to_int(cek)
+        coeffs = [secret] + [
+            int.from_bytes(os.urandom(64), "big") % _P for _ in range(max(0, k - 1))
+        ]
+        used_x: set[int] = set()
+        rec_entries: List[Dict[str, Any]] = []
+        for ref in recipients:
+            rid = _stable_recipient_id(ref)
+            x = _x_from_recipient_id(rid, used_x)
+            y = _poly_eval_at(x, coeffs, _P)
+            header = _encode_share(x, y)
+            rec_entries.append({"id": rid, "header": header})
+        payload = {
+            "kind": "aead",
+            "alg": palg,
+            "nonce": nonce,
+            "ct": ct,
+            "tag": tag,
+            "aad": aad,
+        }
+        env: MultiRecipientEnvelope = {
+            "mode": _MODE,
+            "payload": payload,
+            "recipient_alg": _RECIP_ALG,
+            "recipients": rec_entries,
+            "shared": {
+                "threshold_k": k.to_bytes(2, "big"),
+                "cek_len": _CEK_LEN.to_bytes(2, "big"),
+            },
+        }
+        if shared:
+            extra = dict(shared)
+            extra.pop("threshold_k", None)
+            extra.pop("cek_len", None)
+            env["shared"].update(extra)  # type: ignore[index]
+        return env
+
+    # --------------------------------- open_for --------------------------------
+    async def open_for(
+        self,
+        my_identity: KeyRef,
+        env: MultiRecipientEnvelope,
+        *,
+        aad: Optional[bytes] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bytes:
+        k = _decode_k(env)
+        if k != 1:
+            raise ValueError(
+                "This envelope requires ≥2 shares; call open_for_many(...)."
+            )
+        rid = _stable_recipient_id(my_identity)
+        share = _find_share_for(rid, env)
+        if share is None:
+            raise ValueError("This identity has no share in the envelope.")
+        x, y = _decode_share(share)
+        cek_int = y % _P
+        cek = _int_to_bytes(cek_int).rjust(_decode_cek_len(env), b"\x00")
+        payload = _expect_aead_payload(env)
+        return _aes_gcm_decrypt(
+            cek,
+            payload["nonce"],
+            payload["ct"],
+            payload["tag"],
+            aad or payload.get("aad"),
+        )
+
+    # ------------------------------- open_for_many ------------------------------
+    async def open_for_many(
+        self,
+        my_identities: Sequence[KeyRef],
+        env: MultiRecipientEnvelope,
+        *,
+        aad: Optional[bytes] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bytes:
+        if not my_identities:
+            raise ValueError("No identities provided.")
+        k = _decode_k(env)
+        payload = _expect_aead_payload(env)
+        points: List[Tuple[int, int]] = []
+        seen_x: set[int] = set()
+        for ident in my_identities:
+            rid = _stable_recipient_id(ident)
+            h = _find_share_for(rid, env)
+            if h is None:
+                continue
+            x, y = _decode_share(h)
+            if x in seen_x:
+                continue
+            seen_x.add(x)
+            points.append((x, y))
+            if len(points) >= k:
+                break
+        if len(points) < k:
+            raise ValueError(
+                f"Need at least {k} shares; provided {len(points)} that match the envelope."
+            )
+        cek_int = _lagrange_interpolate_at(0, points, _P)
+        cek = _int_to_bytes(cek_int).rjust(_decode_cek_len(env), b"\x00")
+        return _aes_gcm_decrypt(
+            cek,
+            payload["nonce"],
+            payload["ct"],
+            payload["tag"],
+            aad or payload.get("aad"),
+        )
+
+    # ---------------------------------- rewrap ---------------------------------
+    async def rewrap(
+        self,
+        env: MultiRecipientEnvelope,
+        *,
+        add: Optional[Sequence[KeyRef]] = None,
+        remove: Optional[Sequence[RecipientId]] = None,
+        recipient_alg: Optional[Alg] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> MultiRecipientEnvelope:
+        if env.get("mode") != _MODE or env.get("recipient_alg") != _RECIP_ALG:
+            raise ValueError("Envelope does not match ShamirMreCrypto mode/alg.")
+        if recipient_alg not in (None, _RECIP_ALG):
+            raise ValueError("recipient_alg must be SHAMIR-KOFN for ShamirMreCrypto.")
+        k = _decode_k(env)
+        cek_len = _decode_cek_len(env)
+        recs: List[Dict[str, Any]] = list(env.get("recipients", []))
+        if remove:
+            to_remove = set(remove)
+            recs = [r for r in recs if r.get("id") not in to_remove]
+        rotate = (
+            bool((opts or {}).get("rotate_payload_on_revoke", True))
+            if remove
+            else False
+        )
+        points = _collect_k_points(recs, k)
+        if add and not rotate:
+            used_x = {_decode_share(r["header"])[0] for r in recs}
+            for ref in add:
+                rid = _stable_recipient_id(ref)
+                x_new = _x_from_recipient_id(rid, used_x)
+                y_new = _lagrange_interpolate_at(x_new, points, _P)
+                recs.append({"id": rid, "header": _encode_share(x_new, y_new)})
+            updated = {
+                "mode": _MODE,
+                "payload": env["payload"],
+                "recipient_alg": _RECIP_ALG,
+                "recipients": recs,
+                "shared": dict(env.get("shared", {})),
+            }
+            return updated  # type: ignore[return-value]
+        _ = _lagrange_interpolate_at(0, points, _P)
+        new_cek = os.urandom(cek_len)
+        payload = _expect_aead_payload(env)
+        pt = _aes_gcm_decrypt(
+            cek=_int_to_bytes(_lagrange_interpolate_at(0, points, _P)).rjust(
+                cek_len, b"\x00"
+            ),
+            nonce=payload["nonce"],
+            ct=payload["ct"],
+            tag=payload["tag"],
+            aad=payload.get("aad"),
+        )
+        nonce, ct, tag = _aes_gcm_encrypt(new_cek, pt, payload.get("aad"))
+        secret = _bytes_to_int(new_cek)
+        coeffs = [secret] + [
+            int.from_bytes(os.urandom(64), "big") % _P for _ in range(max(0, k - 1))
+        ]
+        used_x: set[int] = set()
+        new_recs: List[Dict[str, Any]] = []
+        base_ids = [r["id"] for r in recs]
+        add_ids: List[str] = []
+        add = add or []
+        for ref in add:
+            add_ids.append(_stable_recipient_id(ref))
+        all_ids = base_ids + add_ids
+        for rid in all_ids:
+            x = _x_from_recipient_id(rid, used_x)
+            y = _poly_eval_at(x, coeffs, _P)
+            new_recs.append({"id": rid, "header": _encode_share(x, y)})
+        updated_payload = {
+            "kind": "aead",
+            "alg": payload["alg"],
+            "nonce": nonce,
+            "ct": ct,
+            "tag": tag,
+            "aad": payload.get("aad"),
+        }
+        updated = {
+            "mode": _MODE,
+            "payload": updated_payload,
+            "recipient_alg": _RECIP_ALG,
+            "recipients": new_recs,
+            "shared": {
+                **dict(env.get("shared", {})),
+                "cek_len": cek_len.to_bytes(2, "big"),
+                "threshold_k": k.to_bytes(2, "big"),
+            },
+        }
+        return updated  # type: ignore[return-value]
+
+
+# ============================== local helpers ================================
+
+
+def _decode_k(env: MultiRecipientEnvelope) -> int:
+    s = env.get("shared", {}) or {}
+    k_b = s.get("threshold_k")
+    if not isinstance(k_b, (bytes, bytearray)):
+        raise ValueError("Envelope missing 'shared.threshold_k'.")
+    return int.from_bytes(k_b, "big")
+
+
+def _decode_cek_len(env: MultiRecipientEnvelope) -> int:
+    s = env.get("shared", {}) or {}
+    b = s.get("cek_len")
+    if not isinstance(b, (bytes, bytearray)):
+        return _CEK_LEN
+    return int.from_bytes(b, "big")
+
+
+def _expect_aead_payload(env: MultiRecipientEnvelope) -> Dict[str, Any]:
+    payload = env.get("payload")
+    if not isinstance(payload, dict) or payload.get("kind") != "aead":
+        raise ValueError("Envelope payload is not AEAD kind.")
+    for key in ("alg", "nonce", "ct", "tag"):
+        if key not in payload:
+            raise ValueError(f"Envelope payload missing '{key}'.")
+    if payload["alg"] != _PAYLOAD_AEAD_DEFAULT:
+        raise ValueError("Unsupported payload AEAD algorithm.")
+    return payload  # type: ignore[return-value]
+
+
+def _find_share_for(rid: str, env: MultiRecipientEnvelope) -> Optional[bytes]:
+    for r in env.get("recipients", []):
+        if r.get("id") == rid:
+            h = r.get("header")
+            if isinstance(h, (bytes, bytearray)):
+                return bytes(h)
+    return None
+
+
+def _collect_k_points(
+    recs: Sequence[Mapping[str, Any]], k: int
+) -> List[Tuple[int, int]]:
+    points: List[Tuple[int, int]] = []
+    seen: set[int] = set()
+    for r in recs:
+        h = r.get("header")
+        if not isinstance(h, (bytes, bytearray)):
+            continue
+        x, y = _decode_share(h)
+        if x in seen:
+            continue
+        seen.add(x)
+        points.append((x, y))
+        if len(points) >= k:
+            break
+    if len(points) < k:
+        raise ValueError(
+            f"Envelope has only {len(points)} usable shares; need at least {k}."
+        )
+    return points

--- a/pkgs/standards/swarmauri_crypto_shamir/swarmauri_crypto_shamir/__init__.py
+++ b/pkgs/standards/swarmauri_crypto_shamir/swarmauri_crypto_shamir/__init__.py
@@ -1,0 +1,3 @@
+from .ShamirMreCrypto import ShamirMreCrypto
+
+__all__ = ["ShamirMreCrypto"]

--- a/pkgs/standards/swarmauri_crypto_shamir/tests/functional/test_shamir_functional.py
+++ b/pkgs/standards/swarmauri_crypto_shamir/tests/functional/test_shamir_functional.py
@@ -1,0 +1,22 @@
+import asyncio
+from swarmauri_core.crypto.types import KeyRef, KeyType, KeyUse, ExportPolicy
+
+from swarmauri_crypto_shamir import ShamirMreCrypto
+
+
+async def _run() -> bool:
+    crypto = ShamirMreCrypto()
+    r1 = KeyRef("r1", 1, KeyType.SYMMETRIC, (KeyUse.ENCRYPT,), ExportPolicy.PUBLIC_ONLY)
+    r2 = KeyRef("r2", 1, KeyType.SYMMETRIC, (KeyUse.ENCRYPT,), ExportPolicy.PUBLIC_ONLY)
+    r3 = KeyRef("r3", 1, KeyType.SYMMETRIC, (KeyUse.ENCRYPT,), ExportPolicy.PUBLIC_ONLY)
+    env = await crypto.encrypt_for_many(
+        [r1, r2, r3], b"functional", opts={"threshold_k": 2}
+    )
+    r4 = KeyRef("r4", 1, KeyType.SYMMETRIC, (KeyUse.ENCRYPT,), ExportPolicy.PUBLIC_ONLY)
+    env2 = await crypto.rewrap(env, add=[r4], remove=["r1"])
+    pt = await crypto.open_for_many([r2, r3, r4], env2)
+    return pt == b"functional"
+
+
+def test_rewrap_functional():
+    assert asyncio.run(_run())

--- a/pkgs/standards/swarmauri_crypto_shamir/tests/perf/test_shamir_perf.py
+++ b/pkgs/standards/swarmauri_crypto_shamir/tests/perf/test_shamir_perf.py
@@ -1,0 +1,20 @@
+import asyncio
+import pytest
+from swarmauri_core.crypto.types import KeyRef, KeyType, KeyUse, ExportPolicy
+
+from swarmauri_crypto_shamir import ShamirMreCrypto
+
+
+@pytest.mark.perf
+def test_encrypt_perf(benchmark):
+    crypto = ShamirMreCrypto()
+    recips = [
+        KeyRef("r1", 1, KeyType.SYMMETRIC, (KeyUse.ENCRYPT,), ExportPolicy.PUBLIC_ONLY),
+        KeyRef("r2", 1, KeyType.SYMMETRIC, (KeyUse.ENCRYPT,), ExportPolicy.PUBLIC_ONLY),
+        KeyRef("r3", 1, KeyType.SYMMETRIC, (KeyUse.ENCRYPT,), ExportPolicy.PUBLIC_ONLY),
+    ]
+
+    async def _enc():
+        await crypto.encrypt_for_many(recips, b"perf", opts={"threshold_k": 2})
+
+    benchmark(lambda: asyncio.run(_enc()))

--- a/pkgs/standards/swarmauri_crypto_shamir/tests/unit/test_shamir_unit.py
+++ b/pkgs/standards/swarmauri_crypto_shamir/tests/unit/test_shamir_unit.py
@@ -1,0 +1,20 @@
+import asyncio
+from swarmauri_core.crypto.types import KeyRef, KeyType, KeyUse, ExportPolicy
+
+from swarmauri_crypto_shamir import ShamirMreCrypto
+
+
+async def _encrypt_decrypt() -> bool:
+    crypto = ShamirMreCrypto()
+    recips = [
+        KeyRef("r1", 1, KeyType.SYMMETRIC, (KeyUse.ENCRYPT,), ExportPolicy.PUBLIC_ONLY),
+        KeyRef("r2", 1, KeyType.SYMMETRIC, (KeyUse.ENCRYPT,), ExportPolicy.PUBLIC_ONLY),
+        KeyRef("r3", 1, KeyType.SYMMETRIC, (KeyUse.ENCRYPT,), ExportPolicy.PUBLIC_ONLY),
+    ]
+    env = await crypto.encrypt_for_many(recips, b"unit-test", opts={"threshold_k": 2})
+    pt = await crypto.open_for_many(recips[:2], env)
+    return pt == b"unit-test"
+
+
+def test_shamir_encrypt_decrypt_unit():
+    assert asyncio.run(_encrypt_decrypt())

--- a/pkgs/swarmauri/swarmauri/interface_registry.py
+++ b/pkgs/swarmauri/swarmauri/interface_registry.py
@@ -20,6 +20,7 @@ from swarmauri_base.dataconnectors.DataConnectorBase import DataConnectorBase
 from swarmauri_base.crypto.CryptoBase import CryptoBase
 from swarmauri_base.secrets.SecretDriveBase import SecretDriveBase
 from swarmauri_base.signing.SigningBase import SigningBase
+from swarmauri_base.mre_crypto.MreCryptoBase import MreCryptoBase
 from swarmauri_base.distances.DistanceBase import DistanceBase
 from swarmauri_base.documents.DocumentBase import DocumentBase
 from swarmauri_base.embeddings.EmbeddingBase import EmbeddingBase
@@ -116,6 +117,7 @@ class InterfaceRegistry:
         "swarmauri.utils": None,
         "swarmauri.vector_stores": VectorStoreBase,
         "swarmauri.vectors": VectorBase,
+        "swarmauri.mre_cryptos": MreCryptoBase,
         "swarmauri.crypto": CryptoBase,
         "swarmauri.secrets": SecretDriveBase,
         "swarmauri.signings": SigningBase,

--- a/pkgs/swarmauri/swarmauri/plugin_citizenship_registry.py
+++ b/pkgs/swarmauri/swarmauri/plugin_citizenship_registry.py
@@ -299,6 +299,7 @@ class PluginCitizenshipRegistry:
         "swarmauri.rate_limits.TokenBucketRateLimit": "swarmauri_standard.rate_limits.TokenBucketRateLimit",
         "swarmauri.crypto.ParamikoCrypto": "swarmauri_crypto_paramiko.ParamikoCrypto",
         "swarmauri.crypto.PGPCrypto": "swarmauri_crypto_pgp.PGPCrypto",
+        "swarmauri.mre_cryptos.ShamirMreCrypto": "swarmauri_crypto_shamir.ShamirMreCrypto",
         "swarmauri.secret.AutoGpgSecretDrive": "swarmauri_secret_autogpg.AutoGpgSecretDrive",
     }
     SECOND_CLASS_REGISTRY: Dict[str, str] = {}


### PR DESCRIPTION
## Summary
- add Shamir secret sharing multi-recipient encryption plugin
- register plugin in interface and first-class registries
- wire package into monorepo workspace

## Testing
- `uv run --directory pkgs/standards/swarmauri_crypto_shamir --package swarmauri_crypto_shamir ruff format .`
- `uv run --directory pkgs/standards/swarmauri_crypto_shamir --package swarmauri_crypto_shamir ruff check . --fix`
- `uv run --directory pkgs/swarmauri --package swarmauri ruff format .`
- `uv run --directory pkgs/swarmauri --package swarmauri ruff check . --fix`
- `uv run --package swarmauri_crypto_shamir --directory pkgs/standards/swarmauri_crypto_shamir pytest`
- `uv run --package swarmauri --directory pkgs/swarmauri pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6fdc66290832691df9015e7c3fb64