### PR TITLE
Add PGP MRE crypto providers and tests

### DIFF
--- a/pkgs/standards/swarmauri_mre_crypto_pgp/README.md
+++ b/pkgs/standards/swarmauri_mre_crypto_pgp/README.md
@@ -17,10 +17,17 @@
 
 ## Swarmauri MRE Crypto PGP
 
-OpenPGP sealed-per-recipient multi-recipient encryption provider implementing the `IMreCrypto` contract.
+OpenPGP-based multi-recipient encryption providers implementing the
+`IMreCrypto` contract. This package exposes three providers:
 
-- Mode: `sealed_per_recipient`
-- Recipient protection: OpenPGP public key encryption (PGPy)
+* **PGPSealMreCrypto** – per-recipient sealed payloads
+  (`sealed_per_recipient` mode).
+* **PGPSealedCekMreCrypto** – shared AEAD payload with per-recipient sealed
+  CEK (`sealed_cek+aead` mode).
+* **PGPMreCrypto** – composite provider supporting both the
+  `enc_once+per_recipient_header` and `sealed_per_recipient` modes.
+
+All providers use OpenPGP public key encryption via PGPy.
 
 ### Installation
 
@@ -31,12 +38,13 @@ pip install swarmauri_mre_crypto_pgp
 ### Usage
 
 ```python
-from swarmauri_mre_crypto_pgp import PGPSealMreCrypto
+from swarmauri_mre_crypto_pgp import PGPMreCrypto
 
-mre = PGPSealMreCrypto()
+mre = PGPMreCrypto()
 ```
 
 ## Entry point
 
-The provider is registered under the `swarmauri.mre_cryptos` entry-point as `PGPSealMreCrypto`.
+Providers are registered under the `swarmauri.mre_cryptos` entry-point as
+`PGPSealMreCrypto`, `PGPSealedCekMreCrypto` and `PGPMreCrypto`.
 

--- a/pkgs/standards/swarmauri_mre_crypto_pgp/pyproject.toml
+++ b/pkgs/standards/swarmauri_mre_crypto_pgp/pyproject.toml
@@ -20,10 +20,11 @@ classifiers = [
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
-    "pgpy>=0.6.0",
 ]
 
 [project.optional-dependencies]
+pgpy = ["pgpy>=0.6.0"]
+cryptography = ["cryptography>=41.0.0"]
 cbor = ["cbor2>=5.4.6"]
 
 [tool.uv.sources]
@@ -65,6 +66,10 @@ dev = [
 
 [project.entry-points.'swarmauri.mre_cryptos']
 PGPSealMreCrypto = "swarmauri_mre_crypto_pgp:PGPSealMreCrypto"
+PGPSealedCekMreCrypto = "swarmauri_mre_crypto_pgp.pgp_sealed_cek_mre:PGPSealedCekMreCrypto"
+PGPMreCrypto = "swarmauri_mre_crypto_pgp.pgp_mre:PGPMreCrypto"
 
 [project.entry-points."peagen.plugins.mre_cryptos"]
 pgp_seal = "swarmauri_mre_crypto_pgp:PGPSealMreCrypto"
+pgp_sealed_cek = "swarmauri_mre_crypto_pgp.pgp_sealed_cek_mre:PGPSealedCekMreCrypto"
+pgp_mre = "swarmauri_mre_crypto_pgp.pgp_mre:PGPMreCrypto"

--- a/pkgs/standards/swarmauri_mre_crypto_pgp/swarmauri_mre_crypto_pgp/__init__.py
+++ b/pkgs/standards/swarmauri_mre_crypto_pgp/swarmauri_mre_crypto_pgp/__init__.py
@@ -1,3 +1,11 @@
-from .PGPSealMreCrypto import PGPSealMreCrypto
+"""Package exports for the PGP MRE crypto providers."""
 
-__all__ = ["PGPSealMreCrypto"]
+from .PGPSealMreCrypto import PGPSealMreCrypto
+from .pgp_sealed_cek_mre import PGPSealedCekMreCrypto
+from .pgp_mre import PGPMreCrypto
+
+__all__ = [
+    "PGPSealMreCrypto",
+    "PGPSealedCekMreCrypto",
+    "PGPMreCrypto",
+]

--- a/pkgs/standards/swarmauri_mre_crypto_pgp/swarmauri_mre_crypto_pgp/pgp_mre.py
+++ b/pkgs/standards/swarmauri_mre_crypto_pgp/swarmauri_mre_crypto_pgp/pgp_mre.py
@@ -1,0 +1,457 @@
+"""PGPMreCrypto: OpenPGP-backed MRE provider supporting multiple modes."""
+
+from __future__ import annotations
+
+import base64
+import os
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Literal,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+)
+
+from swarmauri_core.mre_crypto.types import MultiRecipientEnvelope, RecipientId, MreMode
+from swarmauri_core.crypto.types import Alg, KeyRef
+from swarmauri_base.mre_crypto.MreCryptoBase import MreCryptoBase
+from swarmauri_base.ComponentBase import ComponentBase
+
+try:  # pragma: no cover - dependency optional at runtime
+    from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+    _CRYPTOGRAPHY_OK = True
+except Exception:  # pragma: no cover
+    _CRYPTOGRAPHY_OK = False
+
+try:  # pragma: no cover - dependency optional at runtime
+    import pgpy
+
+    _PGP_OK = True
+except Exception:  # pragma: no cover
+    _PGP_OK = False
+
+
+def _ensure_crypto() -> None:
+    if not _CRYPTOGRAPHY_OK:
+        raise RuntimeError(
+            "PGPMreCrypto requires 'cryptography'. Install with: pip install cryptography"
+        )
+
+
+def _ensure_pgpy() -> None:
+    if not _PGP_OK:
+        raise RuntimeError(
+            "PGPMreCrypto requires 'PGPy'. Install with: pip install pgpy"
+        )
+
+
+# ---------------------------------------------------------------------------
+# PGP helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_pubkey(ref: KeyRef) -> "pgpy.PGPKey":
+    _ensure_pgpy()
+    if isinstance(ref, dict):
+        kind = ref.get("kind")
+        if kind == "pgpy_pub" and isinstance(ref.get("pub"), pgpy.PGPKey):
+            return ref["pub"]
+        if kind == "pgpy_pub_armored" and isinstance(ref.get("pub"), str):
+            k, _ = pgpy.PGPKey.from_blob(ref["pub"])
+            return k
+    raise TypeError("Unsupported recipient KeyRef for PGP public key.")
+
+
+def _load_privkey(ref: KeyRef, passphrase: Optional[bytes | str]) -> "pgpy.PGPKey":
+    _ensure_pgpy()
+    if isinstance(ref, dict):
+        kind = ref.get("kind")
+        if kind == "pgpy_priv" and isinstance(ref.get("priv"), pgpy.PGPKey):
+            k: pgpy.PGPKey = ref["priv"]
+        elif kind == "pgpy_priv_armored" and isinstance(ref.get("priv"), str):
+            k, _ = pgpy.PGPKey.from_blob(ref["priv"])
+        else:
+            raise TypeError("Unsupported identity KeyRef for PGP private key.")
+        if not k.is_unlocked:
+            if passphrase is None:
+                raise RuntimeError(
+                    "PGP private key is locked; supply opts['passphrase']."
+                )
+            k.unlock(passphrase)
+        return k
+    raise TypeError("Unsupported identity KeyRef for PGP private key.")
+
+
+def _fingerprint_pub(k: "pgpy.PGPKey") -> str:
+    return str(k.fingerprint)
+
+
+def _pgp_encrypt_bytes_for(pub: "pgpy.PGPKey", data: bytes) -> bytes:
+    _ensure_pgpy()
+    msg = pgpy.PGPMessage.new(base64.b64encode(data), file=False)
+    enc = pub.encrypt(msg)
+    return bytes(enc.__bytes__())
+
+
+def _pgp_decrypt_bytes_with(priv: "pgpy.PGPKey", blob: bytes) -> bytes:
+    _ensure_pgpy()
+    msg = pgpy.PGPMessage.from_blob(blob)
+    dec = priv.decrypt(msg)
+    if isinstance(dec.message, str):
+        return base64.b64decode(dec.message.encode("utf-8"))
+    return base64.b64decode(dec.message)
+
+
+# ---------------------------------------------------------------------------
+# AEAD helpers
+# ---------------------------------------------------------------------------
+
+
+def _aead_encrypt_gcm(
+    cek: bytes, pt: bytes, *, aad: Optional[bytes]
+) -> Tuple[bytes, bytes, bytes]:
+    _ensure_crypto()
+    if len(cek) != 32:
+        raise ValueError("AES-256-GCM requires a 32-byte CEK.")
+    aead = AESGCM(cek)
+    nonce = os.urandom(12)
+    cttag = aead.encrypt(nonce, pt, aad)
+    return nonce, cttag[:-16], cttag[-16:]
+
+
+def _aead_decrypt_gcm(
+    cek: bytes, nonce: bytes, ct: bytes, tag: bytes, *, aad: Optional[bytes]
+) -> bytes:
+    _ensure_crypto()
+    aead = AESGCM(cek)
+    return aead.decrypt(nonce, ct + tag, aad)
+
+
+def _make_aead_payload(
+    payload_alg: str, nonce: bytes, ct: bytes, tag: bytes, aad: Optional[bytes]
+) -> Dict[str, Any]:
+    return {
+        "kind": "aead",
+        "alg": payload_alg,
+        "nonce": nonce,
+        "ct": ct,
+        "tag": tag,
+        "aad": aad,
+    }
+
+
+def _make_recipient_header(rid: str, header: bytes) -> Dict[str, Any]:
+    return {"id": rid, "header": header}
+
+
+def _make_sealed_recipient(rid: str, sealed_payload: bytes) -> Dict[str, Any]:
+    return {"id": rid, "sealed": sealed_payload}
+
+
+@ComponentBase.register_type(MreCryptoBase, "PGPMreCrypto")
+class PGPMreCrypto(MreCryptoBase):
+    """OpenPGP-backed multi-recipient encryption provider."""
+
+    type: Literal["PGPMreCrypto"] = "PGPMreCrypto"
+    default_payload_alg: str = "AES-256-GCM"
+    default_recipient_alg: str = "OpenPGP"
+
+    def supports(
+        self,
+    ) -> Dict[str, Iterable[str | MreMode]]:  # pragma: no cover - trivial
+        modes: Tuple[str | MreMode, ...] = (
+            MreMode.ENC_ONCE_HEADERS,
+            MreMode.SEALED_PER_RECIPIENT,
+        )
+        return {
+            "payload": (self.default_payload_alg,),
+            "recipient": ("OpenPGP", "OpenPGP-SEAL"),
+            "modes": modes,
+            "features": ("aad", "rewrap_without_reencrypt"),
+        }
+
+    async def encrypt_for_many(
+        self,
+        recipients: Sequence[KeyRef],
+        pt: bytes,
+        *,
+        payload_alg: Optional[Alg] = None,
+        recipient_alg: Optional[Alg] = None,
+        mode: Optional[MreMode | str] = None,
+        aad: Optional[bytes] = None,
+        shared: Optional[Mapping[str, bytes]] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> MultiRecipientEnvelope:
+        _ensure_pgpy()
+
+        m = (
+            MreMode(mode)
+            if isinstance(mode, str)
+            else (mode or MreMode.ENC_ONCE_HEADERS)
+        )
+        payload_alg = payload_alg or self.default_payload_alg
+        recipient_alg = recipient_alg or self.default_recipient_alg
+
+        pubs = [_load_pubkey(r) for r in recipients]
+        rids = [_fingerprint_pub(pk) for pk in pubs]
+
+        if m == MreMode.ENC_ONCE_HEADERS:
+            if payload_alg != "AES-256-GCM":
+                raise ValueError(
+                    "PGPMreCrypto currently supports only AES-256-GCM for shared payload."
+                )
+            cek = os.urandom(32)
+            nonce, ct, tag = _aead_encrypt_gcm(cek, pt, aad=aad)
+            headers = [
+                _make_recipient_header(rid, _pgp_encrypt_bytes_for(pk, cek))
+                for rid, pk in zip(rids, pubs)
+            ]
+            env: MultiRecipientEnvelope = {
+                "mode": MreMode.ENC_ONCE_HEADERS.value,
+                "payload_alg": payload_alg,
+                "recipient_alg": "OpenPGP",
+                "payload": _make_aead_payload(payload_alg, nonce, ct, tag, aad),
+                "recipients": headers,
+            }
+            if shared:
+                env["shared"] = dict(shared)
+            return env
+
+        if m == MreMode.SEALED_PER_RECIPIENT:
+            sealed_entries = [
+                _make_sealed_recipient(rid, _pgp_encrypt_bytes_for(pk, pt))
+                for rid, pk in zip(rids, pubs)
+            ]
+            env = {
+                "mode": MreMode.SEALED_PER_RECIPIENT.value,
+                "recipient_alg": "OpenPGP-SEAL",
+                "payload": {"kind": "sealed_per_recipient"},
+                "recipients": sealed_entries,
+            }
+            if shared:
+                env["shared"] = dict(shared)
+            return env
+
+        raise ValueError(f"Unsupported mode: {mode}")
+
+    async def open_for(
+        self,
+        my_identity: KeyRef,
+        env: MultiRecipientEnvelope,
+        *,
+        aad: Optional[bytes] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bytes:
+        _ensure_pgpy()
+        mode_str = env.get("mode")
+        m = MreMode(mode_str) if isinstance(mode_str, str) else mode_str
+        priv = _load_privkey(my_identity, (opts or {}).get("passphrase"))
+
+        if m == MreMode.ENC_ONCE_HEADERS:
+            my_id = str(priv.fingerprint)
+            headers: List[Dict[str, Any]] = env.get("recipients", [])
+            target = next((h for h in headers if h.get("id") == my_id), None)
+
+            cek: Optional[bytes] = None
+            if target:
+                cek = _pgp_decrypt_bytes_with(priv, target["header"])
+            else:
+                for h in headers:
+                    try:
+                        cek = _pgp_decrypt_bytes_with(priv, h["header"])
+                        break
+                    except Exception:
+                        continue
+            if cek is None:
+                raise PermissionError("This identity cannot open the envelope.")
+
+            payload = env["payload"]
+            if payload.get("alg") != "AES-256-GCM":
+                raise ValueError("Unsupported payload_alg for PGPMreCrypto open.")
+            nonce, ct, tag = payload["nonce"], payload["ct"], payload["tag"]
+            bound_aad = payload.get("aad", None)
+            if aad is not None and bound_aad is not None and aad != bound_aad:
+                raise ValueError("AAD mismatch.")
+            return _aead_decrypt_gcm(cek, nonce, ct, tag, aad=bound_aad)
+
+        if m == MreMode.SEALED_PER_RECIPIENT:
+            my_id = str(priv.fingerprint)
+            entries: List[Dict[str, Any]] = env.get("recipients", [])
+            target = next((e for e in entries if e.get("id") == my_id), None)
+            if not target:
+                for e in entries:
+                    try:
+                        return _pgp_decrypt_bytes_with(priv, e["sealed"])
+                    except Exception:
+                        continue
+                raise PermissionError("This identity cannot open the sealed envelope.")
+            return _pgp_decrypt_bytes_with(priv, target["sealed"])
+
+        raise ValueError(f"Unsupported mode: {mode_str}")
+
+    async def open_for_many(
+        self,
+        my_identities: Sequence[KeyRef],
+        env: MultiRecipientEnvelope,
+        *,
+        aad: Optional[bytes] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bytes:
+        last_err: Optional[Exception] = None
+        for ident in my_identities:
+            try:
+                return await self.open_for(ident, env, aad=aad, opts=opts)
+            except Exception as e:  # pragma: no cover
+                last_err = e
+                continue
+        raise last_err or PermissionError(
+            "None of the provided identities could open the envelope."
+        )
+
+    async def rewrap(
+        self,
+        env: MultiRecipientEnvelope,
+        *,
+        add: Optional[Sequence[KeyRef]] = None,
+        remove: Optional[Sequence[RecipientId]] = None,
+        recipient_alg: Optional[Alg] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> MultiRecipientEnvelope:
+        _ensure_pgpy()
+        mode_str = env.get("mode")
+        m = MreMode(mode_str) if isinstance(mode_str, str) else mode_str
+
+        add = add or ()
+        remove_ids = set(remove or ())
+
+        new_env: MultiRecipientEnvelope = {k: v for k, v in env.items()}
+
+        if m == MreMode.ENC_ONCE_HEADERS:
+            current_headers: List[Dict[str, Any]] = list(new_env.get("recipients", []))
+            if remove_ids:
+                current_headers = [
+                    h for h in current_headers if h.get("id") not in remove_ids
+                ]
+
+            cek: Optional[bytes] = None
+            if add:
+                if opts and isinstance(opts.get("cek"), (bytes, bytearray)):
+                    cek = bytes(opts["cek"])
+                elif opts and opts.get("manage_key"):
+                    manage_key = _load_privkey(
+                        opts["manage_key"], (opts or {}).get("passphrase")
+                    )
+                    candidate_headers = current_headers or list(
+                        env.get("recipients", [])
+                    )
+                    for h in candidate_headers:
+                        try:
+                            cek = _pgp_decrypt_bytes_with(manage_key, h["header"])
+                            break
+                        except Exception:
+                            continue
+                else:
+                    raise RuntimeError(
+                        "Rewrap(add=...) requires opts['cek'] or opts['manage_key']."
+                    )
+
+            if add and cek is not None:
+                pubs = [_load_pubkey(r) for r in add]
+                rids = [_fingerprint_pub(pk) for pk in pubs]
+                new_headers = [
+                    _make_recipient_header(rid, _pgp_encrypt_bytes_for(pk, cek))
+                    for rid, pk in zip(rids, pubs)
+                ]
+                merged: List[Dict[str, Any]] = []
+                for h in current_headers:
+                    if h["id"] not in {rid for rid in rids}:
+                        merged.append(h)
+                merged.extend(new_headers)
+                current_headers = merged
+
+            rotate = bool(opts.get("rotate_payload_on_revoke")) if opts else False
+            if remove_ids and rotate:
+                if not cek:
+                    if opts and opts.get("manage_key"):
+                        manage_key = _load_privkey(
+                            opts["manage_key"], (opts or {}).get("passphrase")
+                        )
+                        for h in env.get("recipients", []):
+                            try:
+                                cek = _pgp_decrypt_bytes_with(manage_key, h["header"])
+                                break
+                            except Exception:
+                                continue
+                    if not cek:
+                        raise RuntimeError(
+                            "rotate_payload_on_revoke requires CEK via opts['manage_key'] or opts['cek']."
+                        )
+
+                new_cek = os.urandom(32)
+                payload = env["payload"]
+                old_pt = _aead_decrypt_gcm(
+                    cek,
+                    payload["nonce"],
+                    payload["ct"],
+                    payload["tag"],
+                    aad=payload.get("aad"),
+                )
+                nonce, ct, tag = _aead_encrypt_gcm(
+                    new_cek, old_pt, aad=payload.get("aad")
+                )
+                new_env["payload"] = _make_aead_payload(
+                    env.get("payload_alg", self.default_payload_alg),
+                    nonce,
+                    ct,
+                    tag,
+                    payload.get("aad"),
+                )
+
+                add_pubkeys = (opts or {}).get("add_pubkeys")
+                if not isinstance(add_pubkeys, (list, tuple)) or not add_pubkeys:
+                    raise RuntimeError(
+                        "After rotation, provide opts['add_pubkeys'] = [KeyRef(pub=...), ...] for remaining recipients."
+                    )
+                pubs = [_load_pubkey(r) for r in add_pubkeys]
+                rids = [_fingerprint_pub(pk) for pk in pubs]
+                new_headers = [
+                    _make_recipient_header(rid, _pgp_encrypt_bytes_for(pk, new_cek))
+                    for rid, pk in zip(rids, pubs)
+                ]
+                current_headers = new_headers
+
+            new_env["recipients"] = current_headers
+            return new_env
+
+        if m == MreMode.SEALED_PER_RECIPIENT:
+            current_entries: List[Dict[str, Any]] = list(new_env.get("recipients", []))
+            if remove_ids:
+                current_entries = [
+                    e for e in current_entries if e.get("id") not in remove_ids
+                ]
+            if add:
+                pt_bytes = (opts or {}).get("plaintext")
+                if not isinstance(pt_bytes, (bytes, bytearray)):
+                    raise RuntimeError(
+                        "Rewrap(add=...) in sealed_per_recipient mode requires opts['plaintext']."
+                    )
+                pubs = [_load_pubkey(r) for r in add]
+                rids = [_fingerprint_pub(pk) for pk in pubs]
+                new_entries = [
+                    _make_sealed_recipient(rid, _pgp_encrypt_bytes_for(pk, pt_bytes))
+                    for rid, pk in zip(rids, pubs)
+                ]
+                remaining = [
+                    e for e in current_entries if e["id"] not in {rid for rid in rids}
+                ]
+                current_entries = remaining + new_entries
+
+            new_env["recipients"] = current_entries
+            return new_env
+
+        raise ValueError(f"Unsupported mode for rewrap: {mode_str}")

--- a/pkgs/standards/swarmauri_mre_crypto_pgp/swarmauri_mre_crypto_pgp/pgp_sealed_cek_mre.py
+++ b/pkgs/standards/swarmauri_mre_crypto_pgp/swarmauri_mre_crypto_pgp/pgp_sealed_cek_mre.py
@@ -1,0 +1,347 @@
+"""PGPSealedCekMreCrypto
+
+Multi-recipient encryption provider using a shared AEAD payload and OpenPGP
+sealing of the content-encryption key (CEK).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+import os
+
+from swarmauri_core.mre_crypto.IMreCrypto import IMreCrypto
+from swarmauri_core.crypto.types import Alg, KeyRef
+
+try:  # type-checking only
+    from swarmauri_core.mre_crypto.types import MultiRecipientEnvelope, RecipientId
+except Exception:  # pragma: no cover - typing fallback
+    MultiRecipientEnvelope = Dict[str, Any]  # type: ignore
+    RecipientId = str  # type: ignore
+
+try:  # pragma: no cover - optional runtime dep
+    from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+    _CRYPTOGRAPHY_OK = True
+except Exception:  # pragma: no cover
+    _CRYPTOGRAPHY_OK = False
+
+try:  # pragma: no cover - optional runtime dep
+    import pgpy
+
+    _PGP_OK = True
+except Exception:  # pragma: no cover
+    _PGP_OK = False
+
+
+def _ensure_crypto() -> None:
+    if not _CRYPTOGRAPHY_OK:
+        raise RuntimeError(
+            "PGPSealedCekMreCrypto requires 'cryptography'. Install with: pip install cryptography"
+        )
+
+
+def _ensure_pgpy() -> None:
+    if not _PGP_OK:
+        raise RuntimeError(
+            "PGPSealedCekMreCrypto requires 'PGPy'. Install with: pip install pgpy"
+        )
+
+
+# ---------------------------------------------------------------------------
+# PGP helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_pgpy_pubkey(rec: KeyRef) -> Tuple[str, "pgpy.PGPKey"]:
+    _ensure_pgpy()
+    if isinstance(rec, dict):
+        kind = rec.get("kind")
+        if kind == "pgpy_pub" and isinstance(rec.get("pub"), pgpy.PGPKey):
+            pk = rec["pub"]
+        elif kind == "pgpy_key" and isinstance(rec.get("key"), pgpy.PGPKey):
+            k = rec["key"]
+            pk = k.pubkey if hasattr(k, "pubkey") else k
+        elif kind == "pgpy_pub_armored" and isinstance(rec.get("pub"), str):
+            pk, _ = pgpy.PGPKey.from_blob(rec["pub"])
+        else:
+            raise TypeError("Unsupported KeyRef for PGP public key encryption.")
+    else:
+        raise TypeError("Unsupported KeyRef type for PGP public key encryption.")
+
+    if getattr(pk, "is_public", True) is False and hasattr(pk, "pubkey"):
+        pk = pk.pubkey  # type: ignore[arg-type]
+
+    rid = str(pk.fingerprint)
+    return rid, pk
+
+
+def _load_pgpy_privkey(
+    my: KeyRef, *, passphrase: Optional[bytes | str]
+) -> "pgpy.PGPKey":
+    _ensure_pgpy()
+    if isinstance(my, dict):
+        kind = my.get("kind")
+        if kind == "pgpy_key" and isinstance(my.get("key"), pgpy.PGPKey):
+            k = my["key"]
+        elif kind == "pgpy_key_armored" and isinstance(my.get("key"), str):
+            k, _ = pgpy.PGPKey.from_blob(my["key"])
+        else:
+            raise TypeError("Unsupported KeyRef for PGP private key.")
+    else:
+        raise TypeError("Unsupported KeyRef for PGP private key.")
+
+    if getattr(k, "is_unlocked", True) is False:
+        if passphrase is None:
+            raise RuntimeError("PGP private key is locked. Provide opts['passphrase'].")
+        k.unlock(passphrase)
+    return k
+
+
+# ---------------------------------------------------------------------------
+# AEAD helpers
+# ---------------------------------------------------------------------------
+
+
+def _aead_encrypt(
+    cek: bytes, pt: bytes, *, aad: Optional[bytes]
+) -> Tuple[bytes, bytes, bytes]:
+    _ensure_crypto()
+    if len(cek) not in (16, 24, 32):
+        raise ValueError("AES-GCM key must be 16/24/32 bytes.")
+    nonce = os.urandom(12)
+    aead = AESGCM(cek)
+    ct_plus_tag = aead.encrypt(nonce, pt, aad)
+    tag = ct_plus_tag[-16:]
+    ct = ct_plus_tag[:-16]
+    return nonce, ct, tag
+
+
+def _aead_decrypt(
+    cek: bytes, nonce: bytes, ct: bytes, tag: bytes, *, aad: Optional[bytes]
+) -> bytes:
+    _ensure_crypto()
+    aead = AESGCM(cek)
+    return aead.decrypt(nonce, ct + tag, aad)
+
+
+class PGPSealedCekMreCrypto(IMreCrypto):
+    """IMreCrypto provider for the ``sealed_cek+aead`` mode using OpenPGP."""
+
+    def supports(self) -> Dict[str, Iterable[str]]:  # pragma: no cover - trivial
+        return {
+            "payload": ("AES-256-GCM",),
+            "recipient": ("OpenPGP-SEAL",),
+            "modes": ("sealed_cek+aead",),
+            "features": ("aad", "rewrap_without_reencrypt"),
+        }
+
+    async def encrypt_for_many(
+        self,
+        recipients: Sequence[KeyRef],
+        pt: bytes,
+        *,
+        payload_alg: Optional[Alg] = None,
+        recipient_alg: Optional[Alg] = None,
+        mode: Optional[str] = None,
+        aad: Optional[bytes] = None,
+        shared: Optional[Mapping[str, bytes]] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> MultiRecipientEnvelope:
+        mode = mode or "sealed_cek+aead"
+        if mode != "sealed_cek+aead":
+            raise ValueError(
+                "PGPSealedCekMreCrypto only supports mode='sealed_cek+aead'."
+            )
+        payload_alg = payload_alg or "AES-256-GCM"
+        if payload_alg != "AES-256-GCM":
+            raise ValueError("Unsupported payload_alg for PGPSealedCekMreCrypto.")
+        recipient_alg = recipient_alg or "OpenPGP-SEAL"
+        if recipient_alg != "OpenPGP-SEAL":
+            raise ValueError(
+                "Unsupported recipient_alg for PGPSealedCekMreCrypto (expected 'OpenPGP-SEAL')."
+            )
+        if not recipients:
+            raise ValueError("At least one recipient is required.")
+
+        cek = os.urandom(32)
+        nonce, ct, tag = _aead_encrypt(cek, pt, aad=aad)
+
+        _ensure_pgpy()
+        rec_headers: List[Dict[str, Any]] = []
+        for rec in recipients:
+            rid, pub = _load_pgpy_pubkey(rec)
+            literal = pgpy.PGPMessage.new(cek, file=False)
+            enc = pub.encrypt(literal)
+            header_bytes = bytes(enc.__bytes__())
+            rec_headers.append({"id": rid, "header": header_bytes})
+
+        env: MultiRecipientEnvelope = {
+            "mode": "sealed_cek+aead",
+            "payload": {
+                "kind": "aead",
+                "alg": payload_alg,
+                "nonce": nonce,
+                "ct": ct,
+                "tag": tag,
+                "aad": aad,
+            },
+            "recipient_alg": recipient_alg,
+            "recipients": rec_headers,
+            "shared": dict(shared) if shared else None,
+            "version": 1,
+        }
+        return env
+
+    async def open_for(
+        self,
+        my_identity: KeyRef,
+        env: MultiRecipientEnvelope,
+        *,
+        aad: Optional[bytes] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bytes:
+        if env.get("mode") != "sealed_cek+aead":
+            raise ValueError("Unsupported envelope mode.")
+        payload = env.get("payload") or {}
+        if not isinstance(payload, dict) or payload.get("kind") != "aead":
+            raise ValueError("Malformed envelope payload for sealed_cek+aead.")
+        nonce: bytes = payload["nonce"]
+        ct: bytes = payload["ct"]
+        tag: bytes = payload["tag"]
+        bound_aad = payload.get("aad", None)
+        if (
+            (aad is not None)
+            and (bound_aad is not None)
+            and (bytes(aad) != bytes(bound_aad))
+        ):
+            raise ValueError("AAD mismatch.")
+
+        passphrase = None
+        if opts and "passphrase" in opts:
+            passphrase = opts["passphrase"]
+        priv = _load_pgpy_privkey(my_identity, passphrase=passphrase)
+        my_rid = str((priv.pubkey if hasattr(priv, "pubkey") else priv).fingerprint)
+
+        header = None
+        for ent in env.get("recipients") or []:
+            if ent.get("id") == my_rid:
+                header = ent.get("header")
+                break
+        if not isinstance(header, (bytes, bytearray)):
+            raise ValueError("Recipient not found in envelope.")
+
+        sealed = pgpy.PGPMessage.from_blob(bytes(header))
+        lit = priv.decrypt(sealed)
+        cek = bytes(lit.message)
+        return _aead_decrypt(cek, nonce, ct, tag, aad=bound_aad)
+
+    async def open_for_many(
+        self,
+        my_identities: Sequence[KeyRef],
+        env: MultiRecipientEnvelope,
+        *,
+        aad: Optional[bytes] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bytes:
+        last_err: Optional[Exception] = None
+        for kid in my_identities:
+            try:
+                return await self.open_for(kid, env, aad=aad, opts=opts)
+            except Exception as e:  # pragma: no cover - best effort
+                last_err = e
+                continue
+        raise (
+            last_err
+            if last_err
+            else RuntimeError("Failed to open envelope with provided identities.")
+        )
+
+    async def rewrap(
+        self,
+        env: MultiRecipientEnvelope,
+        *,
+        add: Optional[Sequence[KeyRef]] = None,
+        remove: Optional[Sequence[RecipientId]] = None,
+        recipient_alg: Optional[Alg] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> MultiRecipientEnvelope:
+        if env.get("mode") != "sealed_cek+aead":
+            raise ValueError("Unsupported envelope mode for rewrap.")
+        if recipient_alg and recipient_alg != "OpenPGP-SEAL":
+            raise ValueError(
+                "PGPSealedCekMreCrypto only supports recipient_alg='OpenPGP-SEAL' in rewrap."
+            )
+
+        add = add or []
+        remove_ids = set(remove or [])
+        recipients = list(env.get("recipients") or [])
+        payload = env.get("payload") or {}
+        rotate_flag = bool((opts or {}).get("rotate_payload_on_revoke")) and bool(
+            remove_ids
+        )
+
+        cek: Optional[bytes] = None
+        need_cek = add or rotate_flag
+        if need_cek:
+            if opts and isinstance(opts.get("cek"), (bytes, bytearray)):
+                cek = bytes(opts["cek"])
+            else:
+                opener_list = (opts or {}).get("opener_identities")
+                if not opener_list:
+                    raise RuntimeError(
+                        "Rewrap(add=... or rotate) requires opts['cek'] or opts['opener_identities']."
+                    )
+                if not isinstance(opener_list, (list, tuple)):
+                    opener_list = [opener_list]
+                passphrase = (opts or {}).get("passphrase")
+                for ident in opener_list:
+                    try:
+                        priv = _load_pgpy_privkey(ident, passphrase=passphrase)
+                        for ent in recipients:
+                            try:
+                                sealed = pgpy.PGPMessage.from_blob(bytes(ent["header"]))
+                                with priv:
+                                    lit = priv.decrypt(sealed)
+                                cek = bytes(lit.message)
+                                break
+                            except Exception:
+                                continue
+                        if cek:
+                            break
+                    except Exception:
+                        continue
+            if cek is None:
+                raise RuntimeError("Unable to recover CEK for rewrap.")
+
+        if remove_ids:
+            recipients = [r for r in recipients if r.get("id") not in remove_ids]
+
+        if rotate_flag and cek is not None:
+            new_cek = os.urandom(32)
+            bound_aad = payload.get("aad")
+            pt = _aead_decrypt(
+                cek, payload["nonce"], payload["ct"], payload["tag"], aad=bound_aad
+            )
+            nonce, ct, tag = _aead_encrypt(new_cek, pt, aad=bound_aad)
+            env["payload"] = {
+                "kind": "aead",
+                "alg": payload.get("alg", "AES-256-GCM"),
+                "nonce": nonce,
+                "ct": ct,
+                "tag": tag,
+                "aad": bound_aad,
+            }
+            cek = new_cek
+            recipients = []
+
+        for rec in add:
+            rid, pub = _load_pgpy_pubkey(rec)
+            literal = pgpy.PGPMessage.new(cek, file=False)
+            enc = pub.encrypt(literal)
+            header_bytes = bytes(enc.__bytes__())
+            recipients = [r for r in recipients if r.get("id") != rid]
+            recipients.append({"id": rid, "header": header_bytes})
+
+        env["recipients"] = recipients
+        return env

--- a/pkgs/standards/swarmauri_mre_crypto_pgp/tests/i9n/test_pgpmrecrypto_rewrap_integration.py
+++ b/pkgs/standards/swarmauri_mre_crypto_pgp/tests/i9n/test_pgpmrecrypto_rewrap_integration.py
@@ -1,0 +1,48 @@
+import pytest
+from pgpy import PGPKey, PGPUID
+from pgpy.constants import (
+    CompressionAlgorithm,
+    HashAlgorithm,
+    KeyFlags,
+    PubKeyAlgorithm,
+    SymmetricKeyAlgorithm,
+)
+
+from swarmauri_mre_crypto_pgp import PGPMreCrypto
+
+
+def make_key(email: str) -> PGPKey:
+    key = PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 2048)
+    uid = PGPUID.new("User", email=email)
+    key.add_uid(
+        uid,
+        usage={KeyFlags.EncryptCommunications},
+        hashes=[HashAlgorithm.SHA256],
+        ciphers=[SymmetricKeyAlgorithm.AES256],
+        compression=[CompressionAlgorithm.ZLIB],
+    )
+    return key
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_rewrap_add_and_remove_enc_once_headers():
+    crypto = PGPMreCrypto()
+    key1 = make_key("a@example.com")
+    key2 = make_key("b@example.com")
+    pub1 = {"kind": "pgpy_pub", "pub": key1.pubkey}
+    priv1 = {"kind": "pgpy_priv", "priv": key1}
+    pub2 = {"kind": "pgpy_pub", "pub": key2.pubkey}
+    priv2 = {"kind": "pgpy_priv", "priv": key2}
+    pt = b"integration"
+
+    env = await crypto.encrypt_for_many([pub1], pt)
+    env = await crypto.rewrap(env, add=[pub2], opts={"manage_key": priv1})
+    assert len(env["recipients"]) == 2
+    env = await crypto.rewrap(env, remove=[str(key1.fingerprint)])
+    assert len(env["recipients"]) == 1
+
+    rt = await crypto.open_for(priv2, env)
+    assert rt == pt
+    with pytest.raises(PermissionError):
+        await crypto.open_for(priv1, env)

--- a/pkgs/standards/swarmauri_mre_crypto_pgp/tests/perf/test_pgpmrecrypto_encrypt_perf.py
+++ b/pkgs/standards/swarmauri_mre_crypto_pgp/tests/perf/test_pgpmrecrypto_encrypt_perf.py
@@ -1,0 +1,43 @@
+import asyncio
+
+import pytest
+from pgpy import PGPKey, PGPUID
+from pgpy.constants import (
+    CompressionAlgorithm,
+    HashAlgorithm,
+    KeyFlags,
+    PubKeyAlgorithm,
+    SymmetricKeyAlgorithm,
+)
+
+from swarmauri_mre_crypto_pgp import PGPMreCrypto
+
+
+def gen_key() -> PGPKey:
+    key = PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 2048)
+    uid = PGPUID.new("Perf", email="perf@example.com")
+    key.add_uid(
+        uid,
+        usage={KeyFlags.EncryptCommunications},
+        hashes=[HashAlgorithm.SHA256],
+        ciphers=[SymmetricKeyAlgorithm.AES256],
+        compression=[CompressionAlgorithm.ZLIB],
+    )
+    return key
+
+
+@pytest.mark.perf
+@pytest.mark.test
+def test_encrypt_open_perf_pgpmrecrypto(benchmark):
+    crypto = PGPMreCrypto()
+    key = gen_key()
+    pub_ref = {"kind": "pgpy_pub", "pub": key.pubkey}
+    priv_ref = {"kind": "pgpy_priv", "priv": key}
+    pt = b"performance"
+
+    async def run():
+        env = await crypto.encrypt_for_many([pub_ref], pt)
+        return await crypto.open_for(priv_ref, env)
+
+    result = benchmark(lambda: asyncio.run(run()))
+    assert result == pt

--- a/pkgs/standards/swarmauri_mre_crypto_pgp/tests/unit/test_PGPMreCrypto.py
+++ b/pkgs/standards/swarmauri_mre_crypto_pgp/tests/unit/test_PGPMreCrypto.py
@@ -8,7 +8,7 @@ from pgpy.constants import (
     SymmetricKeyAlgorithm,
 )
 
-from swarmauri_mre_crypto_pgp import PGPSealMreCrypto
+from swarmauri_mre_crypto_pgp import PGPMreCrypto
 
 
 def generate_key() -> PGPKey:
@@ -32,20 +32,18 @@ def pgp_keys():
 
 @pytest.fixture
 def crypto():
-    return PGPSealMreCrypto()
+    return PGPMreCrypto()
 
 
 @pytest.mark.unit
 def test_resource_and_type(crypto):
     assert crypto.resource == "Crypto"
-    assert crypto.type == "PGPSealMreCrypto"
+    assert crypto.type == "PGPMreCrypto"
 
 
 @pytest.mark.unit
 def test_serialization(crypto):
-    assert (
-        crypto.id == PGPSealMreCrypto.model_validate_json(crypto.model_dump_json()).id
-    )
+    assert crypto.id == PGPMreCrypto.model_validate_json(crypto.model_dump_json()).id
 
 
 @pytest.mark.asyncio

--- a/pkgs/standards/swarmauri_mre_crypto_pgp/tests/unit/test_PGPSealedCekMreCrypto.py
+++ b/pkgs/standards/swarmauri_mre_crypto_pgp/tests/unit/test_PGPSealedCekMreCrypto.py
@@ -8,7 +8,7 @@ from pgpy.constants import (
     SymmetricKeyAlgorithm,
 )
 
-from swarmauri_mre_crypto_pgp import PGPSealMreCrypto
+from swarmauri_mre_crypto_pgp import PGPSealedCekMreCrypto
 
 
 def generate_key() -> PGPKey:
@@ -27,25 +27,18 @@ def generate_key() -> PGPKey:
 @pytest.fixture
 def pgp_keys():
     key = generate_key()
-    return {"kind": "pgpy_pub", "pub": key.pubkey}, {"kind": "pgpy_priv", "priv": key}
+    return {"kind": "pgpy_pub", "pub": key.pubkey}, {"kind": "pgpy_key", "key": key}
 
 
 @pytest.fixture
 def crypto():
-    return PGPSealMreCrypto()
+    return PGPSealedCekMreCrypto()
 
 
 @pytest.mark.unit
-def test_resource_and_type(crypto):
-    assert crypto.resource == "Crypto"
-    assert crypto.type == "PGPSealMreCrypto"
-
-
-@pytest.mark.unit
-def test_serialization(crypto):
-    assert (
-        crypto.id == PGPSealMreCrypto.model_validate_json(crypto.model_dump_json()).id
-    )
+def test_supports(crypto):
+    caps = crypto.supports()
+    assert "sealed_cek+aead" in caps["modes"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- expand plugin with `PGPSealedCekMreCrypto` and `PGPMreCrypto`
- expose providers via new entry points and optional pgpy/cryptography extras
- cover providers with unit, integration, and performance tests

## Testing
- `uv run --directory pkgs/standards/swarmauri_mre_crypto_pgp --package swarmauri_mre_crypto_pgp ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_mre_crypto_pgp --package swarmauri_mre_crypto_pgp --extra pgpy --extra cryptography pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a702d22948832693deb804fdc46232