### PR TITLE
feat(standards): add JWS signer verifier plugin

### DIFF
--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -93,6 +93,7 @@ members = [
     "standards/swarmauri_secret_autogpg",
     "standards/swarmauri_signing_pgp",
     "standards/swarmauri_signing_rsa",
+    "standards/swarmauri_signing_jws",
     "standards/swarmauri_signing_ssh",
     "community/swarmauri_middleware_circuitbreaker",
     "community/swarmauri_middleware_ratepolicy",

--- a/pkgs/standards/swarmauri_signing_jws/LICENSE
+++ b/pkgs/standards/swarmauri_signing_jws/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/standards/swarmauri_signing_jws/README.md
+++ b/pkgs/standards/swarmauri_signing_jws/README.md
@@ -1,0 +1,28 @@
+![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+
+# Swarmauri Signing JWS
+
+Composite JWS signer/verifier supporting multiple algorithms and JWKS resolution.
+
+Features:
+- Compact and General JSON JWS
+- HMAC, RSA, ECDSA, Ed25519, and optional secp256k1 algorithms
+- RFC 7515 and RFC 7797 (unencoded payload) compliance
+
+## Installation
+
+```bash
+pip install swarmauri_signing_jws
+```
+
+## Usage
+
+```python
+from swarmauri_signing_jws import JwsSignerVerifier
+
+jws = JwsSignerVerifier()
+```
+
+## Entry Point
+
+Registers `JwsSignerVerifier` under the `swarmauri.signings` entry point.

--- a/pkgs/standards/swarmauri_signing_jws/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_jws/pyproject.toml
@@ -1,0 +1,80 @@
+[project]
+name = "swarmauri_signing_jws"
+version = "0.1.0"
+description = "Composite JWS signer/verifier for Swarmauri"
+license = "Apache-2.0"
+readme = "README.md"
+requires-python = ">=3.10,<3.13"
+authors = [{ name = "Swarmauri", email = "opensource@swarmauri.com" }]
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Development Status :: 3 - Alpha",
+    "Topic :: Security :: Cryptography",
+    "Intended Audience :: Developers",
+]
+dependencies = [
+    "swarmauri_core",
+    "swarmauri_base",
+    "swarmauri_signing_hmac",
+    "swarmauri_signing_rsa",
+    "swarmauri_signing_ecdsa",
+    "swarmauri_signing_ed25519",
+    "cryptography",
+]
+
+[project.optional-dependencies]
+secp256k1 = ["swarmauri_signing_secp256k1"]
+cbor = ["cbor2"]
+
+[tool.uv.sources]
+swarmauri_core = { workspace = true }
+swarmauri_base = { workspace = true }
+swarmauri_signing_hmac = { workspace = true }
+swarmauri_signing_rsa = { workspace = true }
+swarmauri_signing_ecdsa = { workspace = true }
+swarmauri_signing_ed25519 = { workspace = true }
+swarmauri_signing_secp256k1 = { workspace = true }
+
+[tool.pytest.ini_options]
+norecursedirs = ["combined", "scripts"]
+markers = [
+    "test: standard test",
+    "unit: Unit tests",
+    "i9n: Integration tests",
+    "r8n: Regression tests",
+    "acceptance: Acceptance tests",
+    "perf: Performance tests",
+]
+timeout = 300
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "pytest-timeout>=2.3.1",
+    "pytest-benchmark>=4.0.0",
+    "flake8>=7.0",
+    "ruff>=0.9.9",
+]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[project.entry-points.'swarmauri.signings']
+JwsSignerVerifier = "swarmauri_signing_jws:JwsSignerVerifier"
+
+[project.entry-points."peagen.plugins.signings"]
+jws = "swarmauri_signing_jws:JwsSignerVerifier"

--- a/pkgs/standards/swarmauri_signing_jws/swarmauri_signing_jws/__init__.py
+++ b/pkgs/standards/swarmauri_signing_jws/swarmauri_signing_jws/__init__.py
@@ -1,0 +1,607 @@
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Mapping, Optional, Sequence, Tuple, Union
+
+from swarmauri_signing_hmac import HmacEnvelopeSigner
+from swarmauri_signing_rsa import RSAEnvelopeSigner
+from swarmauri_signing_ecdsa import EcdsaEnvelopeSigner
+from swarmauri_signing_ed25519 import Ed25519EnvelopeSigner
+
+try:  # optional secp256k1
+    from swarmauri_signing_secp256k1 import Secp256k1EnvelopeSigner
+
+    _HAS_K1 = True
+except Exception:  # pragma: no cover - optional dependency
+    _HAS_K1 = False
+
+try:  # ECDSA DER<->raw conversion
+    from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
+
+    _CRYPTO_OK = True
+except Exception:  # pragma: no cover - cryptography missing
+    _CRYPTO_OK = False
+
+
+def _b64u(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64u_dec(s: str) -> bytes:
+    pad = "=" * ((4 - (len(s) % 4)) % 4)
+    return base64.urlsafe_b64decode(s + pad)
+
+
+_ECDSA_RAW_LEN = {"ES256": 32 * 2, "ES384": 48 * 2, "ES512": 66 * 2}
+
+
+def _ecdsa_der_to_raw(sig_der: bytes, alg: str) -> bytes:
+    if not _CRYPTO_OK:  # pragma: no cover - defensive
+        raise RuntimeError("cryptography is required for ECDSA DER→raw conversion")
+    r, s = decode_dss_signature(sig_der)
+    n = _ECDSA_RAW_LEN[alg] // 2
+    return r.to_bytes(n, "big") + s.to_bytes(n, "big")
+
+
+def _jwk_to_pub_for_signer(jwk: Mapping[str, Any]) -> Any:
+    kty = jwk.get("kty")
+    if kty == "RSA":
+        return jwk
+    if kty == "EC":
+        return jwk
+    if kty == "OKP" and jwk.get("crv") == "Ed25519":
+        x = jwk.get("x")
+        if not isinstance(x, str):
+            raise ValueError("Invalid Ed25519 JWK")
+        return _b64u_dec(x)
+    if kty == "oct":
+        k = jwk.get("k")
+        if not isinstance(k, str):
+            raise ValueError("Invalid oct JWK")
+        return _b64u_dec(k)
+    raise ValueError(f"Unsupported JWK kty: {kty}")
+
+
+_RSA_RS = {
+    "RS256": "RSA-PKCS1v15-SHA256",
+    "RS384": "RSA-PKCS1v15-SHA384",
+    "RS512": "RSA-PKCS1v15-SHA512",
+}
+_RSA_PS = {
+    "PS256": "RSA-PSS-SHA256",
+    "PS384": "RSA-PSS-SHA384",
+    "PS512": "RSA-PSS-SHA512",
+}
+_EC_SET = {"ES256", "ES384", "ES512"}
+_K1_SET = {"ES256K"}
+_HS_SET = {"HS256", "HS384", "HS512"}
+_EDDSA = "EdDSA"
+
+
+def _is_rsa(alg: str) -> bool:
+    return alg in _RSA_RS or alg in _RSA_PS
+
+
+def _is_ec(alg: str) -> bool:
+    return alg in _EC_SET
+
+
+def _is_k1(alg: str) -> bool:
+    return alg in _K1_SET
+
+
+def _is_hmac(alg: str) -> bool:
+    return alg in _HS_SET
+
+
+def _is_eddsa(alg: str) -> bool:
+    return alg == _EDDSA
+
+
+JWSCompact = str
+
+
+@dataclass
+class JwsResult:
+    header: Dict[str, Any]
+    payload: bytes
+
+
+class JwsSignerVerifier:
+    """Composite JWS signer/verifier supporting multiple algorithms."""
+
+    def __init__(
+        self,
+        *,
+        hmac_signer: Optional[HmacEnvelopeSigner] = None,
+        rsa_signer: Optional[RSAEnvelopeSigner] = None,
+        ecdsa_signer: Optional[EcdsaEnvelopeSigner] = None,
+        eddsa_signer: Optional[Ed25519EnvelopeSigner] = None,
+        k1_signer: Optional[Any] = None,
+    ) -> None:
+        self.hmac = hmac_signer or HmacEnvelopeSigner()
+        self.rsa = rsa_signer or RSAEnvelopeSigner()
+        self.ecdsa = ecdsa_signer or EcdsaEnvelopeSigner()
+        self.eddsa = eddsa_signer or Ed25519EnvelopeSigner()
+        self.k1 = k1_signer or (Secp256k1EnvelopeSigner() if _HAS_K1 else None)
+
+    async def sign_compact(
+        self,
+        *,
+        payload: Union[bytes, str, Mapping[str, Any]],
+        alg: str,
+        key: Mapping[str, Any],
+        kid: Optional[str] = None,
+        header_extra: Optional[Mapping[str, Any]] = None,
+        typ: Optional[str] = None,
+    ) -> JWSCompact:
+        if isinstance(payload, str):
+            payload_b = payload.encode("utf-8")
+        elif isinstance(payload, (bytes, bytearray)):
+            payload_b = bytes(payload)
+        else:
+            payload_b = json.dumps(
+                payload, separators=(",", ":"), ensure_ascii=False
+            ).encode("utf-8")
+
+        header: Dict[str, Any] = {"alg": alg}
+        if kid:
+            header["kid"] = kid
+        if typ:
+            header["typ"] = typ
+        if header_extra:
+            header.update(dict(header_extra))
+
+        b64 = header.get("b64", True)
+        if not b64 and "b64" not in header.get("crit", []):
+            raise ValueError("'b64': false requires 'b64' in 'crit'")
+
+        b64_header = _b64u(
+            json.dumps(header, separators=(",", ":"), ensure_ascii=False).encode(
+                "utf-8"
+            )
+        )
+        if b64:
+            b64_payload = _b64u(payload_b)
+            signing_input = f"{b64_header}.{b64_payload}".encode("ascii")
+        else:
+            if isinstance(payload_b, bytes):
+                payload_part = payload_b.decode("utf-8")
+            else:  # pragma: no cover - impossible
+                payload_part = payload_b
+            b64_payload = payload_part
+            signing_input = f"{b64_header}.{b64_payload}".encode("utf-8")
+
+        sig_bytes = await self._sign_for_alg(signing_input, alg, key)
+        b64sig = _b64u(sig_bytes)
+        return f"{b64_header}.{b64_payload}.{b64sig}"
+
+    async def verify_compact(
+        self,
+        jws: JWSCompact,
+        *,
+        hmac_keys: Optional[Sequence[Mapping[str, Any]]] = None,
+        rsa_pubkeys: Optional[Sequence[Any]] = None,
+        ec_pubkeys: Optional[Sequence[Any]] = None,
+        ed_pubkeys: Optional[Sequence[Any]] = None,
+        k1_pubkeys: Optional[Sequence[Any]] = None,
+        jwks_resolver: Optional[callable] = None,
+        alg_allowlist: Optional[Iterable[str]] = None,
+    ) -> JwsResult:
+        parts = jws.split(".")
+        if len(parts) != 3:
+            raise ValueError("Invalid JWS compact serialization.")
+        b64_header, payload_part, b64_sig = parts
+        try:
+            header = json.loads(_b64u_dec(b64_header))
+        except Exception as exc:
+            raise ValueError(f"Invalid JWS header: {exc}")
+        alg = header.get("alg")
+        kid = header.get("kid")
+        if not isinstance(alg, str):
+            raise ValueError("Missing/invalid 'alg' in JWS header.")
+        if alg_allowlist and alg not in set(alg_allowlist):
+            raise ValueError(f"Rejected alg '{alg}' (not in allowlist).")
+
+        b64 = header.get("b64", True)
+        if not b64 and "b64" not in header.get("crit", []):
+            raise ValueError("'b64': false requires 'b64' in 'crit'")
+
+        if b64:
+            payload_b = _b64u_dec(payload_part)
+            signing_input = f"{b64_header}.{payload_part}".encode("ascii")
+        else:
+            payload_b = payload_part.encode("utf-8")
+            signing_input = f"{b64_header}.{payload_part}".encode("utf-8")
+
+        sig = _b64u_dec(b64_sig)
+
+        if jwks_resolver:
+            jwk = jwks_resolver(kid, alg)
+            if _is_hmac(alg):
+                ok = await self.hmac.verify_bytes(
+                    signing_input,
+                    [{"alg": alg, "sig": sig}],
+                    require={"min_signers": 1, "algs": [alg], "kids": set()},
+                    opts={
+                        "keys": [{"kind": "raw", "key": _jwk_to_pub_for_signer(jwk)}]
+                    },
+                )
+            elif _is_rsa(alg):
+                ok = await self.rsa.verify_bytes(
+                    signing_input,
+                    [{"alg": _map_rsa_alg(alg), "sig": sig}],
+                    require={"min_signers": 1, "algs": [_map_rsa_alg(alg)]},
+                    opts={"pubkeys": [_jwk_to_pub_for_signer(jwk)]},
+                )
+            elif _is_ec(alg):
+                ok = await self.ecdsa.verify_bytes(
+                    signing_input,
+                    [{"alg": alg, "sig": sig, "sigfmt": "raw"}],
+                    require={"min_signers": 1, "algs": [alg]},
+                    opts={"pubkeys": [_jwk_to_pub_for_signer(jwk)]},
+                )
+            elif _is_k1(alg):
+                if not self.k1:
+                    raise ValueError(
+                        "ES256K requested but secp256k1 signer is not available"
+                    )
+                ok = await self.k1.verify_bytes(
+                    signing_input,
+                    [{"alg": alg, "sig": sig, "sigfmt": "raw"}],
+                    require={"min_signers": 1, "algs": [alg]},
+                    opts={"pubkeys": [_jwk_to_pub_for_signer(jwk)]},
+                )
+            elif _is_eddsa(alg):
+                ok = await self.eddsa.verify_bytes(
+                    signing_input,
+                    [{"alg": "Ed25519", "sig": sig}],
+                    require={"min_signers": 1, "algs": ["Ed25519"]},
+                    opts={"pubkeys": [_jwk_to_pub_for_signer(jwk)]},
+                )
+            else:
+                raise ValueError(f"Unsupported alg: {alg}")
+            if not ok:
+                raise ValueError("Invalid JWS signature.")
+            return JwsResult(header=header, payload=payload_b)
+
+        if _is_hmac(alg):
+            keys = hmac_keys or []
+            if not keys:
+                raise ValueError("No HMAC keys provided.")
+            ok = await self.hmac.verify_bytes(
+                signing_input,
+                [{"alg": alg, "sig": sig}],
+                require={"min_signers": 1, "algs": [alg]},
+                opts={"keys": list(keys)},
+            )
+            if not ok:
+                raise ValueError("Invalid JWS (HMAC) signature.")
+            return JwsResult(header=header, payload=payload_b)
+
+        if _is_rsa(alg):
+            if not rsa_pubkeys:
+                raise ValueError("No RSA public keys provided.")
+            ok = await self.rsa.verify_bytes(
+                signing_input,
+                [{"alg": _map_rsa_alg(alg), "sig": sig}],
+                require={"min_signers": 1, "algs": [_map_rsa_alg(alg)]},
+                opts={"pubkeys": list(rsa_pubkeys)},
+            )
+            if not ok:
+                raise ValueError("Invalid JWS (RSA) signature.")
+            return JwsResult(header=header, payload=payload_b)
+
+        if _is_ec(alg):
+            if not ec_pubkeys:
+                raise ValueError("No EC public keys provided.")
+            ok = await self.ecdsa.verify_bytes(
+                signing_input,
+                [{"alg": alg, "sig": sig, "sigfmt": "raw"}],
+                require={"min_signers": 1, "algs": [alg]},
+                opts={"pubkeys": list(ec_pubkeys)},
+            )
+            if not ok:
+                raise ValueError("Invalid JWS (ECDSA) signature.")
+            return JwsResult(header=header, payload=payload_b)
+
+        if _is_k1(alg):
+            if not self.k1:
+                raise ValueError(
+                    "ES256K requested but secp256k1 signer is not available"
+                )
+            if not k1_pubkeys:
+                raise ValueError("No secp256k1 public keys provided.")
+            ok = await self.k1.verify_bytes(
+                signing_input,
+                [{"alg": "ES256K", "sig": sig, "sigfmt": "raw"}],
+                require={"min_signers": 1, "algs": ["ES256K"]},
+                opts={"pubkeys": list(k1_pubkeys)},
+            )
+            if not ok:
+                raise ValueError("Invalid JWS (ES256K) signature.")
+            return JwsResult(header=header, payload=payload_b)
+
+        if _is_eddsa(alg):
+            pubs = []
+            for x in ed_pubkeys or []:
+                if isinstance(x, dict) and x.get("kty") == "OKP":
+                    pubs.append(_jwk_to_pub_for_signer(x))
+                else:
+                    pubs.append(x)
+            if not pubs:
+                raise ValueError("No Ed25519 public keys provided.")
+            ok = await self.eddsa.verify_bytes(
+                signing_input,
+                [{"alg": "Ed25519", "sig": sig}],
+                require={"min_signers": 1, "algs": ["Ed25519"]},
+                opts={"pubkeys": pubs},
+            )
+            if not ok:
+                raise ValueError("Invalid JWS (EdDSA) signature.")
+            return JwsResult(header=header, payload=payload_b)
+
+        raise ValueError(f"Unsupported alg: {alg}")
+
+    async def sign_general_json(
+        self,
+        *,
+        payload: Union[bytes, str, Mapping[str, Any]],
+        signatures: Sequence[
+            Tuple[str, Mapping[str, Any], Optional[str], Optional[Mapping[str, Any]]]
+        ],
+    ) -> Dict[str, Any]:
+        if isinstance(payload, str):
+            payload_b = payload.encode("utf-8")
+        elif isinstance(payload, (bytes, bytearray)):
+            payload_b = bytes(payload)
+        else:
+            payload_b = json.dumps(
+                payload, separators=(",", ":"), ensure_ascii=False
+            ).encode("utf-8")
+
+        b64 = True
+        if signatures:
+            hdr = {"alg": signatures[0][0]}
+            if signatures[0][2]:
+                hdr["kid"] = signatures[0][2]
+            if signatures[0][3]:
+                hdr.update(dict(signatures[0][3]))
+            b64 = hdr.get("b64", True)
+            if not b64 and "b64" not in hdr.get("crit", []):
+                raise ValueError("'b64': false requires 'b64' in 'crit'")
+
+        if b64:
+            payload_part = _b64u(payload_b)
+        else:
+            payload_part = payload_b.decode("utf-8")
+
+        out_sigs = []
+        for alg, key, kid, header_extra in signatures:
+            header = {"alg": alg}
+            if kid:
+                header["kid"] = kid
+            if header_extra:
+                header.update(dict(header_extra))
+            b64_hdr = _b64u(
+                json.dumps(header, separators=(",", ":"), ensure_ascii=False).encode(
+                    "utf-8"
+                )
+            )
+            signing_input = (
+                f"{b64_hdr}.{payload_part}".encode("utf-8")
+                if not b64
+                else f"{b64_hdr}.{payload_part}".encode("ascii")
+            )
+            sig_bytes = await self._sign_for_alg(signing_input, alg, key)
+            out_sigs.append({"protected": b64_hdr, "signature": _b64u(sig_bytes)})
+        return {"payload": payload_part, "signatures": out_sigs}
+
+    async def verify_general_json(
+        self,
+        jws_obj: Mapping[str, Any],
+        *,
+        hmac_keys: Optional[Sequence[Mapping[str, Any]]] = None,
+        rsa_pubkeys: Optional[Sequence[Any]] = None,
+        ec_pubkeys: Optional[Sequence[Any]] = None,
+        ed_pubkeys: Optional[Sequence[Any]] = None,
+        k1_pubkeys: Optional[Sequence[Any]] = None,
+        jwks_resolver: Optional[callable] = None,
+        require_any: Optional[Iterable[str]] = None,
+        min_signers: int = 1,
+    ) -> Tuple[int, bytes]:
+        payload_part = jws_obj.get("payload")
+        if not isinstance(payload_part, str):
+            raise ValueError("Invalid JWS JSON: missing payload.")
+        sigs = jws_obj.get("signatures")
+        if not isinstance(sigs, list) or not sigs:
+            raise ValueError("Invalid JWS JSON: missing signatures.")
+
+        payload_b = b""
+        accepted = 0
+        allowed = set(require_any) if require_any else None
+
+        for s in sigs:
+            b64_hdr = s.get("protected")
+            b64sig = s.get("signature")
+            if not (isinstance(b64_hdr, str) and isinstance(b64sig, str)):
+                continue
+            try:
+                header = json.loads(_b64u_dec(b64_hdr))
+            except Exception:
+                continue
+            alg = header.get("alg")
+            kid = header.get("kid")
+            if not isinstance(alg, str):
+                continue
+            if allowed and alg not in allowed:
+                continue
+            b64 = header.get("b64", True)
+            if not b64 and "b64" not in header.get("crit", []):
+                continue
+            if b64:
+                if not payload_b:
+                    payload_b = _b64u_dec(payload_part)
+                signing_input = f"{b64_hdr}.{payload_part}".encode("ascii")
+            else:
+                if not payload_b:
+                    payload_b = payload_part.encode("utf-8")
+                signing_input = f"{b64_hdr}.{payload_part}".encode("utf-8")
+            sig = _b64u_dec(b64sig)
+            if jwks_resolver:
+                jwk = jwks_resolver(kid, alg)
+                ok = await self._verify_one(signing_input, alg, sig, jwk=jwk)
+            else:
+                ok = await self._verify_one(
+                    signing_input,
+                    alg,
+                    sig,
+                    hmac_keys=hmac_keys,
+                    rsa_pubkeys=rsa_pubkeys,
+                    ec_pubkeys=ec_pubkeys,
+                    ed_pubkeys=ed_pubkeys,
+                    k1_pubkeys=k1_pubkeys,
+                )
+            if ok:
+                accepted += 1
+                if accepted >= min_signers:
+                    break
+        return accepted, payload_b
+
+    async def _sign_for_alg(
+        self, signing_input: bytes, alg: str, key: Mapping[str, Any]
+    ) -> bytes:
+        if _is_hmac(alg):
+            sig = await self.hmac.sign_bytes(key, signing_input, alg=alg)
+            return sig[0]["sig"]
+        if _is_rsa(alg):
+            mapped = _map_rsa_alg(alg)
+            sig = await self.rsa.sign_bytes(key, signing_input, alg=mapped)
+            return sig[0]["sig"]
+        if _is_ec(alg):
+            sig = await self.ecdsa.sign_bytes(key, signing_input, alg=alg)
+            der = sig[0]["sig"]
+            return _ecdsa_der_to_raw(der, alg)
+        if _is_k1(alg):
+            if not self.k1:
+                raise ValueError(
+                    "ES256K requested but secp256k1 signer is not available"
+                )
+            sig = await self.k1.sign_bytes(key, signing_input, alg="ES256K")
+            der = sig[0]["sig"]
+            return _ecdsa_der_to_raw(der, "ES256")
+        if _is_eddsa(alg):
+            sig = await self.eddsa.sign_bytes(key, signing_input, alg="Ed25519")
+            return sig[0]["sig"]
+        raise ValueError(f"Unsupported alg: {alg}")
+
+    async def _verify_one(
+        self,
+        signing_input: bytes,
+        alg: str,
+        sig: bytes,
+        *,
+        jwk: Optional[Mapping[str, Any]] = None,
+        hmac_keys: Optional[Sequence[Mapping[str, Any]]] = None,
+        rsa_pubkeys: Optional[Sequence[Any]] = None,
+        ec_pubkeys: Optional[Sequence[Any]] = None,
+        ed_pubkeys: Optional[Sequence[Any]] = None,
+        k1_pubkeys: Optional[Sequence[Any]] = None,
+    ) -> bool:
+        if jwk is not None:
+            if _is_hmac(alg):
+                return await self.hmac.verify_bytes(
+                    signing_input,
+                    [{"alg": alg, "sig": sig}],
+                    require={"min_signers": 1, "algs": [alg]},
+                    opts={
+                        "keys": [{"kind": "raw", "key": _jwk_to_pub_for_signer(jwk)}]
+                    },
+                )
+            if _is_rsa(alg):
+                return await self.rsa.verify_bytes(
+                    signing_input,
+                    [{"alg": _map_rsa_alg(alg), "sig": sig}],
+                    require={"min_signers": 1, "algs": [_map_rsa_alg(alg)]},
+                    opts={"pubkeys": [_jwk_to_pub_for_signer(jwk)]},
+                )
+            if _is_ec(alg):
+                return await self.ecdsa.verify_bytes(
+                    signing_input,
+                    [{"alg": alg, "sig": sig, "sigfmt": "raw"}],
+                    require={"min_signers": 1, "algs": [alg]},
+                    opts={"pubkeys": [_jwk_to_pub_for_signer(jwk)]},
+                )
+            if _is_k1(alg):
+                if not self.k1:
+                    return False
+                return await self.k1.verify_bytes(
+                    signing_input,
+                    [{"alg": "ES256K", "sig": sig, "sigfmt": "raw"}],
+                    require={"min_signers": 1, "algs": ["ES256K"]},
+                    opts={"pubkeys": [_jwk_to_pub_for_signer(jwk)]},
+                )
+            if _is_eddsa(alg):
+                return await self.eddsa.verify_bytes(
+                    signing_input,
+                    [{"alg": "Ed25519", "sig": sig}],
+                    require={"min_signers": 1, "algs": ["Ed25519"]},
+                    opts={"pubkeys": [_jwk_to_pub_for_signer(jwk)]},
+                )
+            return False
+
+        if _is_hmac(alg) and hmac_keys:
+            return await self.hmac.verify_bytes(
+                signing_input,
+                [{"alg": alg, "sig": sig}],
+                require={"min_signers": 1, "algs": [alg]},
+                opts={"keys": list(hmac_keys)},
+            )
+        if _is_rsa(alg) and rsa_pubkeys:
+            return await self.rsa.verify_bytes(
+                signing_input,
+                [{"alg": _map_rsa_alg(alg), "sig": sig}],
+                require={"min_signers": 1, "algs": [_map_rsa_alg(alg)]},
+                opts={"pubkeys": list(rsa_pubkeys)},
+            )
+        if _is_ec(alg) and ec_pubkeys:
+            return await self.ecdsa.verify_bytes(
+                signing_input,
+                [{"alg": alg, "sig": sig, "sigfmt": "raw"}],
+                require={"min_signers": 1, "algs": [alg]},
+                opts={"pubkeys": list(ec_pubkeys)},
+            )
+        if _is_k1(alg) and self.k1 and k1_pubkeys:
+            return await self.k1.verify_bytes(
+                signing_input,
+                [{"alg": "ES256K", "sig": sig, "sigfmt": "raw"}],
+                require={"min_signers": 1, "algs": ["ES256K"]},
+                opts={"pubkeys": list(k1_pubkeys)},
+            )
+        if _is_eddsa(alg) and ed_pubkeys:
+            pubs = []
+            for x in ed_pubkeys:
+                if isinstance(x, dict) and x.get("kty") == "OKP":
+                    pubs.append(_jwk_to_pub_for_signer(x))
+                else:
+                    pubs.append(x)
+            return await self.eddsa.verify_bytes(
+                signing_input,
+                [{"alg": "Ed25519", "sig": sig}],
+                require={"min_signers": 1, "algs": ["Ed25519"]},
+                opts={"pubkeys": pubs},
+            )
+        return False
+
+
+def _map_rsa_alg(alg: str) -> str:
+    if alg in _RSA_RS:
+        return _RSA_RS[alg]
+    if alg in _RSA_PS:
+        return _RSA_PS[alg]
+    raise ValueError(f"Unsupported RSA alg: {alg}")
+
+
+__all__ = ["JwsSignerVerifier", "JwsResult"]

--- a/pkgs/standards/swarmauri_signing_jws/tests/functional/test_jws_functional.py
+++ b/pkgs/standards/swarmauri_signing_jws/tests/functional/test_jws_functional.py
@@ -1,0 +1,29 @@
+import asyncio
+import base64
+import json
+import pytest
+
+from swarmauri_signing_jws import JwsSignerVerifier
+
+
+def _b64u(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+@pytest.mark.test
+def test_jwks_resolver_flow() -> None:
+    signer = JwsSignerVerifier()
+    key = {"kind": "raw", "key": b"secret"}
+    payload = {"msg": "hi"}
+    token = asyncio.run(
+        signer.sign_compact(payload=payload, alg="HS256", key=key, kid="kid1")
+    )
+
+    def resolver(kid: str | None, alg: str) -> dict[str, str]:
+        assert kid == "kid1"
+        assert alg == "HS256"
+        return {"kty": "oct", "k": _b64u(b"secret")}
+
+    result = asyncio.run(signer.verify_compact(token, jwks_resolver=resolver))
+    assert json.loads(result.payload) == payload
+    assert result.header["kid"] == "kid1"

--- a/pkgs/standards/swarmauri_signing_jws/tests/perf/test_jws_perf.py
+++ b/pkgs/standards/swarmauri_signing_jws/tests/perf/test_jws_perf.py
@@ -1,0 +1,16 @@
+import asyncio
+import pytest
+
+from swarmauri_signing_jws import JwsSignerVerifier
+
+
+@pytest.mark.perf
+def test_sign_compact_perf(benchmark) -> None:
+    signer = JwsSignerVerifier()
+    key = {"kind": "raw", "key": b"secret"}
+    payload = "perf"
+
+    async def _sign() -> None:
+        await signer.sign_compact(payload=payload, alg="HS256", key=key)
+
+    benchmark(lambda: asyncio.run(_sign()))

--- a/pkgs/standards/swarmauri_signing_jws/tests/unit/test_rfc7515.py
+++ b/pkgs/standards/swarmauri_signing_jws/tests/unit/test_rfc7515.py
@@ -1,0 +1,20 @@
+import asyncio
+import json
+import pytest
+
+from swarmauri_signing_jws import JwsSignerVerifier
+
+
+@pytest.mark.unit
+def test_rfc7515_hs256_roundtrip() -> None:
+    signer = JwsSignerVerifier()
+    key = {"kind": "raw", "key": b"secret"}
+    payload = {"iss": "joe", "exp": 1300819380, "http://example.com/is_root": True}
+    token = asyncio.run(
+        signer.sign_compact(
+            payload=payload, alg="HS256", key=key, header_extra={"typ": "JWT"}
+        )
+    )
+    result = asyncio.run(signer.verify_compact(token, hmac_keys=[key]))
+    assert json.loads(result.payload) == payload
+    assert result.header["typ"] == "JWT"

--- a/pkgs/standards/swarmauri_signing_jws/tests/unit/test_rfc7797.py
+++ b/pkgs/standards/swarmauri_signing_jws/tests/unit/test_rfc7797.py
@@ -1,0 +1,22 @@
+import asyncio
+import pytest
+
+from swarmauri_signing_jws import JwsSignerVerifier
+
+
+@pytest.mark.unit
+def test_rfc7797_unencoded_payload() -> None:
+    signer = JwsSignerVerifier()
+    key = {"kind": "raw", "key": b"secret"}
+    payload = "Hello world"
+    token = asyncio.run(
+        signer.sign_compact(
+            payload=payload,
+            alg="HS256",
+            key=key,
+            header_extra={"b64": False, "crit": ["b64"]},
+        )
+    )
+    result = asyncio.run(signer.verify_compact(token, hmac_keys=[key]))
+    assert result.payload.decode() == payload
+    assert result.header["b64"] is False


### PR DESCRIPTION
## Summary
- add composite JWS signer/verifier with RFC 7515 & 7797 support
- expose optional secp256k1 and cbor extras
- include unit, functional, and perf tests

## Testing
- `uv run --package swarmauri_signing_jws --directory standards/swarmauri_signing_jws pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a70bfc39bc8326b7c589251ca2d532