### PR TITLE
Add JWE crypto plugin with RFC compliance tests

### DIFF
--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -85,6 +85,7 @@ members = [
     "standards/swarmauri_crypto_shamir",
     "standards/swarmauri_crypto_keyring",
     "standards/swarmauri_crypto_age_mre",
+    "standards/swarmauri_crypto_jwe",
     "standards/swarmauri_mre_crypto_pgp",
     "standards/swarmauri_signing_ed25519",
     "standards/swarmauri_signing_secp256k1",
@@ -221,6 +222,7 @@ swarmauri_crypto_composite = { workspace = true }
 swarmauri_crypto_shamir = { workspace = true }
 swarmauri_crypto_keyring = { workspace = true }
 swarmauri_crypto_age_mre = { workspace = true }
+swarmauri_crypto_jwe = { workspace = true }
 swarmauri_mre_crypto_pgp = { workspace = true }
 swarmauri_signing_ed25519 = { workspace = true }
 swarmauri_signing_secp256k1 = { workspace = true }

--- a/pkgs/standards/swarmauri_crypto_jwe/LICENSE
+++ b/pkgs/standards/swarmauri_crypto_jwe/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/standards/swarmauri_crypto_jwe/README.md
+++ b/pkgs/standards/swarmauri_crypto_jwe/README.md
@@ -1,0 +1,44 @@
+![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_crypto_jwe/"><img src="https://img.shields.io/pypi/dm/swarmauri_crypto_jwe" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_crypto_jwe/"><img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_crypto_jwe.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_crypto_jwe/"><img src="https://img.shields.io/pypi/pyversions/swarmauri_crypto_jwe" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_crypto_jwe/"><img src="https://img.shields.io/pypi/l/swarmauri_crypto_jwe" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_crypto_jwe/"><img src="https://img.shields.io/pypi/v/swarmauri_crypto_jwe?label=swarmauri_crypto_jwe&color=green" alt="PyPI - swarmauri_crypto_jwe"/></a>
+</p>
+
+---
+
+## Swarmauri Crypto JWE
+
+JSON Web Encryption (JWE) provider implementing RFC 7516 and RFC 7518 compliant encryption and decryption helpers.
+
+- Supports `dir`, `RSA-OAEP`, `RSA-OAEP-256`, and `ECDH-ES`
+- Supports `A128GCM`, `A192GCM`, and `A256GCM`
+- Optional compression (`zip` = `DEF`) and Additional Authenticated Data (AAD)
+
+### Installation
+
+```bash
+pip install swarmauri_crypto_jwe
+```
+
+### Usage
+
+```python
+from swarmauri_crypto_jwe import JweCrypto
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+crypto = JweCrypto()
+
+sk = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+pk_pem = sk.public_key().public_bytes(encoding=serialization.Encoding.PEM, format=serialization.PublicFormat.SubjectPublicKeyInfo)
+
+jwe = await crypto.encrypt_compact(payload=b"secret", alg="RSA-OAEP-256", enc="A256GCM", key={"pub": pk_pem})
+res = await crypto.decrypt_compact(jwe, rsa_private_pem=sk.private_bytes(encoding=serialization.Encoding.PEM, format=serialization.PrivateFormat.PKCS8, encryption_algorithm=serialization.NoEncryption()))
+```
+
+## Entry point
+
+The provider is registered under the `swarmauri.cryptos` entry point as `JweCrypto`.

--- a/pkgs/standards/swarmauri_crypto_jwe/pyproject.toml
+++ b/pkgs/standards/swarmauri_crypto_jwe/pyproject.toml
@@ -1,0 +1,71 @@
+[project]
+name = "swarmauri_crypto_jwe"
+version = "0.1.0"
+description = "RFC 7516/7518 compliant JWE crypto provider for Swarmauri"
+license = "Apache-2.0"
+readme = "README.md"
+requires-python = ">=3.10,<3.13"
+authors = [{ name = "Swarmauri", email = "opensource@swarmauri.com" }]
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Development Status :: 3 - Alpha",
+    "Topic :: Security :: Cryptography",
+    "Intended Audience :: Developers",
+]
+dependencies = [
+    "swarmauri_core",
+    "swarmauri_base",
+    "cryptography>=41",
+]
+
+[project.optional-dependencies]
+json = []
+cbor = ["cbor2"]
+
+[tool.uv.sources]
+swarmauri_core = { workspace = true }
+swarmauri_base = { workspace = true }
+
+[tool.pytest.ini_options]
+norecursedirs = ["combined", "scripts"]
+markers = [
+    "test: standard test",
+    "unit: Unit tests",
+    "i9n: Integration tests",
+    "r8n: Regression tests",
+    "acceptance: Acceptance tests",
+    "perf: Performance tests",
+]
+timeout = 300
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "pytest-timeout>=2.3.1",
+    "pytest-benchmark>=4.0.0",
+    "flake8>=7.0",
+    "ruff>=0.9.9",
+]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[project.entry-points.'swarmauri.cryptos']
+JweCrypto = "swarmauri_crypto_jwe:JweCrypto"
+
+[project.entry-points."peagen.plugins.cryptos"]
+jwe = "swarmauri_crypto_jwe:JweCrypto"

--- a/pkgs/standards/swarmauri_crypto_jwe/swarmauri_crypto_jwe/JweCrypto.py
+++ b/pkgs/standards/swarmauri_crypto_jwe/swarmauri_crypto_jwe/JweCrypto.py
@@ -1,0 +1,421 @@
+from __future__ import annotations
+
+import base64
+import json
+import os
+import zlib
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Mapping, Optional, Tuple, Union
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.kdf.concatkdf import ConcatKDFHash
+from cryptography.hazmat.primitives.asymmetric import rsa, padding, ec, x25519
+from cryptography.hazmat.primitives.serialization import (
+    load_pem_public_key,
+    load_pem_private_key,
+)
+
+
+def _b64u(b: bytes) -> str:
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode("ascii")
+
+
+def _b64u_dec(s: str) -> bytes:
+    pad = "=" * ((4 - (len(s) % 4)) % 4)
+    return base64.urlsafe_b64decode(s + pad)
+
+
+def _json_dumps(obj: Any) -> bytes:
+    return json.dumps(
+        obj, separators=(",", ":"), ensure_ascii=False, sort_keys=False
+    ).encode("utf-8")
+
+
+def _cek_len_for_enc(enc: str) -> int:
+    if enc == "A128GCM":
+        return 16
+    if enc == "A192GCM":
+        return 24
+    if enc == "A256GCM":
+        return 32
+    raise ValueError("Unsupported enc '{enc}'. Use A128GCM/A192GCM/A256GCM.")
+
+
+def _hash_for_oaep(alg: str):
+    if alg == "RSA-OAEP":
+        return hashes.SHA1()
+    if alg == "RSA-OAEP-256":
+        return hashes.SHA256()
+    raise ValueError(f"Unsupported RSA OAEP alg '{alg}'.")
+
+
+def _rand(n: int) -> bytes:
+    return os.urandom(n)
+
+
+def _compute_aad(protected_b64: str, aad_bytes: Optional[bytes]) -> bytes:
+    if not aad_bytes:
+        return protected_b64.encode("ascii")
+    return (protected_b64 + "." + _b64u(aad_bytes)).encode("ascii")
+
+
+def _jwk_ec_public_numbers(jwk: Mapping[str, Any]) -> ec.EllipticCurvePublicNumbers:
+    crv = jwk.get("crv")
+    curve_map = {
+        "P-256": ec.SECP256R1(),
+        "P-384": ec.SECP384R1(),
+        "P-521": ec.SECP521R1(),
+    }
+    if crv not in curve_map:
+        raise ValueError(f"Unsupported EC curve in JWK: {crv}")
+    x = int.from_bytes(_b64u_dec(jwk["x"]), "big")
+    y = int.from_bytes(_b64u_dec(jwk["y"]), "big")
+    return ec.EllipticCurvePublicNumbers(x, y, curve_map[crv])
+
+
+def _ec_jwk_from_public_key(pk: ec.EllipticCurvePublicKey) -> Dict[str, Any]:
+    numbers = pk.public_numbers()
+    crv = pk.curve.name
+    crv_map = {"secp256r1": "P-256", "secp384r1": "P-384", "secp521r1": "P-521"}
+    if crv not in crv_map:
+        raise ValueError(f"Unsupported EC curve: {crv}")
+    size = (pk.curve.key_size + 7) // 8
+    x = numbers.x.to_bytes(size, "big")
+    y = numbers.y.to_bytes(size, "big")
+    return {"kty": "EC", "crv": crv_map[crv], "x": _b64u(x), "y": _b64u(y)}
+
+
+def _x25519_jwk_from_public_key(pk: x25519.X25519PublicKey) -> Dict[str, Any]:
+    raw = pk.public_bytes(
+        encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw
+    )
+    return {"kty": "OKP", "crv": "X25519", "x": _b64u(raw)}
+
+
+def _load_rsa_public(key: Any) -> rsa.RSAPublicKey:
+    if isinstance(key, rsa.RSAPublicKey):
+        return key
+    if isinstance(key, (bytes, bytearray, str)):
+        data = key if isinstance(key, (bytes, bytearray)) else key.encode("utf-8")
+        pk = load_pem_public_key(data)
+        if not isinstance(pk, rsa.RSAPublicKey):
+            raise TypeError("PEM provided is not an RSA public key")
+        return pk
+    if isinstance(key, Mapping) and key.get("kty") == "RSA":
+        n = int.from_bytes(_b64u_dec(key["n"]), "big")
+        e = int.from_bytes(_b64u_dec(key["e"]), "big")
+        return rsa.RSAPublicNumbers(e, n).public_key()
+    raise TypeError("Unsupported RSA public key format.")
+
+
+def _load_rsa_private(
+    key: Any, password: Optional[Union[str, bytes]] = None
+) -> rsa.RSAPrivateKey:
+    if isinstance(key, rsa.RSAPrivateKey):
+        return key
+    pwd = None
+    if isinstance(password, str):
+        pwd = password.encode("utf-8")
+    elif isinstance(password, (bytes, bytearray)):
+        pwd = bytes(password)
+    if isinstance(key, (bytes, bytearray, str)):
+        data = key if isinstance(key, (bytes, bytearray)) else key.encode("utf-8")
+        sk = load_pem_private_key(data, password=pwd)
+        if not isinstance(sk, rsa.RSAPrivateKey):
+            raise TypeError("PEM provided is not an RSA private key")
+        return sk
+    raise TypeError("Unsupported RSA private key format.")
+
+
+def _load_ecdh_recipient_public(jwk_or_pem: Any) -> Tuple[str, Any]:
+    if isinstance(jwk_or_pem, Mapping):
+        kty = jwk_or_pem.get("kty")
+        if kty == "EC":
+            pn = _jwk_ec_public_numbers(jwk_or_pem)
+            return jwk_or_pem["crv"], pn.public_key()
+        if kty == "OKP" and jwk_or_pem.get("crv") == "X25519":
+            x = _b64u_dec(jwk_or_pem["x"])
+            return "X25519", x25519.X25519PublicKey.from_public_bytes(x)
+        raise ValueError(
+            f"Unsupported JWK kty/crv for ECDH-ES: {kty}/{jwk_or_pem.get('crv')}"
+        )
+    if isinstance(jwk_or_pem, (bytes, bytearray, str)):
+        data = (
+            jwk_or_pem
+            if isinstance(jwk_or_pem, (bytes, bytearray))
+            else jwk_or_pem.encode("utf-8")
+        )
+        pk = load_pem_public_key(data)
+        if isinstance(pk, ec.EllipticCurvePublicKey):
+            crv = pk.curve.name
+            if crv == "secp256r1":
+                return "P-256", pk
+            if crv == "secp384r1":
+                return "P-384", pk
+            if crv == "secp521r1":
+                return "P-521", pk
+            raise ValueError(f"Unsupported EC curve: {crv}")
+        raise TypeError("PEM must be an EC public key for ECDH-ES.")
+    raise TypeError("Unsupported recipient public key format for ECDH-ES.")
+
+
+def _concat_kdf(
+    z: bytes,
+    enc: str,
+    hash_alg=hashes.SHA256(),
+    apu: Optional[bytes] = None,
+    apv: Optional[bytes] = None,
+) -> bytes:
+    keydatalen_bits = _cek_len_for_enc(enc) * 8
+    alg_id = _jwe_alg_id(enc)
+    ckdf = ConcatKDFHash(
+        algorithm=hash_alg,
+        length=keydatalen_bits // 8,
+        otherinfo=alg_id + (apu or b"") + (apv or b""),
+    )
+    return ckdf.derive(z)
+
+
+def _jwe_alg_id(enc: str) -> bytes:
+    enc_b = enc.encode("ascii")
+    return len(enc_b).to_bytes(4, "big") + enc_b
+
+
+JWECompact = str
+
+
+@dataclass
+class JweDecryptResult:
+    header: Dict[str, Any]
+    plaintext: bytes
+
+
+class JweCrypto:
+    """Utility class for JSON Web Encryption (RFC 7516, RFC 7518)."""
+
+    async def encrypt_compact(
+        self,
+        *,
+        payload: Union[bytes, str, Mapping[str, Any]],
+        alg: str,
+        enc: str,
+        key: Mapping[str, Any],
+        kid: Optional[str] = None,
+        header_extra: Optional[Mapping[str, Any]] = None,
+        aad: Optional[Union[bytes, str]] = None,
+    ) -> JWECompact:
+        if isinstance(payload, str):
+            pt = payload.encode("utf-8")
+        elif isinstance(payload, (bytes, bytearray)):
+            pt = bytes(payload)
+        else:
+            pt = _json_dumps(payload)
+
+        protected: Dict[str, Any] = {"alg": alg, "enc": enc}
+        if kid:
+            protected["kid"] = kid
+        if header_extra:
+            protected.update(dict(header_extra))
+
+        if protected.get("zip") == "DEF":
+            pt = zlib.compress(pt)
+
+        cek: bytes
+        encrypted_key_b64 = ""
+        epk_header: Optional[Dict[str, Any]] = None
+
+        if alg == "dir":
+            secret = key.get("k")
+            secret_b = (
+                secret.encode("utf-8") if isinstance(secret, str) else bytes(secret)
+            )
+            if len(secret_b) != _cek_len_for_enc(enc):
+                raise ValueError(
+                    f"'dir' key size must equal enc key size ({_cek_len_for_enc(enc)} bytes)"
+                )
+            cek = secret_b
+        elif alg in ("RSA-OAEP", "RSA-OAEP-256"):
+            cek = _rand(_cek_len_for_enc(enc))
+            pk = _load_rsa_public(key.get("pub") or key)
+            hash_alg = _hash_for_oaep(alg)
+            ekey = pk.encrypt(
+                cek,
+                padding.OAEP(
+                    mgf=padding.MGF1(algorithm=hash_alg),
+                    algorithm=hash_alg,
+                    label=None,
+                ),
+            )
+            encrypted_key_b64 = _b64u(ekey)
+        elif alg == "ECDH-ES":
+            crv, rpk = _load_ecdh_recipient_public(key.get("pub") or key)
+            if crv == "X25519":
+                esk = x25519.X25519PrivateKey.generate()
+                epk = esk.public_key()
+                z = esk.exchange(rpk)  # type: ignore[arg-type]
+                epk_header = _x25519_jwk_from_public_key(epk)
+            else:
+                curve = {
+                    "P-256": ec.SECP256R1(),
+                    "P-384": ec.SECP384R1(),
+                    "P-521": ec.SECP521R1(),
+                }[crv]
+                esk = ec.generate_private_key(curve)
+                epk = esk.public_key()
+                z = esk.exchange(ec.ECDH(), rpk)  # type: ignore[arg-type]
+                epk_header = _ec_jwk_from_public_key(epk)
+            apu_b = None
+            apv_b = None
+            if "apu" in (header_extra or {}):
+                apu_b = (
+                    _b64u_dec(header_extra["apu"])
+                    if isinstance(header_extra["apu"], str)
+                    else header_extra["apu"]
+                )
+            if "apv" in (header_extra or {}):
+                apv_b = (
+                    _b64u_dec(header_extra["apv"])
+                    if isinstance(header_extra["apv"], str)
+                    else header_extra["apv"]
+                )
+            cek = _concat_kdf(z, enc, hashes.SHA256(), apu_b, apv_b)
+            protected["epk"] = epk_header
+        else:
+            raise ValueError(f"Unsupported alg '{alg}'")
+
+        iv = _rand(12)
+        aadd = _ensure_bytes(aad) if aad is not None else None
+
+        protected_b64 = _b64u(_json_dumps(protected))
+        aead_aad = _compute_aad(protected_b64, aadd)
+
+        aesgcm = AESGCM(cek)
+        ct = aesgcm.encrypt(iv, pt, aead_aad)
+        ciphertext, tag = ct[:-16], ct[-16:]
+
+        return ".".join(
+            [
+                protected_b64,
+                encrypted_key_b64,
+                _b64u(iv),
+                _b64u(ciphertext),
+                _b64u(tag),
+            ]
+        )
+
+    async def decrypt_compact(
+        self,
+        jwe: JWECompact,
+        *,
+        dir_key: Optional[Union[bytes, str]] = None,
+        rsa_private_pem: Optional[Union[str, bytes]] = None,
+        rsa_private_password: Optional[Union[str, bytes]] = None,
+        ecdh_private_key: Optional[Any] = None,
+        expected_algs: Optional[Iterable[str]] = None,
+        expected_encs: Optional[Iterable[str]] = None,
+        aad: Optional[Union[bytes, str]] = None,
+    ) -> JweDecryptResult:
+        parts = jwe.split(".")
+        if len(parts) != 5:
+            raise ValueError("Invalid JWE compact: expected 5 dot-separated parts.")
+        b64_prot, b64_ekey, b64_iv, b64_ct, b64_tag = parts
+
+        header = json.loads(_b64u_dec(b64_prot))
+        alg = header.get("alg")
+        enc = header.get("enc")
+        if not isinstance(alg, str) or not isinstance(enc, str):
+            raise ValueError("JWE header missing 'alg' or 'enc'.")
+        if expected_algs and alg not in set(expected_algs):
+            raise ValueError(f"Unexpected alg '{alg}'.")
+        if expected_encs and enc not in set(expected_encs):
+            raise ValueError(f"Unexpected enc '{enc}'.")
+
+        iv = _b64u_dec(b64_iv)
+        if len(iv) != 12:
+            raise ValueError("Invalid IV length for AES-GCM (must be 96-bit).")
+        ciphertext = _b64u_dec(b64_ct)
+        tag = _b64u_dec(b64_tag)
+        aadd = _ensure_bytes(aad) if aad is not None else None
+        aead_aad = _compute_aad(b64_prot, aadd)
+
+        if alg == "dir":
+            if dir_key is None:
+                raise ValueError("dir_key is required for alg='dir'.")
+            cek = (
+                dir_key.encode("utf-8") if isinstance(dir_key, str) else bytes(dir_key)
+            )
+            if len(cek) != _cek_len_for_enc(enc):
+                raise ValueError("dir_key length mismatch for enc.")
+        elif alg in ("RSA-OAEP", "RSA-OAEP-256"):
+            if rsa_private_pem is None:
+                raise ValueError("rsa_private_pem is required for RSA-OAEP decryption.")
+            sk = _load_rsa_private(rsa_private_pem, password=rsa_private_password)
+            ekey = _b64u_dec(b64_ekey)
+            hash_alg = _hash_for_oaep(alg)
+            cek = sk.decrypt(
+                ekey,
+                padding.OAEP(
+                    mgf=padding.MGF1(algorithm=hash_alg), algorithm=hash_alg, label=None
+                ),
+            )
+        elif alg == "ECDH-ES":
+            if ecdh_private_key is None:
+                raise ValueError("ecdh_private_key is required for ECDH-ES decryption.")
+            epk = header.get("epk")
+            if not isinstance(epk, Mapping):
+                raise ValueError("Missing/invalid 'epk' in JWE header for ECDH-ES.")
+            if epk.get("kty") == "OKP" and epk.get("crv") == "X25519":
+                if not isinstance(ecdh_private_key, x25519.X25519PrivateKey):
+                    raise TypeError("ECDH-ES with X25519 requires an X25519PrivateKey.")
+                z = ecdh_private_key.exchange(
+                    x25519.X25519PublicKey.from_public_bytes(_b64u_dec(epk["x"]))
+                )
+            elif epk.get("kty") == "EC":
+                crv = epk.get("crv")
+                curve = {
+                    "P-256": ec.SECP256R1(),
+                    "P-384": ec.SECP384R1(),
+                    "P-521": ec.SECP521R1(),
+                }.get(crv)
+                if curve is None:
+                    raise ValueError(f"Unsupported EC curve in epk: {crv}")
+                if not isinstance(ecdh_private_key, ec.EllipticCurvePrivateKey):
+                    raise TypeError(
+                        "ECDH-ES with EC requires an EllipticCurvePrivateKey."
+                    )
+                x = int.from_bytes(_b64u_dec(epk["x"]), "big")
+                y = int.from_bytes(_b64u_dec(epk["y"]), "big")
+                rpk = ec.EllipticCurvePublicNumbers(x, y, curve).public_key()
+                z = ecdh_private_key.exchange(ec.ECDH(), rpk)
+            else:
+                raise ValueError("Unsupported 'epk' kty/crv.")
+            apu_b = _b64u_dec(header["apu"]) if "apu" in header else None
+            apv_b = _b64u_dec(header["apv"]) if "apv" in header else None
+            cek = _concat_kdf(z, enc, hashes.SHA256(), apu_b, apv_b)
+        else:
+            raise ValueError(f"Unsupported alg '{alg}'")
+
+        aesgcm = AESGCM(cek)
+        try:
+            pt = aesgcm.decrypt(iv, ciphertext + tag, aead_aad)
+        except Exception as exc:  # noqa: BLE001
+            raise ValueError(
+                "JWE decryption failed (invalid tag or wrong key)."
+            ) from exc
+
+        if header.get("zip") == "DEF":
+            try:
+                pt = zlib.decompress(pt)
+            except Exception as exc:  # noqa: BLE001
+                raise ValueError(f"Failed to decompress (zip=DEF): {exc}") from exc
+
+        return JweDecryptResult(header=header, plaintext=pt)
+
+
+def _ensure_bytes(v: Union[str, bytes, bytearray]) -> bytes:
+    if isinstance(v, (bytes, bytearray)):
+        return bytes(v)
+    if isinstance(v, str):
+        return v.encode("utf-8")
+    raise TypeError("Expected bytes or str")

--- a/pkgs/standards/swarmauri_crypto_jwe/swarmauri_crypto_jwe/__init__.py
+++ b/pkgs/standards/swarmauri_crypto_jwe/swarmauri_crypto_jwe/__init__.py
@@ -1,0 +1,3 @@
+from .JweCrypto import JweCrypto
+
+__all__ = ["JweCrypto"]

--- a/pkgs/standards/swarmauri_crypto_jwe/tests/functional/test_jwe_functional.py
+++ b/pkgs/standards/swarmauri_crypto_jwe/tests/functional/test_jwe_functional.py
@@ -1,0 +1,33 @@
+import asyncio
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from swarmauri_crypto_jwe import JweCrypto
+
+
+@pytest.mark.i9n
+@pytest.mark.test
+def test_rsa_encrypt_decrypt_functional() -> None:
+    crypto = JweCrypto()
+    sk = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pk_pem = sk.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    sk_pem = sk.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    jwe = asyncio.run(
+        crypto.encrypt_compact(
+            payload=b"functional",
+            alg="RSA-OAEP-256",
+            enc="A256GCM",
+            key={"pub": pk_pem},
+        )
+    )
+    res = asyncio.run(crypto.decrypt_compact(jwe, rsa_private_pem=sk_pem))
+    assert res.plaintext == b"functional"

--- a/pkgs/standards/swarmauri_crypto_jwe/tests/perf/test_jwe_perf.py
+++ b/pkgs/standards/swarmauri_crypto_jwe/tests/perf/test_jwe_perf.py
@@ -1,0 +1,20 @@
+import asyncio
+
+import pytest
+
+from swarmauri_crypto_jwe import JweCrypto
+
+
+@pytest.mark.perf
+@pytest.mark.test
+def test_encrypt_perf(benchmark) -> None:  # type: ignore[no-untyped-def]
+    crypto = JweCrypto()
+    key = {"k": b"0" * 32}
+    payload = b"a" * 1024
+
+    async def _run() -> str:
+        return await crypto.encrypt_compact(
+            payload=payload, alg="dir", enc="A256GCM", key=key
+        )
+
+    benchmark(lambda: asyncio.run(_run()))

--- a/pkgs/standards/swarmauri_crypto_jwe/tests/rfc/test_rfc7516.py
+++ b/pkgs/standards/swarmauri_crypto_jwe/tests/rfc/test_rfc7516.py
@@ -1,0 +1,22 @@
+import asyncio
+import base64
+import json
+
+import pytest
+
+from swarmauri_crypto_jwe import JweCrypto
+
+
+@pytest.mark.unit
+@pytest.mark.test
+def test_rfc7516_compact_structure() -> None:
+    crypto = JweCrypto()
+    key = {"k": b"0" * 32}
+    jwe = asyncio.run(
+        crypto.encrypt_compact(payload=b"hi", alg="dir", enc="A256GCM", key=key)
+    )
+    parts = jwe.split(".")
+    assert len(parts) == 5
+    header = json.loads(base64.urlsafe_b64decode(parts[0] + "=="))
+    assert header["alg"] == "dir"
+    assert header["enc"] == "A256GCM"

--- a/pkgs/standards/swarmauri_crypto_jwe/tests/rfc/test_rfc7518.py
+++ b/pkgs/standards/swarmauri_crypto_jwe/tests/rfc/test_rfc7518.py
@@ -1,0 +1,25 @@
+import asyncio
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from swarmauri_crypto_jwe import JweCrypto
+
+
+@pytest.mark.unit
+@pytest.mark.test
+def test_rfc7518_ecdh_es() -> None:
+    crypto = JweCrypto()
+    sk = ec.generate_private_key(ec.SECP256R1())
+    pk_pem = sk.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    jwe = asyncio.run(
+        crypto.encrypt_compact(
+            payload=b"rfc", alg="ECDH-ES", enc="A256GCM", key={"pub": pk_pem}
+        )
+    )
+    res = asyncio.run(crypto.decrypt_compact(jwe, ecdh_private_key=sk))
+    assert res.plaintext == b"rfc"

--- a/pkgs/standards/swarmauri_crypto_jwe/tests/unit/test_jwe_unit.py
+++ b/pkgs/standards/swarmauri_crypto_jwe/tests/unit/test_jwe_unit.py
@@ -1,0 +1,19 @@
+import asyncio
+
+import pytest
+
+from swarmauri_crypto_jwe import JweCrypto
+
+
+@pytest.mark.unit
+@pytest.mark.test
+def test_dir_encrypt_decrypt_unit() -> None:
+    crypto = JweCrypto()
+    key = {"k": b"0" * 32}
+    message = b"unit-test"
+
+    jwe = asyncio.run(
+        crypto.encrypt_compact(payload=message, alg="dir", enc="A256GCM", key=key)
+    )
+    res = asyncio.run(crypto.decrypt_compact(jwe, dir_key=key["k"]))
+    assert res.plaintext == message


### PR DESCRIPTION
## Summary
- add `swarmauri_crypto_jwe` plugin implementing RFC 7516/7518 JWE utilities
- provide optional extras and entry points for plugin discovery
- add unit, integration, performance, and RFC compliance tests

## Testing
- `uv run --directory pkgs/standards/swarmauri_crypto_jwe --package swarmauri_crypto_jwe ruff format .`
- `uv run --directory pkgs/standards/swarmauri_crypto_jwe --package swarmauri_crypto_jwe ruff check . --fix`
- `uv run --package swarmauri_crypto_jwe --directory standards/swarmauri_crypto_jwe pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a70d5dd3708326af5bd6b0ecc5b6d4