### PR TITLE
feat: add key provider framework

### DIFF
--- a/pkgs/base/swarmauri_base/keys/KeyProviderBase.py
+++ b/pkgs/base/swarmauri_base/keys/KeyProviderBase.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import Optional, Literal
+from pydantic import Field
+
+from swarmauri_base.ComponentBase import ComponentBase, ResourceTypes
+from swarmauri_core.keys.IKeyProvider import IKeyProvider
+
+
+class KeyProviderBase(IKeyProvider, ComponentBase):
+    """Base class for key providers within the Swarmauri ecosystem."""
+
+    resource: Optional[str] = Field(default=ResourceTypes.CRYPTO.value, frozen=True)
+    type: Literal["KeyProviderBase"] = "KeyProviderBase"

--- a/pkgs/base/swarmauri_base/keys/__init__.py
+++ b/pkgs/base/swarmauri_base/keys/__init__.py
@@ -1,0 +1,5 @@
+"""Base key provider class."""
+
+from .KeyProviderBase import KeyProviderBase
+
+__all__ = ["KeyProviderBase"]

--- a/pkgs/core/swarmauri_core/keys/IKeyProvider.py
+++ b/pkgs/core/swarmauri_core/keys/IKeyProvider.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Iterable, Mapping, Optional, Tuple
+
+from ..crypto.types import KeyRef
+from .types import KeySpec
+
+
+class IKeyProvider(ABC):
+    """Stable, minimal surface for key lifecycle and randomness/KDF utilities."""
+
+    @abstractmethod
+    def supports(self) -> Mapping[str, Iterable[str]]:
+        """Return capability map for this provider."""
+
+    @abstractmethod
+    async def create_key(self, spec: KeySpec) -> KeyRef:
+        """Generate a new key and return a :class:`KeyRef`."""
+
+    @abstractmethod
+    async def import_key(
+        self,
+        spec: KeySpec,
+        material: bytes,
+        *,
+        public: Optional[bytes] = None,
+    ) -> KeyRef:
+        """Import an existing key and return its :class:`KeyRef`."""
+
+    @abstractmethod
+    async def rotate_key(
+        self, kid: str, *, spec_overrides: Optional[dict] = None
+    ) -> KeyRef:
+        """Create a new version for an existing key."""
+
+    @abstractmethod
+    async def destroy_key(self, kid: str, version: Optional[int] = None) -> bool:
+        """Destroy a key or specific version."""
+
+    @abstractmethod
+    async def get_key(
+        self,
+        kid: str,
+        version: Optional[int] = None,
+        *,
+        include_secret: bool = False,
+    ) -> KeyRef:
+        """Fetch a :class:`KeyRef` for the given key id/version."""
+
+    @abstractmethod
+    async def list_versions(self, kid: str) -> Tuple[int, ...]:
+        """Return available versions for a key."""
+
+    @abstractmethod
+    async def get_public_jwk(self, kid: str, version: Optional[int] = None) -> dict:
+        """Return an RFC 7517 JWK for the public portion of the key."""
+
+    @abstractmethod
+    async def jwks(self, *, prefix_kids: Optional[str] = None) -> dict:
+        """Return a JWKS document containing the latest versions of keys."""
+
+    @abstractmethod
+    async def random_bytes(self, n: int) -> bytes:
+        """Return ``n`` cryptographically secure random bytes."""
+
+    @abstractmethod
+    async def hkdf(self, ikm: bytes, *, salt: bytes, info: bytes, length: int) -> bytes:
+        """Derive key material using HKDF-SHA256."""

--- a/pkgs/core/swarmauri_core/keys/__init__.py
+++ b/pkgs/core/swarmauri_core/keys/__init__.py
@@ -1,0 +1,13 @@
+"""Key provider interfaces and types."""
+
+from .IKeyProvider import IKeyProvider
+from .types import KeySpec, KeyAlg, KeyClass, ExportPolicy, KeyUse
+
+__all__ = [
+    "IKeyProvider",
+    "KeySpec",
+    "KeyAlg",
+    "KeyClass",
+    "ExportPolicy",
+    "KeyUse",
+]

--- a/pkgs/core/swarmauri_core/keys/types.py
+++ b/pkgs/core/swarmauri_core/keys/types.py
@@ -1,0 +1,49 @@
+"""Key specification and related enums for key providers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, Optional, Tuple
+
+from ..crypto.types import ExportPolicy, KeyUse
+
+
+class KeyClass(str, Enum):
+    """Key classification."""
+
+    symmetric = "sym"
+    asymmetric = "asym"
+
+
+class KeyAlg(str, Enum):
+    """Supported key algorithms."""
+
+    AES256_GCM = "AES256_GCM"
+    ED25519 = "ED25519"
+    X25519 = "X25519"
+    RSA_OAEP_SHA256 = "RSA_OAEP_SHA256"
+    RSA_PSS_SHA256 = "RSA_PSS_SHA256"
+    ECDSA_P256_SHA256 = "ECDSA_P256_SHA256"
+
+
+@dataclass(frozen=True)
+class KeySpec:
+    """Parameters for key creation or import."""
+
+    klass: KeyClass
+    alg: KeyAlg
+    uses: Tuple[KeyUse, ...]
+    export_policy: ExportPolicy
+    size_bits: Optional[int] = None
+    label: Optional[str] = None
+    tags: Optional[Dict[str, str]] = None
+
+
+__all__ = [
+    "KeyClass",
+    "KeyAlg",
+    "KeySpec",
+    "ExportPolicy",
+    "KeyUse",
+]

--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -77,6 +77,7 @@ members = [
     "standards/peagen",
     "standards/auto_authn",
     "standards/auto_kms",
+    "standards/swarmauri_keyproviders",
     "standards/swarmauri_crypto_paramiko",
     "standards/swarmauri_crypto_pgp",
     "standards/swarmauri_crypto_sodium",
@@ -228,6 +229,7 @@ swarmauri_mre_crypto_age = { workspace = true }
 swarmauri_mre_crypto_pgp = { workspace = true }
 swarmauri_mre_crypto_ecdh_es_kw = { workspace = true }
 swarmauri_signing_ed25519 = { workspace = true }
+swarmauri_keyproviders = { workspace = true }
 swarmauri_signing_secp256k1 = { workspace = true }
 swarmauri_signing_hmac = { workspace = true }
 swarmauri_signing_ecdsa = { workspace = true }

--- a/pkgs/standards/swarmauri_keyproviders/LICENSE
+++ b/pkgs/standards/swarmauri_keyproviders/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/standards/swarmauri_keyproviders/README.md
+++ b/pkgs/standards/swarmauri_keyproviders/README.md
@@ -1,0 +1,13 @@
+![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+
+# Swarmauri Key Providers
+
+Collection of key provider implementations for the Swarmauri SDK.  These
+providers implement the `IKeyProvider` interface for managing symmetric and
+asymmetric keys and exporting public material via JWK/JWKS.
+
+## Installation
+
+```bash
+pip install swarmauri_keyproviders
+```

--- a/pkgs/standards/swarmauri_keyproviders/pyproject.toml
+++ b/pkgs/standards/swarmauri_keyproviders/pyproject.toml
@@ -1,0 +1,68 @@
+[project]
+name = "swarmauri_keyproviders"
+version = "0.1.0"
+description = "Key provider implementations for Swarmauri"
+license = "Apache-2.0"
+readme = "README.md"
+requires-python = ">=3.10,<3.13"
+authors = [{ name = "Swarmauri", email = "opensource@swarmauri.com" }]
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Development Status :: 3 - Alpha",
+    "Topic :: Security :: Cryptography",
+    "Intended Audience :: Developers",
+]
+dependencies = [
+    "swarmauri_core",
+    "swarmauri_base",
+    "cryptography",
+]
+
+[project.optional-dependencies]
+pkcs11 = ["pkcs11"]
+
+[tool.uv.sources]
+swarmauri_core = { workspace = true }
+swarmauri_base = { workspace = true }
+
+[tool.pytest.ini_options]
+norecursedirs = ["combined", "scripts"]
+markers = [
+    "test: standard test",
+    "unit: Unit tests",
+    "i9n: Integration tests",
+    "r8n: Regression tests",
+    "acceptance: Acceptance tests",
+    "perf: Performance tests",
+]
+timeout = 300
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "pytest-timeout>=2.3.1",
+    "pytest-benchmark>=4.0.0",
+    "ruff>=0.9.9",
+]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[project.entry-points.'swarmauri.key_providers']
+LocalKeyProvider = "swarmauri_keyproviders.LocalKeyProvider:LocalKeyProvider"
+SshKeyProvider = "swarmauri_keyproviders.SshKeyProvider:SshKeyProvider"
+Pkcs11KeyProvider = "swarmauri_keyproviders.Pkcs11KeyProvider:Pkcs11KeyProvider"

--- a/pkgs/standards/swarmauri_keyproviders/swarmauri_keyproviders/LocalKeyProvider.py
+++ b/pkgs/standards/swarmauri_keyproviders/swarmauri_keyproviders/LocalKeyProvider.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+import secrets
+from typing import Iterable, Mapping, Optional, Tuple, Dict, Literal
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from cryptography.hazmat.primitives.asymmetric import ed25519, rsa, ec, x25519
+
+from swarmauri_base.keys.KeyProviderBase import KeyProviderBase
+from swarmauri_core.keys.types import KeySpec, KeyAlg, KeyClass, ExportPolicy
+from swarmauri_core.crypto.types import KeyRef
+
+
+def _b64u(b: bytes) -> str:
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode("ascii")
+
+
+def _pem_pub(priv) -> bytes:
+    return priv.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+
+def _pem_priv(priv) -> bytes:
+    return priv.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+
+
+class LocalKeyProvider(KeyProviderBase):
+    """In-memory key provider for development and testing."""
+
+    type: Literal["LocalKeyProvider"] = "LocalKeyProvider"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._store: Dict[str, Dict[int, KeyRef]] = {}
+
+    def supports(self) -> Mapping[str, Iterable[str]]:
+        algs: tuple[str, ...] = (
+            KeyAlg.AES256_GCM.value,
+            KeyAlg.ED25519.value,
+            KeyAlg.X25519.value,
+            KeyAlg.RSA_OAEP_SHA256.value,
+            KeyAlg.RSA_PSS_SHA256.value,
+            KeyAlg.ECDSA_P256_SHA256.value,
+        )
+        return {
+            "class": ("sym", "asym"),
+            "algs": algs,
+            "features": ("rotate", "import", "jwks", "hkdf", "random"),
+        }
+
+    async def create_key(self, spec: KeySpec) -> KeyRef:
+        kid = hashlib.sha256(os.urandom(16)).hexdigest()[:16]
+        version = 1
+
+        if spec.klass == KeyClass.symmetric:
+            if spec.alg != KeyAlg.AES256_GCM:
+                raise ValueError(f"Unsupported symmetric alg: {spec.alg}")
+            material = secrets.token_bytes(32)
+            public = None
+        else:
+            if spec.alg == KeyAlg.ED25519:
+                sk = ed25519.Ed25519PrivateKey.generate()
+            elif spec.alg == KeyAlg.X25519:
+                sk = x25519.X25519PrivateKey.generate()
+            elif spec.alg in (KeyAlg.RSA_OAEP_SHA256, KeyAlg.RSA_PSS_SHA256):
+                bits = spec.size_bits or 3072
+                sk = rsa.generate_private_key(public_exponent=65537, key_size=bits)
+            elif spec.alg == KeyAlg.ECDSA_P256_SHA256:
+                sk = ec.generate_private_key(ec.SECP256R1())
+            else:
+                raise ValueError(f"Unsupported asymmetric alg: {spec.alg}")
+            material = _pem_priv(sk)
+            public = _pem_pub(sk)
+
+        ref = KeyRef(
+            kid=kid,
+            version=version,
+            type="OPAQUE",
+            uses=tuple(spec.uses),
+            export_policy=spec.export_policy,
+            public=public,
+            material=(material if spec.export_policy != ExportPolicy.NONE else None),
+            tags={"label": spec.label, "alg": spec.alg.value, **(spec.tags or {})},
+        )
+        self._store.setdefault(kid, {})[version] = ref
+        return ref
+
+    async def import_key(
+        self,
+        spec: KeySpec,
+        material: bytes,
+        *,
+        public: Optional[bytes] = None,
+    ) -> KeyRef:
+        kid = hashlib.sha256(material).hexdigest()[:16]
+        ref = KeyRef(
+            kid=kid,
+            version=1,
+            type="OPAQUE",
+            uses=tuple(spec.uses),
+            export_policy=spec.export_policy,
+            public=public,
+            material=(material if spec.export_policy != ExportPolicy.NONE else None),
+            tags={
+                "label": spec.label,
+                "alg": spec.alg.value,
+                "imported": True,
+                **(spec.tags or {}),
+            },
+        )
+        self._store.setdefault(kid, {})[1] = ref
+        return ref
+
+    async def rotate_key(
+        self, kid: str, *, spec_overrides: Optional[dict] = None
+    ) -> KeyRef:
+        if kid not in self._store:
+            raise KeyError(f"Unknown kid: {kid}")
+        latest = max(self._store[kid])
+        base = self._store[kid][latest]
+        alg = KeyAlg(base.tags["alg"])
+        spec = KeySpec(
+            klass=(
+                KeyClass.symmetric if alg == KeyAlg.AES256_GCM else KeyClass.asymmetric
+            ),
+            alg=alg,
+            size_bits=(spec_overrides or {}).get("size_bits"),
+            label=base.tags.get("label"),
+            export_policy=base.export_policy,
+            uses=tuple(base.uses),
+            tags=base.tags,
+        )
+        new_ref = await self.create_key(spec)
+        rotated = new_ref.__class__(
+            **{**new_ref.__dict__, "kid": kid, "version": latest + 1}
+        )
+        self._store[kid][latest + 1] = rotated
+        return rotated
+
+    async def destroy_key(self, kid: str, version: Optional[int] = None) -> bool:
+        bucket = self._store.get(kid)
+        if not bucket:
+            return False
+        if version is None:
+            del self._store[kid]
+            return True
+        bucket.pop(version, None)
+        if not bucket:
+            del self._store[kid]
+        return True
+
+    async def get_key(
+        self,
+        kid: str,
+        version: Optional[int] = None,
+        *,
+        include_secret: bool = False,
+    ) -> KeyRef:
+        bucket = self._store[kid]
+        v = version or max(bucket)
+        ref = bucket[v]
+        if include_secret or ref.material is None:
+            return ref
+        return ref
+
+    async def list_versions(self, kid: str) -> Tuple[int, ...]:
+        return tuple(sorted(self._store[kid].keys()))
+
+    async def get_public_jwk(self, kid: str, version: Optional[int] = None) -> dict:
+        ref = await self.get_key(kid, version)
+        alg = KeyAlg(ref.tags["alg"])
+        if alg == KeyAlg.ED25519:
+            pk = serialization.load_pem_public_key(ref.public)
+            raw = pk.public_bytes(
+                serialization.Encoding.Raw, serialization.PublicFormat.Raw
+            )
+            return {
+                "kty": "OKP",
+                "crv": "Ed25519",
+                "x": _b64u(raw),
+                "kid": f"{ref.kid}.{ref.version}",
+            }
+        if alg in (KeyAlg.RSA_OAEP_SHA256, KeyAlg.RSA_PSS_SHA256):
+            pk = serialization.load_pem_public_key(ref.public)
+            pn = pk.public_numbers()
+            n = pn.n.to_bytes((pn.n.bit_length() + 7) // 8, "big")
+            e = pn.e.to_bytes((pn.e.bit_length() + 7) // 8, "big")
+            return {
+                "kty": "RSA",
+                "n": _b64u(n),
+                "e": _b64u(e),
+                "kid": f"{ref.kid}.{ref.version}",
+            }
+        if alg == KeyAlg.ECDSA_P256_SHA256:
+            pk = serialization.load_pem_public_key(ref.public)
+            nums = pk.public_numbers()
+            x = nums.x.to_bytes(32, "big")
+            y = nums.y.to_bytes(32, "big")
+            return {
+                "kty": "EC",
+                "crv": "P-256",
+                "x": _b64u(x),
+                "y": _b64u(y),
+                "kid": f"{ref.kid}.{ref.version}",
+            }
+        if alg == KeyAlg.X25519:
+            pk = serialization.load_pem_public_key(ref.public)
+            raw = pk.public_bytes(
+                serialization.Encoding.Raw, serialization.PublicFormat.Raw
+            )
+            return {
+                "kty": "OKP",
+                "crv": "X25519",
+                "x": _b64u(raw),
+                "kid": f"{ref.kid}.{ref.version}",
+            }
+        if alg == KeyAlg.AES256_GCM:
+            return {"kty": "oct", "alg": "A256GCM", "kid": f"{ref.kid}.{ref.version}"}
+        raise ValueError(f"Unsupported alg for JWK export: {alg}")
+
+    async def jwks(self, *, prefix_kids: Optional[str] = None) -> dict:
+        out = []
+        for _kid, versions in self._store.items():
+            if prefix_kids and not _kid.startswith(prefix_kids):
+                continue
+            v = max(versions)
+            out.append(await self.get_public_jwk(_kid, v))
+        return {"keys": out}
+
+    async def random_bytes(self, n: int) -> bytes:
+        return secrets.token_bytes(n)
+
+    async def hkdf(self, ikm: bytes, *, salt: bytes, info: bytes, length: int) -> bytes:
+        return HKDF(
+            algorithm=hashes.SHA256(), length=length, salt=salt, info=info
+        ).derive(ikm)

--- a/pkgs/standards/swarmauri_keyproviders/swarmauri_keyproviders/Pkcs11KeyProvider.py
+++ b/pkgs/standards/swarmauri_keyproviders/swarmauri_keyproviders/Pkcs11KeyProvider.py
@@ -1,0 +1,508 @@
+from __future__ import annotations
+
+import os
+import base64
+import hashlib
+import secrets
+from dataclasses import dataclass
+from typing import Dict, Iterable, Mapping, Optional, Tuple, Literal, Any
+
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa, ec
+
+from swarmauri_base.keys.KeyProviderBase import KeyProviderBase
+from swarmauri_core.keys.types import KeySpec, KeyAlg, KeyClass, ExportPolicy, KeyUse
+from swarmauri_core.crypto.types import KeyRef
+
+try:  # pragma: no cover - optional dependency
+    import pkcs11
+    from pkcs11 import Attribute, ObjectClass, KeyType, Mechanism
+
+    _PKCS11_OK = True
+except Exception:  # pragma: no cover - dependency missing
+    _PKCS11_OK = False
+
+
+def _b64u(b: bytes) -> str:
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode("ascii")
+
+
+@dataclass(frozen=True)
+class _IndexEntry:
+    kid: str
+    version: int
+    label: str
+    klass: KeyClass
+    alg: KeyAlg
+    handles: Dict[str, bytes]
+    tags: Dict[str, Any]
+
+
+class Pkcs11KeyProvider(KeyProviderBase):
+    """PKCS#11-backed key provider."""
+
+    type: Literal["Pkcs11KeyProvider"] = "Pkcs11KeyProvider"
+
+    def __init__(
+        self,
+        module_path: str,
+        *,
+        slot: Optional[int] = None,
+        token_label: Optional[str] = None,
+        user_pin: Optional[str] = None,
+        key_label_prefix: str = "sa:",
+        allow_ec: bool = True,
+        allow_rsa: bool = True,
+        allow_aes: bool = True,
+    ) -> None:
+        super().__init__()
+        if not _PKCS11_OK:
+            raise ImportError("pkcs11 is required. Install with: pip install pkcs11")
+
+        self._lib = pkcs11.lib(module_path)
+        if token_label:
+            self._slot = next(
+                (
+                    s
+                    for s in self._lib.get_slots()
+                    if s.get_token().label.strip() == token_label
+                ),
+                None,
+            )
+            if self._slot is None:
+                raise RuntimeError(
+                    f"PKCS#11 token with label={token_label!r} not found"
+                )
+        else:
+            slots = list(self._lib.get_slots())
+            if not slots:
+                raise RuntimeError("No PKCS#11 slots available")
+            self._slot = slots[slot or 0]
+
+        self._pin = user_pin
+        self._prefix = key_label_prefix
+        self._idx: Dict[str, Dict[int, _IndexEntry]] = {}
+        self._allow_ec = allow_ec
+        self._allow_rsa = allow_rsa
+        self._allow_aes = allow_aes
+
+    def _session(self):  # pragma: no cover - thin wrapper
+        return self._slot.get_token().open(rw=True, user_pin=self._pin)
+
+    def supports(self) -> Mapping[str, Iterable[str]]:
+        algs: list[str] = []
+        if self._allow_aes:
+            algs.append(KeyAlg.AES256_GCM.value)
+        if self._allow_ec:
+            algs.append(KeyAlg.ECDSA_P256_SHA256.value)
+        if self._allow_rsa:
+            algs.extend([KeyAlg.RSA_OAEP_SHA256.value, KeyAlg.RSA_PSS_SHA256.value])
+        return {
+            "class": ("sym", "asym"),
+            "algs": tuple(algs),
+            "features": ("rotate", "jwks", "non_exportable", "random", "hkdf"),
+        }
+
+    async def create_key(self, spec: KeySpec) -> KeyRef:
+        kid = hashlib.sha256(os.urandom(16)).hexdigest()[:16]
+        version = 1
+        label = f"{self._prefix}{kid}.v{version}"
+        cka_id = secrets.token_bytes(8)
+
+        if spec.klass == KeyClass.symmetric:
+            if spec.alg != KeyAlg.AES256_GCM:
+                raise ValueError("AES-256 only")
+            if not self._allow_aes:
+                raise RuntimeError("AES disabled")
+            with self._session() as s:
+                s.generate_key(
+                    KeyType.AES,
+                    256,
+                    label=label,
+                    id=cka_id,
+                    template={
+                        Attribute.SENSITIVE: True,
+                        Attribute.EXTRACTABLE: False,
+                        Attribute.ENCRYPT: True,
+                        Attribute.DECRYPT: True,
+                        Attribute.WRAP: True,
+                        Attribute.UNWRAP: True,
+                    },
+                )
+            entry = _IndexEntry(
+                kid=kid,
+                version=version,
+                label=label,
+                klass=KeyClass.symmetric,
+                alg=spec.alg,
+                handles={"sec_id": cka_id},
+                tags={"label": spec.label, "module": "pkcs11", "kty": "oct"},
+            )
+            self._idx.setdefault(kid, {})[version] = entry
+            return KeyRef(
+                kid=kid,
+                version=version,
+                type="OPAQUE",
+                uses=spec.uses,
+                export_policy=ExportPolicy.NONE,
+                public=None,
+                material=None,
+                tags={"label": spec.label, "alg": spec.alg.value, "provider": "pkcs11"},
+            )
+
+        if spec.alg in (KeyAlg.RSA_OAEP_SHA256, KeyAlg.RSA_PSS_SHA256):
+            if not self._allow_rsa:
+                raise RuntimeError("RSA disabled")
+            size_bits = spec.size_bits or 3072
+            with self._session() as s:
+                pub, priv = s.generate_keypair(
+                    KeyType.RSA,
+                    mechanism=Mechanism.RSA_PKCS_KEY_PAIR_GEN,
+                    store=True,
+                    public_template={
+                        Attribute.LABEL: label,
+                        Attribute.ID: cka_id,
+                        Attribute.VERIFY: True,
+                        Attribute.ENCRYPT: True,
+                        Attribute.WRAP: True,
+                        Attribute.PUBLIC_EXPONENT: (65537).to_bytes(3, "big"),
+                        Attribute.MODULUS_BITS: size_bits,
+                    },
+                    private_template={
+                        Attribute.LABEL: label,
+                        Attribute.ID: cka_id,
+                        Attribute.SENSITIVE: True,
+                        Attribute.EXTRACTABLE: False,
+                        Attribute.SIGN: True,
+                        Attribute.DECRYPT: True,
+                        Attribute.UNWRAP: True,
+                    },
+                )
+                n = pub[Attribute.MODULUS]
+                e = pub[Attribute.PUBLIC_EXPONENT]
+            entry = _IndexEntry(
+                kid=kid,
+                version=version,
+                label=label,
+                klass=KeyClass.asymmetric,
+                alg=spec.alg,
+                handles={"pub_id": cka_id, "priv_id": cka_id},
+                tags={
+                    "label": spec.label,
+                    "module": "pkcs11",
+                    "kty": "RSA",
+                    "n_len": len(n) * 8,
+                },
+            )
+            self._idx.setdefault(kid, {})[version] = entry
+            pub_pem = serialization.load_der_public_key(
+                rsa.RSAPublicNumbers(int.from_bytes(n, "big"), int.from_bytes(e, "big"))
+                .public_key()
+                .public_bytes(
+                    serialization.Encoding.DER,
+                    serialization.PublicFormat.SubjectPublicKeyInfo,
+                )
+            ).public_bytes(
+                serialization.Encoding.PEM,
+                serialization.PublicFormat.SubjectPublicKeyInfo,
+            )
+            return KeyRef(
+                kid=kid,
+                version=version,
+                type="OPAQUE",
+                uses=spec.uses,
+                export_policy=ExportPolicy.NONE,
+                public=pub_pem,
+                material=None,
+                tags={"label": spec.label, "alg": spec.alg.value, "provider": "pkcs11"},
+            )
+
+        if spec.alg == KeyAlg.ECDSA_P256_SHA256:
+            if not self._allow_ec:
+                raise RuntimeError("EC disabled")
+            P256_PARAM = bytes.fromhex("06082A8648CE3D030107")
+            with self._session() as s:
+                pub, priv = s.generate_keypair(
+                    KeyType.EC,
+                    store=True,
+                    public_template={
+                        Attribute.LABEL: label,
+                        Attribute.ID: cka_id,
+                        Attribute.VERIFY: True,
+                        Attribute.EC_PARAMS: P256_PARAM,
+                    },
+                    private_template={
+                        Attribute.LABEL: label,
+                        Attribute.ID: cka_id,
+                        Attribute.SENSITIVE: True,
+                        Attribute.EXTRACTABLE: False,
+                        Attribute.SIGN: True,
+                    },
+                )
+                ec_point = pub[Attribute.EC_POINT]
+            x, y = _parse_ec_point_uncompressed(ec_point, 32)
+            entry = _IndexEntry(
+                kid=kid,
+                version=version,
+                label=label,
+                klass=KeyClass.asymmetric,
+                alg=spec.alg,
+                handles={"pub_id": cka_id, "priv_id": cka_id},
+                tags={
+                    "label": spec.label,
+                    "module": "pkcs11",
+                    "kty": "EC",
+                    "crv": "P-256",
+                },
+            )
+            self._idx.setdefault(kid, {})[version] = entry
+            pub_pem = (
+                ec.EllipticCurvePublicNumbers(
+                    int.from_bytes(x, "big"),
+                    int.from_bytes(y, "big"),
+                    ec.SECP256R1(),
+                )
+                .public_key()
+                .public_bytes(
+                    serialization.Encoding.PEM,
+                    serialization.PublicFormat.SubjectPublicKeyInfo,
+                )
+            )
+            return KeyRef(
+                kid=kid,
+                version=version,
+                type="OPAQUE",
+                uses=spec.uses,
+                export_policy=ExportPolicy.NONE,
+                public=pub_pem,
+                material=None,
+                tags={"label": spec.label, "alg": spec.alg.value, "provider": "pkcs11"},
+            )
+
+        raise ValueError(f"Unsupported algorithm: {spec.alg}")
+
+    async def import_key(
+        self, spec: KeySpec, material: bytes, *, public: Optional[bytes] = None
+    ) -> KeyRef:
+        raise NotImplementedError("Private key import not supported")
+
+    async def rotate_key(
+        self, kid: str, *, spec_overrides: Optional[dict] = None
+    ) -> KeyRef:
+        entry_latest = self._latest_entry(kid)
+        spec = KeySpec(
+            klass=entry_latest.klass,
+            alg=entry_latest.alg,
+            size_bits=spec_overrides.get("size_bits") if spec_overrides else None,
+            label=entry_latest.tags.get("label"),
+            export_policy=ExportPolicy.NONE,
+            uses=entry_latest.tags.get("uses", (KeyUse.sign, KeyUse.verify)),
+            tags=entry_latest.tags,
+        )
+        new_ref = await self.create_key(spec)
+        latest_v = max(self._idx[kid].keys())
+        new_entry = self._idx[new_ref.kid][1]
+        self._idx.setdefault(kid, {})[latest_v + 1] = _IndexEntry(
+            kid=kid,
+            version=latest_v + 1,
+            label=new_entry.label,
+            klass=new_entry.klass,
+            alg=new_entry.alg,
+            handles=new_entry.handles,
+            tags=new_entry.tags,
+        )
+        del self._idx[new_ref.kid]
+        return KeyRef(
+            kid=kid,
+            version=latest_v + 1,
+            type=new_ref.type,
+            uses=new_ref.uses,
+            export_policy=ExportPolicy.NONE,
+            public=new_ref.public,
+            material=None,
+            tags=new_ref.tags,
+        )
+
+    async def destroy_key(self, kid: str, version: Optional[int] = None) -> bool:
+        if kid not in self._idx:
+            return False
+        versions = [version] if version is not None else list(self._idx[kid].keys())
+        ok = True
+        with self._session() as s:
+            for v in versions:
+                ent = self._idx[kid].get(v)
+                if not ent:
+                    ok = False
+                    continue
+                try:
+                    for obj in s.get_objects({Attribute.LABEL: ent.label}):
+                        obj.destroy()
+                except pkcs11.PKCS11Error:
+                    ok = False
+                self._idx[kid].pop(v, None)
+        if kid in self._idx and not self._idx[kid]:
+            self._idx.pop(kid, None)
+        return ok
+
+    async def get_key(
+        self, kid: str, version: Optional[int] = None, *, include_secret: bool = False
+    ) -> KeyRef:
+        ent = self._entry(kid, version)
+        public_pem = None
+        if ent.klass == KeyClass.asymmetric:
+            with self._session() as s:
+                pub_obj = _first_or_none(
+                    s.get_objects(
+                        {
+                            Attribute.CLASS: ObjectClass.PUBLIC_KEY,
+                            Attribute.LABEL: ent.label,
+                        }
+                    )
+                )
+                if not pub_obj:
+                    raise KeyError("Public key not found on token")
+                if ent.alg in (KeyAlg.RSA_OAEP_SHA256, KeyAlg.RSA_PSS_SHA256):
+                    n = pub_obj[Attribute.MODULUS]
+                    e = pub_obj[Attribute.PUBLIC_EXPONENT]
+                    pub = rsa.RSAPublicNumbers(
+                        int.from_bytes(n, "big"), int.from_bytes(e, "big")
+                    ).public_key()
+                    public_pem = pub.public_bytes(
+                        serialization.Encoding.PEM,
+                        serialization.PublicFormat.SubjectPublicKeyInfo,
+                    )
+                elif ent.alg == KeyAlg.ECDSA_P256_SHA256:
+                    ec_point = pub_obj[Attribute.EC_POINT]
+                    x, y = _parse_ec_point_uncompressed(ec_point, 32)
+                    pub = ec.EllipticCurvePublicNumbers(
+                        int.from_bytes(x, "big"),
+                        int.from_bytes(y, "big"),
+                        ec.SECP256R1(),
+                    ).public_key()
+                    public_pem = pub.public_bytes(
+                        serialization.Encoding.PEM,
+                        serialization.PublicFormat.SubjectPublicKeyInfo,
+                    )
+        return KeyRef(
+            kid=ent.kid,
+            version=ent.version,
+            type="OPAQUE",
+            uses=(KeyUse.sign, KeyUse.verify)
+            if ent.klass == KeyClass.asymmetric
+            else (KeyUse.wrap, KeyUse.unwrap),
+            export_policy=ExportPolicy.NONE,
+            public=public_pem,
+            material=None,
+            tags={
+                "label": ent.tags.get("label"),
+                "alg": ent.alg.value,
+                "provider": "pkcs11",
+            },
+        )
+
+    async def list_versions(self, kid: str) -> Tuple[int, ...]:
+        if kid not in self._idx:
+            raise KeyError("unknown kid")
+        return tuple(sorted(self._idx[kid].keys()))
+
+    async def get_public_jwk(self, kid: str, version: Optional[int] = None) -> dict:
+        ent = self._entry(kid, version)
+        if ent.klass == KeyClass.symmetric:
+            return {"kty": "oct", "alg": "A256GCM", "kid": f"{ent.kid}.{ent.version}"}
+        with self._session() as s:
+            pub_obj = _first_or_none(
+                s.get_objects(
+                    {
+                        Attribute.CLASS: ObjectClass.PUBLIC_KEY,
+                        Attribute.LABEL: ent.label,
+                    }
+                )
+            )
+            if not pub_obj:
+                raise KeyError("Public key not found on token")
+            if ent.alg in (KeyAlg.RSA_OAEP_SHA256, KeyAlg.RSA_PSS_SHA256):
+                n = pub_obj[Attribute.MODULUS]
+                e = pub_obj[Attribute.PUBLIC_EXPONENT]
+                return {
+                    "kty": "RSA",
+                    "n": _b64u(n),
+                    "e": _b64u(e),
+                    "kid": f"{ent.kid}.{ent.version}",
+                }
+            if ent.alg == KeyAlg.ECDSA_P256_SHA256:
+                ec_point = pub_obj[Attribute.EC_POINT]
+                x, y = _parse_ec_point_uncompressed(ec_point, 32)
+                return {
+                    "kty": "EC",
+                    "crv": "P-256",
+                    "x": _b64u(x),
+                    "y": _b64u(y),
+                    "kid": f"{ent.kid}.{ent.version}",
+                }
+        raise ValueError("Unsupported algorithm for JWK export")
+
+    async def jwks(self, *, prefix_kids: Optional[str] = None) -> dict:
+        out = []
+        for kid, versions in self._idx.items():
+            if prefix_kids and not kid.startswith(prefix_kids):
+                continue
+            v = max(versions)
+            out.append(await self.get_public_jwk(kid, v))
+        return {"keys": out}
+
+    async def random_bytes(self, n: int) -> bytes:
+        with self._session() as s:
+            return s.generate_random(n)
+
+    async def hkdf(self, ikm: bytes, *, salt: bytes, info: bytes, length: int) -> bytes:
+        return HKDF(
+            algorithm=hashes.SHA256(), length=length, salt=salt, info=info
+        ).derive(ikm)
+
+    def _latest_entry(self, kid: str) -> _IndexEntry:
+        if kid not in self._idx or not self._idx[kid]:
+            raise KeyError("unknown kid")
+        v = max(self._idx[kid].keys())
+        return self._idx[kid][v]
+
+    def _entry(self, kid: str, version: Optional[int]) -> _IndexEntry:
+        if kid not in self._idx:
+            raise KeyError("unknown kid")
+        if version is None:
+            return self._latest_entry(kid)
+        ent = self._idx[kid].get(version)
+        if not ent:
+            raise KeyError("unknown key version")
+        return ent
+
+
+def _first_or_none(iterable):
+    for x in iterable:
+        return x
+    return None
+
+
+def _parse_ec_point_uncompressed(
+    ec_point_attr: bytes, coord_len: int
+) -> tuple[bytes, bytes]:
+    data = bytes(ec_point_attr)
+    if (
+        len(data) >= 2
+        and data[0] == 0x04
+        and data[1] == len(data) - 2
+        and data[1] in (coord_len * 2 + 1, coord_len * 2 + 2)
+    ):
+        if len(data) >= 3 and data[2] == 0x04 and len(data) == data[1] + 2:
+            data = data[2:]
+    if not data or data[0] != 0x04:
+        raise ValueError("Unsupported EC_POINT encoding")
+    if len(data) != 1 + 2 * coord_len:
+        body = data[1:]
+        if len(body) % 2 != 0:
+            raise ValueError("Invalid EC_POINT length")
+        half = len(body) // 2
+        x = body[:half].rjust(coord_len, b"\x00")[-coord_len:]
+        y = body[half:].rjust(coord_len, b"\x00")[-coord_len:]
+        return x, y
+    return data[1 : 1 + coord_len], data[1 + coord_len :]

--- a/pkgs/standards/swarmauri_keyproviders/swarmauri_keyproviders/SshKeyProvider.py
+++ b/pkgs/standards/swarmauri_keyproviders/swarmauri_keyproviders/SshKeyProvider.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+import secrets
+from typing import Dict, Iterable, Mapping, Optional, Tuple, Literal
+
+from cryptography.hazmat.primitives import serialization, hashes
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from cryptography.hazmat.primitives.asymmetric import ed25519, rsa, ec
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    PrivateFormat,
+    NoEncryption,
+    PublicFormat,
+)
+
+from swarmauri_base.keys.KeyProviderBase import KeyProviderBase
+from swarmauri_core.keys.types import KeySpec, KeyAlg, KeyClass, ExportPolicy
+from swarmauri_core.crypto.types import KeyRef
+
+
+def _b64u(b: bytes) -> str:
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode("ascii")
+
+
+def _ssh_pub_bytes(pub) -> bytes:
+    return pub.public_bytes(Encoding.OpenSSH, PublicFormat.OpenSSH)
+
+
+def _pem_priv(priv) -> bytes:
+    return priv.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption())
+
+
+def _fingerprint(ssh_pub: bytes) -> str:
+    try:
+        b64 = ssh_pub.split(None, 2)[1]
+        blob = base64.b64decode(b64)
+        h = hashlib.md5(blob).hexdigest()
+        return ":".join(a + b for a, b in zip(h[::2], h[1::2]))
+    except Exception:  # pragma: no cover - defensive
+        return "unknown"
+
+
+class SshKeyProvider(KeyProviderBase):
+    """SSH-focused key provider with JWK/JWKS export."""
+
+    type: Literal["SshKeyProvider"] = "SshKeyProvider"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._store: Dict[str, Dict[int, KeyRef]] = {}
+
+    def supports(self) -> Mapping[str, Iterable[str]]:
+        return {
+            "class": ("asym",),
+            "algs": (KeyAlg.ED25519, KeyAlg.RSA_PSS_SHA256, KeyAlg.ECDSA_P256_SHA256),
+            "features": ("rotate", "import", "jwks", "hkdf", "random"),
+        }
+
+    async def create_key(self, spec: KeySpec) -> KeyRef:
+        if spec.klass != KeyClass.asymmetric:
+            raise ValueError("SshKeyProvider only creates asymmetric keys")
+        kid = hashlib.sha256(os.urandom(16)).hexdigest()[:16]
+        version = 1
+
+        if spec.alg == KeyAlg.ED25519:
+            sk = ed25519.Ed25519PrivateKey.generate()
+        elif spec.alg == KeyAlg.RSA_PSS_SHA256:
+            bits = spec.size_bits or 3072
+            sk = rsa.generate_private_key(public_exponent=65537, key_size=bits)
+        elif spec.alg == KeyAlg.ECDSA_P256_SHA256:
+            sk = ec.generate_private_key(ec.SECP256R1())
+        else:
+            raise ValueError(f"Unsupported alg: {spec.alg}")
+
+        pem = _pem_priv(sk)
+        ssh_pub = _ssh_pub_bytes(sk.public_key())
+
+        ref = KeyRef(
+            kid=kid,
+            version=version,
+            type="OPAQUE",
+            uses=spec.uses,
+            export_policy=spec.export_policy,
+            public=ssh_pub,
+            material=(pem if spec.export_policy != ExportPolicy.NONE else None),
+            tags={
+                "label": spec.label,
+                "alg": spec.alg.value,
+                "ssh_fingerprint": _fingerprint(ssh_pub),
+            },
+        )
+        self._store.setdefault(kid, {})[version] = ref
+        return ref
+
+    async def import_key(
+        self, spec: KeySpec, material: bytes, *, public: Optional[bytes] = None
+    ) -> KeyRef:
+        kid = hashlib.sha256(material if material else (public or b"")).hexdigest()[:16]
+        if material:
+            sk = serialization.load_pem_private_key(material, password=None)
+            ssh_pub = _ssh_pub_bytes(sk.public_key())
+        elif public:
+            ssh_pub = public
+        else:
+            raise ValueError(
+                "Provide either PEM private in 'material' or OpenSSH public in 'public'"
+            )
+
+        ref = KeyRef(
+            kid=kid,
+            version=1,
+            type="OPAQUE",
+            uses=spec.uses,
+            export_policy=spec.export_policy,
+            public=ssh_pub,
+            material=(material if spec.export_policy != ExportPolicy.NONE else None),
+            tags={
+                "label": spec.label,
+                "alg": spec.alg.value,
+                "imported": True,
+                "ssh_fingerprint": _fingerprint(ssh_pub),
+            },
+        )
+        self._store.setdefault(kid, {})[1] = ref
+        return ref
+
+    async def rotate_key(
+        self, kid: str, *, spec_overrides: Optional[dict] = None
+    ) -> KeyRef:
+        if kid not in self._store:
+            raise KeyError("unknown kid")
+        latest = max(self._store[kid])
+        base = self._store[kid][latest]
+        alg = KeyAlg(base.tags["alg"])
+        spec = KeySpec(
+            klass=KeyClass.asymmetric,
+            alg=alg,
+            size_bits=(spec_overrides or {}).get("size_bits"),
+            label=base.tags.get("label"),
+            export_policy=base.export_policy,
+            uses=tuple(base.uses),
+            tags=base.tags,
+        )
+        new = await self.create_key(spec)
+        new = new.__class__(**{**new.__dict__, "kid": kid, "version": latest + 1})
+        self._store[kid][latest + 1] = new
+        return new
+
+    async def destroy_key(self, kid: str, version: Optional[int] = None) -> bool:
+        if kid not in self._store:
+            return False
+        if version is None:
+            del self._store[kid]
+            return True
+        self._store[kid].pop(version, None)
+        if not self._store[kid]:
+            del self._store[kid]
+        return True
+
+    async def get_key(
+        self, kid: str, version: Optional[int] = None, *, include_secret: bool = False
+    ) -> KeyRef:
+        bucket = self._store[kid]
+        v = version or max(bucket)
+        return bucket[v]
+
+    async def list_versions(self, kid: str) -> Tuple[int, ...]:
+        return tuple(sorted(self._store[kid].keys()))
+
+    async def get_public_jwk(self, kid: str, version: Optional[int] = None) -> dict:
+        ref = await self.get_key(kid, version)
+        alg = KeyAlg(ref.tags["alg"])
+        pk = serialization.load_ssh_public_key(ref.public)
+        if alg == KeyAlg.ED25519:
+            raw = pk.public_bytes(Encoding.Raw, PublicFormat.Raw)
+            return {
+                "kty": "OKP",
+                "crv": "Ed25519",
+                "x": _b64u(raw),
+                "kid": f"{ref.kid}.{ref.version}",
+            }
+        if alg == KeyAlg.ECDSA_P256_SHA256:
+            nums = pk.public_numbers()
+            x = nums.x.to_bytes(32, "big")
+            y = nums.y.to_bytes(32, "big")
+            return {
+                "kty": "EC",
+                "crv": "P-256",
+                "x": _b64u(x),
+                "y": _b64u(y),
+                "kid": f"{ref.kid}.{ref.version}",
+            }
+        if alg == KeyAlg.RSA_PSS_SHA256:
+            nums = pk.public_numbers()
+            n = nums.n.to_bytes((nums.n.bit_length() + 7) // 8, "big")
+            e = nums.e.to_bytes((nums.e.bit_length() + 7) // 8, "big")
+            return {
+                "kty": "RSA",
+                "n": _b64u(n),
+                "e": _b64u(e),
+                "kid": f"{ref.kid}.{ref.version}",
+            }
+        raise ValueError("Unsupported alg for JWK export")
+
+    async def jwks(self, *, prefix_kids: Optional[str] = None) -> dict:
+        out = []
+        for kid, versions in self._store.items():
+            if prefix_kids and not kid.startswith(prefix_kids):
+                continue
+            v = max(versions)
+            out.append(await self.get_public_jwk(kid, v))
+        return {"keys": out}
+
+    async def random_bytes(self, n: int) -> bytes:
+        return secrets.token_bytes(n)
+
+    async def hkdf(self, ikm: bytes, *, salt: bytes, info: bytes, length: int) -> bytes:
+        return HKDF(
+            algorithm=hashes.SHA256(), length=length, salt=salt, info=info
+        ).derive(ikm)

--- a/pkgs/standards/swarmauri_keyproviders/swarmauri_keyproviders/__init__.py
+++ b/pkgs/standards/swarmauri_keyproviders/swarmauri_keyproviders/__init__.py
@@ -1,0 +1,11 @@
+"""Concrete key provider implementations."""
+
+from .LocalKeyProvider import LocalKeyProvider
+from .SshKeyProvider import SshKeyProvider
+from .Pkcs11KeyProvider import Pkcs11KeyProvider
+
+__all__ = [
+    "LocalKeyProvider",
+    "SshKeyProvider",
+    "Pkcs11KeyProvider",
+]

--- a/pkgs/standards/swarmauri_keyproviders/tests/test_local_provider.py
+++ b/pkgs/standards/swarmauri_keyproviders/tests/test_local_provider.py
@@ -1,0 +1,46 @@
+import asyncio
+
+import pytest
+
+from swarmauri_keyproviders import LocalKeyProvider
+from swarmauri_core.keys.types import KeySpec, KeyAlg, KeyClass, ExportPolicy, KeyUse
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_ed25519_jwk() -> None:
+    kp = LocalKeyProvider()
+    spec = KeySpec(
+        klass=KeyClass.asymmetric,
+        alg=KeyAlg.ED25519,
+        uses=(KeyUse.SIGN, KeyUse.VERIFY),
+        export_policy=ExportPolicy.PUBLIC_ONLY,
+    )
+    ref = await kp.create_key(spec)
+    jwk = await kp.get_public_jwk(ref.kid)
+    assert jwk["kty"] == "OKP" and jwk["crv"] == "Ed25519"
+
+
+@pytest.mark.acceptance
+@pytest.mark.asyncio
+async def test_random_and_hkdf() -> None:
+    kp = LocalKeyProvider()
+    rnd = await kp.random_bytes(16)
+    assert len(rnd) == 16
+    out = await kp.hkdf(b"ikm", salt=b"s", info=b"i", length=32)
+    assert len(out) == 32
+
+
+@pytest.mark.perf
+def test_create_performance(benchmark) -> None:
+    spec = KeySpec(
+        klass=KeyClass.symmetric,
+        alg=KeyAlg.AES256_GCM,
+        uses=(KeyUse.ENCRYPT, KeyUse.DECRYPT),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+    )
+
+    def run() -> None:
+        asyncio.run(LocalKeyProvider().create_key(spec))
+
+    benchmark(run)

--- a/pkgs/standards/swarmauri_keyproviders/tests/test_pkcs11_provider.py
+++ b/pkgs/standards/swarmauri_keyproviders/tests/test_pkcs11_provider.py
@@ -1,0 +1,12 @@
+import pytest
+
+from swarmauri_keyproviders import Pkcs11KeyProvider
+
+
+@pytest.mark.unit
+def test_pkcs11_missing_dependency(tmp_path) -> None:
+    """Instantiation should fail if pkcs11 module is unavailable."""
+    if Pkcs11KeyProvider.__module__ is None:  # pragma: no cover - sanity
+        pytest.skip("module not loaded")
+    with pytest.raises(ImportError):
+        Pkcs11KeyProvider(module_path=str(tmp_path / "lib.so"))

--- a/pkgs/standards/swarmauri_keyproviders/tests/test_ssh_provider.py
+++ b/pkgs/standards/swarmauri_keyproviders/tests/test_ssh_provider.py
@@ -1,0 +1,35 @@
+import pytest
+
+from swarmauri_keyproviders import SshKeyProvider
+from swarmauri_core.keys.types import KeySpec, KeyAlg, KeyClass, ExportPolicy, KeyUse
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_rsa_jwk() -> None:
+    kp = SshKeyProvider()
+    spec = KeySpec(
+        klass=KeyClass.asymmetric,
+        alg=KeyAlg.RSA_PSS_SHA256,
+        uses=(KeyUse.SIGN, KeyUse.VERIFY),
+        export_policy=ExportPolicy.PUBLIC_ONLY,
+        size_bits=3072,
+    )
+    ref = await kp.create_key(spec)
+    jwk = await kp.get_public_jwk(ref.kid)
+    assert jwk["kty"] == "RSA"
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_jwks_contains_key() -> None:
+    kp = SshKeyProvider()
+    spec = KeySpec(
+        klass=KeyClass.asymmetric,
+        alg=KeyAlg.ECDSA_P256_SHA256,
+        uses=(KeyUse.SIGN, KeyUse.VERIFY),
+        export_policy=ExportPolicy.PUBLIC_ONLY,
+    )
+    ref = await kp.create_key(spec)
+    jwks = await kp.jwks()
+    assert any(key["kid"].startswith(ref.kid) for key in jwks["keys"])


### PR DESCRIPTION
## Summary
- add key provider interfaces and base class
- introduce Local, SSH, and PKCS#11 key providers
- cover key providers with unit, functional, and performance tests

## Testing
- `uv run --package swarmauri_base --directory base ruff format .`
- `uv run --package swarmauri_base --directory base ruff check . --fix`
- `uv run --package swarmauri_core --directory core ruff format .`
- `uv run --package swarmauri_core --directory core ruff check swarmauri_core/keys/types.py --fix`
- `uv run --package swarmauri_keyproviders --directory standards/swarmauri_keyproviders ruff format .`
- `uv run --package swarmauri_keyproviders --directory standards/swarmauri_keyproviders ruff check . --fix`
- `uv run --package swarmauri_base --directory base pytest`
- `uv run --package swarmauri_core --directory core pytest`
- `uv run --package swarmauri_keyproviders --directory standards/swarmauri_keyproviders pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a71fa22bf083268e12c570fd336030