### PR TITLE
Add JWT token service and interfaces

### DIFF
--- a/pkgs/base/swarmauri_base/tokens/TokenServiceBase.py
+++ b/pkgs/base/swarmauri_base/tokens/TokenServiceBase.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import Literal, Optional
+
+from pydantic import Field
+
+from swarmauri_base.ComponentBase import ComponentBase, ResourceTypes
+from swarmauri_core.tokens import ITokenService
+
+
+class TokenServiceBase(ITokenService, ComponentBase):
+    """Base class for token services."""
+
+    resource: Optional[str] = Field(default=ResourceTypes.CRYPTO.value, frozen=True)
+    type: Literal["TokenServiceBase"] = "TokenServiceBase"

--- a/pkgs/base/swarmauri_base/tokens/__init__.py
+++ b/pkgs/base/swarmauri_base/tokens/__init__.py
@@ -1,0 +1,5 @@
+"""Token service base classes."""
+
+from .TokenServiceBase import TokenServiceBase
+
+__all__ = ["TokenServiceBase"]

--- a/pkgs/base/tests/unit/test_token_service_base.py
+++ b/pkgs/base/tests/unit/test_token_service_base.py
@@ -1,0 +1,38 @@
+import pytest
+
+from swarmauri_base.tokens import TokenServiceBase
+from swarmauri_base.ComponentBase import ResourceTypes
+
+
+class DummyTokenService(TokenServiceBase):
+    def supports(self):
+        return {"formats": (), "algs": ()}
+
+    async def mint(
+        self,
+        claims,
+        *,
+        alg,
+        kid=None,
+        key_version=None,
+        headers=None,
+        lifetime_s=3600,
+        issuer=None,
+        subject=None,
+        audience=None,
+        scope=None,
+    ):
+        return ""
+
+    async def verify(self, token, *, issuer=None, audience=None, leeway_s=60):
+        return {}
+
+    async def jwks(self) -> dict:
+        return {}
+
+
+@pytest.mark.unit
+def test_base_defaults() -> None:
+    svc = DummyTokenService()
+    assert svc.resource == ResourceTypes.CRYPTO.value
+    assert svc.type == "DummyTokenService"

--- a/pkgs/core/swarmauri_core/keys/IKeyProvider.py
+++ b/pkgs/core/swarmauri_core/keys/IKeyProvider.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from .types import KeyRef
+
+
+class IKeyProvider(ABC):
+    """Interface for retrieving key material and JWKS documents."""
+
+    @abstractmethod
+    async def get_key(
+        self, kid: str, version: int | None = None, *, include_secret: bool = False
+    ) -> KeyRef:
+        """Return a ``KeyRef`` for ``kid`` and ``version``."""
+
+    @abstractmethod
+    async def jwks(self) -> dict:
+        """Return a JWKS mapping describing available public keys."""

--- a/pkgs/core/swarmauri_core/keys/__init__.py
+++ b/pkgs/core/swarmauri_core/keys/__init__.py
@@ -1,0 +1,6 @@
+"""Key provider interfaces."""
+
+from .IKeyProvider import IKeyProvider
+from .types import KeyAlg, KeyRef
+
+__all__ = ["IKeyProvider", "KeyAlg", "KeyRef"]

--- a/pkgs/core/swarmauri_core/keys/types.py
+++ b/pkgs/core/swarmauri_core/keys/types.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+
+class KeyAlg(str, Enum):
+    """Enumeration of key algorithms supported by token services."""
+
+    RSA_PSS_SHA256 = "RSA-PSS-SHA256"
+    ECDSA_P256_SHA256 = "ECDSA-P256-SHA256"
+    ED25519 = "ED25519"
+    HMAC_SHA256 = "HMAC-SHA256"
+
+
+@dataclass
+class KeyRef:
+    """Reference to a cryptographic key."""
+
+    kid: str
+    version: int
+    material: Optional[bytes]

--- a/pkgs/core/swarmauri_core/tokens/ITokenService.py
+++ b/pkgs/core/swarmauri_core/tokens/ITokenService.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Iterable, Mapping, Optional
+
+
+class ITokenService(ABC):
+    """Stable interface to mint and verify tokens.
+
+    Supports operations such as JSON Web Tokens (JWT) and JSON Web Signatures (JWS).
+    The interface keeps crypto-agnostic policy fields explicit (``iss``, ``aud``,
+    ``exp``, ``scope``).
+    """
+
+    @abstractmethod
+    def supports(self) -> Mapping[str, Iterable[str]]:
+        """Return formats and algorithms supported by the service."""
+
+    @abstractmethod
+    async def mint(
+        self,
+        claims: Dict[str, Any],
+        *,
+        alg: str,
+        kid: str | None = None,
+        key_version: int | None = None,
+        headers: Optional[Dict[str, Any]] = None,
+        lifetime_s: Optional[int] = 3600,
+        issuer: Optional[str] = None,
+        subject: Optional[str] = None,
+        audience: Optional[str | list[str]] = None,
+        scope: Optional[str] = None,
+    ) -> str:
+        """Return a compact JWS/JWT string with normalized timestamps."""
+
+    @abstractmethod
+    async def verify(
+        self,
+        token: str,
+        *,
+        issuer: Optional[str] = None,
+        audience: Optional[str | list[str]] = None,
+        leeway_s: int = 60,
+    ) -> Dict[str, Any]:
+        """Return validated claims or raise an exception on failure."""
+
+    @abstractmethod
+    async def jwks(self) -> dict:
+        """Return a JWKS mapping (``{"keys": [...]}``) for signing key discovery."""

--- a/pkgs/core/swarmauri_core/tokens/__init__.py
+++ b/pkgs/core/swarmauri_core/tokens/__init__.py
@@ -1,0 +1,5 @@
+"""Token service interfaces."""
+
+from .ITokenService import ITokenService
+
+__all__ = ["ITokenService"]

--- a/pkgs/core/tests/unit/test_token_interface.py
+++ b/pkgs/core/tests/unit/test_token_interface.py
@@ -1,0 +1,41 @@
+import pytest
+from swarmauri_core.tokens import ITokenService
+
+
+class DummyTokenService(ITokenService):
+    def supports(self):
+        return {"formats": ("JWT",), "algs": ("HS256",)}
+
+    async def mint(
+        self,
+        claims,
+        *,
+        alg,
+        kid=None,
+        key_version=None,
+        headers=None,
+        lifetime_s=3600,
+        issuer=None,
+        subject=None,
+        audience=None,
+        scope=None,
+    ):
+        return "token"
+
+    async def verify(self, token, *, issuer=None, audience=None, leeway_s=60):
+        return {}
+
+    async def jwks(self) -> dict:
+        return {}
+
+
+@pytest.mark.unit
+def test_itokenservice_is_abstract() -> None:
+    with pytest.raises(TypeError):
+        ITokenService()
+
+
+@pytest.mark.unit
+def test_subclass_supports() -> None:
+    svc = DummyTokenService()
+    assert "JWT" in svc.supports()["formats"]

--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -93,6 +93,7 @@ members = [
     "standards/swarmauri_signing_hmac",
     "standards/swarmauri_signing_ecdsa",
     "standards/swarmauri_signing_jws",
+    "standards/swarmauri_token_jwt",
     "standards/swarmauri_secret_autogpg",
     "standards/swarmauri_signing_pgp",
     "standards/swarmauri_signing_rsa",
@@ -232,6 +233,7 @@ swarmauri_signing_secp256k1 = { workspace = true }
 swarmauri_signing_hmac = { workspace = true }
 swarmauri_signing_ecdsa = { workspace = true }
 swarmauri_signing_jws = { workspace = true }
+swarmauri_token_jwt = { workspace = true }
 swarmauri_signing_pgp = { workspace = true }
 swarmauri_signing_rsa = { workspace = true }
 swarmauri_signing_ssh = { workspace = true }

--- a/pkgs/standards/swarmauri_token_jwt/README.md
+++ b/pkgs/standards/swarmauri_token_jwt/README.md
@@ -1,0 +1,5 @@
+# swarmauri_token_jwt
+
+A standard JWT token service for the Swarmauri framework. This service
+implements minting and verifying JSON Web Tokens and exposes a JWKS
+endpoint for public key discovery.

--- a/pkgs/standards/swarmauri_token_jwt/pyproject.toml
+++ b/pkgs/standards/swarmauri_token_jwt/pyproject.toml
@@ -1,0 +1,68 @@
+[project]
+name = "swarmauri_token_jwt"
+version = "0.1.0"
+description = "JWT token service for Swarmauri"
+license = "Apache-2.0"
+readme = "README.md"
+requires-python = ">=3.10,<3.13"
+authors = [{ name = "Swarmauri", email = "opensource@swarmauri.com" }]
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+
+dependencies = [
+    "swarmauri_core",
+    "swarmauri_base",
+    "pyjwt[crypto]>=2.9.0",
+]
+
+[project.optional-dependencies]
+rsa = ["cryptography"]
+ecdsa = ["cryptography"]
+eddsa = ["cryptography"]
+hmac = []
+
+[tool.uv.sources]
+swarmauri_core = { workspace = true }
+swarmauri_base = { workspace = true }
+
+[tool.pytest.ini_options]
+markers = [
+    "test: standard test",
+    "unit: Unit tests",
+    "i9n: Integration tests",
+    "r8n: Regression tests",
+    "acceptance: Acceptance tests",
+    "perf: Performance tests",
+    "functional: Functional tests",
+]
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "pytest-timeout>=2.3.1",
+    "pytest-benchmark>=4.0.0",
+    "flake8>=7.0",
+    "ruff>=0.9.9",
+]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[project.entry-points.'swarmauri.tokens']
+JWTTokenService = "swarmauri_token_jwt:JWTTokenService"
+
+[project.entry-points.'peagen.plugins.tokens']
+jwt = "swarmauri_token_jwt:JWTTokenService"

--- a/pkgs/standards/swarmauri_token_jwt/swarmauri_token_jwt/JWTTokenService.py
+++ b/pkgs/standards/swarmauri_token_jwt/swarmauri_token_jwt/JWTTokenService.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, Iterable, Literal, Mapping, Optional
+
+import jwt
+from jwt import algorithms
+
+from swarmauri_base.tokens import TokenServiceBase
+from swarmauri_core.keys import IKeyProvider, KeyAlg
+
+ALG_MAP_SIGN = {
+    "RS256": KeyAlg.RSA_PSS_SHA256,
+    "PS256": KeyAlg.RSA_PSS_SHA256,
+    "ES256": KeyAlg.ECDSA_P256_SHA256,
+    "EdDSA": KeyAlg.ED25519,
+    "HS256": KeyAlg.HMAC_SHA256,
+}
+
+
+class JWTTokenService(TokenServiceBase):
+    """JWS/JWT issuer and verifier backed by an ``IKeyProvider``."""
+
+    type: Literal["JWTTokenService"] = "JWTTokenService"
+
+    def __init__(
+        self, key_provider: IKeyProvider, *, default_issuer: Optional[str] = None
+    ) -> None:
+        super().__init__()
+        self._kp = key_provider
+        self._iss = default_issuer
+
+    def supports(self) -> Mapping[str, Iterable[str]]:
+        return {"formats": ("JWT", "JWS"), "algs": tuple(ALG_MAP_SIGN.keys())}
+
+    async def mint(
+        self,
+        claims: Dict[str, Any],
+        *,
+        alg: str,
+        kid: str | None = None,
+        key_version: int | None = None,
+        headers: Optional[Dict[str, Any]] = None,
+        lifetime_s: Optional[int] = 3600,
+        issuer: Optional[str] = None,
+        subject: Optional[str] = None,
+        audience: Optional[str | list[str]] = None,
+        scope: Optional[str] = None,
+    ) -> str:
+        now = int(time.time())
+        payload = dict(claims)
+        payload.setdefault("iat", now)
+        payload.setdefault("nbf", now)
+        if lifetime_s:
+            payload.setdefault("exp", now + int(lifetime_s))
+        if issuer or self._iss:
+            payload.setdefault("iss", issuer or self._iss)
+        if subject:
+            payload.setdefault("sub", subject)
+        if audience:
+            payload.setdefault("aud", audience)
+        if scope:
+            payload.setdefault("scope", scope)
+
+        headers = dict(headers or {})
+
+        if alg == "HS256":
+            if not kid:
+                raise ValueError("HS256 mint requires 'kid' of a symmetric key")
+            ref = await self._kp.get_key(kid, key_version, include_secret=True)
+            if ref.material is None:
+                raise RuntimeError("HMAC secret is not exportable under current policy")
+            key = ref.material
+            headers.setdefault("kid", f"{ref.kid}.{ref.version}")
+            return jwt.encode(payload, key, algorithm="HS256", headers=headers)
+
+        if not kid:
+            raise ValueError("asymmetric mint requires 'kid' of a signing key")
+        ref = await self._kp.get_key(kid, key_version, include_secret=True)
+        headers.setdefault("kid", f"{ref.kid}.{ref.version}")
+
+        key = ref.material
+        if key is None:
+            raise RuntimeError("Signing key is not exportable under current policy")
+
+        return jwt.encode(payload, key, algorithm=alg, headers=headers)
+
+    async def verify(
+        self,
+        token: str,
+        *,
+        issuer: Optional[str] = None,
+        audience: Optional[str | list[str]] = None,
+        leeway_s: int = 60,
+    ) -> Dict[str, Any]:
+        jwks = await self._kp.jwks()
+
+        def _key_resolver(hdr: dict[str, Any], payload: dict[str, Any]) -> Any:
+            kid = hdr.get("kid")
+            if not kid:
+                return None
+            for jwk in jwks.get("keys", []):
+                if jwk.get("kid") != kid:
+                    continue
+                kty = jwk.get("kty")
+                if kty == "RSA":
+                    return algorithms.RSAAlgorithm.from_jwk(jwk)
+                if kty == "EC":
+                    return algorithms.ECAlgorithm.from_jwk(jwk)
+                if kty == "OKP" and jwk.get("crv") == "Ed25519":
+                    return algorithms.Ed25519Algorithm.from_jwk(jwk)
+                if kty == "oct":
+                    return algorithms.HMACAlgorithm.from_jwk(jwk)
+            return None
+
+        hdr = jwt.get_unverified_header(token)
+        key = _key_resolver(hdr, {})
+
+        options = {"verify_aud": audience is not None}
+        return jwt.decode(
+            token,
+            key=key,
+            algorithms=list(self.supports()["algs"]),
+            audience=audience,
+            issuer=issuer or self._iss,
+            leeway=leeway_s,
+            options=options,
+        )
+
+    async def jwks(self) -> dict:
+        return await self._kp.jwks()

--- a/pkgs/standards/swarmauri_token_jwt/swarmauri_token_jwt/__init__.py
+++ b/pkgs/standards/swarmauri_token_jwt/swarmauri_token_jwt/__init__.py
@@ -1,0 +1,3 @@
+from .JWTTokenService import JWTTokenService
+
+__all__ = ["JWTTokenService"]

--- a/pkgs/standards/swarmauri_token_jwt/tests/functional/test_jwttokenservice_functional.py
+++ b/pkgs/standards/swarmauri_token_jwt/tests/functional/test_jwttokenservice_functional.py
@@ -1,0 +1,31 @@
+import base64
+import pytest
+
+from swarmauri_token_jwt import JWTTokenService
+from swarmauri_core.keys import IKeyProvider, KeyRef
+
+
+class DummyKeyProvider(IKeyProvider):
+    def __init__(self) -> None:
+        self.secret = b"secret"
+        self.kid = "sym"
+        self.version = 1
+
+    async def get_key(
+        self, kid: str, version: int | None = None, *, include_secret: bool = False
+    ) -> KeyRef:
+        material = self.secret if include_secret else None
+        return KeyRef(kid=self.kid, version=self.version, material=material)
+
+    async def jwks(self) -> dict:
+        k = base64.urlsafe_b64encode(self.secret).rstrip(b"=").decode()
+        return {"keys": [{"kty": "oct", "kid": f"{self.kid}.{self.version}", "k": k}]}
+
+
+@pytest.mark.functional
+@pytest.mark.asyncio
+async def test_verify_with_audience() -> None:
+    svc = JWTTokenService(DummyKeyProvider(), default_issuer="iss")
+    token = await svc.mint({}, alg="HS256", kid="sym", audience="aud")
+    claims = await svc.verify(token, issuer="iss", audience="aud")
+    assert claims["aud"] == "aud"

--- a/pkgs/standards/swarmauri_token_jwt/tests/perf/test_jwttokenservice_perf.py
+++ b/pkgs/standards/swarmauri_token_jwt/tests/perf/test_jwttokenservice_perf.py
@@ -1,0 +1,34 @@
+import asyncio
+import base64
+import pytest
+
+from swarmauri_token_jwt import JWTTokenService
+from swarmauri_core.keys import IKeyProvider, KeyRef
+
+
+class DummyKeyProvider(IKeyProvider):
+    def __init__(self) -> None:
+        self.secret = b"secret"
+        self.kid = "sym"
+        self.version = 1
+
+    async def get_key(
+        self, kid: str, version: int | None = None, *, include_secret: bool = False
+    ) -> KeyRef:
+        material = self.secret if include_secret else None
+        return KeyRef(kid=self.kid, version=self.version, material=material)
+
+    async def jwks(self) -> dict:
+        k = base64.urlsafe_b64encode(self.secret).rstrip(b"=").decode()
+        return {"keys": [{"kty": "oct", "kid": f"{self.kid}.{self.version}", "k": k}]}
+
+
+@pytest.mark.perf
+def test_mint_verify_perf(benchmark) -> None:
+    svc = JWTTokenService(DummyKeyProvider(), default_issuer="iss")
+
+    async def _run() -> None:
+        token = await svc.mint({"msg": "hi"}, alg="HS256", kid="sym")
+        await svc.verify(token, issuer="iss")
+
+    benchmark(lambda: asyncio.run(_run()))

--- a/pkgs/standards/swarmauri_token_jwt/tests/unit/test_jwttokenservice_unit.py
+++ b/pkgs/standards/swarmauri_token_jwt/tests/unit/test_jwttokenservice_unit.py
@@ -1,0 +1,32 @@
+import base64
+
+import pytest
+
+from swarmauri_token_jwt import JWTTokenService
+from swarmauri_core.keys import IKeyProvider, KeyRef
+
+
+class DummyKeyProvider(IKeyProvider):
+    def __init__(self) -> None:
+        self.secret = b"secret"
+        self.kid = "sym"
+        self.version = 1
+
+    async def get_key(
+        self, kid: str, version: int | None = None, *, include_secret: bool = False
+    ) -> KeyRef:
+        material = self.secret if include_secret else None
+        return KeyRef(kid=self.kid, version=self.version, material=material)
+
+    async def jwks(self) -> dict:
+        k = base64.urlsafe_b64encode(self.secret).rstrip(b"=").decode()
+        return {"keys": [{"kty": "oct", "kid": f"{self.kid}.{self.version}", "k": k}]}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_mint_and_verify_roundtrip() -> None:
+    svc = JWTTokenService(DummyKeyProvider(), default_issuer="iss")
+    token = await svc.mint({"msg": "hi"}, alg="HS256", kid="sym")
+    claims = await svc.verify(token, issuer="iss")
+    assert claims["msg"] == "hi"

--- a/pkgs/standards/swarmauri_token_jwt/tests/unit/test_rfc7517_jwks.py
+++ b/pkgs/standards/swarmauri_token_jwt/tests/unit/test_rfc7517_jwks.py
@@ -1,0 +1,29 @@
+import base64
+import pytest
+from swarmauri_token_jwt import JWTTokenService
+from swarmauri_core.keys import IKeyProvider, KeyRef
+
+
+class DummyKeyProvider(IKeyProvider):
+    def __init__(self) -> None:
+        self.secret = b"secret"
+        self.kid = "sym"
+        self.version = 1
+
+    async def get_key(
+        self, kid: str, version: int | None = None, *, include_secret: bool = False
+    ) -> KeyRef:
+        material = self.secret if include_secret else None
+        return KeyRef(kid=self.kid, version=self.version, material=material)
+
+    async def jwks(self) -> dict:
+        k = base64.urlsafe_b64encode(self.secret).rstrip(b"=").decode()
+        return {"keys": [{"kty": "oct", "kid": f"{self.kid}.{self.version}", "k": k}]}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_rfc7517_jwks_structure() -> None:
+    svc = JWTTokenService(DummyKeyProvider())
+    jwks = await svc.jwks()
+    assert "keys" in jwks and isinstance(jwks["keys"], list)

--- a/pkgs/standards/swarmauri_token_jwt/tests/unit/test_rfc7519_jwt.py
+++ b/pkgs/standards/swarmauri_token_jwt/tests/unit/test_rfc7519_jwt.py
@@ -1,0 +1,31 @@
+import base64
+import pytest
+from swarmauri_token_jwt import JWTTokenService
+from swarmauri_core.keys import IKeyProvider, KeyRef
+
+
+class DummyKeyProvider(IKeyProvider):
+    def __init__(self) -> None:
+        self.secret = b"secret"
+        self.kid = "sym"
+        self.version = 1
+
+    async def get_key(
+        self, kid: str, version: int | None = None, *, include_secret: bool = False
+    ) -> KeyRef:
+        material = self.secret if include_secret else None
+        return KeyRef(kid=self.kid, version=self.version, material=material)
+
+    async def jwks(self) -> dict:
+        k = base64.urlsafe_b64encode(self.secret).rstrip(b"=").decode()
+        return {"keys": [{"kty": "oct", "kid": f"{self.kid}.{self.version}", "k": k}]}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_rfc7519_claims_present() -> None:
+    svc = JWTTokenService(DummyKeyProvider())
+    token = await svc.mint({}, alg="HS256", kid="sym")
+    claims = await svc.verify(token)
+    for field in ("iat", "nbf", "exp"):
+        assert field in claims


### PR DESCRIPTION
## Summary
- add token service interfaces in core and base packages
- implement JWT token service plugin with HS256 support
- add comprehensive unit, functional, and performance tests for JWT service

## Testing
- `uv run --directory core --package swarmauri-core ruff format .`
- `uv run --directory core --package swarmauri-core ruff check . --fix`
- `uv run --directory base --package swarmauri-base ruff format .`
- `uv run --directory base --package swarmauri-base ruff check . --fix`
- `uv run --directory standards/swarmauri_token_jwt --package swarmauri_token_jwt ruff format .`
- `uv run --directory standards/swarmauri_token_jwt --package swarmauri_token_jwt ruff check . --fix`
- `uv run --package swarmauri-core --directory core pytest`
- `uv run --package swarmauri-base --directory base pytest`
- `uv run --package swarmauri_token_jwt --directory standards/swarmauri_token_jwt pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7214206bc8326a2c1734d6187c9ce