### PR TITLE
feat: add hierarchical key provider plugin

### DIFF
--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -78,6 +78,7 @@ members = [
     "standards/auto_authn",
     "standards/auto_kms",
     "standards/swarmauri_keyproviders",
+    "standards/swarmauri_keyprovider_hierarchical",
     "standards/swarmauri_crypto_paramiko",
     "standards/swarmauri_crypto_pgp",
     "standards/swarmauri_crypto_sodium",
@@ -230,6 +231,7 @@ swarmauri_mre_crypto_pgp = { workspace = true }
 swarmauri_mre_crypto_ecdh_es_kw = { workspace = true }
 swarmauri_signing_ed25519 = { workspace = true }
 swarmauri_keyproviders = { workspace = true }
+swarmauri_keyprovider_hierarchical = { workspace = true }
 swarmauri_signing_secp256k1 = { workspace = true }
 swarmauri_signing_hmac = { workspace = true }
 swarmauri_signing_ecdsa = { workspace = true }

--- a/pkgs/standards/swarmauri_keyprovider_hierarchical/LICENSE
+++ b/pkgs/standards/swarmauri_keyprovider_hierarchical/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/standards/swarmauri_keyprovider_hierarchical/README.md
+++ b/pkgs/standards/swarmauri_keyprovider_hierarchical/README.md
@@ -1,0 +1,14 @@
+![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+
+# Swarmauri Hierarchical Key Provider
+
+Plugin providing a policy-driven composite key provider capable of routing
+key operations across multiple child providers. It implements the
+`IKeyProvider` interface and exposes a single `HierarchicalKeyProvider`
+class.
+
+## Installation
+
+```bash
+pip install swarmauri_keyprovider_hierarchical
+```

--- a/pkgs/standards/swarmauri_keyprovider_hierarchical/pyproject.toml
+++ b/pkgs/standards/swarmauri_keyprovider_hierarchical/pyproject.toml
@@ -1,0 +1,68 @@
+[project]
+name = "swarmauri_keyprovider_hierarchical"
+version = "0.1.0"
+description = "Hierarchical key provider for Swarmauri"
+license = "Apache-2.0"
+readme = "README.md"
+requires-python = ">=3.10,<3.13"
+authors = [{ name = "Swarmauri", email = "opensource@swarmauri.com" }]
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Development Status :: 3 - Alpha",
+    "Topic :: Security :: Cryptography",
+    "Intended Audience :: Developers",
+]
+dependencies = [
+    "swarmauri_core",
+    "swarmauri_base",
+    "swarmauri_keyproviders",
+]
+
+[project.optional-dependencies]
+aws = ["boto3"]
+pkcs11 = ["pkcs11"]
+
+[tool.uv.sources]
+swarmauri_core = { workspace = true }
+swarmauri_base = { workspace = true }
+swarmauri_keyproviders = { workspace = true }
+
+[tool.pytest.ini_options]
+norecursedirs = ["combined", "scripts"]
+markers = [
+    "test: standard test",
+    "unit: Unit tests",
+    "perf: Performance tests",
+    "func: Functional tests",
+    "rfc: RFC compliance tests",
+]
+benchmark_min_rounds = 1
+timeout = 300
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "pytest-timeout>=2.3.1",
+    "pytest-benchmark>=4.0.0",
+    "ruff>=0.9.9",
+]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[project.entry-points.'swarmauri.key_providers']
+HierarchicalKeyProvider = "swarmauri_keyprovider_hierarchical.HierarchicalKeyProvider:HierarchicalKeyProvider"

--- a/pkgs/standards/swarmauri_keyprovider_hierarchical/swarmauri_keyprovider_hierarchical/HierarchicalKeyProvider.py
+++ b/pkgs/standards/swarmauri_keyprovider_hierarchical/swarmauri_keyprovider_hierarchical/HierarchicalKeyProvider.py
@@ -1,0 +1,350 @@
+from __future__ import annotations
+
+import json
+import os
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import (
+    Dict,
+    Iterable,
+    Mapping,
+    Optional,
+    Tuple,
+    Literal,
+)
+
+from swarmauri_base.keys.KeyProviderBase import KeyProviderBase
+from swarmauri_core.keys.IKeyProvider import IKeyProvider
+from swarmauri_core.keys.types import KeySpec, KeyAlg, KeyClass, ExportPolicy, KeyUse
+from swarmauri_core.crypto.types import KeyRef
+
+
+@dataclass(frozen=True)
+class CreateRule:
+    """
+    Route selection rule for create/import.
+    Any provided field narrows the match. Lists/tuples mean "any-of".
+    """
+
+    provider: str
+    klass: Optional[KeyClass] = None
+    algs: Optional[Iterable[KeyAlg]] = None
+    uses: Optional[Iterable[KeyUse]] = None
+    export_policies: Optional[Iterable[ExportPolicy]] = None
+
+
+def _normalize_iter(x):
+    if x is None:
+        return None
+    return tuple(x)
+
+
+def _match_create_rule(spec: KeySpec, rule: CreateRule) -> bool:
+    if rule.klass and spec.klass != rule.klass:
+        return False
+    if rule.algs and spec.alg not in rule.algs:
+        return False
+    if rule.export_policies and spec.export_policy not in rule.export_policies:
+        return False
+    if rule.uses:
+        # require that at least one desired use is requested (any-of)
+        if not any(u in spec.uses for u in rule.uses):
+            return False
+    return True
+
+
+class HierarchicalKeyProvider(KeyProviderBase):
+    """
+    A policy-driven composite IKeyProvider.
+
+    Responsibilities
+    ----------------
+    - Route create/import to child providers according to CreateRule policy.
+    - Maintain a kid → provider-name index (in-memory; optional JSON persistence).
+    - Forward rotate/destroy/get/list/jwks/hkdf/random to the owning (or designated) provider.
+    - Merge JWKS from all children.
+
+    Notes
+    -----
+    - On get_key(kid, ...) for an unknown kid, this class will probe children (in order)
+      until it finds it, then caches kid→provider in the index.
+    - For random_bytes/hkdf, you can specify a designated provider; defaults to the first.
+    """
+
+    type: Literal["HierarchicalKeyProvider"] = "HierarchicalKeyProvider"
+
+    def __init__(
+        self,
+        providers: Mapping[str, IKeyProvider],
+        *,
+        create_policy: Iterable[CreateRule] | None = None,
+        import_policy: Iterable[CreateRule] | None = None,
+        index_file: str | os.PathLike | None = None,
+        randomness_provider: str | None = None,
+        derivation_provider: str | None = None,
+    ) -> None:
+        super().__init__()
+        if not providers:
+            raise ValueError(
+                "HierarchicalKeyProvider requires at least one child provider"
+            )
+
+        # child providers, keyed by a stable name
+        self._children: Dict[str, IKeyProvider] = dict(providers)
+
+        # ordered routing policies
+        self._create_rules: Tuple[CreateRule, ...] = tuple(
+            CreateRule(
+                provider=r.provider,
+                klass=r.klass,
+                algs=_normalize_iter(r.algs),
+                uses=_normalize_iter(r.uses),
+                export_policies=_normalize_iter(r.export_policies),
+            )
+            for r in (create_policy or ())
+        )
+        self._import_rules: Tuple[CreateRule, ...] = tuple(
+            CreateRule(
+                provider=r.provider,
+                klass=r.klass,
+                algs=_normalize_iter(r.algs),
+                uses=_normalize_iter(r.uses),
+                export_policies=_normalize_iter(r.export_policies),
+            )
+            for r in (import_policy or ())
+        )
+
+        # where to persist kid→provider index (optional)
+        self._index_path: Optional[Path] = Path(index_file) if index_file else None
+        self._kid_index: Dict[str, str] = {}
+        self._mutex = threading.RLock()
+
+        # designate providers for random/hkdf if desired
+        self._rand_name = randomness_provider or next(iter(self._children.keys()))
+        self._hkdf_name = derivation_provider or self._rand_name
+
+        # load existing index if present
+        if self._index_path and self._index_path.exists():
+            try:
+                data = json.loads(self._index_path.read_text())
+                if isinstance(data, dict):
+                    # validate only known providers
+                    self._kid_index = {
+                        k: v for k, v in data.items() if v in self._children
+                    }
+            except Exception:
+                # ignore corrupted index; start fresh
+                self._kid_index = {}
+
+    # ───────────────────────── utilities ─────────────────────────
+
+    def _persist_index_unlocked(self) -> None:
+        if not self._index_path:
+            return
+        self._index_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self._index_path.with_suffix(self._index_path.suffix + ".tmp")
+        tmp.write_text(json.dumps(self._kid_index, indent=2, sort_keys=True))
+        tmp.replace(self._index_path)
+
+    def _record_owner_unlocked(self, kid: str, provider_name: str) -> None:
+        if self._kid_index.get(kid) == provider_name:
+            return
+        self._kid_index[kid] = provider_name
+        self._persist_index_unlocked()
+
+    def _owner_unlocked(self, kid: str) -> Optional[IKeyProvider]:
+        name = self._kid_index.get(kid)
+        return self._children.get(name) if name else None
+
+    def _pick_by_policy(
+        self, spec: KeySpec, rules: Tuple[CreateRule, ...]
+    ) -> IKeyProvider:
+        # First match wins
+        for rule in rules:
+            if _match_create_rule(spec, rule):
+                prov = self._children.get(rule.provider)
+                if prov:
+                    return prov
+        # Fallback: try simple heuristics if no rules matched
+        #  - favor asymmetric to HSM/KMS if present; symmetric to local/file
+        #  - otherwise first child in dict order
+        names = tuple(self._children.keys())
+
+        # heuristic buckets
+        # Look for a child with "kms" or "pkcs11" in its name for asymmetric/private ops
+        if spec.klass == KeyClass.asymmetric:
+            preferred = next(
+                (n for n in names if "kms" in n.lower() or "pkcs11" in n.lower()), None
+            )
+            if preferred:
+                return self._children[preferred]
+        # symmetric → prefer local/file
+        if spec.klass == KeyClass.symmetric:
+            preferred = next(
+                (n for n in names if "local" in n.lower() or "file" in n.lower()), None
+            )
+            if preferred:
+                return self._children[preferred]
+        # default
+        return self._children[names[0]]
+
+    def _first_child(self) -> IKeyProvider:
+        return next(iter(self._children.values()))
+
+    # ───────────────────────── capabilities ─────────────────────────
+
+    def supports(self) -> Mapping[str, Iterable[str]]:
+        # Union of capabilities with a couple of meta flags
+        out: Dict[str, set] = {
+            "class": set(),
+            "algs": set(),
+            "features": {"hierarchical"},
+        }
+        for prov in self._children.values():
+            caps = prov.supports()
+            for k in ("class", "algs", "features"):
+                if k in caps:
+                    out.setdefault(k, set()).update(caps[k])  # type: ignore[arg-type]
+        if self._index_path:
+            out.setdefault("features", set()).add("index_persistence")
+        return {k: tuple(v) for k, v in out.items()}  # type: ignore[return-value]
+
+    # ───────────────────────── lifecycle ─────────────────────────
+
+    async def create_key(self, spec: KeySpec) -> KeyRef:
+        with self._mutex:
+            prov = self._pick_by_policy(spec, self._create_rules)
+        ref = await prov.create_key(spec)
+        with self._mutex:
+            self._record_owner_unlocked(ref.kid, self._resolve_name(prov))
+        return ref
+
+    async def import_key(
+        self, spec: KeySpec, material: bytes, *, public: Optional[bytes] = None
+    ) -> KeyRef:
+        with self._mutex:
+            # choose provider using import policy if provided; else reuse create policy
+            rules = self._import_rules if self._import_rules else self._create_rules
+            prov = self._pick_by_policy(spec, rules)
+        ref = await prov.import_key(spec, material, public=public)
+        with self._mutex:
+            self._record_owner_unlocked(ref.kid, self._resolve_name(prov))
+        return ref
+
+    async def rotate_key(
+        self, kid: str, *, spec_overrides: Optional[dict] = None
+    ) -> KeyRef:
+        with self._mutex:
+            prov = self._owner_unlocked(kid)
+        if prov is None:
+            # probe children to discover ownership
+            prov = await self._probe_owner(kid)
+        new_ref = await prov.rotate_key(kid, spec_overrides=spec_overrides)
+        # rotation keeps same kid; owner unchanged
+        return new_ref
+
+    async def destroy_key(self, kid: str, version: Optional[int] = None) -> bool:
+        with self._mutex:
+            prov = self._owner_unlocked(kid)
+        if prov is None:
+            # best effort: try all children
+            ok_any = False
+            for p in self._children.values():
+                try:
+                    ok = await p.destroy_key(kid, version)
+                    ok_any = ok_any or ok
+                except Exception:
+                    continue
+            if ok_any and version is None:
+                with self._mutex:
+                    self._kid_index.pop(kid, None)
+                    self._persist_index_unlocked()
+            return ok_any
+        ok = await prov.destroy_key(kid, version)
+        if ok and version is None:
+            with self._mutex:
+                self._kid_index.pop(kid, None)
+                self._persist_index_unlocked()
+        return ok
+
+    async def get_key(
+        self, kid: str, version: Optional[int] = None, *, include_secret: bool = False
+    ) -> KeyRef:
+        with self._mutex:
+            prov = self._owner_unlocked(kid)
+        if prov is None:
+            prov = await self._probe_owner(kid)
+        return await prov.get_key(kid, version, include_secret=include_secret)
+
+    async def list_versions(self, kid: str) -> Tuple[int, ...]:
+        with self._mutex:
+            prov = self._owner_unlocked(kid)
+        if prov is None:
+            prov = await self._probe_owner(kid)
+        return await prov.list_versions(kid)
+
+    # ───────────────────────── public export ─────────────────────────
+
+    async def get_public_jwk(self, kid: str, version: Optional[int] = None) -> dict:
+        with self._mutex:
+            prov = self._owner_unlocked(kid)
+        if prov is None:
+            prov = await self._probe_owner(kid)
+        return await prov.get_public_jwk(kid, version)
+
+    async def jwks(self, *, prefix_kids: Optional[str] = None) -> dict:
+        # Merge all children JWKS; keep order stable by provider name
+        keys = []
+        for name in sorted(self._children.keys()):
+            try:
+                jwks = await self._children[name].jwks(prefix_kids=prefix_kids)  # type: ignore[arg-type]
+            except TypeError:
+                # Some providers may not accept prefix_kids; call without it
+                jwks = await self._children[name].jwks()
+            kid_set = set()
+            for k in jwks.get("keys", []):
+                # Dedup by kid if multiple providers expose the same public
+                kid = k.get("kid")
+                if kid and kid not in kid_set:
+                    keys.append(k)
+                    kid_set.add(kid)
+        return {"keys": keys}
+
+    # ───────────────────────── material helpers ─────────────────────────
+
+    async def random_bytes(self, n: int) -> bytes:
+        prov = self._children[self._rand_name]
+        return await prov.random_bytes(n)
+
+    async def hkdf(self, ikm: bytes, *, salt: bytes, info: bytes, length: int) -> bytes:
+        prov = self._children[self._hkdf_name]
+        return await prov.hkdf(ikm, salt=salt, info=info, length=length)
+
+    # ───────────────────────── internals ─────────────────────────
+
+    async def _probe_owner(self, kid: str) -> IKeyProvider:
+        """
+        Try to locate which child owns 'kid' by attempting a benign get_key.
+        Caches result in index on success.
+        """
+        last_err: Optional[Exception] = None
+        for name, prov in self._children.items():
+            try:
+                _ = await prov.get_key(kid, None, include_secret=False)
+                with self._mutex:
+                    self._record_owner_unlocked(kid, name)
+                return prov
+            except Exception as e:
+                last_err = e
+                continue
+        # Nothing found; rethrow the last error (usually KeyError) for context
+        raise last_err if last_err else KeyError(f"Unknown kid: {kid}")
+
+    def _resolve_name(self, provider: IKeyProvider) -> str:
+        # reverse-lookup by identity
+        for name, prov in self._children.items():
+            if prov is provider:
+                return name
+        # fallback (shouldn't happen)
+        return next(iter(self._children.keys()))

--- a/pkgs/standards/swarmauri_keyprovider_hierarchical/swarmauri_keyprovider_hierarchical/__init__.py
+++ b/pkgs/standards/swarmauri_keyprovider_hierarchical/swarmauri_keyprovider_hierarchical/__init__.py
@@ -1,0 +1,3 @@
+from .HierarchicalKeyProvider import CreateRule, HierarchicalKeyProvider
+
+__all__ = ["HierarchicalKeyProvider", "CreateRule"]

--- a/pkgs/standards/swarmauri_keyprovider_hierarchical/tests/test_functional.py
+++ b/pkgs/standards/swarmauri_keyprovider_hierarchical/tests/test_functional.py
@@ -1,0 +1,24 @@
+import pytest
+
+from swarmauri_keyprovider_hierarchical import HierarchicalKeyProvider
+from swarmauri_keyproviders import LocalKeyProvider
+from swarmauri_core.keys.types import KeySpec, KeyAlg, KeyClass, ExportPolicy, KeyUse
+
+
+@pytest.mark.test
+@pytest.mark.func
+@pytest.mark.asyncio
+async def test_jwks_merge() -> None:
+    child_a = LocalKeyProvider()
+    child_b = LocalKeyProvider()
+    provider = HierarchicalKeyProvider({"a": child_a, "b": child_b})
+    spec = KeySpec(
+        klass=KeyClass.symmetric,
+        alg=KeyAlg.AES256_GCM,
+        uses=(KeyUse.ENCRYPT, KeyUse.DECRYPT),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+    )
+    await provider.create_key(spec)
+    await provider.create_key(spec)
+    jwks = await provider.jwks()
+    assert len(jwks["keys"]) == 2

--- a/pkgs/standards/swarmauri_keyprovider_hierarchical/tests/test_perf.py
+++ b/pkgs/standards/swarmauri_keyprovider_hierarchical/tests/test_perf.py
@@ -1,0 +1,24 @@
+import asyncio
+import pytest
+
+from swarmauri_keyprovider_hierarchical import HierarchicalKeyProvider
+from swarmauri_keyproviders import LocalKeyProvider
+from swarmauri_core.keys.types import KeySpec, KeyAlg, KeyClass, ExportPolicy, KeyUse
+
+
+@pytest.mark.test
+@pytest.mark.perf
+def test_create_performance(benchmark) -> None:
+    child = LocalKeyProvider()
+    provider = HierarchicalKeyProvider({"a": child})
+    spec = KeySpec(
+        klass=KeyClass.symmetric,
+        alg=KeyAlg.AES256_GCM,
+        uses=(KeyUse.ENCRYPT, KeyUse.DECRYPT),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+    )
+
+    def run() -> None:
+        asyncio.run(provider.create_key(spec))
+
+    benchmark(run)

--- a/pkgs/standards/swarmauri_keyprovider_hierarchical/tests/test_rfc7517.py
+++ b/pkgs/standards/swarmauri_keyprovider_hierarchical/tests/test_rfc7517.py
@@ -1,0 +1,23 @@
+import pytest
+
+from swarmauri_keyprovider_hierarchical import HierarchicalKeyProvider
+from swarmauri_keyproviders import LocalKeyProvider
+from swarmauri_core.keys.types import KeySpec, KeyAlg, KeyClass, ExportPolicy, KeyUse
+
+
+@pytest.mark.test
+@pytest.mark.rfc
+@pytest.mark.asyncio
+async def test_jwks_structure() -> None:
+    child = LocalKeyProvider()
+    provider = HierarchicalKeyProvider({"a": child})
+    spec = KeySpec(
+        klass=KeyClass.symmetric,
+        alg=KeyAlg.AES256_GCM,
+        uses=(KeyUse.ENCRYPT, KeyUse.DECRYPT),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+    )
+    await provider.create_key(spec)
+    jwks = await provider.jwks()
+    assert "keys" in jwks and isinstance(jwks["keys"], list)
+    assert all("kid" in jwk and "kty" in jwk for jwk in jwks["keys"])

--- a/pkgs/standards/swarmauri_keyprovider_hierarchical/tests/test_rfc7518.py
+++ b/pkgs/standards/swarmauri_keyprovider_hierarchical/tests/test_rfc7518.py
@@ -1,0 +1,22 @@
+import pytest
+
+from swarmauri_keyprovider_hierarchical import HierarchicalKeyProvider
+from swarmauri_keyproviders import LocalKeyProvider
+from swarmauri_core.keys.types import KeySpec, KeyAlg, KeyClass, ExportPolicy, KeyUse
+
+
+@pytest.mark.test
+@pytest.mark.rfc
+@pytest.mark.asyncio
+async def test_jwk_alg_parameter() -> None:
+    child = LocalKeyProvider()
+    provider = HierarchicalKeyProvider({"a": child})
+    spec = KeySpec(
+        klass=KeyClass.symmetric,
+        alg=KeyAlg.AES256_GCM,
+        uses=(KeyUse.ENCRYPT, KeyUse.DECRYPT),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+    )
+    ref = await provider.create_key(spec)
+    jwk = await provider.get_public_jwk(ref.kid)
+    assert "alg" in jwk

--- a/pkgs/standards/swarmauri_keyprovider_hierarchical/tests/test_unit.py
+++ b/pkgs/standards/swarmauri_keyprovider_hierarchical/tests/test_unit.py
@@ -1,0 +1,31 @@
+import pytest
+
+from swarmauri_keyprovider_hierarchical import HierarchicalKeyProvider, CreateRule
+from swarmauri_keyproviders import LocalKeyProvider
+from swarmauri_core.keys.types import (
+    KeySpec,
+    KeyAlg,
+    KeyClass,
+    ExportPolicy,
+    KeyUse,
+)
+
+
+@pytest.mark.test
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_policy_routing() -> None:
+    child_a = LocalKeyProvider()
+    child_b = LocalKeyProvider()
+    provider = HierarchicalKeyProvider(
+        {"a": child_a, "b": child_b},
+        create_policy=[CreateRule(provider="b", klass=KeyClass.symmetric)],
+    )
+    spec = KeySpec(
+        klass=KeyClass.symmetric,
+        alg=KeyAlg.AES256_GCM,
+        uses=(KeyUse.ENCRYPT, KeyUse.DECRYPT),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+    )
+    ref = await provider.create_key(spec)
+    assert ref.kid in child_b._store


### PR DESCRIPTION
## Summary
- add hierarchical key provider plugin with policy-based routing
- wire optional extras and tooling configuration
- cover unit, performance, functional, and RFC compliance tests

## Testing
- `uv run --directory standards/swarmauri_keyprovider_hierarchical --package swarmauri_keyprovider_hierarchical ruff format .`
- `uv run --directory standards/swarmauri_keyprovider_hierarchical --package swarmauri_keyprovider_hierarchical ruff check . --fix`
- `uv run --package swarmauri_keyprovider_hierarchical --directory standards/swarmauri_keyprovider_hierarchical pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a723ae88c48326b9772ee648da7142