### PR TITLE
Add extras and RFC tests for PKCS#11 key provider

### DIFF
--- a/pkgs/standards/swarmauri_keyproviders/README.md
+++ b/pkgs/standards/swarmauri_keyproviders/README.md
@@ -11,3 +11,9 @@ asymmetric keys and exporting public material via JWK/JWKS.
 ```bash
 pip install swarmauri_keyproviders
 ```
+
+Optional extras are provided for specific key provider canons:
+
+```bash
+pip install swarmauri_keyproviders[pkcs11]  # enable PKCS#11 support
+```

--- a/pkgs/standards/swarmauri_keyproviders/pyproject.toml
+++ b/pkgs/standards/swarmauri_keyproviders/pyproject.toml
@@ -24,6 +24,8 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+local = []
+ssh = []
 pkcs11 = ["pkcs11"]
 
 [tool.uv.sources]
@@ -39,6 +41,7 @@ markers = [
     "r8n: Regression tests",
     "acceptance: Acceptance tests",
     "perf: Performance tests",
+    "func: Functional tests",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_keyproviders/tests/test_pkcs11_functional.py
+++ b/pkgs/standards/swarmauri_keyproviders/tests/test_pkcs11_functional.py
@@ -1,0 +1,29 @@
+import asyncio
+
+import pytest
+
+from swarmauri_keyproviders import Pkcs11KeyProvider
+
+
+@pytest.mark.func
+@pytest.mark.asyncio
+async def test_hkdf_derivation() -> None:
+    """Deriving bytes via HKDF should yield requested length."""
+    provider = object.__new__(Pkcs11KeyProvider)
+    result = await Pkcs11KeyProvider.hkdf(
+        provider, b"input", salt=b"salt", info=b"info", length=32
+    )
+    assert len(result) == 32
+
+
+@pytest.mark.perf
+def test_hkdf_performance(benchmark) -> None:
+    """Benchmark HKDF derivation for basic performance check."""
+    provider = object.__new__(Pkcs11KeyProvider)
+
+    async def run() -> None:
+        await Pkcs11KeyProvider.hkdf(
+            provider, b"input", salt=b"salt", info=b"info", length=32
+        )
+
+    benchmark(lambda: asyncio.run(run()))

--- a/pkgs/standards/swarmauri_keyproviders/tests/test_pkcs11_rfc7517.py
+++ b/pkgs/standards/swarmauri_keyproviders/tests/test_pkcs11_rfc7517.py
@@ -1,0 +1,27 @@
+import pytest
+
+from swarmauri_keyproviders import Pkcs11KeyProvider
+from swarmauri_keyproviders.Pkcs11KeyProvider import _IndexEntry
+from swarmauri_core.keys.types import KeyAlg, KeyClass
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_symmetric_jwk_placeholder() -> None:
+    """Symmetric keys expose placeholder JWK per RFC7517."""
+    provider = object.__new__(Pkcs11KeyProvider)
+    provider._idx = {
+        "sym": {
+            1: _IndexEntry(
+                kid="sym",
+                version=1,
+                label="lbl",
+                klass=KeyClass.symmetric,
+                alg=KeyAlg.AES256_GCM,
+                handles={},
+                tags={},
+            )
+        }
+    }
+    jwk = await Pkcs11KeyProvider.get_public_jwk(provider, "sym", 1)
+    assert jwk == {"kty": "oct", "alg": "A256GCM", "kid": "sym.1"}

--- a/pkgs/standards/swarmauri_keyproviders/tests/test_pkcs11_rfc7518.py
+++ b/pkgs/standards/swarmauri_keyproviders/tests/test_pkcs11_rfc7518.py
@@ -1,0 +1,19 @@
+import pytest
+
+from swarmauri_keyproviders import Pkcs11KeyProvider
+
+
+@pytest.mark.unit
+def test_supported_algorithms() -> None:
+    """Supported algorithms should align with RFC7518 identifiers."""
+    provider = object.__new__(Pkcs11KeyProvider)
+    provider._allow_aes = True
+    provider._allow_ec = True
+    provider._allow_rsa = True
+    algs = set(Pkcs11KeyProvider.supports(provider)["algs"])
+    assert algs == {
+        "AES256_GCM",
+        "ECDSA_P256_SHA256",
+        "RSA_OAEP_SHA256",
+        "RSA_PSS_SHA256",
+    }


### PR DESCRIPTION
## Summary
- document PKCS#11 optional extra
- expose extras in pyproject and register functional test marker
- add RFC-specific tests and HKDF performance benchmark for `Pkcs11KeyProvider`

## Testing
- `uv run --directory . --package swarmauri_keyproviders ruff format .`
- `uv run --directory . --package swarmauri_keyproviders ruff check . --fix`
- `uv run --package swarmauri_keyproviders --directory standards/swarmauri_keyproviders pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a723f941108326b96bdaf2396af7a6