### PR TITLE
Add TLS-bound JWT token service standard plugin

### DIFF
--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -98,6 +98,7 @@ members = [
     "standards/swarmauri_signing_pgp",
     "standards/swarmauri_signing_rsa",
     "standards/swarmauri_signing_ssh",
+    "standards/swarmauri_tokens_tlsboundjwt",
     "community/swarmauri_middleware_circuitbreaker",
     "community/swarmauri_middleware_ratepolicy",
     "community/swarmauri_vectorstore_redis",
@@ -237,6 +238,7 @@ swarmauri_signing_jws = { workspace = true }
 swarmauri_signing_pgp = { workspace = true }
 swarmauri_signing_rsa = { workspace = true }
 swarmauri_signing_ssh = { workspace = true }
+swarmauri_tokens_tlsboundjwt = { workspace = true }
 swarmauri_vectorstore_redis = { workspace = true }
 swarmauri_vectorstore_qdrant = { workspace = true }
 swarmauri_vectorstore_pinecone = { workspace = true }

--- a/pkgs/standards/swarmauri_tokens_tlsboundjwt/LICENSE
+++ b/pkgs/standards/swarmauri_tokens_tlsboundjwt/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/standards/swarmauri_tokens_tlsboundjwt/README.md
+++ b/pkgs/standards/swarmauri_tokens_tlsboundjwt/README.md
@@ -1,0 +1,31 @@
+![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+
+# Swarmauri Tokens TLS-Bound JWT
+
+A mutual-TLS bound JWT token service per [RFC 8705](https://www.rfc-editor.org/rfc/rfc8705).
+It derives the `x5t#S256` confirmation claim from the current client certificate
+and verifies that presented certificates match the token binding.
+
+Features:
+- Automatic `cnf` claim insertion with the SHA-256 thumbprint of the client certificate
+- Verification that rejects tokens when the live certificate is missing or mismatched
+
+## Installation
+
+```bash
+pip install swarmauri_tokens_tlsboundjwt
+```
+
+## Usage
+
+```python
+from swarmauri_tokens_tlsboundjwt import TlsBoundJWTTokenService
+
+svc = TlsBoundJWTTokenService(key_provider, client_cert_der_getter=my_cert_getter)
+await svc.mint({"sub": "alice"}, alg="HS256")
+```
+
+## Entry Point
+
+The service registers under the `swarmauri.tokens` entry point as
+`TlsBoundJWTTokenService`.

--- a/pkgs/standards/swarmauri_tokens_tlsboundjwt/pyproject.toml
+++ b/pkgs/standards/swarmauri_tokens_tlsboundjwt/pyproject.toml
@@ -1,0 +1,70 @@
+[project]
+name = "swarmauri_tokens_tlsboundjwt"
+version = "0.1.0"
+description = "mTLS-bound JWT token service for Swarmauri"
+license = "Apache-2.0"
+readme = "README.md"
+requires-python = ">=3.10,<3.13"
+authors = [{ name = "Swarmauri", email = "opensource@swarmauri.com" }]
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Security :: Cryptography",
+]
+dependencies = [
+    "swarmauri_core",
+    "swarmauri_base",
+]
+
+[project.optional-dependencies]
+cbor = ["cbor2"]
+xml = ["xmltodict"]
+
+[tool.uv.sources]
+swarmauri_core = { workspace = true }
+swarmauri_base = { workspace = true }
+
+[tool.pytest.ini_options]
+norecursedirs = ["combined", "scripts"]
+markers = [
+    "test: standard test",
+    "unit: Unit tests",
+    "i9n: Integration tests",
+    "r8n: Regression tests",
+    "acceptance: Acceptance tests",
+    "perf: Performance tests",
+]
+timeout = 300
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "pytest-timeout>=2.3.1",
+    "pytest-benchmark>=4.0.0",
+    "flake8>=7.0",
+    "ruff>=0.9.9",
+]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[project.entry-points.'swarmauri.tokens']
+TlsBoundJWTTokenService = "swarmauri_tokens_tlsboundjwt:TlsBoundJWTTokenService"
+
+[project.entry-points."peagen.plugins.tokens"]
+tlsboundjwt = "swarmauri_tokens_tlsboundjwt:TlsBoundJWTTokenService"

--- a/pkgs/standards/swarmauri_tokens_tlsboundjwt/swarmauri_tokens_tlsboundjwt/TlsBoundJWTTokenService.py
+++ b/pkgs/standards/swarmauri_tokens_tlsboundjwt/swarmauri_tokens_tlsboundjwt/TlsBoundJWTTokenService.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+from typing import Callable, Dict, Iterable, Mapping, Optional, Literal
+
+from swarmauri_providers.tokens import JWTTokenService
+from swarmauri_core.keys import IKeyProvider
+
+
+def _b64u(b: bytes) -> str:
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode("ascii")
+
+
+def x5tS256_from_der(cert_der: bytes) -> str:
+    """RFC 8705: SHA-256 over DER, base64url without padding."""
+    return _b64u(hashlib.sha256(cert_der).digest())
+
+
+class TlsBoundJWTTokenService(JWTTokenService):
+    """
+    mTLS-bound JWTs per RFC 8705 using the 'cnf' claim:
+      cnf: { "x5t#S256": "<base64url sha-256 of client cert DER>" }
+
+    Verification requires access to the *current request's* client certificate.
+    Provide a getter that returns the DER bytes, or pre-computed x5t#S256.
+    """
+
+    type: Literal["TlsBoundJWTTokenService"] = "TlsBoundJWTTokenService"
+
+    def __init__(
+        self,
+        key_provider: IKeyProvider,
+        *,
+        default_issuer: Optional[str] = None,
+        client_cert_der_getter: Optional[Callable[[], Optional[bytes]]] = None,
+        client_cert_x5tS256_getter: Optional[Callable[[], Optional[str]]] = None,
+    ) -> None:
+        super().__init__(key_provider, default_issuer=default_issuer)
+        self._get_der = client_cert_der_getter
+        self._get_x5t = client_cert_x5tS256_getter
+
+    def supports(self) -> Mapping[str, Iterable[str]]:
+        base = super().supports()
+        return {"formats": (*base["formats"], "JWT"), "algs": base["algs"]}
+
+    # Helper to compute or fetch the live fingerprint
+    def _live_x5tS256(self) -> Optional[str]:
+        if self._get_x5t:
+            v = self._get_x5t()
+            if v:
+                return v
+        if self._get_der:
+            der = self._get_der()
+            if der:
+                return x5tS256_from_der(der)
+        return None
+
+    async def mint(
+        self,
+        claims: Dict[str, object],
+        *,
+        alg: str,
+        kid: str | None = None,
+        key_version: int | None = None,
+        headers: Optional[Dict[str, object]] = None,
+        lifetime_s: Optional[int] = 3600,
+        issuer: Optional[str] = None,
+        subject: Optional[str] = None,
+        audience: Optional[str | list[str]] = None,
+        scope: Optional[str] = None,
+    ) -> str:
+        # Respect explicit cnf if caller already set it.
+        if "cnf" not in claims:
+            x5t = self._live_x5tS256()
+            if x5t:
+                claims = dict(claims)
+                claims["cnf"] = {"x5t#S256": x5t}
+        return await super().mint(
+            claims,
+            alg=alg,
+            kid=kid,
+            key_version=key_version,
+            headers=headers,
+            lifetime_s=lifetime_s,
+            issuer=issuer,
+            subject=subject,
+            audience=audience,
+            scope=scope,
+        )
+
+    async def verify(
+        self,
+        token: str,
+        *,
+        issuer: Optional[str] = None,
+        audience: Optional[str | list[str]] = None,
+        leeway_s: int = 60,
+    ) -> Dict[str, object]:
+        claims = await super().verify(
+            token, issuer=issuer, audience=audience, leeway_s=leeway_s
+        )
+        cnf = claims.get("cnf") if isinstance(claims, dict) else None
+        bound = cnf.get("x5t#S256") if isinstance(cnf, dict) else None
+        if not bound:
+            raise ValueError("mTLS-bound token missing cnf.x5t#S256")
+
+        live = self._live_x5tS256()
+        if not live:
+            raise ValueError("mTLS verification requires the live client certificate")
+        if live != bound:
+            raise ValueError("mTLS binding mismatch (x5t#S256)")
+        return claims

--- a/pkgs/standards/swarmauri_tokens_tlsboundjwt/swarmauri_tokens_tlsboundjwt/__init__.py
+++ b/pkgs/standards/swarmauri_tokens_tlsboundjwt/swarmauri_tokens_tlsboundjwt/__init__.py
@@ -1,0 +1,3 @@
+from .TlsBoundJWTTokenService import TlsBoundJWTTokenService, x5tS256_from_der
+
+__all__ = ["TlsBoundJWTTokenService", "x5tS256_from_der"]

--- a/pkgs/standards/swarmauri_tokens_tlsboundjwt/tests/conftest.py
+++ b/pkgs/standards/swarmauri_tokens_tlsboundjwt/tests/conftest.py
@@ -1,0 +1,46 @@
+import json
+import sys
+import types
+
+providers_mod = types.ModuleType("swarmauri_providers")
+tokens_mod = types.ModuleType("swarmauri_providers.tokens")
+
+
+class JWTTokenService:
+    def __init__(self, key_provider, default_issuer=None) -> None:  # noqa: D401
+        self.key_provider = key_provider
+
+    def supports(self) -> dict:
+        return {"formats": ("JWT",), "algs": ("HS256",)}
+
+    async def mint(
+        self,
+        claims: dict,
+        *,
+        alg: str,
+        kid: str | None = None,
+        key_version: int | None = None,
+        headers: dict | None = None,
+        lifetime_s: int | None = None,
+        issuer: str | None = None,
+        subject: str | None = None,
+        audience: str | list[str] | None = None,
+        scope: str | None = None,
+    ) -> str:
+        return json.dumps(claims)
+
+    async def verify(
+        self,
+        token: str,
+        *,
+        issuer: str | None = None,
+        audience: str | list[str] | None = None,
+        leeway_s: int = 60,
+    ) -> dict:
+        return json.loads(token)
+
+
+tokens_mod.JWTTokenService = JWTTokenService
+providers_mod.tokens = tokens_mod
+sys.modules.setdefault("swarmauri_providers", providers_mod)
+sys.modules.setdefault("swarmauri_providers.tokens", tokens_mod)

--- a/pkgs/standards/swarmauri_tokens_tlsboundjwt/tests/functional/test_tlsboundjwt_functional.py
+++ b/pkgs/standards/swarmauri_tokens_tlsboundjwt/tests/functional/test_tlsboundjwt_functional.py
@@ -1,0 +1,32 @@
+import asyncio
+
+import pytest
+
+from swarmauri_tokens_tlsboundjwt import TlsBoundJWTTokenService, x5tS256_from_der
+
+
+async def _mint(svc: TlsBoundJWTTokenService) -> str:
+    return await svc.mint({"sub": "bob"}, alg="HS256")
+
+
+def test_verify_mismatch_functional():
+    svc_a = TlsBoundJWTTokenService(None, client_cert_der_getter=lambda: b"cert-a")
+    token = asyncio.run(_mint(svc_a))
+    svc_b = TlsBoundJWTTokenService(None, client_cert_der_getter=lambda: b"cert-b")
+    with pytest.raises(ValueError):
+        asyncio.run(svc_b.verify(token))
+
+
+def test_missing_certificate_functional():
+    svc = TlsBoundJWTTokenService(None, client_cert_der_getter=lambda: b"cert-a")
+    token = asyncio.run(_mint(svc))
+    svc_missing = TlsBoundJWTTokenService(None)
+    with pytest.raises(ValueError):
+        asyncio.run(svc_missing.verify(token))
+
+
+def test_cnf_included_functional():
+    svc = TlsBoundJWTTokenService(None, client_cert_der_getter=lambda: b"cert-x")
+    token = asyncio.run(_mint(svc))
+    claims = asyncio.run(svc.verify(token))
+    assert claims["cnf"]["x5t#S256"] == x5tS256_from_der(b"cert-x")

--- a/pkgs/standards/swarmauri_tokens_tlsboundjwt/tests/perf/test_tlsboundjwt_perf.py
+++ b/pkgs/standards/swarmauri_tokens_tlsboundjwt/tests/perf/test_tlsboundjwt_perf.py
@@ -1,0 +1,15 @@
+import asyncio
+
+import pytest
+
+from swarmauri_tokens_tlsboundjwt import TlsBoundJWTTokenService
+
+
+@pytest.mark.perf
+def test_mint_perf(benchmark):
+    svc = TlsBoundJWTTokenService(None, client_cert_der_getter=lambda: b"perf-cert")
+
+    async def _mint() -> None:
+        await svc.mint({"sub": "perf"}, alg="HS256")
+
+    benchmark(lambda: asyncio.run(_mint()))

--- a/pkgs/standards/swarmauri_tokens_tlsboundjwt/tests/unit/test_tlsboundjwt_unit.py
+++ b/pkgs/standards/swarmauri_tokens_tlsboundjwt/tests/unit/test_tlsboundjwt_unit.py
@@ -1,0 +1,20 @@
+import asyncio
+
+from swarmauri_tokens_tlsboundjwt import TlsBoundJWTTokenService, x5tS256_from_der
+
+
+def test_x5t_calculation_unit():
+    cert = b"unit-cert"
+    thumb = x5tS256_from_der(cert)
+    assert thumb == x5tS256_from_der(cert)
+
+
+async def _mint_and_verify() -> bool:
+    svc = TlsBoundJWTTokenService(None, client_cert_der_getter=lambda: b"unit-cert")
+    token = await svc.mint({"sub": "alice"}, alg="HS256")
+    claims = await svc.verify(token)
+    return claims["cnf"]["x5t#S256"] == x5tS256_from_der(b"unit-cert")
+
+
+def test_mint_and_verify_unit():
+    assert asyncio.run(_mint_and_verify())


### PR DESCRIPTION
## Summary
- add `TlsBoundJWTTokenService` implementing mutual-TLS bound JWTs per RFC 8705
- document and configure new `swarmauri_tokens_tlsboundjwt` plugin with optional canon extras
- cover unit, functional, and performance cases for certificate-bound tokens

## Testing
- `uv run --directory standards/swarmauri_tokens_tlsboundjwt --package swarmauri_tokens_tlsboundjwt ruff check . --fix`
- `uv run --directory standards/swarmauri_tokens_tlsboundjwt --package swarmauri_tokens_tlsboundjwt pytest`
- `uv run --package swarmauri-monorepo --directory . ruff check pyproject.toml --fix`

------
https://chatgpt.com/codex/tasks/task_e_68a7243c558883268901b6541cb0ce97