### PR TITLE
feat: add DPoP-bound JWT token service

### DIFF
--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -95,6 +95,7 @@ members = [
     "standards/swarmauri_signing_ecdsa",
     "standards/swarmauri_signing_jws",
     "standards/swarmauri_secret_autogpg",
+    "standards/swarmauri_tokens_dpopboundjwt",
     "standards/swarmauri_signing_pgp",
     "standards/swarmauri_signing_rsa",
     "standards/swarmauri_signing_ssh",
@@ -234,6 +235,7 @@ swarmauri_signing_secp256k1 = { workspace = true }
 swarmauri_signing_hmac = { workspace = true }
 swarmauri_signing_ecdsa = { workspace = true }
 swarmauri_signing_jws = { workspace = true }
+swarmauri_tokens_dpopboundjwt = { workspace = true }
 swarmauri_signing_pgp = { workspace = true }
 swarmauri_signing_rsa = { workspace = true }
 swarmauri_signing_ssh = { workspace = true }

--- a/pkgs/standards/swarmauri_tokens_dpopboundjwt/LICENSE
+++ b/pkgs/standards/swarmauri_tokens_dpopboundjwt/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/standards/swarmauri_tokens_dpopboundjwt/README.md
+++ b/pkgs/standards/swarmauri_tokens_dpopboundjwt/README.md
@@ -1,0 +1,31 @@
+![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+
+# Swarmauri Tokens DPoP Bound JWT
+
+DPoP-bound JSON Web Token (JWT) service for Swarmauri implementing
+[RFC 9449](https://www.rfc-editor.org/rfc/rfc9449) and JWK thumbprint
+handling per [RFC 7638](https://www.rfc-editor.org/rfc/rfc7638).
+
+Features:
+- Mints and verifies DPoP-bound JWTs
+- Computes JWK thumbprints for binding proofs
+- Optional replay protection hook
+
+## Installation
+
+```bash
+pip install swarmauri_tokens_dpopboundjwt
+```
+
+## Usage
+
+```python
+from swarmauri_tokens_dpopboundjwt import DPoPBoundJWTTokenService
+
+service = DPoPBoundJWTTokenService(key_provider)
+```
+
+## Entry Point
+
+The service registers under the `swarmauri.tokens` entry point as
+`DPoPBoundJWTTokenService`.

--- a/pkgs/standards/swarmauri_tokens_dpopboundjwt/pyproject.toml
+++ b/pkgs/standards/swarmauri_tokens_dpopboundjwt/pyproject.toml
@@ -1,0 +1,69 @@
+[project]
+name = "swarmauri_tokens_dpopboundjwt"
+version = "0.1.0"
+description = "DPoP-bound JWT token service for Swarmauri"
+license = "Apache-2.0"
+readme = "README.md"
+requires-python = ">=3.10,<3.13"
+authors = [{ name = "Swarmauri", email = "opensource@swarmauri.com" }]
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Development Status :: 3 - Alpha",
+    "Topic :: Security :: Cryptography",
+    "Intended Audience :: Developers",
+]
+dependencies = [
+    "swarmauri_core",
+    "swarmauri_base",
+    "pyjwt[crypto]>=2.8.0",
+]
+
+[project.optional-dependencies]
+rsa = ["cryptography"]
+ec = ["cryptography"]
+okp = ["cryptography"]
+
+[tool.uv.sources]
+swarmauri_core = { workspace = true }
+swarmauri_base = { workspace = true }
+
+[tool.pytest.ini_options]
+norecursedirs = ["combined", "scripts"]
+markers = [
+    "test: standard test",
+    "unit: Unit tests",
+    "i9n: Integration tests",
+    "r8n: Regression tests",
+    "acceptance: Acceptance tests",
+    "perf: Performance tests",
+]
+timeout = 300
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "pytest-timeout>=2.3.1",
+    "pytest-benchmark>=4.0.0",
+    "flake8>=7.0",
+    "ruff>=0.9.9",
+]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[project.entry-points.'swarmauri.tokens']
+DPoPBoundJWTTokenService = "swarmauri_tokens_dpopboundjwt:DPoPBoundJWTTokenService"

--- a/pkgs/standards/swarmauri_tokens_dpopboundjwt/swarmauri_tokens_dpopboundjwt/DPoPBoundJWTTokenService.py
+++ b/pkgs/standards/swarmauri_tokens_dpopboundjwt/swarmauri_tokens_dpopboundjwt/DPoPBoundJWTTokenService.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import time
+from typing import Callable, Dict, Iterable, Mapping, Optional, Literal
+
+import jwt
+from jwt import algorithms
+
+from .JWTTokenService import JWTTokenService
+from swarmauri_core.keys.IKeyProvider import IKeyProvider
+
+
+def _b64u(b: bytes) -> str:
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode("ascii")
+
+
+def jwk_thumbprint_sha256(jwk: Dict[str, object]) -> str:
+    """
+    RFC 7638 JWK Thumbprint (SHA-256, base64url). We serialize the "required members"
+    for the kty family, with lexicographic member order and no whitespace.
+    """
+    kty = jwk.get("kty")
+    if kty == "OKP":
+        material = {"crv": jwk["crv"], "kty": "OKP", "x": jwk["x"]}
+    elif kty == "EC":
+        material = {"crv": jwk["crv"], "kty": "EC", "x": jwk["x"], "y": jwk["y"]}
+    elif kty == "RSA":
+        material = {"e": jwk["e"], "kty": "RSA", "n": jwk["n"]}
+    else:
+        raise ValueError("Unsupported JWK kty for thumbprint")
+    blob = json.dumps(material, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return _b64u(hashlib.sha256(blob).digest())
+
+
+class DPoPBoundJWTTokenService(JWTTokenService):
+    """
+    DPoP-bound JWTs per RFC 9449 using the 'cnf' claim with the JWK thumbprint:
+      cnf: { "jkt": "<base64url sha-256 of JWK thumbprint (RFC 7638)>" }
+
+    Verification requires access to the current request's DPoP proof JWT and request
+    context (HTTP method + URI, optional nonce). Provide a getter that returns:
+        {
+          "proof": "<DPoP-Proof-JWT>",
+          "htm": "GET",
+          "htu": "https://api.example.com/resource",
+          "nonce": "<optional server-provided nonce>"
+        }
+    """
+
+    type: Literal["DPoPBoundJWTTokenService"] = "DPoPBoundJWTTokenService"
+
+    def __init__(
+        self,
+        key_provider: IKeyProvider,
+        *,
+        default_issuer: Optional[str] = None,
+        dpop_ctx_getter: Optional[Callable[[], Optional[Dict[str, object]]]] = None,
+        proof_max_age_s: int = 300,
+        replay_check: Optional[Callable[[str], bool]] = None,
+    ) -> None:
+        super().__init__(key_provider, default_issuer=default_issuer)
+        self._get_ctx = dpop_ctx_getter
+        self._max_age = int(proof_max_age_s)
+        # replay_check(jti) should return True if JTI is fresh (i.e., not seen before).
+        # If None, replay protection is skipped.
+        self._replay_check = replay_check
+
+    def supports(self) -> Mapping[str, Iterable[str]]:
+        base = super().supports()
+        return {"formats": (*base["formats"], "JWT"), "algs": base["algs"]}
+
+    async def mint(
+        self,
+        claims: Dict[str, object],
+        *,
+        alg: str,
+        kid: str | None = None,
+        key_version: int | None = None,
+        headers: Optional[Dict[str, object]] = None,
+        lifetime_s: Optional[int] = 3600,
+        issuer: Optional[str] = None,
+        subject: Optional[str] = None,
+        audience: Optional[str | list[str]] = None,
+        scope: Optional[str] = None,
+    ) -> str:
+        # Respect explicit cnf if caller already set it.
+        if "cnf" not in claims:
+            # If caller wired a context getter that exposes the public JWK (e.g., during token mint),
+            # compute jkt automatically. Otherwise require caller to provide claims["cnf"]["jkt"].
+            ctx = self._get_ctx() if self._get_ctx else None
+            jwk = ctx.get("jwk") if isinstance(ctx, dict) else None
+            if isinstance(jwk, dict):
+                claims = dict(claims)
+                claims["cnf"] = {"jkt": jwk_thumbprint_sha256(jwk)}
+        return await super().mint(
+            claims,
+            alg=alg,
+            kid=kid,
+            key_version=key_version,
+            headers=headers,
+            lifetime_s=lifetime_s,
+            issuer=issuer,
+            subject=subject,
+            audience=audience,
+            scope=scope,
+        )
+
+    async def verify(
+        self,
+        token: str,
+        *,
+        issuer: Optional[str] = None,
+        audience: Optional[str | list[str]] = None,
+        leeway_s: int = 60,
+    ) -> Dict[str, object]:
+        claims = await super().verify(
+            token, issuer=issuer, audience=audience, leeway_s=leeway_s
+        )
+        cnf = claims.get("cnf") if isinstance(claims, dict) else None
+        jkt = cnf.get("jkt") if isinstance(cnf, dict) else None
+        if not jkt:
+            raise ValueError("DPoP-bound token missing cnf.jkt")
+
+        if not self._get_ctx:
+            raise ValueError("DPoP verification requires a context getter")
+        ctx = self._get_ctx() or {}
+        proof_jwt = ctx.get("proof")
+        htm = ctx.get("htm")
+        htu = ctx.get("htu")
+        nonce = ctx.get("nonce")
+
+        if (
+            not isinstance(proof_jwt, str)
+            or not isinstance(htm, str)
+            or not isinstance(htu, str)
+        ):
+            raise ValueError("Missing DPoP context (proof, htm, htu)")
+
+        # 1) Extract JWK from the DPoP proof header and verify the proof signature
+        hdr = jwt.get_unverified_header(proof_jwt)
+        jwk = hdr.get("jwk")
+        if not isinstance(jwk, dict):
+            raise ValueError("DPoP proof missing 'jwk' in header")
+        key = None
+        if jwk.get("kty") == "RSA":
+            key = algorithms.RSAAlgorithm.from_jwk(jwk)
+        elif jwk.get("kty") == "EC":
+            key = algorithms.ECAlgorithm.from_jwk(jwk)
+        elif jwk.get("kty") == "OKP":
+            key = algorithms.OKPAlgorithm.from_jwk(jwk)
+        else:
+            raise ValueError("Unsupported DPoP JWK kty")
+
+        proof_claims = jwt.decode(
+            proof_jwt,
+            key=key,
+            algorithms=[alg for alg in ("RS256", "PS256", "ES256", "EdDSA")],
+            options={"verify_aud": False, "verify_iss": False},
+        )
+
+        # 2) Check the JWK thumbprint matches the token's cnf.jkt
+        thumb = jwk_thumbprint_sha256(jwk)
+        if thumb != jkt:
+            raise ValueError("DPoP binding mismatch (cnf.jkt != proof JWK thumbprint)")
+
+        # 3) Validate method, URL, iat, nonce (if present)
+        if proof_claims.get("htm") != htm:
+            raise ValueError("DPoP proof 'htm' mismatch")
+        if proof_claims.get("htu") != htu:
+            raise ValueError("DPoP proof 'htu' mismatch")
+        iat = int(proof_claims.get("iat", 0))
+        now = int(time.time())
+        if not (now - self._max_age <= iat <= now + leeway_s):
+            raise ValueError("DPoP proof 'iat' out of acceptable window")
+        if nonce is not None and proof_claims.get("nonce") != nonce:
+            raise ValueError("DPoP proof 'nonce' mismatch")
+
+        # 4) Replay protection (optional but recommended): require fresh JTI
+        jti = proof_claims.get("jti")
+        if self._replay_check and (
+            not isinstance(jti, str) or not self._replay_check(jti)
+        ):
+            raise ValueError("DPoP proof replay detected")
+
+        return claims

--- a/pkgs/standards/swarmauri_tokens_dpopboundjwt/swarmauri_tokens_dpopboundjwt/JWTTokenService.py
+++ b/pkgs/standards/swarmauri_tokens_dpopboundjwt/swarmauri_tokens_dpopboundjwt/JWTTokenService.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import time
+from typing import Iterable, Mapping, Optional
+
+import jwt
+
+from swarmauri_core.keys.IKeyProvider import IKeyProvider
+
+
+class JWTTokenService:
+    """Basic JWT minting and verification service."""
+
+    type = "JWTTokenService"
+
+    def __init__(
+        self, key_provider: IKeyProvider, *, default_issuer: Optional[str] = None
+    ) -> None:
+        self._keys = key_provider
+        self._issuer = default_issuer
+
+    def supports(self) -> Mapping[str, Iterable[str]]:
+        return {
+            "formats": ("JWT",),
+            "algs": ("HS256", "RS256", "PS256", "ES256", "EdDSA"),
+        }
+
+    async def mint(
+        self,
+        claims: dict[str, object],
+        *,
+        alg: str,
+        kid: str | None = None,
+        key_version: int | None = None,
+        headers: Optional[dict[str, object]] = None,
+        lifetime_s: Optional[int] = 3600,
+        issuer: Optional[str] = None,
+        subject: Optional[str] = None,
+        audience: Optional[str | list[str]] = None,
+        scope: Optional[str] = None,
+    ) -> str:
+        now = int(time.time())
+        payload = dict(claims)
+        if issuer or self._issuer:
+            payload["iss"] = issuer or self._issuer
+        if subject:
+            payload["sub"] = subject
+        if audience:
+            payload["aud"] = audience
+        if scope:
+            payload["scope"] = scope
+        if lifetime_s is not None:
+            payload["iat"] = now
+            payload["exp"] = now + int(lifetime_s)
+
+        kid = kid or "default"
+        keyref = await self._keys.get_key(kid, version=key_version, include_secret=True)
+        secret = keyref.material or b""
+        return jwt.encode(
+            payload, secret, algorithm=alg, headers={"kid": kid, **(headers or {})}
+        )
+
+    async def verify(
+        self,
+        token: str,
+        *,
+        issuer: Optional[str] = None,
+        audience: Optional[str | list[str]] = None,
+        leeway_s: int = 60,
+    ) -> dict[str, object]:
+        hdr = jwt.get_unverified_header(token)
+        alg = hdr.get("alg")
+        kid = hdr.get("kid", "default")
+        keyref = await self._keys.get_key(kid, include_secret=True)
+        secret = keyref.material or b""
+        return jwt.decode(
+            token,
+            key=secret,
+            algorithms=[alg],
+            issuer=issuer or self._issuer,
+            audience=audience,
+            leeway=leeway_s,
+        )

--- a/pkgs/standards/swarmauri_tokens_dpopboundjwt/swarmauri_tokens_dpopboundjwt/__init__.py
+++ b/pkgs/standards/swarmauri_tokens_dpopboundjwt/swarmauri_tokens_dpopboundjwt/__init__.py
@@ -1,0 +1,4 @@
+from .DPoPBoundJWTTokenService import DPoPBoundJWTTokenService, jwk_thumbprint_sha256
+from .JWTTokenService import JWTTokenService
+
+__all__ = ["DPoPBoundJWTTokenService", "JWTTokenService", "jwk_thumbprint_sha256"]

--- a/pkgs/standards/swarmauri_tokens_dpopboundjwt/tests/functional/test_rfc9449_dpop_functional.py
+++ b/pkgs/standards/swarmauri_tokens_dpopboundjwt/tests/functional/test_rfc9449_dpop_functional.py
@@ -1,0 +1,103 @@
+import asyncio
+import base64
+import time
+from typing import Dict, Optional
+from uuid import uuid4
+
+import jwt
+from cryptography.hazmat.primitives.asymmetric import ed25519
+from cryptography.hazmat.primitives import serialization
+from swarmauri_core.crypto.types import ExportPolicy, KeyRef, KeyType, KeyUse
+from swarmauri_core.keys.IKeyProvider import IKeyProvider
+
+from swarmauri_tokens_dpopboundjwt import (
+    DPoPBoundJWTTokenService,
+    jwk_thumbprint_sha256,
+)
+
+
+def _b64u(b: bytes) -> str:
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode("ascii")
+
+
+class StaticKeyProvider(IKeyProvider):
+    def __init__(self, secret: bytes) -> None:
+        self._secret = secret
+
+    def supports(self) -> Dict[str, list[str]]:
+        return {"algs": ["HS256"]}
+
+    async def create_key(self, spec):
+        raise NotImplementedError
+
+    async def import_key(self, spec, material, *, public=None):
+        raise NotImplementedError
+
+    async def rotate_key(self, kid: str, *, spec_overrides: Optional[dict] = None):
+        raise NotImplementedError
+
+    async def destroy_key(self, kid: str, version: Optional[int] = None) -> bool:
+        raise NotImplementedError
+
+    async def get_key(
+        self, kid: str, version: Optional[int] = None, *, include_secret: bool = False
+    ) -> KeyRef:
+        return KeyRef(
+            kid=kid,
+            version=1,
+            type=KeyType.SYMMETRIC,
+            uses=(KeyUse.SIGN,),
+            export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+            material=self._secret,
+        )
+
+    async def list_versions(self, kid: str):
+        return (1,)
+
+    async def get_public_jwk(self, kid: str, version: Optional[int] = None) -> dict:
+        return {"kty": "oct", "k": _b64u(self._secret)}
+
+    async def jwks(self, *, prefix_kids: Optional[str] = None) -> dict:
+        raise NotImplementedError
+
+    async def random_bytes(self, n: int) -> bytes:
+        raise NotImplementedError
+
+    async def hkdf(self, ikm: bytes, *, salt: bytes, info: bytes, length: int) -> bytes:
+        raise NotImplementedError
+
+
+async def _run_flow() -> bool:
+    ctx: Dict[str, object] = {}
+    provider = StaticKeyProvider(b"secret")
+    svc = DPoPBoundJWTTokenService(provider, dpop_ctx_getter=lambda: ctx)
+
+    sk = ed25519.Ed25519PrivateKey.generate()
+    pk = sk.public_key()
+    pub = pk.public_bytes(
+        encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw
+    )
+    jwk = {"kty": "OKP", "crv": "Ed25519", "x": _b64u(pub)}
+
+    ctx["jwk"] = jwk
+    token = await svc.mint({}, alg="HS256")
+    del ctx["jwk"]
+
+    now = int(time.time())
+    proof_payload = {
+        "htu": "https://api.example.com/resource",
+        "htm": "GET",
+        "iat": now,
+        "jti": str(uuid4()),
+    }
+    proof = jwt.encode(proof_payload, sk, algorithm="EdDSA", headers={"jwk": jwk})
+    ctx.update(
+        {"proof": proof, "htm": "GET", "htu": "https://api.example.com/resource"}
+    )
+
+    out = await svc.verify(token)
+    return out.get("cnf", {}).get("jkt") == jwk_thumbprint_sha256(jwk)
+
+
+def test_dpop_functional_flow() -> None:
+    assert asyncio.run(_run_flow())

--- a/pkgs/standards/swarmauri_tokens_dpopboundjwt/tests/perf/test_dpop_verify_perf.py
+++ b/pkgs/standards/swarmauri_tokens_dpopboundjwt/tests/perf/test_dpop_verify_perf.py
@@ -1,0 +1,100 @@
+import asyncio
+import base64
+import time
+from typing import Dict, Optional
+from uuid import uuid4
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ed25519
+from swarmauri_core.crypto.types import ExportPolicy, KeyRef, KeyType, KeyUse
+from swarmauri_core.keys.IKeyProvider import IKeyProvider
+
+from swarmauri_tokens_dpopboundjwt import DPoPBoundJWTTokenService
+
+
+def _b64u(b: bytes) -> str:
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode("ascii")
+
+
+class StaticKeyProvider(IKeyProvider):
+    def __init__(self, secret: bytes) -> None:
+        self._secret = secret
+
+    def supports(self) -> Dict[str, list[str]]:
+        return {"algs": ["HS256"]}
+
+    async def create_key(self, spec):
+        raise NotImplementedError
+
+    async def import_key(self, spec, material, *, public=None):
+        raise NotImplementedError
+
+    async def rotate_key(self, kid: str, *, spec_overrides: Optional[dict] = None):
+        raise NotImplementedError
+
+    async def destroy_key(self, kid: str, version: Optional[int] = None) -> bool:
+        raise NotImplementedError
+
+    async def get_key(
+        self, kid: str, version: Optional[int] = None, *, include_secret: bool = False
+    ) -> KeyRef:
+        return KeyRef(
+            kid=kid,
+            version=1,
+            type=KeyType.SYMMETRIC,
+            uses=(KeyUse.SIGN,),
+            export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+            material=self._secret,
+        )
+
+    async def list_versions(self, kid: str):
+        return (1,)
+
+    async def get_public_jwk(self, kid: str, version: Optional[int] = None) -> dict:
+        return {"kty": "oct", "k": _b64u(self._secret)}
+
+    async def jwks(self, *, prefix_kids: Optional[str] = None) -> dict:
+        raise NotImplementedError
+
+    async def random_bytes(self, n: int) -> bytes:
+        raise NotImplementedError
+
+    async def hkdf(self, ikm: bytes, *, salt: bytes, info: bytes, length: int) -> bytes:
+        raise NotImplementedError
+
+
+@pytest.mark.perf
+def test_verify_perf(benchmark) -> None:
+    ctx: Dict[str, object] = {}
+    provider = StaticKeyProvider(b"secret")
+    svc = DPoPBoundJWTTokenService(provider, dpop_ctx_getter=lambda: ctx)
+
+    sk = ed25519.Ed25519PrivateKey.generate()
+    pk = sk.public_key()
+    pub = pk.public_bytes(
+        encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw
+    )
+    jwk = {"kty": "OKP", "crv": "Ed25519", "x": _b64u(pub)}
+
+    ctx["jwk"] = jwk
+    token = asyncio.run(svc.mint({}, alg="HS256"))
+    del ctx["jwk"]
+
+    now = int(time.time())
+    proof_payload = {
+        "htu": "https://api.example.com/resource",
+        "htm": "GET",
+        "iat": now,
+        "jti": str(uuid4()),
+    }
+    proof = jwt.encode(proof_payload, sk, algorithm="EdDSA", headers={"jwk": jwk})
+    ctx.update(
+        {"proof": proof, "htm": "GET", "htu": "https://api.example.com/resource"}
+    )
+
+    def _verify() -> None:
+        asyncio.run(svc.verify(token))
+
+    benchmark(_verify)

--- a/pkgs/standards/swarmauri_tokens_dpopboundjwt/tests/unit/test_rfc7638_thumbprint_unit.py
+++ b/pkgs/standards/swarmauri_tokens_dpopboundjwt/tests/unit/test_rfc7638_thumbprint_unit.py
@@ -1,0 +1,11 @@
+from swarmauri_tokens_dpopboundjwt import jwk_thumbprint_sha256
+
+
+def test_rfc7638_example_thumbprint() -> None:
+    jwk = {
+        "kty": "RSA",
+        "n": "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
+        "e": "AQAB",
+    }
+    thumb = jwk_thumbprint_sha256(jwk)
+    assert thumb == "NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs"


### PR DESCRIPTION
## Summary
- add DPoPBoundJWTTokenService plugin for DPoP-bound JWTs
- include RFC 7638 thumbprint helper and tests for RFC 9449/7638
- register plugin with workspace and provide pyproject extras

## Testing
- `uv run --directory pkgs/standards/swarmauri_tokens_dpopboundjwt --package swarmauri_tokens_dpopboundjwt ruff format .`
- `uv run --directory pkgs/standards/swarmauri_tokens_dpopboundjwt --package swarmauri_tokens_dpopboundjwt ruff check . --fix`
- `uv run --package swarmauri_tokens_dpopboundjwt --directory pkgs/standards/swarmauri_tokens_dpopboundjwt pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7245759408326bb68940c77403fc0