### PR TITLE
Add RFC coverage for PKCS#11 key provider

### DIFF
--- a/pkgs/standards/swarmauri_keyproviders/pyproject.toml
+++ b/pkgs/standards/swarmauri_keyproviders/pyproject.toml
@@ -25,6 +25,9 @@ dependencies = [
 
 [project.optional-dependencies]
 pkcs11 = ["pkcs11"]
+rfc7517 = []
+rfc7518 = []
+rfc5869 = []
 
 [tool.uv.sources]
 swarmauri_core = { workspace = true }
@@ -39,6 +42,7 @@ markers = [
     "r8n: Regression tests",
     "acceptance: Acceptance tests",
     "perf: Performance tests",
+    "functional: Functional tests",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_keyproviders/tests/test_pkcs11_functional.py
+++ b/pkgs/standards/swarmauri_keyproviders/tests/test_pkcs11_functional.py
@@ -1,0 +1,15 @@
+"""Functional tests for HKDF per RFC 5869."""
+
+import asyncio
+import pytest
+
+from swarmauri_keyproviders.Pkcs11KeyProvider import Pkcs11KeyProvider
+
+
+@pytest.mark.functional
+def test_hkdf_deterministic() -> None:
+    provider = Pkcs11KeyProvider.__new__(Pkcs11KeyProvider)
+    result1 = asyncio.run(provider.hkdf(b"ikm", salt=b"salt", info=b"info", length=32))
+    result2 = asyncio.run(provider.hkdf(b"ikm", salt=b"salt", info=b"info", length=32))
+    assert result1 == result2
+    assert len(result1) == 32

--- a/pkgs/standards/swarmauri_keyproviders/tests/test_pkcs11_performance.py
+++ b/pkgs/standards/swarmauri_keyproviders/tests/test_pkcs11_performance.py
@@ -1,0 +1,16 @@
+"""Performance benchmark for HKDF per RFC 5869."""
+
+import asyncio
+import pytest
+
+from swarmauri_keyproviders.Pkcs11KeyProvider import Pkcs11KeyProvider
+
+
+@pytest.mark.perf
+def test_hkdf_performance(benchmark) -> None:
+    provider = Pkcs11KeyProvider.__new__(Pkcs11KeyProvider)
+
+    def run() -> bytes:
+        return asyncio.run(provider.hkdf(b"ikm", salt=b"salt", info=b"info", length=32))
+
+    benchmark(run)

--- a/pkgs/standards/swarmauri_keyproviders/tests/test_pkcs11_rfc7517.py
+++ b/pkgs/standards/swarmauri_keyproviders/tests/test_pkcs11_rfc7517.py
@@ -1,0 +1,29 @@
+"""Tests for RFC 7517 (JSON Web Key) compliance."""
+
+import asyncio
+import pytest
+
+from swarmauri_core.keys.types import KeyAlg, KeyClass
+from swarmauri_keyproviders.Pkcs11KeyProvider import Pkcs11KeyProvider, _IndexEntry
+
+
+@pytest.mark.unit
+def test_symmetric_jwk_placeholder() -> None:
+    provider = Pkcs11KeyProvider.__new__(Pkcs11KeyProvider)
+    provider._idx = {
+        "kid": {
+            1: _IndexEntry(
+                kid="kid",
+                version=1,
+                label="lbl",
+                klass=KeyClass.symmetric,
+                alg=KeyAlg.AES256_GCM,
+                handles={},
+                tags={},
+            )
+        }
+    }
+    jwk = asyncio.run(provider.get_public_jwk("kid", 1))
+    assert jwk["kty"] == "oct"
+    assert jwk["alg"] == "A256GCM"
+    assert jwk["kid"] == "kid.1"

--- a/pkgs/standards/swarmauri_keyproviders/tests/test_pkcs11_rfc7518.py
+++ b/pkgs/standards/swarmauri_keyproviders/tests/test_pkcs11_rfc7518.py
@@ -1,0 +1,18 @@
+"""Tests for RFC 7518 (JSON Web Algorithms) compliance."""
+
+import pytest
+
+from swarmauri_keyproviders.Pkcs11KeyProvider import Pkcs11KeyProvider
+
+
+@pytest.mark.unit
+def test_supported_algorithms() -> None:
+    provider = Pkcs11KeyProvider.__new__(Pkcs11KeyProvider)
+    provider._allow_aes = True
+    provider._allow_ec = True
+    provider._allow_rsa = True
+    algs = provider.supports()["algs"]
+    assert "AES256_GCM" in algs
+    assert "ECDSA_P256_SHA256" in algs
+    assert "RSA_OAEP_SHA256" in algs
+    assert "RSA_PSS_SHA256" in algs


### PR DESCRIPTION
## Summary
- add optional extras for RFC 7517/7518/5869
- register functional test marker
- add JWK, JWA, and HKDF tests for Pkcs11KeyProvider

## Testing
- `uv run --directory pkgs/standards/swarmauri_keyproviders --package swarmauri_keyproviders ruff format .`
- `uv run --directory pkgs/standards/swarmauri_keyproviders --package swarmauri_keyproviders ruff check . --fix`
- `uv run --package swarmauri_keyproviders --directory pkgs/standards/swarmauri_keyproviders pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a724a6a8048326a9f8fcbb33f78f2f