### PR TITLE
feat: add JWKS verifier middleware plugin

### DIFF
--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -63,6 +63,7 @@ members = [
     "standards/swarmauri_middleware_cors",
     "standards/swarmauri_middleware_exceptionhandling",
     "standards/swarmauri_middleware_gzipcompression",
+    "standards/swarmauri_middleware_jwksverifier",
     "standards/swarmauri_middleware_llamaguard",
     "standards/swarmauri_middleware_logging",
     "standards/swarmauri_middleware_ratelimit",
@@ -200,6 +201,7 @@ swarmauri_middleware_cachecontrol = { workspace = true }
 swarmauri_middleware_cors = { workspace = true }
 swarmauri_middleware_exceptionhadling = { workspace = true }
 swarmauri_middleware_gzipcompression = { workspace = true }
+swarmauri_middleware_jwksverifier = { workspace = true }
 swarmauri_middleware_llamaguard = { workspace = true }
 swarmauri_middleware_logging = { workspace = true }
 swarmauri_middleware_ratelimit = { workspace = true }

--- a/pkgs/standards/swarmauri_middleware_jwksverifier/LICENSE
+++ b/pkgs/standards/swarmauri_middleware_jwksverifier/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/standards/swarmauri_middleware_jwksverifier/README.md
+++ b/pkgs/standards/swarmauri_middleware_jwksverifier/README.md
@@ -1,0 +1,29 @@
+![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+
+# Swarmauri Middleware JWKS Verifier
+
+A middleware component providing JWT verification using a cached JWKS with TTL and LRU eviction.
+
+Features:
+- Supports RSA, EC, Ed25519, and HMAC keys from JWKS (RFC 7517)
+- Thread-safe cache with TTL refresh and LRU eviction
+- Optional issuer and algorithm whitelisting
+
+## Installation
+
+```bash
+pip install swarmauri_middleware_jwksverifier
+```
+
+## Usage
+
+```python
+from swarmauri_middleware_jwksverifier import CachedJWKSVerifier
+
+verifier = CachedJWKSVerifier(fetch=my_fetch_jwks)
+claims = verifier.verify(token, algorithms_whitelist=["RS256"], audience="me")
+```
+
+## Entry Point
+
+The middleware registers under the `swarmauri.middlewares` entry point as `CachedJWKSVerifier`.

--- a/pkgs/standards/swarmauri_middleware_jwksverifier/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_jwksverifier/pyproject.toml
@@ -1,0 +1,72 @@
+[project]
+name = "swarmauri_middleware_jwksverifier"
+version = "0.1.0"
+description = "JWKS-based JWT verification middleware for Swarmauri"
+license = "Apache-2.0"
+readme = "README.md"
+requires-python = ">=3.10,<3.13"
+authors = [{ name = "Swarmauri", email = "opensource@swarmauri.com" }]
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Development Status :: 3 - Alpha",
+    "Topic :: Security :: Cryptography",
+    "Intended Audience :: Developers",
+]
+dependencies = [
+    "swarmauri_core",
+    "swarmauri_base",
+    "swarmauri_standard",
+    "PyJWT>=2.8",
+    "cryptography",
+]
+
+[project.optional-dependencies]
+json = []
+cbor = ["cbor2"]
+yaml = ["pyyaml"]
+
+[tool.uv.sources]
+swarmauri_core = { workspace = true }
+swarmauri_base = { workspace = true }
+swarmauri_standard = { workspace = true }
+
+[tool.pytest.ini_options]
+norecursedirs = ["combined", "scripts"]
+markers = [
+    "test: standard test",
+    "unit: Unit tests",
+    "i9n: Integration tests",
+    "r8n: Regression tests",
+    "acceptance: Acceptance tests",
+    "perf: Performance tests",
+]
+timeout = 300
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "pytest-timeout>=2.3.1",
+    "pytest-benchmark>=4.0.0",
+    "flake8>=7.0",
+    "ruff>=0.9.9",
+]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[project.entry-points.'swarmauri.middlewares']
+CachedJWKSVerifier = "swarmauri_middleware_jwksverifier:CachedJWKSVerifier"

--- a/pkgs/standards/swarmauri_middleware_jwksverifier/swarmauri_middleware_jwksverifier/__init__.py
+++ b/pkgs/standards/swarmauri_middleware_jwksverifier/swarmauri_middleware_jwksverifier/__init__.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import base64
+import threading
+import time
+from collections import OrderedDict
+from typing import Any, Callable, Dict, Iterable, Literal, Mapping, Optional, Tuple
+
+import jwt
+from jwt import algorithms
+
+JsonDict = Dict[str, Any]
+JWKSFetcher = Callable[[], JsonDict]
+
+
+def _b64u_decode(data: str) -> bytes:
+    pad = "=" * (-len(data) % 4)
+    return base64.urlsafe_b64decode(data + pad)
+
+
+class CachedJWKSVerifier:
+    type: Literal["CachedJWKSVerifier"] = "CachedJWKSVerifier"
+
+    def __init__(
+        self,
+        *,
+        fetch: JWKSFetcher,
+        ttl_s: int = 300,
+        max_entries: int = 256,
+        allowed_algs: Optional[Iterable[str]] = None,
+        allowed_issuers: Optional[Iterable[str]] = None,
+        user_agent: str = "CachedJWKSVerifier/1.0",
+    ) -> None:
+        if not callable(fetch):
+            raise TypeError("fetch must be a callable returning a JWKS object")
+        self._fetch = fetch
+        self._ttl = int(ttl_s)
+        self._max = int(max_entries)
+        self._ua = user_agent
+
+        self._lock = threading.RLock()
+        self._jwks: JsonDict | None = None
+        self._fetched_at: float = 0.0
+
+        self._lru: OrderedDict[str, Any] = OrderedDict()
+        self._by_family: Dict[Tuple[str, str], Tuple[str, ...]] = {}
+
+        self._overrides: Dict[str, Any] = {}
+        self._override_jwks: Dict[str, JsonDict] = {}
+
+        self._allowed_algs = tuple(a for a in (allowed_algs or ()))
+        self._allowed_issuers = tuple(i.rstrip("/") for i in (allowed_issuers or ()))
+
+    def key_resolver(self) -> Callable[[JsonDict, JsonDict], Any]:
+        def _resolver(header: JsonDict, payload: JsonDict) -> Any:
+            alg = header.get("alg")
+            if self._allowed_algs and alg not in self._allowed_algs:
+                raise jwt.InvalidAlgorithmError(f"Algorithm {alg!r} not allowed")
+
+            kid = header.get("kid")
+            if kid:
+                key = self._get_key_by_kid(kid)
+                if key is not None:
+                    return key
+
+            kty = header.get("kty")
+            crv = header.get("crv") or header.get("alg") or ""
+            fam = (kty, crv)
+            with self._lock:
+                self._ensure_fresh_locked()
+                candidates = self._by_family.get(fam, ())
+
+            for cand_kid in candidates:
+                key = self._get_key_by_kid(cand_kid)
+                if key is not None:
+                    return key
+
+            if kty:
+                with self._lock:
+                    self._ensure_fresh_locked()
+                    for jwk in self._jwks.get("keys", []):  # type: ignore[union-attr]
+                        if jwk.get("kty") == kty:
+                            obj = self._parse_and_admit(jwk)
+                            if obj is not None:
+                                return obj
+
+            with self._lock:
+                self._ensure_fresh_locked(force=True)
+            if kid:
+                key = self._get_key_by_kid(kid)
+                if key is not None:
+                    return key
+
+            return None
+
+        return _resolver
+
+    def refresh(self, *, force: bool = False) -> None:
+        with self._lock:
+            self._ensure_fresh_locked(force=force)
+
+    def inject_override_key(self, kid: str, key_obj: Any) -> None:
+        with self._lock:
+            self._overrides[kid] = key_obj
+            self._lru.pop(kid, None)
+            self._lru[kid] = key_obj
+            self._trim_lru_locked()
+
+    def inject_override_jwk(self, kid: str, jwk: JsonDict) -> None:
+        with self._lock:
+            self._override_jwks[kid] = jwk
+            self._lru.pop(kid, None)
+
+    def invalidate(self, kid: Optional[str] = None) -> None:
+        with self._lock:
+            if kid:
+                self._lru.pop(kid, None)
+                self._overrides.pop(kid, None)
+                self._override_jwks.pop(kid, None)
+            else:
+                self._jwks = None
+                self._fetched_at = 0.0
+                self._lru.clear()
+                self._by_family.clear()
+                self._overrides.clear()
+                self._override_jwks.clear()
+
+    def verify(
+        self,
+        token: str,
+        *,
+        algorithms_whitelist: Iterable[str],
+        audience: Optional[str | Iterable[str]] = None,
+        issuer: Optional[str] = None,
+        leeway_s: int = 60,
+        options: Optional[Mapping[str, Any]] = None,
+    ) -> Mapping[str, Any]:
+        iss = issuer
+        if iss is None and self._allowed_issuers:
+            iss = self._allowed_issuers[0]
+
+        header = jwt.get_unverified_header(token)
+        payload = jwt.decode(token, options={"verify_signature": False})
+        key = self.key_resolver()(header, payload)
+        return jwt.decode(
+            token,
+            key=key,
+            algorithms=list(algorithms_whitelist),
+            audience=audience,
+            issuer=iss,
+            leeway=leeway_s,
+            options={"verify_aud": audience is not None, **(options or {})},
+        )
+
+    def _get_key_by_kid(self, kid: str) -> Any | None:
+        with self._lock:
+            if kid in self._overrides:
+                return self._overrides[kid]
+            if kid in self._override_jwks:
+                obj = self._parse_and_admit(self._override_jwks[kid])
+                if obj is not None:
+                    return obj
+
+            obj = self._lru.get(kid)
+            if obj is not None:
+                self._lru.move_to_end(kid)
+                return obj
+
+            self._ensure_fresh_locked()
+            for jwk in self._jwks.get("keys", []):  # type: ignore[union-attr]
+                if jwk.get("kid") == kid:
+                    return self._parse_and_admit(jwk)
+        return None
+
+    def _ensure_fresh_locked(self, *, force: bool = False) -> None:
+        age = time.time() - self._fetched_at
+        if (not force) and self._jwks is not None and age < self._ttl:
+            return
+        jwks = self._fetch()
+        if (
+            not isinstance(jwks, dict)
+            or "keys" not in jwks
+            or not isinstance(jwks["keys"], list)
+        ):
+            raise RuntimeError("JWKS fetcher returned an invalid JWKS object")
+        self._jwks = jwks
+        self._fetched_at = time.time()
+        fam: Dict[Tuple[str, str], Tuple[str, ...]] = {}
+        for jwk in jwks["keys"]:
+            kty = jwk.get("kty")
+            if not kty:
+                continue
+            crv_or_alg = jwk.get("crv") or jwk.get("alg") or ""
+            kid = jwk.get("kid") or ""
+            if kid:
+                key = (kty, crv_or_alg)
+                fam[key] = tuple((*fam.get(key, ()), kid))
+        self._by_family = fam
+
+    def _parse_and_admit(self, jwk: JsonDict) -> Any | None:
+        kid = jwk.get("kid") or ""
+        try:
+            obj = self._parse_jwk(jwk)
+        except Exception:
+            return None
+        if kid:
+            self._lru[kid] = obj
+            self._trim_lru_locked()
+        return obj
+
+    def _trim_lru_locked(self) -> None:
+        while len(self._lru) > self._max:
+            self._lru.popitem(last=False)
+
+    @staticmethod
+    def _parse_jwk(jwk: JsonDict) -> Any:
+        kty = jwk.get("kty")
+        if kty == "RSA":
+            return algorithms.RSAAlgorithm.from_jwk(jwk)
+        if kty == "EC":
+            return algorithms.ECAlgorithm.from_jwk(jwk)
+        if kty == "OKP":
+            crv = jwk.get("crv")
+            if crv == "Ed25519":
+                return algorithms.Ed25519Algorithm.from_jwk(jwk)
+            raise ValueError("Unsupported OKP curve for JWS verification")
+        if kty == "oct":
+            k = jwk.get("k")
+            if not isinstance(k, str):
+                raise ValueError("oct JWK must include 'k'")
+            return _b64u_decode(k)
+        raise ValueError(f"Unsupported JWK kty: {kty!r}")
+
+
+__all__ = ["CachedJWKSVerifier"]

--- a/pkgs/standards/swarmauri_middleware_jwksverifier/tests/functional/test_jwksverifier_functional.py
+++ b/pkgs/standards/swarmauri_middleware_jwksverifier/tests/functional/test_jwksverifier_functional.py
@@ -1,0 +1,31 @@
+import json
+from typing import Dict
+
+import jwt
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from swarmauri_middleware_jwksverifier import CachedJWKSVerifier
+
+
+def _pub_jwk(pk, kid: str) -> Dict[str, object]:
+    jwk = json.loads(jwt.algorithms.RSAAlgorithm.to_jwk(pk.public_key()))
+    jwk["kid"] = kid
+    return jwk
+
+
+def test_refresh_and_verify_functional() -> None:
+    pk1 = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pk2 = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    current = {"keys": [_pub_jwk(pk1, "a")]}
+
+    def fetch():
+        return current
+
+    v = CachedJWKSVerifier(fetch=fetch, ttl_s=0)
+    t1 = jwt.encode({"iss": "me"}, pk1, algorithm="RS256", headers={"kid": "a"})
+    assert v.verify(t1, algorithms_whitelist=["RS256"], issuer="me")["iss"] == "me"
+
+    current["keys"] = [_pub_jwk(pk2, "b")]
+    t2 = jwt.encode({"iss": "me"}, pk2, algorithm="RS256", headers={"kid": "b"})
+    v.invalidate()
+    assert v.verify(t2, algorithms_whitelist=["RS256"], issuer="me")["iss"] == "me"

--- a/pkgs/standards/swarmauri_middleware_jwksverifier/tests/perf/test_jwksverifier_perf.py
+++ b/pkgs/standards/swarmauri_middleware_jwksverifier/tests/perf/test_jwksverifier_perf.py
@@ -1,0 +1,29 @@
+import json
+
+import jwt
+from cryptography.hazmat.primitives.asymmetric import rsa
+import pytest
+
+from swarmauri_middleware_jwksverifier import CachedJWKSVerifier
+
+
+def _fetch(pk):
+    jwk = json.loads(jwt.algorithms.RSAAlgorithm.to_jwk(pk.public_key()))
+    jwk["kid"] = "perf"
+    return {"keys": [jwk]}
+
+
+@pytest.mark.perf
+def test_verify_perf(benchmark):
+    pk = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+    def fetch():
+        return _fetch(pk)
+
+    v = CachedJWKSVerifier(fetch=fetch)
+    token = jwt.encode({"iss": "me"}, pk, algorithm="RS256", headers={"kid": "perf"})
+
+    def _run():
+        v.verify(token, algorithms_whitelist=["RS256"], issuer="me")
+
+    benchmark(_run)

--- a/pkgs/standards/swarmauri_middleware_jwksverifier/tests/unit/test_jwksverifier_unit.py
+++ b/pkgs/standards/swarmauri_middleware_jwksverifier/tests/unit/test_jwksverifier_unit.py
@@ -1,0 +1,25 @@
+import json
+from typing import Dict
+
+import jwt
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from swarmauri_middleware_jwksverifier import CachedJWKSVerifier
+
+
+def _make_fetcher(pk) -> Dict[str, object]:
+    jwk = json.loads(jwt.algorithms.RSAAlgorithm.to_jwk(pk.public_key()))
+    jwk["kid"] = "unit"
+    return {"keys": [jwk]}
+
+
+def test_verify_rsa_unit() -> None:
+    pk = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+    def fetch() -> Dict[str, object]:
+        return _make_fetcher(pk)
+
+    v = CachedJWKSVerifier(fetch=fetch)
+    token = jwt.encode({"iss": "me"}, pk, algorithm="RS256", headers={"kid": "unit"})
+    claims = v.verify(token, algorithms_whitelist=["RS256"], issuer="me")
+    assert claims["iss"] == "me"

--- a/pkgs/standards/swarmauri_middleware_jwksverifier/tests/unit/test_rfc7515_unit.py
+++ b/pkgs/standards/swarmauri_middleware_jwksverifier/tests/unit/test_rfc7515_unit.py
@@ -1,0 +1,24 @@
+import json
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+import jwt
+
+from swarmauri_middleware_jwksverifier import CachedJWKSVerifier
+
+
+def _jwks(pk):
+    jwk = json.loads(jwt.algorithms.RSAAlgorithm.to_jwk(pk.public_key()))
+    jwk["kid"] = "alg"
+    return {"keys": [jwk]}
+
+
+def test_alg_whitelist_rfc7515() -> None:
+    pk = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    token = jwt.encode({"iss": "me"}, pk, algorithm="RS256", headers={"kid": "alg"})
+
+    def fetch():
+        return _jwks(pk)
+
+    v = CachedJWKSVerifier(fetch=fetch, allowed_algs=["HS256"])
+    with pytest.raises(jwt.InvalidAlgorithmError):
+        v.verify(token, algorithms_whitelist=["RS256"], issuer="me")

--- a/pkgs/standards/swarmauri_middleware_jwksverifier/tests/unit/test_rfc7517_unit.py
+++ b/pkgs/standards/swarmauri_middleware_jwksverifier/tests/unit/test_rfc7517_unit.py
@@ -1,0 +1,12 @@
+import pytest
+
+from swarmauri_middleware_jwksverifier import CachedJWKSVerifier
+
+
+def test_invalid_jwks_structure_rfc7517() -> None:
+    def bad_fetch():
+        return {"k": []}
+
+    v = CachedJWKSVerifier(fetch=bad_fetch)
+    with pytest.raises(RuntimeError):
+        v.refresh(force=True)

--- a/pkgs/standards/swarmauri_middleware_jwksverifier/tests/unit/test_rfc7519_unit.py
+++ b/pkgs/standards/swarmauri_middleware_jwksverifier/tests/unit/test_rfc7519_unit.py
@@ -1,0 +1,30 @@
+import json
+from typing import Dict
+
+import jwt
+from cryptography.hazmat.primitives.asymmetric import rsa
+import pytest
+
+from swarmauri_middleware_jwksverifier import CachedJWKSVerifier
+
+
+def _jwks(pk) -> Dict[str, object]:
+    jwk = json.loads(jwt.algorithms.RSAAlgorithm.to_jwk(pk.public_key()))
+    jwk["kid"] = "claims"
+    return {"keys": [jwk]}
+
+
+def test_issuer_and_audience_rfc7519() -> None:
+    pk = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    token = jwt.encode(
+        {"iss": "me", "aud": "you"}, pk, algorithm="RS256", headers={"kid": "claims"}
+    )
+
+    def fetch():
+        return _jwks(pk)
+
+    v = CachedJWKSVerifier(fetch=fetch, allowed_issuers=["me"])
+    claims = v.verify(token, algorithms_whitelist=["RS256"], audience="you")
+    assert claims["aud"] == "you"
+    with pytest.raises(jwt.InvalidAudienceError):
+        v.verify(token, algorithms_whitelist=["RS256"], audience="them")


### PR DESCRIPTION
## Summary
- add CachedJWKSVerifier middleware for JWT validation with cached JWKS support
- document and configure package with optional canon extras
- register middleware in workspace config and test RFC compliance

## Testing
- `uv run --directory standards/swarmauri_middleware_jwksverifier --package swarmauri_middleware_jwksverifier ruff format .`
- `uv run --directory standards/swarmauri_middleware_jwksverifier --package swarmauri_middleware_jwksverifier ruff check . --fix`
- `uv run --package swarmauri_middleware_jwksverifier --directory standards/swarmauri_middleware_jwksverifier pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7274450ec832681f140a8d90af613