### PR TITLE
feat: add vault transit key provider plugin

### DIFF
--- a/pkgs/community/swarmauri_keyprovider_vaulttransit/LICENSE
+++ b/pkgs/community/swarmauri_keyprovider_vaulttransit/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/community/swarmauri_keyprovider_vaulttransit/README.md
+++ b/pkgs/community/swarmauri_keyprovider_vaulttransit/README.md
@@ -1,0 +1,34 @@
+# Swarmauri Vault Transit Key Provider
+
+Community plugin providing a `KeyProvider` backed by the HashiCorp Vault Transit engine.
+
+## Features
+- Non-exportable secret keys managed by Vault
+- JWKS export for RSA, EC P-256, and Ed25519 keys
+- Local HKDF and RNG with optional Vault-backed randomness
+
+## Installation
+```bash
+pip install swarmauri_keyprovider_vaulttransit
+# or with optional CBOR canonicalization support
+pip install swarmauri_keyprovider_vaulttransit[cbor]
+```
+
+## Usage
+```python
+from swarmauri_keyprovider_vaulttransit import VaultTransitKeyProvider
+from swarmauri_core.keys.types import KeySpec, KeyAlg, KeyClass, KeyUse, ExportPolicy
+
+provider = VaultTransitKeyProvider(url="https://vault.example", token="s.xxxxx")
+spec = KeySpec(
+    klass=KeyClass.asymmetric,
+    alg=KeyAlg.ED25519,
+    uses=(KeyUse.SIGN, KeyUse.VERIFY),
+    export_policy=ExportPolicy.PUBLIC_ONLY,
+)
+key_ref = await provider.create_key(spec)
+```
+
+## Testing
+Unit, functional, and performance tests are located under `tests/` and
+can be run with `pytest`.

--- a/pkgs/community/swarmauri_keyprovider_vaulttransit/pyproject.toml
+++ b/pkgs/community/swarmauri_keyprovider_vaulttransit/pyproject.toml
@@ -1,0 +1,69 @@
+[project]
+name = "swarmauri_keyprovider_vaulttransit"
+version = "0.1.0"
+description = "HashiCorp Vault Transit key provider for Swarmauri"
+license = "Apache-2.0"
+readme = "README.md"
+repository = "http://github.com/swarmauri/swarmauri-sdk"
+requires-python = ">=3.10,<3.13"
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+authors = [{ name = "Swarmauri", email = "opensource@swarmauri.com" }]
+dependencies = [
+    "hvac>=2.1.0",
+    "cryptography",
+    "swarmauri_core",
+    "swarmauri_base",
+]
+
+[project.optional-dependencies]
+cbor = ["cbor2"]
+
+[tool.uv.sources]
+swarmauri_core = { workspace = true }
+swarmauri_base = { workspace = true }
+
+[tool.pytest.ini_options]
+norecursedirs = ["combined", "scripts"]
+markers = [
+    "test: standard test",
+    "unit: Unit tests",
+    "i9n: Integration tests",
+    "r8n: Regression tests",
+    "timeout: mark test to timeout after X seconds",
+    "xpass: Expected passes",
+    "xfail: Expected failures",
+    "acceptance: Acceptance tests",
+    "perf: Performance tests that measure execution time and resource usage",
+]
+timeout = 300
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
+
+[project.entry-points.'swarmauri.key_providers']
+VaultTransitKeyProvider = "swarmauri_keyprovider_vaulttransit.VaultTransitKeyProvider:VaultTransitKeyProvider"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "python-dotenv",
+    "requests>=2.32.3",
+    "flake8>=7.0",
+    "pytest-timeout>=2.3.1",
+    "ruff>=0.9.9",
+    "pytest-benchmark>=4.0.0",
+]

--- a/pkgs/community/swarmauri_keyprovider_vaulttransit/swarmauri_keyprovider_vaulttransit/VaultTransitKeyProvider.py
+++ b/pkgs/community/swarmauri_keyprovider_vaulttransit/swarmauri_keyprovider_vaulttransit/VaultTransitKeyProvider.py
@@ -1,0 +1,312 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+from typing import Iterable, Mapping, Optional, Tuple, Literal, List
+
+try:
+    import hvac  # pip install hvac
+except Exception:  # pragma: no cover
+    hvac = None
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from cryptography.hazmat.primitives.asymmetric import rsa, ec, ed25519
+
+from swarmauri_base.keys.KeyProviderBase import KeyProviderBase
+from swarmauri_core.keys.types import KeySpec, KeyAlg, ExportPolicy
+from swarmauri_core.crypto.types import KeyRef
+
+
+def _b64u(b: bytes) -> str:
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode("ascii")
+
+
+def _pem_to_jwk(pem: bytes) -> dict:
+    """Convert a PEM public key to a JWK dict (RSA / EC P-256 / Ed25519)."""
+    pub = serialization.load_pem_public_key(pem)
+    if isinstance(pub, rsa.RSAPublicKey):
+        nums = pub.public_numbers()
+        n = nums.n.to_bytes((nums.n.bit_length() + 7) // 8, "big")
+        e = nums.e.to_bytes((nums.e.bit_length() + 7) // 8, "big")
+        return {"kty": "RSA", "n": _b64u(n), "e": _b64u(e)}
+    if isinstance(pub, ec.EllipticCurvePublicKey):
+        curve = pub.curve
+        nums = pub.public_numbers()
+        if isinstance(curve, ec.SECP256R1):
+            x = nums.x.to_bytes(32, "big")
+            y = nums.y.to_bytes(32, "big")
+            return {"kty": "EC", "crv": "P-256", "x": _b64u(x), "y": _b64u(y)}
+        raise ValueError("Unsupported EC curve for JWKS export")
+    if isinstance(pub, ed25519.Ed25519PublicKey):
+        raw = pub.public_bytes(
+            serialization.Encoding.Raw, serialization.PublicFormat.Raw
+        )
+        return {"kty": "OKP", "crv": "Ed25519", "x": _b64u(raw)}
+    raise ValueError("Unsupported public key type")
+
+
+class VaultTransitKeyProvider(KeyProviderBase):
+    """Key provider backed by HashiCorp Vault Transit engine."""
+
+    type: Literal["VaultTransitKeyProvider"] = "VaultTransitKeyProvider"
+
+    def __init__(
+        self,
+        url: str,
+        token: str,
+        *,
+        mount: str = "transit",
+        namespace: Optional[str] = None,
+        verify: bool | str = True,
+        prefer_vault_rng: bool = True,
+    ) -> None:
+        super().__init__()
+        if hvac is None:  # pragma: no cover
+            raise ImportError(
+                "hvac is required for VaultTransitKeyProvider (pip install hvac)"
+            )
+        self._client = hvac.Client(
+            url=url, token=token, namespace=namespace, verify=verify
+        )
+        if not self._client.is_authenticated():
+            raise RuntimeError(
+                "VaultTransitKeyProvider: failed to authenticate to Vault"
+            )
+        self._mount = mount
+        self._transit = self._client.secrets.transit
+        self._prefer_vault_rng = prefer_vault_rng
+
+    def supports(self) -> Mapping[str, Iterable[str]]:
+        return {
+            "class": ("sym", "asym"),
+            "algs": (
+                KeyAlg.AES256_GCM,
+                KeyAlg.RSA_OAEP_SHA256,
+                KeyAlg.RSA_PSS_SHA256,
+                KeyAlg.ECDSA_P256_SHA256,
+                KeyAlg.ED25519,
+            ),
+            "features": ("rotate", "jwks", "non_exportable"),
+        }
+
+    @staticmethod
+    def _vault_type_for_alg(alg: KeyAlg) -> Tuple[str, str]:
+        """Map KeyAlg -> (vault key type, purpose)."""
+        if alg == KeyAlg.AES256_GCM:
+            return "aes256-gcm96", "encryption"
+        if alg == KeyAlg.RSA_OAEP_SHA256:
+            return "rsa-3072", "encryption"
+        if alg == KeyAlg.RSA_PSS_SHA256:
+            return "rsa-3072", "signing"
+        if alg == KeyAlg.ECDSA_P256_SHA256:
+            return "ecdsa-p256", "signing"
+        if alg == KeyAlg.ED25519:
+            return "ed25519", "signing"
+        raise ValueError(f"Unsupported alg: {alg}")
+
+    def _export_type_for_purpose(self, purpose: str) -> str:
+        if purpose == "encryption":
+            return "encryption-key"
+        if purpose == "signing":
+            return "signing-key"
+        raise ValueError("Unknown purpose")
+
+    def _key_status(self, name: str) -> dict:
+        res = self._transit.read_key(name=name, mount_point=self._mount)
+        return res["data"]
+
+    def _list_key_names(self) -> List[str]:
+        res = self._transit.list_keys(mount_point=self._mount)
+        return (res.get("data") or {}).get("keys", []) or []
+
+    def _export_public_pem(
+        self, name: str, version: Optional[int], purpose: str
+    ) -> Optional[bytes]:
+        export_type = self._export_type_for_purpose(purpose)
+        try:
+            res = self._transit.export_key(
+                name=name,
+                key_type=export_type,
+                version=None if version is None else str(int(version)),
+                mount_point=self._mount,
+            )
+            data = res.get("data") or {}
+            keys = data.get("keys") or {}
+            if version is None:
+                if keys:
+                    ver = max(int(v) for v in keys.keys())
+                    val = keys.get(str(ver))
+                else:
+                    val = None
+            else:
+                val = keys.get(str(int(version)))
+            if isinstance(val, str) and "BEGIN PUBLIC KEY" in val:
+                return val.encode("utf-8")
+        except Exception:
+            pass
+        try:
+            status = self._key_status(name)
+            keys = status.get("keys") or {}
+            idx = str(version or status.get("latest_version"))
+            entry = keys.get(idx) or {}
+            val = entry.get("public_key")
+            if isinstance(val, str) and "BEGIN PUBLIC KEY" in val:
+                return val.encode("utf-8")
+        except Exception:
+            pass
+        return None
+
+    async def create_key(self, spec: KeySpec) -> KeyRef:
+        vtype, purpose = self._vault_type_for_alg(spec.alg)
+        name = (
+            spec.label or f"k-{hashlib.sha256(os.urandom(16)).hexdigest()[:12]}"
+        ).strip()
+        self._transit.create_key(
+            name=name,
+            type=vtype,
+            exportable=False,
+            allow_plaintext_backup=False,
+            mount_point=self._mount,
+        )
+        status = self._key_status(name)
+        latest = int(status["latest_version"])
+        public_pem = None
+        if purpose in ("signing", "encryption") and spec.alg != KeyAlg.AES256_GCM:
+            public_pem = self._export_public_pem(name, latest, purpose)
+        return KeyRef(
+            kid=name,
+            version=latest,
+            type="OPAQUE",
+            uses=spec.uses,
+            export_policy=ExportPolicy.PUBLIC_ONLY,
+            public=public_pem,
+            material=None,
+            tags={
+                "label": spec.label,
+                "alg": spec.alg.value,
+                "vault_mount": self._mount,
+                "vault_type": vtype,
+                "vault_purpose": purpose,
+            },
+        )
+
+    async def import_key(
+        self, spec: KeySpec, material: bytes, *, public: Optional[bytes] = None
+    ) -> KeyRef:
+        raise NotImplementedError(
+            "VaultTransitKeyProvider.import_key is intentionally not supported"
+        )
+
+    async def rotate_key(
+        self, kid: str, *, spec_overrides: Optional[dict] = None
+    ) -> KeyRef:
+        self._transit.rotate_key(name=kid, mount_point=self._mount)
+        status = self._key_status(kid)
+        latest = int(status["latest_version"])
+        purpose = "signing"
+        public_pem = None
+        for p in ("signing", "encryption"):
+            public_pem = self._export_public_pem(kid, latest, p)
+            if public_pem:
+                purpose = p
+                break
+        return KeyRef(
+            kid=kid,
+            version=latest,
+            type="OPAQUE",
+            uses=(),
+            export_policy=ExportPolicy.PUBLIC_ONLY,
+            public=public_pem,
+            material=None,
+            tags={
+                "vault_mount": self._mount,
+                "vault_purpose": purpose,
+            },
+        )
+
+    async def destroy_key(self, kid: str, version: Optional[int] = None) -> bool:
+        if version is None:
+            self._transit.delete_key(name=kid, mount_point=self._mount)
+            return True
+        self._transit.destroy_key(
+            name=kid, versions=[int(version)], mount_point=self._mount
+        )
+        return True
+
+    async def get_key(
+        self, kid: str, version: Optional[int] = None, *, include_secret: bool = False
+    ) -> KeyRef:
+        status = self._key_status(kid)
+        latest = int(status["latest_version"])
+        ver = int(version or latest)
+        public_pem = None
+        purpose_detected = None
+        for p in ("signing", "encryption"):
+            public_pem = self._export_public_pem(kid, ver, p)
+            if public_pem:
+                purpose_detected = p
+                break
+        return KeyRef(
+            kid=kid,
+            version=ver,
+            type="OPAQUE",
+            uses=(),
+            export_policy=ExportPolicy.PUBLIC_ONLY,
+            public=public_pem,
+            material=None,
+            tags={
+                "vault_mount": self._mount,
+                "vault_purpose": purpose_detected,
+                "latest_version": latest,
+            },
+        )
+
+    async def list_versions(self, kid: str) -> Tuple[int, ...]:
+        status = self._key_status(kid)
+        keys = status.get("keys") or {}
+        return tuple(sorted(int(v) for v in keys.keys()))
+
+    async def get_public_jwk(self, kid: str, version: Optional[int] = None) -> dict:
+        ref = await self.get_key(kid, version)
+        if isinstance(ref.public, (bytes, bytearray)):
+            jwk = _pem_to_jwk(bytes(ref.public))
+            jwk["kid"] = f"{ref.kid}.{ref.version}"
+            return jwk
+        return {"kty": "oct", "alg": "A256GCM", "kid": f"{ref.kid}.{ref.version}"}
+
+    async def jwks(self, *, prefix_kids: Optional[str] = None) -> dict:
+        out: List[dict] = []
+        try:
+            names = self._list_key_names()
+        except Exception:
+            names = []
+        for name in names:
+            if prefix_kids and not str(name).startswith(prefix_kids):
+                continue
+            try:
+                status = self._key_status(name)
+                latest = int(status.get("latest_version", 1))
+                jwk = await self.get_public_jwk(name, latest)
+                out.append(jwk)
+            except Exception:
+                continue
+        return {"keys": out}
+
+    async def random_bytes(self, n: int) -> bytes:
+        if self._prefer_vault_rng:
+            try:
+                res = self._client.sys.generate_random_bytes(n_bytes=n)
+                data = res.get("data") or {}
+                b64 = data.get("random_bytes")
+                if b64:
+                    return base64.b64decode(b64)
+            except Exception:
+                pass
+        return os.urandom(n)
+
+    async def hkdf(self, ikm: bytes, *, salt: bytes, info: bytes, length: int) -> bytes:
+        return HKDF(
+            algorithm=hashes.SHA256(), length=length, salt=salt, info=info
+        ).derive(ikm)

--- a/pkgs/community/swarmauri_keyprovider_vaulttransit/swarmauri_keyprovider_vaulttransit/__init__.py
+++ b/pkgs/community/swarmauri_keyprovider_vaulttransit/swarmauri_keyprovider_vaulttransit/__init__.py
@@ -1,0 +1,5 @@
+"""Vault Transit key provider plugin for Swarmauri."""
+
+from .VaultTransitKeyProvider import VaultTransitKeyProvider
+
+__all__ = ["VaultTransitKeyProvider"]

--- a/pkgs/community/swarmauri_keyprovider_vaulttransit/tests/functional/test_jwk.py
+++ b/pkgs/community/swarmauri_keyprovider_vaulttransit/tests/functional/test_jwk.py
@@ -1,0 +1,32 @@
+import pytest
+
+from swarmauri_core.crypto.types import KeyRef
+from swarmauri_core.keys.types import ExportPolicy
+from swarmauri_keyprovider_vaulttransit.VaultTransitKeyProvider import (
+    VaultTransitKeyProvider,
+)
+
+
+class DummyProvider(VaultTransitKeyProvider):
+    def __init__(self) -> None:  # pragma: no cover - used only in tests
+        self._prefer_vault_rng = False
+
+    async def get_key(self, kid, version=None, *, include_secret: bool = False):  # type: ignore[override]
+        return KeyRef(
+            kid=kid,
+            version=1,
+            type="OPAQUE",
+            uses=(),
+            export_policy=ExportPolicy.PUBLIC_ONLY,
+            public=None,
+            material=None,
+            tags={},
+        )
+
+
+@pytest.mark.acceptance
+@pytest.mark.asyncio
+async def test_get_public_jwk_symmetric():
+    dummy = DummyProvider()
+    jwk = await dummy.get_public_jwk("sym")
+    assert jwk["kty"] == "oct" and jwk["alg"] == "A256GCM"

--- a/pkgs/community/swarmauri_keyprovider_vaulttransit/tests/perf/test_hkdf_perf.py
+++ b/pkgs/community/swarmauri_keyprovider_vaulttransit/tests/perf/test_hkdf_perf.py
@@ -1,0 +1,26 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from swarmauri_keyprovider_vaulttransit.VaultTransitKeyProvider import (
+    VaultTransitKeyProvider,
+)
+
+
+class DummyProvider(VaultTransitKeyProvider):
+    def __init__(self) -> None:  # pragma: no cover - used only in tests
+        self._prefer_vault_rng = False
+        self._client = SimpleNamespace(
+            sys=SimpleNamespace(generate_random_bytes=lambda n_bytes: {})
+        )
+
+
+@pytest.mark.perf
+def test_hkdf_performance(benchmark) -> None:
+    provider = DummyProvider()
+
+    def run() -> None:
+        asyncio.run(provider.hkdf(b"ikm", salt=b"s", info=b"i", length=32))
+
+    benchmark(run)

--- a/pkgs/community/swarmauri_keyprovider_vaulttransit/tests/unit/test_mappings.py
+++ b/pkgs/community/swarmauri_keyprovider_vaulttransit/tests/unit/test_mappings.py
@@ -1,0 +1,84 @@
+from types import SimpleNamespace
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec, ed25519, rsa
+
+from swarmauri_core.keys.types import KeyAlg
+from swarmauri_keyprovider_vaulttransit.VaultTransitKeyProvider import (
+    VaultTransitKeyProvider,
+    _pem_to_jwk,
+)
+
+
+class DummyProvider(VaultTransitKeyProvider):
+    def __init__(self) -> None:  # pragma: no cover - used only in tests
+        self._prefer_vault_rng = False
+        self._client = SimpleNamespace(
+            sys=SimpleNamespace(generate_random_bytes=lambda n_bytes: {})
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "alg,expected",
+    [
+        (KeyAlg.AES256_GCM, ("aes256-gcm96", "encryption")),
+        (KeyAlg.RSA_OAEP_SHA256, ("rsa-3072", "encryption")),
+        (KeyAlg.RSA_PSS_SHA256, ("rsa-3072", "signing")),
+        (KeyAlg.ECDSA_P256_SHA256, ("ecdsa-p256", "signing")),
+        (KeyAlg.ED25519, ("ed25519", "signing")),
+    ],
+)
+def test_vault_type_for_alg(alg, expected):
+    assert VaultTransitKeyProvider._vault_type_for_alg(alg) == expected
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "purpose,expected",
+    [("encryption", "encryption-key"), ("signing", "signing-key")],
+)
+def test_export_type_for_purpose(purpose, expected):
+    dummy = DummyProvider()
+    assert dummy._export_type_for_purpose(purpose) == expected
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_random_bytes_and_hkdf():
+    dummy = DummyProvider()
+    rnd = await dummy.random_bytes(8)
+    assert len(rnd) == 8
+    out = await dummy.hkdf(b"ikm", salt=b"s", info=b"i", length=16)
+    assert len(out) == 16
+
+
+@pytest.mark.unit
+def test_pem_to_jwk_rsa():
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pem = key.public_key().public_bytes(
+        serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    jwk = _pem_to_jwk(pem)
+    assert jwk["kty"] == "RSA" and "n" in jwk and "e" in jwk
+
+
+@pytest.mark.unit
+def test_pem_to_jwk_ec():
+    key = ec.generate_private_key(ec.SECP256R1())
+    pem = key.public_key().public_bytes(
+        serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    jwk = _pem_to_jwk(pem)
+    assert jwk["kty"] == "EC" and jwk["crv"] == "P-256"
+
+
+@pytest.mark.unit
+def test_pem_to_jwk_ed25519():
+    key = ed25519.Ed25519PrivateKey.generate()
+    pem = key.public_key().public_bytes(
+        serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    jwk = _pem_to_jwk(pem)
+    assert jwk["kty"] == "OKP" and jwk["crv"] == "Ed25519"

--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -101,6 +101,7 @@ members = [
     "standards/swarmauri_signing_ssh",
     "community/swarmauri_middleware_circuitbreaker",
     "community/swarmauri_middleware_ratepolicy",
+    "community/swarmauri_keyprovider_vaulttransit",
     "community/swarmauri_vectorstore_redis",
     "community/swarmauri_vectorstore_qdrant",
     "community/swarmauri_vectorstore_pinecone",
@@ -231,6 +232,7 @@ swarmauri_mre_crypto_pgp = { workspace = true }
 swarmauri_mre_crypto_ecdh_es_kw = { workspace = true }
 swarmauri_signing_ed25519 = { workspace = true }
 swarmauri_keyproviders = { workspace = true }
+swarmauri_keyprovider_vaulttransit = { workspace = true }
 swarmauri_signing_secp256k1 = { workspace = true }
 swarmauri_signing_hmac = { workspace = true }
 swarmauri_signing_ecdsa = { workspace = true }


### PR DESCRIPTION
## Summary
- add community Vault Transit key provider with JWKS support
- expose optional CBOR canonicalization extra
- include unit, acceptance, and performance tests

## Testing
- `uv run --package swarmauri_keyprovider_vaulttransit --directory pkgs/community/swarmauri_keyprovider_vaulttransit ruff format .`
- `uv run --package swarmauri_keyprovider_vaulttransit --directory pkgs/community/swarmauri_keyprovider_vaulttransit ruff check . --fix`
- `cd pkgs && uv run --package swarmauri_keyprovider_vaulttransit --directory community/swarmauri_keyprovider_vaulttransit pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a729536d4c832685b154d32cb02e3b