### PR TITLE
feat: add AWS KMS key provider plugin

### DIFF
--- a/pkgs/community/swarmauri_keyprovider_aws_kms/LICENSE
+++ b/pkgs/community/swarmauri_keyprovider_aws_kms/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/community/swarmauri_keyprovider_aws_kms/README.md
+++ b/pkgs/community/swarmauri_keyprovider_aws_kms/README.md
@@ -1,0 +1,20 @@
+# Swarmauri AWS KMS Key Provider
+
+Community plugin providing an AWS KMS backed `KeyProvider` for Swarmauri.
+
+## Features
+- Manage RSA and AES keys via AWS KMS
+- Publish JWKs following [RFC 7517](https://datatracker.ietf.org/doc/html/rfc7517)
+- Generate cryptographically secure random bytes
+
+## Installation
+```bash
+pip install swarmauri_keyprovider_aws_kms
+```
+
+## Usage
+```python
+from swarmauri_keyprovider_aws_kms import AwsKmsKeyProvider
+
+provider = AwsKmsKeyProvider(region="us-east-1")
+```

--- a/pkgs/community/swarmauri_keyprovider_aws_kms/pyproject.toml
+++ b/pkgs/community/swarmauri_keyprovider_aws_kms/pyproject.toml
@@ -1,0 +1,72 @@
+[project]
+name = "swarmauri_keyprovider_aws_kms"
+version = "0.1.0"
+description = "AWS KMS KeyProvider for Swarmauri"
+license = "Apache-2.0"
+readme = "README.md"
+repository = "http://github.com/swarmauri/swarmauri-sdk"
+requires-python = ">=3.10,<3.13"
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+authors = [{ name = "Swarmauri", email = "opensource@swarmauri.com" }]
+dependencies = [
+    "boto3>=1.28.0",
+    "swarmauri_core",
+    "swarmauri_base",
+    "swarmauri_standard",
+    "cryptography",
+]
+
+[project.optional-dependencies]
+docs = ["mkdocs"]
+perf = ["pytest-benchmark>=4.0.0"]
+
+[tool.uv.sources]
+swarmauri_core = { workspace = true }
+swarmauri_base = { workspace = true }
+swarmauri_standard = { workspace = true }
+
+[tool.pytest.ini_options]
+norecursedirs = ["combined", "scripts"]
+markers = [
+    "test: standard test",
+    "unit: Unit tests",
+    "i9n: Integration tests",
+    "r8n: Regression tests",
+    "timeout: mark test to timeout after X seconds",
+    "xpass: Expected passes",
+    "xfail: Expected failures",
+    "acceptance: Acceptance tests",
+    "perf: Performance tests that measure execution time and resource usage",
+]
+timeout = 300
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
+
+[project.entry-points.'swarmauri.key_providers']
+AwsKmsKeyProvider = "swarmauri_keyprovider_aws_kms.AwsKmsKeyProvider:AwsKmsKeyProvider"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "python-dotenv",
+    "requests>=2.32.3",
+    "flake8>=7.0",
+    "pytest-timeout>=2.3.1",
+    "ruff>=0.9.9",
+    "pytest-benchmark>=4.0.0",
+]

--- a/pkgs/community/swarmauri_keyprovider_aws_kms/swarmauri_keyprovider_aws_kms/AwsKmsKeyProvider.py
+++ b/pkgs/community/swarmauri_keyprovider_aws_kms/swarmauri_keyprovider_aws_kms/AwsKmsKeyProvider.py
@@ -1,0 +1,434 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+from dataclasses import dataclass
+from typing import Dict, Iterable, Mapping, Optional, Tuple, Literal
+
+try:
+    import boto3
+    from botocore.exceptions import ClientError
+except Exception as e:  # pragma: no cover
+    raise ImportError(
+        "AwsKmsKeyProvider requires 'boto3'. Install with: pip install boto3"
+    ) from e
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa, ec
+
+from swarmauri_base.keys.KeyProviderBase import KeyProviderBase
+from swarmauri_core.keys.types import KeySpec, KeyAlg, KeyClass, ExportPolicy, KeyUse
+from swarmauri_core.crypto.types import KeyRef
+
+
+def _b64u(b: bytes) -> str:
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode("ascii")
+
+
+@dataclass(frozen=True)
+class _KmsSpec:
+    KeySpec: str
+    KeyUsage: str
+
+
+class AwsKmsKeyProvider(KeyProviderBase):
+    """
+    AWS KMS-backed KeyProvider.
+
+    - Creates new KMS CMKs per (kid, version); maintains stable alias:
+        alias/<alias_prefix>/<kid>          -> latest version
+        alias/<alias_prefix>/<kid>/v<ver>   -> specific version
+    - Rotation = create new KMS key (same alg/usage), bump /vN alias, repoint "latest".
+    - get_key(include_secret=...) never returns private material (KMS non-exportable).
+    - get_public_jwk() parses GetPublicKey DER to RFC 7517 JWK.
+    - jwks() publishes latest per 'kid' (resolved via stable alias) with kid.version.
+
+    IAM needed (minimum):
+      kms:CreateKey, kms:CreateAlias, kms:UpdateAlias, kms:ListAliases,
+      kms:DescribeKey, kms:ListResourceTags, kms:GetPublicKey, kms:ScheduleKeyDeletion
+    """
+
+    type: Literal["AwsKmsKeyProvider"] = "AwsKmsKeyProvider"
+
+    def __init__(
+        self,
+        *,
+        region: str,
+        alias_prefix: str = "swarmauri",
+        key_policy: Optional[dict] = None,
+    ):
+        """
+        region: AWS region name (e.g., "us-east-1")
+        alias_prefix: alias namespace (no 'alias/' prefix here). Final aliases look like:
+                      'alias/<alias_prefix>/<kid>' and 'alias/<alias_prefix>/<kid>/v<ver>'
+        key_policy: optional explicit key policy JSON; if None, KMS uses account default.
+        """
+        super().__init__()
+        self._region = region
+        self._alias_prefix = alias_prefix.strip("/")
+
+        self._kms = boto3.client("kms", region_name=region)
+        self._key_policy = key_policy
+
+    def supports(self) -> Mapping[str, Iterable[str]]:
+        return {
+            "class": ("sym", "asym"),
+            "algs": (
+                KeyAlg.AES256_GCM,
+                KeyAlg.RSA_OAEP_SHA256,
+                KeyAlg.RSA_PSS_SHA256,
+                KeyAlg.ECDSA_P256_SHA256,
+            ),
+            "features": ("rotate", "jwks", "non_exportable"),
+        }
+
+    def _gen_kid(self) -> str:
+        return hashlib.sha256(os.urandom(16)).hexdigest()[:16]
+
+    def _alias_latest(self, kid: str) -> str:
+        return f"alias/{self._alias_prefix}/{kid}"
+
+    def _alias_version(self, kid: str, version: int) -> str:
+        return f"alias/{self._alias_prefix}/{kid}/v{version}"
+
+    def _create_or_update_alias(self, alias_name: str, target_key_id: str) -> None:
+        try:
+            self._kms.create_alias(AliasName=alias_name, TargetKeyId=target_key_id)
+        except ClientError as e:
+            if e.response.get("Error", {}).get("Code") == "AlreadyExistsException":
+                self._kms.update_alias(AliasName=alias_name, TargetKeyId=target_key_id)
+            else:
+                raise
+
+    def _kms_spec_for_alg(self, spec: KeySpec) -> _KmsSpec:
+        if spec.klass == KeyClass.symmetric:
+            if spec.alg != KeyAlg.AES256_GCM:
+                raise ValueError(f"Unsupported symmetric alg for AWS KMS: {spec.alg}")
+            return _KmsSpec(KeySpec="SYMMETRIC_DEFAULT", KeyUsage="ENCRYPT_DECRYPT")
+
+        if spec.alg == KeyAlg.RSA_OAEP_SHA256:
+            bits = spec.size_bits or 3072
+            if bits not in (2048, 3072, 4096):
+                raise ValueError("AWS KMS RSA supports 2048/3072/4096 bit sizes")
+            return _KmsSpec(KeySpec=f"RSA_{bits}", KeyUsage="ENCRYPT_DECRYPT")
+
+        if spec.alg == KeyAlg.RSA_PSS_SHA256:
+            bits = spec.size_bits or 3072
+            if bits not in (2048, 3072, 4096):
+                raise ValueError("AWS KMS RSA supports 2048/3072/4096 bit sizes")
+            return _KmsSpec(KeySpec=f"RSA_{bits}", KeyUsage="SIGN_VERIFY")
+
+        if spec.alg == KeyAlg.ECDSA_P256_SHA256:
+            return _KmsSpec(KeySpec="ECC_NIST_P256", KeyUsage="SIGN_VERIFY")
+
+        raise ValueError(f"Unsupported alg for AWS KMS: {spec.alg}")
+
+    def _get_tags(self, key_id: str) -> Dict[str, str]:
+        out: Dict[str, str] = {}
+        paginator = self._kms.get_paginator("list_resource_tags")
+        for page in paginator.paginate(KeyId=key_id):
+            for t in page.get("Tags", []):
+                out[t["TagKey"]] = t["TagValue"]
+        return out
+
+    def _public_jwk_from_der(self, der: bytes, jwk_kid: str) -> dict:
+        pk = serialization.load_der_public_key(der)
+        if isinstance(pk, rsa.RSAPublicKey):
+            nums = pk.public_numbers()
+            n = nums.n.to_bytes((nums.n.bit_length() + 7) // 8, "big")
+            e = nums.e.to_bytes((nums.e.bit_length() + 7) // 8, "big")
+            return {"kty": "RSA", "n": _b64u(n), "e": _b64u(e), "kid": jwk_kid}
+        if isinstance(pk, ec.EllipticCurvePublicKey):
+            curve = pk.curve
+            if isinstance(curve, ec.SECP256R1):
+                nums = pk.public_numbers()
+                x = nums.x.to_bytes(32, "big")
+                y = nums.y.to_bytes(32, "big")
+                return {
+                    "kty": "EC",
+                    "crv": "P-256",
+                    "x": _b64u(x),
+                    "y": _b64u(y),
+                    "kid": jwk_kid,
+                }
+        raise ValueError("Unsupported public key type returned by KMS")
+
+    def _keyref_from_key_id(
+        self,
+        kid: str,
+        version: int,
+        key_id: str,
+        *,
+        tags: Optional[Dict[str, str]] = None,
+    ) -> KeyRef:
+        public: Optional[bytes] = None
+        try:
+            resp = self._kms.get_public_key(KeyId=key_id)
+            der = resp.get("PublicKey")
+            if der:
+                public = serialization.load_der_public_key(der).public_bytes(
+                    serialization.Encoding.PEM,
+                    serialization.PublicFormat.SubjectPublicKeyInfo,
+                )
+        except ClientError as e:
+            code = e.response.get("Error", {}).get("Code")
+            if code not in (
+                "UnsupportedOperationException",
+                "NotFoundException",
+                "InvalidArnException",
+                "IncorrectKeySpecException",
+            ):
+                raise
+
+        uses: Tuple[KeyUse, ...] = (KeyUse.encrypt, KeyUse.decrypt)
+        try:
+            md = self._kms.describe_key(KeyId=key_id)["KeyMetadata"]
+            if md.get("KeyUsage") == "SIGN_VERIFY":
+                uses = (KeyUse.sign, KeyUse.verify)
+            elif md.get("KeyUsage") == "ENCRYPT_DECRYPT":
+                uses = (KeyUse.encrypt, KeyUse.decrypt)
+        except Exception:
+            pass
+
+        tag_map = dict(tags or {})
+        return KeyRef(
+            kid=kid,
+            version=version,
+            type="OPAQUE",
+            uses=uses,
+            export_policy=ExportPolicy.never_export_secret,
+            public=public,
+            material=None,
+            tags={
+                "alg": tag_map.get("saur:alg"),
+                "kms:key_id": key_id,
+                "kms:region": self._region,
+                "label": tag_map.get("saur:label"),
+            },
+        )
+
+    async def create_key(self, spec: KeySpec) -> KeyRef:
+        kid = self._gen_kid()
+        version = 1
+        kms_spec = self._kms_spec_for_alg(spec)
+
+        kwargs = {
+            "KeyUsage": kms_spec.KeyUsage,
+            "KeySpec": kms_spec.KeySpec,
+            "Tags": [
+                {"TagKey": "saur:kid", "TagValue": kid},
+                {"TagKey": "saur:version", "TagValue": str(version)},
+                {"TagKey": "saur:alg", "TagValue": spec.alg.value},
+            ],
+        }
+        if spec.label:
+            kwargs["Tags"].append({"TagKey": "saur:label", "TagValue": spec.label})
+        if self._key_policy:
+            kwargs["Policy"] = self._key_policy
+
+        resp = self._kms.create_key(**kwargs)
+        key_id = resp["KeyMetadata"]["KeyId"]
+
+        self._create_or_update_alias(self._alias_version(kid, version), key_id)
+        self._create_or_update_alias(self._alias_latest(kid), key_id)
+
+        tags = {t["TagKey"]: t["TagValue"] for t in kwargs["Tags"]}
+        return self._keyref_from_key_id(kid, version, key_id, tags=tags)
+
+    async def import_key(
+        self, spec: KeySpec, material: bytes, *, public: Optional[bytes] = None
+    ) -> KeyRef:
+        raise NotImplementedError(
+            "AWS KMS does not support importing private keys via this provider; use create_key()."
+        )
+
+    async def rotate_key(
+        self, kid: str, *, spec_overrides: Optional[dict] = None
+    ) -> KeyRef:
+        latest_alias = self._alias_latest(kid)
+        try:
+            alias_desc = self._find_alias(latest_alias)
+        except KeyError:
+            raise KeyError(f"Unknown kid: {kid}")
+
+        current_key_id = alias_desc["TargetKeyId"]
+        current_tags = self._get_tags(current_key_id)
+        current_alg = current_tags.get("saur:alg")
+        if not current_alg:
+            raise RuntimeError("Missing 'saur:alg' tag on current KMS key")
+
+        alg = KeyAlg(current_alg)
+        size_bits = (spec_overrides or {}).get("size_bits")
+        label = (spec_overrides or {}).get("label", current_tags.get("saur:label"))
+        uses = ()
+        new_spec = KeySpec(
+            klass=(
+                KeyClass.symmetric if alg == KeyAlg.AES256_GCM else KeyClass.asymmetric
+            ),
+            alg=alg,
+            size_bits=size_bits,
+            label=label,
+            export_policy=ExportPolicy.never_export_secret,
+            uses=uses,
+            tags=None,
+        )
+
+        try:
+            versions = await self.list_versions(kid)
+            next_version = (max(versions) + 1) if versions else 2
+        except Exception:
+            v = int(current_tags.get("saur:version", "1"))
+            next_version = v + 1
+
+        kms_spec = self._kms_spec_for_alg(new_spec)
+        kwargs = {
+            "KeyUsage": kms_spec.KeyUsage,
+            "KeySpec": kms_spec.KeySpec,
+            "Tags": [
+                {"TagKey": "saur:kid", "TagValue": kid},
+                {"TagKey": "saur:version", "TagValue": str(next_version)},
+                {"TagKey": "saur:alg", "TagValue": alg.value},
+            ],
+        }
+        if label:
+            kwargs["Tags"].append({"TagKey": "saur:label", "TagValue": label})
+        if self._key_policy:
+            kwargs["Policy"] = self._key_policy
+
+        resp = self._kms.create_key(**kwargs)
+        new_key_id = resp["KeyMetadata"]["KeyId"]
+
+        self._create_or_update_alias(self._alias_version(kid, next_version), new_key_id)
+        self._create_or_update_alias(self._alias_latest(kid), new_key_id)
+
+        return self._keyref_from_key_id(
+            kid,
+            next_version,
+            new_key_id,
+            tags={t["TagKey"]: t["TagValue"] for t in kwargs["Tags"]},
+        )
+
+    async def destroy_key(self, kid: str, version: Optional[int] = None) -> bool:
+        try:
+            if version is None:
+                for ver in await self.list_versions(kid):
+                    alias_name = self._alias_version(kid, ver)
+                    alias_desc = self._find_alias(alias_name)
+                    self._kms.schedule_key_deletion(
+                        KeyId=alias_desc["TargetKeyId"], PendingWindowInDays=7
+                    )
+                return True
+            else:
+                alias_name = self._alias_version(kid, version)
+                alias_desc = self._find_alias(alias_name)
+                self._kms.schedule_key_deletion(
+                    KeyId=alias_desc["TargetKeyId"], PendingWindowInDays=7
+                )
+                return True
+        except Exception:
+            return False
+
+    async def get_key(
+        self, kid: str, version: Optional[int] = None, *, include_secret: bool = False
+    ) -> KeyRef:
+        alias_name = (
+            self._alias_version(kid, version) if version else self._alias_latest(kid)
+        )
+        alias_desc = self._find_alias(alias_name)
+        key_id = alias_desc["TargetKeyId"]
+
+        tags = self._get_tags(key_id)
+        ver = int(tags.get("saur:version") or (version or 1))
+        return self._keyref_from_key_id(kid, ver, key_id, tags=tags)
+
+    async def list_versions(self, kid: str) -> Tuple[int, ...]:
+        prefix = f"alias/{self._alias_prefix}/{kid}/v"
+        out: list[int] = []
+        paginator = self._kms.get_paginator("list_aliases")
+        for page in paginator.paginate():
+            for a in page.get("Aliases", []):
+                name = a.get("AliasName")
+                if not name or not name.startswith(prefix):
+                    continue
+                tail = name[len(prefix) :]
+                if tail.isdigit():
+                    out.append(int(tail))
+        if not out:
+            try:
+                self._find_alias(self._alias_latest(kid))
+                out = [1]
+            except KeyError:
+                pass
+        out.sort()
+        return tuple(out)
+
+    async def get_public_jwk(self, kid: str, version: Optional[int] = None) -> dict:
+        alias_name = (
+            self._alias_version(kid, version) if version else self._alias_latest(kid)
+        )
+        alias_desc = self._find_alias(alias_name)
+        key_id = alias_desc["TargetKeyId"]
+
+        tags = self._get_tags(key_id)
+        ver = int(tags.get("saur:version") or (version or 1))
+        jwk_kid = f"{kid}.{ver}"
+
+        try:
+            pk = self._kms.get_public_key(KeyId=key_id).get("PublicKey")
+            if not pk:
+                return {"kty": "oct", "alg": "A256GCM", "kid": jwk_kid}
+            return self._public_jwk_from_der(pk, jwk_kid)
+        except ClientError as e:
+            code = e.response.get("Error", {}).get("Code")
+            if code in ("UnsupportedOperationException", "IncorrectKeySpecException"):
+                return {"kty": "oct", "alg": "A256GCM", "kid": jwk_kid}
+            raise
+
+    async def jwks(self, *, prefix_kids: Optional[str] = None) -> dict:
+        keys = []
+        base_prefix = f"alias/{self._alias_prefix}/"
+        paginator = self._kms.get_paginator("list_aliases")
+        seen_latest: set[str] = set()
+        for page in paginator.paginate():
+            for a in page.get("Aliases", []):
+                name = a.get("AliasName") or ""
+                if not name.startswith(base_prefix):
+                    continue
+                tail = name[len(base_prefix) :]
+                if "/v" in tail:
+                    continue
+                kid = tail
+                if prefix_kids and not kid.startswith(prefix_kids):
+                    continue
+                if kid in seen_latest:
+                    continue
+                seen_latest.add(kid)
+                try:
+                    key_id = a["TargetKeyId"]
+                    tags = self._get_tags(key_id)
+                    ver = int(tags.get("saur:version", "1"))
+                    jwk = await self.get_public_jwk(kid, ver)
+                    keys.append(jwk)
+                except Exception:
+                    continue
+        return {"keys": keys}
+
+    async def random_bytes(self, n: int) -> bytes:
+        return os.urandom(n)
+
+    async def hkdf(self, ikm: bytes, *, salt: bytes, info: bytes, length: int) -> bytes:
+        from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+        from cryptography.hazmat.primitives import hashes
+
+        return HKDF(
+            algorithm=hashes.SHA256(), length=length, salt=salt, info=info
+        ).derive(ikm)
+
+    def _find_alias(self, alias_name: str) -> dict:
+        paginator = self._kms.get_paginator("list_aliases")
+        for page in paginator.paginate():
+            for a in page.get("Aliases", []):
+                if a.get("AliasName") == alias_name and "TargetKeyId" in a:
+                    return a
+        raise KeyError(f"Alias not found or no target: {alias_name}")

--- a/pkgs/community/swarmauri_keyprovider_aws_kms/swarmauri_keyprovider_aws_kms/__init__.py
+++ b/pkgs/community/swarmauri_keyprovider_aws_kms/swarmauri_keyprovider_aws_kms/__init__.py
@@ -1,0 +1,3 @@
+from .AwsKmsKeyProvider import AwsKmsKeyProvider, _b64u
+
+__all__ = ["AwsKmsKeyProvider", "_b64u"]

--- a/pkgs/community/swarmauri_keyprovider_aws_kms/tests/functional/jwk_functional_test.py
+++ b/pkgs/community/swarmauri_keyprovider_aws_kms/tests/functional/jwk_functional_test.py
@@ -1,0 +1,17 @@
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+import pytest
+
+from swarmauri_keyprovider_aws_kms import AwsKmsKeyProvider
+
+
+@pytest.mark.i9n
+def test_public_jwk_from_der_rsa():
+    priv = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    der = priv.public_key().public_bytes(
+        serialization.Encoding.DER, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    provider = AwsKmsKeyProvider(region="us-east-1")
+    jwk = provider._public_jwk_from_der(der, "testkid")
+    assert jwk["kty"] == "RSA"
+    assert jwk["kid"] == "testkid"

--- a/pkgs/community/swarmauri_keyprovider_aws_kms/tests/perf/random_bytes_perf_test.py
+++ b/pkgs/community/swarmauri_keyprovider_aws_kms/tests/perf/random_bytes_perf_test.py
@@ -1,0 +1,16 @@
+import asyncio
+
+import pytest
+
+from swarmauri_keyprovider_aws_kms import AwsKmsKeyProvider
+
+
+@pytest.mark.perf
+def test_random_bytes_perf(benchmark):
+    provider = AwsKmsKeyProvider(region="us-east-1")
+
+    def run():
+        return asyncio.run(provider.random_bytes(64))
+
+    result = benchmark(run)
+    assert len(result) == 64

--- a/pkgs/community/swarmauri_keyprovider_aws_kms/tests/rfc/test_rfc7515.py
+++ b/pkgs/community/swarmauri_keyprovider_aws_kms/tests/rfc/test_rfc7515.py
@@ -1,0 +1,11 @@
+import pytest
+
+from swarmauri_keyprovider_aws_kms import _b64u
+
+
+@pytest.mark.unit
+def test_base64url_encoding_no_padding():
+    data = b"\x00\x01"
+    encoded = _b64u(data)
+    assert "=" not in encoded
+    assert encoded == "AAE"

--- a/pkgs/community/swarmauri_keyprovider_aws_kms/tests/rfc/test_rfc7517.py
+++ b/pkgs/community/swarmauri_keyprovider_aws_kms/tests/rfc/test_rfc7517.py
@@ -1,0 +1,16 @@
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+import pytest
+
+from swarmauri_keyprovider_aws_kms import AwsKmsKeyProvider
+
+
+@pytest.mark.unit
+def test_jwk_contains_required_fields():
+    priv = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    der = priv.public_key().public_bytes(
+        serialization.Encoding.DER, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    provider = AwsKmsKeyProvider(region="us-east-1")
+    jwk = provider._public_jwk_from_der(der, "rfc7517")
+    assert {"kty", "kid"}.issubset(jwk.keys())

--- a/pkgs/community/swarmauri_keyprovider_aws_kms/tests/unit/AwsKmsKeyProvider_test.py
+++ b/pkgs/community/swarmauri_keyprovider_aws_kms/tests/unit/AwsKmsKeyProvider_test.py
@@ -1,0 +1,18 @@
+import pytest
+
+from swarmauri_keyprovider_aws_kms import AwsKmsKeyProvider
+from swarmauri_core.keys.types import KeyAlg
+
+
+@pytest.mark.unit
+def test_supports_includes_rsa():
+    provider = AwsKmsKeyProvider(region="us-east-1")
+    assert KeyAlg.RSA_OAEP_SHA256 in provider.supports()["algs"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_random_bytes_length():
+    provider = AwsKmsKeyProvider(region="us-east-1")
+    data = await provider.random_bytes(32)
+    assert len(data) == 32

--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -101,6 +101,7 @@ members = [
     "standards/swarmauri_signing_ssh",
     "community/swarmauri_middleware_circuitbreaker",
     "community/swarmauri_middleware_ratepolicy",
+    "community/swarmauri_keyprovider_aws_kms",
     "community/swarmauri_vectorstore_redis",
     "community/swarmauri_vectorstore_qdrant",
     "community/swarmauri_vectorstore_pinecone",
@@ -231,6 +232,7 @@ swarmauri_mre_crypto_pgp = { workspace = true }
 swarmauri_mre_crypto_ecdh_es_kw = { workspace = true }
 swarmauri_signing_ed25519 = { workspace = true }
 swarmauri_keyproviders = { workspace = true }
+swarmauri_keyprovider_aws_kms = { workspace = true }
 swarmauri_signing_secp256k1 = { workspace = true }
 swarmauri_signing_hmac = { workspace = true }
 swarmauri_signing_ecdsa = { workspace = true }


### PR DESCRIPTION
## Summary
- add community AWS KMS key provider plugin with JWK support and rotation helpers
- integrate package into workspace and expose entrypoint
- include tests for unit, performance and RFC compliance

## Testing
- `uv run --directory community/swarmauri_keyprovider_aws_kms --package swarmauri_keyprovider_aws_kms ruff format .`
- `uv run --directory community/swarmauri_keyprovider_aws_kms --package swarmauri_keyprovider_aws_kms ruff check . --fix`
- `uv run --package swarmauri_keyprovider_aws_kms --directory community/swarmauri_keyprovider_aws_kms pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a72984c058832691110de93c883391