### PR TITLE
feat: add GCP KMS key provider community plugin

### DIFF
--- a/pkgs/community/swarmauri_keyprovider_gcpkms/LICENSE
+++ b/pkgs/community/swarmauri_keyprovider_gcpkms/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/community/swarmauri_keyprovider_gcpkms/README.md
+++ b/pkgs/community/swarmauri_keyprovider_gcpkms/README.md
@@ -1,0 +1,40 @@
+# Swarmauri GCP KMS Key Provider
+
+GCP KMS-backed key provider for the Swarmauri framework. This plugin exposes
+Google Cloud KMS keys through the common `IKeyProvider` interface, enabling
+signing, verification, encryption and random byte generation.
+
+## Optional Canonicalization Extras
+
+- `cbor` – enables CBOR canonicalization utilities via `cbor2`.
+
+## Features
+
+- AES encryption and decryption using KMS-managed symmetric keys.
+- RSA and EC signing backed by Cloud KMS.
+- RSA wrapping and unwrapping of data encryption keys.
+- JWKS export for asymmetric public keys.
+
+## Installation
+
+```bash
+uv add swarmauri_keyprovider_gcpkms
+```
+
+Enable CBOR canonicalization support:
+
+```bash
+uv add swarmauri_keyprovider_gcpkms[cbor]
+```
+
+## Usage
+
+```python
+from swarmauri_keyprovider_gcpkms import GcpKmsKeyProvider
+
+kp = GcpKmsKeyProvider(
+    project_id="my-project",
+    location_id="us-east1",
+    key_ring_id="my-ring",
+)
+```

--- a/pkgs/community/swarmauri_keyprovider_gcpkms/pyproject.toml
+++ b/pkgs/community/swarmauri_keyprovider_gcpkms/pyproject.toml
@@ -1,0 +1,73 @@
+[project]
+name = "swarmauri_keyprovider_gcpkms"
+version = "0.7.6.dev0"
+description = "Google Cloud KMS Key Provider for Swarmauri"
+license = "Apache-2.0"
+readme = "README.md"
+repository = "http://github.com/swarmauri/swarmauri-sdk"
+requires-python = ">=3.10,<3.13"
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+authors = [{ name = "Swarmauri", email = "opensource@swarmauri.com" }]
+dependencies = [
+    "google-auth",
+    "requests",
+    "cryptography",
+    "swarmauri_core",
+    "swarmauri_base",
+    "swarmauri_standard",
+]
+
+[project.optional-dependencies]
+cbor = ["cbor2"]
+
+[tool.uv.sources]
+swarmauri_core = { workspace = true }
+swarmauri_base = { workspace = true }
+swarmauri_standard = { workspace = true }
+
+[tool.pytest.ini_options]
+norecursedirs = ["combined", "scripts"]
+markers = [
+    "test: standard test",
+    "unit: Unit tests",
+    "i9n: Integration tests",
+    "r8n: Regression tests",
+    "timeout: mark test to timeout after X seconds",
+    "xpass: Expected passes",
+    "xfail: Expected failures",
+    "acceptance: Acceptance tests",
+    "perf: Performance tests that measure execution time and resource usage",
+    "functional: Functional tests",
+]
+timeout = 300
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
+
+[project.entry-points.'swarmauri.key_providers']
+GcpKmsKeyProvider = "swarmauri_keyprovider_gcpkms.GcpKmsKeyProvider:GcpKmsKeyProvider"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "python-dotenv",
+    "requests>=2.32.3",
+    "flake8>=7.0",
+    "pytest-timeout>=2.3.1",
+    "ruff>=0.9.9",
+    "pytest-benchmark>=4.0.0",
+]

--- a/pkgs/community/swarmauri_keyprovider_gcpkms/swarmauri_keyprovider_gcpkms/GcpKmsKeyProvider.py
+++ b/pkgs/community/swarmauri_keyprovider_gcpkms/swarmauri_keyprovider_gcpkms/GcpKmsKeyProvider.py
@@ -1,0 +1,560 @@
+from __future__ import annotations
+
+import base64
+import json
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Literal, Mapping, Optional, Tuple
+
+import google.auth
+from google.auth.transport.requests import Request as GARequest
+import requests
+
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
+from cryptography.hazmat.primitives.asymmetric.utils import Prehashed
+from cryptography.hazmat.primitives.serialization import load_pem_public_key
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+import secrets
+
+from pydantic import PrivateAttr
+
+from swarmauri_base.keys.KeyProviderBase import KeyProviderBase
+from swarmauri_core.keys.types import ExportPolicy, KeySpec, KeyUse
+from swarmauri_core.crypto.types import KeyRef
+
+
+API_ROOT = "https://cloudkms.googleapis.com/v1"
+SCOPE = "https://www.googleapis.com/auth/cloud-platform"
+
+
+# ---------- Helpers ----------
+
+
+def _b64e(b: bytes) -> str:
+    return base64.b64encode(b).decode("ascii")
+
+
+def _b64d(s: str) -> bytes:
+    return base64.b64decode(s.encode("ascii"))
+
+
+def _now() -> float:
+    return time.time()
+
+
+def _is_rsa_decrypt_purpose(algorithm: str) -> bool:
+    return algorithm.startswith("RSA_DECRYPT_")
+
+
+def _is_rsa_sign_purpose(algorithm: str) -> bool:
+    return algorithm.startswith("RSA_SIGN_")
+
+
+def _is_ec_sign_purpose(algorithm: str) -> bool:
+    return algorithm.startswith("EC_SIGN_")
+
+
+def _hash_from_algo(algorithm: str):
+    if algorithm.endswith("SHA256"):
+        return hashes.SHA256()
+    if algorithm.endswith("SHA384"):
+        return hashes.SHA384()
+    if algorithm.endswith("SHA512"):
+        return hashes.SHA512()
+    return hashes.SHA256()
+
+
+def _ec_curve_from_algo(algorithm: str):
+    if "P256" in algorithm:
+        return ec.SECP256R1()
+    if "P384" in algorithm:
+        return ec.SECP384R1()
+    if "SECP256K1" in algorithm:
+        return ec.SECP256K1()
+    return ec.SECP256R1()
+
+
+def _jwk_from_pem_public_key(pem_bytes: bytes) -> Dict[str, Any]:
+    pub = load_pem_public_key(pem_bytes)
+    if isinstance(pub, rsa.RSAPublicKey):
+        numbers = pub.public_numbers()
+        n = numbers.n.to_bytes((numbers.n.bit_length() + 7) // 8, "big")
+        e = numbers.e.to_bytes((numbers.e.bit_length() + 7) // 8, "big")
+        return {
+            "kty": "RSA",
+            "n": base64.urlsafe_b64encode(n).rstrip(b"=").decode("ascii"),
+            "e": base64.urlsafe_b64encode(e).rstrip(b"=").decode("ascii"),
+        }
+    if isinstance(pub, ec.EllipticCurvePublicKey):
+        numbers = pub.public_numbers()
+        x = numbers.x.to_bytes((numbers.curve.key_size + 7) // 8, "big")
+        y = numbers.y.to_bytes((numbers.curve.key_size + 7) // 8, "big")
+        crv = "P-256"
+        if isinstance(numbers.curve, ec.SECP384R1):
+            crv = "P-384"
+        elif isinstance(numbers.curve, ec.SECP256K1):
+            crv = "secp256k1"
+        return {
+            "kty": "EC",
+            "crv": crv,
+            "x": base64.urlsafe_b64encode(x).rstrip(b"=").decode("ascii"),
+            "y": base64.urlsafe_b64encode(y).rstrip(b"=").decode("ascii"),
+        }
+    raise ValueError("Unsupported public key type in PEM")
+
+
+@dataclass(frozen=True)
+class _GcpKeyRef(KeyRef):
+    """Read-only reference to a KMS key version."""
+
+
+class GcpKmsKeyProvider(KeyProviderBase):
+    type: Literal["GcpKmsKeyProvider"] = "GcpKmsKeyProvider"
+    _creds = PrivateAttr()
+    _ga_req = PrivateAttr()
+    _lock: threading.RLock = PrivateAttr(default_factory=threading.RLock)
+    _pub_cache: Dict[str, Tuple[bytes, str]] = PrivateAttr(default_factory=dict)
+    _pub_cache_at: Dict[str, float] = PrivateAttr(default_factory=dict)
+    _pub_ttl: float = PrivateAttr(default=300.0)
+
+    def __init__(
+        self,
+        *,
+        project_id: str,
+        location_id: str,
+        key_ring_id: str,
+        http_timeout_s: int = 8,
+        user_agent: str = "GcpKmsKeyProvider/1.0",
+    ) -> None:
+        super().__init__()
+        self._project = project_id
+        self._location = location_id
+        self._ring = key_ring_id
+        self._timeout = http_timeout_s
+        self._ua = user_agent
+
+        creds, _ = google.auth.default(scopes=[SCOPE])
+        self._creds = creds
+        self._ga_req = GARequest()
+
+    def supports(self) -> Mapping[str, Iterable[str]]:
+        return {
+            "class": ("kms", "asym", "sym"),
+            "algs": ("AES", "RSA", "EC"),
+            "features": (
+                "encrypt",
+                "decrypt",
+                "sign",
+                "verify",
+                "wrap",
+                "unwrap",
+                "jwks",
+            ),
+        }
+
+    async def create_key(self, spec: KeySpec) -> KeyRef:
+        purpose = "ENCRYPT_DECRYPT"
+        token = self._token()
+        url = (
+            f"{API_ROOT}/projects/{self._project}/locations/{self._location}/"
+            f"keyRings/{self._ring}/cryptoKeys?cryptoKeyId={spec.name}"
+        )
+        body = {"purpose": purpose}
+        r = requests.post(
+            url, headers=self._hdr(token), json=body, timeout=self._timeout
+        )
+        if r.status_code not in (200, 201):
+            raise RuntimeError(f"create_key failed: {r.status_code} {r.text}")
+        return _GcpKeyRef(
+            kid=spec.name,
+            version=1,
+            type="OPAQUE",
+            uses=(KeyUse.encrypt, KeyUse.decrypt),
+            export_policy=ExportPolicy.public_only,
+            public=None,
+            material=None,
+            tags={"kms": "gcp"},
+        )
+
+    async def import_key(
+        self, spec: KeySpec, material: bytes, *, public: Optional[bytes] = None
+    ) -> KeyRef:
+        raise NotImplementedError(
+            "Use Cloud KMS ImportJobs to import external keys (not provided here)"
+        )
+
+    async def rotate_key(
+        self, kid: str, *, spec_overrides: Optional[dict] = None
+    ) -> KeyRef:
+        raise NotImplementedError(
+            "Configure rotation via Cloud KMS CryptoKey rotation config or create new versions"
+        )
+
+    async def destroy_key(self, kid: str, version: Optional[int] = None) -> bool:
+        if version is None:
+            raise ValueError("GCP KMS requires a specific version to destroy")
+        name = self._version_name(kid, version)
+        token = self._token()
+        url = f"{API_ROOT}/{name}:destroy"
+        r = requests.post(url, headers=self._hdr(token), json={}, timeout=self._timeout)
+        if r.status_code != 200:
+            raise RuntimeError(f"destroy_key failed: {r.status_code} {r.text}")
+        return True
+
+    async def get_key(
+        self, kid: str, version: Optional[int] = None, *, include_secret: bool = False
+    ) -> KeyRef:
+        vname, algo = self._effective_version_and_algo(kid, version)
+        public_pem = self._maybe_fetch_public_pem(vname, algo)
+        public_bytes = None
+        tags: Dict[str, Any] = {"kms": "gcp", "algorithm": algo}
+        if public_pem:
+            jwk = _jwk_from_pem_public_key(public_pem)
+            tags["kty"] = jwk.get("kty")
+            public_bytes = json.dumps(
+                jwk, separators=(",", ":"), sort_keys=True
+            ).encode("utf-8")
+
+        ver_num = int(vname.rsplit("/", 1)[-1])
+        if _is_rsa_decrypt_purpose(algo):
+            uses = (KeyUse.wrap, KeyUse.unwrap)
+        elif _is_rsa_sign_purpose(algo) or _is_ec_sign_purpose(algo):
+            uses = (KeyUse.sign, KeyUse.verify)
+        else:
+            uses = (KeyUse.encrypt, KeyUse.decrypt)
+
+        return _GcpKeyRef(
+            kid=kid,
+            version=ver_num,
+            type="OPAQUE",
+            uses=uses,
+            export_policy=ExportPolicy.public_only,
+            public=public_bytes,
+            material=None,
+            tags=tags,
+        )
+
+    async def list_versions(self, kid: str) -> Tuple[int, ...]:
+        token = self._token()
+        name = self._key_name(kid)
+        url = f"{API_ROOT}/{name}/cryptoKeyVersions?pageSize=1000"
+        r = requests.get(url, headers=self._hdr(token), timeout=self._timeout)
+        if r.status_code != 200:
+            raise RuntimeError(f"list_versions failed: {r.status_code} {r.text}")
+        obj = r.json()
+        vers = []
+        for v in obj.get("cryptoKeyVersions", []):
+            if v.get("state") == "ENABLED":
+                vers.append(int(v["name"].split("/")[-1]))
+        return tuple(sorted(vers))
+
+    async def get_public_jwk(self, kid: str, version: Optional[int] = None) -> dict:
+        ref = await self.get_key(kid, version)
+        if not ref.public:
+            raise RuntimeError("no public key material available")
+        return json.loads(ref.public.decode("utf-8"))
+
+    async def jwks(self, *, prefix_kids: Optional[str] = None) -> dict:
+        token = self._token()
+        list_url = f"{API_ROOT}/projects/{self._project}/locations/{self._location}/keyRings/{self._ring}/cryptoKeys?pageSize=1000"
+        r = requests.get(list_url, headers=self._hdr(token), timeout=self._timeout)
+        if r.status_code != 200:
+            raise RuntimeError(f"jwks list keys failed: {r.status_code} {r.text}")
+        keys_out = []
+        for ck in r.json().get("cryptoKeys", []):
+            kid = ck["name"].split("/")[-1]
+            if prefix_kids and not kid.startswith(prefix_kids):
+                continue
+            v_url = f"{API_ROOT}/{ck['name']}/cryptoKeyVersions?pageSize=1000"
+            rv = requests.get(v_url, headers=self._hdr(token), timeout=self._timeout)
+            if rv.status_code != 200:
+                continue
+            for v in rv.json().get("cryptoKeyVersions", []):
+                if v.get("state") != "ENABLED":
+                    continue
+                algo = v.get("algorithm", "")
+                if (
+                    _is_rsa_sign_purpose(algo)
+                    or _is_ec_sign_purpose(algo)
+                    or _is_rsa_decrypt_purpose(algo)
+                ):
+                    vname = v["name"]
+                    pem = self._maybe_fetch_public_pem(vname, algo)
+                    if not pem:
+                        continue
+                    jwk = _jwk_from_pem_public_key(pem)
+                    jwk["kid"] = f"{kid}.{int(vname.split('/')[-1])}"
+                    if _is_rsa_sign_purpose(algo):
+                        jwk["alg"] = (
+                            "PS256" if "PKCS1_PSS" in algo or "PSS" in algo else "RS256"
+                        )
+                    elif _is_ec_sign_purpose(algo):
+                        jwk["alg"] = "ES256" if "P256" in algo else "ES384"
+                    elif _is_rsa_decrypt_purpose(algo):
+                        jwk["alg"] = "RSA-OAEP-256"
+                    keys_out.append(jwk)
+        return {"keys": keys_out}
+
+    async def encrypt(
+        self,
+        kid: str,
+        plaintext: bytes,
+        *,
+        aad: Optional[bytes] = None,
+        version: Optional[int] = None,
+    ) -> bytes:
+        name = self._key_name(kid)
+        token = self._token()
+        url = f"{API_ROOT}/{name}:encrypt"
+        body: Dict[str, Any] = {"plaintext": _b64e(plaintext)}
+        if aad:
+            body["additionalAuthenticatedData"] = _b64e(aad)
+        r = requests.post(
+            url, headers=self._hdr(token), json=body, timeout=self._timeout
+        )
+        if r.status_code != 200:
+            raise RuntimeError(f"encrypt failed: {r.status_code} {r.text}")
+        return _b64d(r.json()["ciphertext"])
+
+    async def decrypt(
+        self,
+        kid: str,
+        ciphertext: bytes,
+        *,
+        aad: Optional[bytes] = None,
+        version: Optional[int] = None,
+    ) -> bytes:
+        name = self._key_name(kid)
+        token = self._token()
+        url = f"{API_ROOT}/{name}:decrypt"
+        body: Dict[str, Any] = {"ciphertext": _b64e(ciphertext)}
+        if aad:
+            body["additionalAuthenticatedData"] = _b64e(aad)
+        r = requests.post(
+            url, headers=self._hdr(token), json=body, timeout=self._timeout
+        )
+        if r.status_code != 200:
+            raise RuntimeError(f"decrypt failed: {r.status_code} {r.text}")
+        return _b64d(r.json()["plaintext"])
+
+    async def wrap_key(
+        self, kid: str, dek: bytes, *, version: Optional[int] = None
+    ) -> bytes:
+        vname, algo = self._effective_version_and_algo(kid, version)
+        if not _is_rsa_decrypt_purpose(algo):
+            raise ValueError(f"wrap_key requires RSA_DECRYPT_* algorithm, got {algo}")
+        pem = self._maybe_fetch_public_pem(vname, algo)
+        if not pem:
+            raise RuntimeError("No public key available for wrap_key")
+        pub = load_pem_public_key(pem)
+        if not isinstance(pub, rsa.RSAPublicKey):
+            raise ValueError("wrap_key requires RSA public key")
+        oaep_hash = _hash_from_algo(algo)
+        ct = pub.encrypt(
+            dek,
+            padding.OAEP(
+                mgf=padding.MGF1(algorithm=oaep_hash),
+                algorithm=oaep_hash,
+                label=None,
+            ),
+        )
+        return ct
+
+    async def unwrap_key(
+        self, kid: str, wrapped: bytes, *, version: Optional[int] = None
+    ) -> bytes:
+        vname, algo = self._effective_version_and_algo(kid, version)
+        if not _is_rsa_decrypt_purpose(algo):
+            raise ValueError(f"unwrap_key requires RSA_DECRYPT_* algorithm, got {algo}")
+        token = self._token()
+        url = f"{API_ROOT}/{vname}:asymmetricDecrypt"
+        body = {"ciphertext": _b64e(wrapped)}
+        r = requests.post(
+            url, headers=self._hdr(token), json=body, timeout=self._timeout
+        )
+        if r.status_code != 200:
+            raise RuntimeError(f"unwrap_key failed: {r.status_code} {r.text}")
+        return _b64d(r.json()["plaintext"])
+
+    async def sign(
+        self,
+        kid: str,
+        message: bytes,
+        *,
+        version: Optional[int] = None,
+        prehashed: bool = False,
+    ) -> bytes:
+        vname, algo = self._effective_version_and_algo(kid, version)
+        if not (_is_rsa_sign_purpose(algo) or _is_ec_sign_purpose(algo)):
+            raise ValueError(
+                f"sign requires RSA_SIGN_* or EC_SIGN_* algorithm, got {algo}"
+            )
+
+        h = _hash_from_algo(algo)
+        if prehashed:
+            digest_bytes = message
+        else:
+            digest = hashes.Hash(h)
+            digest.update(message)
+            digest_bytes = digest.finalize()
+
+        token = self._token()
+        url = f"{API_ROOT}/{vname}:asymmetricSign"
+        body = {"digest": {f"sha{h.digest_size * 8}": _b64e(digest_bytes)}}
+        r = requests.post(
+            url, headers=self._hdr(token), json=body, timeout=self._timeout
+        )
+        if r.status_code != 200:
+            raise RuntimeError(f"sign failed: {r.status_code} {r.text}")
+        return _b64d(r.json()["signature"])
+
+    async def verify(
+        self,
+        kid: str,
+        message: bytes,
+        signature: bytes,
+        *,
+        version: Optional[int] = None,
+        prehashed: bool = False,
+    ) -> bool:
+        vname, algo = self._effective_version_and_algo(kid, version)
+        pem = self._maybe_fetch_public_pem(vname, algo)
+        if not pem:
+            raise RuntimeError("No public key available for verify")
+        pub = load_pem_public_key(pem)
+
+        h = _hash_from_algo(algo)
+        if prehashed:
+            digest_bytes = message
+        else:
+            digest_calc = hashes.Hash(h)
+            digest_calc.update(message)
+            digest_bytes = digest_calc.finalize()
+
+        try:
+            if isinstance(pub, rsa.RSAPublicKey):
+                if "PKCS1" in algo and "PSS" not in algo:
+                    pub.verify(
+                        signature,
+                        digest_bytes,
+                        padding.PKCS1v15(),
+                        Prehashed(h),
+                    )
+                else:
+                    pub.verify(
+                        signature,
+                        digest_bytes,
+                        padding.PSS(
+                            mgf=padding.MGF1(h),
+                            salt_length=padding.PSS.MAX_LENGTH,
+                        ),
+                        Prehashed(h),
+                    )
+                return True
+            if isinstance(pub, ec.EllipticCurvePublicKey):
+                pub.verify(signature, digest_bytes, ec.ECDSA(Prehashed(h)))
+                return True
+        except Exception:
+            return False
+        return False
+
+    async def random_bytes(self, n: int) -> bytes:
+        return secrets.token_bytes(n)
+
+    async def hkdf(self, ikm: bytes, *, salt: bytes, info: bytes, length: int) -> bytes:
+        return HKDF(
+            algorithm=hashes.SHA256(), length=length, salt=salt, info=info
+        ).derive(ikm)
+
+    def _token(self) -> str:
+        with self._lock:
+            if not self._creds.valid:
+                self._creds.refresh(self._ga_req)
+            return self._creds.token  # type: ignore[return-value]
+
+    def _hdr(self, token: str) -> Dict[str, str]:
+        return {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": self._ua,
+        }
+
+    def _key_name(self, kid: str) -> str:
+        return f"projects/{self._project}/locations/{self._location}/keyRings/{self._ring}/cryptoKeys/{kid}"
+
+    def _version_name(self, kid: str, version: int) -> str:
+        return f"{self._key_name(kid)}/cryptoKeyVersions/{int(version)}"
+
+    def _effective_version_and_algo(
+        self, kid: str, version: Optional[int]
+    ) -> Tuple[str, str]:
+        token = self._token()
+        if version is None:
+            ck_url = f"{API_ROOT}/{self._key_name(kid)}"
+            r = requests.get(ck_url, headers=self._hdr(token), timeout=self._timeout)
+            if r.status_code != 200:
+                raise RuntimeError(f"get CryptoKey failed: {r.status_code} {r.text}")
+            obj = r.json()
+            primary = obj.get("primary", {}).get("name")
+            if primary:
+                vname = primary
+            else:
+                lv_url = (
+                    f"{API_ROOT}/{self._key_name(kid)}/cryptoKeyVersions?pageSize=1000"
+                )
+                rv = requests.get(
+                    lv_url, headers=self._hdr(token), timeout=self._timeout
+                )
+                if rv.status_code != 200:
+                    raise RuntimeError(
+                        f"list versions failed: {rv.status_code} {rv.text}"
+                    )
+                enabled = [
+                    (
+                        int(v["name"].split("/")[-1]),
+                        v["name"],
+                        v.get("algorithm", ""),
+                    )
+                    for v in rv.json().get("cryptoKeyVersions", [])
+                    if v.get("state") == "ENABLED"
+                ]
+                if not enabled:
+                    raise RuntimeError("no ENABLED versions available")
+                enabled.sort(key=lambda t: t[0], reverse=True)
+                vname = enabled[0][1]
+        else:
+            vname = self._version_name(kid, version)
+
+        v_url = f"{API_ROOT}/{vname}"
+        rv = requests.get(v_url, headers=self._hdr(token), timeout=self._timeout)
+        if rv.status_code != 200:
+            raise RuntimeError(f"get version failed: {rv.status_code} {rv.text}")
+        algo = rv.json().get("algorithm", "")
+        return vname, algo
+
+    def _maybe_fetch_public_pem(
+        self, version_name: str, algorithm: str
+    ) -> Optional[bytes]:
+        if not (
+            _is_rsa_sign_purpose(algorithm)
+            or _is_ec_sign_purpose(algorithm)
+            or _is_rsa_decrypt_purpose(algorithm)
+        ):
+            return None
+        with self._lock:
+            ts = self._pub_cache_at.get(version_name, 0.0)
+            if version_name in self._pub_cache and (_now() - ts) < self._pub_ttl:
+                return self._pub_cache[version_name][0]
+        token = self._token()
+        url = f"{API_ROOT}/{version_name}/publicKey"
+        r = requests.get(url, headers=self._hdr(token), timeout=self._timeout)
+        if r.status_code != 200:
+            raise RuntimeError(f"getPublicKey failed: {r.status_code} {r.text}")
+        pem = r.json().get("pem", "").encode("utf-8")
+        with self._lock:
+            self._pub_cache[version_name] = (pem, algorithm)
+            self._pub_cache_at[version_name] = _now()
+        return pem

--- a/pkgs/community/swarmauri_keyprovider_gcpkms/swarmauri_keyprovider_gcpkms/__init__.py
+++ b/pkgs/community/swarmauri_keyprovider_gcpkms/swarmauri_keyprovider_gcpkms/__init__.py
@@ -1,0 +1,3 @@
+from .GcpKmsKeyProvider import GcpKmsKeyProvider
+
+__all__ = ["GcpKmsKeyProvider"]

--- a/pkgs/community/swarmauri_keyprovider_gcpkms/tests/functional/test_hkdf_functional.py
+++ b/pkgs/community/swarmauri_keyprovider_gcpkms/tests/functional/test_hkdf_functional.py
@@ -1,0 +1,27 @@
+import pytest
+
+from swarmauri_keyprovider_gcpkms.GcpKmsKeyProvider import GcpKmsKeyProvider
+
+
+class DummyCreds:
+    token = "token"
+    valid = True
+
+    def refresh(self, request):
+        return None
+
+
+@pytest.fixture
+def provider(monkeypatch):
+    def fake_default(scopes=None):
+        return DummyCreds(), None
+
+    monkeypatch.setattr("google.auth.default", fake_default)
+    return GcpKmsKeyProvider(project_id="p", location_id="l", key_ring_id="r")
+
+
+@pytest.mark.functional
+@pytest.mark.asyncio
+async def test_hkdf_derivation(provider):
+    key = await provider.hkdf(b"input", salt=b"salt", info=b"info", length=32)
+    assert len(key) == 32

--- a/pkgs/community/swarmauri_keyprovider_gcpkms/tests/perf/test_b64_perf.py
+++ b/pkgs/community/swarmauri_keyprovider_gcpkms/tests/perf/test_b64_perf.py
@@ -1,0 +1,14 @@
+import pytest
+
+from swarmauri_keyprovider_gcpkms.GcpKmsKeyProvider import _b64d, _b64e
+
+
+@pytest.mark.perf
+def test_b64_roundtrip_perf(benchmark):
+    data = b"performance" * 10
+
+    def roundtrip():
+        return _b64d(_b64e(data))
+
+    result = benchmark(roundtrip)
+    assert result == data

--- a/pkgs/community/swarmauri_keyprovider_gcpkms/tests/unit/test_gcpkms_provider_unit.py
+++ b/pkgs/community/swarmauri_keyprovider_gcpkms/tests/unit/test_gcpkms_provider_unit.py
@@ -1,0 +1,36 @@
+import pytest
+
+from swarmauri_keyprovider_gcpkms.GcpKmsKeyProvider import GcpKmsKeyProvider
+
+
+class DummyCreds:
+    token = "token"
+    valid = True
+
+    def refresh(self, request):
+        return None
+
+
+@pytest.fixture
+def provider(monkeypatch):
+    def fake_default(scopes=None):
+        return DummyCreds(), None
+
+    monkeypatch.setattr("google.auth.default", fake_default)
+    return GcpKmsKeyProvider(project_id="p", location_id="l", key_ring_id="r")
+
+
+@pytest.mark.unit
+def test_type(provider):
+    assert provider.type == "GcpKmsKeyProvider"
+
+
+@pytest.mark.unit
+def test_id_is_str(provider):
+    assert isinstance(provider.id, str)
+
+
+@pytest.mark.functional
+@pytest.mark.asyncio
+async def test_random_bytes(provider):
+    assert len(await provider.random_bytes(32)) == 32

--- a/pkgs/community/swarmauri_keyprovider_gcpkms/tests/unit/test_rfc7517_jwk.py
+++ b/pkgs/community/swarmauri_keyprovider_gcpkms/tests/unit/test_rfc7517_jwk.py
@@ -1,0 +1,28 @@
+import pytest
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.hazmat.primitives import serialization
+
+from swarmauri_keyprovider_gcpkms.GcpKmsKeyProvider import _jwk_from_pem_public_key
+
+
+@pytest.mark.unit
+def test_rfc7517_jwk_rsa():
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pem = key.public_key().public_bytes(
+        serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    jwk = _jwk_from_pem_public_key(pem)
+    assert jwk["kty"] == "RSA"
+    assert "n" in jwk and "e" in jwk
+
+
+@pytest.mark.unit
+def test_rfc7517_jwk_ec():
+    key = ec.generate_private_key(ec.SECP256R1())
+    pem = key.public_key().public_bytes(
+        serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    jwk = _jwk_from_pem_public_key(pem)
+    assert jwk["kty"] == "EC"
+    assert jwk["crv"] == "P-256"
+    assert "x" in jwk and "y" in jwk

--- a/pkgs/community/swarmauri_keyprovider_gcpkms/tests/unit/test_rfc7518_algorithms.py
+++ b/pkgs/community/swarmauri_keyprovider_gcpkms/tests/unit/test_rfc7518_algorithms.py
@@ -1,0 +1,14 @@
+import pytest
+from cryptography.hazmat.primitives import hashes
+
+from swarmauri_keyprovider_gcpkms.GcpKmsKeyProvider import _hash_from_algo
+
+
+@pytest.mark.unit
+def test_rfc7518_hash_sha256():
+    assert isinstance(_hash_from_algo("RSA_SIGN_PKCS1_2048_SHA256"), hashes.SHA256)
+
+
+@pytest.mark.unit
+def test_rfc7518_hash_default():
+    assert isinstance(_hash_from_algo("RSA_SIGN_PKCS1_2048_SHA1"), hashes.SHA256)

--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -161,6 +161,7 @@ members = [
     "community/swarmauri_tool_jupytergetiopubmessage",
     "community/swarmauri_parser_slate",
     "community/swarmauri_tool_searchword",
+    "community/swarmauri_keyprovider_gcpkms",
     "standards/swarmauri_tool_containernewsession",
     "standards/swarmauri_tool_containerfeedchars",
     "standards/swarmauri_tool_containermakepr",
@@ -299,6 +300,7 @@ swarmauri_toolkit_jupytertoolkit = { workspace = true }
 swarmauri_tool_jupytergetiopubmessage = { workspace = true }
 swarmauri_parser_slate = { workspace = true }
 swarmauri_tool_searchword = { workspace = true }
+swarmauri_keyprovider_gcpkms = { workspace = true }
 swarmauri_tool_containernewsession = { workspace = true }
 swarmauri_tool_containerfeedchars = { workspace = true }
 swarmauri_tool_containermakepr = { workspace = true }


### PR DESCRIPTION
## Summary
- add `swarmauri_keyprovider_gcpkms` community plugin for Google Cloud KMS
- expose entry point for key provider and optional CBOR canonicalization extras
- include unit, functional, performance, and RFC-focused tests

## Testing
- `uv run --directory community/swarmauri_keyprovider_gcpkms --package swarmauri_keyprovider_gcpkms ruff format .`
- `uv run --directory community/swarmauri_keyprovider_gcpkms --package swarmauri_keyprovider_gcpkms ruff check . --fix`
- `uv run --directory community/swarmauri_keyprovider_gcpkms --package swarmauri_keyprovider_gcpkms pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7298b0f5c832692975294c5e22417