### PR TITLE
Include ECDH-ES A128KW plugin and resolve PGP MRE dependency

### DIFF
--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -92,6 +92,7 @@ members = [
     "standards/swarmauri_crypto_nacl_pkcs11",
     "standards/swarmauri_crypto_jwe",
     "standards/swarmauri_crypto_composite",
+    "standards/swarmauri_crypto_ecdh_es_a128kw",
     "standards/swarmauri_mre_crypto_shamir",
     "standards/swarmauri_mre_crypto_keyring",
     "standards/swarmauri_mre_crypto_age",
@@ -243,6 +244,7 @@ swarmauri_crypto_paramiko = { workspace = true }
 swarmauri_crypto_pgp = { workspace = true }
 swarmauri_crypto_nacl_pkcs11 = { workspace = true }
 swarmauri_crypto_composite = { workspace = true }
+swarmauri_crypto_ecdh_es_a128kw = { workspace = true }
 swarmauri_crypto_jwe = { workspace = true }
 swarmauri_mre_crypto_shamir = { workspace = true }
 swarmauri_mre_crypto_keyring = { workspace = true }

--- a/pkgs/standards/swarmauri_mre_crypto_pgp/pyproject.toml
+++ b/pkgs/standards/swarmauri_mre_crypto_pgp/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
+    "pgpy>=0.6.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- register `swarmauri_crypto_ecdh_es_a128kw` in workspace and uv sources
- ensure PGP MRE crypto plugin installs `pgpy`

## Testing
- `uv run --package swarmauri_crypto_ecdh_es_a128kw --directory pkgs/standards/swarmauri_crypto_ecdh_es_a128kw ruff check . --fix`
- `uv run --package swarmauri_crypto_ecdh_es_a128kw --directory pkgs/standards/swarmauri_crypto_ecdh_es_a128kw pytest`
- `uv run --package swarmauri_crypto_sodium --directory pkgs/standards/swarmauri_crypto_sodium pytest`
- `uv run --package swarmauri_mre_crypto_pgp --directory pkgs/standards/swarmauri_mre_crypto_pgp ruff check . --fix`
- `uv run --package swarmauri_mre_crypto_pgp --directory pkgs/standards/swarmauri_mre_crypto_pgp pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a734521c10832688ba78d6824c51fb