### PR TITLE
feat: add self-signed certificate standard

### DIFF
--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -112,6 +112,7 @@ members = [
     "standards/swarmauri_signing_pgp",
     "standards/swarmauri_signing_rsa",
     "standards/swarmauri_signing_ssh",
+    "standards/swarmauri_standards",
     "standards/swarmauri_tokens_introspection",
     "standards/swarmauri_tokens_paseto_v4",
     "standards/swarmauri_tokens_composite",
@@ -272,6 +273,7 @@ swarmauri_tokens_sshcert = { workspace = true }
 swarmauri_signing_pgp = { workspace = true }
 swarmauri_signing_rsa = { workspace = true }
 swarmauri_signing_ssh = { workspace = true }
+swarmauri_standards = { workspace = true }
 swarmauri_tokens_introspection = { workspace = true }
 swarmauri_tokens_paseto_v4 = { workspace = true }
 swarmauri_tokens_composite = { workspace = true }

--- a/pkgs/standards/swarmauri_standards/LICENSE
+++ b/pkgs/standards/swarmauri_standards/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/standards/swarmauri_standards/README.md
+++ b/pkgs/standards/swarmauri_standards/README.md
@@ -1,0 +1,15 @@
+![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+
+# Swarmauri Self-Signed Certificate Utilities
+
+Utilities for issuing self-signed X.509 certificates using the `SelfSignedCertificate` builder.
+
+## Installation
+
+```bash
+pip install swarmauri_standards
+```
+
+## Entry Point
+
+This package registers `SelfSignedCertificate` under the `swarmauri.cert_services` entry point.

--- a/pkgs/standards/swarmauri_standards/pyproject.toml
+++ b/pkgs/standards/swarmauri_standards/pyproject.toml
@@ -1,0 +1,64 @@
+[project]
+name = "swarmauri_standards"
+version = "0.1.0"
+description = "Self-signed certificate utilities for Swarmauri"
+license = "Apache-2.0"
+readme = "README.md"
+requires-python = ">=3.10,<3.13"
+authors = [{ name = "Swarmauri", email = "opensource@swarmauri.com" }]
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Development Status :: 3 - Alpha",
+    "Topic :: Security :: Cryptography",
+    "Intended Audience :: Developers",
+]
+dependencies = [
+    "swarmauri_core",
+    "cryptography",
+]
+
+[project.optional-dependencies]
+ocsp = ["pyopenssl"]
+
+[tool.uv.sources]
+swarmauri_core = { workspace = true }
+
+[tool.pytest.ini_options]
+norecursedirs = ["combined", "scripts"]
+markers = [
+    "test: standard test",
+    "unit: Unit tests",
+    "i9n: Integration tests",
+    "r8n: Regression tests",
+    "acceptance: Acceptance tests",
+    "perf: Performance tests",
+]
+timeout = 300
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "pytest-timeout>=2.3.1",
+    "pytest-benchmark>=4.0.0",
+    "ruff>=0.9.9",
+]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[project.entry-points.'swarmauri.cert_services']
+SelfSignedCertificate = "swarmauri_standards.certs.SelfSignedCertificate:SelfSignedCertificate"

--- a/pkgs/standards/swarmauri_standards/swarmauri_standards/__init__.py
+++ b/pkgs/standards/swarmauri_standards/swarmauri_standards/__init__.py
@@ -1,0 +1,3 @@
+from .certs.SelfSignedCertificate import SelfSignedCertificate
+
+__all__ = ["SelfSignedCertificate"]

--- a/pkgs/standards/swarmauri_standards/swarmauri_standards/certs/SelfSignedCertificate.py
+++ b/pkgs/standards/swarmauri_standards/swarmauri_standards/certs/SelfSignedCertificate.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Optional, Sequence
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ed25519, ed448
+from cryptography.x509.oid import NameOID, ExtendedKeyUsageOID
+
+from swarmauri_core.crypto.types import KeyRef
+from swarmauri_core.certs.ICertService import (
+    SubjectSpec,
+    AltNameSpec,
+    CertExtensionSpec,
+    KeyUsageSpec,
+    ExtendedKeyUsageSpec,
+    BasicConstraintsSpec,
+)
+
+
+_OID_MAP = {
+    "serverAuth": ExtendedKeyUsageOID.SERVER_AUTH,
+    "clientAuth": ExtendedKeyUsageOID.CLIENT_AUTH,
+    "codeSigning": ExtendedKeyUsageOID.CODE_SIGNING,
+    "emailProtection": ExtendedKeyUsageOID.EMAIL_PROTECTION,
+    "timeStamping": ExtendedKeyUsageOID.TIME_STAMPING,
+    "OCSPSigning": ExtendedKeyUsageOID.OCSP_SIGNING,
+}
+
+
+def _now_utc() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+def _name_from_subject(spec: SubjectSpec) -> x509.Name:
+    rdns = []
+    if "C" in spec and spec["C"]:
+        rdns.append(x509.NameAttribute(NameOID.COUNTRY_NAME, spec["C"]))
+    if "ST" in spec and spec["ST"]:
+        rdns.append(x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, spec["ST"]))
+    if "L" in spec and spec["L"]:
+        rdns.append(x509.NameAttribute(NameOID.LOCALITY_NAME, spec["L"]))
+    if "O" in spec and spec["O"]:
+        rdns.append(x509.NameAttribute(NameOID.ORGANIZATION_NAME, spec["O"]))
+    if "OU" in spec and spec["OU"]:
+        rdns.append(x509.NameAttribute(NameOID.ORGANIZATIONAL_UNIT_NAME, spec["OU"]))
+    if "emailAddress" in spec and spec["emailAddress"]:
+        rdns.append(x509.NameAttribute(NameOID.EMAIL_ADDRESS, spec["emailAddress"]))
+    if "CN" in spec and spec["CN"]:
+        rdns.append(x509.NameAttribute(NameOID.COMMON_NAME, spec["CN"]))
+
+    extra = spec.get("extra_rdns") or {}
+    for k, v in extra.items():
+        if not v:
+            continue
+        rdns.append(
+            x509.NameAttribute(
+                x509.ObjectIdentifier(k) if k.count(".") >= 2 else NameOID.COMMON_NAME,
+                v,
+            )
+        )
+    return x509.Name(rdns)
+
+
+def _san_from_spec(san: Optional[AltNameSpec]) -> Optional[x509.SubjectAlternativeName]:
+    if not san:
+        return None
+    gns = []
+    for d in san.get("dns") or []:
+        gns.append(x509.DNSName(d))
+    for ip in san.get("ip") or []:
+        gns.append(x509.IPAddress(x509.ipaddress.ip_address(ip)))  # type: ignore[attr-defined]
+    for uri in san.get("uri") or []:
+        gns.append(x509.UniformResourceIdentifier(uri))
+    for email in san.get("email") or []:
+        gns.append(x509.RFC822Name(email))
+    return x509.SubjectAlternativeName(gns) if gns else None
+
+
+def _eku_from_spec(
+    eku: Optional[ExtendedKeyUsageSpec],
+) -> Optional[x509.ExtendedKeyUsage]:
+    if not eku:
+        return None
+    items = []
+    for token in eku.get("oids") or []:
+        if token in _OID_MAP:
+            items.append(_OID_MAP[token])
+        else:
+            items.append(x509.ObjectIdentifier(token))
+    return x509.ExtendedKeyUsage(items) if items else None
+
+
+def _ku_from_spec(ku: Optional[KeyUsageSpec]) -> Optional[x509.KeyUsage]:
+    if not ku:
+        return None
+    return x509.KeyUsage(
+        digital_signature=bool(ku.get("digital_signature", False)),
+        content_commitment=bool(ku.get("content_commitment", False)),
+        key_encipherment=bool(ku.get("key_encipherment", False)),
+        data_encipherment=bool(ku.get("data_encipherment", False)),
+        key_agreement=bool(ku.get("key_agreement", False)),
+        key_cert_sign=bool(ku.get("key_cert_sign", False)),
+        crl_sign=bool(ku.get("crl_sign", False)),
+        encipher_only=bool(ku.get("encipher_only", False)),
+        decipher_only=bool(ku.get("decipher_only", False)),
+    )
+
+
+def _bc_from_spec(
+    bc: Optional[BasicConstraintsSpec],
+) -> Optional[x509.BasicConstraints]:
+    if not bc:
+        return None
+    return x509.BasicConstraints(
+        ca=bool(bc.get("ca", False)), path_length=bc.get("path_len", None)
+    )
+
+
+def _choose_sig_hash(private_key) -> Optional[hashes.HashAlgorithm]:
+    if isinstance(private_key, (ed25519.Ed25519PrivateKey, ed448.Ed448PrivateKey)):
+        return None
+    return hashes.SHA256()
+
+
+@dataclass
+class SelfSignedCertificate:
+    """Minimal builder for self-signed X.509 certificates."""
+
+    subject: SubjectSpec = field(default_factory=lambda: SubjectSpec(CN="localhost"))  # type: ignore[call-arg]
+    san: Optional[AltNameSpec] = None
+    extensions: Optional[CertExtensionSpec] = None
+    not_before: Optional[int] = None
+    not_after: Optional[int] = None
+    lifetime_days: int = 365
+    serial: Optional[int] = None
+    output_der: bool = False
+    password: Optional[bytes] = None
+
+    def issue(self, key: KeyRef) -> bytes:
+        if key.material is None:
+            raise ValueError(
+                "Self-signed issuance requires a private key in KeyRef.material (PEM)."
+            )
+        pwd = self.password
+        if (
+            pwd is None
+            and key.tags
+            and isinstance(key.tags.get("passphrase"), (str, bytes))
+        ):
+            pwd = (
+                key.tags["passphrase"].encode()
+                if isinstance(key.tags["passphrase"], str)
+                else key.tags["passphrase"]
+            )
+
+        private_key = serialization.load_pem_private_key(key.material, password=pwd)
+        public_key = private_key.public_key()
+        subj = _name_from_subject(self.subject)
+        issuer = subj
+
+        if self.not_before is not None and self.not_after is not None:
+            nb = datetime.fromtimestamp(int(self.not_before), tz=timezone.utc)
+            na = datetime.fromtimestamp(int(self.not_after), tz=timezone.utc)
+        else:
+            nb = _now_utc() - timedelta(seconds=300)
+            na = nb + timedelta(days=int(self.lifetime_days))
+
+        serial = self.serial if self.serial is not None else x509.random_serial_number()
+
+        builder = (
+            x509.CertificateBuilder()
+            .subject_name(subj)
+            .issuer_name(issuer)
+            .public_key(public_key)
+            .serial_number(serial)
+            .not_valid_before(nb)
+            .not_valid_after(na)
+        )
+
+        bc = _bc_from_spec(
+            self.extensions.get("basic_constraints") if self.extensions else None
+        )
+        if bc:
+            builder = builder.add_extension(bc, critical=True)
+
+        ku = _ku_from_spec(
+            self.extensions.get("key_usage") if self.extensions else None
+        )
+        if ku:
+            builder = builder.add_extension(ku, critical=True)
+
+        eku = _eku_from_spec(
+            self.extensions.get("extended_key_usage") if self.extensions else None
+        )
+        if eku:
+            builder = builder.add_extension(eku, critical=False)
+
+        san = _san_from_spec(
+            self.extensions.get("subject_alt_name")
+            if self.extensions and self.extensions.get("subject_alt_name")
+            else self.san
+        )
+        if san:
+            builder = builder.add_extension(san, critical=False)
+
+        skid = x509.SubjectKeyIdentifier.from_public_key(public_key)
+        builder = builder.add_extension(skid, critical=False)
+        akid = x509.AuthorityKeyIdentifier.from_issuer_public_key(public_key)
+        builder = builder.add_extension(akid, critical=False)
+
+        if self.extensions and self.extensions.get("name_constraints"):
+            nc = self.extensions["name_constraints"]
+            permitted_dns = [x509.DNSName(d) for d in (nc.get("permitted_dns") or [])]
+            excluded_dns = [x509.DNSName(d) for d in (nc.get("excluded_dns") or [])]
+            permitted_ip = [
+                x509.IPAddress(x509.ipaddress.ip_address(ip))
+                for ip in (nc.get("permitted_ip") or [])
+            ]  # type: ignore[attr-defined]
+            excluded_ip = [
+                x509.IPAddress(x509.ipaddress.ip_address(ip))
+                for ip in (nc.get("excluded_ip") or [])
+            ]  # type: ignore[attr-defined]
+            permitted_uri = [
+                x509.UniformResourceIdentifier(u)
+                for u in (nc.get("permitted_uri") or [])
+            ]
+            excluded_uri = [
+                x509.UniformResourceIdentifier(u)
+                for u in (nc.get("excluded_uri") or [])
+            ]
+            permitted_email = [
+                x509.RFC822Name(e) for e in (nc.get("permitted_email") or [])
+            ]
+            excluded_email = [
+                x509.RFC822Name(e) for e in (nc.get("excluded_email") or [])
+            ]
+
+            builder = builder.add_extension(
+                x509.NameConstraints(
+                    permitted_subtrees=(
+                        permitted_dns + permitted_ip + permitted_uri + permitted_email
+                    )
+                    or None,
+                    excluded_subtrees=(
+                        excluded_dns + excluded_ip + excluded_uri + excluded_email
+                    )
+                    or None,
+                ),
+                critical=True,
+            )
+
+        sig_hash = _choose_sig_hash(private_key)
+        cert = builder.sign(private_key=private_key, algorithm=sig_hash)
+
+        if self.output_der:
+            return cert.public_bytes(serialization.Encoding.DER)
+        return cert.public_bytes(serialization.Encoding.PEM)
+
+    @classmethod
+    def tls_server(
+        cls,
+        common_name: str,
+        dns_names: Sequence[str] = (),
+        ip_addrs: Sequence[str] = (),
+        lifetime_days: int = 397,
+    ) -> SelfSignedCertificate:
+        subject: SubjectSpec = SubjectSpec(CN=common_name)  # type: ignore[call-arg]
+        san = AltNameSpec(dns=list(dns_names), ip=list(ip_addrs))  # type: ignore[call-arg]
+        ext: CertExtensionSpec = CertExtensionSpec(  # type: ignore[call-arg]
+            basic_constraints=BasicConstraintsSpec(ca=False, path_len=None),  # type: ignore[call-arg]
+            key_usage=KeyUsageSpec(  # type: ignore[call-arg]
+                digital_signature=True,
+                key_encipherment=True,
+                data_encipherment=False,
+                key_agreement=False,
+                content_commitment=False,
+                key_cert_sign=False,
+                crl_sign=False,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            extended_key_usage=ExtendedKeyUsageSpec(oids=["serverAuth"]),  # type: ignore[call-arg]
+            subject_alt_name=san,
+        )
+        return cls(
+            subject=subject, san=san, extensions=ext, lifetime_days=lifetime_days
+        )
+
+    @classmethod
+    def mTLS_client(
+        cls,
+        common_name: str,
+        emails: Sequence[str] = (),
+        lifetime_days: int = 365,
+    ) -> SelfSignedCertificate:
+        subject: SubjectSpec = SubjectSpec(CN=common_name)  # type: ignore[call-arg]
+        san = AltNameSpec(email=list(emails))  # type: ignore[call-arg]
+        ext: CertExtensionSpec = CertExtensionSpec(  # type: ignore[call-arg]
+            basic_constraints=BasicConstraintsSpec(ca=False, path_len=None),  # type: ignore[call-arg]
+            key_usage=KeyUsageSpec(  # type: ignore[call-arg]
+                digital_signature=True,
+                key_encipherment=False,
+                data_encipherment=False,
+                key_agreement=False,
+                content_commitment=False,
+                key_cert_sign=False,
+                crl_sign=False,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            extended_key_usage=ExtendedKeyUsageSpec(oids=["clientAuth"]),  # type: ignore[call-arg]
+            subject_alt_name=san,
+        )
+        return cls(
+            subject=subject, san=san, extensions=ext, lifetime_days=lifetime_days
+        )

--- a/pkgs/standards/swarmauri_standards/swarmauri_standards/certs/__init__.py
+++ b/pkgs/standards/swarmauri_standards/swarmauri_standards/certs/__init__.py
@@ -1,0 +1,3 @@
+from .SelfSignedCertificate import SelfSignedCertificate
+
+__all__ = ["SelfSignedCertificate"]

--- a/pkgs/standards/swarmauri_standards/tests/test_rfc5280_cert.py
+++ b/pkgs/standards/swarmauri_standards/tests/test_rfc5280_cert.py
@@ -1,0 +1,37 @@
+"""Tests for RFC 5280 compliance."""
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography import x509
+
+from swarmauri_standards import SelfSignedCertificate
+from swarmauri_core.crypto.types import KeyRef, KeyType, KeyUse, ExportPolicy
+
+
+@pytest.mark.test
+@pytest.mark.unit
+def test_basic_constraints_and_key_usage():
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+    keyref = KeyRef(
+        kid="k4",
+        version=1,
+        type=KeyType.RSA,
+        uses=(KeyUse.SIGN,),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+        material=pem,
+    )
+    cert_bytes = SelfSignedCertificate.tls_server(
+        "example.com", dns_names=["example.com"]
+    ).issue(keyref)
+    cert = x509.load_pem_x509_certificate(cert_bytes)
+    bc = cert.extensions.get_extension_for_class(x509.BasicConstraints)
+    assert bc.value.ca is False
+    ku = cert.extensions.get_extension_for_class(x509.KeyUsage)
+    assert ku.value.digital_signature
+    assert not ku.value.crl_sign

--- a/pkgs/standards/swarmauri_standards/tests/test_self_signed_certificate_basic.py
+++ b/pkgs/standards/swarmauri_standards/tests/test_self_signed_certificate_basic.py
@@ -1,0 +1,33 @@
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography import x509
+
+from swarmauri_standards import SelfSignedCertificate
+from swarmauri_core.crypto.types import KeyRef, KeyType, KeyUse, ExportPolicy
+
+
+@pytest.mark.test
+@pytest.mark.unit
+def test_issue_basic():
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+    keyref = KeyRef(
+        kid="k1",
+        version=1,
+        type=KeyType.RSA,
+        uses=(KeyUse.SIGN,),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+        material=pem,
+    )
+    cert_bytes = SelfSignedCertificate().issue(keyref)
+    cert = x509.load_pem_x509_certificate(cert_bytes)
+    assert cert.subject == cert.issuer
+    assert (
+        cert.subject.get_attributes_for_oid(x509.oid.NameOID.COMMON_NAME)[0].value
+        == "localhost"
+    )

--- a/pkgs/standards/swarmauri_standards/tests/test_self_signed_certificate_functional.py
+++ b/pkgs/standards/swarmauri_standards/tests/test_self_signed_certificate_functional.py
@@ -1,0 +1,32 @@
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ed25519
+from cryptography import x509
+
+from swarmauri_standards import SelfSignedCertificate
+from swarmauri_core.crypto.types import KeyRef, KeyType, KeyUse, ExportPolicy
+
+
+@pytest.mark.test
+@pytest.mark.i9n
+def test_tls_server_preset():
+    key = ed25519.Ed25519PrivateKey.generate()
+    pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+    keyref = KeyRef(
+        kid="k2",
+        version=1,
+        type=KeyType.ED25519,
+        uses=(KeyUse.SIGN,),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+        material=pem,
+    )
+    cert_bytes = SelfSignedCertificate.tls_server(
+        "example.com", dns_names=["example.com"]
+    ).issue(keyref)
+    cert = x509.load_pem_x509_certificate(cert_bytes)
+    san = cert.extensions.get_extension_for_class(x509.SubjectAlternativeName)
+    assert "example.com" in san.value.get_values_for_type(x509.DNSName)

--- a/pkgs/standards/swarmauri_standards/tests/test_self_signed_certificate_perf.py
+++ b/pkgs/standards/swarmauri_standards/tests/test_self_signed_certificate_perf.py
@@ -1,0 +1,31 @@
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from swarmauri_standards import SelfSignedCertificate
+from swarmauri_core.crypto.types import KeyRef, KeyType, KeyUse, ExportPolicy
+
+
+@pytest.mark.test
+@pytest.mark.perf
+def test_issue_perf(benchmark):
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+    keyref = KeyRef(
+        kid="k3",
+        version=1,
+        type=KeyType.RSA,
+        uses=(KeyUse.SIGN,),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+        material=pem,
+    )
+    cert_builder = SelfSignedCertificate()
+
+    def issue():
+        cert_builder.issue(keyref)
+
+    benchmark(issue)


### PR DESCRIPTION
## Summary
- add `SelfSignedCertificate` builder for issuing self-signed X.509 certs
- register new `swarmauri_standards` plugin with optional OCSP extra
- cover basic, functional, performance, and RFC 5280 tests

## Testing
- `uv run --package swarmauri_standards --directory standards/swarmauri_standards ruff format .`
- `uv run --package swarmauri_standards --directory standards/swarmauri_standards ruff check . --fix`
- `uv run --package swarmauri_standards --directory standards/swarmauri_standards pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a73c963e0c8326af82e6f92dec9fd0