### PR TITLE
feat: add composite certificate service package

### DIFF
--- a/pkgs/community/swarmauri_cert_composite/LICENSE
+++ b/pkgs/community/swarmauri_cert_composite/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/community/swarmauri_cert_composite/README.md
+++ b/pkgs/community/swarmauri_cert_composite/README.md
@@ -1,0 +1,27 @@
+# swarmauri_cert_composite
+
+Composite certificate service for Swarmauri.
+
+This package provides `CompositeCertService`, a routing facade over multiple
+`ICertService` providers.  It selects a provider based on advertised features or
+an explicit `backend` option, allowing applications to work against a single
+interface while leveraging different certificate backends (ACME, PKCS#11,
+Vault, etc.).
+
+## Features
+- Delegated CSR creation (RFC 2986)
+- Delegated certificate operations (RFC 5280)
+- Optional backend override per call
+
+## Optional Extras
+- `aws`: support for AWS-based certificate providers.
+- `vault`: support for Hashicorp Vault-based providers.
+
+## Development
+Run formatting and tests from the repository root:
+
+```bash
+uv run --directory pkgs/community/swarmauri_cert_composite --package swarmauri_cert_composite ruff format .
+uv run --directory pkgs/community/swarmauri_cert_composite --package swarmauri_cert_composite ruff check . --fix
+cd pkgs && uv run --package swarmauri_cert_composite --directory community/swarmauri_cert_composite pytest
+```

--- a/pkgs/community/swarmauri_cert_composite/pyproject.toml
+++ b/pkgs/community/swarmauri_cert_composite/pyproject.toml
@@ -1,0 +1,68 @@
+[project]
+name = "swarmauri_cert_composite"
+version = "0.7.6.dev5"
+description = "Composite certificate service router for Swarmauri"
+license = "Apache-2.0"
+readme = "README.md"
+repository = "http://github.com/swarmauri/swarmauri-sdk"
+requires-python = ">=3.10,<3.13"
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
+dependencies = [
+    "swarmauri_core",
+    "swarmauri_base",
+]
+
+[project.optional-dependencies]
+aws = ["boto3>=1.20"]
+vault = ["hvac>=2.0"]
+
+[tool.uv.sources]
+swarmauri_core = { workspace = true }
+swarmauri_base = { workspace = true }
+
+[tool.pytest.ini_options]
+norecursedirs = ["combined", "scripts"]
+markers = [
+    "test: standard test",
+    "unit: Unit tests",
+    "i9n: Integration tests",
+    "r8n: Regression tests",
+    "timeout: mark test to timeout after X seconds",
+    "xpass: Expected passes",
+    "xfail: Expected failures",
+    "acceptance: Acceptance tests",
+    "perf: Performance tests that measure execution time and resource usage",
+]
+timeout = 300
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
+
+[project.entry-points.'swarmauri.cert_services']
+CompositeCertService = "swarmauri_cert_composite.CompositeCertService:CompositeCertService"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "python-dotenv",
+    "requests>=2.32.3",
+    "flake8>=7.0",
+    "pytest-timeout>=2.3.1",
+    "ruff>=0.9.9",
+    "pytest-benchmark>=4.0.0",
+]

--- a/pkgs/community/swarmauri_cert_composite/swarmauri_cert_composite/CompositeCertService.py
+++ b/pkgs/community/swarmauri_cert_composite/swarmauri_cert_composite/CompositeCertService.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from typing import Iterable, Mapping, Optional, Sequence, Dict, Any, Literal
+
+from swarmauri_core.certs.ICertService import ICertService
+from swarmauri_base.certs.CertServiceBase import CertServiceBase
+from swarmauri_core.crypto.types import KeyRef
+
+
+class CompositeCertService(CertServiceBase):
+    """
+    Router that delegates ``ICertService`` operations to one of several providers.
+    Useful when you have multiple backends (local CA, ACME, PKCS#11, Vault, etc.)
+    and want one facade for apps.
+
+    Routing strategy:
+      - For ``create_csr``: first provider that advertises ``"csr"`` in ``supports()``.
+      - For ``create_self_signed``: first provider with ``"self_signed"``.
+      - For ``sign_cert``: provider chosen by ``opts["backend"]`` if provided,
+        otherwise first with ``"sign_from_csr"``.
+      - For ``verify_cert``/``parse_cert``: first provider with ``"verify"``/``"parse"``.
+
+    Callers can override routing by passing ``opts={"backend":"ProviderType"}``.
+    """
+
+    type: Literal["CompositeCertService"] = "CompositeCertService"
+
+    def __init__(self, providers: Sequence[ICertService]) -> None:
+        super().__init__()
+        if not providers:
+            raise ValueError("CompositeCertService requires at least one provider")
+        self._providers: Dict[str, ICertService] = {p.type: p for p in providers}
+
+    def supports(self) -> Mapping[str, Iterable[str]]:
+        """Aggregate union of all provider capabilities."""
+        agg: Dict[str, set[str]] = {}
+        for p in self._providers.values():
+            caps = p.supports()
+            for k, v in caps.items():
+                agg.setdefault(k, set()).update(v)
+        return {k: tuple(v) for k, v in agg.items()}
+
+    # ------------------ routing helpers ------------------
+
+    def _pick(
+        self, feature: str, opts: Optional[Dict[str, Any]] = None
+    ) -> ICertService:
+        """Select a provider for the requested feature.
+
+        ``opts["backend"]`` may be supplied to explicitly choose a provider by type.
+        Otherwise, the first provider advertising the feature is used.
+        """
+        # Explicit backend request wins
+        if opts and "backend" in opts:
+            backend = opts["backend"]
+            if backend in self._providers:
+                return self._providers[backend]
+            raise ValueError(f"No such backend registered: {backend}")
+
+        # Otherwise, pick first provider that advertises the feature
+        for p in self._providers.values():
+            if feature in p.supports().get("features", ()):  # type: ignore[arg-type]
+                return p
+        raise RuntimeError(f"No provider supports feature={feature!r}")
+
+    # ------------------ delegated methods ------------------
+
+    async def create_csr(self, key: KeyRef, subject, **kw) -> bytes:  # RFC 2986
+        return await self._pick("csr", kw.get("opts")).create_csr(key, subject, **kw)
+
+    async def create_self_signed(self, key: KeyRef, subject, **kw) -> bytes:  # RFC 5280
+        return await self._pick("self_signed", kw.get("opts")).create_self_signed(
+            key, subject, **kw
+        )
+
+    async def sign_cert(self, csr: bytes, ca_key: KeyRef, **kw) -> bytes:  # RFC 5280
+        return await self._pick("sign_from_csr", kw.get("opts")).sign_cert(
+            csr, ca_key, **kw
+        )
+
+    async def verify_cert(self, cert: bytes, **kw) -> Dict[str, Any]:  # RFC 5280
+        return await self._pick("verify", kw.get("opts")).verify_cert(cert, **kw)
+
+    async def parse_cert(self, cert: bytes, **kw) -> Dict[str, Any]:  # RFC 5280
+        return await self._pick("parse", kw.get("opts")).parse_cert(cert, **kw)

--- a/pkgs/community/swarmauri_cert_composite/swarmauri_cert_composite/__init__.py
+++ b/pkgs/community/swarmauri_cert_composite/swarmauri_cert_composite/__init__.py
@@ -1,0 +1,3 @@
+from .CompositeCertService import CompositeCertService
+
+__all__ = ["CompositeCertService"]

--- a/pkgs/community/swarmauri_cert_composite/tests/conftest.py
+++ b/pkgs/community/swarmauri_cert_composite/tests/conftest.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import pytest
+from typing import Iterable, Mapping, Sequence, Dict, Any
+
+from swarmauri_core.certs.ICertService import ICertService
+from swarmauri_base.certs.CertServiceBase import CertServiceBase
+from swarmauri_core.crypto.types import KeyRef, KeyType, KeyUse, ExportPolicy
+from swarmauri_cert_composite import CompositeCertService
+
+
+class DummyCertService(CertServiceBase, ICertService):
+    """Minimal in-memory cert service used for testing."""
+
+    def __init__(self, name: str, features: Sequence[str]) -> None:
+        super().__init__()
+        self.type = name
+        self._features = tuple(features)
+        self.calls: list[str] = []
+
+    def supports(self) -> Mapping[str, Iterable[str]]:
+        return {"features": self._features}
+
+    async def create_csr(self, key: KeyRef, subject, **kw) -> bytes:
+        self.calls.append("create_csr")
+        return f"csr-{self.type}".encode()
+
+    async def create_self_signed(self, key: KeyRef, subject, **kw) -> bytes:
+        self.calls.append("create_self_signed")
+        return f"self-{self.type}".encode()
+
+    async def sign_cert(self, csr: bytes, ca_key: KeyRef, **kw) -> bytes:
+        self.calls.append("sign_cert")
+        return f"cert-{self.type}".encode()
+
+    async def verify_cert(self, cert: bytes, **kw) -> Dict[str, Any]:
+        self.calls.append("verify_cert")
+        return {"backend": self.type, "cert": cert}
+
+    async def parse_cert(self, cert: bytes, **kw) -> Dict[str, Any]:
+        self.calls.append("parse_cert")
+        return {"backend": self.type, "cert": cert}
+
+
+@pytest.fixture
+def dummy_providers() -> tuple[DummyCertService, DummyCertService]:
+    a = DummyCertService("A", ["csr", "self_signed", "verify", "parse"])
+    b = DummyCertService("B", ["sign_from_csr"])
+    return a, b
+
+
+@pytest.fixture
+def composite(
+    dummy_providers: tuple[DummyCertService, DummyCertService],
+) -> CompositeCertService:
+    return CompositeCertService(list(dummy_providers))
+
+
+@pytest.fixture
+def sample_key() -> KeyRef:
+    return KeyRef(
+        kid="kid1",
+        version=1,
+        type=KeyType.RSA,
+        uses=(KeyUse.SIGN,),
+        export_policy=ExportPolicy.NONE,
+    )

--- a/pkgs/community/swarmauri_cert_composite/tests/functional/certs/test_compositecertservice_functional.py
+++ b/pkgs/community/swarmauri_cert_composite/tests/functional/certs/test_compositecertservice_functional.py
@@ -1,0 +1,17 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_backend_override(composite, sample_key):
+    cert = await composite.create_self_signed(
+        sample_key, {"CN": "example"}, opts={"backend": "B"}
+    )
+    assert cert == b"self-B"
+
+
+@pytest.mark.asyncio
+async def test_invalid_backend(composite, sample_key):
+    with pytest.raises(ValueError):
+        await composite.create_csr(
+            sample_key, {"CN": "example"}, opts={"backend": "missing"}
+        )

--- a/pkgs/community/swarmauri_cert_composite/tests/perf/certs/test_compositecertservice_perf.py
+++ b/pkgs/community/swarmauri_cert_composite/tests/perf/certs/test_compositecertservice_perf.py
@@ -1,0 +1,8 @@
+import asyncio
+
+
+def test_create_csr_perf(benchmark, composite, sample_key):
+    async def run():
+        await composite.create_csr(sample_key, {"CN": "example"})
+
+    benchmark(lambda: asyncio.run(run()))

--- a/pkgs/community/swarmauri_cert_composite/tests/unit/certs/test_compositecertservice_rfc2986.py
+++ b/pkgs/community/swarmauri_cert_composite/tests/unit/certs/test_compositecertservice_rfc2986.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_create_csr_routes_to_provider(composite, sample_key):
+    csr = await composite.create_csr(sample_key, {"CN": "example"})
+    assert csr == b"csr-A"

--- a/pkgs/community/swarmauri_cert_composite/tests/unit/certs/test_compositecertservice_rfc5280.py
+++ b/pkgs/community/swarmauri_cert_composite/tests/unit/certs/test_compositecertservice_rfc5280.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_sign_and_verify_certificate(composite, sample_key):
+    cert = await composite.sign_cert(b"csr-bytes", sample_key)
+    assert cert == b"cert-B"
+    info = await composite.verify_cert(cert)
+    assert info["backend"] == "A"
+    parsed = await composite.parse_cert(cert)
+    assert parsed["backend"] == "A"

--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -156,6 +156,7 @@ members = [
     "community/swarmauri_embedding_mlm",
     "community/swarmauri_tool_entityrecognition",
     "community/swarmauri_llm_leptonai",
+    "community/swarmauri_cert_composite",
     "community/swarmauri_vectorstore_annoy",
     "community/swarmauri_tool_jupyterwritenotebook",
     "community/swarmauri_tool_jupytervalidatenotebook",
@@ -245,6 +246,7 @@ swarmauri_crypto_paramiko = { workspace = true }
 swarmauri_crypto_pgp = { workspace = true }
 swarmauri_crypto_nacl_pkcs11 = { workspace = true }
 swarmauri_crypto_composite = { workspace = true }
+swarmauri_cert_composite = { workspace = true }
 swarmauri_crypto_ecdh_es_a128kw = { workspace = true }
 swarmauri_crypto_jwe = { workspace = true }
 swarmauri_mre_crypto_shamir = { workspace = true }


### PR DESCRIPTION
## Summary
- add `swarmauri_cert_composite` community package with `CompositeCertService`
- expose optional extras for AWS and Vault providers
- include unit, functional, and performance tests covering CSR and certificate operations

## Testing
- `uv run --directory pkgs/community/swarmauri_cert_composite --package swarmauri_cert_composite ruff format .`
- `uv run --directory pkgs/community/swarmauri_cert_composite --package swarmauri_cert_composite ruff check . --fix`
- `cd pkgs && uv run --package swarmauri_cert_composite --directory community/swarmauri_cert_composite pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a73e4533508326b781fd0c3b8e896e