### PR TITLE
Optimize plugin discovery and add performance tests

### DIFF
--- a/pkgs/swarmauri/swarmauri/plugin_citizenship_registry.py
+++ b/pkgs/swarmauri/swarmauri/plugin_citizenship_registry.py
@@ -473,7 +473,11 @@ class PluginCitizenshipRegistry:
     @classmethod
     def resource_exists(cls, resource_path: str) -> bool:
         """Check if a resource path is registered in any registry."""
-        return resource_path in cls.total_registry()
+        return (
+            resource_path in cls.FIRST_CLASS_REGISTRY
+            or resource_path in cls.SECOND_CLASS_REGISTRY
+            or resource_path in cls.THIRD_CLASS_REGISTRY
+        )
 
     @classmethod
     def known_groups(cls) -> set[str]:

--- a/pkgs/swarmauri/tests/test_plugin_manager_performance.py
+++ b/pkgs/swarmauri/tests/test_plugin_manager_performance.py
@@ -1,0 +1,45 @@
+import time
+import importlib
+
+from swarmauri.plugin_manager import (
+    discover_and_register_plugins,
+    invalidate_entry_point_cache,
+)
+from swarmauri.plugin_citizenship_registry import PluginCitizenshipRegistry
+
+
+def _reset_registries():
+    PluginCitizenshipRegistry.FIRST_CLASS_REGISTRY = {}
+    PluginCitizenshipRegistry.SECOND_CLASS_REGISTRY = {}
+    PluginCitizenshipRegistry.THIRD_CLASS_REGISTRY = {}
+
+
+def test_discovery_registers_plugins():
+    _reset_registries()
+    invalidate_entry_point_cache()
+    discover_and_register_plugins()
+    registry = PluginCitizenshipRegistry.total_registry()
+    assert "swarmauri.vector_stores.Doc2VecVectorStore" in registry
+
+
+def test_discovery_caching_speed():
+    _reset_registries()
+    invalidate_entry_point_cache()
+    start = time.perf_counter()
+    discover_and_register_plugins()
+    first = time.perf_counter() - start
+
+    _reset_registries()
+    invalidate_entry_point_cache()
+    start = time.perf_counter()
+    discover_and_register_plugins()
+    second = time.perf_counter() - start
+
+    assert second <= first * 1.1
+
+
+def test_plugin_import_time():
+    start = time.perf_counter()
+    importlib.import_module("swarmauri_vectorstore_doc2vec")
+    elapsed = time.perf_counter() - start
+    assert elapsed < 5


### PR DESCRIPTION
## Summary
- streamline entry-point scanning and add metadata caching for faster discovery
- simplify registry lookups and sequential plugin registration
- add plugin-manager performance tests

## Testing
- `uv run --package swarmauri --directory swarmauri --extra full pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a76478544083269d44a864c61e41bf