### PR TITLE
feat: add __main__ entrypoints for peagen services

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/Dockerfile
+++ b/pkgs/standards/peagen/peagen/gateway/Dockerfile
@@ -32,4 +32,4 @@ ENV \
     MINIO_USER="" \
     MINIO_ROOT_PASSWORD=""
     
-CMD ["sh", "-c", "python -c 'import uvicorn; uvicorn.run(\"peagen.gateway:app\", host=\"0.0.0.0\", port=8000, log_level=\"info\", proxy_headers=True, forwarded_allow_ips=\"*\")'"]
+CMD ["python", "-m", "peagen.gateway"]

--- a/pkgs/standards/peagen/peagen/gateway/__main__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__main__.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import os
+import uvicorn
+
+
+def main() -> None:
+    """Run the peagen gateway using uvicorn."""
+    host = os.getenv("HOST", "0.0.0.0")
+    port = int(os.getenv("PORT", "8000"))
+    log_level = os.getenv("PEAGEN_LOG_LEVEL", "info").lower()
+    uvicorn.run(
+        "peagen.gateway:app",
+        host=host,
+        port=port,
+        log_level=log_level,
+        proxy_headers=True,
+        forwarded_allow_ips="*",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/standards/peagen/peagen/worker/Dockerfile
+++ b/pkgs/standards/peagen/peagen/worker/Dockerfile
@@ -26,4 +26,4 @@ ENV \
     PEAGEN_GATEWAY=""\
     PG_PORT="5432"
 
-CMD ["sh", "-c", "python -c 'import uvicorn; uvicorn.run(\"peagen.worker:app\", host=\"0.0.0.0\", port=8000, log_level=\"info\")'"]
+CMD ["python", "-m", "peagen.worker"]

--- a/pkgs/standards/peagen/peagen/worker/__main__.py
+++ b/pkgs/standards/peagen/peagen/worker/__main__.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import os
+import uvicorn
+
+
+def main() -> None:
+    """Run the peagen worker using uvicorn."""
+    host = os.getenv("HOST", "0.0.0.0")
+    port = int(os.getenv("PORT", "8000"))
+    log_level = os.getenv("PEAGEN_LOG_LEVEL", "info").lower()
+    uvicorn.run(
+        "peagen.worker:app",
+        host=host,
+        port=port,
+        log_level=log_level,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `__main__.py` modules for peagen gateway and worker to run via `python -m`
- update gateway and worker Dockerfiles to invoke new entrypoints

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format peagen/gateway/__main__.py peagen/worker/__main__.py`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/gateway/__main__.py peagen/worker/__main__.py --fix`

------
https://chatgpt.com/codex/tasks/task_e_68a783a10fb883268132ced84e91f900