### PR TITLE
Add performance tests for typing utilities

### DIFF
--- a/pkgs/typing/tests/unit/test_Intersection.py
+++ b/pkgs/typing/tests/unit/test_Intersection.py
@@ -1,5 +1,8 @@
 from typing import Annotated, Union, get_args, get_origin
 
+import time
+import pytest
+
 from swarmauri_typing.Intersection import Intersection, IntersectionMetadata
 
 
@@ -80,3 +83,23 @@ def test_intersection_multi_inheritance():
     # Verify metadata
     assert isinstance(args[1], IntersectionMetadata)
     assert args[1].classes == (B, C, D)
+
+
+@pytest.mark.perf
+def test_intersection_performance_happy_path():
+    """Ensure happy path intersection performs efficiently"""
+    start = time.perf_counter()
+    for _ in range(1000):
+        Intersection[B, D]
+    duration = time.perf_counter() - start
+    assert duration < 0.05
+
+
+@pytest.mark.perf
+def test_intersection_performance_worst_case():
+    """Ensure worst-case intersection performs within bounds"""
+    start = time.perf_counter()
+    for _ in range(1000):
+        Intersection[A, C]
+    duration = time.perf_counter() - start
+    assert duration < 0.05

--- a/pkgs/typing/tests/unit/test_UnionFactory.py
+++ b/pkgs/typing/tests/unit/test_UnionFactory.py
@@ -1,5 +1,8 @@
 from typing import Annotated, Any, Union, get_args, get_origin
 
+import time
+import pytest
+
 from swarmauri_typing.UnionFactory import UnionFactory, UnionFactoryMetadata
 
 
@@ -149,3 +152,25 @@ def test_add_metadata_to_annotated_type():
     assert args[1].value == "first"
     assert isinstance(args[2], CustomMetadata)
     assert args[2].value == "second"
+
+
+@pytest.mark.perf
+def test_union_factory_performance_happy_path():
+    """Ensure creating unions in happy path performs efficiently"""
+    factory = UnionFactory(get_types_by_class)
+    start = time.perf_counter()
+    for _ in range(1000):
+        factory[A]
+    duration = time.perf_counter() - start
+    assert duration < 0.05
+
+
+@pytest.mark.perf
+def test_union_factory_performance_worst_case():
+    """Ensure creating unions with empty result stays performant"""
+    factory = UnionFactory(get_types_by_class)
+    start = time.perf_counter()
+    for _ in range(1000):
+        factory["empty"]
+    duration = time.perf_counter() - start
+    assert duration < 0.05


### PR DESCRIPTION
## Summary
- add perf tests for Intersection and UnionFactory to cover happy and worst-case paths

## Testing
- `uv run --package swarmauri-typing --directory typing pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7c656eac48326bcb8ade58dc56732