### PR TITLE
Optimize plugin discovery with caching and add plugin tests

### DIFF
--- a/pkgs/swarmauri/tests/unit/test_accessibility_toolkit_serialization.py
+++ b/pkgs/swarmauri/tests/unit/test_accessibility_toolkit_serialization.py
@@ -1,0 +1,25 @@
+from swarmauri.plugin_manager import discover_and_register_plugins
+from swarmauri.toolkits.AccessibilityToolkit import AccessibilityToolkit
+from swarmauri.tools.AutomatedReadabilityIndexTool import (
+    AutomatedReadabilityIndexTool,
+)
+from swarmauri.tools.ColemanLiauIndexTool import ColemanLiauIndexTool
+from swarmauri.tools.FleschKincaidTool import FleschKincaidTool
+from swarmauri.tools.FleschReadingEaseTool import FleschReadingEaseTool
+from swarmauri.tools.GunningFogTool import GunningFogTool
+
+
+def test_accessibility_toolkit_serialization_roundtrip():
+    discover_and_register_plugins()
+    toolkit = AccessibilityToolkit()
+    assert isinstance(
+        toolkit.tools["AutomatedReadabilityIndexTool"], AutomatedReadabilityIndexTool
+    )
+    assert isinstance(toolkit.tools["ColemanLiauIndexTool"], ColemanLiauIndexTool)
+    assert isinstance(toolkit.tools["FleschKincaidTool"], FleschKincaidTool)
+    assert isinstance(toolkit.tools["FleschReadingEaseTool"], FleschReadingEaseTool)
+    assert isinstance(toolkit.tools["GunningFogTool"], GunningFogTool)
+
+    serialized = toolkit.model_dump_json()
+    restored = AccessibilityToolkit.model_validate_json(serialized)
+    assert isinstance(restored.tools["GunningFogTool"], GunningFogTool)

--- a/pkgs/swarmauri/tests/unit/test_plugin_import_time.py
+++ b/pkgs/swarmauri/tests/unit/test_plugin_import_time.py
@@ -1,0 +1,16 @@
+import time
+
+from swarmauri.plugin_manager import discover_and_register_plugins
+
+
+def test_plugin_import_time_under_one_second():
+    discover_and_register_plugins()
+    start = time.perf_counter()
+    from swarmauri.toolkits.AccessibilityToolkit import AccessibilityToolkit  # noqa: F401
+    from swarmauri.tools.AutomatedReadabilityIndexTool import (
+        AutomatedReadabilityIndexTool,  # noqa: F401
+    )
+    from swarmauri.tools.GunningFogTool import GunningFogTool  # noqa: F401
+
+    duration = time.perf_counter() - start
+    assert duration < 1.0

--- a/pkgs/swarmauri/tests/unit/test_plugin_manager_cache.py
+++ b/pkgs/swarmauri/tests/unit/test_plugin_manager_cache.py
@@ -1,0 +1,24 @@
+import time
+
+from swarmauri.plugin_citizenship_registry import PluginCitizenshipRegistry
+from swarmauri.plugin_manager import (
+    discover_and_register_plugins,
+    invalidate_entry_point_cache,
+)
+
+
+def test_discovery_cache_performance_happy_vs_worst():
+    """Verify caching speeds up discovery (>75%) from worst to happy path."""
+    PluginCitizenshipRegistry.SECOND_CLASS_REGISTRY.clear()
+    PluginCitizenshipRegistry.THIRD_CLASS_REGISTRY.clear()
+    invalidate_entry_point_cache()
+
+    start = time.perf_counter()
+    discover_and_register_plugins()
+    uncached = time.perf_counter() - start
+
+    start = time.perf_counter()
+    discover_and_register_plugins()
+    cached = time.perf_counter() - start
+
+    assert cached <= uncached * 0.25

--- a/pkgs/swarmauri/tests/unit/test_plugin_manager_paths.py
+++ b/pkgs/swarmauri/tests/unit/test_plugin_manager_paths.py
@@ -1,0 +1,28 @@
+import time
+from importlib.metadata import EntryPoint
+
+import pytest
+
+from swarmauri.plugin_manager import PluginLoadError, process_plugin
+
+
+def test_process_plugin_happy_path():
+    """Processing a real plugin succeeds."""
+    valid_ep = EntryPoint(
+        name="CalculatorTool",
+        value="swarmauri_standard.tools.calculator_tool:CalculatorTool",
+        group="swarmauri.tools",
+    )
+    assert process_plugin(valid_ep)
+
+
+def test_process_plugin_worst_case_path_performance():
+    """Failing plugins raise errors quickly (<100ms)."""
+    bad_ep = EntryPoint(
+        name="missing", value="nonexistent.module:obj", group="swarmauri.agents"
+    )
+    start = time.perf_counter()
+    with pytest.raises(PluginLoadError):
+        process_plugin(bad_ep)
+    duration = time.perf_counter() - start
+    assert duration < 0.1


### PR DESCRIPTION
## Summary
- optimize plugin discovery to scan only relevant entry point groups and process plugins concurrently
- add tests for plugin manager cache performance and accessibility toolkit serialization
- document plugin import timing for key first-class plugins
- expand tests with happy and worst-case plugin processing scenarios

## Testing
- `uv run --package swarmauri --directory swarmauri ruff format .`
- `uv run --package swarmauri --directory swarmauri ruff check . --fix`
- `uv run --package swarmauri --directory swarmauri pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a76cb459908326a5309db2df3b1e9f