### PR TITLE
feat: speed up plugin discovery

### DIFF
--- a/pkgs/swarmauri/tests/performance/test_plugin_discovery_benchmark.py
+++ b/pkgs/swarmauri/tests/performance/test_plugin_discovery_benchmark.py
@@ -1,0 +1,35 @@
+import importlib
+from swarmauri.plugin_manager import (
+    invalidate_entry_point_cache,
+    discover_and_register_plugins,
+)
+
+FIRST_CLASS_PLUGINS = [
+    "swarmauri.agents.QAAgent",
+    "swarmauri.llms.OpenAIModel",
+    "swarmauri.chains.CallableChain",
+]
+
+
+def import_first_class_plugins():
+    invalidate_entry_point_cache()
+    discover_and_register_plugins()
+    for module in FIRST_CLASS_PLUGINS:
+        importlib.import_module(module)
+
+
+def test_first_class_plugin_imports(benchmark):
+    benchmark(import_first_class_plugins)
+
+
+def import_missing_plugin():
+    invalidate_entry_point_cache()
+    discover_and_register_plugins()
+    try:
+        importlib.import_module("swarmauri.agents.DoesNotExist")
+    except Exception:
+        pass
+
+
+def test_missing_plugin_import(benchmark):
+    benchmark(import_missing_plugin)

--- a/pkgs/swarmauri/tests/unit/test_plugin_manager_cache.py
+++ b/pkgs/swarmauri/tests/unit/test_plugin_manager_cache.py
@@ -11,6 +11,8 @@ def test_discovery_cache_performance_happy_vs_worst():
     """Verify caching speeds up discovery (>75%) from worst to happy path."""
     PluginCitizenshipRegistry.SECOND_CLASS_REGISTRY.clear()
     PluginCitizenshipRegistry.THIRD_CLASS_REGISTRY.clear()
+    original_first = PluginCitizenshipRegistry.FIRST_CLASS_REGISTRY.copy()
+    PluginCitizenshipRegistry.FIRST_CLASS_REGISTRY.clear()
     invalidate_entry_point_cache()
 
     start = time.perf_counter()
@@ -22,3 +24,5 @@ def test_discovery_cache_performance_happy_vs_worst():
     cached = time.perf_counter() - start
 
     assert cached <= uncached * 0.25
+
+    PluginCitizenshipRegistry.FIRST_CLASS_REGISTRY = original_first


### PR DESCRIPTION
## Summary
- remove redundant plugin loads during registration
- skip discovery when plugins already registered
- add benchmarks for first-class and missing plugin imports

## Testing
- `uv run --package swarmauri --directory swarmauri pytest tests/performance/test_plugin_discovery_benchmark.py -q`
- `uv run --package swarmauri --directory swarmauri pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7ce52aa7c832683ec85417509b611