### PR TITLE
optimize plugin discovery

### DIFF
--- a/pkgs/swarmauri/tests/performance/test_plugin_discovery_benchmark.py
+++ b/pkgs/swarmauri/tests/performance/test_plugin_discovery_benchmark.py
@@ -1,0 +1,44 @@
+import importlib
+import pytest
+
+from swarmauri.plugin_manager import (
+    discover_and_register_plugins,
+    invalidate_entry_point_cache,
+)
+from swarmauri.plugin_citizenship_registry import PluginCitizenshipRegistry
+
+PLUGINS = [
+    "swarmauri_standard.tools.AdditionTool",
+    "swarmauri_standard.tools.CalculatorTool",
+    "swarmauri_standard.tools.CodeInterpreterTool",
+]
+
+
+def _import_plugins() -> None:
+    for path in PLUGINS:
+        importlib.import_module(path)
+
+
+@pytest.mark.benchmark
+def test_discovery_registration_fresh(benchmark) -> None:
+    def run():
+        invalidate_entry_point_cache()
+        discover_and_register_plugins()
+        _import_plugins()
+
+    benchmark(run)
+    assert PluginCitizenshipRegistry.resource_exists("swarmauri.tools.AdditionTool")
+
+
+@pytest.mark.benchmark
+def test_discovery_registration_cached(benchmark) -> None:
+    invalidate_entry_point_cache()
+    discover_and_register_plugins()
+    _import_plugins()
+
+    def run():
+        discover_and_register_plugins()
+        _import_plugins()
+
+    benchmark(run)
+    assert PluginCitizenshipRegistry.resource_exists("swarmauri.tools.AdditionTool")


### PR DESCRIPTION
## Summary
- cache processed entry points to skip redundant plugin imports
- default to lazy registration when metadata is missing and handle missing modules gracefully
- add benchmarks covering fresh and cached discovery paths

## Testing
- `uv run --package swarmauri --directory swarmauri ruff format .`
- `uv run --package swarmauri --directory swarmauri ruff check . --fix`
- `uv run --extra default --package swarmauri --directory swarmauri pytest tests/performance/test_plugin_discovery_benchmark.py::test_discovery_registration_fresh -q`
- `uv run --extra default --package swarmauri --directory swarmauri pytest tests/performance/test_plugin_discovery_benchmark.py::test_discovery_registration_cached -q`
- `uv run --extra default --package swarmauri --directory swarmauri pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a7ce53c4ac83268b7c25d7eaaa5d7d