### PR TITLE
Optimize plugin discovery and add benchmarks

### DIFF
--- a/pkgs/swarmauri/tests/performance/test_plugin_discovery_benchmark.py
+++ b/pkgs/swarmauri/tests/performance/test_plugin_discovery_benchmark.py
@@ -1,0 +1,35 @@
+from swarmauri.plugin_manager import (
+    discover_and_register_plugins,
+    invalidate_entry_point_cache,
+)
+from importlib.metadata import EntryPoint
+
+
+def test_discovery_perf_happy(benchmark):
+    def run():
+        invalidate_entry_point_cache()
+        discover_and_register_plugins()
+
+    benchmark(run)
+
+
+def test_discovery_perf_worst_case(benchmark, monkeypatch):
+    fake_ep = EntryPoint(
+        name="missing", value="missing.module:attr", group="swarmauri.agents"
+    )
+
+    def fake_get_entry_points(prefix: str = "swarmauri."):
+        return {"agents": [fake_ep]}
+
+    monkeypatch.setattr(
+        "swarmauri.plugin_manager.get_entry_points", fake_get_entry_points
+    )
+
+    def run():
+        invalidate_entry_point_cache()
+        try:
+            discover_and_register_plugins()
+        except Exception:
+            pass
+
+    benchmark(run)

--- a/pkgs/swarmauri/tests/performance/test_plugin_imports.py
+++ b/pkgs/swarmauri/tests/performance/test_plugin_imports.py
@@ -1,0 +1,9 @@
+
+
+def test_import_multiple_first_class_plugins():
+    from swarmauri.llms import OpenAIModel, GroqModel
+    from swarmauri.agents import QAAgent
+
+    assert OpenAIModel is not None
+    assert GroqModel is not None
+    assert QAAgent is not None


### PR DESCRIPTION
## Summary
- streamline plugin entry point discovery with single-pass grouping and distribution caching
- add performance benchmarks for plugin discovery and failure scenarios
- test importing several first-class plugins via the namespace importer

## Testing
- `uv run --package swarmauri --directory swarmauri ruff format swarmauri/plugin_manager.py`
- `uv run --package swarmauri --directory swarmauri ruff check swarmauri/plugin_manager.py --fix`
- `uv run --package swarmauri --directory swarmauri ruff format tests/performance/test_plugin_discovery_benchmark.py tests/performance/test_plugin_imports.py`
- `uv run --package swarmauri --directory swarmauri ruff check tests/performance/test_plugin_discovery_benchmark.py tests/performance/test_plugin_imports.py --fix`
- `uv run --package swarmauri --directory swarmauri pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7ce949e7483268560a9b431b111c2