### PR TITLE
docs: add example usage for age crypto provider

### DIFF
--- a/pkgs/standards/swarmauri_mre_crypto_age/README.md
+++ b/pkgs/standards/swarmauri_mre_crypto_age/README.md
@@ -31,18 +31,35 @@ pip install swarmauri_mre_crypto_age
 
 ### Usage
 
+The provider exposes asynchronous helpers for encrypting data to many
+recipients and decrypting it for a specific private key.  The example below
+walks through a complete round trip.
+
+1. Create the crypto provider.
+2. Generate key pairs for two recipients.
+3. Encrypt a payload for both recipients.
+4. Decrypt the payload for one recipient.
+
 ```python
 from swarmauri_mre_crypto_age import AgeMreCrypto
 from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
 
 crypto = AgeMreCrypto()
 
-sk = X25519PrivateKey.generate()
-pk = sk.public_key()
-recipient = {"kind": "cryptography_obj", "obj": pk}
+# generate key pairs for each participant
+sk1 = X25519PrivateKey.generate()
+pk1 = sk1.public_key()
+sk2 = X25519PrivateKey.generate()
+pk2 = sk2.public_key()
 
-env = await crypto.encrypt_for_many([recipient], b"secret")
-pt = await crypto.open_for({"kind": "cryptography_obj", "obj": sk}, env)
+recipients = [
+    {"kind": "cryptography_obj", "obj": pk1},
+    {"kind": "cryptography_obj", "obj": pk2},
+]
+
+env = await crypto.encrypt_for_many(recipients, b"secret")
+pt = await crypto.open_for({"kind": "cryptography_obj", "obj": sk1}, env)
+assert pt == b"secret"
 ```
 
 ## Entry point

--- a/pkgs/standards/swarmauri_mre_crypto_age/pyproject.toml
+++ b/pkgs/standards/swarmauri_mre_crypto_age/pyproject.toml
@@ -39,6 +39,7 @@ markers = [
     "r8n: Regression tests",
     "acceptance: Acceptance tests",
     "perf: Performance tests",
+    "example: Example usage tests",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_mre_crypto_age/tests/functional/test_example_usage.py
+++ b/pkgs/standards/swarmauri_mre_crypto_age/tests/functional/test_example_usage.py
@@ -1,0 +1,24 @@
+from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
+import pytest
+
+from swarmauri_mre_crypto_age import AgeMreCrypto
+
+
+@pytest.mark.example
+@pytest.mark.asyncio
+async def test_readme_usage_example() -> None:
+    crypto = AgeMreCrypto()
+
+    sk1 = X25519PrivateKey.generate()
+    pk1 = sk1.public_key()
+    sk2 = X25519PrivateKey.generate()
+    pk2 = sk2.public_key()
+
+    recipients = [
+        {"kind": "cryptography_obj", "obj": pk1},
+        {"kind": "cryptography_obj", "obj": pk2},
+    ]
+
+    env = await crypto.encrypt_for_many(recipients, b"secret")
+    pt = await crypto.open_for({"kind": "cryptography_obj", "obj": sk1}, env)
+    assert pt == b"secret"


### PR DESCRIPTION
## Summary
- document step-by-step usage for AgeMreCrypto
- add example test exercising README snippet
- register `example` pytest marker

## Testing
- `uv run --directory standards/swarmauri_mre_crypto_age --package swarmauri_mre_crypto_age ruff format .`
- `uv run --directory standards/swarmauri_mre_crypto_age --package swarmauri_mre_crypto_age ruff check . --fix`
- `uv run --package swarmauri_mre_crypto_age --directory standards/swarmauri_mre_crypto_age pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a96d1ceac883268b24cb7844480286