### PR TITLE
docs: add detailed PGP MRE usage and example tests

### DIFF
--- a/pkgs/standards/swarmauri_mre_crypto_pgp/README.md
+++ b/pkgs/standards/swarmauri_mre_crypto_pgp/README.md
@@ -38,9 +38,44 @@ pip install swarmauri_mre_crypto_pgp
 ### Usage
 
 ```python
+import asyncio
+from pgpy import PGPKey, PGPUID
+from pgpy.constants import (
+    CompressionAlgorithm,
+    HashAlgorithm,
+    KeyFlags,
+    PubKeyAlgorithm,
+    SymmetricKeyAlgorithm,
+)
 from swarmauri_mre_crypto_pgp import PGPMreCrypto
 
-mre = PGPMreCrypto()
+
+async def main():
+    # Generate an OpenPGP key pair with pgpy
+    key = PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 2048)
+    uid = PGPUID.new("Test User", email="test@example.com")
+    key.add_uid(
+        uid,
+        usage={KeyFlags.EncryptCommunications},
+        hashes=[HashAlgorithm.SHA256],
+        ciphers=[SymmetricKeyAlgorithm.AES256],
+        compression=[CompressionAlgorithm.ZLIB],
+    )
+
+    # Create references understood by the provider
+    pub_ref = {"kind": "pgpy_pub", "pub": key.pubkey}
+    priv_ref = {"kind": "pgpy_priv", "priv": key}
+
+    # Encrypt for many and open with the private key
+    mre = PGPMreCrypto()
+    pt = b"hello"
+    env = await mre.encrypt_for_many([pub_ref], pt)
+    rt = await mre.open_for(priv_ref, env)
+    print(rt)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 ## Entry point

--- a/pkgs/standards/swarmauri_mre_crypto_pgp/pyproject.toml
+++ b/pkgs/standards/swarmauri_mre_crypto_pgp/pyproject.toml
@@ -41,6 +41,7 @@ markers = [
     "r8n: Regression tests",
     "acceptance: Acceptance tests",
     "perf: Performance tests",
+    "example: Example usage tests",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_mre_crypto_pgp/tests/unit/test_usage_example.py
+++ b/pkgs/standards/swarmauri_mre_crypto_pgp/tests/unit/test_usage_example.py
@@ -1,0 +1,38 @@
+import pytest
+from pgpy import PGPKey, PGPUID
+from pgpy.constants import (
+    CompressionAlgorithm,
+    HashAlgorithm,
+    KeyFlags,
+    PubKeyAlgorithm,
+    SymmetricKeyAlgorithm,
+)
+
+from swarmauri_mre_crypto_pgp import PGPMreCrypto
+
+
+def generate_key() -> PGPKey:
+    key = PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 2048)
+    uid = PGPUID.new("Test User", email="test@example.com")
+    key.add_uid(
+        uid,
+        usage={KeyFlags.EncryptCommunications},
+        hashes=[HashAlgorithm.SHA256],
+        ciphers=[SymmetricKeyAlgorithm.AES256],
+        compression=[CompressionAlgorithm.ZLIB],
+    )
+    return key
+
+
+@pytest.mark.example
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_readme_usage_example():
+    key = generate_key()
+    pub_ref = {"kind": "pgpy_pub", "pub": key.pubkey}
+    priv_ref = {"kind": "pgpy_priv", "priv": key}
+    mre = PGPMreCrypto()
+    pt = b"hello"
+    env = await mre.encrypt_for_many([pub_ref], pt)
+    rt = await mre.open_for(priv_ref, env)
+    assert rt == pt


### PR DESCRIPTION
## Summary
- expand README with detailed PGPMreCrypto usage example
- add `example` pytest marker and example test

## Testing
- `uv run --package swarmauri_mre_crypto_pgp --directory standards/swarmauri_mre_crypto_pgp ruff format .`
- `uv run --package swarmauri_mre_crypto_pgp --directory standards/swarmauri_mre_crypto_pgp ruff check . --fix`
- `uv run --package swarmauri_mre_crypto_pgp --directory standards/swarmauri_mre_crypto_pgp pytest`
- `uv run --package swarmauri_mre_crypto_pgp --directory standards/swarmauri_mre_crypto_pgp pytest -m example`


------
https://chatgpt.com/codex/tasks/task_e_68a96d48cad08326a01d466820647d8f