### PR TITLE
docs: add keyring usage example

### DIFF
--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -396,6 +396,7 @@ markers = [
     "xfail: Expected failures",
     "acceptance: Acceptance tests",
     "perf: Performance tests that measure execution time and resource usage",
+    "example: Example usage tests",
 ]
 
 timeout = 300

--- a/pkgs/standards/swarmauri_mre_crypto_keyring/README.md
+++ b/pkgs/standards/swarmauri_mre_crypto_keyring/README.md
@@ -10,6 +10,50 @@ Multi-recipient encryption provider using external keyrings/HSMs.
 pip install swarmauri_mre_crypto_keyring
 ```
 
+## Usage
+
+`KeyringMreCrypto` delegates CEK (content-encryption key) management to
+user-provided keyring clients. Each client must implement `id`,
+`wrap_cek`, and `unwrap_cek`. The example below shows how to register an
+in-memory keyring and use it to encrypt and decrypt a payload.
+
+```python
+import asyncio
+import secrets
+from swarmauri_mre_crypto_keyring import KeyringMreCrypto
+
+
+class MemoryKeyring:
+    def __init__(self):
+        self._store = {}
+
+    def id(self) -> str:
+        return "memory"
+
+    async def wrap_cek(self, cek: bytes, *, context):
+        token = secrets.token_bytes(8)
+        self._store[token] = cek
+        return token
+
+    async def unwrap_cek(self, header: bytes, *, context):
+        return self._store[header]
+
+
+async def main():
+    keyring = MemoryKeyring()
+    keyref = {"kind": "keyring_client", "client": keyring}
+    crypto = KeyringMreCrypto()
+    env = await crypto.encrypt_for_many([keyref], b"sensitive data")
+    recovered = await crypto.open_for(keyref, env)
+    assert recovered == b"sensitive data"
+
+
+asyncio.run(main())
+```
+
+The snippet encrypts `b"sensitive data"` for the memory keyring and
+recovers the original plaintext using the same keyring client.
+
 ## Want to help?
 
 If you want to contribute to swarmauri-sdk, read up on our [guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/contributing.md) that will help you get started.

--- a/pkgs/standards/swarmauri_mre_crypto_keyring/pyproject.toml
+++ b/pkgs/standards/swarmauri_mre_crypto_keyring/pyproject.toml
@@ -40,6 +40,7 @@ markers = [
     "acceptance: Acceptance tests",
     "functional: Functional tests",
     "perf: Performance tests",
+    "example: Example usage tests",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_mre_crypto_keyring/tests/example/test_readme_example.py
+++ b/pkgs/standards/swarmauri_mre_crypto_keyring/tests/example/test_readme_example.py
@@ -1,0 +1,36 @@
+import secrets
+
+import pytest
+
+from swarmauri_mre_crypto_keyring import KeyringMreCrypto
+
+
+class MemoryKeyring:
+    """In-memory keyring used to demonstrate README usage."""
+
+    def __init__(self) -> None:  # pragma: no cover - simple init
+        self._store: dict[bytes, bytes] = {}
+
+    def id(self) -> str:  # pragma: no cover - simple return
+        return "memory"
+
+    async def wrap_cek(self, cek: bytes, *, context):  # pragma: no cover
+        token = secrets.token_bytes(8)
+        self._store[token] = cek
+        return token
+
+    async def unwrap_cek(self, header: bytes, *, context):  # pragma: no cover
+        return self._store[header]
+
+
+@pytest.mark.asyncio
+@pytest.mark.example
+async def test_readme_usage_example() -> None:
+    keyring = MemoryKeyring()
+    keyref = {"kind": "keyring_client", "client": keyring}
+    crypto = KeyringMreCrypto()
+
+    env = await crypto.encrypt_for_many([keyref], b"hello")
+    pt = await crypto.open_for(keyref, env)
+
+    assert pt == b"hello"


### PR DESCRIPTION
## Summary
- document how to use `KeyringMreCrypto` with a simple in-memory keyring
- add example test verifying README instructions
- register `example` pytest marker in package and workspace configs

## Testing
- `uv run --package swarmauri_mre_crypto_keyring --directory standards/swarmauri_mre_crypto_keyring ruff format .`
- `uv run --package swarmauri_mre_crypto_keyring --directory standards/swarmauri_mre_crypto_keyring ruff check . --fix`
- `uv run --package swarmauri_mre_crypto_keyring --directory standards/swarmauri_mre_crypto_keyring pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a96d4efd988326bcb19833b791a4e6