### PR TITLE
docs: add usage examples for SSH key provider

### DIFF
--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -396,6 +396,7 @@ markers = [
     "xfail: Expected failures",
     "acceptance: Acceptance tests",
     "perf: Performance tests that measure execution time and resource usage",
+    "example: Example usage tests",
 ]
 
 timeout = 300

--- a/pkgs/standards/swarmauri_keyprovider_ssh/README.md
+++ b/pkgs/standards/swarmauri_keyprovider_ssh/README.md
@@ -9,3 +9,45 @@ Interfaces with local SSH keys to generate and manage signing keys.
 ```bash
 pip install swarmauri_keyprovider_ssh
 ```
+
+## Usage
+
+The provider exposes an asynchronous interface for creating and managing
+SSH-based signing keys.  The snippet below creates a new Ed25519 key and
+exports its public component as a JSON Web Key (JWK):
+
+```python
+import asyncio
+from swarmauri_keyprovider_ssh import SshKeyProvider
+from swarmauri_core.keys.types import (
+    KeySpec,
+    KeyAlg,
+    KeyClass,
+    ExportPolicy,
+    KeyUse,
+)
+
+
+async def main() -> None:
+    provider = SshKeyProvider()
+    spec = KeySpec(
+        klass=KeyClass.asymmetric,
+        alg=KeyAlg.ED25519,
+        uses=(KeyUse.SIGN, KeyUse.VERIFY),
+        export_policy=ExportPolicy.PUBLIC_ONLY,
+    )
+    ref = await provider.create_key(spec)
+    jwk = await provider.get_public_jwk(ref.kid)
+    print(jwk)
+
+
+asyncio.run(main())
+```
+
+Keys can also be rotated, and the provider will track key versions:
+
+```python
+ref = await provider.create_key(spec)
+await provider.rotate_key(ref.kid)
+assert await provider.list_versions(ref.kid) == (1, 2)
+```

--- a/pkgs/standards/swarmauri_keyprovider_ssh/pyproject.toml
+++ b/pkgs/standards/swarmauri_keyprovider_ssh/pyproject.toml
@@ -36,6 +36,7 @@ markers = [
     "r8n: Regression tests",
     "acceptance: Acceptance tests",
     "perf: Performance tests",
+    "example: Example usage tests",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_keyprovider_ssh/tests/unit/test_readme_examples.py
+++ b/pkgs/standards/swarmauri_keyprovider_ssh/tests/unit/test_readme_examples.py
@@ -1,0 +1,36 @@
+import pytest
+
+from swarmauri_keyprovider_ssh import SshKeyProvider
+from swarmauri_core.keys.types import KeySpec, KeyAlg, KeyClass, ExportPolicy, KeyUse
+
+
+@pytest.mark.example
+@pytest.mark.asyncio
+async def test_create_ed25519_key_and_export_jwk() -> None:
+    provider = SshKeyProvider()
+    spec = KeySpec(
+        klass=KeyClass.asymmetric,
+        alg=KeyAlg.ED25519,
+        uses=(KeyUse.SIGN, KeyUse.VERIFY),
+        export_policy=ExportPolicy.PUBLIC_ONLY,
+    )
+    ref = await provider.create_key(spec)
+    jwk = await provider.get_public_jwk(ref.kid)
+    assert jwk["kty"] == "OKP"
+    assert jwk["crv"] == "Ed25519"
+
+
+@pytest.mark.example
+@pytest.mark.asyncio
+async def test_rotate_key_tracks_versions() -> None:
+    provider = SshKeyProvider()
+    spec = KeySpec(
+        klass=KeyClass.asymmetric,
+        alg=KeyAlg.ED25519,
+        uses=(KeyUse.SIGN,),
+        export_policy=ExportPolicy.PUBLIC_ONLY,
+    )
+    ref = await provider.create_key(spec)
+    await provider.rotate_key(ref.kid)
+    versions = await provider.list_versions(ref.kid)
+    assert versions == (1, 2)


### PR DESCRIPTION
## Summary
- document asynchronous key creation, JWK export, and rotation for the SSH key provider
- register `example` pytest marker
- add example tests that follow the documented workflow

## Testing
- `uv run ruff check pyproject.toml --fix`
- `uv run --directory standards/swarmauri_keyprovider_ssh --package swarmauri_keyprovider_ssh ruff check pyproject.toml --fix`
- `uv run --package swarmauri_keyprovider_ssh --directory standards/swarmauri_keyprovider_ssh pytest -m example`


------
https://chatgpt.com/codex/tasks/task_e_68a96d5cbb448326b4961b4ea1bb64d0