### PR TITLE
docs: add usage example for RemoteCaCertService

### DIFF
--- a/pkgs/standards/swarmauri_certs_remote_ca/README.md
+++ b/pkgs/standards/swarmauri_certs_remote_ca/README.md
@@ -21,3 +21,41 @@ pip install swarmauri_certs_remote_ca
 
 The service registers under the `swarmauri.certs` entry point as
 `RemoteCaCertService`.
+
+## Usage
+
+The service is asynchronous and expects an existing CSR (certificate signing
+request) in PEM or DER form.  Configure the remote CA endpoint and submit the
+CSR to receive the issued certificate:
+
+```python
+import asyncio
+import base64
+import json
+import httpx
+from swarmauri_certs_remote_ca import RemoteCaCertService
+
+csr = b"example-csr"
+cert_bytes = b"example-cert"
+
+
+async def main() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        data = json.loads(request.content)
+        assert base64.b64decode(data["csr"]) == csr
+        return httpx.Response(200, json={"cert": base64.b64encode(cert_bytes).decode()})
+
+    transport = httpx.MockTransport(handler)
+    svc = RemoteCaCertService("https://ca.example/sign")
+    svc._client = httpx.AsyncClient(transport=transport)
+
+    cert = await svc.sign_cert(csr, {"kind": "dummy"})
+    print(cert)
+
+
+asyncio.run(main())
+```
+
+The example above mocks a CA using `httpx.MockTransport`.  In real scenarios
+`RemoteCaCertService` posts the CSR to the configured endpoint and returns the
+certificate bytes supplied by the remote CA.

--- a/pkgs/standards/swarmauri_certs_remote_ca/pyproject.toml
+++ b/pkgs/standards/swarmauri_certs_remote_ca/pyproject.toml
@@ -39,6 +39,7 @@ markers = [
     "r8n: Regression tests",
     "acceptance: Acceptance tests",
     "perf: Performance tests",
+    "example: Example usage tests",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_certs_remote_ca/tests/example/test_readme_usage.py
+++ b/pkgs/standards/swarmauri_certs_remote_ca/tests/example/test_readme_usage.py
@@ -1,0 +1,25 @@
+import asyncio
+import base64
+import httpx
+import json
+import pytest
+
+from swarmauri_certs_remote_ca import RemoteCaCertService
+
+
+@pytest.mark.example
+def test_readme_usage_example() -> None:
+    csr = b"example-csr"
+    cert_bytes = b"example-cert"
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        data = json.loads(request.content)
+        assert base64.b64decode(data["csr"]) == csr
+        return httpx.Response(200, json={"cert": base64.b64encode(cert_bytes).decode()})
+
+    transport = httpx.MockTransport(handler)
+    svc = RemoteCaCertService("https://ca.example/sign")
+    svc._client = httpx.AsyncClient(transport=transport)
+
+    result = asyncio.run(svc.sign_cert(csr, {"kind": "dummy"}))
+    assert result == cert_bytes


### PR DESCRIPTION
## Summary
- document how to submit CSRs with `RemoteCaCertService`
- provide example test exercising documentation snippet
- expose new `example` pytest marker

## Testing
- `uv run --directory standards/swarmauri_certs_remote_ca --package swarmauri_certs_remote_ca ruff format .`
- `uv run --directory standards/swarmauri_certs_remote_ca --package swarmauri_certs_remote_ca ruff check . --fix`
- `uv run --package swarmauri_certs_remote_ca --directory standards/swarmauri_certs_remote_ca pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a96de6ea7c83269bd937f70805b63b