### PR TITLE
docs: add usage examples for composite certs service

### DIFF
--- a/pkgs/standards/swarmauri_certs_composite/README.md
+++ b/pkgs/standards/swarmauri_certs_composite/README.md
@@ -27,11 +27,44 @@ pip install swarmauri_certs_composite
 
 ## Usage
 
+The composite accepts a sequence of certificate service implementations and
+routes each call to the first provider that advertises a matching capability.
+Below is a minimal example using two toy providers:
+
 ```python
 from swarmauri_certs_composite import CompositeCertService
+from swarmauri_base.certs.CertServiceBase import CertServiceBase
 
-svc = CompositeCertService([...])  # pass in other ICertService providers
+
+class SelfSignedOnly(CertServiceBase):
+
+    def supports(self):
+        return {"features": ("self_signed",)}
+
+    async def create_self_signed(self, key, subject, **kw):
+        return b"self-signed-cert"
+
+
+class CsrOnly(CertServiceBase):
+
+    def supports(self):
+        return {"features": ("csr",)}
+
+    async def create_csr(self, key, subject, **kw):
+        return b"csr-data"
+
+
+svc = CompositeCertService([SelfSignedOnly(), CsrOnly()])
+
+# create a self-signed certificate - routed to SelfSignedOnly
+cert = await svc.create_self_signed("key", {"CN": "example"})
+
+# create a CSR and explicitly route to the second provider by class name
+csr = await svc.create_csr("key", {"CN": "example"}, opts={"backend": "CsrOnly"})
 ```
+
+`supports()` aggregates the advertised features of all child providers,
+allowing callers to inspect available capabilities before invoking them.
 
 ## Entry point
 

--- a/pkgs/standards/swarmauri_certs_composite/pyproject.toml
+++ b/pkgs/standards/swarmauri_certs_composite/pyproject.toml
@@ -40,6 +40,7 @@ markers = [
     "acceptance: Acceptance tests",
     "perf: Performance tests",
     "functional: Functional tests",
+    "example: Example usage tests",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/swarmauri_certs_composite/tests/example/test_usage_example.py
+++ b/pkgs/standards/swarmauri_certs_composite/tests/example/test_usage_example.py
@@ -1,0 +1,48 @@
+import pytest
+
+from swarmauri_certs_composite import CompositeCertService
+from swarmauri_base.certs.CertServiceBase import CertServiceBase
+
+
+class SelfSignedOnly(CertServiceBase):
+    def supports(self):
+        return {"features": ("self_signed",)}
+
+    async def create_self_signed(self, key, subject, **kw):
+        return b"self-signed-cert"
+
+
+class PrimaryCSR(CertServiceBase):
+    def supports(self):
+        return {"features": ("csr",)}
+
+    async def create_csr(self, key, subject, **kw):
+        return b"primary-csr"
+
+
+class SecondaryCSR(CertServiceBase):
+    def supports(self):
+        return {"features": ("csr",)}
+
+    async def create_csr(self, key, subject, **kw):
+        return b"secondary-csr"
+
+
+@pytest.mark.example
+@pytest.mark.asyncio
+async def test_composite_usage_example():
+    svc = CompositeCertService([SelfSignedOnly(), PrimaryCSR(), SecondaryCSR()])
+
+    features = svc.supports()["features"]
+    assert "self_signed" in features and "csr" in features
+
+    cert = await svc.create_self_signed("key", {"CN": "example"})
+    assert cert == b"self-signed-cert"
+
+    csr = await svc.create_csr("key", {"CN": "example"})
+    assert csr == b"primary-csr"
+
+    csr_override = await svc.create_csr(
+        "key", {"CN": "example"}, opts={"backend": "SecondaryCSR"}
+    )
+    assert csr_override == b"secondary-csr"


### PR DESCRIPTION
## Summary
- expand README with detailed composite certificate service usage
- add example pytest marker and example usage test

## Testing
- `uv run --package swarmauri_certs_composite --directory pkgs/standards/swarmauri_certs_composite ruff check . --fix`
- `uv run --package swarmauri_certs_composite --directory standards/swarmauri_certs_composite pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a96e6f5c388326bfefe2b25751ec38