### PR TITLE
Add in-memory key provider

### DIFF
--- a/pkgs/swarmauri_standard/swarmauri_standard/key_providers/InMemoryKeyProvider.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/key_providers/InMemoryKeyProvider.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from typing import Dict, Iterable, Mapping, Optional, Tuple, Literal
+import secrets
+import hashlib
+import hmac
+
+from swarmauri_base.keys.KeyProviderBase import KeyProviderBase
+from swarmauri_core.crypto.types import KeyRef, KeyType, ExportPolicy
+from swarmauri_core.keys.types import KeySpec, KeyClass
+
+
+class InMemoryKeyProvider(KeyProviderBase):
+    """Simple in-memory key provider for testing or ephemeral usage."""
+
+    type: Literal["InMemoryKeyProvider"] = "InMemoryKeyProvider"
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._store: Dict[str, Dict[int, KeyRef]] = {}
+
+    def supports(self) -> Mapping[str, Iterable[str]]:
+        return {"class": ("sym", "asym"), "algs": (), "features": ("import", "rotate")}
+
+    async def create_key(self, spec: KeySpec) -> KeyRef:
+        kid = secrets.token_hex(8)
+        version = 1
+        material = secrets.token_bytes(32)
+        ref = KeyRef(
+            kid=kid,
+            version=version,
+            type=(
+                KeyType.SYMMETRIC
+                if spec.klass == KeyClass.symmetric
+                else KeyType.OPAQUE
+            ),
+            uses=tuple(spec.uses),
+            export_policy=spec.export_policy,
+            material=(material if spec.export_policy != ExportPolicy.NONE else None),
+            tags={"label": spec.label or "", **(spec.tags or {})},
+        )
+        self._store.setdefault(kid, {})[version] = ref
+        return ref
+
+    async def import_key(
+        self,
+        spec: KeySpec,
+        material: bytes,
+        *,
+        public: Optional[bytes] = None,
+    ) -> KeyRef:
+        kid = secrets.token_hex(8)
+        version = 1
+        ref = KeyRef(
+            kid=kid,
+            version=version,
+            type=(
+                KeyType.SYMMETRIC
+                if spec.klass == KeyClass.symmetric
+                else KeyType.OPAQUE
+            ),
+            uses=tuple(spec.uses),
+            export_policy=spec.export_policy,
+            material=(material if spec.export_policy != ExportPolicy.NONE else None),
+            public=public,
+            tags={"label": spec.label or "", **(spec.tags or {})},
+        )
+        self._store.setdefault(kid, {})[version] = ref
+        return ref
+
+    async def rotate_key(
+        self, kid: str, *, spec_overrides: Optional[dict] = None
+    ) -> KeyRef:
+        bucket = self._store.get(kid)
+        if not bucket:
+            raise KeyError(f"Unknown kid: {kid}")
+        latest = max(bucket)
+        base = bucket[latest]
+        material = secrets.token_bytes(len(base.material or b"\x00" * 32))
+        version = latest + 1
+        ref = KeyRef(
+            kid=kid,
+            version=version,
+            type=base.type,
+            uses=base.uses,
+            export_policy=base.export_policy,
+            material=(material if base.export_policy != ExportPolicy.NONE else None),
+            public=base.public,
+            tags=base.tags,
+            uri=base.uri,
+        )
+        bucket[version] = ref
+        return ref
+
+    async def destroy_key(self, kid: str, version: Optional[int] = None) -> bool:
+        bucket = self._store.get(kid)
+        if not bucket:
+            return False
+        if version is None:
+            del self._store[kid]
+            return True
+        bucket.pop(version, None)
+        if not bucket:
+            del self._store[kid]
+        return True
+
+    async def get_key(
+        self,
+        kid: str,
+        version: Optional[int] = None,
+        *,
+        include_secret: bool = False,
+    ) -> KeyRef:
+        bucket = self._store[kid]
+        v = version or max(bucket)
+        return bucket[v]
+
+    async def list_versions(self, kid: str) -> Tuple[int, ...]:
+        bucket = self._store.get(kid)
+        if not bucket:
+            raise KeyError(f"Unknown kid: {kid}")
+        return tuple(sorted(bucket.keys()))
+
+    async def get_public_jwk(self, kid: str, version: Optional[int] = None) -> dict:
+        raise NotImplementedError("JWK export not supported")
+
+    async def jwks(self, *, prefix_kids: Optional[str] = None) -> dict:
+        raise NotImplementedError("JWKS export not supported")
+
+    async def random_bytes(self, n: int) -> bytes:
+        return secrets.token_bytes(n)
+
+    async def hkdf(self, ikm: bytes, *, salt: bytes, info: bytes, length: int) -> bytes:
+        """Derive key material using HKDF-SHA256."""
+        prk = hmac.new(salt, ikm, hashlib.sha256).digest()
+        t = b""
+        okm = b""
+        counter = 1
+        while len(okm) < length:
+            t = hmac.new(prk, t + info + bytes([counter]), hashlib.sha256).digest()
+            okm += t
+            counter += 1
+        return okm[:length]

--- a/pkgs/swarmauri_standard/swarmauri_standard/key_providers/__init__.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/key_providers/__init__.py
@@ -1,0 +1,3 @@
+from .InMemoryKeyProvider import InMemoryKeyProvider
+
+__all__ = ["InMemoryKeyProvider"]

--- a/pkgs/swarmauri_standard/tests/unit/key_providers/test_inmemory_provider_unit.py
+++ b/pkgs/swarmauri_standard/tests/unit/key_providers/test_inmemory_provider_unit.py
@@ -1,0 +1,49 @@
+import pytest
+
+from swarmauri_standard.key_providers import InMemoryKeyProvider
+from swarmauri_base.keys import KeyProviderBase
+from swarmauri_core.keys.types import KeySpec, KeyClass, KeyAlg, ExportPolicy, KeyUse
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_import_and_get() -> None:
+    provider = InMemoryKeyProvider()
+    spec = KeySpec(
+        klass=KeyClass.symmetric,
+        alg=KeyAlg.AES256_GCM,
+        uses=(KeyUse.ENCRYPT, KeyUse.DECRYPT),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+    )
+    material = b"s3cr3t"
+    ref = await provider.import_key(spec, material)
+    fetched = await provider.get_key(ref.kid)
+    assert fetched.kid == ref.kid
+    assert fetched.material == material
+
+
+@pytest.mark.unit
+def test_ubc_resource() -> None:
+    provider = InMemoryKeyProvider()
+    assert provider.resource == "Crypto"
+
+
+@pytest.mark.unit
+def test_ubc_type() -> None:
+    assert InMemoryKeyProvider().type == "InMemoryKeyProvider"
+
+
+@pytest.mark.unit
+def test_serialization_and_name() -> None:
+    provider = InMemoryKeyProvider(name="mem-provider")
+    data = provider.model_dump_json()
+    restored = InMemoryKeyProvider.model_validate_json(data)
+    assert restored.id == provider.id
+    assert restored.name == "mem-provider"
+    assert restored.resource == "Crypto"
+
+
+@pytest.mark.unit
+def test_inheritance() -> None:
+    provider = InMemoryKeyProvider()
+    assert isinstance(provider, KeyProviderBase)


### PR DESCRIPTION
## Summary
- add `InMemoryKeyProvider` plugin for ephemeral key storage
- test storing and retrieving keys via the new provider
- cover provider metadata and serialization

## Testing
- `uv run --directory swarmauri_standard --package swarmauri_standard ruff format .`
- `uv run --directory swarmauri_standard --package swarmauri_standard ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68a97220a4c4832687f8228a77435a4b