### PR TITLE
Bundle latest libsodium with meson build

### DIFF
--- a/pkgs/standards/swarmauri_crypto_sodium/meson.build
+++ b/pkgs/standards/swarmauri_crypto_sodium/meson.build
@@ -9,32 +9,10 @@ project('swarmauri_crypto_sodium', 'c',
 # Python installation
 py = import('python').find_installation('python3')
 
-# Get build options
-use_system_libsodium = get_option('use_system_libsodium')
-static_link = get_option('static_link')
-debug_build = get_option('debug_build')
-
-# Configure libsodium dependency
-if use_system_libsodium
-  libsodium_dep = dependency('libsodium', version: '>=1.0.11', required: true)
-else
-  # Try system libsodium first, then fallback to subproject
-  libsodium_dep = dependency('libsodium', 
-                            version: '>=1.0.11', 
-                            required: false)
-  
-  if not libsodium_dep.found()
-    # Use libsodium as a subproject
-    libsodium_subproject_options = ['default_library=static']
-    if debug_build
-      libsodium_subproject_options += ['buildtype=debug']
-    endif
-    
-    libsodium_proj = subproject('libsodium', 
-                               default_options: libsodium_subproject_options)
-    libsodium_dep = libsodium_proj.get_variable('libsodium_dep')
-  endif
-endif
+# Always build and bundle libsodium as a subproject so the Python package
+# ships with the latest available version.
+libsodium_proj = subproject('libsodium', default_options: ['default_library=static'])
+libsodium_dep = libsodium_proj.get_variable('libsodium_dep')
 
 # Create a C extension module that provides libsodium bindings
 # This will be used by the Python code to load the bundled library
@@ -45,28 +23,20 @@ sodium_c_sources = [
 # Define include directories
 inc_dirs = include_directories('src')
 
-# Configure extension module build options
-ext_options = {}
-if debug_build
-  ext_options += {'c_args': ['-g', '-O0']}
-else
-  ext_options += {'c_args': ['-O2']}
-endif
-
-# Build shared library extension
+# Build shared library extension with optimization
 sodium_ext = py.extension_module('_sodium_loader',
     sources: sodium_c_sources,
     dependencies: [libsodium_dep],
     include_directories: inc_dirs,
     install: true,
     install_tag: 'python-runtime',
-    kwargs: ext_options
+    c_args: ['-O2'],
 )
 
 # Install Python source files
 py.install_sources([
     'swarmauri_crypto_sodium/__init__.py',
     'swarmauri_crypto_sodium/SodiumCrypto.py',
-], 
+],
 subdir: 'swarmauri_crypto_sodium',
 install_tag: 'python-runtime')

--- a/pkgs/standards/swarmauri_crypto_sodium/subprojects/libsodium.wrap
+++ b/pkgs/standards/swarmauri_crypto_sodium/subprojects/libsodium.wrap
@@ -1,7 +1,9 @@
-[wrap-git]
-url = https://github.com/jedisct1/libsodium.git
-revision = 1.0.19
-depth = 1
+[wrap-file]
+directory = libsodium-1.0.20
+source_url = https://download.libsodium.org/libsodium/releases/libsodium-1.0.20.tar.gz
+source_filename = libsodium-1.0.20.tar.gz
+source_hash = ebb65ef6ca439333c2bb41a0c1990587288da07f6c7fd07cb3a18cc18d30ce19
+buildsystem = autotools
 
 [provide]
 libsodium = libsodium_dep


### PR DESCRIPTION
## Summary
- Always build bundled libsodium using Meson subproject for the sodium crypto provider
- Fetch and build libsodium 1.0.20 via autotools wrap so installs include the C library

## Testing
- `uv run --no-sync --directory standards/swarmauri_crypto_sodium --package swarmauri_crypto_sodium ruff format .`
- `uv run --no-sync --directory standards/swarmauri_crypto_sodium --package swarmauri_crypto_sodium ruff check . --fix`
- `uv run --directory standards/swarmauri_crypto_sodium --package swarmauri_crypto_sodium pytest` *(fails: Subproject libsodium is buildable: NO)*

------
https://chatgpt.com/codex/tasks/task_e_68a9769f6ba08326adf3316b2de0fe02