### PR TITLE
docs: document local CA usage examples

### DIFF
--- a/pkgs/swarmauri_certs_local_ca/pyproject.toml
+++ b/pkgs/swarmauri_certs_local_ca/pyproject.toml
@@ -39,6 +39,7 @@ markers = [
     "r8n: Regression tests",
     "acceptance: Acceptance tests",
     "perf: Performance tests",
+    "example: Usage example tests",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/swarmauri_certs_local_ca/tests/functional/test_usage_example.py
+++ b/pkgs/swarmauri_certs_local_ca/tests/functional/test_usage_example.py
@@ -1,0 +1,35 @@
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from swarmauri_certs_local_ca import LocalCaCertService
+from swarmauri_core.crypto.types import ExportPolicy, KeyRef, KeyType, KeyUse
+
+
+def _key(name: str) -> KeyRef:
+    sk = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pem = sk.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+    return KeyRef(
+        kid=name,
+        version=1,
+        type=KeyType.RSA,
+        uses=(KeyUse.SIGN,),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+        material=pem,
+    )
+
+
+@pytest.mark.example
+@pytest.mark.asyncio
+async def test_readme_example_usage() -> None:
+    svc = LocalCaCertService()
+    ca_key = _key("ca")
+    leaf_key = _key("leaf")
+    csr = await svc.create_csr(leaf_key, {"CN": "leaf"})
+    cert = await svc.sign_cert(csr, ca_key, issuer={"CN": "ca"})
+    result = await svc.verify_cert(cert)
+    assert result["valid"] is True


### PR DESCRIPTION
## Summary
- expand LocalCaCertService README with step-by-step certificate issuance example
- register `example` pytest marker and add usage example test

## Testing
- `uv run --directory swarmauri_certs_local_ca --package swarmauri_certs_local_ca ruff format .`
- `uv run --directory swarmauri_certs_local_ca --package swarmauri_certs_local_ca ruff check . --fix`
- `uv run --package swarmauri_certs_local_ca --directory swarmauri_certs_local_ca pytest`
- `uv run --package swarmauri_certs_local_ca --directory swarmauri_certs_local_ca pytest -m example -vv`


------
https://chatgpt.com/codex/tasks/task_e_68a978d61ec08326a69bbaabe64624e6