### PR TITLE
core: add pytest-asyncio for async tests

### DIFF
--- a/pkgs/core/pyproject.toml
+++ b/pkgs/core/pyproject.toml
@@ -27,14 +27,16 @@ dependencies = [
 dev = [
 "flake8>=7.0",
 "pytest>=8.0",
+"pytest-asyncio>=0.24.0",
 "pytest-xdist>=3.6.1",
 "pytest-json-report>=1.5.0",
 "pytest-timeout>=2.3.1",
 "ruff>=0.9.9",
-"pytest-benchmark>=4.0.0"
+"pytest-benchmark>=4.0.0",
 ]
 
 [tool.pytest.ini_options]
+asyncio_mode = "auto"
 markers = [
     "test: standard test",
     "unit: Unit tests",
@@ -51,6 +53,7 @@ log_cli = true
 log_cli_level = "INFO"
 log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
 log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pkgs/core/swarmauri_core/keys/__init__.py
+++ b/pkgs/core/swarmauri_core/keys/__init__.py
@@ -2,7 +2,9 @@
 
 from .IKeyProvider import IKeyProvider
 from .types import KeyAlg, KeyClass, KeySpec, ExportPolicy, KeyUse
-from ..crypto.types import KeyRef # We should relocate KeyRef from crypto.types to keys.types
+from ..crypto.types import (
+    KeyRef,
+)  # We should relocate KeyRef from crypto.types to keys.types
 
 __all__ = [
     "IKeyProvider",
@@ -11,4 +13,5 @@ __all__ = [
     "KeyClass",
     "ExportPolicy",
     "KeyUse",
+    "KeyRef",
 ]


### PR DESCRIPTION
## Summary
- add pytest-asyncio dev dependency and configure pytest for asyncio
- export KeyRef in keys package to satisfy lint

## Testing
- `uv run --directory pkgs/core --package swarmauri-core ruff format .`
- `uv run --directory pkgs/core --package swarmauri-core ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68a990c5f7bc832691cf89fc75be52c5