### PR TITLE
test: cover swarmauri_typing metadata

### DIFF
--- a/pkgs/typing/tests/unit/test_MetadataRepr.py
+++ b/pkgs/typing/tests/unit/test_MetadataRepr.py
@@ -1,0 +1,22 @@
+from swarmauri_typing import IntersectionMetadata, UnionFactoryMetadata
+
+
+class A:
+    pass
+
+
+class B:
+    pass
+
+
+def test_union_factory_metadata_repr():
+    """UnionFactoryMetadata should provide informative representation."""
+    meta = UnionFactoryMetadata(data="A", name="UF")
+    assert repr(meta) == "UnionFactoryMetadata(name='UF', data='A')"
+
+
+def test_intersection_metadata_repr():
+    """IntersectionMetadata __repr__ should include the classes tuple."""
+    meta = IntersectionMetadata((A, B))
+    expected = f"IntersectionMetadata(classes=({A!r}, {B!r}))"
+    assert repr(meta) == expected

--- a/pkgs/typing/tests/unit/test_UnionFactory.py
+++ b/pkgs/typing/tests/unit/test_UnionFactory.py
@@ -152,6 +152,8 @@ def test_add_metadata_to_annotated_type():
     assert args[1].value == "first"
     assert isinstance(args[2], CustomMetadata)
     assert args[2].value == "second"
+    assert isinstance(args[3], CustomMetadata)
+    assert args[3].value == "third"
 
 
 @pytest.mark.perf


### PR DESCRIPTION
## Summary
- assert _add_metadata appends new metadata to existing `Annotated` types
- add tests verifying `__repr__` for IntersectionMetadata and UnionFactoryMetadata

## Testing
- `uv run --package swarmauri-typing --directory typing pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab0c7623d48326896423612ef13811