### PR TITLE
feat: mixin-aware registration across multiple inheritance

### DIFF
--- a/pkgs/base/swarmauri_base/ComponentBase.py
+++ b/pkgs/base/swarmauri_base/ComponentBase.py
@@ -28,7 +28,7 @@ from swarmauri_base.YamlMixin import YamlMixin
 T = TypeVar("T", bound="ComponentBase")
 
 
-@DynamicBase.register_type()
+@DynamicBase.register_model()
 class ComponentBase(LoggerMixin, YamlMixin, ServiceMixin, DynamicBase):
     """
     Base class for all components.

--- a/pkgs/base/swarmauri_base/LoggerMixin.py
+++ b/pkgs/base/swarmauri_base/LoggerMixin.py
@@ -8,7 +8,7 @@ from swarmauri_base.loggers.LoggerBase import LoggerBase
 from swarmauri_base.DynamicBase import DynamicBase
 
 
-@DynamicBase.register_model()
+@DynamicBase.register_model(mixin=True)
 class LoggerMixin(BaseModel):
     """Provide logger configuration fields to derived models."""
 

--- a/pkgs/base/swarmauri_base/ObserveBase.py
+++ b/pkgs/base/swarmauri_base/ObserveBase.py
@@ -15,7 +15,7 @@ from swarmauri_base.DynamicBase import DynamicBase
 T = TypeVar("T", bound="ObserveBase")
 
 
-@DynamicBase.register_type()
+@DynamicBase.register_model()
 class ObserveBase(YamlMixin, ServiceMixin, DynamicBase):
     """
     Base class for all components.

--- a/pkgs/base/swarmauri_base/ServiceMixin.py
+++ b/pkgs/base/swarmauri_base/ServiceMixin.py
@@ -13,7 +13,7 @@ def generate_id() -> str:
     return str(uuid4())
 
 
-@DynamicBase.register_model()
+@DynamicBase.register_model(mixin=True)
 class ServiceMixin(BaseModel):
     """Attach service-related metadata fields to a model."""
 

--- a/pkgs/base/tests/unit/test_register_type_multiple_inheritance.py
+++ b/pkgs/base/tests/unit/test_register_type_multiple_inheritance.py
@@ -1,0 +1,52 @@
+from pydantic import BaseModel
+
+
+from swarmauri_base import register_model, register_type
+from swarmauri_base.DynamicBase import DynamicBase
+
+
+def test_registers_all_inherited_bases():
+    @register_model()
+    class BaseParent(DynamicBase):
+        pass
+
+    @register_model()
+    class BaseA(BaseParent):
+        pass
+
+    @register_model()
+    class BaseB(DynamicBase):
+        pass
+
+    @register_type()
+    class Child(BaseA, BaseB):
+        pass
+
+    assert "Child" in DynamicBase._registry["BaseA"]["subtypes"]
+    assert "Child" in DynamicBase._registry["BaseB"]["subtypes"]
+    assert "Child" in DynamicBase._registry["BaseParent"]["subtypes"]
+
+    for name in ["BaseParent", "BaseA", "BaseB", "Child"]:
+        DynamicBase._registry.pop(name, None)
+    DynamicBase._recreate_models()
+
+
+def test_excludes_mixins_from_registration():
+    @register_model()
+    class BaseB(DynamicBase):
+        pass
+
+    @register_model(mixin=True)
+    class MixinA(BaseModel):
+        pass
+
+    @register_type()
+    class ChildMixin(MixinA, BaseB):
+        pass
+
+    assert "ChildMixin" in DynamicBase._registry["BaseB"]["subtypes"]
+    assert "ChildMixin" not in DynamicBase._registry["MixinA"]["subtypes"]
+
+    for name in ["BaseB", "MixinA", "ChildMixin"]:
+        DynamicBase._registry.pop(name, None)
+    DynamicBase._recreate_models()

--- a/pkgs/swarmauri/tests/unit/test_plugin_manager_multiple_inheritance.py
+++ b/pkgs/swarmauri/tests/unit/test_plugin_manager_multiple_inheritance.py
@@ -1,0 +1,68 @@
+from types import SimpleNamespace
+from copy import deepcopy
+
+from pydantic import BaseModel
+
+from swarmauri_base import register_model
+from swarmauri_base.DynamicBase import DynamicBase
+from swarmauri.plugin_manager import _process_class_plugin
+from swarmauri.plugin_citizenship_registry import PluginCitizenshipRegistry
+from swarmauri.interface_registry import InterfaceRegistry
+
+
+# Backup registries
+_original_interface_registry = deepcopy(InterfaceRegistry.INTERFACE_REGISTRY)
+_original_import_paths = deepcopy(InterfaceRegistry.INTERFACE_IMPORT_PATHS)
+_original_first = deepcopy(PluginCitizenshipRegistry.FIRST_CLASS_REGISTRY)
+_original_second = deepcopy(PluginCitizenshipRegistry.SECOND_CLASS_REGISTRY)
+_original_third = deepcopy(PluginCitizenshipRegistry.THIRD_CLASS_REGISTRY)
+_original_known = PluginCitizenshipRegistry._KNOWN_GROUPS_CACHE
+_original_dynamic = deepcopy(DynamicBase._registry)
+
+
+@register_model()
+class BaseX(DynamicBase):
+    pass
+
+
+@register_model()
+class BaseY(DynamicBase):
+    pass
+
+
+@register_model(mixin=True)
+class MixinX(BaseModel):
+    pass
+
+
+class Plugin(BaseX, BaseY, MixinX):
+    pass
+
+
+def test_registers_only_base_interfaces():
+    InterfaceRegistry.register_interface("swarmauri.test_x", BaseX)
+    InterfaceRegistry.register_interface("swarmauri.test_y", BaseY)
+    InterfaceRegistry.register_interface("swarmauri.test_m", MixinX)
+
+    ep = SimpleNamespace(name="Plugin", group="swarmauri.test_x", value="pkg:Plugin")
+    assert _process_class_plugin(ep, "swarmauri.test_x.Plugin", Plugin, None)
+
+    assert "swarmauri.test_x.Plugin" in PluginCitizenshipRegistry.SECOND_CLASS_REGISTRY
+    assert "swarmauri.test_y.Plugin" in PluginCitizenshipRegistry.SECOND_CLASS_REGISTRY
+    assert (
+        "swarmauri.test_m.Plugin" not in PluginCitizenshipRegistry.SECOND_CLASS_REGISTRY
+    )
+
+    InterfaceRegistry.unregister_interface("swarmauri.test_x")
+    InterfaceRegistry.unregister_interface("swarmauri.test_y")
+    InterfaceRegistry.unregister_interface("swarmauri.test_m")
+
+
+def teardown_module():
+    InterfaceRegistry.INTERFACE_REGISTRY = deepcopy(_original_interface_registry)
+    InterfaceRegistry.INTERFACE_IMPORT_PATHS = deepcopy(_original_import_paths)
+    PluginCitizenshipRegistry.FIRST_CLASS_REGISTRY = deepcopy(_original_first)
+    PluginCitizenshipRegistry.SECOND_CLASS_REGISTRY = deepcopy(_original_second)
+    PluginCitizenshipRegistry.THIRD_CLASS_REGISTRY = deepcopy(_original_third)
+    PluginCitizenshipRegistry._KNOWN_GROUPS_CACHE = _original_known
+    DynamicBase._registry = deepcopy(_original_dynamic)


### PR DESCRIPTION
## Summary
- support registering mixins and all inherited bases in `DynamicBase`
- allow swarmauri plugin manager to validate multiple bases and mixins
- add regression tests for mixin and multiple inheritance registration

## Testing
- `uv run --directory base --package swarmauri-base ruff format .`
- `uv run --directory base --package swarmauri-base ruff check . --fix`
- `uv run --directory base --package swarmauri-base pytest`
- `uv run --directory swarmauri --package swarmauri ruff format .`
- `uv run --directory swarmauri --package swarmauri ruff check . --fix`
- `uv run --directory swarmauri --package swarmauri pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abd0d7d82c8326aac25afa6fbce50d