### PR TITLE
refactor: convert v3 mixins to ACOL

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
@@ -8,7 +8,6 @@ import typing as _typing
 from types import SimpleNamespace
 from typing import Any, Awaitable, Callable, Dict, Mapping, Optional, Sequence, Tuple
 
-from collections.abc import Mapping as _Mapping
 from typing import get_origin as _get_origin, get_args as _get_args
 
 try:
@@ -101,9 +100,9 @@ def _ensure_jsonable(obj: Any) -> Any:
     if isinstance(obj, (list, tuple)):
         return [_ensure_jsonable(x) for x in obj]
 
-    if isinstance(mapping, Mapping):
+    if isinstance(obj, Mapping):
         try:
-            return {k: _ensure_jsonable(v) for k, v in dict(mapping).items()}
+            return {k: _ensure_jsonable(v) for k, v in dict(obj).items()}
         except Exception:  # pragma: no cover - fall back to original object
             pass
 
@@ -113,6 +112,7 @@ def _ensure_jsonable(obj: Any) -> Any:
         return obj
 
     return {k: _ensure_jsonable(v) for k, v in data.items() if not k.startswith("_")}
+
 
 def _req_state_db(request: Request) -> Any:
     return getattr(request.state, "db", None)

--- a/pkgs/standards/autoapi/autoapi/v3/mixins/ownable.py
+++ b/pkgs/standards/autoapi/autoapi/v3/mixins/ownable.py
@@ -6,12 +6,11 @@ from enum import Enum
 from typing import Any, Mapping
 from uuid import UUID
 
-from sqlalchemy import Column, ForeignKey
-from sqlalchemy.dialects.postgresql import UUID as PgUUID
-from sqlalchemy.orm import declared_attr
-
+from ..columns import acol as col
+from ..specs import IO, S, F, acol as spec_acol
+from ..specs.storage_spec import ForeignKeySpec
+from ..types import PgUUID, declared_attr
 from ..runtime.errors import create_standardized_error
-from ..schema.col_info import check as _info_check
 from ..config.constants import (
     AUTOAPI_HOOKS_ATTR,
     AUTOAPI_OWNER_POLICY_ATTR,
@@ -129,21 +128,23 @@ class Ownable:
         pol = getattr(cls, AUTOAPI_OWNER_POLICY_ATTR, OwnerPolicy.CLIENT_SET)
         schema = _infer_schema(cls, default="public")
 
-        autoapi_meta: dict[str, Any] = {}
-        # non-client policy means the server controls the value → hide on write verbs
-        if pol != OwnerPolicy.CLIENT_SET:
-            autoapi_meta["disable_on"] = ["update", "replace"]
-            autoapi_meta["read_only"] = True
-
-        _info_check(autoapi_meta, "owner_id", cls.__name__)
-
-        return Column(
-            PgUUID(as_uuid=True),
-            ForeignKey(f"{schema}.users.id"),
+        storage = S(
+            type_=PgUUID(as_uuid=True),
+            fk=ForeignKeySpec(target=f"{schema}.users.id"),
             nullable=False,
             index=True,
-            info={"autoapi": autoapi_meta} if autoapi_meta else {},
         )
+        field = F(py_type=UUID)
+        if pol == OwnerPolicy.CLIENT_SET:
+            io = IO(
+                in_verbs=("create", "update", "replace"),
+                out_verbs=("read", "list"),
+                mutable_verbs=("create", "update", "replace"),
+            )
+        else:
+            io = IO(out_verbs=("read", "list"))
+
+        return col(spec=spec_acol(storage=storage, field=field, io=io))
 
     # ── hook installers --------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- refactor Ownable and TenantBound mixins to use ACOL column specs
- fix undefined variable in REST bindings

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest` *(fails: 27 failed, 363 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68abd66d21388326bc57703028b78578