### PR TITLE
test: verify OAuth2 password grant parameters

### DIFF
--- a/pkgs/standards/auto_authn/tests/unit/test_rfc6749_token_endpoint.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc6749_token_endpoint.py
@@ -1,0 +1,47 @@
+"""Tests for OAuth2 password grant compliance with RFC 6749."""
+
+import pytest
+from fastapi import FastAPI, status
+from httpx import ASGITransport, AsyncClient
+
+from auto_authn.v2.routers.auth_flows import router
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_token_rejects_unsupported_grant_type():
+    """RFC 6749 §4.3: grant_type must be "password"."""
+    app = FastAPI()
+    app.include_router(router)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        data = {
+            "username": "user",
+            "password": "pass",
+            "grant_type": "client_credentials",
+        }
+        resp = await client.post("/token", data=data)
+    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    detail = resp.json()["detail"]
+    assert detail[0]["loc"][-1] == "grant_type"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "data,missing",
+    [
+        ({"grant_type": "password", "username": "user"}, "password"),
+        ({"grant_type": "password", "password": "pass"}, "username"),
+    ],
+)
+async def test_token_requires_username_and_password(data, missing):
+    """RFC 6749 §4.3: username and password parameters are required."""
+    app = FastAPI()
+    app.include_router(router)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/token", data=data)
+    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    fields = {err["loc"][-1] for err in resp.json()["detail"]}
+    assert missing in fields


### PR DESCRIPTION
## Summary
- add unit tests asserting OAuth2 token endpoint handles unsupported grant types and missing credentials per RFC 6749

## Testing
- `uv run --package auto_authn --directory standards/auto_authn ruff format tests/unit/test_rfc6749_token_endpoint.py`
- `uv run --package auto_authn --directory standards/auto_authn ruff check tests/unit/test_rfc6749_token_endpoint.py --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc6749_token_endpoint.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac107a1d588326a728d43f075c5b14