### PR TITLE
test(auto-authn): add RFC 7662 compliance tests

### DIFF
--- a/pkgs/standards/auto_authn/tests/i9n/test_rfc7662.py
+++ b/pkgs/standards/auto_authn/tests/i9n/test_rfc7662.py
@@ -1,0 +1,32 @@
+"""Tests for RFC 7662 token introspection compliance."""
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.xfail(reason="RFC 7662 compliant token introspection planned")
+async def test_introspect_valid_api_key(async_client: AsyncClient, test_api_key):
+    """Valid API key should yield an active introspection response."""
+    response = await async_client.post(
+        "/api_key/introspect", json={"api_key": test_api_key._test_raw_key}
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert "active" in body
+    assert body["active"] is True
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.xfail(reason="RFC 7662 compliant token introspection planned")
+async def test_introspect_invalid_api_key(async_client: AsyncClient):
+    """Invalid API key should yield inactive response per RFC 7662."""
+    response = await async_client.post(
+        "/api_key/introspect", json={"api_key": "does-not-exist"}
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert "active" in body
+    assert body["active"] is False


### PR DESCRIPTION
## Summary
- add integration tests for RFC 7662 token introspection compliance in auto_authn

## Testing
- `uv run --directory standards/auto_authn --package auto_authn ruff format .`
- `uv run --directory standards/auto_authn --package auto_authn ruff check . --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest`
- `uv run --package auto_authn --directory standards/auto_authn pytest -m integration tests/i9n/test_rfc7662.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_68ac109dcfd48326bb93eb6d2a6fa3b0