### PR TITLE
test: add RFC 8414 metadata xfail tests

### DIFF
--- a/pkgs/standards/auto_authn/tests/i9n/test_rfc8414_metadata.py
+++ b/pkgs/standards/auto_authn/tests/i9n/test_rfc8414_metadata.py
@@ -1,0 +1,36 @@
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.integration
+class TestRFC8414AuthorizationServerMetadata:
+    """Tests for the OAuth 2.0 Authorization Server Metadata endpoint."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.xfail(reason="RFC 8414 endpoint not yet implemented; feature planned")
+    async def test_metadata_endpoint_returns_valid_json(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Endpoint should return valid JSON document per RFC 8414."""
+        response = await async_client.get("/.well-known/oauth-authorization-server")
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("application/json")
+        metadata = response.json()
+        assert isinstance(metadata, dict)
+
+    @pytest.mark.asyncio
+    @pytest.mark.xfail(reason="RFC 8414 endpoint not yet implemented; feature planned")
+    async def test_metadata_document_contains_required_fields(
+        self, async_client: AsyncClient
+    ) -> None:
+        """Metadata document should include required RFC 8414 fields."""
+        response = await async_client.get("/.well-known/oauth-authorization-server")
+        assert response.status_code == 200
+        metadata = response.json()
+        required_fields = [
+            "issuer",
+            "authorization_endpoint",
+            "token_endpoint",
+        ]
+        for field in required_fields:
+            assert field in metadata, f"Missing required field: {field}"


### PR DESCRIPTION
## Summary
- add integration tests for RFC 8414 OAuth 2.0 Authorization Server Metadata endpoint
- mark tests as xfail since the feature is planned but not yet implemented

## Testing
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff format .`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check . --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/i9n/test_rfc8414_metadata.py -m integration`


------
https://chatgpt.com/codex/tasks/task_e_68ac10a4bbbc8326b8d107a5833bf773