### PR TITLE
Add xfail RFC 8705 compliance tests

### DIFF
--- a/pkgs/standards/auto_authn/tests/unit/test_rfc8705_compliance.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc8705_compliance.py
@@ -1,0 +1,29 @@
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from auto_authn.v2.jwtoken import JWTCoder
+
+
+@pytest.mark.unit
+@pytest.mark.xfail(reason="RFC 8705 support planned")
+def test_jwt_includes_cnf_claim_for_mtls():
+    """JWTs should embed cnf.x5t#S256 when mTLS is used."""
+    private_key_obj = Ed25519PrivateKey.generate()
+    public_key_obj = private_key_obj.public_key()
+
+    private_pem = private_key_obj.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_pem = public_key_obj.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+    coder = JWTCoder(private_pem, public_pem)
+    token = coder.sign(sub="alice", tid="tenant")
+    payload = coder.decode(token)
+
+    assert "cnf" in payload

--- a/pkgs/standards/swarmauri_tokens_tlsboundjwt/tests/unit/test_rfc8705_compliance.py
+++ b/pkgs/standards/swarmauri_tokens_tlsboundjwt/tests/unit/test_rfc8705_compliance.py
@@ -1,0 +1,13 @@
+import asyncio
+import pytest
+
+from swarmauri_tokens_tlsboundjwt import TlsBoundJWTTokenService
+
+
+@pytest.mark.unit
+@pytest.mark.xfail(reason="Enforcing certificate requirement planned")
+def test_mint_requires_client_certificate():
+    """Minting without a client certificate should be rejected."""
+    svc = TlsBoundJWTTokenService(None)
+    with pytest.raises(ValueError):
+        asyncio.run(svc.mint({"sub": "alice"}, alg="HS256"))


### PR DESCRIPTION
## Summary
- add placeholder RFC 8705 compliance test for auto_authn
- add placeholder RFC 8705 compliance test for swarmauri_tokens_tlsboundjwt

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest`
- `uv run --package swarmauri_tokens_tlsboundjwt --directory standards/swarmauri_tokens_tlsboundjwt pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac10c1f850832689a3ac3cd3b4b5ea