### PR TITLE
feat(auto_authn): validate native redirect URIs per RFC 8252

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/tables.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/tables.py
@@ -49,6 +49,7 @@ from autoapi.v2.mixins import (
     UserMixin,
 )
 from ..crypto import hash_pw  # bcrypt helper shared across package
+from ..rfc8252 import validate_native_redirect_uri
 
 
 # ────────────────────────────────────────────────────────────────────
@@ -94,6 +95,8 @@ class Client(ClientBase):  # Tenant FK via mix-in
     ):
         if not _CLIENT_ID_RE.fullmatch(client_id):
             raise ValueError("invalid client_id format")
+        for uri in redirects:
+            validate_native_redirect_uri(uri)
         secret_hash = hash_pw(client_secret)
         return cls(
             tenant_id=tenant_id,

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc8252_native_app_redirects.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc8252_native_app_redirects.py
@@ -1,0 +1,57 @@
+"""Tests for RFC 8252 compliance (OAuth 2.0 for Native Apps).
+
+RFC 8252 section 7 restricts redirect URIs for native applications to
+private-use URI schemes or loopback addresses with a dynamically chosen
+port. The tests below assert that auto_authn enforces these rules.
+"""
+
+import uuid
+
+import pytest
+
+from auto_authn.v2.rfc8252 import is_native_redirect_uri
+from auto_authn.v2.orm.tables import Client
+
+
+@pytest.mark.unit
+def test_accepts_loopback_redirect_uri() -> None:
+    """RFC 8252 §7.3 allows loopback interface redirect URIs with any port."""
+    assert is_native_redirect_uri("http://127.0.0.1:49152/callback")
+
+
+@pytest.mark.unit
+def test_accepts_private_scheme_redirect_uri() -> None:
+    """RFC 8252 §7.1 permits private-use URI scheme redirects."""
+    assert is_native_redirect_uri("com.example.app:/oauth2redirect")
+
+
+@pytest.mark.unit
+def test_rejects_public_http_redirect_uri() -> None:
+    """Public network hosts are not valid for native app redirect URIs."""
+    assert not is_native_redirect_uri("http://example.com/callback")
+
+
+@pytest.mark.unit
+def test_client_new_enforces_rfc8252_redirects() -> None:
+    """Client.new should reject redirect URIs that violate RFC 8252."""
+    tenant_id = uuid.uuid4()
+    with pytest.raises(ValueError):
+        Client.new(
+            tenant_id,
+            "client1234",
+            "secret",
+            ["http://example.com/callback"],
+        )
+
+
+@pytest.mark.unit
+def test_client_new_accepts_loopback_redirect() -> None:
+    """Client.new accepts loopback redirect URIs per RFC 8252."""
+    tenant_id = uuid.uuid4()
+    client = Client.new(
+        tenant_id,
+        "client5678",
+        "secret",
+        ["http://localhost:8080/callback"],
+    )
+    assert client.redirect_uris == "http://localhost:8080/callback"


### PR DESCRIPTION
## Summary
- validate OAuth client redirect URIs against RFC 8252
- add RFC 8252 redirect URI compliance tests

## Testing
- `uv run --directory . --package auto_authn ruff format .`
- `uv run --directory . --package auto_authn ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68ac2bce21f483268526dfbb55d85a5f