### PR TITLE
Add PKCE utilities and RFC 8252 compliance tests

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
@@ -1,0 +1,13 @@
+"""auto_authn.v2 – OAuth utilities and helpers."""
+
+from .pkce import (
+    create_code_challenge,
+    create_code_verifier,
+    verify_code_challenge,
+)
+
+__all__ = [
+    "create_code_verifier",
+    "create_code_challenge",
+    "verify_code_challenge",
+]

--- a/pkgs/standards/auto_authn/auto_authn/v2/pkce.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/pkce.py
@@ -1,0 +1,68 @@
+"""PKCE utilities for RFC 8252 compliance.
+
+This module implements the Proof Key for Code Exchange (PKCE) helpers
+required by RFC 8252 for native applications.  It follows the rules laid
+out in RFC 7636 §4.1 for generating and validating ``code_verifier``
+strings and deriving ``code_challenge`` values using the ``S256``
+transformation.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import re
+import secrets
+from typing import Final
+
+# Allowed characters for the code_verifier as defined by RFC 7636 §4.1
+_VERIFIER_CHARSET: Final = (
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+)
+
+# Regular expression to validate code_verifier values
+_VERIFIER_RE: Final = re.compile(r"^[A-Za-z0-9\-._~]{43,128}$")
+
+
+def create_code_verifier(length: int = 43) -> str:
+    """Return a high-entropy ``code_verifier`` string.
+
+    RFC 7636 §4.1 specifies that a ``code_verifier`` MUST be between 43 and
+    128 characters and use only ``ALPHA / DIGIT / "-" / "." / "_" / "~"``.
+    ``length`` defaults to the minimum 43 characters.
+    """
+
+    if not 43 <= length <= 128:
+        raise ValueError("length must be between 43 and 128 characters")
+    return "".join(secrets.choice(_VERIFIER_CHARSET) for _ in range(length))
+
+
+def create_code_challenge(verifier: str) -> str:
+    """Derive an ``S256`` ``code_challenge`` from *verifier*.
+
+    The verifier is first validated against the RFC 7636 §4.1 character and
+    length requirements and then hashed using SHA-256 with the result encoded
+    using base64url without padding, as required by RFC 7636 §4.2.
+    """
+
+    if not _VERIFIER_RE.fullmatch(verifier):
+        raise ValueError("invalid code_verifier")
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    return base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+
+
+def verify_code_challenge(verifier: str, challenge: str) -> bool:
+    """Return ``True`` if *challenge* matches *verifier* using ``S256``."""
+
+    try:
+        expected = create_code_challenge(verifier)
+    except ValueError:
+        return False
+    return secrets.compare_digest(expected, challenge)
+
+
+__all__ = [
+    "create_code_verifier",
+    "create_code_challenge",
+    "verify_code_challenge",
+]

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc8252_pkce.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc8252_pkce.py
@@ -1,0 +1,55 @@
+"""Tests for OAuth 2.0 for Native Apps (RFC 8252) PKCE requirements.
+
+RFC excerpt (RFC 8252 §7.3 and RFC 7636 §4.1):
+
+Native apps MUST use the Proof Key for Code Exchange (PKCE [RFC7636])
+extension to OAuth 2.0 when using the authorization code grant.
+
+The code_verifier MUST be a high-entropy cryptographic random string using the
+unreserved characters [A-Z] / [a-z] / [0-9] / "-" / "." / "_" / "~",
+with a minimum length of 43 characters and a maximum length of 128 characters.
+"""
+
+import pytest
+
+from auto_authn.v2 import (
+    create_code_challenge,
+    create_code_verifier,
+    verify_code_challenge,
+)
+
+
+@pytest.mark.unit
+def test_code_verifier_meets_rfc7636_requirements():
+    """Generated verifier satisfies RFC 7636 §4.1."""
+
+    verifier = create_code_verifier()
+    assert 43 <= len(verifier) <= 128
+    allowed = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+    assert all(ch in allowed for ch in verifier)
+
+
+@pytest.mark.unit
+def test_code_challenge_s256_matches_known_example():
+    """RFC 7636 Appendix B example."""
+
+    verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+    expected = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+    assert create_code_challenge(verifier) == expected
+
+
+@pytest.mark.unit
+def test_verify_code_challenge_round_trip():
+    """Challenge derived from verifier validates correctly."""
+
+    verifier = create_code_verifier(60)
+    challenge = create_code_challenge(verifier)
+    assert verify_code_challenge(verifier, challenge)
+
+
+@pytest.mark.unit
+def test_invalid_verifier_rejected():
+    """Invalid verifier raises ValueError."""
+
+    with pytest.raises(ValueError):
+        create_code_challenge("short")


### PR DESCRIPTION
## Summary
- add PKCE helpers and expose them via auto_authn.v2
- verify RFC 8252 requirements with new PKCE tests including spec excerpts

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac2b4c6fdc83269f5f727047ac7213