### PR TITLE
feat: enforce JWA enum usage

### DIFF
--- a/pkgs/standards/swarmauri_tokens_dpopboundjwt/swarmauri_tokens_dpopboundjwt/DPoPBoundJWTTokenService.py
+++ b/pkgs/standards/swarmauri_tokens_dpopboundjwt/swarmauri_tokens_dpopboundjwt/DPoPBoundJWTTokenService.py
@@ -10,6 +10,7 @@ import jwt
 from jwt import algorithms
 
 from .JWTTokenService import JWTTokenService
+from swarmauri_core.crypto.types import JWAAlg
 from swarmauri_core.keys.IKeyProvider import IKeyProvider
 
 
@@ -68,7 +69,7 @@ class DPoPBoundJWTTokenService(JWTTokenService):
         # If None, replay protection is skipped.
         self._replay_check = replay_check
 
-    def supports(self) -> Mapping[str, Iterable[str]]:
+    def supports(self) -> Mapping[str, Iterable[JWAAlg]]:
         base = super().supports()
         return {"formats": (*base["formats"], "JWT"), "algs": base["algs"]}
 
@@ -76,7 +77,7 @@ class DPoPBoundJWTTokenService(JWTTokenService):
         self,
         claims: Dict[str, object],
         *,
-        alg: str,
+        alg: JWAAlg,
         kid: str | None = None,
         key_version: int | None = None,
         headers: Optional[Dict[str, object]] = None,
@@ -157,7 +158,10 @@ class DPoPBoundJWTTokenService(JWTTokenService):
         proof_claims = jwt.decode(
             proof_jwt,
             key=key,
-            algorithms=[alg for alg in ("RS256", "PS256", "ES256", "EdDSA")],
+            algorithms=[
+                alg.value
+                for alg in (JWAAlg.RS256, JWAAlg.PS256, JWAAlg.ES256, JWAAlg.EDDSA)
+            ],
             options={"verify_aud": False, "verify_iss": False},
         )
 

--- a/pkgs/standards/swarmauri_tokens_dpopboundjwt/swarmauri_tokens_dpopboundjwt/JWTTokenService.py
+++ b/pkgs/standards/swarmauri_tokens_dpopboundjwt/swarmauri_tokens_dpopboundjwt/JWTTokenService.py
@@ -5,6 +5,7 @@ from typing import Iterable, Mapping, Optional
 
 import jwt
 
+from swarmauri_core.crypto.types import JWAAlg
 from swarmauri_core.keys.IKeyProvider import IKeyProvider
 
 
@@ -19,17 +20,23 @@ class JWTTokenService:
         self._keys = key_provider
         self._issuer = default_issuer
 
-    def supports(self) -> Mapping[str, Iterable[str]]:
+    def supports(self) -> Mapping[str, Iterable[JWAAlg]]:
         return {
             "formats": ("JWT",),
-            "algs": ("HS256", "RS256", "PS256", "ES256", "EdDSA"),
+            "algs": (
+                JWAAlg.HS256,
+                JWAAlg.RS256,
+                JWAAlg.PS256,
+                JWAAlg.ES256,
+                JWAAlg.EDDSA,
+            ),
         }
 
     async def mint(
         self,
         claims: dict[str, object],
         *,
-        alg: str,
+        alg: JWAAlg,
         kid: str | None = None,
         key_version: int | None = None,
         headers: Optional[dict[str, object]] = None,
@@ -57,7 +64,10 @@ class JWTTokenService:
         keyref = await self._keys.get_key(kid, version=key_version, include_secret=True)
         secret = keyref.material or b""
         return jwt.encode(
-            payload, secret, algorithm=alg, headers={"kid": kid, **(headers or {})}
+            payload,
+            secret,
+            algorithm=alg.value,
+            headers={"kid": kid, **(headers or {})},
         )
 
     async def verify(
@@ -69,14 +79,14 @@ class JWTTokenService:
         leeway_s: int = 60,
     ) -> dict[str, object]:
         hdr = jwt.get_unverified_header(token)
-        alg = hdr.get("alg")
+        alg = JWAAlg(hdr.get("alg"))
         kid = hdr.get("kid", "default")
         keyref = await self._keys.get_key(kid, include_secret=True)
         secret = keyref.material or b""
         return jwt.decode(
             token,
             key=secret,
-            algorithms=[alg],
+            algorithms=[alg.value],
             issuer=issuer or self._issuer,
             audience=audience,
             leeway=leeway_s,

--- a/pkgs/standards/swarmauri_tokens_dpopboundjwt/tests/functional/test_rfc9449_dpop_functional.py
+++ b/pkgs/standards/swarmauri_tokens_dpopboundjwt/tests/functional/test_rfc9449_dpop_functional.py
@@ -7,7 +7,13 @@ from uuid import uuid4
 import jwt
 from cryptography.hazmat.primitives.asymmetric import ed25519
 from cryptography.hazmat.primitives import serialization
-from swarmauri_core.crypto.types import ExportPolicy, KeyRef, KeyType, KeyUse
+from swarmauri_core.crypto.types import (
+    ExportPolicy,
+    JWAAlg,
+    KeyRef,
+    KeyType,
+    KeyUse,
+)
 from swarmauri_core.keys.IKeyProvider import IKeyProvider
 
 from swarmauri_tokens_dpopboundjwt import (
@@ -25,7 +31,7 @@ class StaticKeyProvider(IKeyProvider):
         self._secret = secret
 
     def supports(self) -> Dict[str, list[str]]:
-        return {"algs": ["HS256"]}
+        return {"algs": [JWAAlg.HS256.value]}
 
     async def create_key(self, spec):
         raise NotImplementedError
@@ -80,7 +86,7 @@ async def _run_flow() -> bool:
     jwk = {"kty": "OKP", "crv": "Ed25519", "x": _b64u(pub)}
 
     ctx["jwk"] = jwk
-    token = await svc.mint({}, alg="HS256")
+    token = await svc.mint({}, alg=JWAAlg.HS256)
     del ctx["jwk"]
 
     now = int(time.time())

--- a/pkgs/standards/swarmauri_tokens_dpopboundjwt/tests/perf/test_dpop_verify_perf.py
+++ b/pkgs/standards/swarmauri_tokens_dpopboundjwt/tests/perf/test_dpop_verify_perf.py
@@ -8,7 +8,13 @@ import jwt
 import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ed25519
-from swarmauri_core.crypto.types import ExportPolicy, KeyRef, KeyType, KeyUse
+from swarmauri_core.crypto.types import (
+    ExportPolicy,
+    JWAAlg,
+    KeyRef,
+    KeyType,
+    KeyUse,
+)
 from swarmauri_core.keys.IKeyProvider import IKeyProvider
 
 from swarmauri_tokens_dpopboundjwt import DPoPBoundJWTTokenService
@@ -23,7 +29,7 @@ class StaticKeyProvider(IKeyProvider):
         self._secret = secret
 
     def supports(self) -> Dict[str, list[str]]:
-        return {"algs": ["HS256"]}
+        return {"algs": [JWAAlg.HS256.value]}
 
     async def create_key(self, spec):
         raise NotImplementedError
@@ -79,7 +85,7 @@ def test_verify_perf(benchmark) -> None:
     jwk = {"kty": "OKP", "crv": "Ed25519", "x": _b64u(pub)}
 
     ctx["jwk"] = jwk
-    token = asyncio.run(svc.mint({}, alg="HS256"))
+    token = asyncio.run(svc.mint({}, alg=JWAAlg.HS256))
     del ctx["jwk"]
 
     now = int(time.time())

--- a/pkgs/standards/swarmauri_tokens_jwt/README.md
+++ b/pkgs/standards/swarmauri_tokens_jwt/README.md
@@ -20,7 +20,7 @@ from swarmauri_core.keys import (
     KeyRef,
     KeyUse,
 )
-from swarmauri_core.crypto.types import KeyType
+from swarmauri_core.crypto.types import JWAAlg, KeyType
 
 
 class InMemoryKeyProvider(IKeyProvider):
@@ -74,7 +74,7 @@ class InMemoryKeyProvider(IKeyProvider):
 
 async def main() -> None:
     svc = JWTTokenService(InMemoryKeyProvider(), default_issuer="issuer")
-    token = await svc.mint({"sub": "alice"}, alg="HS256", kid="sym")
+    token = await svc.mint({"sub": "alice"}, alg=JWAAlg.HS256, kid="sym")
     claims = await svc.verify(token, issuer="issuer")
     assert claims["sub"] == "alice"
 

--- a/pkgs/standards/swarmauri_tokens_jwt/tests/functional/test_jwttokenservice_functional.py
+++ b/pkgs/standards/swarmauri_tokens_jwt/tests/functional/test_jwttokenservice_functional.py
@@ -2,7 +2,14 @@ import base64
 import pytest
 
 from swarmauri_tokens_jwt import JWTTokenService
-from swarmauri_core.keys import IKeyProvider, KeyRef
+from swarmauri_core.crypto.types import (
+    ExportPolicy,
+    JWAAlg,
+    KeyRef,
+    KeyType,
+    KeyUse,
+)
+from swarmauri_core.keys import IKeyProvider
 
 
 class DummyKeyProvider(IKeyProvider):
@@ -11,21 +18,65 @@ class DummyKeyProvider(IKeyProvider):
         self.kid = "sym"
         self.version = 1
 
+    def supports(self) -> dict[str, list[str]]:
+        return {}
+
+    async def create_key(self, spec):  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def import_key(
+        self, spec, material, *, public=None
+    ):  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def rotate_key(
+        self, kid: str, *, spec_overrides: dict | None = None
+    ):  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def destroy_key(
+        self, kid: str, version: int | None = None
+    ) -> bool:  # pragma: no cover - unused
+        return False
+
     async def get_key(
         self, kid: str, version: int | None = None, *, include_secret: bool = False
     ) -> KeyRef:
         material = self.secret if include_secret else None
-        return KeyRef(kid=self.kid, version=self.version, material=material)
+        return KeyRef(
+            kid=self.kid,
+            version=self.version,
+            type=KeyType.OPAQUE,
+            uses=(KeyUse.SIGN,),
+            export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+            material=material,
+        )
 
     async def jwks(self) -> dict:
         k = base64.urlsafe_b64encode(self.secret).rstrip(b"=").decode()
         return {"keys": [{"kty": "oct", "kid": f"{self.kid}.{self.version}", "k": k}]}
+
+    async def list_versions(self, kid: str):  # pragma: no cover - unused
+        return (1,)
+
+    async def get_public_jwk(
+        self, kid: str, version: int | None = None
+    ) -> dict:  # pragma: no cover - unused
+        return {}
+
+    async def random_bytes(self, n: int) -> bytes:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def hkdf(
+        self, ikm: bytes, *, salt: bytes, info: bytes, length: int
+    ) -> bytes:  # pragma: no cover - unused
+        raise NotImplementedError
 
 
 @pytest.mark.functional
 @pytest.mark.asyncio
 async def test_verify_with_audience() -> None:
     svc = JWTTokenService(DummyKeyProvider(), default_issuer="iss")
-    token = await svc.mint({}, alg="HS256", kid="sym", audience="aud")
+    token = await svc.mint({}, alg=JWAAlg.HS256, kid="sym", audience="aud")
     claims = await svc.verify(token, issuer="iss", audience="aud")
     assert claims["aud"] == "aud"

--- a/pkgs/standards/swarmauri_tokens_jwt/tests/perf/test_jwttokenservice_perf.py
+++ b/pkgs/standards/swarmauri_tokens_jwt/tests/perf/test_jwttokenservice_perf.py
@@ -3,7 +3,14 @@ import base64
 import pytest
 
 from swarmauri_tokens_jwt import JWTTokenService
-from swarmauri_core.keys import IKeyProvider, KeyRef
+from swarmauri_core.crypto.types import (
+    ExportPolicy,
+    JWAAlg,
+    KeyRef,
+    KeyType,
+    KeyUse,
+)
+from swarmauri_core.keys import IKeyProvider
 
 
 class DummyKeyProvider(IKeyProvider):
@@ -12,15 +19,59 @@ class DummyKeyProvider(IKeyProvider):
         self.kid = "sym"
         self.version = 1
 
+    def supports(self) -> dict[str, list[str]]:
+        return {}
+
+    async def create_key(self, spec):  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def import_key(
+        self, spec, material, *, public=None
+    ):  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def rotate_key(
+        self, kid: str, *, spec_overrides: dict | None = None
+    ):  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def destroy_key(
+        self, kid: str, version: int | None = None
+    ) -> bool:  # pragma: no cover - unused
+        return False
+
     async def get_key(
         self, kid: str, version: int | None = None, *, include_secret: bool = False
     ) -> KeyRef:
         material = self.secret if include_secret else None
-        return KeyRef(kid=self.kid, version=self.version, material=material)
+        return KeyRef(
+            kid=self.kid,
+            version=self.version,
+            type=KeyType.OPAQUE,
+            uses=(KeyUse.SIGN,),
+            export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+            material=material,
+        )
 
     async def jwks(self) -> dict:
         k = base64.urlsafe_b64encode(self.secret).rstrip(b"=").decode()
         return {"keys": [{"kty": "oct", "kid": f"{self.kid}.{self.version}", "k": k}]}
+
+    async def list_versions(self, kid: str):  # pragma: no cover - unused
+        return (1,)
+
+    async def get_public_jwk(
+        self, kid: str, version: int | None = None
+    ) -> dict:  # pragma: no cover - unused
+        return {}
+
+    async def random_bytes(self, n: int) -> bytes:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def hkdf(
+        self, ikm: bytes, *, salt: bytes, info: bytes, length: int
+    ) -> bytes:  # pragma: no cover - unused
+        raise NotImplementedError
 
 
 @pytest.mark.perf
@@ -28,7 +79,7 @@ def test_mint_verify_perf(benchmark) -> None:
     svc = JWTTokenService(DummyKeyProvider(), default_issuer="iss")
 
     async def _run() -> None:
-        token = await svc.mint({"msg": "hi"}, alg="HS256", kid="sym")
+        token = await svc.mint({"msg": "hi"}, alg=JWAAlg.HS256, kid="sym")
         await svc.verify(token, issuer="iss")
 
     benchmark(lambda: asyncio.run(_run()))

--- a/pkgs/standards/swarmauri_tokens_jwt/tests/unit/test_jwttokenservice_unit.py
+++ b/pkgs/standards/swarmauri_tokens_jwt/tests/unit/test_jwttokenservice_unit.py
@@ -3,7 +3,14 @@ import base64
 import pytest
 
 from swarmauri_tokens_jwt import JWTTokenService
-from swarmauri_core.keys import IKeyProvider, KeyRef
+from swarmauri_core.crypto.types import (
+    ExportPolicy,
+    JWAAlg,
+    KeyRef,
+    KeyType,
+    KeyUse,
+)
+from swarmauri_core.keys import IKeyProvider
 
 
 class DummyKeyProvider(IKeyProvider):
@@ -12,21 +19,65 @@ class DummyKeyProvider(IKeyProvider):
         self.kid = "sym"
         self.version = 1
 
+    def supports(self) -> dict[str, list[str]]:
+        return {}
+
+    async def create_key(self, spec):  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def import_key(
+        self, spec, material, *, public=None
+    ):  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def rotate_key(
+        self, kid: str, *, spec_overrides: dict | None = None
+    ):  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def destroy_key(
+        self, kid: str, version: int | None = None
+    ) -> bool:  # pragma: no cover - unused
+        return False
+
     async def get_key(
         self, kid: str, version: int | None = None, *, include_secret: bool = False
     ) -> KeyRef:
         material = self.secret if include_secret else None
-        return KeyRef(kid=self.kid, version=self.version, material=material)
+        return KeyRef(
+            kid=self.kid,
+            version=self.version,
+            type=KeyType.OPAQUE,
+            uses=(KeyUse.SIGN,),
+            export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+            material=material,
+        )
 
     async def jwks(self) -> dict:
         k = base64.urlsafe_b64encode(self.secret).rstrip(b"=").decode()
         return {"keys": [{"kty": "oct", "kid": f"{self.kid}.{self.version}", "k": k}]}
+
+    async def list_versions(self, kid: str):  # pragma: no cover - unused
+        return (1,)
+
+    async def get_public_jwk(
+        self, kid: str, version: int | None = None
+    ) -> dict:  # pragma: no cover - unused
+        return {}
+
+    async def random_bytes(self, n: int) -> bytes:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def hkdf(
+        self, ikm: bytes, *, salt: bytes, info: bytes, length: int
+    ) -> bytes:  # pragma: no cover - unused
+        raise NotImplementedError
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_mint_and_verify_roundtrip() -> None:
     svc = JWTTokenService(DummyKeyProvider(), default_issuer="iss")
-    token = await svc.mint({"msg": "hi"}, alg="HS256", kid="sym")
+    token = await svc.mint({"msg": "hi"}, alg=JWAAlg.HS256, kid="sym")
     claims = await svc.verify(token, issuer="iss")
     assert claims["msg"] == "hi"

--- a/pkgs/standards/swarmauri_tokens_jwt/tests/unit/test_rfc7515_jws.py
+++ b/pkgs/standards/swarmauri_tokens_jwt/tests/unit/test_rfc7515_jws.py
@@ -2,7 +2,14 @@ import base64
 import jwt
 import pytest
 from swarmauri_tokens_jwt import JWTTokenService
-from swarmauri_core.keys import IKeyProvider, KeyRef
+from swarmauri_core.crypto.types import (
+    ExportPolicy,
+    JWAAlg,
+    KeyRef,
+    KeyType,
+    KeyUse,
+)
+from swarmauri_core.keys import IKeyProvider
 
 
 class DummyKeyProvider(IKeyProvider):
@@ -11,21 +18,65 @@ class DummyKeyProvider(IKeyProvider):
         self.kid = "sym"
         self.version = 1
 
+    def supports(self) -> dict[str, list[str]]:
+        return {}
+
+    async def create_key(self, spec):  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def import_key(
+        self, spec, material, *, public=None
+    ):  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def rotate_key(
+        self, kid: str, *, spec_overrides: dict | None = None
+    ):  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def destroy_key(
+        self, kid: str, version: int | None = None
+    ) -> bool:  # pragma: no cover - unused
+        return False
+
     async def get_key(
         self, kid: str, version: int | None = None, *, include_secret: bool = False
     ) -> KeyRef:
         material = self.secret if include_secret else None
-        return KeyRef(kid=self.kid, version=self.version, material=material)
+        return KeyRef(
+            kid=self.kid,
+            version=self.version,
+            type=KeyType.OPAQUE,
+            uses=(KeyUse.SIGN,),
+            export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+            material=material,
+        )
 
     async def jwks(self) -> dict:
         k = base64.urlsafe_b64encode(self.secret).rstrip(b"=").decode()
         return {"keys": [{"kty": "oct", "kid": f"{self.kid}.{self.version}", "k": k}]}
+
+    async def list_versions(self, kid: str):  # pragma: no cover - unused
+        return (1,)
+
+    async def get_public_jwk(
+        self, kid: str, version: int | None = None
+    ) -> dict:  # pragma: no cover - unused
+        return {}
+
+    async def random_bytes(self, n: int) -> bytes:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def hkdf(
+        self, ikm: bytes, *, salt: bytes, info: bytes, length: int
+    ) -> bytes:  # pragma: no cover - unused
+        raise NotImplementedError
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_rfc7515_header_alg() -> None:
     svc = JWTTokenService(DummyKeyProvider())
-    token = await svc.mint({}, alg="HS256", kid="sym")
+    token = await svc.mint({}, alg=JWAAlg.HS256, kid="sym")
     header = jwt.get_unverified_header(token)
-    assert header["alg"] == "HS256"
+    assert header["alg"] == JWAAlg.HS256.value

--- a/pkgs/standards/swarmauri_tokens_jwt/tests/unit/test_rfc7517_jwks.py
+++ b/pkgs/standards/swarmauri_tokens_jwt/tests/unit/test_rfc7517_jwks.py
@@ -1,7 +1,13 @@
 import base64
 import pytest
 from swarmauri_tokens_jwt import JWTTokenService
-from swarmauri_core.keys import IKeyProvider, KeyRef
+from swarmauri_core.crypto.types import (
+    ExportPolicy,
+    KeyRef,
+    KeyType,
+    KeyUse,
+)
+from swarmauri_core.keys import IKeyProvider
 
 
 class DummyKeyProvider(IKeyProvider):
@@ -10,15 +16,59 @@ class DummyKeyProvider(IKeyProvider):
         self.kid = "sym"
         self.version = 1
 
+    def supports(self) -> dict[str, list[str]]:
+        return {}
+
+    async def create_key(self, spec):  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def import_key(
+        self, spec, material, *, public=None
+    ):  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def rotate_key(
+        self, kid: str, *, spec_overrides: dict | None = None
+    ):  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def destroy_key(
+        self, kid: str, version: int | None = None
+    ) -> bool:  # pragma: no cover - unused
+        return False
+
     async def get_key(
         self, kid: str, version: int | None = None, *, include_secret: bool = False
     ) -> KeyRef:
         material = self.secret if include_secret else None
-        return KeyRef(kid=self.kid, version=self.version, material=material)
+        return KeyRef(
+            kid=self.kid,
+            version=self.version,
+            type=KeyType.OPAQUE,
+            uses=(KeyUse.SIGN,),
+            export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+            material=material,
+        )
 
     async def jwks(self) -> dict:
         k = base64.urlsafe_b64encode(self.secret).rstrip(b"=").decode()
         return {"keys": [{"kty": "oct", "kid": f"{self.kid}.{self.version}", "k": k}]}
+
+    async def list_versions(self, kid: str):  # pragma: no cover - unused
+        return (1,)
+
+    async def get_public_jwk(
+        self, kid: str, version: int | None = None
+    ) -> dict:  # pragma: no cover - unused
+        return {}
+
+    async def random_bytes(self, n: int) -> bytes:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def hkdf(
+        self, ikm: bytes, *, salt: bytes, info: bytes, length: int
+    ) -> bytes:  # pragma: no cover - unused
+        raise NotImplementedError
 
 
 @pytest.mark.unit

--- a/pkgs/standards/swarmauri_tokens_jwt/tests/unit/test_rfc7519_jwt.py
+++ b/pkgs/standards/swarmauri_tokens_jwt/tests/unit/test_rfc7519_jwt.py
@@ -1,7 +1,14 @@
 import base64
 import pytest
 from swarmauri_tokens_jwt import JWTTokenService
-from swarmauri_core.keys import IKeyProvider, KeyRef
+from swarmauri_core.crypto.types import (
+    ExportPolicy,
+    JWAAlg,
+    KeyRef,
+    KeyType,
+    KeyUse,
+)
+from swarmauri_core.keys import IKeyProvider
 
 
 class DummyKeyProvider(IKeyProvider):
@@ -10,22 +17,66 @@ class DummyKeyProvider(IKeyProvider):
         self.kid = "sym"
         self.version = 1
 
+    def supports(self) -> dict[str, list[str]]:
+        return {}
+
+    async def create_key(self, spec):  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def import_key(
+        self, spec, material, *, public=None
+    ):  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def rotate_key(
+        self, kid: str, *, spec_overrides: dict | None = None
+    ):  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def destroy_key(
+        self, kid: str, version: int | None = None
+    ) -> bool:  # pragma: no cover - unused
+        return False
+
     async def get_key(
         self, kid: str, version: int | None = None, *, include_secret: bool = False
     ) -> KeyRef:
         material = self.secret if include_secret else None
-        return KeyRef(kid=self.kid, version=self.version, material=material)
+        return KeyRef(
+            kid=self.kid,
+            version=self.version,
+            type=KeyType.OPAQUE,
+            uses=(KeyUse.SIGN,),
+            export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+            material=material,
+        )
 
     async def jwks(self) -> dict:
         k = base64.urlsafe_b64encode(self.secret).rstrip(b"=").decode()
         return {"keys": [{"kty": "oct", "kid": f"{self.kid}.{self.version}", "k": k}]}
+
+    async def list_versions(self, kid: str):  # pragma: no cover - unused
+        return (1,)
+
+    async def get_public_jwk(
+        self, kid: str, version: int | None = None
+    ) -> dict:  # pragma: no cover - unused
+        return {}
+
+    async def random_bytes(self, n: int) -> bytes:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def hkdf(
+        self, ikm: bytes, *, salt: bytes, info: bytes, length: int
+    ) -> bytes:  # pragma: no cover - unused
+        raise NotImplementedError
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_rfc7519_claims_present() -> None:
     svc = JWTTokenService(DummyKeyProvider())
-    token = await svc.mint({}, alg="HS256", kid="sym")
+    token = await svc.mint({}, alg=JWAAlg.HS256, kid="sym")
     claims = await svc.verify(token)
     for field in ("iat", "nbf", "exp"):
         assert field in claims

--- a/pkgs/standards/swarmauri_tokens_jwt/tests/unit/test_usage_example.py
+++ b/pkgs/standards/swarmauri_tokens_jwt/tests/unit/test_usage_example.py
@@ -3,6 +3,7 @@ import base64
 import pytest
 
 from swarmauri_tokens_jwt import JWTTokenService
+from swarmauri_core.crypto.types import JWAAlg, KeyType
 from swarmauri_core.keys import (
     ExportPolicy,
     IKeyProvider,
@@ -10,7 +11,6 @@ from swarmauri_core.keys import (
     KeySpec,
     KeyUse,
 )
-from swarmauri_core.crypto.types import KeyType
 
 
 class InMemoryKeyProvider(IKeyProvider):
@@ -81,6 +81,6 @@ class InMemoryKeyProvider(IKeyProvider):
 @pytest.mark.asyncio
 async def test_usage_mint_and_verify() -> None:
     svc = JWTTokenService(InMemoryKeyProvider(), default_issuer="issuer")
-    token = await svc.mint({"sub": "alice"}, alg="HS256", kid="sym")
+    token = await svc.mint({"sub": "alice"}, alg=JWAAlg.HS256, kid="sym")
     claims = await svc.verify(token, issuer="issuer")
     assert claims["sub"] == "alice"


### PR DESCRIPTION
## Summary
- adopt `JWAAlg` enum in JWTTokenService for algorithm selection
- require `JWAAlg` throughout DPoP-bound JWT services
- document and test enum-based usage

## Testing
- `uv run --package swarmauri_tokens_jwt --directory standards/swarmauri_tokens_jwt ruff format .`
- `uv run --package swarmauri_tokens_jwt --directory standards/swarmauri_tokens_jwt ruff check . --fix`
- `uv run --package swarmauri_tokens_dpopboundjwt --directory standards/swarmauri_tokens_dpopboundjwt ruff format .`
- `uv run --package swarmauri_tokens_dpopboundjwt --directory standards/swarmauri_tokens_dpopboundjwt ruff check . --fix`
- `uv run --package swarmauri_tokens_jwt --directory standards/swarmauri_tokens_jwt pytest`
- `uv run --package swarmauri_tokens_dpopboundjwt --directory standards/swarmauri_tokens_dpopboundjwt pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac2c617c608326bbde461daece41eb