### PR TITLE
Add RFC 9396 compliance tests for auto_authn

### DIFF
--- a/pkgs/standards/auto_authn/tests/unit/test_rfc9396.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc9396.py
@@ -1,0 +1,44 @@
+"""Tests for OAuth 2.0 Rich Authorization Requests (RFC 9396)."""
+
+import pytest
+
+from auto_authn.v2.routers import auth_flows
+
+
+@pytest.mark.unit
+@pytest.mark.xfail(reason="OAuth 2.0 RAR (RFC 9396) support is planned")
+def test_authorization_request_includes_authorization_details():
+    """Authorization requests can include authorization_details."""
+    request_data = {
+        "authorization_details": [
+            {
+                "type": "payment",
+                "locations": ["https://api.example.com/payments"],
+                "actions": ["initiate", "status"],
+            }
+        ]
+    }
+
+    response = auth_flows.handle_authorization_request(request_data)
+
+    assert response["authorization_details"] == request_data["authorization_details"]
+
+
+@pytest.mark.unit
+@pytest.mark.xfail(reason="OAuth 2.0 RAR (RFC 9396) support is planned")
+def test_token_response_includes_authorization_details():
+    """Token responses echo authorization_details."""
+    token_request = {
+        "authorization_details": [
+            {
+                "type": "payment",
+            }
+        ]
+    }
+
+    token_response = auth_flows.issue_token(token_request)
+
+    assert (
+        token_response["authorization_details"]
+        == token_request["authorization_details"]
+    )


### PR DESCRIPTION
## Summary
- add xfail unit tests for OAuth 2.0 Rich Authorization Requests (RFC 9396) in auto_authn

## Testing
- `uv run --package auto_authn --directory pkgs/standards/auto_authn ruff format .`
- `uv run --package auto_authn --directory pkgs/standards/auto_authn ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68ac10d8f56c83268af88b05776c48a0