### PR TITLE
feat(auto_authn): add RFC9396 authorization_details support

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
@@ -5,9 +5,12 @@ from .pkce import (
     create_code_verifier,
     verify_code_challenge,
 )
+from .rfc9396 import AuthorizationDetail, parse_authorization_details
 
 __all__ = [
     "create_code_verifier",
     "create_code_challenge",
     "verify_code_challenge",
+    "parse_authorization_details",
+    "AuthorizationDetail",
 ]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc9396.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc9396.py
@@ -1,0 +1,64 @@
+"""Utilities for OAuth 2.0 Rich Authorization Requests (RFC 9396).
+
+This module parses and validates the ``authorization_details`` request
+parameter as defined by RFC 9396 section 2. Support for this feature can be
+toggled via the ``ENABLE_RFC9396`` environment variable
+(``settings.enable_rfc9396``).
+"""
+
+from __future__ import annotations
+
+from typing import Any, List
+import json
+
+from pydantic import BaseModel, ValidationError
+
+from .runtime_cfg import settings
+
+
+class AuthorizationDetail(BaseModel):
+    """Minimal representation of an authorization detail item."""
+
+    type: str
+
+
+def parse_authorization_details(raw: str) -> List[AuthorizationDetail]:
+    """Parse the RFC 9396 ``authorization_details`` parameter.
+
+    Parameters
+    ----------
+    raw:
+        A JSON string containing either a single authorization detail object
+        or an array of such objects.
+
+    Returns
+    -------
+    list[AuthorizationDetail]
+        The parsed authorization details.
+
+    Raises
+    ------
+    NotImplementedError
+        If RFC 9396 support is disabled via runtime settings.
+    ValueError
+        If the input is not valid JSON or does not conform to the minimal
+        requirements of RFC 9396.
+    """
+
+    if not settings.enable_rfc9396:
+        raise NotImplementedError("authorization_details not enabled")
+
+    try:
+        data: Any = json.loads(raw)
+    except json.JSONDecodeError as exc:  # pragma: no cover - invalid JSON
+        raise ValueError("authorization_details must be valid JSON") from exc
+
+    if isinstance(data, dict):
+        data = [data]
+    if not isinstance(data, list):
+        raise ValueError("authorization_details must be an object or array")
+
+    try:
+        return [AuthorizationDetail.model_validate(item) for item in data]
+    except ValidationError as exc:
+        raise ValueError("invalid authorization_details") from exc

--- a/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
@@ -63,6 +63,7 @@ class Settings(BaseSettings):
     # ─────── Other global settings ───────
     jwt_secret: str = Field(os.environ.get("JWT_SECRET", "insecure-dev-secret"))
     log_level: str = Field(os.environ.get("LOG_LEVEL", "INFO"))
+    enable_rfc9396: bool = Field(default=os.environ.get("ENABLE_RFC9396", "0") == "1")
 
     model_config = SettingsConfigDict(env_file=None)
 

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc9396_authorization_details.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc9396_authorization_details.py
@@ -1,0 +1,39 @@
+"""Tests for RFC 9396 Rich Authorization Requests.
+
+Excerpt from RFC 9396 §2:
+
+    The request parameter authorization_details contains, in JSON notation,
+    an array of objects. Each JSON object contains the data to specify the
+    authorization requirements for a certain type of resource. The type
+    field is REQUIRED.
+
+These tests ensure that our parser follows the above requirements and can be
+conditionally enabled or disabled via runtime configuration.
+"""
+
+import pytest
+
+from auto_authn.v2 import parse_authorization_details
+from auto_authn.v2 import AuthorizationDetail
+from auto_authn.v2.runtime_cfg import settings
+
+
+def test_parse_authorization_details_enabled(monkeypatch):
+    monkeypatch.setattr(settings, "enable_rfc9396", True)
+    details = parse_authorization_details(
+        '{"type": "payment_initiation", "actions": ["initiate"]}'
+    )
+    assert isinstance(details[0], AuthorizationDetail)
+    assert details[0].type == "payment_initiation"
+
+
+def test_parse_authorization_details_missing_type(monkeypatch):
+    monkeypatch.setattr(settings, "enable_rfc9396", True)
+    with pytest.raises(ValueError):
+        parse_authorization_details('{"actions": ["initiate"]}')
+
+
+def test_parse_authorization_details_disabled(monkeypatch):
+    monkeypatch.setattr(settings, "enable_rfc9396", False)
+    with pytest.raises(NotImplementedError):
+        parse_authorization_details('{"type": "payment_initiation"}')


### PR DESCRIPTION
## Summary
- add RFC9396 parser and feature flag to auto_authn
- expose new authorization_details utilities
- cover RFC9396 behavior with unit tests referencing spec

## Testing
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff format .`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68ac2f976b108326a7bc35a01db91d48