### PR TITLE
refactor: apply JWA enum to JWS signer

### DIFF
--- a/pkgs/standards/swarmauri_signing_jws/tests/functional/test_jws_functional.py
+++ b/pkgs/standards/swarmauri_signing_jws/tests/functional/test_jws_functional.py
@@ -3,6 +3,7 @@ import base64
 import json
 
 from swarmauri_signing_jws import JwsSignerVerifier
+from swarmauri_core.crypto.types import JWAAlg
 
 
 async def _run() -> bool:
@@ -13,14 +14,14 @@ async def _run() -> bool:
     general = await jws.sign_general_json(
         payload=payload,
         signatures=[
-            ("HS256", key1, None, None),
-            ("HS512", key2, None, None),
+            (JWAAlg.HS256, key1, None, None),
+            (JWAAlg.HS512, key2, None, None),
         ],
     )
     accepted, out_payload = await jws.verify_general_json(
         general,
         hmac_keys=[key1, key2],
-        require_any=["HS256", "HS512"],
+        require_any=[JWAAlg.HS256, JWAAlg.HS512],
         min_signers=2,
     )
     tampered = dict(general)
@@ -35,7 +36,7 @@ async def _run() -> bool:
     bad_accepted, _ = await jws.verify_general_json(
         tampered,
         hmac_keys=[key1, key2],
-        require_any=["HS256", "HS512"],
+        require_any=[JWAAlg.HS256, JWAAlg.HS512],
         min_signers=2,
     )
     return accepted == 2 and out_payload == b'{"msg":"func"}' and bad_accepted == 0

--- a/pkgs/standards/swarmauri_signing_jws/tests/perf/test_jws_perf.py
+++ b/pkgs/standards/swarmauri_signing_jws/tests/perf/test_jws_perf.py
@@ -2,6 +2,7 @@ import asyncio
 import pytest
 
 from swarmauri_signing_jws import JwsSignerVerifier
+from swarmauri_core.crypto.types import JWAAlg
 
 
 @pytest.mark.perf
@@ -11,6 +12,6 @@ def test_sign_compact_perf(benchmark) -> None:
     payload = {"msg": "perf"}
 
     async def _sign() -> None:
-        await jws.sign_compact(payload=payload, alg="HS256", key=key)
+        await jws.sign_compact(payload=payload, alg=JWAAlg.HS256, key=key)
 
     benchmark(lambda: asyncio.run(_sign()))

--- a/pkgs/standards/swarmauri_signing_jws/tests/unit/test_jws_unit.py
+++ b/pkgs/standards/swarmauri_signing_jws/tests/unit/test_jws_unit.py
@@ -1,12 +1,13 @@
 import asyncio
 
 from swarmauri_signing_jws import JwsSignerVerifier
+from swarmauri_core.crypto.types import JWAAlg
 
 
 async def _sign_and_verify() -> bool:
     jws = JwsSignerVerifier()
     key = {"kind": "raw", "key": "secret"}
-    token = await jws.sign_compact(payload={"msg": "unit"}, alg="HS256", key=key)
+    token = await jws.sign_compact(payload={"msg": "unit"}, alg=JWAAlg.HS256, key=key)
     res = await jws.verify_compact(token, hmac_keys=[key])
     return res.payload == b'{"msg":"unit"}'
 


### PR DESCRIPTION
## Summary
- refactor JWS signer to use JWAAlg enum for RFC7518 compliance
- update signing tests to use the JWAAlg enumeration

## Testing
- `uv run --package swarmauri_signing_jws --directory standards/swarmauri_signing_jws ruff format .`
- `uv run --package swarmauri_signing_jws --directory standards/swarmauri_signing_jws ruff check . --fix`
- `uv run --package swarmauri_signing_jws --directory standards/swarmauri_signing_jws pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac3cc4e80083269025effb117edc01