### PR TITLE
feat(auto_authn): add optional RFC7636 PKCE support

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
@@ -1,6 +1,6 @@
 """auto_authn.v2 – OAuth utilities and helpers."""
 
-from .pkce import (
+from .rfc7636_pkce import (
     create_code_challenge,
     create_code_verifier,
     verify_code_challenge,

--- a/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
@@ -70,6 +70,11 @@ class Settings(BaseSettings):
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC8705", "false").lower()
         in {"1", "true", "yes"}
     )
+    enable_rfc7636: bool = Field(
+        default=os.environ.get("AUTO_AUTHN_ENABLE_RFC7636", "true").lower()
+        in {"1", "true", "yes"},
+        description="Enable Proof Key for Code Exchange per RFC 7636",
+    )
     enforce_rfc8252: bool = Field(
         default=True,
         description="Validate redirect URIs according to RFC 8252",

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7636_pkce.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7636_pkce.py
@@ -1,6 +1,6 @@
-"""Tests for OAuth 2.0 for Native Apps (RFC 8252) PKCE requirements.
+"""Tests for Proof Key for Code Exchange (RFC 7636).
 
-RFC excerpt (RFC 8252 §7.3 and RFC 7636 §4.1):
+RFC excerpt (RFC 7636 §4.1):
 
 Native apps MUST use the Proof Key for Code Exchange (PKCE [RFC7636])
 extension to OAuth 2.0 when using the authorization code grant.
@@ -17,6 +17,7 @@ from auto_authn.v2 import (
     create_code_verifier,
     verify_code_challenge,
 )
+import auto_authn.v2.rfc7636_pkce as pkce_mod
 
 
 @pytest.mark.unit
@@ -53,3 +54,18 @@ def test_invalid_verifier_rejected():
 
     with pytest.raises(ValueError):
         create_code_challenge("short")
+
+
+@pytest.mark.unit
+def test_verify_code_challenge_rejects_invalid():
+    """verify_code_challenge returns False for invalid verifier."""
+
+    assert not verify_code_challenge("short", "bad")
+
+
+@pytest.mark.unit
+def test_verification_skipped_when_disabled(monkeypatch):
+    """When RFC 7636 is disabled, verification returns True regardless."""
+
+    monkeypatch.setattr(pkce_mod.settings, "enable_rfc7636", False)
+    assert pkce_mod.verify_code_challenge("short", "bad")


### PR DESCRIPTION
## Summary
- add runtime flag to enable or disable PKCE verification for RFC 7636
- move PKCE helpers into rfc7636_pkce module and respect new setting
- add RFC 7636-focused test cases including toggle behavior

## Testing
- `uv run --directory standards/auto_authn --package auto_authn ruff format .`
- `uv run --directory standards/auto_authn --package auto_authn ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68ac3cd731e883268f43073a99eb4b74