### PR TITLE
feat: add RFC 7009 token revocation support

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7009.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7009.py
@@ -1,0 +1,28 @@
+"""Utilities for OAuth 2.0 Token Revocation (RFC 7009).
+
+This module provides a simple in-memory registry for revoked tokens to
+illustrate compliance with RFC 7009. The registry can be toggled on or off
+via the ``enable_rfc7009`` setting in ``runtime_cfg.Settings``.
+"""
+
+from __future__ import annotations
+
+from typing import Set
+
+# In-memory set storing revoked tokens for demonstration and testing purposes
+_REVOKED_TOKENS: Set[str] = set()
+
+
+def revoke_token(token: str) -> None:
+    """Revoke *token* by adding it to the registry."""
+    _REVOKED_TOKENS.add(token)
+
+
+def is_revoked(token: str) -> bool:
+    """Return ``True`` if *token* has been revoked."""
+    return token in _REVOKED_TOKENS
+
+
+def reset_revocations() -> None:
+    """Clear the revocation registry. Intended for test setup/teardown."""
+    _REVOKED_TOKENS.clear()

--- a/pkgs/standards/auto_authn/auto_authn/v2/routers/auth_flows.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/routers/auth_flows.py
@@ -39,8 +39,8 @@ from ..fastapi_deps import get_async_db
 from ..orm.tables import Tenant, User
 from ..runtime_cfg import settings
 from ..typing import StrUUID
-from ..runtime_cfg import settings
 from ..rfc8707 import extract_resource
+from ..rfc7009 import revoke_token
 from autoapi.v2.error import IntegrityError
 
 router = APIRouter()
@@ -318,3 +318,14 @@ async def introspect(token: str = Form(...), db: AsyncSession = Depends(get_asyn
         tid=str(principal.tenant_id),
         kind=kind,
     )
+
+
+# --------------------------------------------------------------------------
+#  RFC 7009 token revocation
+# --------------------------------------------------------------------------
+@router.post("/revoke")
+async def revoke(token: str = Form(...), token_type_hint: str | None = Form(None)):
+    if not settings.enable_rfc7009:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "revocation disabled")
+    revoke_token(token)
+    return {}

--- a/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
@@ -82,6 +82,10 @@ class Settings(BaseSettings):
         default=os.environ.get("AUTO_AUTHN_ENABLE_DPOP", "0") in {"1", "true", "True"}
     )
     enable_rfc9396: bool = Field(default=os.environ.get("ENABLE_RFC9396", "0") == "1")
+    enable_rfc7009: bool = Field(
+        default=os.environ.get("AUTO_AUTHN_ENABLE_RFC7009", "false").lower()
+        in {"1", "true", "yes"}
+    )
 
     model_config = SettingsConfigDict(env_file=None)
 

--- a/pkgs/standards/auto_authn/tests/conftest.py
+++ b/pkgs/standards/auto_authn/tests/conftest.py
@@ -105,6 +105,22 @@ def enable_rfc7662():
 
 
 @pytest.fixture
+def enable_rfc7009():
+    """Enable RFC 7009 token revocation for tests."""
+    from auto_authn.v2.runtime_cfg import settings
+    from auto_authn.v2.rfc7009 import reset_revocations
+
+    original = settings.enable_rfc7009
+    settings.enable_rfc7009 = True
+    reset_revocations()
+    try:
+        yield
+    finally:
+        settings.enable_rfc7009 = original
+        reset_revocations()
+
+
+@pytest.fixture
 def temp_key_file():
     """Create a temporary JWT key file path for testing (file doesn't exist initially)."""
     # Create a temp file path but don't create the file

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7009_token_revocation.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7009_token_revocation.py
@@ -1,0 +1,55 @@
+"""Tests for OAuth 2.0 Token Revocation compliance with RFC 7009."""
+
+import pytest
+from fastapi import FastAPI, status
+from httpx import ASGITransport, AsyncClient
+
+from auto_authn.v2.routers.auth_flows import router
+from auto_authn.v2.fastapi_deps import get_async_db
+from auto_authn.v2.rfc7009 import is_revoked
+
+# RFC 7009 specification excerpt for reference within tests
+RFC7009_SPEC = """
+RFC 7009 - OAuth 2.0 Token Revocation
+
+2.2. Revocation Response
+   The authorization server responds with HTTP status code 200
+   in all cases, even if the token is invalid.
+"""
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_revoke_returns_200_and_marks_token_revoked(enable_rfc7009, monkeypatch):
+    """RFC 7009 §2.2: Revocation returns HTTP 200 and token becomes invalid."""
+    app = FastAPI()
+    app.include_router(router)
+
+    async def override_db():
+        yield None
+
+    app.dependency_overrides[get_async_db] = override_db
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/revoke", data={"token": "abc"})
+    assert resp.status_code == status.HTTP_200_OK
+    assert is_revoked("abc")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_revoke_returns_200_for_unknown_token(enable_rfc7009):
+    """RFC 7009 §2.2: Endpoint must return HTTP 200 even for unknown tokens."""
+    app = FastAPI()
+    app.include_router(router)
+
+    async def override_db():
+        yield None
+
+    app.dependency_overrides[get_async_db] = override_db
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/revoke", data={"token": "nonexistent"})
+    assert resp.status_code == status.HTTP_200_OK


### PR DESCRIPTION
## Summary
- add RFC 7009 token revocation module and optional FastAPI endpoint
- expose `enable_rfc7009` runtime setting for toggling revocation feature
- test token revocation behavior against RFC 7009 requirements

## Testing
- `uv run --directory standards/auto_authn --package auto_authn ruff format . && uv run --directory standards/auto_authn --package auto_authn ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68ac3cdd2a14832685f513b131c158e2