### PR TITLE
Add RFC 7662 token introspection utilities

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
@@ -6,6 +6,7 @@ from .rfc7636_pkce import (
     verify_code_challenge,
 )
 from .rfc9396 import AuthorizationDetail, parse_authorization_details
+from .rfc7662 import introspect_token, register_token, reset_tokens
 
 __all__ = [
     "create_code_verifier",
@@ -13,4 +14,7 @@ __all__ = [
     "verify_code_challenge",
     "parse_authorization_details",
     "AuthorizationDetail",
+    "introspect_token",
+    "register_token",
+    "reset_tokens",
 ]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7662.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7662.py
@@ -1,0 +1,44 @@
+"""Utilities for OAuth 2.0 Token Introspection (RFC 7662).
+
+This module provides a simple in-memory registry for token introspection to
+illustrate compliance with RFC 7662. The registry can be toggled on or off via
+the ``enable_rfc7662`` setting in ``runtime_cfg.Settings``.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Any
+
+from .runtime_cfg import settings
+
+# In-memory store mapping tokens to their introspection responses
+_ACTIVE_TOKENS: Dict[str, Dict[str, Any]] = {}
+
+
+def register_token(token: str, claims: Dict[str, Any] | None = None) -> None:
+    """Register *token* as active with optional introspection *claims*."""
+    data: Dict[str, Any] = {"active": True}
+    if claims:
+        data.update(claims)
+    _ACTIVE_TOKENS[token] = data
+
+
+def introspect_token(token: str) -> Dict[str, Any]:
+    """Return the RFC 7662 introspection response for *token*.
+
+    Raises
+    ------
+    RuntimeError
+        If RFC 7662 support is disabled via settings.
+    """
+    if not settings.enable_rfc7662:
+        raise RuntimeError("RFC 7662 support is disabled")
+    return _ACTIVE_TOKENS.get(token, {"active": False})
+
+
+def reset_tokens() -> None:
+    """Clear the introspection registry. Intended for tests."""
+    _ACTIVE_TOKENS.clear()
+
+
+__all__ = ["register_token", "introspect_token", "reset_tokens"]

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7662_unit.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7662_unit.py
@@ -1,0 +1,35 @@
+"""Tests for OAuth 2.0 Token Introspection (RFC 7662)."""
+
+import pytest
+
+from auto_authn.v2 import rfc7662
+from auto_authn.v2.runtime_cfg import settings
+
+RFC_7662 = "RFC 7662"
+
+
+def setup_function() -> None:
+    rfc7662.reset_tokens()
+
+
+def test_introspect_active_token(monkeypatch):
+    """RFC 7662 requires active tokens to return claims including active=True."""
+    monkeypatch.setattr(settings, "enable_rfc7662", True)
+    rfc7662.register_token("tok123", {"sub": "alice"})
+    result = rfc7662.introspect_token("tok123")
+    assert result["active"] is True
+    assert result["sub"] == "alice"
+
+
+def test_introspect_inactive_token(monkeypatch):
+    """RFC 7662 mandates inactive tokens return only active=False."""
+    monkeypatch.setattr(settings, "enable_rfc7662", True)
+    result = rfc7662.introspect_token("missing")
+    assert result == {"active": False}
+
+
+def test_introspection_disabled(monkeypatch):
+    """The feature can be toggled off via settings.enable_rfc7662."""
+    monkeypatch.setattr(settings, "enable_rfc7662", False)
+    with pytest.raises(RuntimeError):
+        rfc7662.introspect_token("tok123")


### PR DESCRIPTION
## Summary
- add in-memory RFC 7662 token introspection module
- expose introspection helpers via auto_authn.v2
- verify behavior with RFC 7662 unit tests

## Testing
- `uv run --package auto_authn --directory standards/auto_authn ruff format .`
- `uv run --package auto_authn --directory standards/auto_authn ruff check . --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest` *(fails: KeyError in other tests)*
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc7662_unit.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac3ee068a883268099eb8249c6d5fa