### PR TITLE
feat(auto_authn): add RFC 6749 validation toggle

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
@@ -6,6 +6,7 @@ from .rfc7636_pkce import (
     verify_code_challenge,
 )
 from .rfc9396 import AuthorizationDetail, parse_authorization_details
+from .rfc6749 import RFC6749ComplianceError, validate_token_request
 
 __all__ = [
     "create_code_verifier",
@@ -13,4 +14,6 @@ __all__ = [
     "verify_code_challenge",
     "parse_authorization_details",
     "AuthorizationDetail",
+    "validate_token_request",
+    "RFC6749ComplianceError",
 ]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc6749.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc6749.py
@@ -1,0 +1,33 @@
+"""Minimal helpers for OAuth 2.0 Authorization Framework (RFC 6749).
+
+This module offers basic validation for token requests and can be toggled via
+``settings.enable_rfc6749`` in :mod:`runtime_cfg`.
+"""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+from .runtime_cfg import settings
+
+
+class RFC6749ComplianceError(ValueError):
+    """Raised when a request violates RFC 6749 requirements."""
+
+
+def validate_token_request(data: Mapping[str, str]) -> None:
+    """Validate *data* representing a token request per RFC 6749.
+
+    Checks for the presence of ``grant_type`` and ``client_id`` parameters as
+    outlined in RFC 6749 Sections 4 and 2.3.1. Validation occurs only when
+    ``settings.enable_rfc6749`` is ``True``.
+    """
+    if not settings.enable_rfc6749:
+        return
+
+    if "grant_type" not in data:
+        raise RFC6749ComplianceError("'grant_type' is required per RFC 6749 section 4")
+    if "client_id" not in data:
+        raise RFC6749ComplianceError(
+            "'client_id' is required per RFC 6749 section 2.3.1"
+        )

--- a/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
@@ -91,6 +91,11 @@ class Settings(BaseSettings):
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC7009", "false").lower()
         in {"1", "true", "yes"}
     )
+    enable_rfc6749: bool = Field(
+        default=os.environ.get("AUTO_AUTHN_ENABLE_RFC6749", "false").lower()
+        in {"1", "true", "yes"},
+        description="Enable core OAuth 2.0 validation per RFC 6749",
+    )
 
     model_config = SettingsConfigDict(env_file=None)
 

--- a/pkgs/standards/auto_authn/tests/conftest.py
+++ b/pkgs/standards/auto_authn/tests/conftest.py
@@ -121,6 +121,19 @@ def enable_rfc7009():
 
 
 @pytest.fixture
+def enable_rfc6749():
+    """Enable RFC 6749 core validation for tests."""
+    from auto_authn.v2.runtime_cfg import settings
+
+    original = settings.enable_rfc6749
+    settings.enable_rfc6749 = True
+    try:
+        yield
+    finally:
+        settings.enable_rfc6749 = original
+
+
+@pytest.fixture
 def temp_key_file():
     """Create a temporary JWT key file path for testing (file doesn't exist initially)."""
     # Create a temp file path but don't create the file

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc6749.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc6749.py
@@ -1,0 +1,31 @@
+"""Tests for OAuth 2.0 core compliance (RFC 6749).
+
+These tests verify that the optional RFC 6749 feature enforces required token
+request parameters when enabled.
+"""
+
+import pytest
+
+from auto_authn.v2 import RFC6749ComplianceError, validate_token_request
+from auto_authn.v2.runtime_cfg import settings
+
+RFC6749_URL = "https://www.rfc-editor.org/rfc/rfc6749"
+
+
+def test_token_request_validation_enforced(enable_rfc6749):
+    """RFC 6749 requires ``grant_type`` and ``client_id`` in token requests."""
+    with pytest.raises(RFC6749ComplianceError):
+        validate_token_request({"client_id": "abc"})
+    with pytest.raises(RFC6749ComplianceError):
+        validate_token_request({"grant_type": "authorization_code"})
+
+
+def test_token_request_validation_disabled():
+    """Validation is skipped when RFC 6749 enforcement is disabled."""
+    original = settings.enable_rfc6749
+    settings.enable_rfc6749 = False
+    try:
+        validate_token_request({"client_id": "abc"})
+        validate_token_request({"grant_type": "authorization_code"})
+    finally:
+        settings.enable_rfc6749 = original


### PR DESCRIPTION
## Summary
- add runtime flag to enable RFC 6749 OAuth2 core validation
- provide token request validator enforcing grant_type and client_id
- test optional RFC 6749 validation behavior

## Testing
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff format .`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68ac3eb15e5883269560834c4e1cda73