### PR TITLE
feat(auto_authn): add RFC 6750 bearer token extraction

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
@@ -6,6 +6,7 @@ from .rfc7636_pkce import (
     verify_code_challenge,
 )
 from .rfc9396 import AuthorizationDetail, parse_authorization_details
+from .rfc6750 import extract_bearer_token
 
 __all__ = [
     "create_code_verifier",
@@ -13,4 +14,5 @@ __all__ = [
     "verify_code_challenge",
     "parse_authorization_details",
     "AuthorizationDetail",
+    "extract_bearer_token",
 ]

--- a/pkgs/standards/auto_authn/auto_authn/v2/fastapi_deps.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/fastapi_deps.py
@@ -34,6 +34,7 @@ from .crypto import public_key, signing_key
 from .runtime_cfg import settings
 from .rfc9449_dpop import verify_proof
 from .principal_ctx import principal_var
+from .rfc6750 import extract_bearer_token
 
 
 # ---------------------------------------------------------------------
@@ -124,8 +125,8 @@ async def get_current_principal(  # type: ignore[override]
         if user := await _user_from_api_key(api_key, db):
             return user
 
-    if authorization.startswith("Bearer "):
-        token = authorization.split()[1]
+    token = await extract_bearer_token(request, authorization)
+    if token:
         if settings.enable_dpop:
             if not dpop:
                 raise HTTPException(

--- a/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
@@ -91,6 +91,18 @@ class Settings(BaseSettings):
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC7009", "false").lower()
         in {"1", "true", "yes"}
     )
+    enable_rfc6750_query: bool = Field(
+        default=os.environ.get("AUTO_AUTHN_ENABLE_RFC6750_QUERY", "false").lower()
+        in {"1", "true", "yes"},
+        description="Allow access_token as URI query parameter per RFC 6750 §2.3",
+    )
+    enable_rfc6750_form: bool = Field(
+        default=os.environ.get("AUTO_AUTHN_ENABLE_RFC6750_FORM", "false").lower()
+        in {"1", "true", "yes"},
+        description=(
+            "Allow access_token in application/x-www-form-urlencoded bodies per RFC 6750 §2.2"
+        ),
+    )
 
     model_config = SettingsConfigDict(env_file=None)
 


### PR DESCRIPTION
## Summary
- add RFC 6750 helper with configurable query and form token extraction
- wire FastAPI deps to use RFC 6750 helper
- test bearer token usage from header, query, and form bodies

## Testing
- `uv run --package auto_authn --directory standards/auto_authn ruff format .`
- `uv run --package auto_authn --directory standards/auto_authn ruff check . --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc6750_bearer_token.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac3ec1ae9c8326baf6e30ed048d9ea