### PR TITLE
Add modular RFC6749 enforcement to auto_authn

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc6749.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc6749.py
@@ -1,13 +1,27 @@
 """Utilities for core OAuth 2.0 Authorization Framework (RFC 6749).
 
 This module provides helpers for validating token endpoint requests according
- to RFC 6749 Section 5.2. Validation can be toggled on or off via the
- ``enable_rfc6749`` setting in ``runtime_cfg.Settings``.
+to RFC 6749 Section 5.2. Validation can be toggled on or off via the
+``enable_rfc6749`` setting in :mod:`runtime_cfg`.
+
+The public ``enforce_*`` helpers automatically respect the runtime flag making
+RFC 6749 enforcement modular.
 """
 
 from __future__ import annotations
 
 from typing import Iterable, Mapping
+
+from .runtime_cfg import settings
+
+__all__ = [
+    "RFC6749Error",
+    "validate_grant_type",
+    "validate_password_grant",
+    "is_enabled",
+    "enforce_grant_type",
+    "enforce_password_grant",
+]
 
 
 class RFC6749Error(ValueError):
@@ -34,3 +48,25 @@ def validate_password_grant(form: Mapping[str, str]) -> None:
     """
     if "username" not in form or "password" not in form:
         raise RFC6749Error("invalid_request")
+
+
+def is_enabled() -> bool:
+    """Return ``True`` if RFC 6749 enforcement is active."""
+
+    return settings.enable_rfc6749
+
+
+def enforce_grant_type(grant_type: str | None, allowed: Iterable[str]) -> None:
+    """Validate ``grant_type`` only when RFC 6749 enforcement is enabled."""
+
+    if not is_enabled():
+        return
+    validate_grant_type(grant_type, allowed)
+
+
+def enforce_password_grant(form: Mapping[str, str]) -> None:
+    """Validate password grant requirements when enforcement is enabled."""
+
+    if not is_enabled():
+        return
+    validate_password_grant(form)

--- a/pkgs/standards/auto_authn/auto_authn/v2/routers/auth_flows.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/routers/auth_flows.py
@@ -42,7 +42,12 @@ from ..runtime_cfg import settings
 from ..typing import StrUUID
 from ..rfc8707 import extract_resource
 from ..rfc7009 import revoke_token
-from ..rfc6749 import RFC6749Error, validate_grant_type, validate_password_grant
+from ..rfc6749 import (
+    RFC6749Error,
+    enforce_grant_type,
+    enforce_password_grant,
+    is_enabled as rfc6749_enabled,
+)
 from autoapi.v2.error import IntegrityError
 
 router = APIRouter()
@@ -232,13 +237,12 @@ async def token(
     data.pop("resource", None)
     grant_type = data.get("grant_type")
     aud = None
-    if settings.enable_rfc6749:
-        try:
-            validate_grant_type(grant_type, _ALLOWED_GRANT_TYPES)
-        except RFC6749Error as exc:
-            return JSONResponse(
-                {"error": str(exc)}, status_code=status.HTTP_400_BAD_REQUEST
-            )
+    try:
+        enforce_grant_type(grant_type, _ALLOWED_GRANT_TYPES)
+    except RFC6749Error as exc:
+        return JSONResponse(
+            {"error": str(exc)}, status_code=status.HTTP_400_BAD_REQUEST
+        )
     if settings.rfc8707_enabled:
         try:
             aud = extract_resource(resources)
@@ -247,13 +251,12 @@ async def token(
                 {"error": "invalid_target"}, status_code=status.HTTP_400_BAD_REQUEST
             )
     if grant_type == "password":
-        if settings.enable_rfc6749:
-            try:
-                validate_password_grant(data)
-            except RFC6749Error as exc:
-                return JSONResponse(
-                    {"error": str(exc)}, status_code=status.HTTP_400_BAD_REQUEST
-                )
+        try:
+            enforce_password_grant(data)
+        except RFC6749Error as exc:
+            return JSONResponse(
+                {"error": str(exc)}, status_code=status.HTTP_400_BAD_REQUEST
+            )
         try:
             parsed = PasswordGrantForm(**data)
         except ValidationError as exc:
@@ -290,7 +293,7 @@ async def token(
         )
         _DEVICE_CODES.pop(parsed.device_code, None)
         return TokenPair(access_token=access, refresh_token=refresh)
-    if settings.enable_rfc6749:
+    if rfc6749_enabled():
         return JSONResponse(
             {"error": "unsupported_grant_type"},
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
@@ -95,6 +95,7 @@ class Settings(BaseSettings):
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC8414", "true").lower()
         in {"1", "true", "yes"},
         description="Enable OAuth 2.0 Authorization Server Metadata per RFC 8414",
+    )
     enable_rfc6750_query: bool = Field(
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC6750_QUERY", "false").lower()
         in {"1", "true", "yes"},
@@ -106,6 +107,7 @@ class Settings(BaseSettings):
         description=(
             "Allow access_token in application/x-www-form-urlencoded bodies per RFC 6750 §2.2"
         ),
+    )
     enable_rfc6749: bool = Field(
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC6749", "true").lower()
         in {"1", "true", "yes"},

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc6749_validators.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc6749_validators.py
@@ -1,0 +1,50 @@
+"""Unit tests for RFC 6749 validation helpers."""
+
+import pytest
+
+from auto_authn.v2.rfc6749 import (
+    RFC6749Error,
+    enforce_grant_type,
+    enforce_password_grant,
+)
+from auto_authn.v2.runtime_cfg import settings
+
+
+@pytest.fixture()
+def toggle_rfc6749():
+    original = settings.enable_rfc6749
+    settings.enable_rfc6749 = True
+    try:
+        yield
+    finally:
+        settings.enable_rfc6749 = original
+
+
+@pytest.mark.unit
+def test_enforce_grant_type_validates_when_enabled(toggle_rfc6749):
+    """RFC 6749 §5.2 requires ``grant_type`` presence and support."""
+    with pytest.raises(RFC6749Error):
+        enforce_grant_type(None, {"password"})
+    with pytest.raises(RFC6749Error):
+        enforce_grant_type("client_credentials", {"password"})
+
+
+@pytest.mark.unit
+def test_enforce_password_grant_requires_credentials(toggle_rfc6749):
+    """RFC 6749 §4.3 mandates ``username`` and ``password``."""
+    with pytest.raises(RFC6749Error):
+        enforce_password_grant({"username": "user"})
+    with pytest.raises(RFC6749Error):
+        enforce_password_grant({"password": "pass"})
+
+
+@pytest.mark.unit
+def test_enforcement_noop_when_disabled():
+    """Validation helpers are skipped when RFC 6749 enforcement is disabled."""
+    original = settings.enable_rfc6749
+    settings.enable_rfc6749 = False
+    try:
+        enforce_grant_type(None, {"password"})
+        enforce_password_grant({})
+    finally:
+        settings.enable_rfc6749 = original


### PR DESCRIPTION
## Summary
- centralize RFC 6749 validation with toggle-aware helper functions
- enforce RFC 6749 rules in token endpoint
- add tests for RFC 6749 grant and password validation helpers

## Testing
- ❌ `uv run --package auto_authn --directory standards/auto_authn pytest`
- ✅ `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc6749_token_endpoint.py tests/unit/test_rfc6749_validators.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac41964c2c8326bdc25cba7c3dad3b