### PR TITLE
feat: make RFC 6750 support optional

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc6750.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc6750.py
@@ -1,9 +1,10 @@
 """Helpers for OAuth 2.0 Bearer Token Usage (RFC 6750).
 
 This module extracts bearer tokens from HTTP requests according to
-:rfc:`6750`. Support for providing the token in the URI query parameter or the
-request body can be toggled via settings to allow deployments to opt out of
-these optional, and potentially insecure, mechanisms.
+:rfc:`6750`. Support can be disabled entirely via ``settings.enable_rfc6750``.
+Optional mechanisms for supplying the token in the URI query parameter or the
+request body can also be toggled via settings to allow deployments to opt out
+of these potentially insecure features.
 """
 
 from __future__ import annotations
@@ -19,11 +20,15 @@ async def extract_bearer_token(request: Request, authorization: str) -> str | No
     The function follows the extraction rules from RFC 6750:
 
     - The ``Authorization`` header uses a case-insensitive ``Bearer`` scheme.
+    - Extraction occurs only when ``settings.enable_rfc6750`` is ``True``.
     - If ``settings.enable_rfc6750_query`` is ``True`` an ``access_token``
       parameter in the URI query is accepted.
     - If ``settings.enable_rfc6750_form`` is ``True`` an ``access_token``
       field in an ``application/x-www-form-urlencoded`` body is accepted.
     """
+
+    if not settings.enable_rfc6750:
+        return None
 
     parts = authorization.split()
     if len(parts) == 2 and parts[0].lower() == "bearer":

--- a/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
@@ -95,6 +95,12 @@ class Settings(BaseSettings):
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC8414", "true").lower()
         in {"1", "true", "yes"},
         description="Enable OAuth 2.0 Authorization Server Metadata per RFC 8414",
+    )
+    enable_rfc6750: bool = Field(
+        default=os.environ.get("AUTO_AUTHN_ENABLE_RFC6750", "true").lower()
+        in {"1", "true", "yes"},
+        description="Enable Bearer Token Usage per RFC 6750",
+    )
     enable_rfc6750_query: bool = Field(
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC6750_QUERY", "false").lower()
         in {"1", "true", "yes"},
@@ -106,6 +112,7 @@ class Settings(BaseSettings):
         description=(
             "Allow access_token in application/x-www-form-urlencoded bodies per RFC 6750 §2.2"
         ),
+    )
     enable_rfc6749: bool = Field(
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC6749", "true").lower()
         in {"1", "true", "yes"},


### PR DESCRIPTION
## Summary
- make RFC 6750 bearer token usage togglable via `enable_rfc6750`
- document and guard token extraction behind new feature flag
- expand RFC 6750 unit tests to cover feature toggle

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc6750_bearer_token.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac4199fb188326958a33ce97814258