### PR TITLE
feat(auto_authn): add modular PKCE verification

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7636_pkce.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7636_pkce.py
@@ -53,14 +53,19 @@ def create_code_challenge(verifier: str) -> str:
     return base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
 
 
-def verify_code_challenge(verifier: str, challenge: str) -> bool:
+def verify_code_challenge(
+    verifier: str, challenge: str, *, enabled: bool | None = None
+) -> bool:
     """Return ``True`` if *challenge* matches *verifier* using ``S256``.
 
-    When ``settings.enable_rfc7636`` is ``False`` the check is skipped and
-    ``True`` is returned to allow clients that do not implement PKCE.
+    The check may be toggled by passing ``enabled`` or globally via the
+    ``AUTO_AUTHN_ENABLE_RFC7636`` environment variable. When disabled the
+    function returns ``True`` to allow non-PKCE clients.
     """
 
-    if not settings.enable_rfc7636:
+    if enabled is None:
+        enabled = settings.enable_rfc7636
+    if not enabled:
         return True
     try:
         expected = create_code_challenge(verifier)

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7636_pkce.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7636_pkce.py
@@ -49,6 +49,15 @@ def test_verify_code_challenge_round_trip():
 
 
 @pytest.mark.unit
+def test_verify_code_challenge_mismatch_fails():
+    """Mismatched challenge fails when RFC 7636 is enabled."""
+
+    verifier = create_code_verifier()
+    other = create_code_challenge(create_code_verifier())
+    assert not verify_code_challenge(verifier, other)
+
+
+@pytest.mark.unit
 def test_invalid_verifier_rejected():
     """Invalid verifier raises ValueError."""
 
@@ -69,3 +78,11 @@ def test_verification_skipped_when_disabled(monkeypatch):
 
     monkeypatch.setattr(pkce_mod.settings, "enable_rfc7636", False)
     assert pkce_mod.verify_code_challenge("short", "bad")
+
+
+@pytest.mark.unit
+def test_verification_skipped_with_param(monkeypatch):
+    """Passing ``enabled=False`` bypasses verification."""
+
+    monkeypatch.setattr(pkce_mod.settings, "enable_rfc7636", True)
+    assert pkce_mod.verify_code_challenge("short", "bad", enabled=False)


### PR DESCRIPTION
## Summary
- allow PKCE verification to be toggled per call
- expand RFC7636 test coverage for mismatched challenges and explicit disable flag

## Testing
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff format .` *(failed: Failed to parse auto_authn/v2/runtime_cfg.py:98:5)*
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff format auto_authn/v2/rfc7636_pkce.py tests/unit/test_rfc7636_pkce.py`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check . --fix` *(failed: invalid syntax in runtime_cfg.py)*
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check auto_authn/v2/rfc7636_pkce.py tests/unit/test_rfc7636_pkce.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_68ac41a37c588326a30de26a5a6398aa