### PR TITLE
feat(auto_authn): add RFC 8628 device flow support

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
@@ -5,6 +5,7 @@ from .rfc7636_pkce import (
     create_code_verifier,
     verify_code_challenge,
 )
+from .rfc8628 import generate_device_code, generate_user_code, validate_user_code
 from .rfc9396 import AuthorizationDetail, parse_authorization_details
 from .rfc6750 import extract_bearer_token
 from .rfc7662 import introspect_token, register_token, reset_tokens
@@ -13,6 +14,9 @@ __all__ = [
     "create_code_verifier",
     "create_code_challenge",
     "verify_code_challenge",
+    "generate_user_code",
+    "validate_user_code",
+    "generate_device_code",
     "parse_authorization_details",
     "AuthorizationDetail",
     "extract_bearer_token",

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8628.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8628.py
@@ -1,0 +1,57 @@
+"""Device Authorization Grant helpers for RFC 8628 compliance.
+
+This module implements utility helpers for the OAuth 2.0 Device Authorization
+Grant as defined in :rfc:`8628`.  It provides functions for generating and
+validating ``user_code`` values as well as creating high-entropy
+``device_code`` strings.  The validation helpers may be disabled via runtime
+configuration allowing deployments to opt-out of RFC 8628 enforcement.
+"""
+
+from __future__ import annotations
+
+import re
+import secrets
+import string
+from typing import Final
+
+from .runtime_cfg import settings
+
+# Character set for user_code per RFC 8628 §6.1 (uppercase letters and digits)
+_USER_CODE_CHARSET: Final = string.ascii_uppercase + string.digits
+_USER_CODE_RE: Final = re.compile(r"^[A-Z0-9]{8}$")
+
+
+def generate_user_code(length: int = 8) -> str:
+    """Return a user_code suitable for RFC 8628 §6.1.
+
+    ``length`` defaults to the minimum 8 characters recommended by the spec
+    and must be positive.  The resulting code uses only uppercase letters and
+    digits for ease of transcription.
+    """
+
+    if length <= 0:
+        raise ValueError("length must be positive")
+    return "".join(secrets.choice(_USER_CODE_CHARSET) for _ in range(length))
+
+
+def validate_user_code(code: str) -> bool:
+    """Return ``True`` if *code* conforms to RFC 8628 §6.1.
+
+    When ``settings.enable_rfc8628`` is ``False`` the check is skipped and
+    ``True`` is returned to allow clients that do not implement the Device
+    Authorization Grant.
+    """
+
+    if not settings.enable_rfc8628:
+        return True
+    return bool(_USER_CODE_RE.fullmatch(code))
+
+
+def generate_device_code() -> str:
+    """Return a high-entropy ``device_code`` per RFC 8628 §6.3."""
+
+    # 32 bytes of randomness yields a 43-character URL-safe string
+    return secrets.token_urlsafe(32)
+
+
+__all__ = ["generate_user_code", "validate_user_code", "generate_device_code"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
@@ -95,6 +95,7 @@ class Settings(BaseSettings):
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC8414", "true").lower()
         in {"1", "true", "yes"},
         description="Enable OAuth 2.0 Authorization Server Metadata per RFC 8414",
+    )
     enable_rfc6750_query: bool = Field(
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC6750_QUERY", "false").lower()
         in {"1", "true", "yes"},
@@ -106,10 +107,16 @@ class Settings(BaseSettings):
         description=(
             "Allow access_token in application/x-www-form-urlencoded bodies per RFC 6750 §2.2"
         ),
+    )
     enable_rfc6749: bool = Field(
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC6749", "true").lower()
         in {"1", "true", "yes"},
         description="Enforce core OAuth 2.0 error handling per RFC 6749",
+    )
+    enable_rfc8628: bool = Field(
+        default=os.environ.get("AUTO_AUTHN_ENABLE_RFC8628", "true").lower()
+        in {"1", "true", "yes"},
+        description="Enable Device Authorization Grant per RFC 8628",
     )
 
     model_config = SettingsConfigDict(env_file=None)

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc8628.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc8628.py
@@ -1,0 +1,56 @@
+"""Tests for OAuth 2.0 Device Authorization Grant (RFC 8628).
+
+RFC excerpt (RFC 8628 §6.1):
+
+The client SHOULD generate a user code that is easy to read and type and
+that is at least 8 characters long and consists of upper-case letters and
+digits.
+"""
+
+import pytest
+
+from auto_authn.v2 import generate_device_code, generate_user_code, validate_user_code
+import auto_authn.v2.rfc8628 as rfc8628_mod
+
+
+@pytest.mark.unit
+def test_generate_user_code_matches_rfc8628_requirements():
+    """Generated user_code satisfies RFC 8628 §6.1."""
+
+    code = generate_user_code()
+    assert len(code) == 8
+    assert code.isupper() and code.isalnum()
+
+
+@pytest.mark.unit
+def test_validate_user_code_accepts_valid():
+    """validate_user_code returns True for valid codes."""
+
+    code = "ABC12345"
+    assert validate_user_code(code)
+
+
+@pytest.mark.unit
+def test_validate_user_code_rejects_invalid():
+    """Invalid user_code values are rejected when enabled."""
+
+    assert not validate_user_code("bad-code")
+    assert not validate_user_code("SHORT")
+
+
+@pytest.mark.unit
+def test_validation_skipped_when_disabled(monkeypatch):
+    """When RFC 8628 is disabled validation always passes."""
+
+    monkeypatch.setattr(rfc8628_mod.settings, "enable_rfc8628", False)
+    assert validate_user_code("bad-code")
+
+
+@pytest.mark.unit
+def test_generate_device_code_characteristics():
+    """Generated device_code is URL-safe and sufficiently long."""
+
+    code = generate_device_code()
+    assert len(code) >= 43
+    allowed = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+    assert all(ch in allowed for ch in code)


### PR DESCRIPTION
## Summary
- add helpers for RFC 8628 device authorization grant
- expose user and device code utilities and runtime toggle
- cover device flow helpers with RFC-based tests

## Testing
- `uv run --directory standards/auto_authn --package auto_authn ruff format .`
- `uv run --directory standards/auto_authn --package auto_authn ruff check . --fix`
- `uv run --directory standards/auto_authn --package auto_authn pytest` *(skipped: per user instruction)*

------
https://chatgpt.com/codex/tasks/task_e_68ac41b0322c832698e4cfc72ae39cec