### PR TITLE
feat(auto_authn): add RFC 9101 JAR support

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc9101.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc9101.py
@@ -1,0 +1,48 @@
+"""Utilities for JWT-Secured Authorization Request (RFC 9101).
+
+This module provides helpers to encode and decode authorization request
+parameters as JSON Web Tokens (JWT) per RFC 9101 \u00a72.1. The feature can be
+turned on or off using ``settings.enable_rfc9101``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable
+
+import jwt
+
+from .runtime_cfg import settings
+
+
+def create_request_object(
+    params: Dict[str, Any], *, secret: str, algorithm: str = "HS256"
+) -> str:
+    """Return a JWT request object representing ``params``.
+
+    Raises
+    ------
+    RuntimeError
+        If RFC 9101 support is disabled via ``settings.enable_rfc9101``.
+    """
+    if not settings.enable_rfc9101:
+        raise RuntimeError("RFC 9101 support disabled")
+    return jwt.encode(params, secret, algorithm=algorithm)
+
+
+def parse_request_object(
+    token: str, *, secret: str, algorithms: Iterable[str] | None = None
+) -> Dict[str, Any]:
+    """Decode ``token`` into authorization request parameters.
+
+    Raises
+    ------
+    RuntimeError
+        If RFC 9101 support is disabled via ``settings.enable_rfc9101``.
+    """
+    if not settings.enable_rfc9101:
+        raise RuntimeError("RFC 9101 support disabled")
+    algs = list(algorithms) if algorithms is not None else ["HS256"]
+    return jwt.decode(token, secret, algorithms=algs)
+
+
+__all__ = ["create_request_object", "parse_request_object"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
@@ -87,6 +87,11 @@ class Settings(BaseSettings):
         default=os.environ.get("AUTO_AUTHN_ENABLE_DPOP", "0") in {"1", "true", "True"}
     )
     enable_rfc9396: bool = Field(default=os.environ.get("ENABLE_RFC9396", "0") == "1")
+    enable_rfc9101: bool = Field(
+        default=os.environ.get("AUTO_AUTHN_ENABLE_RFC9101", "false").lower()
+        in {"1", "true", "yes"},
+        description="Enable JWT-Secured Authorization Request per RFC 9101",
+    )
     enable_rfc7009: bool = Field(
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC7009", "false").lower()
         in {"1", "true", "yes"}
@@ -95,6 +100,7 @@ class Settings(BaseSettings):
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC8414", "true").lower()
         in {"1", "true", "yes"},
         description="Enable OAuth 2.0 Authorization Server Metadata per RFC 8414",
+    )
     enable_rfc6750_query: bool = Field(
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC6750_QUERY", "false").lower()
         in {"1", "true", "yes"},
@@ -106,6 +112,7 @@ class Settings(BaseSettings):
         description=(
             "Allow access_token in application/x-www-form-urlencoded bodies per RFC 6750 §2.2"
         ),
+    )
     enable_rfc6749: bool = Field(
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC6749", "true").lower()
         in {"1", "true", "yes"},

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc9101_jwt_secured_authorization_request.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc9101_jwt_secured_authorization_request.py
@@ -1,0 +1,29 @@
+"""Tests for JWT-Secured Authorization Request (RFC 9101).
+
+RFC 9101 \u00a72.1 allows OAuth 2.0 authorization requests to be encoded as
+JWTs. These tests verify that request parameters round-trip through the
+helpers when the feature is enabled and that usage is rejected when the
+feature is disabled.
+"""
+
+import pytest
+
+from auto_authn.v2 import runtime_cfg, rfc9101
+
+
+@pytest.mark.unit
+def test_jwt_request_round_trip(monkeypatch):
+    """RFC 9101 \u00a72.1 round-trips parameters through a Request Object."""
+    monkeypatch.setattr(runtime_cfg.settings, "enable_rfc9101", True)
+    params = {"client_id": "abc", "scope": "read", "response_type": "code"}
+    token = rfc9101.create_request_object(params, secret="secret")
+    decoded = rfc9101.parse_request_object(token, secret="secret")
+    assert decoded == params
+
+
+@pytest.mark.unit
+def test_feature_toggle_disabled(monkeypatch):
+    """When disabled, helpers raise a runtime error."""
+    monkeypatch.setattr(runtime_cfg.settings, "enable_rfc9101", False)
+    with pytest.raises(RuntimeError):
+        rfc9101.create_request_object({"client_id": "abc"}, secret="secret")


### PR DESCRIPTION
## Summary
- add helpers for JWT-Secured Authorization Request (RFC 9101)
- expose feature toggle for RFC 9101 in runtime config
- cover RFC 9101 behavior with unit tests

## Testing
- `uv run --directory . --package auto_authn ruff format .`
- `uv run --directory . --package auto_authn ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68ac41bdd9ac8326b06a604153360d95