### PR TITLE
feat(auto_authn): add RFC 9126 PAR support

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
@@ -8,6 +8,7 @@ from .rfc7636_pkce import (
 from .rfc9396 import AuthorizationDetail, parse_authorization_details
 from .rfc6750 import extract_bearer_token
 from .rfc7662 import introspect_token, register_token, reset_tokens
+from .rfc9126 import store_par_request, get_par_request, reset_par_store
 
 __all__ = [
     "create_code_verifier",
@@ -19,4 +20,7 @@ __all__ = [
     "introspect_token",
     "register_token",
     "reset_tokens",
+    "store_par_request",
+    "get_par_request",
+    "reset_par_store",
 ]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc9126.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc9126.py
@@ -1,0 +1,58 @@
+"""Pushed Authorization Requests support (RFC 9126).
+
+This module implements a minimal in-memory store for OAuth 2.0 Pushed
+Authorization Requests (PAR) as defined in RFC 9126. The feature can be
+enabled or disabled via ``settings.enable_rfc9126`` in
+``runtime_cfg.Settings``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta
+from typing import Dict, Tuple, Any
+
+# In-memory storage mapping request_uri -> (params, expiry)
+_PAR_STORE: Dict[str, Tuple[Dict[str, Any], datetime]] = {}
+
+DEFAULT_PAR_EXPIRY = 90  # seconds
+
+
+def store_par_request(
+    params: Dict[str, Any], expires_in: int = DEFAULT_PAR_EXPIRY
+) -> str:
+    """Store *params* and return a unique ``request_uri``.
+
+    Parameters expire after *expires_in* seconds.
+    """
+    request_uri = f"urn:ietf:params:oauth:request_uri:{uuid.uuid4()}"
+    _PAR_STORE[request_uri] = (
+        params,
+        datetime.utcnow() + timedelta(seconds=expires_in),
+    )
+    return request_uri
+
+
+def get_par_request(request_uri: str) -> Dict[str, Any] | None:
+    """Retrieve parameters for *request_uri* if present and not expired."""
+    record = _PAR_STORE.get(request_uri)
+    if not record:
+        return None
+    params, expiry = record
+    if datetime.utcnow() > expiry:
+        del _PAR_STORE[request_uri]
+        return None
+    return params
+
+
+def reset_par_store() -> None:
+    """Clear stored pushed authorization requests (test helper)."""
+    _PAR_STORE.clear()
+
+
+__all__ = [
+    "store_par_request",
+    "get_par_request",
+    "reset_par_store",
+    "DEFAULT_PAR_EXPIRY",
+]

--- a/pkgs/standards/auto_authn/auto_authn/v2/routers/auth_flows.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/routers/auth_flows.py
@@ -43,6 +43,7 @@ from ..typing import StrUUID
 from ..rfc8707 import extract_resource
 from ..rfc7009 import revoke_token
 from ..rfc6749 import RFC6749Error, validate_grant_type, validate_password_grant
+from ..rfc9126 import store_par_request, DEFAULT_PAR_EXPIRY
 from autoapi.v2.error import IntegrityError
 
 router = APIRouter()
@@ -325,6 +326,18 @@ async def refresh(body: RefreshIn):
     except Exception:
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, "invalid refresh token")
     return TokenPair(access_token=access, refresh_token=refresh)
+
+
+# --------------------------------------------------------------------------
+#  RFC 9126 pushed authorization requests
+# --------------------------------------------------------------------------
+@router.post("/par", status_code=status.HTTP_201_CREATED)
+async def pushed_authorization_request(request: Request):
+    if not settings.enable_rfc9126:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "PAR disabled")
+    form = await request.form()
+    request_uri = store_par_request(dict(form))
+    return {"request_uri": request_uri, "expires_in": DEFAULT_PAR_EXPIRY}
 
 
 # --------------------------------------------------------------------------

--- a/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
@@ -95,6 +95,12 @@ class Settings(BaseSettings):
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC8414", "true").lower()
         in {"1", "true", "yes"},
         description="Enable OAuth 2.0 Authorization Server Metadata per RFC 8414",
+    )
+    enable_rfc9126: bool = Field(
+        default=os.environ.get("AUTO_AUTHN_ENABLE_RFC9126", "false").lower()
+        in {"1", "true", "yes"},
+        description="Enable Pushed Authorization Requests per RFC 9126",
+    )
     enable_rfc6750_query: bool = Field(
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC6750_QUERY", "false").lower()
         in {"1", "true", "yes"},
@@ -106,6 +112,7 @@ class Settings(BaseSettings):
         description=(
             "Allow access_token in application/x-www-form-urlencoded bodies per RFC 6750 §2.2"
         ),
+    )
     enable_rfc6749: bool = Field(
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC6749", "true").lower()
         in {"1", "true", "yes"},

--- a/pkgs/standards/auto_authn/tests/conftest.py
+++ b/pkgs/standards/auto_authn/tests/conftest.py
@@ -134,6 +134,22 @@ def enable_rfc8414():
 
 
 @pytest.fixture
+def enable_rfc9126():
+    """Enable RFC 9126 pushed authorization requests for tests."""
+    from auto_authn.v2.runtime_cfg import settings
+    from auto_authn.v2.rfc9126 import reset_par_store
+
+    original = settings.enable_rfc9126
+    settings.enable_rfc9126 = True
+    reset_par_store()
+    try:
+        yield
+    finally:
+        settings.enable_rfc9126 = original
+        reset_par_store()
+
+
+@pytest.fixture
 def temp_key_file():
     """Create a temporary JWT key file path for testing (file doesn't exist initially)."""
     # Create a temp file path but don't create the file

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc9126_pushed_authorization_requests.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc9126_pushed_authorization_requests.py
@@ -1,0 +1,66 @@
+"""Tests for OAuth 2.0 Pushed Authorization Requests compliance with RFC 9126."""
+
+import pytest
+from fastapi import FastAPI, status
+from httpx import ASGITransport, AsyncClient
+
+from auto_authn.v2.routers.auth_flows import router
+from auto_authn.v2.fastapi_deps import get_async_db
+from auto_authn.v2.rfc9126 import DEFAULT_PAR_EXPIRY
+
+# RFC 9126 specification excerpt for reference within tests
+RFC9126_SPEC = """
+RFC 9126 - OAuth 2.0 Pushed Authorization Requests
+
+3.1. Pushed Authorization Request Endpoint
+   Successful responses MUST include a "request_uri" and "expires_in" value
+   and use HTTP status code 201 (Created).
+"""
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_par_returns_request_uri_and_expires(enable_rfc9126, monkeypatch):
+    """RFC 9126 §3.1: Response includes request_uri and expires_in."""
+    app = FastAPI()
+    app.include_router(router)
+
+    async def override_db():
+        yield None
+
+    app.dependency_overrides[get_async_db] = override_db
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/par", data={"client_id": "abc", "response_type": "code"}
+        )
+    assert resp.status_code == status.HTTP_201_CREATED
+    body = resp.json()
+    assert "request_uri" in body
+    assert body["expires_in"] == DEFAULT_PAR_EXPIRY
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_par_disabled_returns_404(monkeypatch):
+    """RFC 9126 §3.1: Endpoint returns 404 when PAR is disabled."""
+    from auto_authn.v2.runtime_cfg import settings
+
+    app = FastAPI()
+    app.include_router(router)
+
+    async def override_db():
+        yield None
+
+    app.dependency_overrides[get_async_db] = override_db
+
+    original = settings.enable_rfc9126
+    settings.enable_rfc9126 = False
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post("/par", data={})
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+    finally:
+        settings.enable_rfc9126 = original


### PR DESCRIPTION
## Summary
- add runtime config flag for RFC 9126 Pushed Authorization Requests
- implement minimal PAR store and /par endpoint
- cover RFC 9126 behaviour with unit tests

## Testing
- `uv run --directory . --package auto_authn ruff format .`
- `uv run --directory . --package auto_authn ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68ac41c2fcdc832687aa144bf737f99f