### PR TITLE
feat(auto_authn): add rfc9207 issuer identification support

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
@@ -13,11 +13,12 @@ from .rfc8628 import generate_device_code, generate_user_code, validate_user_cod
 from .rfc9396 import AuthorizationDetail, parse_authorization_details
 from .rfc6750 import extract_bearer_token
 from .rfc7662 import introspect_token, register_token, reset_tokens
-from .rfc9207 import extract_issuer
+from .rfc9207 import RFC9207_SPEC_URL, extract_issuer
 from .rfc9126 import store_par_request, get_par_request, reset_par_store
 from .rfc8707 import extract_resource, RFC8707_SPEC_URL
 from .rfc8705 import thumbprint_from_cert_pem, validate_certificate_binding
 from .rfc8252 import is_native_redirect_uri, validate_native_redirect_uri
+
 __all__ = [
     "create_code_verifier",
     "create_code_challenge",
@@ -31,6 +32,7 @@ __all__ = [
     "extract_issuer",
     "extract_resource",
     "RFC8707_SPEC_URL",
+    "RFC9207_SPEC_URL",
     "introspect_token",
     "register_token",
     "reset_tokens",

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc9207.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc9207.py
@@ -11,6 +11,8 @@ from typing import Mapping
 
 from .runtime_cfg import settings
 
+RFC9207_SPEC_URL = "https://www.rfc-editor.org/rfc/rfc9207"
+
 
 def extract_issuer(params: Mapping[str, str], expected_issuer: str) -> str:
     """Return the issuer identifier from ``params`` after validation.
@@ -31,4 +33,4 @@ def extract_issuer(params: Mapping[str, str], expected_issuer: str) -> str:
     return issuer
 
 
-__all__ = ["extract_issuer"]
+__all__ = ["extract_issuer", "RFC9207_SPEC_URL"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
@@ -102,10 +102,12 @@ class Settings(BaseSettings):
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC9207", "false").lower()
         in {"1", "true", "yes"},
         description="Enable Authorization Server Issuer Identification per RFC 9207",
+    )
     enable_rfc9126: bool = Field(
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC9126", "false").lower()
         in {"1", "true", "yes"},
         description="Enable Pushed Authorization Requests per RFC 9126",
+    )
     enable_rfc6750: bool = Field(
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC6750", "true").lower()
         in {"1", "true", "yes"},

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc9207_issuer_identification.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc9207_issuer_identification.py
@@ -13,7 +13,7 @@ validate the stated requirements.
 
 import pytest
 
-from auto_authn.v2 import extract_issuer
+from auto_authn.v2 import RFC9207_SPEC_URL, extract_issuer
 from auto_authn.v2.runtime_cfg import settings
 
 
@@ -33,10 +33,22 @@ def test_extract_issuer_mismatch(monkeypatch):
 
 
 @pytest.mark.unit
+def test_extract_issuer_missing(monkeypatch):
+    monkeypatch.setattr(settings, "enable_rfc9207", True)
+    with pytest.raises(ValueError):
+        extract_issuer({}, "https://as.example.com")
+
+
+@pytest.mark.unit
 def test_extract_issuer_disabled(monkeypatch):
     monkeypatch.setattr(settings, "enable_rfc9207", False)
     with pytest.raises(NotImplementedError):
         extract_issuer({"iss": "https://as.example.com"}, "https://as.example.com")
+
+
+@pytest.mark.unit
+def test_spec_url_constant():
+    assert RFC9207_SPEC_URL == "https://www.rfc-editor.org/rfc/rfc9207"
 
 
 # RFC 9207 full specification text appended for reference


### PR DESCRIPTION
## Summary
- add RFC 9207 spec URL constant and expose issuer validation helper
- fix runtime config enabling of RFC 9207 feature toggle
- extend RFC 9207 issuer identification tests with missing parameter case

## Testing
- `uv run --package auto_authn --directory standards/auto_authn ruff format .`
- `uv run --package auto_authn --directory standards/auto_authn ruff check . --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc9207_issuer_identification.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac46c8355c83269ddeb0f351a4b5a1