### PR TITLE
Add modular JOSE RFC utilities and tests for auto_authn

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
@@ -18,6 +18,13 @@ from .rfc9126 import store_par_request, get_par_request, reset_par_store
 from .rfc8707 import extract_resource, RFC8707_SPEC_URL
 from .rfc8705 import thumbprint_from_cert_pem, validate_certificate_binding
 from .rfc8252 import is_native_redirect_uri, validate_native_redirect_uri
+from .rfc7515 import sign_jws, verify_jws
+from .rfc7516 import encrypt_jwe, decrypt_jwe
+from .rfc7517 import load_signing_jwk, load_public_jwk
+from .rfc7518 import supported_algorithms
+from .rfc7519 import encode_jwt, decode_jwt
+from .rfc7520 import jws_then_jwe, jwe_then_jws
+
 __all__ = [
     "create_code_verifier",
     "create_code_challenge",
@@ -41,4 +48,15 @@ __all__ = [
     "validate_certificate_binding",
     "is_native_redirect_uri",
     "validate_native_redirect_uri",
+    "sign_jws",
+    "verify_jws",
+    "encrypt_jwe",
+    "decrypt_jwe",
+    "load_signing_jwk",
+    "load_public_jwk",
+    "supported_algorithms",
+    "encode_jwt",
+    "decode_jwt",
+    "jws_then_jwe",
+    "jwe_then_jws",
 ]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7515.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7515.py
@@ -1,0 +1,39 @@
+"""RFC 7515 - JSON Web Signature (JWS).
+
+This module provides thin wrappers around :mod:`jwcrypto.jws` to create and
+verify JWS objects. Functionality can be toggled via the
+``AUTO_AUTHN_ENABLE_RFC7515`` environment variable.
+"""
+
+from jwcrypto import jws, jwk
+
+from .runtime_cfg import settings
+
+
+def sign_jws(payload: str, key: jwk.JWK) -> str:
+    """Return a JWS compact serialization of *payload* using *key*."""
+    if not settings.enable_rfc7515:
+        raise RuntimeError("RFC 7515 support disabled")
+    token = jws.JWS(payload.encode())
+    token.add_signature(key, None, json_encode({"alg": "EdDSA"}))
+    return token.serialize()
+
+
+def verify_jws(token: str, key: jwk.JWK) -> str:
+    """Verify *token* and return the decoded payload as a string."""
+    if not settings.enable_rfc7515:
+        raise RuntimeError("RFC 7515 support disabled")
+    obj = jws.JWS()
+    obj.deserialize(token)
+    obj.verify(key)
+    return obj.payload.decode()
+
+
+def json_encode(data: dict) -> str:
+    """Minimal JSON encoder to avoid pulling in ``json`` at import time."""
+    import json
+
+    return json.dumps(data)
+
+
+__all__ = ["sign_jws", "verify_jws"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7516.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7516.py
@@ -1,0 +1,39 @@
+"""RFC 7516 - JSON Web Encryption (JWE).
+
+Helpers for encrypting and decrypting content using the compact JWE
+serialization. This feature can be toggled with the
+``AUTO_AUTHN_ENABLE_RFC7516`` environment variable.
+"""
+
+from jwcrypto import jwe, jwk
+
+from .runtime_cfg import settings
+
+
+def encrypt_jwe(plaintext: str, key: jwk.JWK) -> str:
+    """Encrypt *plaintext* for *key* and return the compact JWE string."""
+    if not settings.enable_rfc7516:
+        raise RuntimeError("RFC 7516 support disabled")
+    protected = {"alg": "dir", "enc": "A256GCM"}
+    token = jwe.JWE(plaintext.encode(), json_encode(protected))
+    token.add_recipient(key)
+    return token.serialize()
+
+
+def decrypt_jwe(token: str, key: jwk.JWK) -> str:
+    """Decrypt *token* with *key* and return the plaintext string."""
+    if not settings.enable_rfc7516:
+        raise RuntimeError("RFC 7516 support disabled")
+    obj = jwe.JWE()
+    obj.deserialize(token)
+    obj.decrypt(key)
+    return obj.payload.decode()
+
+
+def json_encode(data: dict) -> str:
+    import json
+
+    return json.dumps(data)
+
+
+__all__ = ["encrypt_jwe", "decrypt_jwe"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7517.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7517.py
@@ -1,0 +1,27 @@
+"""RFC 7517 - JSON Web Key (JWK).
+
+Utility helpers for exporting the service's Ed25519 key pair as JWKs. These
+helpers respect the ``AUTO_AUTHN_ENABLE_RFC7517`` feature flag.
+"""
+
+from jwcrypto import jwk
+
+from .crypto import public_key, signing_key
+from .runtime_cfg import settings
+
+
+def load_signing_jwk() -> jwk.JWK:
+    """Return the private signing key as a :class:`~jwcrypto.jwk.JWK`."""
+    if not settings.enable_rfc7517:
+        raise RuntimeError("RFC 7517 support disabled")
+    return jwk.JWK.from_pem(signing_key())
+
+
+def load_public_jwk() -> jwk.JWK:
+    """Return the public key as a :class:`~jwcrypto.jwk.JWK`."""
+    if not settings.enable_rfc7517:
+        raise RuntimeError("RFC 7517 support disabled")
+    return jwk.JWK.from_pem(public_key())
+
+
+__all__ = ["load_signing_jwk", "load_public_jwk"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7518.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7518.py
@@ -1,0 +1,17 @@
+"""RFC 7518 - JSON Web Algorithms (JWA).
+
+Expose the list of algorithms supported by this service. Controlled via the
+``AUTO_AUTHN_ENABLE_RFC7518`` environment variable.
+"""
+
+from .runtime_cfg import settings
+
+
+def supported_algorithms() -> list[str]:
+    """Return algorithms supported for JOSE operations."""
+    if not settings.enable_rfc7518:
+        raise RuntimeError("RFC 7518 support disabled")
+    return ["EdDSA"]
+
+
+__all__ = ["supported_algorithms"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7519.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7519.py
@@ -1,0 +1,25 @@
+"""RFC 7519 - JSON Web Token (JWT).
+
+Convenience wrappers around :class:`auto_authn.v2.jwtoken.JWTCoder` that can be
+enabled or disabled via ``AUTO_AUTHN_ENABLE_RFC7519``.
+"""
+
+from .jwtoken import JWTCoder
+from .runtime_cfg import settings
+
+
+def encode_jwt(**claims) -> str:
+    """Encode *claims* as a JWT string."""
+    if not settings.enable_rfc7519:
+        raise RuntimeError("RFC 7519 support disabled")
+    return JWTCoder.default().sign(**claims)
+
+
+def decode_jwt(token: str) -> dict:
+    """Decode and verify *token* returning the claims dictionary."""
+    if not settings.enable_rfc7519:
+        raise RuntimeError("RFC 7519 support disabled")
+    return JWTCoder.default().decode(token)
+
+
+__all__ = ["encode_jwt", "decode_jwt"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7520.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7520.py
@@ -1,0 +1,31 @@
+"""RFC 7520 - Examples of Protecting Content Using JOSE.
+
+Provides simple composition helpers that demonstrate signing followed by
+encryption and the reverse. Controlled via the
+``AUTO_AUTHN_ENABLE_RFC7520`` environment variable.
+"""
+
+from jwcrypto import jwk
+
+from .runtime_cfg import settings
+from .rfc7515 import sign_jws, verify_jws
+from .rfc7516 import encrypt_jwe, decrypt_jwe
+
+
+def jws_then_jwe(payload: str, key: jwk.JWK) -> str:
+    """Sign *payload* then encrypt the resulting JWS."""
+    if not settings.enable_rfc7520:
+        raise RuntimeError("RFC 7520 support disabled")
+    jws_token = sign_jws(payload, key)
+    return encrypt_jwe(jws_token, key)
+
+
+def jwe_then_jws(token: str, key: jwk.JWK) -> str:
+    """Decrypt a JWE then verify the contained JWS."""
+    if not settings.enable_rfc7520:
+        raise RuntimeError("RFC 7520 support disabled")
+    jws_token = decrypt_jwe(token, key)
+    return verify_jws(jws_token, key)
+
+
+__all__ = ["jws_then_jwe", "jwe_then_jws"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
@@ -102,10 +102,12 @@ class Settings(BaseSettings):
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC9207", "false").lower()
         in {"1", "true", "yes"},
         description="Enable Authorization Server Issuer Identification per RFC 9207",
+    )
     enable_rfc9126: bool = Field(
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC9126", "false").lower()
         in {"1", "true", "yes"},
         description="Enable Pushed Authorization Requests per RFC 9126",
+    )
     enable_rfc6750: bool = Field(
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC6750", "true").lower()
         in {"1", "true", "yes"},
@@ -132,6 +134,36 @@ class Settings(BaseSettings):
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC8628", "true").lower()
         in {"1", "true", "yes"},
         description="Enable Device Authorization Grant per RFC 8628",
+    )
+    enable_rfc7515: bool = Field(
+        default=os.environ.get("AUTO_AUTHN_ENABLE_RFC7515", "true").lower()
+        in {"1", "true", "yes"},
+        description="Enable JSON Web Signature per RFC 7515",
+    )
+    enable_rfc7516: bool = Field(
+        default=os.environ.get("AUTO_AUTHN_ENABLE_RFC7516", "true").lower()
+        in {"1", "true", "yes"},
+        description="Enable JSON Web Encryption per RFC 7516",
+    )
+    enable_rfc7517: bool = Field(
+        default=os.environ.get("AUTO_AUTHN_ENABLE_RFC7517", "true").lower()
+        in {"1", "true", "yes"},
+        description="Enable JSON Web Key per RFC 7517",
+    )
+    enable_rfc7518: bool = Field(
+        default=os.environ.get("AUTO_AUTHN_ENABLE_RFC7518", "true").lower()
+        in {"1", "true", "yes"},
+        description="Enable JSON Web Algorithms per RFC 7518",
+    )
+    enable_rfc7519: bool = Field(
+        default=os.environ.get("AUTO_AUTHN_ENABLE_RFC7519", "true").lower()
+        in {"1", "true", "yes"},
+        description="Enable JSON Web Token per RFC 7519",
+    )
+    enable_rfc7520: bool = Field(
+        default=os.environ.get("AUTO_AUTHN_ENABLE_RFC7520", "true").lower()
+        in {"1", "true", "yes"},
+        description="Enable JOSE examples per RFC 7520",
     )
 
     model_config = SettingsConfigDict(env_file=None)

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7515_jws.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7515_jws.py
@@ -1,0 +1,12 @@
+"""Tests for RFC 7515: JSON Web Signature (JWS)."""
+
+from jwcrypto import jwk
+
+from auto_authn.v2 import sign_jws, verify_jws
+
+
+def test_sign_and_verify_jws() -> None:
+    key = jwk.JWK.generate(kty="oct", size=256)
+    payload = "payload"
+    token = sign_jws(payload, key)
+    assert verify_jws(token, key) == payload

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7516_jwe.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7516_jwe.py
@@ -1,0 +1,12 @@
+"""Tests for RFC 7516: JSON Web Encryption (JWE)."""
+
+from jwcrypto import jwk
+
+from auto_authn.v2 import encrypt_jwe, decrypt_jwe
+
+
+def test_encrypt_and_decrypt_jwe() -> None:
+    key = jwk.JWK.generate(kty="oct", size=256)
+    secret = "sensitive"
+    token = encrypt_jwe(secret, key)
+    assert decrypt_jwe(token, key) == secret

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7517_jwk.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7517_jwk.py
@@ -1,0 +1,10 @@
+"""Tests for RFC 7517: JSON Web Key (JWK)."""
+
+from auto_authn.v2 import load_signing_jwk, load_public_jwk
+
+
+def test_jwk_contains_required_fields() -> None:
+    priv = load_signing_jwk()
+    pub = load_public_jwk()
+    assert priv.kty == "OKP"
+    assert pub.kty == "OKP"

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7518_jwa.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7518_jwa.py
@@ -1,0 +1,7 @@
+"""Tests for RFC 7518: JSON Web Algorithms (JWA)."""
+
+from auto_authn.v2 import supported_algorithms
+
+
+def test_supported_algorithms_contains_eddsa() -> None:
+    assert "EdDSA" in supported_algorithms()

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7519_jwt.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7519_jwt.py
@@ -1,0 +1,10 @@
+"""Tests for RFC 7519: JSON Web Token (JWT)."""
+
+from auto_authn.v2 import encode_jwt, decode_jwt
+
+
+def test_encode_and_decode_jwt() -> None:
+    token = encode_jwt(sub="user", tid="tenant")
+    payload = decode_jwt(token)
+    assert payload["sub"] == "user"
+    assert payload["tid"] == "tenant"

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7520_examples.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7520_examples.py
@@ -1,0 +1,12 @@
+"""Tests for RFC 7520: JOSE Examples."""
+
+from jwcrypto import jwk
+
+from auto_authn.v2 import jws_then_jwe, jwe_then_jws
+
+
+def test_jws_then_jwe_roundtrip() -> None:
+    key = jwk.JWK.generate(kty="oct", size=256)
+    message = "hello"
+    token = jws_then_jwe(message, key)
+    assert jwe_then_jws(token, key) == message


### PR DESCRIPTION
## Summary
- add feature flags and modules for RFCs 7515-7520 in auto_authn
- expose helpers for JWS, JWE, JWK, JWA, JWT and JOSE examples
- add unit tests validating each JOSE RFC module

## Testing
- `uv run --package auto_authn --directory standards/auto_authn ruff format .`
- `uv run --package auto_authn --directory standards/auto_authn ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68ac473871e083269af4de0c750abc4e