### PR TITLE
feat(auto_authn): test RFC9396 authorization_details parsing

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
@@ -1,7 +1,8 @@
 """auto_authn.v2 – OAuth utilities and helpers.
 
 This package aggregates optional helpers for various OAuth 2.0 RFCs such as
-RFC 7636 (PKCE) and RFC 8705 (mutual-TLS client authentication).
+RFC 7636 (PKCE), RFC 8705 (mutual-TLS client authentication), and RFC 9396
+(Rich Authorization Requests).
 """
 
 from .rfc7636_pkce import (
@@ -10,7 +11,11 @@ from .rfc7636_pkce import (
     verify_code_challenge,
 )
 from .rfc8628 import generate_device_code, generate_user_code, validate_user_code
-from .rfc9396 import AuthorizationDetail, parse_authorization_details
+from .rfc9396 import (
+    AuthorizationDetail,
+    parse_authorization_details,
+    RFC9396_SPEC_URL,
+)
 from .rfc6750 import extract_bearer_token
 from .rfc7662 import introspect_token, register_token, reset_tokens
 from .rfc9207 import extract_issuer
@@ -18,6 +23,7 @@ from .rfc9126 import store_par_request, get_par_request, reset_par_store
 from .rfc8707 import extract_resource, RFC8707_SPEC_URL
 from .rfc8705 import thumbprint_from_cert_pem, validate_certificate_binding
 from .rfc8252 import is_native_redirect_uri, validate_native_redirect_uri
+
 __all__ = [
     "create_code_verifier",
     "create_code_challenge",
@@ -27,6 +33,7 @@ __all__ = [
     "generate_device_code",
     "parse_authorization_details",
     "AuthorizationDetail",
+    "RFC9396_SPEC_URL",
     "extract_bearer_token",
     "extract_issuer",
     "extract_resource",

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc9396.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc9396.py
@@ -2,7 +2,7 @@
 
 This module parses and validates the ``authorization_details`` request
 parameter as defined by RFC 9396 section 2. Support for this feature can be
-toggled via the ``ENABLE_RFC9396`` environment variable
+toggled via the ``AUTO_AUTHN_ENABLE_RFC9396`` environment variable
 (``settings.enable_rfc9396``).
 """
 
@@ -14,6 +14,8 @@ import json
 from pydantic import BaseModel, ValidationError
 
 from .runtime_cfg import settings
+
+RFC9396_SPEC_URL = "https://www.rfc-editor.org/rfc/rfc9396"
 
 
 class AuthorizationDetail(BaseModel):
@@ -62,3 +64,10 @@ def parse_authorization_details(raw: str) -> List[AuthorizationDetail]:
         return [AuthorizationDetail.model_validate(item) for item in data]
     except ValidationError as exc:
         raise ValueError("invalid authorization_details") from exc
+
+
+__all__ = [
+    "AuthorizationDetail",
+    "parse_authorization_details",
+    "RFC9396_SPEC_URL",
+]

--- a/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
@@ -88,7 +88,11 @@ class Settings(BaseSettings):
     enable_dpop: bool = Field(
         default=os.environ.get("AUTO_AUTHN_ENABLE_DPOP", "0") in {"1", "true", "True"}
     )
-    enable_rfc9396: bool = Field(default=os.environ.get("ENABLE_RFC9396", "0") == "1")
+    enable_rfc9396: bool = Field(
+        default=os.environ.get("AUTO_AUTHN_ENABLE_RFC9396", "0").lower()
+        in {"1", "true", "yes"},
+        description=("Enable OAuth 2.0 Rich Authorization Requests per RFC 9396"),
+    )
     enable_rfc7009: bool = Field(
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC7009", "false").lower()
         in {"1", "true", "yes"}
@@ -102,10 +106,12 @@ class Settings(BaseSettings):
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC9207", "false").lower()
         in {"1", "true", "yes"},
         description="Enable Authorization Server Issuer Identification per RFC 9207",
+    )
     enable_rfc9126: bool = Field(
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC9126", "false").lower()
         in {"1", "true", "yes"},
         description="Enable Pushed Authorization Requests per RFC 9126",
+    )
     enable_rfc6750: bool = Field(
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC6750", "true").lower()
         in {"1", "true", "yes"},

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc9396_authorization_details.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc9396_authorization_details.py
@@ -13,8 +13,11 @@ conditionally enabled or disabled via runtime configuration.
 
 import pytest
 
-from auto_authn.v2 import parse_authorization_details
-from auto_authn.v2 import AuthorizationDetail
+from auto_authn.v2 import (
+    AuthorizationDetail,
+    RFC9396_SPEC_URL,
+    parse_authorization_details,
+)
 from auto_authn.v2.runtime_cfg import settings
 
 
@@ -37,3 +40,26 @@ def test_parse_authorization_details_disabled(monkeypatch):
     monkeypatch.setattr(settings, "enable_rfc9396", False)
     with pytest.raises(NotImplementedError):
         parse_authorization_details('{"type": "payment_initiation"}')
+
+
+def test_parse_authorization_details_list(monkeypatch):
+    monkeypatch.setattr(settings, "enable_rfc9396", True)
+    raw = '[{"type": "a"}, {"type": "b"}]'
+    details = parse_authorization_details(raw)
+    assert [d.type for d in details] == ["a", "b"]
+
+
+def test_parse_authorization_details_invalid_json(monkeypatch):
+    monkeypatch.setattr(settings, "enable_rfc9396", True)
+    with pytest.raises(ValueError):
+        parse_authorization_details("not-json")
+
+
+def test_parse_authorization_details_wrong_type(monkeypatch):
+    monkeypatch.setattr(settings, "enable_rfc9396", True)
+    with pytest.raises(ValueError):
+        parse_authorization_details("123")
+
+
+def test_rfc9396_spec_url():
+    assert RFC9396_SPEC_URL.endswith("rfc9396")


### PR DESCRIPTION
## Summary
- add Rich Authorization Requests (RFC 9396) parser helpers and constants
- expose feature flag for RFC 9396 via `AUTO_AUTHN_ENABLE_RFC9396`
- expand RFC 9396 tests covering arrays, invalid inputs, and spec URL

## Testing
- `uv run --package auto_authn --directory standards ruff format auto_authn`
- `uv run --package auto_authn --directory standards ruff check auto_authn --fix`
- `uv run --package auto_authn --directory standards pytest auto_authn/tests/unit/test_rfc9396_authorization_details.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac46e1b3308326ae01905108f168a8