### PR TITLE
feat(auto_authn): add RFC7515 JWS validation

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
@@ -17,7 +17,9 @@ from .rfc9207 import extract_issuer
 from .rfc9126 import store_par_request, get_par_request, reset_par_store
 from .rfc8707 import extract_resource, RFC8707_SPEC_URL
 from .rfc8705 import thumbprint_from_cert_pem, validate_certificate_binding
+from .rfc7515 import RFC7515_SPEC_URL, validate_jws_header
 from .rfc8252 import is_native_redirect_uri, validate_native_redirect_uri
+
 __all__ = [
     "create_code_verifier",
     "create_code_challenge",
@@ -31,6 +33,7 @@ __all__ = [
     "extract_issuer",
     "extract_resource",
     "RFC8707_SPEC_URL",
+    "RFC7515_SPEC_URL",
     "introspect_token",
     "register_token",
     "reset_tokens",
@@ -39,6 +42,7 @@ __all__ = [
     "reset_par_store",
     "thumbprint_from_cert_pem",
     "validate_certificate_binding",
+    "validate_jws_header",
     "is_native_redirect_uri",
     "validate_native_redirect_uri",
 ]

--- a/pkgs/standards/auto_authn/auto_authn/v2/jwtoken.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/jwtoken.py
@@ -39,6 +39,7 @@ from jwt.exceptions import InvalidTokenError
 from .crypto import public_key, signing_key
 from .runtime_cfg import settings
 from .rfc8705 import validate_certificate_binding
+from .rfc7515 import validate_jws_header
 
 _ALG = "EdDSA"
 _ACCESS_TTL = timedelta(minutes=60)
@@ -140,6 +141,8 @@ class JWTCoder:
             If signature is invalid, token is expired, or malformed.
         """
         options = {"verify_exp": verify_exp, "verify_aud": False}
+        if settings.enable_rfc7515:
+            validate_jws_header(token)
         payload = jwt.decode(
             token,
             self._pub,

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7515.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7515.py
@@ -1,0 +1,32 @@
+"""Utilities for JSON Web Signature (RFC 7515).
+
+This module implements helpers for validating JWS structures as required by
+RFC 7515. At present it focuses on verifying that the JOSE header includes the
+``alg`` parameter and that it is not set to the unsecured ``none`` algorithm
+per RFC 7515 §4.1.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import jwt
+from jwt.exceptions import InvalidTokenError
+
+RFC7515_SPEC_URL = "https://datatracker.ietf.org/doc/html/rfc7515"
+
+
+def validate_jws_header(token: str) -> None:
+    """Validate the JOSE header of *token*.
+
+    Raises
+    ------
+    InvalidTokenError
+        If the ``alg`` header parameter is missing or set to ``none`` in
+        violation of RFC 7515 §4.1.
+    """
+
+    header: Dict[str, Any] = jwt.get_unverified_header(token)
+    alg = header.get("alg")
+    if not alg or alg.lower() == "none":
+        raise InvalidTokenError("JWS alg header missing or 'none' per RFC 7515")

--- a/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
@@ -102,10 +102,12 @@ class Settings(BaseSettings):
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC9207", "false").lower()
         in {"1", "true", "yes"},
         description="Enable Authorization Server Issuer Identification per RFC 9207",
+    )
     enable_rfc9126: bool = Field(
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC9126", "false").lower()
         in {"1", "true", "yes"},
         description="Enable Pushed Authorization Requests per RFC 9126",
+    )
     enable_rfc6750: bool = Field(
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC6750", "true").lower()
         in {"1", "true", "yes"},
@@ -132,6 +134,11 @@ class Settings(BaseSettings):
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC8628", "true").lower()
         in {"1", "true", "yes"},
         description="Enable Device Authorization Grant per RFC 8628",
+    )
+    enable_rfc7515: bool = Field(
+        default=os.environ.get("AUTO_AUTHN_ENABLE_RFC7515", "true").lower()
+        in {"1", "true", "yes"},
+        description="Enable JSON Web Signature validation per RFC 7515",
     )
 
     model_config = SettingsConfigDict(env_file=None)

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7515_json_web_signature.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7515_json_web_signature.py
@@ -1,0 +1,67 @@
+"""Tests for JSON Web Signature (RFC 7515).
+
+RFC 7515 §4.1 requires that the JOSE header include an ``alg`` parameter and
+forbids the unsecured ``none`` algorithm. These tests ensure the auto_authn
+package enforces that requirement when the feature flag is enabled.
+"""
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ed25519
+from jwt.exceptions import InvalidTokenError
+
+from auto_authn.v2 import runtime_cfg
+from auto_authn.v2.jwtoken import JWTCoder
+from auto_authn.v2.rfc7515 import RFC7515_SPEC_URL
+
+
+@pytest.mark.unit
+def test_jws_alg_header_enforced(monkeypatch):
+    """RFC 7515 §4.1 forbids using the ``none`` algorithm when enabled."""
+    monkeypatch.setattr(runtime_cfg.settings, "enable_rfc7515", True)
+    priv = ed25519.Ed25519PrivateKey.generate()
+    pub = priv.public_key()
+    private_pem = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_pem = pub.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    coder = JWTCoder(private_pem, public_pem)
+    token = coder.sign(sub="alice", tid="tenant")
+    assert coder.decode(token)["sub"] == "alice"
+
+    bad = jwt.encode({"sub": "alice"}, key="", algorithm="none")
+    with pytest.raises(InvalidTokenError, match="RFC 7515"):
+        coder.decode(bad)
+
+
+@pytest.mark.unit
+def test_feature_toggle_skips_header_validation(monkeypatch):
+    """When disabled, RFC 7515 validation is not applied."""
+    monkeypatch.setattr(runtime_cfg.settings, "enable_rfc7515", False)
+    priv = ed25519.Ed25519PrivateKey.generate()
+    pub = priv.public_key()
+    private_pem = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_pem = pub.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    coder = JWTCoder(private_pem, public_pem)
+    bad = jwt.encode({"sub": "alice"}, key="", algorithm="none")
+    with pytest.raises(InvalidTokenError) as exc:
+        coder.decode(bad)
+    assert "RFC 7515" not in str(exc.value)
+
+
+def test_spec_url_constant():
+    """Ensure the module exposes the official RFC 7515 specification URL."""
+    assert RFC7515_SPEC_URL.endswith("rfc7515")


### PR DESCRIPTION
## Summary
- add RFC 7515 JSON Web Signature header validation
- gate JWS checks behind new `enable_rfc7515` setting
- test RFC 7515 behavior and feature flag

## Testing
- `uv run --package auto_authn --directory standards/auto_authn ruff format .`
- `uv run --package auto_authn --directory standards/auto_authn ruff check . --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc7515_json_web_signature.py`
- `uv run --package auto_authn --directory pkgs/standards/auto_authn pytest` *(fails: import file mismatch)*


------
https://chatgpt.com/codex/tasks/task_e_68ac46ee377c832694e35537f0b6f95e