### PR TITLE
Add RFC 9068 spec constant and compliance tests

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
@@ -1,7 +1,8 @@
 """auto_authn.v2 – OAuth utilities and helpers.
 
 This package aggregates optional helpers for various OAuth 2.0 RFCs such as
-RFC 7636 (PKCE) and RFC 8705 (mutual-TLS client authentication).
+RFC 7636 (PKCE), RFC 8705 (mutual-TLS client authentication), and
+RFC 9068 (JWT profile for OAuth 2.0 access tokens).
 """
 
 from .rfc7636_pkce import (
@@ -22,7 +23,11 @@ from .rfc9207 import RFC9207_SPEC_URL, extract_issuer
 from .rfc9126 import store_par_request, get_par_request, reset_par_store
 from .rfc8707 import extract_resource, RFC8707_SPEC_URL
 from .rfc8705 import thumbprint_from_cert_pem, validate_certificate_binding
-from .rfc9068 import add_rfc9068_claims, validate_rfc9068_claims
+from .rfc9068 import (
+    RFC9068_SPEC_URL,
+    add_rfc9068_claims,
+    validate_rfc9068_claims,
+)
 from .rfc8252 import is_native_redirect_uri, validate_native_redirect_uri
 
 __all__ = [
@@ -40,6 +45,7 @@ __all__ = [
     "extract_resource",
     "RFC8707_SPEC_URL",
     "RFC9207_SPEC_URL",
+    "RFC9068_SPEC_URL",
     "introspect_token",
     "register_token",
     "reset_tokens",

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc9068.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc9068.py
@@ -8,9 +8,12 @@ It is designed to be feature-flagged via ``enable_rfc9068`` in
 
 from __future__ import annotations
 
-from typing import Any, Dict, Iterable, Set
+from typing import Any, Dict, Final, Iterable, Set
 
 from jwt.exceptions import InvalidTokenError
+
+
+RFC9068_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc9068"
 
 
 def add_rfc9068_claims(


### PR DESCRIPTION
## Summary
- expose `RFC9068_SPEC_URL` and export through `auto_authn.v2`
- expand JWT profile tests with spec URL reference and mandatory claim checks

## Testing
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68ac48bdfb98832697071df1061974ad