### PR TITLE
feat(auto_authn): add RFC 7520 compliance tests

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
@@ -29,7 +29,7 @@ from .rfc7516 import encrypt_jwe, decrypt_jwe
 from .rfc7517 import load_signing_jwk, load_public_jwk
 from .rfc7518 import supported_algorithms
 from .rfc7519 import encode_jwt, decode_jwt
-from .rfc7520 import jws_then_jwe, jwe_then_jws
+from .rfc7520 import jws_then_jwe, jwe_then_jws, RFC7520_SPEC_URL
 
 __all__ = [
     "create_code_verifier",
@@ -69,4 +69,5 @@ __all__ = [
     "decode_jwt",
     "jws_then_jwe",
     "jwe_then_jws",
+    "RFC7520_SPEC_URL",
 ]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7515.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7515.py
@@ -15,7 +15,8 @@ def sign_jws(payload: str, key: jwk.JWK) -> str:
     if not settings.enable_rfc7515:
         raise RuntimeError("RFC 7515 support disabled")
     token = jws.JWS(payload.encode())
-    token.add_signature(key, None, json_encode({"alg": "EdDSA"}))
+    alg = "HS256" if key.kty == "oct" else "EdDSA"
+    token.add_signature(key, None, json_encode({"alg": alg}))
     return token.serialize()
 
 

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7520.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7520.py
@@ -1,15 +1,19 @@
-"""RFC 7520 - Examples of Protecting Content Using JOSE.
+"""JOSE composition helpers for RFC 7520 compliance.
 
-Provides simple composition helpers that demonstrate signing followed by
-encryption and the reverse. Controlled via the
-``AUTO_AUTHN_ENABLE_RFC7520`` environment variable.
+This module demonstrates the JOSE patterns defined in :rfc:`7520`, providing
+helpers that sign payloads before encrypting them and vice‑versa.  Support can
+be toggled via the ``AUTO_AUTHN_ENABLE_RFC7520`` environment variable.
 """
+
+from typing import Final
 
 from jwcrypto import jwk
 
 from .runtime_cfg import settings
 from .rfc7515 import sign_jws, verify_jws
 from .rfc7516 import encrypt_jwe, decrypt_jwe
+
+RFC7520_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc7520"
 
 
 def jws_then_jwe(payload: str, key: jwk.JWK) -> str:
@@ -28,4 +32,4 @@ def jwe_then_jws(token: str, key: jwk.JWK) -> str:
     return verify_jws(jws_token, key)
 
 
-__all__ = ["jws_then_jwe", "jwe_then_jws"]
+__all__ = ["jws_then_jwe", "jwe_then_jws", "RFC7520_SPEC_URL"]


### PR DESCRIPTION
## Summary
- expose RFC 7520 spec URL and gate JOSE composition helpers behind runtime flag
- allow JWS signing with symmetric keys and add constant for the spec
- test JOSE composition helpers and feature toggle for RFC 7520

## Testing
- `uv run --directory standards/auto_authn --package auto_authn ruff check . --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc7520_examples.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac4953a6408326a46a22f7106a0821