### PR TITLE
feat(auto_authn): add rfc7521 assertion validation

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
@@ -30,6 +30,7 @@ from .rfc7517 import load_signing_jwk, load_public_jwk
 from .rfc7518 import supported_algorithms
 from .rfc7519 import encode_jwt, decode_jwt
 from .rfc7520 import jws_then_jwe, jwe_then_jws
+from .rfc7521 import validate_jwt_assertion, RFC7521_SPEC_URL
 
 __all__ = [
     "create_code_verifier",
@@ -69,4 +70,6 @@ __all__ = [
     "decode_jwt",
     "jws_then_jwe",
     "jwe_then_jws",
+    "validate_jwt_assertion",
+    "RFC7521_SPEC_URL",
 ]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7521.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7521.py
@@ -1,0 +1,36 @@
+"""RFC 7521 - Assertion Framework for OAuth 2.0.
+
+This module provides helpers for validating JWT assertions used for client
+authentication and authorization grants. Support can be toggled via the
+``AUTO_AUTHN_ENABLE_RFC7521`` environment variable.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Set
+
+from .runtime_cfg import settings
+from .rfc7519 import decode_jwt
+
+RFC7521_SPEC_URL = "https://www.rfc-editor.org/rfc/rfc7521"
+REQUIRED_CLAIMS: Set[str] = {"iss", "sub", "aud", "exp"}
+
+
+def validate_jwt_assertion(assertion: str) -> Dict[str, object]:
+    """Validate a JWT ``assertion`` per RFC 7521.
+
+    The JWT MUST contain the ``iss``, ``sub``, ``aud`` and ``exp`` claims as
+    required by RFC 7521 §3. If support for RFC 7521 is disabled, a
+    ``RuntimeError`` is raised.
+    """
+
+    if not settings.enable_rfc7521:
+        raise RuntimeError("RFC 7521 support disabled")
+    claims = decode_jwt(assertion)
+    missing = REQUIRED_CLAIMS - claims.keys()
+    if missing:
+        raise ValueError(f"missing claims: {', '.join(sorted(missing))}")
+    return claims
+
+
+__all__ = ["validate_jwt_assertion", "RFC7521_SPEC_URL"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
@@ -176,6 +176,11 @@ class Settings(BaseSettings):
         in {"1", "true", "yes"},
         description="Enable JOSE examples per RFC 7520",
     )
+    enable_rfc7521: bool = Field(
+        default=os.environ.get("AUTO_AUTHN_ENABLE_RFC7521", "true").lower()
+        in {"1", "true", "yes"},
+        description="Enable Assertion Framework for OAuth 2.0 per RFC 7521",
+    )
 
     model_config = SettingsConfigDict(env_file=None)
 

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7521_assertion_framework.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7521_assertion_framework.py
@@ -1,0 +1,57 @@
+"""Tests for RFC 7521: Assertion Framework for OAuth 2.0 Client Authentication and Authorization Grants.
+
+See RFC at https://www.rfc-editor.org/rfc/rfc7521.
+"""
+
+import time
+from unittest.mock import patch
+
+import pytest
+
+from auto_authn.v2 import encode_jwt
+from auto_authn.v2.rfc7521 import (
+    RFC7521_SPEC_URL,
+    validate_jwt_assertion,
+)
+from auto_authn.v2.runtime_cfg import settings
+
+
+@pytest.mark.unit
+def test_validate_jwt_assertion_success() -> None:
+    """RFC 7521 §3: assertions contain required claims."""
+    token = encode_jwt(
+        iss="issuer",
+        sub="subject",
+        tid="tenant",
+        aud="audience",
+        exp=int(time.time()) + 60,
+    )
+    claims = validate_jwt_assertion(token)
+    assert claims["iss"] == "issuer"
+    assert claims["sub"] == "subject"
+    assert RFC7521_SPEC_URL.startswith("https://")
+
+
+@pytest.mark.unit
+def test_validate_jwt_assertion_missing_claim() -> None:
+    """RFC 7521 §3: missing required claim results in ValueError."""
+    token = encode_jwt(
+        iss="issuer", sub="subject", tid="tenant", exp=int(time.time()) + 60
+    )
+    with pytest.raises(ValueError):
+        validate_jwt_assertion(token)
+
+
+@pytest.mark.unit
+def test_validate_jwt_assertion_disabled() -> None:
+    """RFC 7521: validation disabled when feature is off."""
+    token = encode_jwt(
+        iss="issuer",
+        sub="subject",
+        tid="tenant",
+        aud="audience",
+        exp=int(time.time()) + 60,
+    )
+    with patch.object(settings, "enable_rfc7521", False):
+        with pytest.raises(RuntimeError):
+            validate_jwt_assertion(token)


### PR DESCRIPTION
## Summary
- add RFC 7521 JWT assertion validation with runtime toggle
- expose assertion validator in auto_authn v2 API
- test RFC 7521 behavior and claim requirements

## Testing
- `uv run --directory pkgs/standards/auto_authn --package auto-authn ruff format .`
- `uv run --directory pkgs/standards/auto_authn --package auto-authn ruff check . --fix`
- `uv run --package auto-authn --directory pkgs/standards/auto_authn pytest` *(fails: 19 failed, 194 passed)*
- `uv run --package auto-authn --directory pkgs/standards/auto_authn pytest tests/unit/test_rfc7521_assertion_framework.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac4959655c83269f05a2ce88450f1c