### PR TITLE
feat(auto_authn): add modular RFC helpers and tests

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
@@ -30,6 +30,10 @@ from .rfc7517 import load_signing_jwk, load_public_jwk
 from .rfc7518 import supported_algorithms
 from .rfc7519 import encode_jwt, decode_jwt
 from .rfc7520 import jws_then_jwe, jwe_then_jws
+from .rfc7638 import jwk_thumbprint, RFC7638_SPEC_URL
+from .rfc7800 import validate_cnf_claim, RFC7800_SPEC_URL
+from .rfc8291 import encrypt_webpush, decrypt_webpush, RFC8291_SPEC_URL
+from .rfc8812 import is_supported_cose_alg, RFC8812_SPEC_URL
 
 __all__ = [
     "create_code_verifier",
@@ -69,4 +73,13 @@ __all__ = [
     "decode_jwt",
     "jws_then_jwe",
     "jwe_then_jws",
+    "jwk_thumbprint",
+    "RFC7638_SPEC_URL",
+    "validate_cnf_claim",
+    "RFC7800_SPEC_URL",
+    "encrypt_webpush",
+    "decrypt_webpush",
+    "RFC8291_SPEC_URL",
+    "is_supported_cose_alg",
+    "RFC8812_SPEC_URL",
 ]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7638.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7638.py
@@ -1,0 +1,41 @@
+"""JSON Web Key (JWK) Thumbprint (RFC 7638).
+
+This module provides a helper to compute the JWK thumbprint as defined in
+`RFC 7638 <https://datatracker.ietf.org/doc/html/rfc7638>`_. The helper is
+feature flagged via ``enable_rfc7638`` in :mod:`auto_authn.v2.runtime_cfg` so
+that projects may opt in to this behaviour.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from typing import Any, Dict
+
+from .runtime_cfg import settings
+
+RFC7638_SPEC_URL = "https://datatracker.ietf.org/doc/html/rfc7638"
+
+
+def jwk_thumbprint(jwk: Dict[str, Any]) -> str:
+    """Return the base64url-encoded SHA-256 JWK thumbprint.
+
+    Raises ``RuntimeError`` if the feature is disabled. Only RSA and EC keys
+    are supported for simplicity.
+    """
+    if not settings.enable_rfc7638:
+        raise RuntimeError("RFC 7638 support disabled")
+    kty = jwk.get("kty")
+    if kty == "RSA":
+        members = {k: jwk[k] for k in ("e", "kty", "n")}
+    elif kty == "EC":
+        members = {k: jwk[k] for k in ("crv", "kty", "x", "y")}
+    else:
+        raise ValueError("Unsupported key type for thumbprint")
+    json_str = json.dumps(members, separators=(",", ":"), sort_keys=True)
+    digest = hashlib.sha256(json_str.encode()).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+
+
+__all__ = ["jwk_thumbprint", "RFC7638_SPEC_URL"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7800.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7800.py
@@ -1,0 +1,33 @@
+"""Proof-of-Possession Key Semantics for JWTs (RFC 7800).
+
+Minimal helper to validate that a JWT's ``cnf`` claim references the provided
+JSON Web Key. Compliance can be toggled with ``enable_rfc7800`` in
+:mod:`auto_authn.v2.runtime_cfg`.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .runtime_cfg import settings
+from .rfc7638 import jwk_thumbprint
+
+RFC7800_SPEC_URL = "https://datatracker.ietf.org/doc/html/rfc7800"
+
+
+def validate_cnf_claim(payload: Dict[str, Any], jwk: Dict[str, Any]) -> bool:
+    """Return True if ``payload`` proves possession of *jwk*.
+
+    When RFC 7800 support is disabled this function returns ``True``.
+    """
+    if not settings.enable_rfc7800:
+        return True
+    try:
+        cnf = payload["cnf"]
+        jkt = cnf["jkt"]
+    except KeyError:
+        return False
+    return jkt == jwk_thumbprint(jwk)
+
+
+__all__ = ["validate_cnf_claim", "RFC7800_SPEC_URL"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8291.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8291.py
@@ -1,0 +1,40 @@
+"""Message Encryption for Web Push (RFC 8291).
+
+This module exposes small helpers for AES-128-GCM encryption used in Web Push
+messages. Support is controlled by ``enable_rfc8291`` in
+:mod:`auto_authn.v2.runtime_cfg`.
+"""
+
+from __future__ import annotations
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from .runtime_cfg import settings
+
+RFC8291_SPEC_URL = "https://datatracker.ietf.org/doc/html/rfc8291"
+
+
+def encrypt_webpush(message: bytes, key: bytes, nonce: bytes) -> bytes:
+    """Encrypt *message* using AES-128-GCM.
+
+    Returns the ciphertext. If the feature is disabled the plaintext is
+    returned unchanged.
+    """
+    if not settings.enable_rfc8291:
+        return message
+    aes = AESGCM(key)
+    return aes.encrypt(nonce, message, None)
+
+
+def decrypt_webpush(ciphertext: bytes, key: bytes, nonce: bytes) -> bytes:
+    """Decrypt a ciphertext produced by :func:`encrypt_webpush`.
+
+    If the feature is disabled the ciphertext is returned as-is.
+    """
+    if not settings.enable_rfc8291:
+        return ciphertext
+    aes = AESGCM(key)
+    return aes.decrypt(nonce, ciphertext, None)
+
+
+__all__ = ["encrypt_webpush", "decrypt_webpush", "RFC8291_SPEC_URL"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8812.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8812.py
@@ -1,0 +1,28 @@
+"""COSE and JOSE Registrations for Web Authentication (RFC 8812).
+
+Provides a helper to check whether a COSE algorithm identifier is among those
+registered for WebAuthn by `RFC 8812 <https://datatracker.ietf.org/doc/html/rfc8812>`_.
+The check is gated by ``enable_rfc8812`` in :mod:`auto_authn.v2.runtime_cfg`.
+"""
+
+from __future__ import annotations
+
+from .runtime_cfg import settings
+
+RFC8812_SPEC_URL = "https://datatracker.ietf.org/doc/html/rfc8812"
+
+# Algorithm identifiers registered by RFC 8812
+RFC8812_ALGORITHMS = {-257, -258, -259, -65535, -47}
+
+
+def is_supported_cose_alg(alg: int) -> bool:
+    """Return True if *alg* is registered for WebAuthn per RFC 8812.
+
+    When disabled, this function always returns ``False``.
+    """
+    if not settings.enable_rfc8812:
+        return False
+    return alg in RFC8812_ALGORITHMS
+
+
+__all__ = ["is_supported_cose_alg", "RFC8812_SPEC_URL", "RFC8812_ALGORITHMS"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
@@ -176,6 +176,26 @@ class Settings(BaseSettings):
         in {"1", "true", "yes"},
         description="Enable JOSE examples per RFC 7520",
     )
+    enable_rfc7638: bool = Field(
+        default=os.environ.get("AUTO_AUTHN_ENABLE_RFC7638", "true").lower()
+        in {"1", "true", "yes"},
+        description="Enable JWK Thumbprint per RFC 7638",
+    )
+    enable_rfc7800: bool = Field(
+        default=os.environ.get("AUTO_AUTHN_ENABLE_RFC7800", "false").lower()
+        in {"1", "true", "yes"},
+        description="Enable Proof-of-Possession semantics per RFC 7800",
+    )
+    enable_rfc8291: bool = Field(
+        default=os.environ.get("AUTO_AUTHN_ENABLE_RFC8291", "false").lower()
+        in {"1", "true", "yes"},
+        description="Enable Message Encryption for Web Push per RFC 8291",
+    )
+    enable_rfc8812: bool = Field(
+        default=os.environ.get("AUTO_AUTHN_ENABLE_RFC8812", "false").lower()
+        in {"1", "true", "yes"},
+        description="Enable WebAuthn algorithm registrations per RFC 8812",
+    )
 
     model_config = SettingsConfigDict(env_file=None)
 

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7638_jwk_thumbprint.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7638_jwk_thumbprint.py
@@ -1,0 +1,36 @@
+"""Tests for JSON Web Key (JWK) Thumbprint (RFC 7638)."""
+
+import pytest
+
+from auto_authn.v2 import runtime_cfg
+from auto_authn.v2.rfc7638 import jwk_thumbprint
+
+
+@pytest.mark.unit
+def test_thumbprint_example(monkeypatch):
+    """The example JWK thumbprint from RFC 7638 is produced."""
+    monkeypatch.setattr(runtime_cfg.settings, "enable_rfc7638", True)
+    jwk = {
+        "kty": "RSA",
+        "n": (
+            "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAt"
+            "VT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn6"
+            "4tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FD"
+            "W2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n9"
+            "1CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINH"
+            "aQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw"
+        ),
+        "e": "AQAB",
+        "alg": "RS256",
+        "kid": "2011-04-29",
+    }
+    thumbprint = jwk_thumbprint(jwk)
+    assert thumbprint == "NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs"
+
+
+@pytest.mark.unit
+def test_disabled(monkeypatch):
+    """When the feature is disabled a RuntimeError is raised."""
+    monkeypatch.setattr(runtime_cfg.settings, "enable_rfc7638", False)
+    with pytest.raises(RuntimeError):
+        jwk_thumbprint({"kty": "RSA", "n": "", "e": ""})

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7800_proof_of_possession.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7800_proof_of_possession.py
@@ -1,0 +1,38 @@
+"""Tests for Proof-of-Possession Key Semantics for JWTs (RFC 7800)."""
+
+import pytest
+
+from auto_authn.v2 import runtime_cfg
+from auto_authn.v2.rfc7638 import jwk_thumbprint
+from auto_authn.v2.rfc7800 import validate_cnf_claim
+
+
+@pytest.mark.unit
+def test_validate_cnf(monkeypatch):
+    """A matching ``cnf`` claim validates against the supplied JWK."""
+    monkeypatch.setattr(runtime_cfg.settings, "enable_rfc7800", True)
+    monkeypatch.setattr(runtime_cfg.settings, "enable_rfc7638", True)
+    jwk = {
+        "kty": "RSA",
+        "n": (
+            "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAt"
+            "VT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn6"
+            "4tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FD"
+            "W2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n9"
+            "1CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINH"
+            "aQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw"
+        ),
+        "e": "AQAB",
+    }
+    jkt = jwk_thumbprint(jwk)
+    payload = {"sub": "alice", "cnf": {"jkt": jkt}}
+    assert validate_cnf_claim(payload, jwk)
+    payload["cnf"]["jkt"] = "other"
+    assert not validate_cnf_claim(payload, jwk)
+
+
+@pytest.mark.unit
+def test_disabled(monkeypatch):
+    """When disabled mismatched thumbprints are ignored."""
+    monkeypatch.setattr(runtime_cfg.settings, "enable_rfc7800", False)
+    assert validate_cnf_claim({}, {}) is True

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc8291_web_push.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc8291_web_push.py
@@ -1,0 +1,32 @@
+"""Tests for Message Encryption for Web Push (RFC 8291)."""
+
+import os
+
+import pytest
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from auto_authn.v2 import runtime_cfg
+from auto_authn.v2.rfc8291 import decrypt_webpush, encrypt_webpush
+
+
+@pytest.mark.unit
+def test_encrypt_decrypt(monkeypatch):
+    """Ciphertext decrypts back to the original message when enabled."""
+    monkeypatch.setattr(runtime_cfg.settings, "enable_rfc8291", True)
+    key = AESGCM.generate_key(bit_length=128)
+    nonce = os.urandom(12)
+    message = b"hello"
+    ct = encrypt_webpush(message, key, nonce)
+    assert ct != message
+    pt = decrypt_webpush(ct, key, nonce)
+    assert pt == message
+
+
+@pytest.mark.unit
+def test_disabled_returns_plain(monkeypatch):
+    """When disabled messages are returned unmodified."""
+    monkeypatch.setattr(runtime_cfg.settings, "enable_rfc8291", False)
+    key = AESGCM.generate_key(bit_length=128)
+    nonce = os.urandom(12)
+    message = b"hi"
+    assert encrypt_webpush(message, key, nonce) == message

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc8812_cose_algorithms.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc8812_cose_algorithms.py
@@ -1,0 +1,21 @@
+"""Tests for WebAuthn algorithm registrations (RFC 8812)."""
+
+import pytest
+
+from auto_authn.v2 import runtime_cfg
+from auto_authn.v2.rfc8812 import is_supported_cose_alg
+
+
+@pytest.mark.unit
+def test_algorithm_membership(monkeypatch):
+    """Known algorithm identifiers are recognised when enabled."""
+    monkeypatch.setattr(runtime_cfg.settings, "enable_rfc8812", True)
+    assert is_supported_cose_alg(-257)
+    assert not is_supported_cose_alg(-999)
+
+
+@pytest.mark.unit
+def test_disabled(monkeypatch):
+    """When disabled no algorithms are treated as supported."""
+    monkeypatch.setattr(runtime_cfg.settings, "enable_rfc8812", False)
+    assert not is_supported_cose_alg(-257)


### PR DESCRIPTION
## Summary
- add toggles and helpers for RFC 7638, 7800, 8291 and 8812
- expose new helpers from auto_authn.v2
- add unit tests covering each RFC module

## Testing
- `uv run --package auto_authn --directory pkgs/standards/auto_authn ruff format .`
- `uv run --package auto_authn --directory pkgs/standards/auto_authn ruff check . --fix`

No tests were executed per repository instructions.

------
https://chatgpt.com/codex/tasks/task_e_68ac49a35df08326ab24e5992fce26dc