### PR TITLE
Add RFC 7521 and RFC 7523 support to auto_authn

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
@@ -30,6 +30,12 @@ from .rfc7517 import load_signing_jwk, load_public_jwk
 from .rfc7518 import supported_algorithms
 from .rfc7519 import encode_jwt, decode_jwt
 from .rfc7520 import jws_then_jwe, jwe_then_jws
+from .rfc7521 import extract_client_assertion, RFC7521_SPEC_URL
+from .rfc7523 import (
+    create_jwt_bearer_assertion,
+    verify_jwt_bearer_assertion,
+    RFC7523_SPEC_URL,
+)
 
 __all__ = [
     "create_code_verifier",
@@ -69,4 +75,9 @@ __all__ = [
     "decode_jwt",
     "jws_then_jwe",
     "jwe_then_jws",
+    "extract_client_assertion",
+    "RFC7521_SPEC_URL",
+    "create_jwt_bearer_assertion",
+    "verify_jwt_bearer_assertion",
+    "RFC7523_SPEC_URL",
 ]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7521.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7521.py
@@ -1,0 +1,24 @@
+"""RFC 7521 - Assertion Framework for OAuth 2.0 Client Authentication and Authorization Grants.
+
+This module provides helpers for handling OAuth 2.0 assertions. The feature can
+be toggled with the ``AUTO_AUTHN_ENABLE_RFC7521`` environment variable.
+"""
+
+from .runtime_cfg import settings
+
+RFC7521_SPEC_URL = "https://www.rfc-editor.org/rfc/rfc7521"
+
+
+def extract_client_assertion(params: dict) -> tuple[str, str]:
+    """Extract ``client_assertion`` and ``client_assertion_type`` from *params*.
+
+    Raises:
+        RuntimeError: If RFC 7521 support is disabled.
+        KeyError: If required parameters are missing.
+    """
+    if not settings.enable_rfc7521:
+        raise RuntimeError("RFC 7521 support disabled")
+    return params["client_assertion"], params["client_assertion_type"]
+
+
+__all__ = ["extract_client_assertion", "RFC7521_SPEC_URL"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7523.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7523.py
@@ -1,0 +1,31 @@
+"""RFC 7523 - JSON Web Token (JWT) Bearer Token Profile for OAuth 2.0.
+
+Helpers for creating and verifying JWT bearer assertions. This feature can be
+turned on or off with the ``AUTO_AUTHN_ENABLE_RFC7523`` environment variable.
+"""
+
+from .runtime_cfg import settings
+from .rfc7519 import encode_jwt, decode_jwt
+
+RFC7523_SPEC_URL = "https://www.rfc-editor.org/rfc/rfc7523"
+
+
+def create_jwt_bearer_assertion(**claims) -> str:
+    """Return a JWT bearer assertion containing *claims* per RFC 7523."""
+    if not settings.enable_rfc7523:
+        raise RuntimeError("RFC 7523 support disabled")
+    return encode_jwt(**claims)
+
+
+def verify_jwt_bearer_assertion(token: str) -> dict:
+    """Decode *token* and return the claims dictionary."""
+    if not settings.enable_rfc7523:
+        raise RuntimeError("RFC 7523 support disabled")
+    return decode_jwt(token)
+
+
+__all__ = [
+    "create_jwt_bearer_assertion",
+    "verify_jwt_bearer_assertion",
+    "RFC7523_SPEC_URL",
+]

--- a/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
@@ -176,6 +176,16 @@ class Settings(BaseSettings):
         in {"1", "true", "yes"},
         description="Enable JOSE examples per RFC 7520",
     )
+    enable_rfc7521: bool = Field(
+        default=os.environ.get("AUTO_AUTHN_ENABLE_RFC7521", "true").lower()
+        in {"1", "true", "yes"},
+        description="Enable Assertion Framework for OAuth 2.0 per RFC 7521",
+    )
+    enable_rfc7523: bool = Field(
+        default=os.environ.get("AUTO_AUTHN_ENABLE_RFC7523", "true").lower()
+        in {"1", "true", "yes"},
+        description="Enable JWT Bearer Token Profile for OAuth 2.0 per RFC 7523",
+    )
 
     model_config = SettingsConfigDict(env_file=None)
 

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7521_assertion_framework.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7521_assertion_framework.py
@@ -1,0 +1,31 @@
+"""Tests for RFC 7521: Assertion Framework for OAuth 2.0 Client Authentication and Authorization Grants."""
+
+import pytest
+
+from auto_authn.v2 import extract_client_assertion, runtime_cfg
+
+
+@pytest.mark.unit
+def test_extract_client_assertion(monkeypatch):
+    """RFC 7521 requires both client_assertion and client_assertion_type."""
+    monkeypatch.setattr(runtime_cfg.settings, "enable_rfc7521", True)
+    params = {
+        "client_assertion": "token",
+        "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+    }
+    assertion, assertion_type = extract_client_assertion(params)
+    assert assertion == "token"
+    assert assertion_type.endswith("jwt-bearer")
+
+
+@pytest.mark.unit
+def test_disabled(monkeypatch):
+    """When the feature is disabled a RuntimeError is raised."""
+    monkeypatch.setattr(runtime_cfg.settings, "enable_rfc7521", False)
+    with pytest.raises(RuntimeError):
+        extract_client_assertion(
+            {
+                "client_assertion": "token",
+                "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+            }
+        )

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7523_jwt_bearer.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7523_jwt_bearer.py
@@ -1,0 +1,26 @@
+"""Tests for RFC 7523: JWT Bearer Token Profile for OAuth 2.0."""
+
+import pytest
+
+from auto_authn.v2 import (
+    create_jwt_bearer_assertion,
+    verify_jwt_bearer_assertion,
+    runtime_cfg,
+)
+
+
+@pytest.mark.unit
+def test_create_and_verify_assertion(monkeypatch):
+    """A JWT bearer assertion can be created and verified when enabled."""
+    monkeypatch.setattr(runtime_cfg.settings, "enable_rfc7523", True)
+    token = create_jwt_bearer_assertion(sub="alice")
+    claims = verify_jwt_bearer_assertion(token)
+    assert claims["sub"] == "alice"
+
+
+@pytest.mark.unit
+def test_disabled(monkeypatch):
+    """Disabling RFC 7523 causes helper functions to raise."""
+    monkeypatch.setattr(runtime_cfg.settings, "enable_rfc7523", False)
+    with pytest.raises(RuntimeError):
+        create_jwt_bearer_assertion(sub="alice")


### PR DESCRIPTION
## Summary
- add RFC 7521 assertion framework helpers and tests
- implement RFC 7523 JWT bearer assertion helpers and tests
- make both features toggleable via runtime configuration flags

## Testing
- `uv run --directory /workspace/swarmauri-sdk/pkgs/standards/auto_authn --package auto_authn ruff format .`
- `uv run --directory /workspace/swarmauri-sdk/pkgs/standards/auto_authn --package auto_authn ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68ac49bebf788326a7e295ae8f186036