### PR TITLE
feat(auto_authn): add dynamic client registration

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
@@ -30,6 +30,13 @@ from .rfc7517 import load_signing_jwk, load_public_jwk
 from .rfc7518 import supported_algorithms
 from .rfc7519 import encode_jwt, decode_jwt
 from .rfc7520 import jws_then_jwe, jwe_then_jws
+from .rfc7591 import (
+    register_client,
+    get_client,
+    reset_client_registry,
+    RFC7591_SPEC_URL,
+)
+from .rfc7592 import update_client, delete_client, RFC7592_SPEC_URL
 
 __all__ = [
     "create_code_verifier",
@@ -69,4 +76,11 @@ __all__ = [
     "decode_jwt",
     "jws_then_jwe",
     "jwe_then_jws",
+    "register_client",
+    "get_client",
+    "reset_client_registry",
+    "RFC7591_SPEC_URL",
+    "update_client",
+    "delete_client",
+    "RFC7592_SPEC_URL",
 ]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7591.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7591.py
@@ -1,0 +1,73 @@
+"""Utilities for OAuth 2.0 Dynamic Client Registration (RFC 7591).
+
+This module provides a minimal in-memory client registry to illustrate
+compliance with RFC 7591. Functionality can be toggled via
+``runtime_cfg.Settings.enable_rfc7591`` so deployments may opt in or out
+as needed.
+"""
+
+from __future__ import annotations
+
+import secrets
+from typing import Dict, Final
+
+from .runtime_cfg import settings
+
+# In-memory registry of dynamically registered clients
+_CLIENT_REGISTRY: Dict[str, dict] = {}
+
+# Public URL for the RFC specification
+RFC7591_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc7591"
+
+
+def register_client(metadata: dict, *, enabled: bool | None = None) -> dict:
+    """Register a new OAuth client as described in RFC 7591.
+
+    Parameters
+    ----------
+    metadata: dict
+        Client metadata defined by RFC 7591 §2.
+    enabled: bool | None
+        Override global toggle for RFC 7591.
+
+    Returns
+    -------
+    dict
+        The stored client metadata including generated credentials.
+
+    Raises
+    ------
+    RuntimeError
+        If RFC 7591 support is disabled.
+    """
+
+    if enabled is None:
+        enabled = settings.enable_rfc7591
+    if not enabled:
+        raise RuntimeError("RFC 7591 support is disabled")
+
+    client_id = secrets.token_urlsafe(16)
+    client_secret = secrets.token_urlsafe(32)
+    data = {"client_id": client_id, "client_secret": client_secret, **metadata}
+    _CLIENT_REGISTRY[client_id] = data
+    return data
+
+
+def get_client(client_id: str) -> dict | None:
+    """Return metadata for *client_id* or ``None`` if unknown."""
+
+    return _CLIENT_REGISTRY.get(client_id)
+
+
+def reset_client_registry() -> None:
+    """Clear the in-memory client registry (primarily for tests)."""
+
+    _CLIENT_REGISTRY.clear()
+
+
+__all__ = [
+    "register_client",
+    "get_client",
+    "reset_client_registry",
+    "RFC7591_SPEC_URL",
+]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7592.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7592.py
@@ -1,0 +1,52 @@
+"""Utilities for OAuth 2.0 Dynamic Client Registration Management (RFC 7592).
+
+Helpers for updating and deleting clients registered via RFC 7591.
+Functionality can be toggled using ``runtime_cfg.Settings.enable_rfc7592``.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from .runtime_cfg import settings
+from . import rfc7591
+
+# Public URL for the RFC specification
+RFC7592_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc7592"
+
+
+def update_client(
+    client_id: str, updates: dict, *, enabled: bool | None = None
+) -> dict:
+    """Update metadata for a registered client and return the new record.
+
+    Raises ``RuntimeError`` if RFC 7592 support is disabled and ``KeyError``
+    if the client is unknown.
+    """
+
+    if enabled is None:
+        enabled = settings.enable_rfc7592
+    if not enabled:
+        raise RuntimeError("RFC 7592 support is disabled")
+    client = rfc7591.get_client(client_id)
+    if client is None:
+        raise KeyError("unknown client")
+    client.update(updates)
+    return client
+
+
+def delete_client(client_id: str, *, enabled: bool | None = None) -> bool:
+    """Remove *client_id* from the registry. Return ``True`` if removed."""
+
+    if enabled is None:
+        enabled = settings.enable_rfc7592
+    if not enabled:
+        raise RuntimeError("RFC 7592 support is disabled")
+    return rfc7591._CLIENT_REGISTRY.pop(client_id, None) is not None
+
+
+__all__ = [
+    "update_client",
+    "delete_client",
+    "RFC7592_SPEC_URL",
+]

--- a/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
@@ -176,6 +176,16 @@ class Settings(BaseSettings):
         in {"1", "true", "yes"},
         description="Enable JOSE examples per RFC 7520",
     )
+    enable_rfc7591: bool = Field(
+        default=os.environ.get("AUTO_AUTHN_ENABLE_RFC7591", "false").lower()
+        in {"1", "true", "yes"},
+        description="Enable OAuth 2.0 Dynamic Client Registration per RFC 7591",
+    )
+    enable_rfc7592: bool = Field(
+        default=os.environ.get("AUTO_AUTHN_ENABLE_RFC7592", "false").lower()
+        in {"1", "true", "yes"},
+        description="Enable OAuth 2.0 Client Registration Management per RFC 7592",
+    )
 
     model_config = SettingsConfigDict(env_file=None)
 

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7591_dynamic_client_registration.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7591_dynamic_client_registration.py
@@ -1,0 +1,31 @@
+"""Unit tests for OAuth 2.0 Dynamic Client Registration Protocol (RFC 7591).
+
+These tests verify that the minimal client registration helpers behave as
+specified when RFC 7591 support is toggled on or off.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from auto_authn.v2 import rfc7591
+
+
+def test_register_client_when_enabled() -> None:
+    """Registration succeeds and client is stored when RFC 7591 is enabled."""
+
+    with patch.object(rfc7591.settings, "enable_rfc7591", True):
+        rfc7591.reset_client_registry()
+        client = rfc7591.register_client({"redirect_uris": ["https://a.example/cb"]})
+        assert "client_id" in client
+        stored = rfc7591.get_client(client["client_id"])
+        assert stored is not None
+        assert stored["redirect_uris"] == ["https://a.example/cb"]
+
+
+def test_register_client_disabled_raises() -> None:
+    """Registration is rejected when RFC 7591 support is disabled."""
+
+    with patch.object(rfc7591.settings, "enable_rfc7591", False):
+        with pytest.raises(RuntimeError):
+            rfc7591.register_client({})

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7592_client_registration_management.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7592_client_registration_management.py
@@ -1,0 +1,48 @@
+"""Unit tests for OAuth 2.0 Dynamic Client Registration Management (RFC 7592).
+
+These tests ensure that client metadata can be updated or removed when RFC 7592
+support is enabled and that operations are rejected when disabled.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from auto_authn.v2 import rfc7591, rfc7592
+
+
+def test_update_and_delete_client_when_enabled() -> None:
+    """Clients may be updated and deleted when RFC 7592 is enabled."""
+
+    with (
+        patch.object(rfc7591.settings, "enable_rfc7591", True),
+        patch.object(rfc7592.settings, "enable_rfc7592", True),
+    ):
+        rfc7591.reset_client_registry()
+        client = rfc7591.register_client({})
+        updated = rfc7592.update_client(client["client_id"], {"client_name": "example"})
+        assert updated["client_name"] == "example"
+        assert rfc7592.delete_client(client["client_id"]) is True
+        assert rfc7591.get_client(client["client_id"]) is None
+
+
+def test_update_client_disabled_raises() -> None:
+    """Updating a client fails when RFC 7592 support is disabled."""
+
+    with patch.object(rfc7591.settings, "enable_rfc7591", True):
+        rfc7591.reset_client_registry()
+        client = rfc7591.register_client({})
+    with patch.object(rfc7592.settings, "enable_rfc7592", False):
+        with pytest.raises(RuntimeError):
+            rfc7592.update_client(client["client_id"], {})
+
+
+def test_delete_client_disabled_raises() -> None:
+    """Deleting a client fails when RFC 7592 support is disabled."""
+
+    with patch.object(rfc7591.settings, "enable_rfc7591", True):
+        rfc7591.reset_client_registry()
+        client = rfc7591.register_client({})
+    with patch.object(rfc7592.settings, "enable_rfc7592", False):
+        with pytest.raises(RuntimeError):
+            rfc7592.delete_client(client["client_id"])


### PR DESCRIPTION
## Summary
- add runtime settings for RFC 7591 and RFC 7592
- implement toggleable client registration and management helpers
- cover RFC 7591 and 7592 behaviour with unit tests

## Testing
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff format .`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68ac49df772c8326b9be07396b538199