### PR TITLE
Add WebAuthn algorithm registry with RFC flags in auto_authn

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
@@ -10,18 +10,17 @@ from .rfc7636_pkce import (
     create_code_verifier,
     verify_code_challenge,
 )
-from .rfc8628 import generate_device_code, generate_user_code, validate_user_code
-from .rfc9396 import (
-    AuthorizationDetail,
-    parse_authorization_details,
-    RFC9396_SPEC_URL,
-)8 import (
+from .rfc8628 import (
+    RFC8628_SPEC_URL,
     generate_device_code,
     generate_user_code,
     validate_user_code,
-    RFC8628_SPEC_URL,
 )
-from .rfc9396 import AuthorizationDetail, parse_authorization_details
+from .rfc9396 import (
+    AuthorizationDetail,
+    RFC9396_SPEC_URL,
+    parse_authorization_details,
+)
 
 from .rfc6750 import extract_bearer_token
 from .rfc7662 import introspect_token, register_token, reset_tokens
@@ -34,19 +33,17 @@ from .rfc8705 import (
     validate_certificate_binding,
 )
 from .rfc8252 import is_native_redirect_uri, validate_native_redirect_uri
-from .rfc8705 import thumbprint_from_cert_pem, validate_certificate_binding
 from .rfc7638 import jwk_thumbprint, verify_jwk_thumbprint
 from .rfc7800 import add_cnf_claim, verify_proof_of_possession
 from .rfc8291 import encrypt_push_message, decrypt_push_message
 from .rfc9068 import add_rfc9068_claims, validate_rfc9068_claims
-from .rfc8252 import is_native_redirect_uri, validate_native_redirect_uri
 
 from .rfc7515 import sign_jws, verify_jws
 from .rfc7516 import encrypt_jwe, decrypt_jwe
 from .rfc7517 import load_signing_jwk, load_public_jwk
 from .rfc7518 import supported_algorithms
 from .rfc7519 import encode_jwt, decode_jwt
-from .rfc7520 import jws_then_jwe, jwe_then_jws
+from .rfc7520 import RFC7520_SPEC_URL, jwe_then_jws, jws_then_jwe
 from .rfc7521 import validate_jwt_assertion, RFC7521_SPEC_URL
 
 __all__ = [

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8812.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8812.py
@@ -1,0 +1,41 @@
+"""WebAuthn algorithm registrations for RFC 8812 compliance.
+
+This module provides minimal constants and helpers for the algorithms
+registered in :rfc:`8812`.  Support can be toggled via
+``runtime_cfg.Settings.enable_rfc8812`` so deployments may opt out of
+validation.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from .runtime_cfg import settings
+
+RFC8812_SPEC_URL = "https://www.rfc-editor.org/rfc/rfc8812"
+
+#: Mapping of JOSE algorithm names to COSE numeric values as defined by RFC 8812.
+WEBAUTHN_ALGORITHMS: Dict[str, int] = {
+    "RS256": -257,
+    "RS384": -258,
+    "RS512": -259,
+    "RS1": -65535,
+    "ES256K": -47,
+}
+
+
+def is_webauthn_algorithm(name: str, *, enabled: bool | None = None) -> bool:
+    """Return ``True`` if *name* is a registered WebAuthn algorithm.
+
+    When ``enabled`` is ``False`` the check always succeeds.  If ``enabled`` is
+    ``None`` the global feature toggle is used.
+    """
+
+    if enabled is None:
+        enabled = settings.enable_rfc8812
+    if not enabled:
+        return True
+    return name in WEBAUTHN_ALGORITHMS
+
+
+__all__ = ["RFC8812_SPEC_URL", "WEBAUTHN_ALGORITHMS", "is_webauthn_algorithm"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
@@ -96,6 +96,11 @@ class Settings(BaseSettings):
         in {"1", "true", "yes"},
         description="Enable Message Encryption for Web Push per RFC 8291",
     )
+    enable_rfc8812: bool = Field(
+        default=os.environ.get("AUTO_AUTHN_ENABLE_RFC8812", "false").lower()
+        in {"1", "true", "yes"},
+        description="Enable WebAuthn algorithm registrations per RFC 8812",
+    )
     enable_rfc7662: bool = Field(
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC7662", "false").lower()
         in {"1", "true", "yes"}
@@ -106,13 +111,12 @@ class Settings(BaseSettings):
     enable_rfc9396: bool = Field(
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC9396", "0").lower()
         in {"1", "true", "yes"},
-        description=("Enable OAuth 2.0 Rich Authorization Requests per RFC 9396"),
-    enable_rfc9396: bool = Field(default=os.environ.get("ENABLE_RFC9396", "0") == "1")
+        description="Enable OAuth 2.0 Rich Authorization Requests per RFC 9396",
+    )
     enable_rfc9101: bool = Field(
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC9101", "false").lower()
         in {"1", "true", "yes"},
         description="Enable JWT-Secured Authorization Request per RFC 9101",
-
     )
     enable_rfc7009: bool = Field(
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC7009", "false").lower()

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7517_jwk.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7517_jwk.py
@@ -1,5 +1,8 @@
 """Tests for RFC 7517: JSON Web Key (JWK)."""
 
+import pytest
+
+from auto_authn.v2 import runtime_cfg
 from auto_authn.v2 import load_signing_jwk, load_public_jwk
 
 
@@ -8,3 +11,12 @@ def test_jwk_contains_required_fields() -> None:
     pub = load_public_jwk()
     assert priv.kty == "OKP"
     assert pub.kty == "OKP"
+
+
+def test_feature_flag(monkeypatch) -> None:
+    """Disabling RFC 7517 raises errors when loading keys."""
+    monkeypatch.setattr(runtime_cfg.settings, "enable_rfc7517", False)
+    with pytest.raises(RuntimeError):
+        load_signing_jwk()
+    with pytest.raises(RuntimeError):
+        load_public_jwk()

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc8812_webauthn_algorithms.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc8812_webauthn_algorithms.py
@@ -1,0 +1,32 @@
+"""Tests for RFC 8812: WebAuthn algorithm registrations."""
+
+import pytest
+
+from auto_authn.v2 import runtime_cfg
+from auto_authn.v2.rfc8812 import (
+    RFC8812_SPEC_URL,
+    WEBAUTHN_ALGORITHMS,
+    is_webauthn_algorithm,
+)
+
+
+@pytest.mark.unit
+def test_algorithm_lookup_enabled() -> None:
+    """Known algorithms are recognised when the feature is enabled."""
+    assert is_webauthn_algorithm("ES256K", enabled=True)
+    assert not is_webauthn_algorithm("UNKNOWN", enabled=True)
+
+
+@pytest.mark.unit
+def test_feature_toggle(monkeypatch) -> None:
+    """When disabled, any algorithm is accepted."""
+    monkeypatch.setattr(runtime_cfg.settings, "enable_rfc8812", False)
+    assert is_webauthn_algorithm("UNKNOWN")
+    assert is_webauthn_algorithm("ES256K")
+    monkeypatch.setattr(runtime_cfg.settings, "enable_rfc8812", True)
+    assert "ES256K" in WEBAUTHN_ALGORITHMS
+
+
+def test_spec_url_constant() -> None:
+    """Expose the spec URL for documentation purposes."""
+    assert "8812" in RFC8812_SPEC_URL

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc9068_jwt_profile.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc9068_jwt_profile.py
@@ -20,12 +20,16 @@ from auto_authn.v2.rfc9068 import add_rfc9068_claims, validate_rfc9068_claims
 def test_helpers_apply_and_validate():
     """RFC 9068 claim helpers add and validate ``iss`` and ``aud``."""
     payload = {"sub": "alice", "exp": 1}
-    augmented = add_rfc9068_claims(payload, issuer="issuer", audience=["api"])
+    augmented = add_rfc9068_claims(
+        payload, issuer="issuer", audience=["api"], enabled=True
+    )
     assert augmented["iss"] == "issuer"
     assert augmented["aud"] == ["api"]
-    validate_rfc9068_claims(augmented, issuer="issuer", audience=["api"])
+    validate_rfc9068_claims(augmented, issuer="issuer", audience=["api"], enabled=True)
     with pytest.raises(InvalidTokenError):
-        validate_rfc9068_claims(augmented, issuer="other", audience=["api"])
+        validate_rfc9068_claims(
+            augmented, issuer="other", audience=["api"], enabled=True
+        )
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- add feature flag for RFC 8812 WebAuthn algorithm registrations
- allow RFC 9068 JWT helpers to be toggled via settings
- verify RFC 7517, 7638, 7800, 8291, 9068 and 8812 behaviour with focused tests

## Testing
- `uv run --package auto_authn --directory . ruff format .`
- `uv run --package auto_authn --directory . ruff check . --fix`
- `uv run --package auto_authn --directory . pytest tests/unit/test_rfc7517_jwk.py tests/unit/test_rfc7638_jwk_thumbprint.py tests/unit/test_rfc7800_proof_of_possession.py tests/unit/test_rfc8291_webpush_encryption.py tests/unit/test_rfc9068_jwt_profile.py tests/unit/test_rfc8812_webauthn_algorithms.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac4c0c24908326aac42cddf89a7dc3