### PR TITLE
Add RFC 8725 JWT best practices validation

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8725.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8725.py
@@ -1,0 +1,50 @@
+"""JWT Best Current Practices utilities for RFC 8725 compliance.
+
+This module validates JSON Web Tokens according to :rfc:`8725`.  Validation
+may be toggled via ``enable_rfc8725`` in
+:mod:`auto_authn.v2.runtime_cfg.Settings` to allow deployments to opt in or out
+of enforcement.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import jwt
+from jwt.exceptions import InvalidTokenError
+
+from .jwtoken import JWTCoder
+from .runtime_cfg import settings
+
+RFC8725_SPEC_URL = "https://www.rfc-editor.org/rfc/rfc8725"
+
+
+def validate_jwt_best_practices(
+    token: str, *, enabled: bool | None = None
+) -> Dict[str, Any]:
+    """Return decoded *token* if it satisfies :rfc:`8725` recommendations.
+
+    When ``enabled`` is ``False`` the token is decoded without additional
+    validation.  If ``enabled`` is ``None`` the global runtime setting is used.
+    """
+
+    if enabled is None:
+        enabled = settings.enable_rfc8725
+
+    # Always decode using the standard JWTCoder to verify signature and expiry
+    claims = JWTCoder.default().decode(token)
+    if not enabled:
+        return claims
+
+    header = jwt.get_unverified_header(token)
+    if header.get("alg", "").lower() == "none":
+        raise InvalidTokenError("alg 'none' is prohibited by RFC 8725")
+
+    for required in ("iss", "aud", "exp", "sub"):
+        if required not in claims:
+            raise InvalidTokenError(f"missing '{required}' claim required by RFC 8725")
+
+    return claims
+
+
+__all__ = ["validate_jwt_best_practices", "RFC8725_SPEC_URL"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
@@ -71,6 +71,11 @@ class Settings(BaseSettings):
         in {"1", "true", "yes"},
         description=("Enable OAuth 2.0 Mutual-TLS client authentication per RFC 8705"),
     )
+    enable_rfc8725: bool = Field(
+        default=os.environ.get("AUTO_AUTHN_ENABLE_RFC8725", "false").lower()
+        in {"1", "true", "yes"},
+        description=("Enable JSON Web Token Best Current Practices per RFC 8725"),
+    )
     enable_rfc7636: bool = Field(
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC7636", "true").lower()
         in {"1", "true", "yes"},
@@ -107,12 +112,11 @@ class Settings(BaseSettings):
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC9396", "0").lower()
         in {"1", "true", "yes"},
         description=("Enable OAuth 2.0 Rich Authorization Requests per RFC 9396"),
-    enable_rfc9396: bool = Field(default=os.environ.get("ENABLE_RFC9396", "0") == "1")
+    )
     enable_rfc9101: bool = Field(
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC9101", "false").lower()
         in {"1", "true", "yes"},
         description="Enable JWT-Secured Authorization Request per RFC 9101",
-
     )
     enable_rfc7009: bool = Field(
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC7009", "false").lower()

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc8725_jwt_best_practices.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc8725_jwt_best_practices.py
@@ -1,0 +1,56 @@
+"""Tests for JWT Best Current Practices compliance with RFC 8725.
+
+Spec URL: https://www.rfc-editor.org/rfc/rfc8725
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import jwt
+import pytest
+from jwt import InvalidTokenError
+
+from auto_authn.v2.jwtoken import JWTCoder
+from auto_authn.v2.rfc8725 import RFC8725_SPEC_URL, validate_jwt_best_practices
+from auto_authn.v2.runtime_cfg import settings
+
+
+@pytest.mark.unit
+def test_validation_succeeds(monkeypatch):
+    monkeypatch.setattr(settings, "enable_rfc8725", True)
+    token = JWTCoder.default().sign(
+        sub="user", tid="tenant", iss="https://issuer", aud="audience"
+    )
+    claims = validate_jwt_best_practices(token)
+    assert claims["aud"] == "audience"
+    assert RFC8725_SPEC_URL.endswith("8725")
+
+
+@pytest.mark.unit
+def test_rejects_none_algorithm(monkeypatch):
+    monkeypatch.setattr(settings, "enable_rfc8725", True)
+    payload = {
+        "sub": "user",
+        "tid": "tenant",
+        "iss": "https://issuer",
+        "aud": "audience",
+        "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
+    }
+    token = jwt.encode(payload, key="", algorithm="none")
+    with pytest.raises(InvalidTokenError):
+        validate_jwt_best_practices(token)
+
+
+@pytest.mark.unit
+def test_missing_claim(monkeypatch):
+    monkeypatch.setattr(settings, "enable_rfc8725", True)
+    token = JWTCoder.default().sign(sub="user", tid="tenant")
+    with pytest.raises(InvalidTokenError):
+        validate_jwt_best_practices(token)
+
+
+@pytest.mark.unit
+def test_validation_skipped_when_disabled(monkeypatch):
+    monkeypatch.setattr(settings, "enable_rfc8725", False)
+    token = JWTCoder.default().sign(sub="user", tid="tenant")
+    claims = validate_jwt_best_practices(token)
+    assert claims["sub"] == "user"


### PR DESCRIPTION
## Summary
- add RFC 8725 JWT Best Current Practices helpers with feature toggle
- expose AUTO_AUTHN_ENABLE_RFC8725 configuration flag
- test JWT best practices compliance

## Testing
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff format .` *(fails: Failed to parse auto_authn/v2/__init__.py:18:2)*
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check . --fix` *(fails: invalid-syntax at auto_authn/v2/__init__.py)*
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff format auto_authn/v2/runtime_cfg.py auto_authn/v2/rfc8725.py tests/unit/test_rfc8725_jwt_best_practices.py`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check auto_authn/v2/runtime_cfg.py auto_authn/v2/rfc8725.py tests/unit/test_rfc8725_jwt_best_practices.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_68ac4c5e8ad88326ad06789ec1e8cc4b