### PR TITLE
Add SPEC_URL constants and spec links for auto_authn RFC modules

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc6749.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc6749.py
@@ -6,13 +6,17 @@ to RFC 6749 Section 5.2. Validation can be toggled on or off via the
 
 The public ``enforce_*`` helpers automatically respect the runtime flag making
 RFC 6749 enforcement modular.
+
+See RFC 6749: https://www.rfc-editor.org/rfc/rfc6749
 """
 
 from __future__ import annotations
 
-from typing import Iterable, Mapping
+from typing import Final, Iterable, Mapping
 
 from .runtime_cfg import settings
+
+RFC6749_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc6749"
 
 __all__ = [
     "RFC6749Error",
@@ -21,6 +25,7 @@ __all__ = [
     "is_enabled",
     "enforce_grant_type",
     "enforce_password_grant",
+    "RFC6749_SPEC_URL",
 ]
 
 

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc6750.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc6750.py
@@ -5,13 +5,18 @@ This module extracts bearer tokens from HTTP requests according to
 Optional mechanisms for supplying the token in the URI query parameter or the
 request body can also be toggled via settings to allow deployments to opt out
 of these potentially insecure features.
+
+See RFC 6750: https://www.rfc-editor.org/rfc/rfc6750
 """
 
 from __future__ import annotations
 
 from fastapi import Request
+from typing import Final
 
 from .runtime_cfg import settings
+
+RFC6750_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc6750"
 
 
 async def extract_bearer_token(request: Request, authorization: str) -> str | None:
@@ -53,4 +58,4 @@ async def extract_bearer_token(request: Request, authorization: str) -> str | No
     return None
 
 
-__all__ = ["extract_bearer_token"]
+__all__ = ["extract_bearer_token", "RFC6750_SPEC_URL"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7009.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7009.py
@@ -3,13 +3,17 @@
 This module provides a simple in-memory registry for revoked tokens to
 illustrate compliance with RFC 7009. The registry can be toggled on or off
 via the ``enable_rfc7009`` setting in ``runtime_cfg.Settings``.
+
+See RFC 7009: https://www.rfc-editor.org/rfc/rfc7009
 """
 
 from __future__ import annotations
 
-from typing import Set
+from typing import Final, Set
 
 from .runtime_cfg import settings
+
+RFC7009_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc7009"
 
 # In-memory set storing revoked tokens for demonstration and testing purposes
 _REVOKED_TOKENS: Set[str] = set()
@@ -38,3 +42,6 @@ def is_revoked(token: str) -> bool:
 def reset_revocations() -> None:
     """Clear the revocation registry. Intended for test setup/teardown."""
     _REVOKED_TOKENS.clear()
+
+
+__all__ = ["revoke_token", "is_revoked", "reset_revocations", "RFC7009_SPEC_URL"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7515.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7515.py
@@ -3,17 +3,23 @@
 This module provides thin wrappers around :mod:`jwcrypto.jws` to create and
 verify JWS objects. Functionality can be toggled via the
 ``AUTO_AUTHN_ENABLE_RFC7515`` environment variable.
+
+See RFC 7515: https://www.rfc-editor.org/rfc/rfc7515
 """
+
+from typing import Final
 
 from jwcrypto import jws, jwk
 
 from .runtime_cfg import settings
 
+RFC7515_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc7515"
+
 
 def sign_jws(payload: str, key: jwk.JWK) -> str:
     """Return a JWS compact serialization of *payload* using *key*."""
     if not settings.enable_rfc7515:
-        raise RuntimeError("RFC 7515 support disabled")
+        raise RuntimeError(f"RFC 7515 support disabled: {RFC7515_SPEC_URL}")
     token = jws.JWS(payload.encode())
     alg = "HS256" if key.kty == "oct" else "EdDSA"
     token.add_signature(key, None, json_encode({"alg": alg}))
@@ -23,7 +29,7 @@ def sign_jws(payload: str, key: jwk.JWK) -> str:
 def verify_jws(token: str, key: jwk.JWK) -> str:
     """Verify *token* and return the decoded payload as a string."""
     if not settings.enable_rfc7515:
-        raise RuntimeError("RFC 7515 support disabled")
+        raise RuntimeError(f"RFC 7515 support disabled: {RFC7515_SPEC_URL}")
     obj = jws.JWS()
     obj.deserialize(token)
     obj.verify(key)
@@ -37,4 +43,4 @@ def json_encode(data: dict) -> str:
     return json.dumps(data)
 
 
-__all__ = ["sign_jws", "verify_jws"]
+__all__ = ["sign_jws", "verify_jws", "RFC7515_SPEC_URL"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7516.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7516.py
@@ -3,17 +3,23 @@
 Helpers for encrypting and decrypting content using the compact JWE
 serialization. This feature can be toggled with the
 ``AUTO_AUTHN_ENABLE_RFC7516`` environment variable.
+
+See RFC 7516: https://www.rfc-editor.org/rfc/rfc7516
 """
+
+from typing import Final
 
 from jwcrypto import jwe, jwk
 
 from .runtime_cfg import settings
 
+RFC7516_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc7516"
+
 
 def encrypt_jwe(plaintext: str, key: jwk.JWK) -> str:
     """Encrypt *plaintext* for *key* and return the compact JWE string."""
     if not settings.enable_rfc7516:
-        raise RuntimeError("RFC 7516 support disabled")
+        raise RuntimeError(f"RFC 7516 support disabled: {RFC7516_SPEC_URL}")
     protected = {"alg": "dir", "enc": "A256GCM"}
     token = jwe.JWE(plaintext.encode(), json_encode(protected))
     token.add_recipient(key)
@@ -23,7 +29,7 @@ def encrypt_jwe(plaintext: str, key: jwk.JWK) -> str:
 def decrypt_jwe(token: str, key: jwk.JWK) -> str:
     """Decrypt *token* with *key* and return the plaintext string."""
     if not settings.enable_rfc7516:
-        raise RuntimeError("RFC 7516 support disabled")
+        raise RuntimeError(f"RFC 7516 support disabled: {RFC7516_SPEC_URL}")
     obj = jwe.JWE()
     obj.deserialize(token)
     obj.decrypt(key)
@@ -36,4 +42,4 @@ def json_encode(data: dict) -> str:
     return json.dumps(data)
 
 
-__all__ = ["encrypt_jwe", "decrypt_jwe"]
+__all__ = ["encrypt_jwe", "decrypt_jwe", "RFC7516_SPEC_URL"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7517.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7517.py
@@ -2,26 +2,32 @@
 
 Utility helpers for exporting the service's Ed25519 key pair as JWKs. These
 helpers respect the ``AUTO_AUTHN_ENABLE_RFC7517`` feature flag.
+
+See RFC 7517: https://www.rfc-editor.org/rfc/rfc7517
 """
+
+from typing import Final
 
 from jwcrypto import jwk
 
 from .crypto import public_key, signing_key
 from .runtime_cfg import settings
 
+RFC7517_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc7517"
+
 
 def load_signing_jwk() -> jwk.JWK:
     """Return the private signing key as a :class:`~jwcrypto.jwk.JWK`."""
     if not settings.enable_rfc7517:
-        raise RuntimeError("RFC 7517 support disabled")
+        raise RuntimeError(f"RFC 7517 support disabled: {RFC7517_SPEC_URL}")
     return jwk.JWK.from_pem(signing_key())
 
 
 def load_public_jwk() -> jwk.JWK:
     """Return the public key as a :class:`~jwcrypto.jwk.JWK`."""
     if not settings.enable_rfc7517:
-        raise RuntimeError("RFC 7517 support disabled")
+        raise RuntimeError(f"RFC 7517 support disabled: {RFC7517_SPEC_URL}")
     return jwk.JWK.from_pem(public_key())
 
 
-__all__ = ["load_signing_jwk", "load_public_jwk"]
+__all__ = ["load_signing_jwk", "load_public_jwk", "RFC7517_SPEC_URL"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7518.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7518.py
@@ -2,16 +2,22 @@
 
 Expose the list of algorithms supported by this service. Controlled via the
 ``AUTO_AUTHN_ENABLE_RFC7518`` environment variable.
+
+See RFC 7518: https://www.rfc-editor.org/rfc/rfc7518
 """
 
+from typing import Final
+
 from .runtime_cfg import settings
+
+RFC7518_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc7518"
 
 
 def supported_algorithms() -> list[str]:
     """Return algorithms supported for JOSE operations."""
     if not settings.enable_rfc7518:
-        raise RuntimeError("RFC 7518 support disabled")
+        raise RuntimeError(f"RFC 7518 support disabled: {RFC7518_SPEC_URL}")
     return ["EdDSA"]
 
 
-__all__ = ["supported_algorithms"]
+__all__ = ["supported_algorithms", "RFC7518_SPEC_URL"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7519.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7519.py
@@ -2,24 +2,30 @@
 
 Convenience wrappers around :class:`auto_authn.v2.jwtoken.JWTCoder` that can be
 enabled or disabled via ``AUTO_AUTHN_ENABLE_RFC7519``.
+
+See RFC 7519: https://www.rfc-editor.org/rfc/rfc7519
 """
+
+from typing import Final
 
 from .jwtoken import JWTCoder
 from .runtime_cfg import settings
+
+RFC7519_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc7519"
 
 
 def encode_jwt(**claims) -> str:
     """Encode *claims* as a JWT string."""
     if not settings.enable_rfc7519:
-        raise RuntimeError("RFC 7519 support disabled")
+        raise RuntimeError(f"RFC 7519 support disabled: {RFC7519_SPEC_URL}")
     return JWTCoder.default().sign(**claims)
 
 
 def decode_jwt(token: str) -> dict:
     """Decode and verify *token* returning the claims dictionary."""
     if not settings.enable_rfc7519:
-        raise RuntimeError("RFC 7519 support disabled")
+        raise RuntimeError(f"RFC 7519 support disabled: {RFC7519_SPEC_URL}")
     return JWTCoder.default().decode(token)
 
 
-__all__ = ["encode_jwt", "decode_jwt"]
+__all__ = ["encode_jwt", "decode_jwt", "RFC7519_SPEC_URL"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7520.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7520.py
@@ -1,8 +1,10 @@
 """JOSE composition helpers for RFC 7520 compliance.
 
 This module demonstrates the JOSE patterns defined in :rfc:`7520`, providing
-helpers that sign payloads before encrypting them and vice‑versa.  Support can
+helpers that sign payloads before encrypting them and vice‑versa. Support can
 be toggled via the ``AUTO_AUTHN_ENABLE_RFC7520`` environment variable.
+
+See RFC 7520: https://www.rfc-editor.org/rfc/rfc7520
 """
 
 from typing import Final
@@ -19,7 +21,7 @@ RFC7520_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc7520"
 def jws_then_jwe(payload: str, key: jwk.JWK) -> str:
     """Sign *payload* then encrypt the resulting JWS."""
     if not settings.enable_rfc7520:
-        raise RuntimeError("RFC 7520 support disabled")
+        raise RuntimeError(f"RFC 7520 support disabled: {RFC7520_SPEC_URL}")
     jws_token = sign_jws(payload, key)
     return encrypt_jwe(jws_token, key)
 
@@ -27,7 +29,7 @@ def jws_then_jwe(payload: str, key: jwk.JWK) -> str:
 def jwe_then_jws(token: str, key: jwk.JWK) -> str:
     """Decrypt a JWE then verify the contained JWS."""
     if not settings.enable_rfc7520:
-        raise RuntimeError("RFC 7520 support disabled")
+        raise RuntimeError(f"RFC 7520 support disabled: {RFC7520_SPEC_URL}")
     jws_token = decrypt_jwe(token, key)
     return verify_jws(jws_token, key)
 

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7521.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7521.py
@@ -3,6 +3,8 @@
 This module provides helpers for validating JWT assertions used for client
 authentication and authorization grants. Support can be toggled via the
 ``AUTO_AUTHN_ENABLE_RFC7521`` environment variable.
+
+See RFC 7521: https://www.rfc-editor.org/rfc/rfc7521
 """
 
 from __future__ import annotations
@@ -25,7 +27,7 @@ def validate_jwt_assertion(assertion: str) -> Dict[str, object]:
     """
 
     if not settings.enable_rfc7521:
-        raise RuntimeError("RFC 7521 support disabled")
+        raise RuntimeError(f"RFC 7521 support disabled: {RFC7521_SPEC_URL}")
     claims = decode_jwt(assertion)
     missing = REQUIRED_CLAIMS - claims.keys()
     if missing:

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7591.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7591.py
@@ -4,6 +4,8 @@ This module provides a minimal in-memory client registry to illustrate
 compliance with RFC 7591. Functionality can be toggled via
 ``runtime_cfg.Settings.enable_rfc7591`` so deployments may opt in or out
 as needed.
+
+See RFC 7591: https://www.rfc-editor.org/rfc/rfc7591
 """
 
 from __future__ import annotations
@@ -44,7 +46,7 @@ def register_client(metadata: dict, *, enabled: bool | None = None) -> dict:
     if enabled is None:
         enabled = settings.enable_rfc7591
     if not enabled:
-        raise RuntimeError("RFC 7591 support is disabled")
+        raise RuntimeError(f"RFC 7591 support is disabled: {RFC7591_SPEC_URL}")
 
     client_id = secrets.token_urlsafe(16)
     client_secret = secrets.token_urlsafe(32)

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7592.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7592.py
@@ -2,6 +2,8 @@
 
 Helpers for updating and deleting clients registered via RFC 7591.
 Functionality can be toggled using ``runtime_cfg.Settings.enable_rfc7592``.
+
+See RFC 7592: https://www.rfc-editor.org/rfc/rfc7592
 """
 
 from __future__ import annotations
@@ -27,7 +29,7 @@ def update_client(
     if enabled is None:
         enabled = settings.enable_rfc7592
     if not enabled:
-        raise RuntimeError("RFC 7592 support is disabled")
+        raise RuntimeError(f"RFC 7592 support is disabled: {RFC7592_SPEC_URL}")
     client = rfc7591.get_client(client_id)
     if client is None:
         raise KeyError("unknown client")
@@ -41,7 +43,7 @@ def delete_client(client_id: str, *, enabled: bool | None = None) -> bool:
     if enabled is None:
         enabled = settings.enable_rfc7592
     if not enabled:
-        raise RuntimeError("RFC 7592 support is disabled")
+        raise RuntimeError(f"RFC 7592 support is disabled: {RFC7592_SPEC_URL}")
     return rfc7591._CLIENT_REGISTRY.pop(client_id, None) is not None
 
 

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7636_pkce.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7636_pkce.py
@@ -1,10 +1,12 @@
 """PKCE utilities for RFC 7636 compliance.
 
 This module implements the Proof Key for Code Exchange (PKCE)
-requirements defined in :rfc:`7636`.  It provides helpers for creating
+requirements defined in :rfc:`7636`. It provides helpers for creating
 ``code_verifier`` strings and deriving ``code_challenge`` values using the
-``S256`` transformation.  The functions may be disabled via runtime
-configuration to allow deployments to opt-out of RFC 7636 enforcement.
+``S256`` transformation. The functions may be disabled via runtime
+configuration to allow deployments to opt out of RFC 7636 enforcement.
+
+See RFC 7636: https://www.rfc-editor.org/rfc/rfc7636
 """
 
 from __future__ import annotations
@@ -16,6 +18,8 @@ import secrets
 from typing import Final
 
 from .runtime_cfg import settings
+
+RFC7636_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc7636"
 
 # Allowed characters for the code_verifier as defined by RFC 7636 §4.1
 _VERIFIER_CHARSET: Final = (
@@ -78,4 +82,5 @@ __all__ = [
     "create_code_verifier",
     "create_code_challenge",
     "verify_code_challenge",
+    "RFC7636_SPEC_URL",
 ]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7638.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7638.py
@@ -1,8 +1,10 @@
 """JWK Thumbprint utilities for RFC 7638 compliance.
 
 This module computes and verifies JSON Web Key (JWK) thumbprints as defined in
-:rfc:`7638`.  The helpers are feature flagged via ``enable_rfc7638`` in
+:rfc:`7638`. The helpers are feature flagged via ``enable_rfc7638`` in
 :mod:`auto_authn.v2.runtime_cfg` so deployments may opt out of enforcement.
+
+See RFC 7638: https://www.rfc-editor.org/rfc/rfc7638
 """
 
 from __future__ import annotations
@@ -10,9 +12,11 @@ from __future__ import annotations
 import base64
 import json
 from hashlib import sha256
-from typing import Any, Mapping
+from typing import Any, Final, Mapping
 
 from .runtime_cfg import settings
+
+RFC7638_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc7638"
 
 # Required members for each key type according to RFC 7638 §3.1
 _REQUIRED_MEMBERS = {
@@ -65,4 +69,4 @@ def verify_jwk_thumbprint(
     return expected == thumbprint
 
 
-__all__ = ["jwk_thumbprint", "verify_jwk_thumbprint"]
+__all__ = ["jwk_thumbprint", "verify_jwk_thumbprint", "RFC7638_SPEC_URL"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7662.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7662.py
@@ -3,13 +3,17 @@
 This module provides a simple in-memory registry for token introspection to
 illustrate compliance with RFC 7662. The registry can be toggled on or off via
 the ``enable_rfc7662`` setting in ``runtime_cfg.Settings``.
+
+See RFC 7662: https://www.rfc-editor.org/rfc/rfc7662
 """
 
 from __future__ import annotations
 
-from typing import Dict, Any
+from typing import Any, Dict, Final
 
 from .runtime_cfg import settings
+
+RFC7662_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc7662"
 
 # In-memory store mapping tokens to their introspection responses
 _ACTIVE_TOKENS: Dict[str, Dict[str, Any]] = {}
@@ -32,7 +36,7 @@ def introspect_token(token: str) -> Dict[str, Any]:
         If RFC 7662 support is disabled via settings.
     """
     if not settings.enable_rfc7662:
-        raise RuntimeError("RFC 7662 support is disabled")
+        raise RuntimeError(f"RFC 7662 support is disabled: {RFC7662_SPEC_URL}")
     return _ACTIVE_TOKENS.get(token, {"active": False})
 
 
@@ -41,4 +45,4 @@ def reset_tokens() -> None:
     _ACTIVE_TOKENS.clear()
 
 
-__all__ = ["register_token", "introspect_token", "reset_tokens"]
+__all__ = ["register_token", "introspect_token", "reset_tokens", "RFC7662_SPEC_URL"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7800.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7800.py
@@ -1,17 +1,21 @@
 """Proof-of-Possession helpers for RFC 7800 compliance.
 
 The functions in this module assist with creating and validating the ``cnf``
-(claims confirmation) structure defined in :rfc:`7800`.  Enforcement may be
+(claims confirmation) structure defined in :rfc:`7800`. Enforcement may be
 enabled or disabled via ``enable_rfc7800`` in
 :mod:`auto_authn.v2.runtime_cfg.Settings`.
+
+See RFC 7800: https://www.rfc-editor.org/rfc/rfc7800
 """
 
 from __future__ import annotations
 
-from typing import Any, Dict, Mapping
+from typing import Any, Dict, Final, Mapping
 
 from .runtime_cfg import settings
 from .rfc7638 import jwk_thumbprint
+
+RFC7800_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc7800"
 
 
 def add_cnf_claim(payload: Mapping[str, Any], jwk: Mapping[str, Any]) -> Dict[str, Any]:
@@ -50,4 +54,4 @@ def verify_proof_of_possession(
     return jkt == expected
 
 
-__all__ = ["add_cnf_claim", "verify_proof_of_possession"]
+__all__ = ["add_cnf_claim", "verify_proof_of_possession", "RFC7800_SPEC_URL"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8252.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8252.py
@@ -7,13 +7,16 @@ dynamically chosen port. Redirect URIs that fall outside of these
 patterns are considered non-compliant. Enforcement of these rules can be
 toggled via ``runtime_cfg.Settings.enforce_rfc8252`` which is controlled
 by the ``AUTO_AUTHN_ENFORCE_RFC8252`` environment variable.
+
+See RFC 8252: https://www.rfc-editor.org/rfc/rfc8252
 """
 
 from __future__ import annotations
 
 from urllib.parse import urlparse
+from typing import Final
 
-RFC_SPEC = "RFC 8252"  # OAuth 2.0 for Native Apps
+RFC8252_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc8252"
 
 # Hosts that resolve to the loopback interface as defined by RFC 8252 §7.3
 _LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1"}
@@ -46,4 +49,9 @@ def validate_native_redirect_uri(uri: str) -> None:
     """
 
     if not is_native_redirect_uri(uri):
-        raise ValueError("redirect URI not permitted for native apps per RFC 8252")
+        raise ValueError(
+            f"redirect URI not permitted for native apps per RFC 8252: {RFC8252_SPEC_URL}"
+        )
+
+
+__all__ = ["is_native_redirect_uri", "validate_native_redirect_uri", "RFC8252_SPEC_URL"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8291.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8291.py
@@ -1,16 +1,21 @@
 """Web Push message encryption helpers for RFC 8291 compliance.
 
 This module offers minimal AES-128-GCM helpers inspired by
-:rfc:`8291`.  The encryption utilities can be disabled via the
+:rfc:`8291`. The encryption utilities can be disabled via the
 ``enable_rfc8291`` flag in :mod:`auto_authn.v2.runtime_cfg` to allow
 unencrypted operation in constrained environments.
+
+See RFC 8291: https://www.rfc-editor.org/rfc/rfc8291
 """
 
 from __future__ import annotations
 
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from typing import Final
 
 from .runtime_cfg import settings
+
+RFC8291_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc8291"
 
 
 def encrypt_push_message(
@@ -46,4 +51,4 @@ def decrypt_push_message(
     return aesgcm.decrypt(nonce, ciphertext, associated_data=None)
 
 
-__all__ = ["encrypt_push_message", "decrypt_push_message"]
+__all__ = ["encrypt_push_message", "decrypt_push_message", "RFC8291_SPEC_URL"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8414.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8414.py
@@ -4,14 +4,19 @@ This module provides a minimal implementation of the OAuth 2.0 Authorization
 Server Metadata specification as defined in RFC 8414. When enabled via
 ``settings.enable_rfc8414`` it exposes a discovery document at
 ``/.well-known/oauth-authorization-server``.
+
+See RFC 8414: https://www.rfc-editor.org/rfc/rfc8414
 """
 
 from __future__ import annotations
 
 import os
 from fastapi import APIRouter, FastAPI, HTTPException, status
+from typing import Final
 
 from .runtime_cfg import settings
+
+RFC8414_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc8414"
 
 router = APIRouter()
 
@@ -24,7 +29,9 @@ ISSUER = os.getenv("AUTHN_ISSUER", "https://authn.example.com")
 async def authorization_server_metadata():
     """Return OAuth 2.0 Authorization Server Metadata per RFC 8414."""
     if not settings.enable_rfc8414:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "RFC 8414 disabled")
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND, f"RFC 8414 disabled: {RFC8414_SPEC_URL}"
+        )
     return {
         "issuer": ISSUER,
         "authorization_endpoint": f"{ISSUER}/authorize",
@@ -41,4 +48,4 @@ def include_rfc8414(app: FastAPI) -> None:
         app.include_router(router)
 
 
-__all__ = ["router", "JWKS_PATH", "ISSUER", "include_rfc8414"]
+__all__ = ["router", "JWKS_PATH", "ISSUER", "include_rfc8414", "RFC8414_SPEC_URL"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8628.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8628.py
@@ -1,10 +1,12 @@
 """Device Authorization Grant helpers for RFC 8628 compliance.
 
 This module implements utility helpers for the OAuth 2.0 Device Authorization
-Grant as defined in :rfc:`8628`.  It provides functions for generating and
+Grant as defined in :rfc:`8628`. It provides functions for generating and
 validating ``user_code`` values as well as creating high-entropy
-``device_code`` strings.  The validation helpers may be disabled via runtime
-configuration allowing deployments to opt-out of RFC 8628 enforcement.
+``device_code`` strings. The validation helpers may be disabled via runtime
+configuration allowing deployments to opt out of RFC 8628 enforcement.
+
+See RFC 8628: https://www.rfc-editor.org/rfc/rfc8628
 """
 
 from __future__ import annotations

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8705.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8705.py
@@ -4,6 +4,8 @@ This module implements helpers for certificate-bound access tokens as
 specified in RFC 8705 section 3.1. When mutual TLS is used, access tokens
 must contain a ``cnf`` claim with an ``x5t#S256`` member that matches the
 SHA-256 thumbprint of the client's certificate.
+
+See RFC 8705: https://www.rfc-editor.org/rfc/rfc8705
 """
 
 from __future__ import annotations
@@ -49,7 +51,9 @@ def validate_certificate_binding(
     """
     cnf = payload.get("cnf")
     if not isinstance(cnf, dict):
-        raise InvalidTokenError("cnf claim required by RFC 8705")
+        raise InvalidTokenError(f"cnf claim required by RFC 8705: {RFC8705_SPEC_URL}")
     bound = cnf.get("x5t#S256")
     if bound != presented_thumbprint:
-        raise InvalidTokenError("certificate thumbprint mismatch per RFC 8705")
+        raise InvalidTokenError(
+            f"certificate thumbprint mismatch per RFC 8705: {RFC8705_SPEC_URL}"
+        )

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8707.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8707.py
@@ -5,6 +5,8 @@ This module validates the ``resource`` parameter defined in RFC 8707.
 Values MUST be absolute URIs, MAY appear multiple times, and MUST NOT
 contain fragments. The helper returns the first valid resource or
 ``None`` if none were supplied.
+
+See RFC 8707: https://www.rfc-editor.org/rfc/rfc8707
 """
 
 from __future__ import annotations
@@ -27,7 +29,7 @@ def extract_resource(resources: Sequence[str]) -> Optional[str]:
     for value in resources:
         parsed = urlparse(value)
         if not parsed.scheme or not parsed.netloc or parsed.fragment:
-            raise ValueError("invalid resource indicator")
+            raise ValueError(f"invalid resource indicator: {RFC8707_SPEC_URL}")
     return resources[0]
 
 

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc9068.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc9068.py
@@ -8,9 +8,11 @@ It is designed to be feature-flagged via ``enable_rfc9068`` in
 
 from __future__ import annotations
 
-from typing import Any, Dict, Iterable, Set
+from typing import Any, Dict, Final, Iterable, Set
 
 from jwt.exceptions import InvalidTokenError
+
+RFC9068_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc9068"
 
 
 def add_rfc9068_claims(
@@ -44,14 +46,19 @@ def validate_rfc9068_claims(
     Raises ``InvalidTokenError`` if any requirement is not met.
     """
     if payload.get("iss") != issuer:
-        raise InvalidTokenError("issuer mismatch per RFC 9068")
+        raise InvalidTokenError(f"issuer mismatch per RFC 9068: {RFC9068_SPEC_URL}")
     token_aud = payload.get("aud")
     expected: Set[str] = {audience} if isinstance(audience, str) else set(audience)
     presented: Set[str] = (
         {token_aud} if isinstance(token_aud, str) else set(token_aud or [])
     )
     if not (expected & presented):
-        raise InvalidTokenError("audience mismatch per RFC 9068")
+        raise InvalidTokenError(f"audience mismatch per RFC 9068: {RFC9068_SPEC_URL}")
     for claim in ("sub", "exp"):
         if claim not in payload:
-            raise InvalidTokenError(f"{claim} claim required by RFC 9068")
+            raise InvalidTokenError(
+                f"{claim} claim required by RFC 9068: {RFC9068_SPEC_URL}"
+            )
+
+
+__all__ = ["add_rfc9068_claims", "validate_rfc9068_claims", "RFC9068_SPEC_URL"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc9101.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc9101.py
@@ -3,15 +3,19 @@
 This module provides helpers to encode and decode authorization request
 parameters as JSON Web Tokens (JWT) per RFC 9101 \u00a72.1. The feature can be
 turned on or off using ``settings.enable_rfc9101``.
+
+See RFC 9101: https://www.rfc-editor.org/rfc/rfc9101
 """
 
 from __future__ import annotations
 
-from typing import Any, Dict, Iterable
+from typing import Any, Dict, Final, Iterable
 
 import jwt
 
 from .runtime_cfg import settings
+
+RFC9101_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc9101"
 
 
 def create_request_object(
@@ -25,7 +29,7 @@ def create_request_object(
         If RFC 9101 support is disabled via ``settings.enable_rfc9101``.
     """
     if not settings.enable_rfc9101:
-        raise RuntimeError("RFC 9101 support disabled")
+        raise RuntimeError(f"RFC 9101 support disabled: {RFC9101_SPEC_URL}")
     return jwt.encode(params, secret, algorithm=algorithm)
 
 
@@ -40,9 +44,9 @@ def parse_request_object(
         If RFC 9101 support is disabled via ``settings.enable_rfc9101``.
     """
     if not settings.enable_rfc9101:
-        raise RuntimeError("RFC 9101 support disabled")
+        raise RuntimeError(f"RFC 9101 support disabled: {RFC9101_SPEC_URL}")
     algs = list(algorithms) if algorithms is not None else ["HS256"]
     return jwt.decode(token, secret, algorithms=algs)
 
 
-__all__ = ["create_request_object", "parse_request_object"]
+__all__ = ["create_request_object", "parse_request_object", "RFC9101_SPEC_URL"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc9126.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc9126.py
@@ -4,18 +4,22 @@ This module implements a minimal in-memory store for OAuth 2.0 Pushed
 Authorization Requests (PAR) as defined in RFC 9126. The feature can be
 enabled or disabled via ``settings.enable_rfc9126`` in
 ``runtime_cfg.Settings``.
+
+See RFC 9126: https://www.rfc-editor.org/rfc/rfc9126
 """
 
 from __future__ import annotations
 
 import uuid
 from datetime import datetime, timedelta
-from typing import Dict, Tuple, Any
+from typing import Any, Dict, Final, Tuple
 
 # In-memory storage mapping request_uri -> (params, expiry)
 _PAR_STORE: Dict[str, Tuple[Dict[str, Any], datetime]] = {}
 
 DEFAULT_PAR_EXPIRY = 90  # seconds
+
+RFC9126_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc9126"
 
 
 def store_par_request(
@@ -55,4 +59,5 @@ __all__ = [
     "get_par_request",
     "reset_par_store",
     "DEFAULT_PAR_EXPIRY",
+    "RFC9126_SPEC_URL",
 ]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc9207.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc9207.py
@@ -3,6 +3,8 @@
 This module validates the ``iss`` parameter returned in the authorization
 response as described by RFC 9207. Support for this feature can be toggled via
 ``settings.enable_rfc9207``.
+
+See RFC 9207: https://www.rfc-editor.org/rfc/rfc9207
 """
 
 from __future__ import annotations
@@ -23,13 +25,15 @@ def extract_issuer(params: Mapping[str, str], expected_issuer: str) -> str:
     """
 
     if not settings.enable_rfc9207:
-        raise NotImplementedError("issuer identification not enabled")
+        raise NotImplementedError(
+            f"issuer identification not enabled: {RFC9207_SPEC_URL}"
+        )
 
     issuer = params.get("iss")
     if issuer is None:
-        raise ValueError("missing iss parameter")
+        raise ValueError(f"missing iss parameter: {RFC9207_SPEC_URL}")
     if issuer != expected_issuer:
-        raise ValueError("issuer mismatch")
+        raise ValueError(f"issuer mismatch: {RFC9207_SPEC_URL}")
     return issuer
 
 

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc9396.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc9396.py
@@ -4,6 +4,8 @@ This module parses and validates the ``authorization_details`` request
 parameter as defined by RFC 9396 section 2. Support for this feature can be
 toggled via the ``AUTO_AUTHN_ENABLE_RFC9396`` environment variable
 (``settings.enable_rfc9396``).
+
+See RFC 9396: https://www.rfc-editor.org/rfc/rfc9396
 """
 
 from __future__ import annotations
@@ -48,22 +50,28 @@ def parse_authorization_details(raw: str) -> List[AuthorizationDetail]:
     """
 
     if not settings.enable_rfc9396:
-        raise NotImplementedError("authorization_details not enabled")
+        raise NotImplementedError(
+            f"authorization_details not enabled: {RFC9396_SPEC_URL}"
+        )
 
     try:
         data: Any = json.loads(raw)
     except json.JSONDecodeError as exc:  # pragma: no cover - invalid JSON
-        raise ValueError("authorization_details must be valid JSON") from exc
+        raise ValueError(
+            f"authorization_details must be valid JSON: {RFC9396_SPEC_URL}"
+        ) from exc
 
     if isinstance(data, dict):
         data = [data]
     if not isinstance(data, list):
-        raise ValueError("authorization_details must be an object or array")
+        raise ValueError(
+            f"authorization_details must be an object or array: {RFC9396_SPEC_URL}"
+        )
 
     try:
         return [AuthorizationDetail.model_validate(item) for item in data]
     except ValidationError as exc:
-        raise ValueError("invalid authorization_details") from exc
+        raise ValueError(f"invalid authorization_details: {RFC9396_SPEC_URL}") from exc
 
 
 __all__ = [

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc9449_dpop.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc9449_dpop.py
@@ -3,6 +3,8 @@
 This module provides helpers to create and verify DPoP proofs as defined in
 RFC 9449. It currently supports Ed25519 keys and is intentionally lightweight
 so the feature can be enabled or disabled via runtime configuration.
+
+See RFC 9449: https://www.rfc-editor.org/rfc/rfc9449
 """
 
 from __future__ import annotations
@@ -12,7 +14,7 @@ import hashlib
 import json
 import time
 from datetime import datetime, timezone
-from typing import Dict
+from typing import Dict, Final
 from uuid import uuid4
 
 import jwt
@@ -24,6 +26,8 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import (
 
 _ALG = "EdDSA"
 _ALLOWED_SKEW = 300  # seconds
+
+RFC9449_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc9449"
 
 
 def _b64url(data: bytes) -> str:
@@ -85,13 +89,13 @@ def verify_proof(proof: str, method: str, url: str, *, jkt: str | None = None) -
     try:
         header = jwt.get_unverified_header(proof)
     except jwt.exceptions.DecodeError as exc:  # pragma: no cover - sanity
-        raise ValueError("malformed DPoP proof") from exc
+        raise ValueError(f"malformed DPoP proof: {RFC9449_SPEC_URL}") from exc
 
     jwk = header.get("jwk")
     if not jwk:
-        raise ValueError("missing jwk in DPoP header")
+        raise ValueError(f"missing jwk in DPoP header: {RFC9449_SPEC_URL}")
     if jwk.get("kty") != "OKP" or jwk.get("crv") != "Ed25519":
-        raise ValueError("unsupported jwk")
+        raise ValueError(f"unsupported jwk: {RFC9449_SPEC_URL}")
 
     public_key = Ed25519PublicKey.from_public_bytes(
         base64.urlsafe_b64decode(jwk["x"] + "==")
@@ -99,19 +103,25 @@ def verify_proof(proof: str, method: str, url: str, *, jkt: str | None = None) -
     payload = jwt.decode(proof, public_key, algorithms=[_ALG])
 
     if payload.get("htm") != method.upper():
-        raise ValueError("htm mismatch")
+        raise ValueError(f"htm mismatch: {RFC9449_SPEC_URL}")
     if payload.get("htu") != url:
-        raise ValueError("htu mismatch")
+        raise ValueError(f"htu mismatch: {RFC9449_SPEC_URL}")
 
     now = int(time.time())
     iat = int(payload.get("iat", 0))
     if abs(now - iat) > _ALLOWED_SKEW:
-        raise ValueError("iat out of range")
+        raise ValueError(f"iat out of range: {RFC9449_SPEC_URL}")
 
     thumb = jwk_thumbprint(jwk)
     if jkt and thumb != jkt:
-        raise ValueError("jkt mismatch")
+        raise ValueError(f"jkt mismatch: {RFC9449_SPEC_URL}")
     return thumb
 
 
-__all__ = ["create_proof", "verify_proof", "jwk_from_public_key", "jwk_thumbprint"]
+__all__ = [
+    "create_proof",
+    "verify_proof",
+    "jwk_from_public_key",
+    "jwk_thumbprint",
+    "RFC9449_SPEC_URL",
+]


### PR DESCRIPTION
## Summary
- add RFC `SPEC_URL` constants across auto_authn modules
- embed spec links in module docstrings and error messages

## Testing
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff format .` *(fails: Failed to parse auto_authn/v2/__init__.py:18:2: Simple statements must be separated by newlines or semicolons; Failed to parse auto_authn/v2/runtime_cfg.py:110:5: Positional argument cannot follow keyword argument)*
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check . --fix` *(fails: invalid-syntax in auto_authn/v2/__init__.py and auto_authn/v2/runtime_cfg.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4d6aac188326b084cde340330fe5