### PR TITLE
feat: toggleable RFC8037, 8176 and 8291 helpers

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8037.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8037.py
@@ -12,10 +12,11 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import (
     Ed25519PrivateKey,
     Ed25519PublicKey,
 )
+from typing import Final
 
 from .runtime_cfg import settings
 
-RFC8037_SPEC_URL = "https://www.rfc-editor.org/rfc/rfc8037"
+RFC8037_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc8037"
 
 
 def sign_eddsa(

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8176.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8176.py
@@ -9,10 +9,11 @@ allow acceptance of non-standard values.
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import Final
 
 from .runtime_cfg import settings
 
-RFC8176_SPEC_URL = "https://www.rfc-editor.org/rfc/rfc8176"
+RFC8176_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc8176"
 
 # Common Authentication Method Reference values from RFC 8176
 AMR_VALUES: set[str] = {

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8291.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8291.py
@@ -31,6 +31,10 @@ def encrypt_push_message(
         enabled = settings.enable_rfc8291
     if not enabled:
         return plaintext
+    if len(key) != 16:
+        raise ValueError("RFC 8291 requires a 16-byte key")
+    if len(nonce) != 12:
+        raise ValueError("RFC 8291 requires a 12-byte nonce")
     aesgcm = AESGCM(key)
     return aesgcm.encrypt(nonce, plaintext, associated_data=None)
 
@@ -47,6 +51,10 @@ def decrypt_push_message(
         enabled = settings.enable_rfc8291
     if not enabled:
         return ciphertext
+    if len(key) != 16:
+        raise ValueError("RFC 8291 requires a 16-byte key")
+    if len(nonce) != 12:
+        raise ValueError("RFC 8291 requires a 12-byte nonce")
     aesgcm = AESGCM(key)
     return aesgcm.decrypt(nonce, ciphertext, associated_data=None)
 

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc8037_eddsa.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc8037_eddsa.py
@@ -7,7 +7,12 @@ flag behaviour defined in :mod:`auto_authn.v2.rfc8037`.
 import pytest
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
-from auto_authn.v2.rfc8037 import sign_eddsa, verify_eddsa
+from auto_authn.v2.rfc8037 import (
+    RFC8037_SPEC_URL,
+    sign_eddsa,
+    verify_eddsa,
+)
+from auto_authn.v2.runtime_cfg import settings
 
 
 @pytest.mark.unit
@@ -30,3 +35,24 @@ def test_sign_verify_disabled():
     sig = sign_eddsa(message, priv, enabled=False)
     assert sig == message
     assert verify_eddsa(message, sig, pub, enabled=False)
+
+
+@pytest.mark.unit
+def test_respects_runtime_setting(monkeypatch):
+    """Default behaviour follows :mod:`runtime_cfg` toggle."""
+    priv = Ed25519PrivateKey.generate()
+    pub = priv.public_key()
+    message = b"payload"
+    monkeypatch.setattr(settings, "enable_rfc8037", False)
+    assert sign_eddsa(message, priv) == message
+    assert verify_eddsa(message, message, pub)
+    monkeypatch.setattr(settings, "enable_rfc8037", True)
+    sig = sign_eddsa(message, priv)
+    assert sig != message
+    assert verify_eddsa(message, sig, pub)
+
+
+@pytest.mark.unit
+def test_spec_url_constant():
+    """Spec URL constant references the official RFC document."""
+    assert RFC8037_SPEC_URL.endswith("rfc8037")

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc8176_amr.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc8176_amr.py
@@ -6,7 +6,8 @@ The :func:`auto_authn.v2.rfc8176.validate_amr_claim` helper ensures that
 
 import pytest
 
-from auto_authn.v2.rfc8176 import validate_amr_claim
+from auto_authn.v2.rfc8176 import RFC8176_SPEC_URL, validate_amr_claim
+from auto_authn.v2.runtime_cfg import settings
 
 
 @pytest.mark.unit
@@ -25,3 +26,18 @@ def test_invalid_amr_values_enabled():
 def test_invalid_amr_values_disabled():
     """When disabled, validation accepts any values."""
     assert validate_amr_claim(["unknown"], enabled=False)
+
+
+@pytest.mark.unit
+def test_respects_runtime_setting(monkeypatch):
+    """Default behaviour follows the runtime configuration toggle."""
+    monkeypatch.setattr(settings, "enable_rfc8176", False)
+    assert validate_amr_claim(["bogus"])  # disabled -> accepts
+    monkeypatch.setattr(settings, "enable_rfc8176", True)
+    assert not validate_amr_claim(["bogus"])  # enabled -> rejects
+
+
+@pytest.mark.unit
+def test_spec_url_constant():
+    """Spec URL constant references the official RFC document."""
+    assert RFC8176_SPEC_URL.endswith("rfc8176")

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc8291_webpush_encryption.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc8291_webpush_encryption.py
@@ -8,7 +8,12 @@ import os
 
 import pytest
 
-from auto_authn.v2.rfc8291 import decrypt_push_message, encrypt_push_message
+from auto_authn.v2.rfc8291 import (
+    RFC8291_SPEC_URL,
+    decrypt_push_message,
+    encrypt_push_message,
+)
+from auto_authn.v2.runtime_cfg import settings
 
 
 @pytest.mark.unit
@@ -31,3 +36,35 @@ def test_disabled_returns_plain():
     ciphertext = encrypt_push_message(plaintext, key, nonce, enabled=False)
     assert ciphertext == plaintext
     assert decrypt_push_message(ciphertext, key, nonce, enabled=False) == ciphertext
+
+
+@pytest.mark.unit
+def test_respects_runtime_setting(monkeypatch):
+    """Default behaviour follows the runtime configuration toggle."""
+    key = os.urandom(16)
+    nonce = os.urandom(12)
+    plaintext = b"hello"
+    monkeypatch.setattr(settings, "enable_rfc8291", False)
+    assert encrypt_push_message(plaintext, key, nonce) == plaintext
+    monkeypatch.setattr(settings, "enable_rfc8291", True)
+    ciphertext = encrypt_push_message(plaintext, key, nonce)
+    assert decrypt_push_message(ciphertext, key, nonce) == plaintext
+
+
+@pytest.mark.unit
+def test_invalid_key_or_nonce_length():
+    """Incorrect key or nonce lengths raise errors when enabled."""
+    key = os.urandom(15)
+    nonce = os.urandom(12)
+    with pytest.raises(ValueError):
+        encrypt_push_message(b"data", key, nonce, enabled=True)
+    key = os.urandom(16)
+    nonce = os.urandom(11)
+    with pytest.raises(ValueError):
+        decrypt_push_message(b"data", key, nonce, enabled=True)
+
+
+@pytest.mark.unit
+def test_spec_url_constant():
+    """Spec URL constant references the official RFC document."""
+    assert RFC8291_SPEC_URL.endswith("rfc8291")


### PR DESCRIPTION
## Summary
- add Final spec URL constants for RFC 8037 and 8176
- enforce key and nonce length for RFC 8291 Web Push encryption
- test runtime toggle behavior and spec URL constants for RFC 8037, 8176, and 8291

## Testing
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff format .`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68ac4fe56e648326992d2715e6ccf3ea