### PR TITLE
Add RFC 8812 WebAuthn algorithm support

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
@@ -36,6 +36,11 @@ from .rfc8252 import is_native_redirect_uri, validate_native_redirect_uri
 from .rfc7638 import jwk_thumbprint, verify_jwk_thumbprint
 from .rfc7800 import add_cnf_claim, verify_proof_of_possession
 from .rfc8291 import encrypt_push_message, decrypt_push_message, RFC8291_SPEC_URL
+from .rfc8812 import (
+    is_webauthn_algorithm,
+    WEBAUTHN_ALGORITHMS,
+    RFC8812_SPEC_URL,
+)
 from .rfc9068 import add_rfc9068_claims, validate_rfc9068_claims
 from .rfc8037 import sign_eddsa, verify_eddsa, RFC8037_SPEC_URL
 from .rfc8176 import (
@@ -116,6 +121,9 @@ __all__ = [
     "encrypt_push_message",
     "decrypt_push_message",
     "RFC8291_SPEC_URL",
+    "is_webauthn_algorithm",
+    "WEBAUTHN_ALGORITHMS",
+    "RFC8812_SPEC_URL",
     "validate_jwt_assertion",
     "RFC7521_SPEC_URL",
     "RFC7520_SPEC_URL",

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7518.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7518.py
@@ -9,6 +9,7 @@ See RFC 7518: https://www.rfc-editor.org/rfc/rfc7518
 from typing import Final
 
 from .runtime_cfg import settings
+from .rfc8812 import WEBAUTHN_ALGORITHMS
 
 RFC7518_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc7518"
 
@@ -17,7 +18,10 @@ def supported_algorithms() -> list[str]:
     """Return algorithms supported for JOSE operations."""
     if not settings.enable_rfc7518:
         raise RuntimeError(f"RFC 7518 support disabled: {RFC7518_SPEC_URL}")
-    return ["EdDSA"]
+    algs = ["EdDSA"]
+    if settings.enable_rfc8812:
+        algs.extend(sorted(WEBAUTHN_ALGORITHMS))
+    return algs
 
 
 __all__ = ["supported_algorithms", "RFC7518_SPEC_URL"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8812.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8812.py
@@ -1,0 +1,36 @@
+"""WebAuthn algorithm helpers for RFC 8812 compliance.
+
+This module exposes the set of COSE/JOSE algorithm identifiers registered
+for use with Web Authentication (WebAuthn) by :rfc:`8812`. Validation is
+feature flagged via ``enable_rfc8812`` in :mod:`auto_authn.v2.runtime_cfg` so
+systems may opt in or out of enforcement.
+
+See RFC 8812: https://www.rfc-editor.org/rfc/rfc8812
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from .runtime_cfg import settings
+
+RFC8812_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc8812"
+
+WEBAUTHN_ALGORITHMS: Final[set[str]] = {"RS256", "RS384", "RS512", "RS1", "ES256K"}
+
+
+def is_webauthn_algorithm(alg: str, *, enabled: bool | None = None) -> bool:
+    """Return ``True`` if *alg* is registered for WebAuthn per :rfc:`8812`.
+
+    When the feature is disabled the check always returns ``True`` to allow
+    deployments to accept non-registered algorithms.
+    """
+
+    if enabled is None:
+        enabled = settings.enable_rfc8812
+    if not enabled:
+        return True
+    return alg in WEBAUTHN_ALGORITHMS
+
+
+__all__ = ["is_webauthn_algorithm", "WEBAUTHN_ALGORITHMS", "RFC8812_SPEC_URL"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
@@ -101,6 +101,11 @@ class Settings(BaseSettings):
         in {"1", "true", "yes"},
         description="Enable Message Encryption for Web Push per RFC 8291",
     )
+    enable_rfc8812: bool = Field(
+        default=os.environ.get("AUTO_AUTHN_ENABLE_RFC8812", "false").lower()
+        in {"1", "true", "yes"},
+        description=("Enable WebAuthn algorithm registrations per RFC 8812",),
+    )
     enable_rfc8037: bool = Field(
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC8037", "true").lower()
         in {"1", "true", "yes"},

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc8812_webauthn_algorithms.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc8812_webauthn_algorithms.py
@@ -1,0 +1,40 @@
+"""Tests for WebAuthn algorithm registrations (RFC 8812).
+
+The tests ensure that only algorithms registered by RFC 8812 are accepted when
+its feature flag is enabled and that any algorithm is allowed when the feature
+is disabled.
+"""
+
+import pytest
+
+from auto_authn.v2 import runtime_cfg, supported_algorithms
+from auto_authn.v2.rfc8812 import WEBAUTHN_ALGORITHMS, is_webauthn_algorithm
+
+
+@pytest.mark.unit
+def test_known_algorithms_allowed(monkeypatch):
+    """Algorithms listed in RFC 8812 pass validation when enabled."""
+    monkeypatch.setattr(runtime_cfg.settings, "enable_rfc8812", True)
+    for alg in WEBAUTHN_ALGORITHMS:
+        assert is_webauthn_algorithm(alg)
+    assert not is_webauthn_algorithm("HS256")
+
+
+@pytest.mark.unit
+def test_supported_algorithms_extends_when_enabled(monkeypatch):
+    """Supported algorithm list includes RFC 8812 entries when enabled."""
+    monkeypatch.setattr(runtime_cfg.settings, "enable_rfc8812", True)
+    algs = supported_algorithms()
+    for alg in WEBAUTHN_ALGORITHMS:
+        assert alg in algs
+    monkeypatch.setattr(runtime_cfg.settings, "enable_rfc8812", False)
+    algs = supported_algorithms()
+    assert not any(alg in algs for alg in WEBAUTHN_ALGORITHMS)
+
+
+@pytest.mark.unit
+def test_disabled_allows_any_alg(monkeypatch):
+    """When disabled, validation always succeeds."""
+    monkeypatch.setattr(runtime_cfg.settings, "enable_rfc8812", False)
+    assert is_webauthn_algorithm("HS256")
+    assert is_webauthn_algorithm("unknown")


### PR DESCRIPTION
## Summary
- add RFC 8812 WebAuthn algorithm helpers with feature flag
- expose WebAuthn algorithms via rfc7518 supported_algorithms
- document and test WebAuthn algorithm registrations

## Testing
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff format .`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check . --fix`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ac4fe9008c8326bcf9d99e393b19da