### PR TITLE
feat: enhance RFC7523 validation in auto_authn

### DIFF
--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7523_jwt_profile.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7523_jwt_profile.py
@@ -7,6 +7,7 @@ import time
 from unittest.mock import patch
 
 import pytest
+from jwt.exceptions import InvalidTokenError
 
 from auto_authn.v2 import encode_jwt
 from auto_authn.v2.rfc7523 import (
@@ -26,7 +27,7 @@ def test_validate_client_jwt_bearer_success() -> None:
         aud="token-endpoint",
         exp=int(time.time()) + 60,
     )
-    claims = validate_client_jwt_bearer(token)
+    claims = validate_client_jwt_bearer(token, audience="token-endpoint")
     assert claims["iss"] == "client"
     assert claims["sub"] == "client"
     assert RFC7523_SPEC_URL.startswith("https://")
@@ -42,7 +43,7 @@ def test_validate_client_jwt_bearer_missing_claim() -> None:
         exp=int(time.time()) + 60,
     )
     with pytest.raises(ValueError):
-        validate_client_jwt_bearer(token)
+        validate_client_jwt_bearer(token, audience="token-endpoint")
 
 
 @pytest.mark.unit
@@ -57,4 +58,46 @@ def test_validate_client_jwt_bearer_disabled() -> None:
     )
     with patch.object(settings, "enable_rfc7523", False):
         with pytest.raises(RuntimeError):
-            validate_client_jwt_bearer(token)
+            validate_client_jwt_bearer(token, audience="token-endpoint")
+
+
+@pytest.mark.unit
+def test_validate_client_jwt_bearer_mismatched_subject() -> None:
+    """RFC 7523 §2.2: iss and sub must be equal."""
+    token = encode_jwt(
+        iss="clientA",
+        sub="clientB",
+        tid="tenant",
+        aud="token-endpoint",
+        exp=int(time.time()) + 60,
+    )
+    with pytest.raises(ValueError):
+        validate_client_jwt_bearer(token, audience="token-endpoint")
+
+
+@pytest.mark.unit
+def test_validate_client_jwt_bearer_invalid_audience() -> None:
+    """RFC 7523 §2.2: aud must target the token endpoint."""
+    token = encode_jwt(
+        iss="client",
+        sub="client",
+        tid="tenant",
+        aud="token-endpoint",
+        exp=int(time.time()) + 60,
+    )
+    with pytest.raises(ValueError):
+        validate_client_jwt_bearer(token, audience="other-endpoint")
+
+
+@pytest.mark.unit
+def test_validate_client_jwt_bearer_expired_assertion() -> None:
+    """RFC 7523 §2.2: exp claim must be in the future."""
+    token = encode_jwt(
+        iss="client",
+        sub="client",
+        tid="tenant",
+        aud="token-endpoint",
+        exp=int(time.time()) - 1,
+    )
+    with pytest.raises(InvalidTokenError):
+        validate_client_jwt_bearer(token, audience="token-endpoint")


### PR DESCRIPTION
## Summary
- add optional audience check to RFC 7523 validator
- expand RFC 7523 unit tests to cover success, failure, and feature-toggle cases

## Testing
- `uv run --directory standards/auto_authn --package auto_authn pytest tests/unit/test_rfc7523_jwt_profile.py`
- `uv run --directory standards/auto_authn --package auto_authn pytest` *(fails: TypeError: get_current_principal() missing 1 required positional argument: 'next'* )

------
https://chatgpt.com/codex/tasks/task_e_68ac504dbe548326a09a439e1badf644