### PR TITLE
Fix client identifier handling and update principal tests

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/tables.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/tables.py
@@ -102,7 +102,7 @@ class Client(ClientBase):  # Tenant FK via mix-in
         secret_hash = hash_pw(client_secret)
         return cls(
             tenant_id=tenant_id,
-            client_id=client_id,
+            id=client_id,
             client_secret_hash=secret_hash,
             redirect_uris=" ".join(redirects),
         )

--- a/pkgs/standards/auto_authn/tests/unit/test_fastapi_deps.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_fastapi_deps.py
@@ -251,8 +251,12 @@ class TestGetCurrentPrincipal:
         with patch(
             "auto_authn.v2.fastapi_deps._user_from_api_key", return_value=mock_user
         ):
+            request = Request(scope={"type": "http"})
             principal = await get_current_principal(
-                authorization="", api_key=api_key, db=mock_db
+                request,
+                authorization="",
+                api_key=api_key,
+                db=mock_db,
             )
 
             assert principal is not None
@@ -268,8 +272,12 @@ class TestGetCurrentPrincipal:
         authorization = "Bearer valid.jwt.token"
 
         with patch("auto_authn.v2.fastapi_deps._user_from_jwt", return_value=mock_user):
+            request = Request(scope={"type": "http"})
             principal = await get_current_principal(
-                authorization=authorization, api_key=None, db=mock_db
+                request,
+                authorization=authorization,
+                api_key=None,
+                db=mock_db,
             )
 
             assert principal is not None
@@ -291,8 +299,12 @@ class TestGetCurrentPrincipal:
             with patch(
                 "auto_authn.v2.fastapi_deps._user_from_jwt", return_value=mock_user
             ) as mock_jwt:
+                request = Request(scope={"type": "http"})
                 principal = await get_current_principal(
-                    authorization=authorization, api_key=api_key, db=mock_db
+                    request,
+                    authorization=authorization,
+                    api_key=api_key,
+                    db=mock_db,
                 )
 
                 assert principal is not None
@@ -317,8 +329,12 @@ class TestGetCurrentPrincipal:
             with patch(
                 "auto_authn.v2.fastapi_deps._user_from_jwt", return_value=mock_user
             ):
+                request = Request(scope={"type": "http"})
                 principal = await get_current_principal(
-                    authorization=authorization, api_key=api_key, db=mock_db
+                    request,
+                    authorization=authorization,
+                    api_key=api_key,
+                    db=mock_db,
                 )
 
                 assert principal is not None
@@ -329,8 +345,11 @@ class TestGetCurrentPrincipal:
         """Test principal resolution with no credentials raises HTTP 401."""
         mock_db = AsyncMock(spec=AsyncSession)
 
+        request = Request(scope={"type": "http"})
         with pytest.raises(HTTPException) as exc_info:
-            await get_current_principal(authorization="", api_key=None, db=mock_db)
+            await get_current_principal(
+                request, authorization="", api_key=None, db=mock_db
+            )
 
         assert exc_info.value.status_code == 401
         assert "invalid or missing credentials" in exc_info.value.detail
@@ -342,9 +361,13 @@ class TestGetCurrentPrincipal:
         mock_db = AsyncMock(spec=AsyncSession)
         authorization = "InvalidFormat token"
 
+        request = Request(scope={"type": "http"})
         with pytest.raises(HTTPException) as exc_info:
             await get_current_principal(
-                authorization=authorization, api_key=None, db=mock_db
+                request,
+                authorization=authorization,
+                api_key=None,
+                db=mock_db,
             )
 
         assert exc_info.value.status_code == 401
@@ -358,9 +381,13 @@ class TestGetCurrentPrincipal:
 
         with patch("auto_authn.v2.fastapi_deps._user_from_api_key", return_value=None):
             with patch("auto_authn.v2.fastapi_deps._user_from_jwt", return_value=None):
+                request = Request(scope={"type": "http"})
                 with pytest.raises(HTTPException) as exc_info:
                     await get_current_principal(
-                        authorization=authorization, api_key=api_key, db=mock_db
+                        request,
+                        authorization=authorization,
+                        api_key=api_key,
+                        db=mock_db,
                     )
 
                 assert exc_info.value.status_code == 401


### PR DESCRIPTION
## Summary
- ensure `Client.new` stores custom client identifiers via `id`
- update FastAPI dependency tests to provide `Request` objects

## Testing
- `uv run --package auto_authn --directory standards/auto_authn ruff check . --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest -q` *(fails: 10 failed, 246 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac51beef1483268018866f0c11da66