### PR TITLE
test: update auto_authn tests for new API

### DIFF
--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7662_token_introspection.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7662_token_introspection.py
@@ -5,7 +5,6 @@ from fastapi import FastAPI, status
 from httpx import ASGITransport, AsyncClient
 from uuid import uuid4
 
-from auto_authn.v2.routers.auth_flows import router
 from auto_authn.v2.fastapi_deps import get_async_db
 
 
@@ -29,6 +28,8 @@ RFC 7662 - OAuth 2.0 Token Introspection
 @pytest.mark.asyncio
 async def test_introspection_endpoint_returns_active_field(enable_rfc7662, monkeypatch):
     """RFC 7662 §2.2: Response must include an 'active' boolean."""
+    from auto_authn.v2.routers.auth_flows import router
+
     app = FastAPI()
     app.include_router(router)
 
@@ -60,6 +61,8 @@ async def test_introspection_endpoint_returns_active_field(enable_rfc7662, monke
 @pytest.mark.asyncio
 async def test_introspection_requires_token_parameter(enable_rfc7662):
     """RFC 7662 §2.1: Request body MUST include the 'token' parameter."""
+    from auto_authn.v2.routers.auth_flows import router
+
     app = FastAPI()
     app.include_router(router)
 

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc8705_compliance.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc8705_compliance.py
@@ -50,9 +50,9 @@ def test_thumbprint_and_binding_helpers():
     cert_pem = _generate_cert_pem()
     thumbprint = thumbprint_from_cert_pem(cert_pem)
     payload = {"cnf": {"x5t#S256": thumbprint}}
-    validate_certificate_binding(payload, thumbprint)  # should not raise
+    validate_certificate_binding(payload, thumbprint, enabled=True)  # should not raise
     with pytest.raises(InvalidTokenError):
-        validate_certificate_binding(payload, "mismatch")
+        validate_certificate_binding(payload, "mismatch", enabled=True)
 
 
 @pytest.mark.unit

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc9126_pushed_authorization_requests.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc9126_pushed_authorization_requests.py
@@ -4,7 +4,6 @@ import pytest
 from fastapi import FastAPI, status
 from httpx import ASGITransport, AsyncClient
 
-from auto_authn.v2.routers.auth_flows import router
 from auto_authn.v2.fastapi_deps import get_async_db
 from auto_authn.v2.rfc9126 import DEFAULT_PAR_EXPIRY
 
@@ -22,6 +21,8 @@ RFC 9126 - OAuth 2.0 Pushed Authorization Requests
 @pytest.mark.asyncio
 async def test_par_returns_request_uri_and_expires(enable_rfc9126, monkeypatch):
     """RFC 9126 §3.1: Response includes request_uri and expires_in."""
+    from auto_authn.v2.routers.auth_flows import router
+
     app = FastAPI()
     app.include_router(router)
 
@@ -46,6 +47,8 @@ async def test_par_returns_request_uri_and_expires(enable_rfc9126, monkeypatch):
 async def test_par_disabled_returns_404(monkeypatch):
     """RFC 9126 §3.1: Endpoint returns 404 when PAR is disabled."""
     from auto_authn.v2.runtime_cfg import settings
+
+    from auto_authn.v2.routers.auth_flows import router
 
     app = FastAPI()
     app.include_router(router)


### PR DESCRIPTION
## Summary
- fix get_current_principal tests to include a dummy Request object
- import auth_flows router within feature-gated tests
- ensure certificate binding helper is validated when enabled

## Testing
- `uv run --package auto_authn --directory standards/auto_authn ruff format .`
- `uv run --package auto_authn --directory standards/auto_authn ruff check . --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest` *(fails: 11 failed, 237 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac509269c483268854caeedd4b842b