### PR TITLE
fix: correct auto_authn plugin imports

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/crypto.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/crypto.py
@@ -42,6 +42,7 @@ def verify_pw(plain: str, hashed: bytes) -> bool:
 # ---------------------------------------------------------------------
 _DEFAULT_KEY_DIR = pathlib.Path(os.getenv("JWT_ED25519_KEY_DIR", "runtime_secrets"))
 _KID_PATH = _DEFAULT_KEY_DIR / "jwt_ed25519.kid"
+_DEFAULT_KEY_PATH = _DEFAULT_KEY_DIR / "jwt_ed25519.pem"
 
 
 @lru_cache(maxsize=1)

--- a/pkgs/standards/auto_authn/auto_authn/v2/deps.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/deps.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
-from swarmauri.key_providers import FileKeyProvider, LocalKeyProvider
-from swarmauri.tokens import JWTTokenService
-from swarmauri.signings import Ed25519EnvelopeSigner, JwsSignerVerifier
-from swarmauri.crypto import JweCrypto
+from swarmauri_keyprovider_file import FileKeyProvider
+from swarmauri_keyprovider_local import LocalKeyProvider
+from swarmauri_tokens_jwt import JWTTokenService
+from swarmauri_signing_ed25519 import Ed25519EnvelopeSigner
+from swarmauri_signing_jws import JwsSignerVerifier
+from swarmauri_crypto_jwe import JweCrypto
 from swarmauri_core.crypto.types import JWAAlg, KeyUse, ExportPolicy
 from swarmauri_core.keys.types import KeyAlg, KeyClass, KeySpec
 

--- a/pkgs/standards/auto_authn/pyproject.toml
+++ b/pkgs/standards/auto_authn/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "swarmauri_signing_ed25519",
     "swarmauri_crypto_jwe",
     "swarmauri_keyprovider_file",
+    "swarmauri_keyprovider_local",
     "python-multipart>=0.0.9",
     "sqlalchemy[asyncio]>=2.0,<3.0",
     "asyncpg>=0.29,<1.0",


### PR DESCRIPTION
## Summary
- fix auto_authn v2 deps to import plugin packages directly
- ensure JWT key compatibility via default path constant
- declare LocalKeyProvider dependency

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_fastapi_deps.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac5651d0ac8326a54892bea5f0a6cd