### PR TITLE
Fix auto_authn dependencies for RFC8705 tests

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/deps.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/deps.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
-from swarmauri.key_providers import FileKeyProvider, LocalKeyProvider
-from swarmauri.tokens import JWTTokenService
-from swarmauri.signings import Ed25519EnvelopeSigner, JwsSignerVerifier
-from swarmauri.crypto import JweCrypto
+from swarmauri_keyprovider_file import FileKeyProvider
+from swarmauri_keyprovider_local import LocalKeyProvider
+from swarmauri_tokens_jwt import JWTTokenService
+from swarmauri_signing_ed25519 import Ed25519EnvelopeSigner
+from swarmauri_signing_jws import JwsSignerVerifier
+from swarmauri_crypto_jwe import JweCrypto
 from swarmauri_core.crypto.types import JWAAlg, KeyUse, ExportPolicy
 from swarmauri_core.keys.types import KeyAlg, KeyClass, KeySpec
 

--- a/pkgs/standards/auto_authn/pyproject.toml
+++ b/pkgs/standards/auto_authn/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "swarmauri_signing_ed25519",
     "swarmauri_crypto_jwe",
     "swarmauri_keyprovider_file",
+    "swarmauri_keyprovider_local",
     "python-multipart>=0.0.9",
     "sqlalchemy[asyncio]>=2.0,<3.0",
     "asyncpg>=0.29,<1.0",

--- a/pkgs/standards/swarmauri_tokens_jwt/swarmauri_tokens_jwt/JWTTokenService.py
+++ b/pkgs/standards/swarmauri_tokens_jwt/swarmauri_tokens_jwt/JWTTokenService.py
@@ -108,8 +108,8 @@ class JWTTokenService(TokenServiceBase):
                     return algorithms.RSAAlgorithm.from_jwk(jwk)
                 if kty == "EC":
                     return algorithms.ECAlgorithm.from_jwk(jwk)
-                if kty == "OKP" and jwk.get("crv") == "Ed25519":
-                    return algorithms.Ed25519Algorithm.from_jwk(jwk)
+                if kty == "OKP":
+                    return algorithms.OKPAlgorithm.from_jwk(jwk)
                 if kty == "oct":
                     return algorithms.HMACAlgorithm.from_jwk(jwk)
             return None


### PR DESCRIPTION
## Summary
- replace swarmauri umbrella imports with direct package imports
- align JWT token service with PyJWT OKPAlgorithm
- update auto_authn fixtures and tests for new key provider

## Testing
- `uv run --package auto_authn --directory standards/auto_authn ruff check . --fix`
- `uv run --package swarmauri_tokens_jwt --directory standards/swarmauri_tokens_jwt ruff check . --fix`
- `uv run --package swarmauri_tokens_jwt --directory standards/swarmauri_tokens_jwt pytest`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc8705_compliance.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac56612de48326a2666b1a43f74d4f