### PR TITLE
feat: include key providers in namespace registries

### DIFF
--- a/pkgs/swarmauri/swarmauri/interface_registry.py
+++ b/pkgs/swarmauri/swarmauri/interface_registry.py
@@ -68,6 +68,7 @@ class InterfaceRegistry:
         "swarmauri.crypto": "swarmauri_base.crypto.CryptoBase",
         "swarmauri.secrets": "swarmauri_base.secrets.SecretDriveBase",
         "swarmauri.signings": "swarmauri_base.signing.SigningBase",
+        "swarmauri.key_providers": "swarmauri_base.keys.KeyProviderBase",
         "swarmauri.logger_formatters": "swarmauri_base.logger_formatters.FormatterBase",
         "swarmauri.loggers": "swarmauri_base.loggers.LoggerBase",
         "swarmauri.logger_handlers": "swarmauri_base.logger_handlers.HandlerBase",

--- a/pkgs/swarmauri/swarmauri/plugin_citizenship_registry.py
+++ b/pkgs/swarmauri/swarmauri/plugin_citizenship_registry.py
@@ -69,6 +69,12 @@ class PluginCitizenshipRegistry:
         "swarmauri.tokens.DPoPBoundJWTTokenService": "swarmauri_tokens_dpopboundjwt.DPoPBoundJWTTokenService",
         "swarmauri.tokens.RotatingJWTTokenService": "swarmauri_tokens_rotatingjwt.RotatingJWTTokenService",
         "swarmauri.tokens.TlsBoundJWTTokenService": "swarmauri_tokens_tlsboundjwt.TlsBoundJWTTokenService",
+        ###
+        # key providers
+        ###
+        "swarmauri.key_providers.IKeyProvider": "swarmauri_core.keys.IKeyProvider",
+        "swarmauri.key_providers.KeyProviderBase": "swarmauri_base.keys.KeyProviderBase",
+        "swarmauri.key_providers.InMemoryKeyProvider": "swarmauri_standard.key_providers.InMemoryKeyProvider",
         "swarmauri.agents.ExampleAgent": "swm_example_package.ExampleAgent",
         "swarmauri.agents.QAAgent": "swarmauri_standard.agents.QAAgent",
         "swarmauri.agents.RagAgent": "swarmauri_standard.agents.RagAgent",

--- a/pkgs/swarmauri/tests/unit/interface_registry_unit_test.py
+++ b/pkgs/swarmauri/tests/unit/interface_registry_unit_test.py
@@ -2,6 +2,7 @@ import pytest
 
 from swarmauri.interface_registry import InterfaceRegistry
 from swarmauri_base.agents.AgentBase import AgentBase
+from swarmauri_base.keys.KeyProviderBase import KeyProviderBase
 
 
 @pytest.fixture(autouse=True)
@@ -28,3 +29,11 @@ def test_register_and_unregister_interface():
     assert InterfaceRegistry.get_interface_for_resource("swarmauri.tests") is AgentBase
     InterfaceRegistry.unregister_interface("swarmauri.tests")
     assert InterfaceRegistry.INTERFACE_REGISTRY["swarmauri.tests"] is None
+
+
+@pytest.mark.unit
+def test_get_key_provider_interface():
+    assert (
+        InterfaceRegistry.get_interface_for_resource("swarmauri.key_providers")
+        is KeyProviderBase
+    )


### PR DESCRIPTION
## Summary
- register `swarmauri.key_providers` in the interface registry
- map key provider interfaces and InMemoryKeyProvider in the plugin citizenship registry
- cover key provider namespace resolution with unit test

## Testing
- `uv run --directory pkgs/swarmauri --package swarmauri ruff format .`
- `uv run --directory pkgs/swarmauri --package swarmauri ruff check . --fix`
- `uv run --package swarmauri --directory swarmauri pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac5820e5248326977ec66d855ff3ae