### PR TITLE
test(auto-authn): add endpoint coverage

### DIFF
--- a/pkgs/standards/auto_authn/tests/unit/test_openid_userinfo_endpoint.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_openid_userinfo_endpoint.py
@@ -1,0 +1,19 @@
+"""Tests for missing OpenID Connect UserInfo endpoint."""
+
+import pytest
+from fastapi import FastAPI, status
+from httpx import ASGITransport, AsyncClient
+
+from auto_authn.v2.routers.auth_flows import router
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_openid_userinfo_endpoint_missing() -> None:
+    """`/userinfo` should return 404 because the endpoint is not implemented."""
+    app = FastAPI()
+    app.include_router(router)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/userinfo")
+    assert resp.status_code == status.HTTP_404_NOT_FOUND

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc6749_auth_flow_endpoints.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc6749_auth_flow_endpoints.py
@@ -1,0 +1,36 @@
+"""Tests for presence of core OAuth2 endpoints and missing authorization endpoint per RFC 6749."""
+
+import pytest
+from fastapi import FastAPI
+
+from auto_authn.v2.routers.auth_flows import router
+
+
+def _collect_paths(app: FastAPI) -> set[str]:
+    """Return the set of route paths registered on ``app``."""
+    return {route.path for route in app.routes}
+
+
+@pytest.mark.unit
+def test_rfc6749_core_endpoints_present() -> None:
+    """Verify implemented credential endpoints exist."""
+    app = FastAPI()
+    app.include_router(router)
+    paths = _collect_paths(app)
+    assert {
+        "/register",
+        "/login",
+        "/token",
+        "/logout",
+        "/token/refresh",
+        "/introspect",
+    } <= paths
+
+
+@pytest.mark.unit
+def test_rfc6749_authorization_endpoint_missing() -> None:
+    """The `/authorize` endpoint advertised by RFC 6749 is not implemented."""
+    app = FastAPI()
+    app.include_router(router)
+    paths = _collect_paths(app)
+    assert "/authorize" not in paths

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7591_client_registration_endpoint.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7591_client_registration_endpoint.py
@@ -1,0 +1,20 @@
+"""Tests for missing OAuth2 Dynamic Client Registration endpoint (RFC 7591)."""
+
+import pytest
+from fastapi import FastAPI, status
+from httpx import ASGITransport, AsyncClient
+
+from auto_authn.v2.routers.auth_flows import router
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_rfc7591_client_registration_not_implemented() -> None:
+    """Posting RFC 7591 client metadata to `/register` yields validation error."""
+    app = FastAPI()
+    app.include_router(router)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        payload = {"redirect_uris": ["https://client.example/cb"]}
+        resp = await client.post("/register", json=payload)
+    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7592_client_management_endpoint.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7592_client_management_endpoint.py
@@ -1,0 +1,19 @@
+"""Tests for missing OAuth2 Client Management endpoints (RFC 7592)."""
+
+import pytest
+from fastapi import FastAPI, status
+from httpx import ASGITransport, AsyncClient
+
+from auto_authn.v2.routers.auth_flows import router
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_rfc7592_client_management_not_implemented() -> None:
+    """Attempts to manage clients return 404 as the endpoints are absent."""
+    app = FastAPI()
+    app.include_router(router)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/register/some-client-id")
+    assert resp.status_code == status.HTTP_404_NOT_FOUND


### PR DESCRIPTION
## Summary
- add RFC 6749 auth flow endpoint coverage including missing /authorize route
- add tests flagging absent RFC 7591/7592 client registration endpoints
- add OpenID Connect userinfo endpoint test

## Testing
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff format .`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68ac599601c08326b0461058a2a2f101