### PR TITLE
feat: modularize OAuth extension endpoints

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/app.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/app.py
@@ -24,6 +24,9 @@ from autoapi.v2 import get_schema  # convenience helper for /methodz
 from .routers.auth_flows import router as flows_router
 from .routers.crud import crud_api as crud_api
 from .rfc8414 import include_rfc8414
+from .rfc8628 import include_rfc8628
+from .rfc9126 import include_rfc9126
+from .rfc7009 import include_rfc7009
 
 
 # --------------------------------------------------------------------
@@ -39,6 +42,9 @@ app = fastapi.FastAPI(
 # Mount routers
 app.include_router(crud_api.router)  # /authn/<model> CRUD (AutoAPI)
 app.include_router(flows_router)  # /register, /login, etc.
+include_rfc8628(app)
+include_rfc9126(app)
+include_rfc7009(app)
 include_rfc8414(app)
 
 

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7009.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7009.py
@@ -11,12 +11,16 @@ from __future__ import annotations
 
 from typing import Final, Set
 
+from fastapi import APIRouter, FastAPI, Form, HTTPException, status
+
 from .runtime_cfg import settings
 
 RFC7009_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc7009"
 
 # In-memory set storing revoked tokens for demonstration and testing purposes
 _REVOKED_TOKENS: Set[str] = set()
+
+router = APIRouter()
 
 
 def revoke_token(token: str) -> None:
@@ -44,4 +48,30 @@ def reset_revocations() -> None:
     _REVOKED_TOKENS.clear()
 
 
-__all__ = ["revoke_token", "is_revoked", "reset_revocations", "RFC7009_SPEC_URL"]
+@router.post("/revoke")
+async def revoke(token: str = Form(...), token_type_hint: str | None = Form(None)):
+    """RFC 7009 token revocation endpoint."""
+
+    if not settings.enable_rfc7009:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "revocation disabled")
+    revoke_token(token)
+    return {}
+
+
+def include_rfc7009(app: FastAPI) -> None:
+    """Attach the RFC 7009 router to *app* if enabled."""
+
+    if settings.enable_rfc7009 and not any(
+        route.path == "/revoke" for route in app.routes
+    ):
+        app.include_router(router)
+
+
+__all__ = [
+    "revoke_token",
+    "is_revoked",
+    "reset_revocations",
+    "router",
+    "include_rfc7009",
+    "RFC7009_SPEC_URL",
+]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8414.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8414.py
@@ -44,7 +44,9 @@ async def authorization_server_metadata():
 
 def include_rfc8414(app: FastAPI) -> None:
     """Attach the RFC 8414 router to *app* if enabled."""
-    if settings.enable_rfc8414:
+    if settings.enable_rfc8414 and not any(
+        route.path == "/.well-known/oauth-authorization-server" for route in app.routes
+    ):
         app.include_router(router)
 
 

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8628.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8628.py
@@ -1,20 +1,24 @@
-"""Device Authorization Grant helpers for RFC 8628 compliance.
+"""Device Authorization Grant helpers and endpoint (RFC 8628).
 
-This module implements utility helpers for the OAuth 2.0 Device Authorization
-Grant as defined in :rfc:`8628`. It provides functions for generating and
-validating ``user_code`` values as well as creating high-entropy
-``device_code`` strings. The validation helpers may be disabled via runtime
-configuration allowing deployments to opt out of RFC 8628 enforcement.
+This module implements utility helpers and the ``/device_authorization``
+endpoint for the OAuth 2.0 Device Authorization Grant as defined in
+RFC 8628.  The feature can be toggled via ``settings.enable_rfc8628`` and is
+only mounted on the FastAPI application when enabled.
 
 See RFC 8628: https://www.rfc-editor.org/rfc/rfc8628
 """
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta
+from uuid import uuid4
 import re
 import secrets
 import string
-from typing import Final
+from typing import Any, Dict, Final, Literal
+
+from fastapi import APIRouter, FastAPI, HTTPException, status
+from pydantic import BaseModel
 
 from .runtime_cfg import settings
 
@@ -25,6 +29,92 @@ _USER_CODE_RE: Final = re.compile(r"^[A-Z0-9]{8,}$")
 
 # Public URL of the RFC for reference in logs or documentation
 RFC8628_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc8628"
+
+
+# ---------------------------------------------------------------------------
+#  In-memory device authorization store
+# ---------------------------------------------------------------------------
+router = APIRouter()
+
+DEVICE_CODES: Dict[str, Dict[str, Any]] = {}
+DEVICE_VERIFICATION_URI = "https://example.com/device"
+DEVICE_CODE_EXPIRES_IN = 600  # seconds
+DEVICE_CODE_INTERVAL = 5  # seconds
+
+
+class DeviceAuthIn(BaseModel):
+    """Request body for device authorization."""
+
+    client_id: str
+    scope: str | None = None
+
+
+class DeviceAuthOut(BaseModel):
+    """Response body for device authorization."""
+
+    device_code: str
+    user_code: str
+    verification_uri: str
+    verification_uri_complete: str
+    expires_in: int
+    interval: int
+
+
+class DeviceGrantForm(BaseModel):
+    """Form model for the device_code grant at the token endpoint."""
+
+    grant_type: Literal["urn:ietf:params:oauth:grant-type:device_code"]
+    device_code: str
+    client_id: str
+
+
+@router.post("/device_authorization", response_model=DeviceAuthOut)
+async def device_authorization(body: DeviceAuthIn) -> DeviceAuthOut:
+    """Issue a new device and user code pair."""
+
+    if not settings.enable_rfc8628:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "device authorization disabled")
+
+    device_code = uuid4().hex
+    user_code = uuid4().hex[:8]
+    verification_uri = DEVICE_VERIFICATION_URI
+    verification_uri_complete = f"{verification_uri}?user_code={user_code}"
+    expires_at = datetime.utcnow() + timedelta(seconds=DEVICE_CODE_EXPIRES_IN)
+    DEVICE_CODES[device_code] = {
+        "user_code": user_code,
+        "client_id": body.client_id,
+        "expires_at": expires_at,
+        "interval": DEVICE_CODE_INTERVAL,
+        "authorized": False,
+        "sub": None,
+        "tid": None,
+    }
+    return DeviceAuthOut(
+        device_code=device_code,
+        user_code=user_code,
+        verification_uri=verification_uri,
+        verification_uri_complete=verification_uri_complete,
+        expires_in=DEVICE_CODE_EXPIRES_IN,
+        interval=DEVICE_CODE_INTERVAL,
+    )
+
+
+def approve_device_code(device_code: str, sub: str, tid: str) -> None:
+    """Mark a device code as authorized (testing helper)."""
+
+    if device_code in DEVICE_CODES:
+        DEVICE_CODES[device_code]["authorized"] = True
+        DEVICE_CODES[device_code]["sub"] = sub
+        DEVICE_CODES[device_code]["tid"] = tid
+
+
+def include_rfc8628(app: FastAPI) -> None:
+    """Attach the RFC 8628 router to *app* if enabled."""
+
+    if settings.enable_rfc8628 and not any(
+        route.path == "/device_authorization" for route in app.routes
+    ):
+        app.include_router(router)
 
 
 def generate_user_code(length: int = 8) -> str:
@@ -64,5 +154,12 @@ __all__ = [
     "generate_user_code",
     "validate_user_code",
     "generate_device_code",
+    "DeviceAuthIn",
+    "DeviceAuthOut",
+    "DeviceGrantForm",
+    "DEVICE_CODES",
+    "approve_device_code",
+    "include_rfc8628",
+    "router",
     "RFC8628_SPEC_URL",
 ]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc9126.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc9126.py
@@ -14,8 +14,14 @@ import uuid
 from datetime import datetime, timedelta
 from typing import Any, Dict, Final, Tuple
 
+from fastapi import APIRouter, FastAPI, HTTPException, Request, status
+
+from .runtime_cfg import settings
+
 # In-memory storage mapping request_uri -> (params, expiry)
 _PAR_STORE: Dict[str, Tuple[Dict[str, Any], datetime]] = {}
+
+router = APIRouter()
 
 DEFAULT_PAR_EXPIRY = 90  # seconds
 
@@ -54,10 +60,32 @@ def reset_par_store() -> None:
     _PAR_STORE.clear()
 
 
+@router.post("/par", status_code=status.HTTP_201_CREATED)
+async def pushed_authorization_request(request: Request):
+    """Endpoint for RFC 9126 pushed authorization requests."""
+
+    if not settings.enable_rfc9126:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "PAR disabled")
+    form = await request.form()
+    request_uri = store_par_request(dict(form))
+    return {"request_uri": request_uri, "expires_in": DEFAULT_PAR_EXPIRY}
+
+
+def include_rfc9126(app: FastAPI) -> None:
+    """Attach the RFC 9126 router to *app* if enabled."""
+
+    if settings.enable_rfc9126 and not any(
+        route.path == "/par" for route in app.routes
+    ):
+        app.include_router(router)
+
+
 __all__ = [
     "store_par_request",
     "get_par_request",
     "reset_par_store",
     "DEFAULT_PAR_EXPIRY",
     "RFC9126_SPEC_URL",
+    "router",
+    "include_rfc9126",
 ]

--- a/pkgs/standards/auto_authn/auto_authn/v2/routers/auth_flows.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/routers/auth_flows.py
@@ -1,31 +1,32 @@
-"""
-autoapi_authn.routers.auth_flows
-================================
+"""Credential and token flow endpoints.
 
-Public-facing credential endpoints:
+This router exposes the core credential flow endpoints:
 
-    • POST /register
-    • POST /login
-    • POST /token          (OAuth2 password grant)
-    • POST /logout
-    • POST /token/refresh
-    • POST /introspect
+* ``POST /register``
+* ``POST /login``
+* ``POST /token`` (OAuth2 password grant)
+* ``POST /logout``
+* ``POST /token/refresh``
+* ``POST /introspect``
+
+Additional OAuth 2.0 features such as device authorization, pushed
+authorization requests and token revocation are provided in dedicated modules
+and can be attached to the application conditionally.
 
 Notes
 -----
 * CRUD for tenants / clients / users / api_keys is already provided by
-  AutoAPI under `/authn/<resource>` and is **not** re-implemented here.
+  AutoAPI under ``/authn/<resource>`` and is **not** re-implemented here.
 * All endpoints are JSON; schemas are strict (Pydantic).
-* `logout` is implemented as a no-op stub — token revocation / key
+* ``logout`` is implemented as a no-op stub — token revocation / key
   deactivation should be wired to your datastore or cache later.
 """
 
 from __future__ import annotations
 
 
-from datetime import datetime, timedelta
-from uuid import uuid4
-from typing import Any, Dict, Literal, Optional
+from datetime import datetime
+from typing import Literal, Optional
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Request, status
 from fastapi.responses import JSONResponse
@@ -41,15 +42,13 @@ from ..orm.tables import Tenant, User
 from ..runtime_cfg import settings
 from ..typing import StrUUID
 from ..rfc8707 import extract_resource
-from ..rfc7009 import revoke_token
-from ..rfc6749 import RFC6749Error, validate_grant_type, validate_password_grant
-from ..rfc9126 import store_par_request, DEFAULT_PAR_EXPIRY
 from ..rfc6749 import (
     RFC6749Error,
     enforce_grant_type,
     enforce_password_grant,
     is_enabled as rfc6749_enabled,
 )
+from ..rfc8628 import DEVICE_CODES, DeviceGrantForm
 from autoapi.v2.error import IntegrityError
 
 router = APIRouter()
@@ -58,16 +57,9 @@ _jwt = JWTCoder.default()
 _pwd_backend = PasswordBackend()
 _api_backend = ApiKeyBackend()
 
-# In-memory store for device authorization data as per RFC 8628
-_DEVICE_CODES: Dict[str, Dict[str, Any]] = {}
-_DEVICE_VERIFICATION_URI = "https://example.com/device"
-_DEVICE_CODE_EXPIRES_IN = 600  # seconds
-_DEVICE_CODE_INTERVAL = 5  # seconds
-
-_ALLOWED_GRANT_TYPES = {
-    "password",
-    "urn:ietf:params:oauth:grant-type:device_code",
-}
+_ALLOWED_GRANT_TYPES = {"password"}
+if settings.enable_rfc8628:
+    _ALLOWED_GRANT_TYPES.add("urn:ietf:params:oauth:grant-type:device_code")
 
 # ============================================================================
 #  Helper Pydantic models
@@ -105,34 +97,10 @@ class IntrospectOut(BaseModel):
     kind: Optional[str] = None
 
 
-class DeviceAuthIn(BaseModel):
-    """Request body for RFC 8628 device authorization."""
-
-    client_id: str
-    scope: str | None = None
-
-
-class DeviceAuthOut(BaseModel):
-    """Response body for RFC 8628 device authorization."""
-
-    device_code: str
-    user_code: str
-    verification_uri: str
-    verification_uri_complete: str
-    expires_in: int
-    interval: int
-
-
 class PasswordGrantForm(BaseModel):
     grant_type: Literal["password"]
     username: str
     password: str
-
-
-class DeviceGrantForm(BaseModel):
-    grant_type: Literal["urn:ietf:params:oauth:grant-type:device_code"]
-    device_code: str
-    client_id: str
 
 
 # ============================================================================
@@ -195,40 +163,6 @@ async def login(body: CredsIn, db: AsyncSession = Depends(get_async_db)):
     return TokenPair(access_token=access, refresh_token=refresh)
 
 
-@router.post("/device_authorization", response_model=DeviceAuthOut)
-async def device_authorization(body: DeviceAuthIn) -> DeviceAuthOut:
-    device_code = uuid4().hex
-    user_code = uuid4().hex[:8]
-    verification_uri = _DEVICE_VERIFICATION_URI
-    verification_uri_complete = f"{verification_uri}?user_code={user_code}"
-    expires_at = datetime.utcnow() + timedelta(seconds=_DEVICE_CODE_EXPIRES_IN)
-    _DEVICE_CODES[device_code] = {
-        "user_code": user_code,
-        "client_id": body.client_id,
-        "expires_at": expires_at,
-        "interval": _DEVICE_CODE_INTERVAL,
-        "authorized": False,
-        "sub": None,
-        "tid": None,
-    }
-    return DeviceAuthOut(
-        device_code=device_code,
-        user_code=user_code,
-        verification_uri=verification_uri,
-        verification_uri_complete=verification_uri_complete,
-        expires_in=_DEVICE_CODE_EXPIRES_IN,
-        interval=_DEVICE_CODE_INTERVAL,
-    )
-
-
-def approve_device_code(device_code: str, sub: str, tid: str) -> None:
-    """Mark a device code as authorized for testing purposes."""
-    if device_code in _DEVICE_CODES:
-        _DEVICE_CODES[device_code]["authorized"] = True
-        _DEVICE_CODES[device_code]["sub"] = sub
-        _DEVICE_CODES[device_code]["tid"] = tid
-
-
 @router.post("/token", response_model=TokenPair)
 async def token(
     request: Request, db: AsyncSession = Depends(get_async_db)
@@ -277,11 +211,11 @@ async def token(
             parsed = DeviceGrantForm(**data)
         except ValidationError as exc:
             raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, exc.errors())
-        record = _DEVICE_CODES.get(parsed.device_code)
+        record = DEVICE_CODES.get(parsed.device_code)
         if not record or record["client_id"] != parsed.client_id:
             raise HTTPException(status.HTTP_400_BAD_REQUEST, {"error": "invalid_grant"})
         if datetime.utcnow() > record["expires_at"]:
-            _DEVICE_CODES.pop(parsed.device_code, None)
+            DEVICE_CODES.pop(parsed.device_code, None)
             raise HTTPException(status.HTTP_400_BAD_REQUEST, {"error": "expired_token"})
         if not record.get("authorized"):
             raise HTTPException(
@@ -293,7 +227,7 @@ async def token(
             tid=record.get("tid", "device-tenant"),
             **jwt_kwargs,
         )
-        _DEVICE_CODES.pop(parsed.device_code, None)
+        DEVICE_CODES.pop(parsed.device_code, None)
         return TokenPair(access_token=access, refresh_token=refresh)
     if rfc6749_enabled():
         return JSONResponse(
@@ -333,18 +267,6 @@ async def refresh(body: RefreshIn):
 
 
 # --------------------------------------------------------------------------
-#  RFC 9126 pushed authorization requests
-# --------------------------------------------------------------------------
-@router.post("/par", status_code=status.HTTP_201_CREATED)
-async def pushed_authorization_request(request: Request):
-    if not settings.enable_rfc9126:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "PAR disabled")
-    form = await request.form()
-    request_uri = store_par_request(dict(form))
-    return {"request_uri": request_uri, "expires_in": DEFAULT_PAR_EXPIRY}
-
-
-# --------------------------------------------------------------------------
 #  RFC 7662 token introspection
 # --------------------------------------------------------------------------
 @router.post("/introspect", response_model=IntrospectOut)
@@ -361,14 +283,3 @@ async def introspect(token: str = Form(...), db: AsyncSession = Depends(get_asyn
         tid=str(principal.tenant_id),
         kind=kind,
     )
-
-
-# --------------------------------------------------------------------------
-#  RFC 7009 token revocation
-# --------------------------------------------------------------------------
-@router.post("/revoke")
-async def revoke(token: str = Form(...), token_type_hint: str | None = Form(None)):
-    if not settings.enable_rfc7009:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "revocation disabled")
-    revoke_token(token)
-    return {}

--- a/pkgs/standards/auto_authn/tests/conftest.py
+++ b/pkgs/standards/auto_authn/tests/conftest.py
@@ -108,11 +108,12 @@ def enable_rfc7662():
 def enable_rfc7009():
     """Enable RFC 7009 token revocation for tests."""
     from auto_authn.v2.runtime_cfg import settings
-    from auto_authn.v2.rfc7009 import reset_revocations
+    from auto_authn.v2.rfc7009 import reset_revocations, include_rfc7009
 
     original = settings.enable_rfc7009
     settings.enable_rfc7009 = True
     reset_revocations()
+    include_rfc7009(app)
     try:
         yield
     finally:
@@ -124,9 +125,11 @@ def enable_rfc7009():
 def enable_rfc8414():
     """Enable RFC 8414 authorization server metadata for tests."""
     from auto_authn.v2.runtime_cfg import settings
+    from auto_authn.v2.rfc8414 import include_rfc8414
 
     original = settings.enable_rfc8414
     settings.enable_rfc8414 = True
+    include_rfc8414(app)
     try:
         yield
     finally:
@@ -137,11 +140,12 @@ def enable_rfc8414():
 def enable_rfc9126():
     """Enable RFC 9126 pushed authorization requests for tests."""
     from auto_authn.v2.runtime_cfg import settings
-    from auto_authn.v2.rfc9126 import reset_par_store
+    from auto_authn.v2.rfc9126 import reset_par_store, include_rfc9126
 
     original = settings.enable_rfc9126
     settings.enable_rfc9126 = True
     reset_par_store()
+    include_rfc9126(app)
     try:
         yield
     finally:

--- a/pkgs/standards/auto_authn/tests/i9n/test_rfc8628.py
+++ b/pkgs/standards/auto_authn/tests/i9n/test_rfc8628.py
@@ -48,7 +48,7 @@ async def test_device_token_polling(async_client: AsyncClient) -> None:
     assert pending.status_code == status.HTTP_400_BAD_REQUEST
     assert pending.json()["error"] == "authorization_pending"
 
-    from auto_authn.v2.routers.auth_flows import approve_device_code
+    from auto_authn.v2.rfc8628 import approve_device_code
 
     approve_device_code(device_code, sub="user", tid="tenant")
     success = await async_client.post("/token", data=payload)

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7009_token_revocation.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7009_token_revocation.py
@@ -4,7 +4,7 @@ import pytest
 from fastapi import FastAPI, status
 from httpx import ASGITransport, AsyncClient
 
-from auto_authn.v2.routers.auth_flows import router
+from auto_authn.v2.rfc7009 import router
 from auto_authn.v2.fastapi_deps import get_async_db
 from auto_authn.v2.runtime_cfg import settings
 from auto_authn.v2.rfc7009 import is_revoked, reset_revocations

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc9126_pushed_authorization_requests.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc9126_pushed_authorization_requests.py
@@ -4,9 +4,8 @@ import pytest
 from fastapi import FastAPI, status
 from httpx import ASGITransport, AsyncClient
 
-from auto_authn.v2.routers.auth_flows import router
+from auto_authn.v2.rfc9126 import DEFAULT_PAR_EXPIRY, router
 from auto_authn.v2.fastapi_deps import get_async_db
-from auto_authn.v2.rfc9126 import DEFAULT_PAR_EXPIRY
 
 # RFC 9126 specification excerpt for reference within tests
 RFC9126_SPEC = """


### PR DESCRIPTION
## Summary
- add routers for RFC 8628 device authorization, RFC 9126 PAR, and RFC 7009 token revocation
- wire optional OAuth endpoints into app only when enabled
- adjust token flow and tests for modular feature flags

## Testing
- `uv run --directory standards/auto_authn --package auto_authn ruff format .`
- `uv run --directory standards/auto_authn --package auto_authn ruff check . --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest` *(fails: ModuleNotFoundError: No module named 'jwcrypto')*

------
https://chatgpt.com/codex/tasks/task_e_68ac585ea0f88326972316242859c74f