### PR TITLE
Fix JWK test to handle dict return

### DIFF
--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7517_jwk.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7517_jwk.py
@@ -6,5 +6,5 @@ from auto_authn.v2 import load_signing_jwk, load_public_jwk
 def test_jwk_contains_required_fields() -> None:
     priv = load_signing_jwk()
     pub = load_public_jwk()
-    assert priv.kty == "OKP"
-    assert pub.kty == "OKP"
+    assert priv["kty"] == "OKP"
+    assert pub["kty"] == "OKP"


### PR DESCRIPTION
## Summary
- update JWK test to check dictionary keys

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc7517_jwk.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac5bbd159083269564de8fee9f5028