### PR TITLE
fix: align RFC8725 errors with pyjwt

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8725.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8725.py
@@ -12,12 +12,15 @@ from typing import Any, Dict
 import base64
 import json
 
+from jwt import InvalidTokenError as JWTInvalidTokenError
+
 from .jwtoken import JWTCoder
 from .runtime_cfg import settings
 
 
-class InvalidTokenError(Exception):
+class InvalidTokenError(JWTInvalidTokenError):
     """Raised when a JWT violates RFC 8725 recommendations."""
+
 
 RFC8725_SPEC_URL = "https://www.rfc-editor.org/rfc/rfc8725"
 


### PR DESCRIPTION
## Summary
- ensure RFC8725 validator raises `jwt.InvalidTokenError`

## Testing
- `uv run --package auto_authn --directory standards/auto_authn ruff format auto_authn/v2/rfc8725.py`
- `uv run --package auto_authn --directory standards/auto_authn ruff check auto_authn/v2/rfc8725.py --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc8725_jwt_best_practices.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac5beb357c8326ad03458dc8e8dff9