### PR TITLE
Fix JWTCoder initialization for RFC 9068 JWT profile tests

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/fastapi_deps.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/fastapi_deps.py
@@ -30,7 +30,6 @@ from .orm.tables import User
 from .typing import Principal
 from .db import get_async_db
 from .jwtoken import JWTCoder
-from .crypto import public_key, signing_key
 from .runtime_cfg import settings
 from .rfc9449_dpop import verify_proof
 from .principal_ctx import principal_var
@@ -41,7 +40,7 @@ from .rfc6750 import extract_bearer_token
 # Backends + Coder
 # ---------------------------------------------------------------------
 _api_key_backend = ApiKeyBackend()
-_jwt_coder = JWTCoder(public_key, signing_key)
+_jwt_coder = JWTCoder.default()
 
 
 # ---------------------------------------------------------------------

--- a/pkgs/standards/auto_authn/auto_authn/v2/jwtoken.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/jwtoken.py
@@ -16,6 +16,7 @@ from .deps import (
     ExportPolicy,
     FileKeyProvider,
     JWTTokenService,
+    LocalKeyProvider,
     JWAAlg,
     KeyAlg,
     KeyClass,
@@ -53,13 +54,47 @@ def _svc() -> Tuple[JWTTokenService, str]:
 
 
 class JWTCoder:
-    """Stateless JWT helper backed by ``JWTTokenService``."""
+    """Stateless JWT helper backed by ``JWTTokenService``.
+
+    ``JWTCoder`` historically accepted a private/public key pair and
+    constructed its own :class:`JWTTokenService`.  Recent refactoring switched
+    the constructor to require an already configured service instance.  The
+    tests for RFC 9068 still rely on the original behaviour, so the
+    initializer now supports both invocation styles:
+
+    ``JWTCoder(service, kid)`` -- use the provided service directly.
+
+    ``JWTCoder(private_key_pem, public_key_pem)`` -- build an ephemeral
+    service from the PEM encoded Ed25519 key pair.
+    """
 
     __slots__ = ("_svc", "_kid")
 
-    def __init__(self, service: JWTTokenService, kid: str):
-        self._svc = service
-        self._kid = kid
+    def __init__(self, arg1: JWTTokenService | bytes, arg2: str | bytes):
+        if isinstance(arg1, JWTTokenService) and isinstance(arg2, str):
+            self._svc = arg1
+            self._kid = arg2
+            return
+
+        if isinstance(arg1, (bytes, bytearray)) and isinstance(
+            arg2, (bytes, bytearray)
+        ):
+            kp = LocalKeyProvider()
+            spec = KeySpec(
+                klass=KeyClass.asymmetric,
+                alg=KeyAlg.ED25519,
+                uses=(KeyUse.SIGN, KeyUse.VERIFY),
+                export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+                label="jwt_ed25519",
+            )
+            ref = asyncio.run(kp.import_key(spec, arg1, public=arg2))
+            self._svc = JWTTokenService(kp)
+            self._kid = ref.kid
+            return
+
+        raise TypeError(
+            "JWTCoder requires (JWTTokenService, kid) or (private_pem, public_pem)"
+        )
 
     @classmethod
     def default(cls) -> "JWTCoder":


### PR DESCRIPTION
## Summary
- allow `JWTCoder` to accept either a `JWTTokenService` or a PEM key pair
- instantiate default `JWTCoder` in FastAPI dependencies

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc9068_jwt_profile.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac5bf980fc83269d88dc21a88c024a