### PR TITLE
Use timezone-aware timestamps for PAR expiration

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc9126.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc9126.py
@@ -11,7 +11,7 @@ See RFC 9126: https://www.rfc-editor.org/rfc/rfc9126
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Final, Tuple
 
 # In-memory storage mapping request_uri -> (params, expiry)
@@ -32,7 +32,7 @@ def store_par_request(
     request_uri = f"urn:ietf:params:oauth:request_uri:{uuid.uuid4()}"
     _PAR_STORE[request_uri] = (
         params,
-        datetime.utcnow() + timedelta(seconds=expires_in),
+        datetime.now(tz=timezone.utc) + timedelta(seconds=expires_in),
     )
     return request_uri
 
@@ -43,7 +43,7 @@ def get_par_request(request_uri: str) -> Dict[str, Any] | None:
     if not record:
         return None
     params, expiry = record
-    if datetime.utcnow() > expiry:
+    if datetime.now(tz=timezone.utc) > expiry:
         del _PAR_STORE[request_uri]
         return None
     return params


### PR DESCRIPTION
## Summary
- use timezone-aware UTC timestamps when storing and validating pushed authorization requests, replacing deprecated `datetime.utcnow`

## Testing
- `uv run --package auto_authn --directory standards ruff format auto_authn/auto_authn/v2/rfc9126.py`
- `uv run --package auto_authn --directory standards ruff check auto_authn/auto_authn/v2/rfc9126.py --fix`
- `uv run --package auto_authn --directory standards pytest auto_authn/tests/unit/test_rfc9126_pushed_authorization_requests.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac5c01431c8326b1cf736ef931592b