### PR TITLE
Enable DPoP by default and fix proof signing

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
@@ -121,7 +121,7 @@ class Settings(BaseSettings):
         in {"1", "true", "yes"}
     )
     enable_rfc9449: bool = Field(
-        default=os.environ.get("AUTO_AUTHN_ENABLE_RFC9449", "false").lower()
+        default=os.environ.get("AUTO_AUTHN_ENABLE_RFC9449", "true").lower()
         in {"1", "true", "yes"},
         description=(
             "Enable OAuth 2.0 Demonstrating Proof of Possession (DPoP) per RFC 9449"


### PR DESCRIPTION
## Summary
- enable RFC 9449 DPoP support by default
- correct DPoP proof creation using PEM key and cryptography signer

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc9449_dpop.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ac5c061b6c83269800e3df8cdb4a67