### PR TITLE
feat(auto_authn): expand WebAuthn algorithm support

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8812.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8812.py
@@ -16,7 +16,23 @@ from .runtime_cfg import settings
 
 RFC8812_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc8812"
 
-WEBAUTHN_ALGORITHMS: Final[set[str]] = {"RS256", "RS384", "RS512", "RS1", "ES256K"}
+# Algorithms registered for WebAuthn. Using ``frozenset`` prevents accidental
+# mutation of the registry at runtime.
+WEBAUTHN_ALGORITHMS: Final[frozenset[str]] = frozenset(
+    {
+        "RS256",
+        "RS384",
+        "RS512",
+        "RS1",
+        "PS256",
+        "PS384",
+        "PS512",
+        "ES256",
+        "ES384",
+        "ES512",
+        "ES256K",
+    }
+)
 
 
 def is_webauthn_algorithm(alg: str, *, enabled: bool | None = None) -> bool:

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc8812_webauthn_algorithms.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc8812_webauthn_algorithms.py
@@ -10,11 +10,26 @@ import pytest
 from auto_authn.v2 import runtime_cfg, supported_algorithms
 from auto_authn.v2.rfc8812 import WEBAUTHN_ALGORITHMS, is_webauthn_algorithm
 
+EXPECTED_ALGORITHMS = {
+    "RS256",
+    "RS384",
+    "RS512",
+    "RS1",
+    "PS256",
+    "PS384",
+    "PS512",
+    "ES256",
+    "ES384",
+    "ES512",
+    "ES256K",
+}
+
 
 @pytest.mark.unit
 def test_known_algorithms_allowed(monkeypatch):
     """Algorithms listed in RFC 8812 pass validation when enabled."""
     monkeypatch.setattr(runtime_cfg.settings, "enable_rfc8812", True)
+    assert WEBAUTHN_ALGORITHMS == EXPECTED_ALGORITHMS
     for alg in WEBAUTHN_ALGORITHMS:
         assert is_webauthn_algorithm(alg)
     assert not is_webauthn_algorithm("HS256")
@@ -27,6 +42,7 @@ def test_supported_algorithms_extends_when_enabled(monkeypatch):
     algs = supported_algorithms()
     for alg in WEBAUTHN_ALGORITHMS:
         assert alg in algs
+    assert "PS256" in algs
     monkeypatch.setattr(runtime_cfg.settings, "enable_rfc8812", False)
     algs = supported_algorithms()
     assert not any(alg in algs for alg in WEBAUTHN_ALGORITHMS)


### PR DESCRIPTION
## Summary
- expand RFC 8812 WebAuthn algorithm registry
- validate expanded algorithm set in tests

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc8812_webauthn_algorithms.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac5bf00d9c83269d0cf2f5a40bd6c8