### PR TITLE
fix: make JWT coder async-friendly

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/routers/auth_flows.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/routers/auth_flows.py
@@ -42,10 +42,9 @@ from ..runtime_cfg import settings
 from ..typing import StrUUID
 from ..rfc8707 import extract_resource
 from ..rfc7009 import revoke_token
-from ..rfc6749 import RFC6749Error, validate_grant_type, validate_password_grant
+from ..rfc6749 import RFC6749Error
 from ..rfc9126 import store_par_request, DEFAULT_PAR_EXPIRY
 from ..rfc6749 import (
-    RFC6749Error,
     enforce_grant_type,
     enforce_password_grant,
     is_enabled as rfc6749_enabled,
@@ -180,7 +179,7 @@ async def register(body: RegisterIn, db: AsyncSession = Depends(get_async_db)):
             status.HTTP_500_INTERNAL_SERVER_ERROR, "database error"
         ) from exc
 
-    access, refresh = _jwt.sign_pair(sub=str(user.id), tid=str(tenant.id))
+    access, refresh = await _jwt.async_sign_pair(sub=str(user.id), tid=str(tenant.id))
     return TokenPair(access_token=access, refresh_token=refresh)
 
 
@@ -191,7 +190,9 @@ async def login(body: CredsIn, db: AsyncSession = Depends(get_async_db)):
     except AuthError:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "invalid credentials")
 
-    access, refresh = _jwt.sign_pair(sub=str(user.id), tid=str(user.tenant_id))
+    access, refresh = await _jwt.async_sign_pair(
+        sub=str(user.id), tid=str(user.tenant_id)
+    )
     return TokenPair(access_token=access, refresh_token=refresh)
 
 
@@ -268,7 +269,7 @@ async def token(
         except AuthError:
             raise HTTPException(status.HTTP_404_NOT_FOUND, "invalid credentials")
         jwt_kwargs = {"aud": aud} if aud else {}
-        access, refresh = _jwt.sign_pair(
+        access, refresh = await _jwt.async_sign_pair(
             sub=str(user.id), tid=str(user.tenant_id), **jwt_kwargs
         )
         return TokenPair(access_token=access, refresh_token=refresh)
@@ -288,7 +289,7 @@ async def token(
                 status.HTTP_400_BAD_REQUEST, {"error": "authorization_pending"}
             )
         jwt_kwargs = {"aud": aud} if aud else {}
-        access, refresh = _jwt.sign_pair(
+        access, refresh = await _jwt.async_sign_pair(
             sub=record.get("sub", "device-user"),
             tid=record.get("tid", "device-tenant"),
             **jwt_kwargs,

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc8707_resource_indicators.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc8707_resource_indicators.py
@@ -40,7 +40,7 @@ async def test_token_includes_aud_when_resource_provided(monkeypatch):
             },
         )
     assert resp.status_code == status.HTTP_200_OK
-    payload = _jwt.decode(resp.json()["access_token"])
+    payload = await _jwt.async_decode(resp.json()["access_token"])
     assert payload["aud"] == "https://rs.example"
 
 
@@ -92,7 +92,7 @@ async def test_multiple_resources_uses_first(monkeypatch):
             },
         )
     assert resp.status_code == status.HTTP_200_OK
-    payload = _jwt.decode(resp.json()["access_token"])
+    payload = await _jwt.async_decode(resp.json()["access_token"])
     assert payload["aud"] == "https://rs.example"
 
 
@@ -144,7 +144,7 @@ async def test_feature_flag_disables_resource(monkeypatch):
             },
         )
     assert resp.status_code == status.HTTP_200_OK
-    payload = _jwt.decode(resp.json()["access_token"])
+    payload = await _jwt.async_decode(resp.json()["access_token"])
     assert "aud" not in payload
 
 


### PR DESCRIPTION
## Summary
- add async helpers to `JWTCoder` to avoid `asyncio.run` inside running loops
- use async signing helpers in auth flows
- adjust RFC 8707 resource indicator tests to await token decoding

## Testing
- `uv run --package auto_authn --directory standards/auto_authn ruff format .`
- `uv run --package auto_authn --directory standards/auto_authn ruff check . --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc8707_resource_indicators.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac5be46bf083269a510c17e090500a