### PR TITLE
Raise InvalidTokenError for expired JWTs

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/jwtoken.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/jwtoken.py
@@ -12,6 +12,8 @@ from datetime import datetime, timedelta, timezone
 from functools import lru_cache
 from typing import Any, Dict, Iterable, Optional, Tuple
 
+from jwt.exceptions import InvalidTokenError
+
 from .deps import (
     ExportPolicy,
     FileKeyProvider,
@@ -143,7 +145,7 @@ class JWTCoder:
             if exp is not None and int(exp) < int(
                 datetime.now(timezone.utc).timestamp()
             ):
-                raise ValueError("token is expired")
+                raise InvalidTokenError("token is expired")
         if settings.enable_rfc8705:
             if cert_thumbprint is None:
                 raise ValueError(


### PR DESCRIPTION
## Summary
- raise `InvalidTokenError` when a JWT's `exp` claim is in the past
- import `InvalidTokenError` in JWTCoder

## Testing
- `uv run --package auto-authn --directory standards/auto_authn ruff format .`
- `uv run --package auto-authn --directory standards/auto_authn ruff check . --fix`
- `uv run --package auto-authn --directory standards/auto_authn pytest tests/unit/test_rfc7523_jwt_profile.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac5bce1d048326a6c9726e67cf0025