### PR TITLE
Remove jwcrypto dependency from JWS test

### DIFF
--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7515_jws.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7515_jws.py
@@ -1,12 +1,19 @@
 """Tests for RFC 7515: JSON Web Signature (JWS)."""
 
-from jwcrypto import jwk
+import base64
+import secrets
 
 from auto_authn.v2 import sign_jws, verify_jws
 
 
 def test_sign_and_verify_jws() -> None:
-    key = jwk.JWK.generate(kty="oct", size=256)
+    secret = secrets.token_bytes(32)
+    key = {
+        "kty": "oct",
+        "kind": "raw",
+        "key": secret,
+        "k": base64.urlsafe_b64encode(secret).rstrip(b"=").decode(),
+    }
     payload = "payload"
     token = sign_jws(payload, key)
     assert verify_jws(token, key) == payload


### PR DESCRIPTION
## Summary
- Simplify JWS unit test by generating an HS256 key with standard libraries instead of relying on `jwcrypto`.

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc7515_jws.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac5baa323083268135275f49528b39