### PR TITLE
fix: use timezone-aware cert validity

### DIFF
--- a/pkgs/standards/auto_authn/tests/unit/test_rfc8705_compliance.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc8705_compliance.py
@@ -7,7 +7,7 @@ The tests below verify that behavior is enforced when the feature flag is
 enabled and bypassed when disabled.
 """
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from cryptography import x509
@@ -37,8 +37,8 @@ def _generate_cert_pem() -> bytes:
         .issuer_name(issuer)
         .public_key(key.public_key())
         .serial_number(x509.random_serial_number())
-        .not_valid_before(datetime.utcnow())
-        .not_valid_after(datetime.utcnow() + timedelta(days=1))
+        .not_valid_before(datetime.now(UTC))
+        .not_valid_after(datetime.now(UTC) + timedelta(days=1))
         .sign(key, hashes.SHA256())
     )
     return cert.public_bytes(serialization.Encoding.PEM)


### PR DESCRIPTION
## Summary
- use timezone-aware datetimes when generating test certificates

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc8705_compliance.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac5bdd85348326ab83350275c850cb