### PR TITLE
Use internal JWK utilities for auto_authn tests

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/app.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/app.py
@@ -97,9 +97,9 @@ async def jwks():
     """
     Return Ed25519 public key in RFC 7517 JWK Set format.
     """
-    from .crypto import _provider, _load_keypair
+    from .crypto import _provider, _ensure_key
 
-    kid, _, _ = _load_keypair()
+    kid, _, _ = await _ensure_key()
     kp = _provider()
     key_dict = await kp.get_public_jwk(kid)
     key_dict.setdefault("kid", f"{kid}.1")

--- a/pkgs/standards/auto_authn/tests/conftest.py
+++ b/pkgs/standards/auto_authn/tests/conftest.py
@@ -43,6 +43,7 @@ async def test_db_engine():
         poolclass=StaticPool,
         connect_args={"check_same_thread": False},
         echo=False,
+        execution_options={"schema_translate_map": {"authn": None}},
     )
 
     # Create all tables
@@ -162,10 +163,10 @@ def temp_key_file():
     import auto_authn.v2.crypto as crypto_module
 
     original_dir = crypto_module._DEFAULT_KEY_DIR
-    original_kid = crypto_module._KID_PATH
+    original_path = crypto_module._DEFAULT_KEY_PATH
 
     crypto_module._DEFAULT_KEY_DIR = temp_dir
-    crypto_module._KID_PATH = temp_kid
+    crypto_module._DEFAULT_KEY_PATH = temp_kid
     crypto_module._load_keypair.cache_clear()
 
     yield temp_kid
@@ -176,7 +177,7 @@ def temp_key_file():
         f.unlink()
     temp_dir.rmdir()
     crypto_module._DEFAULT_KEY_DIR = original_dir
-    crypto_module._KID_PATH = original_kid
+    crypto_module._DEFAULT_KEY_PATH = original_path
     crypto_module._load_keypair.cache_clear()
 
 

--- a/pkgs/standards/auto_authn/tests/i9n/test_oidc_endpoints.py
+++ b/pkgs/standards/auto_authn/tests/i9n/test_oidc_endpoints.py
@@ -12,7 +12,7 @@ from urllib.parse import urlparse
 
 import pytest
 from httpx import AsyncClient
-from jwcrypto import jwk
+from swarmauri_signing_jws.JwsSignerVerifier import _jwk_to_pub_for_signer
 
 
 @pytest.mark.integration
@@ -230,23 +230,18 @@ class TestJWKSEndpoint:
 
     @pytest.mark.asyncio
     async def test_jwk_can_create_jwk_object(self, async_client):
-        """Test that the JWK can be used to create a valid jwcrypto JWK object."""
+        """Test that the JWK can be parsed using Swarmauri utilities."""
         response = await async_client.get("/.well-known/jwks.json")
         jwks_doc = response.json()
 
         key_dict = jwks_doc["keys"][0]
 
-        # Should be able to create a JWK object from the dict
+        # Should be able to convert the JWK to a public key representation
         try:
-            key_obj = jwk.JWK(**key_dict)
-            assert key_obj is not None
-
-            # Should be able to export it back
-            exported = key_obj.export(as_dict=True)
-            assert isinstance(exported, dict)
-            assert exported["kty"] == key_dict["kty"]
+            pub = _jwk_to_pub_for_signer(key_dict)
+            assert pub is not None
         except Exception as e:
-            pytest.fail(f"Failed to create JWK object from JWKS response: {e}")
+            pytest.fail(f"Failed to parse JWK from JWKS response: {e}")
 
     @pytest.mark.asyncio
     async def test_jwks_key_consistency(self, async_client):


### PR DESCRIPTION
## Summary
- replace jwcrypto usage in OIDC endpoint tests with Swarmauri JWS utilities
- load keypair asynchronously in JWKS endpoint
- adjust tests to work with schema-qualified tables and temporary key files

## Testing
- `uv run --package auto_authn --directory standards/auto_authn ruff format tests/conftest.py tests/i9n/test_oidc_endpoints.py auto_authn/v2/app.py`
- `uv run --package auto_authn --directory standards/auto_authn ruff check tests/conftest.py tests/i9n/test_oidc_endpoints.py auto_authn/v2/app.py --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/i9n/test_oidc_endpoints.py -m integration -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac605aaea88326bfa8cfe367999b18