### PR TITLE
Use native key generation for JWE test

### DIFF
--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7516_jwe.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7516_jwe.py
@@ -1,12 +1,12 @@
 """Tests for RFC 7516: JSON Web Encryption (JWE)."""
 
-from jwcrypto import jwk
+from secrets import token_bytes
 
-from auto_authn.v2 import encrypt_jwe, decrypt_jwe
+from auto_authn.v2 import decrypt_jwe, encrypt_jwe
 
 
 def test_encrypt_and_decrypt_jwe() -> None:
-    key = jwk.JWK.generate(kty="oct", size=256)
+    key = {"kty": "oct", "k": token_bytes(32)}
     secret = "sensitive"
     token = encrypt_jwe(secret, key)
     assert decrypt_jwe(token, key) == secret


### PR DESCRIPTION
## Summary
- avoid jwcrypto dependency in JWE test by generating symmetric key using secrets module

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc7516_jwe.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac607220948326ac7eb64ea8d4bc01