### PR TITLE
feat: expand KeySpec with serialization options

### DIFF
--- a/pkgs/core/swarmauri_core/keys/types.py
+++ b/pkgs/core/swarmauri_core/keys/types.py
@@ -36,6 +36,10 @@ class KeySpec:
     alg: KeyAlg
     uses: Tuple[KeyUse, ...]
     export_policy: ExportPolicy
+    encoding: Optional[str] = None
+    private_format: Optional[str] = None
+    public_format: Optional[str] = None
+    encryption: Optional[str] = None
     size_bits: Optional[int] = None
     label: Optional[str] = None
     tags: Optional[Dict[str, str]] = None

--- a/pkgs/swarmauri_standard/tests/unit/key_providers/test_inmemory_provider_unit.py
+++ b/pkgs/swarmauri_standard/tests/unit/key_providers/test_inmemory_provider_unit.py
@@ -14,6 +14,10 @@ async def test_import_and_get() -> None:
         alg=KeyAlg.AES256_GCM,
         uses=(KeyUse.ENCRYPT, KeyUse.DECRYPT),
         export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+        encoding="PEM",
+        private_format="PKCS8",
+        public_format="SubjectPublicKeyInfo",
+        encryption="NoEncryption",
     )
     material = b"s3cr3t"
     ref = await provider.import_key(spec, material)


### PR DESCRIPTION
## Summary
- allow KeySpec to capture encoding, private/public formats and encryption
- cover InMemoryKeyProvider with extended KeySpec in tests

## Testing
- `uv run --directory pkgs/core --package swarmauri_core ruff check . --fix`
- `uv run --directory pkgs/swarmauri_standard --package swarmauri_standard ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68ac61b45c00832688a5acc4ec2698b0