### PR TITLE
fix: support cryptography keys in eddsa signing

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8037.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8037.py
@@ -5,29 +5,42 @@ from __future__ import annotations
 import asyncio
 
 from .deps import Ed25519EnvelopeSigner
-
 from .runtime_cfg import settings
+
+try:  # pragma: no cover - optional dependency
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+        Ed25519PrivateKey,
+        Ed25519PublicKey,
+    )
+except Exception:  # pragma: no cover - runtime check
+    Ed25519PrivateKey = Ed25519PublicKey = object  # type: ignore[assignment]
 
 RFC8037_SPEC_URL = "https://www.rfc-editor.org/rfc/rfc8037"
 _signer = Ed25519EnvelopeSigner()
 
 
-def sign_eddsa(message: bytes, key: bytes, *, enabled: bool | None = None) -> bytes:
+def _to_keyref(key: bytes | Ed25519PrivateKey) -> dict[str, object]:
+    if isinstance(key, (bytes, bytearray)):
+        return {"kind": "raw_ed25519_sk", "bytes": key}
+    return {"kind": "cryptography_obj", "obj": key}
+
+
+def sign_eddsa(
+    message: bytes, key: bytes | Ed25519PrivateKey, *, enabled: bool | None = None
+) -> bytes:
     """Return an Ed25519 signature for *message* per RFC 8037."""
     if enabled is None:
         enabled = settings.enable_rfc8037
     if not enabled:
         return message
-    sigs = asyncio.run(
-        _signer.sign_bytes({"kind": "raw_ed25519_sk", "bytes": key}, message)
-    )
+    sigs = asyncio.run(_signer.sign_bytes(_to_keyref(key), message))
     return sigs[0]["sig"]  # type: ignore[index]
 
 
 def verify_eddsa(
     message: bytes,
     signature: bytes,
-    key: bytes,
+    key: bytes | Ed25519PublicKey,
     *,
     enabled: bool | None = None,
 ) -> bool:


### PR DESCRIPTION
## Summary
- accept cryptography key objects in RFC 8037 helpers
- ensure Ed25519 signatures work when runtime toggle enabled

## Testing
- `uv run --package auto_authn --directory standards/auto_authn ruff format auto_authn/v2/rfc8037.py`
- `uv run --package auto_authn --directory standards/auto_authn ruff check auto_authn/v2/rfc8037.py --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc8037_eddsa.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac607c7ccc83269f615551de296715