### PR TITLE
refactor: remove pyjwt usage in auto_authn

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/errors.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/errors.py
@@ -1,0 +1,20 @@
+"""Custom JWT-related exceptions for auto_authn.
+
+The auto_authn package relies on swarmauri token services and avoids direct
+use of external libraries such as PyJWT.  These lightweight exception classes
+provide a small surface that mirrors the errors previously exposed by PyJWT
+without requiring a dependency on that package.
+"""
+
+from __future__ import annotations
+
+
+class InvalidTokenError(Exception):
+    """Raised when a JWT cannot be decoded or fails validation."""
+
+
+class InvalidKeyError(Exception):
+    """Raised when a suitable key for JWT processing cannot be found."""
+
+
+__all__ = ["InvalidTokenError", "InvalidKeyError"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/jwtoken.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/jwtoken.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta, timezone
 from functools import lru_cache
 from typing import Any, Dict, Iterable, Optional, Tuple
 
-from jwt.exceptions import InvalidKeyError, InvalidTokenError
+from .errors import InvalidTokenError
 
 from .deps import (
     ExportPolicy,
@@ -208,8 +208,9 @@ class JWTCoder:
     ) -> Dict[str, Any]:
         try:
             payload = await self._svc.verify(token, issuer=issuer, audience=audience)
-        except InvalidKeyError as exc:
-            raise InvalidTokenError("unable to resolve verification key") from exc
+        except Exception as exc:
+            # Delegate any verification issues to our own domain specific error
+            raise InvalidTokenError("unable to verify token") from exc
         if verify_exp:
             exp = payload.get("exp")
             if exp is not None and int(exp) < int(

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8705.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8705.py
@@ -14,7 +14,7 @@ import base64
 import hashlib
 from typing import Any, Dict
 
-from jwt.exceptions import InvalidTokenError
+from .errors import InvalidTokenError
 from cryptography import x509
 from cryptography.hazmat.primitives import serialization
 

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8725.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8725.py
@@ -12,13 +12,13 @@ from typing import Any, Dict
 import base64
 import json
 
-from jwt import InvalidTokenError as JWTInvalidTokenError
+from .errors import InvalidTokenError as BaseInvalidTokenError
 
 from .jwtoken import JWTCoder
 from .runtime_cfg import settings
 
 
-class InvalidTokenError(JWTInvalidTokenError):
+class InvalidTokenError(BaseInvalidTokenError):
     """Raised when a JWT violates RFC 8725 recommendations."""
 
 

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc9068.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc9068.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, Final, Iterable, Set
 
-from jwt.exceptions import InvalidTokenError
+from .errors import InvalidTokenError
 
 RFC9068_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc9068"
 


### PR DESCRIPTION
## Summary
- add internal JWT error types to avoid PyJWT dependency
- refactor auto_authn modules to use new errors instead of jwt.exceptions

## Testing
- `uv run --package auto_authn --directory standards/auto_authn ruff format .`
- `uv run --package auto_authn --directory standards/auto_authn ruff check . --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc6750_bearer_token.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac62c63ba48326b1b50429ccc2143e