### PR TITLE
feat: advertise key generation ability

### DIFF
--- a/pkgs/community/swarmauri_keyprovider_aws_kms/swarmauri_keyprovider_aws_kms/AwsKmsKeyProvider.py
+++ b/pkgs/community/swarmauri_keyprovider_aws_kms/swarmauri_keyprovider_aws_kms/AwsKmsKeyProvider.py
@@ -80,7 +80,7 @@ class AwsKmsKeyProvider(KeyProviderBase):
                 KeyAlg.RSA_PSS_SHA256,
                 KeyAlg.ECDSA_P256_SHA256,
             ),
-            "features": ("rotate", "jwks", "non_exportable"),
+            "features": ("create", "rotate", "jwks", "non_exportable"),
         }
 
     def _gen_kid(self) -> str:

--- a/pkgs/community/swarmauri_keyprovider_gcpkms/swarmauri_keyprovider_gcpkms/GcpKmsKeyProvider.py
+++ b/pkgs/community/swarmauri_keyprovider_gcpkms/swarmauri_keyprovider_gcpkms/GcpKmsKeyProvider.py
@@ -144,6 +144,7 @@ class GcpKmsKeyProvider(KeyProviderBase):
             "class": ("kms", "asym", "sym"),
             "algs": ("AES", "RSA", "EC"),
             "features": (
+                "create",
                 "encrypt",
                 "decrypt",
                 "sign",

--- a/pkgs/community/swarmauri_keyprovider_vaulttransit/swarmauri_keyprovider_vaulttransit/VaultTransitKeyProvider.py
+++ b/pkgs/community/swarmauri_keyprovider_vaulttransit/swarmauri_keyprovider_vaulttransit/VaultTransitKeyProvider.py
@@ -93,7 +93,7 @@ class VaultTransitKeyProvider(KeyProviderBase):
                 KeyAlg.ECDSA_P256_SHA256,
                 KeyAlg.ED25519,
             ),
-            "features": ("rotate", "jwks", "non_exportable"),
+            "features": ("create", "rotate", "jwks", "non_exportable"),
         }
 
     # ------------------------------------------------------------------

--- a/pkgs/standards/swarmauri_keyprovider_file/swarmauri_keyprovider_file/FileKeyProvider.py
+++ b/pkgs/standards/swarmauri_keyprovider_file/swarmauri_keyprovider_file/FileKeyProvider.py
@@ -75,7 +75,15 @@ class FileKeyProvider(KeyProviderBase):
                 KeyAlg.RSA_PSS_SHA256,
                 KeyAlg.ECDSA_P256_SHA256,
             ),
-            "features": ("rotate", "import", "jwks", "hkdf", "random", "persist"),
+            "features": (
+                "create",
+                "rotate",
+                "import",
+                "jwks",
+                "hkdf",
+                "random",
+                "persist",
+            ),
         }
 
     def _key_dir(self, kid: str) -> Path:

--- a/pkgs/standards/swarmauri_keyprovider_local/swarmauri_keyprovider_local/LocalKeyProvider.py
+++ b/pkgs/standards/swarmauri_keyprovider_local/swarmauri_keyprovider_local/LocalKeyProvider.py
@@ -55,7 +55,7 @@ class LocalKeyProvider(KeyProviderBase):
         return {
             "class": ("sym", "asym"),
             "algs": algs,
-            "features": ("rotate", "import", "jwks", "hkdf", "random"),
+            "features": ("create", "rotate", "import", "jwks", "hkdf", "random"),
         }
 
     async def create_key(self, spec: KeySpec) -> KeyRef:

--- a/pkgs/standards/swarmauri_keyprovider_pkcs11/swarmauri_keyprovider_pkcs11/Pkcs11KeyProvider.py
+++ b/pkgs/standards/swarmauri_keyprovider_pkcs11/swarmauri_keyprovider_pkcs11/Pkcs11KeyProvider.py
@@ -101,7 +101,14 @@ class Pkcs11KeyProvider(KeyProviderBase):
         return {
             "class": ("sym", "asym"),
             "algs": tuple(algs),
-            "features": ("rotate", "jwks", "non_exportable", "random", "hkdf"),
+            "features": (
+                "create",
+                "rotate",
+                "jwks",
+                "non_exportable",
+                "random",
+                "hkdf",
+            ),
         }
 
     async def create_key(self, spec: KeySpec) -> KeyRef:

--- a/pkgs/standards/swarmauri_keyprovider_ssh/swarmauri_keyprovider_ssh/SshKeyProvider.py
+++ b/pkgs/standards/swarmauri_keyprovider_ssh/swarmauri_keyprovider_ssh/SshKeyProvider.py
@@ -56,7 +56,7 @@ class SshKeyProvider(KeyProviderBase):
         return {
             "class": ("asym",),
             "algs": (KeyAlg.ED25519, KeyAlg.RSA_PSS_SHA256, KeyAlg.ECDSA_P256_SHA256),
-            "features": ("rotate", "import", "jwks", "hkdf", "random"),
+            "features": ("create", "rotate", "import", "jwks", "hkdf", "random"),
         }
 
     async def create_key(self, spec: KeySpec) -> KeyRef:

--- a/pkgs/swarmauri_standard/swarmauri_standard/key_providers/InMemoryKeyProvider.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/key_providers/InMemoryKeyProvider.py
@@ -20,7 +20,11 @@ class InMemoryKeyProvider(KeyProviderBase):
         self._store: Dict[str, Dict[int, KeyRef]] = {}
 
     def supports(self) -> Mapping[str, Iterable[str]]:
-        return {"class": ("sym", "asym"), "algs": (), "features": ("import", "rotate")}
+        return {
+            "class": ("sym", "asym"),
+            "algs": (),
+            "features": ("create", "import", "rotate"),
+        }
 
     async def create_key(self, spec: KeySpec) -> KeyRef:
         kid = secrets.token_hex(8)


### PR DESCRIPTION
## Summary
- advertise `create` support across key providers so all can generate keys

## Testing
- `uv run --directory pkgs/swarmauri_standard --package swarmauri-standard ruff format .`
- `uv run --directory pkgs/swarmauri_standard --package swarmauri-standard ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_keyprovider_file --package swarmauri_keyprovider_file ruff format .`
- `uv run --directory pkgs/standards/swarmauri_keyprovider_file --package swarmauri_keyprovider_file ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_keyprovider_local --package swarmauri_keyprovider_local ruff format .`
- `uv run --directory pkgs/standards/swarmauri_keyprovider_local --package swarmauri_keyprovider_local ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_keyprovider_ssh --package swarmauri_keyprovider_ssh ruff format .`
- `uv run --directory pkgs/standards/swarmauri_keyprovider_ssh --package swarmauri_keyprovider_ssh ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_keyprovider_pkcs11 --no-sync --with ruff ruff format .`
- `uv run --directory pkgs/standards/swarmauri_keyprovider_pkcs11 --no-sync --with ruff ruff check . --fix`
- `uv run --directory pkgs/community/swarmauri_keyprovider_vaulttransit --package swarmauri_keyprovider_vaulttransit ruff format .`
- `uv run --directory pkgs/community/swarmauri_keyprovider_vaulttransit --package swarmauri_keyprovider_vaulttransit ruff check . --fix`
- `uv run --directory pkgs/community/swarmauri_keyprovider_aws_kms --package swarmauri_keyprovider_aws_kms ruff format .`
- `uv run --directory pkgs/community/swarmauri_keyprovider_aws_kms --package swarmauri_keyprovider_aws_kms ruff check . --fix`
- `uv run --directory pkgs/community/swarmauri_keyprovider_gcpkms --package swarmauri_keyprovider_gcpkms ruff format .`
- `uv run --directory pkgs/community/swarmauri_keyprovider_gcpkms --package swarmauri_keyprovider_gcpkms ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68ac61469bcc83268a43cad348772e4c