### PR TITLE
feat: support key spec serialization options

### DIFF
--- a/pkgs/standards/swarmauri_keyprovider_file/swarmauri_keyprovider_file/FileKeyProvider.py
+++ b/pkgs/standards/swarmauri_keyprovider_file/swarmauri_keyprovider_file/FileKeyProvider.py
@@ -29,19 +29,37 @@ def _hash_hex(b: bytes, nbytes: int = 16) -> str:
     return h.finalize().hex()[: 2 * nbytes]
 
 
-def _pem_pub(priv) -> bytes:
-    return priv.public_key().public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    )
+def _serialize_keypair(priv, spec: KeySpec) -> tuple[bytes, Optional[bytes]]:
+    """Serialize private and public key material according to ``spec``."""
 
-
-def _pem_priv(priv) -> bytes:
-    return priv.private_bytes(
-        serialization.Encoding.PEM,
-        serialization.PrivateFormat.PKCS8,
-        serialization.NoEncryption(),
+    encoding = (
+        serialization.Encoding[spec.encoding]
+        if spec.encoding
+        else serialization.Encoding.PEM
     )
+    public_format = (
+        serialization.PublicFormat[spec.public_format]
+        if spec.public_format
+        else serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    public = priv.public_key().public_bytes(encoding=encoding, format=public_format)
+
+    material: Optional[bytes] = None
+    if spec.export_policy != ExportPolicy.PUBLIC_ONLY:
+        private_format = (
+            serialization.PrivateFormat[spec.private_format]
+            if spec.private_format
+            else serialization.PrivateFormat.PKCS8
+        )
+        if spec.encryption and spec.encryption != "NoEncryption":
+            raise ValueError(f"Unsupported encryption: {spec.encryption}")
+        material = priv.private_bytes(
+            encoding,
+            private_format,
+            serialization.NoEncryption(),
+        )
+
+    return public, material
 
 
 def _ensure_dir(p: Path) -> None:
@@ -170,9 +188,7 @@ class FileKeyProvider(KeyProviderBase):
                 else:
                     raise ValueError(f"Unsupported asymmetric alg: {spec.alg}")
 
-                public = _pem_pub(sk)
-                if spec.export_policy != ExportPolicy.PUBLIC_ONLY:
-                    material = _pem_priv(sk)
+                public, material = _serialize_keypair(sk, spec)
                 (vdir / "public.pem").write_bytes(public)
                 if material is not None:
                     (vdir / "private.pem").write_bytes(material)
@@ -318,9 +334,13 @@ class FileKeyProvider(KeyProviderBase):
                 else:
                     raise ValueError(f"Unsupported alg during rotate: {alg}")
 
-                public = _pem_pub(sk)
-                if export_policy != ExportPolicy.PUBLIC_ONLY:
-                    material = _pem_priv(sk)
+                tmp_spec = KeySpec(
+                    klass=klass,
+                    alg=alg,
+                    uses=uses,
+                    export_policy=export_policy,
+                )
+                public, material = _serialize_keypair(sk, tmp_spec)
                 (vdir / "public.pem").write_bytes(public)
                 if material is not None:
                     (vdir / "private.pem").write_bytes(material)

--- a/pkgs/standards/swarmauri_keyprovider_file/tests/test_file_keyprovider_basic.py
+++ b/pkgs/standards/swarmauri_keyprovider_file/tests/test_file_keyprovider_basic.py
@@ -15,8 +15,31 @@ async def test_create_and_get(tmp_path):
         alg=KeyAlg.AES256_GCM,
         uses=(KeyUse.ENCRYPT,),
         export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+        encoding="PEM",
+        private_format="PKCS8",
+        public_format="SubjectPublicKeyInfo",
+        encryption="NoEncryption",
     )
     ref = await provider.create_key(spec)
     fetched = await provider.get_key(ref.kid, include_secret=True)
     assert fetched.material is not None
     assert fetched.kid == ref.kid
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_create_ed25519_with_formats(tmp_path):
+    provider = FileKeyProvider(tmp_path)
+    spec = KeySpec(
+        klass=KeyClass.asymmetric,
+        alg=KeyAlg.ED25519,
+        uses=(KeyUse.SIGN,),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+        encoding="PEM",
+        private_format="PKCS8",
+        public_format="SubjectPublicKeyInfo",
+        encryption="NoEncryption",
+    )
+    ref = await provider.create_key(spec)
+    priv_path = tmp_path / "keys" / ref.kid / "v1" / "private.pem"
+    assert priv_path.read_text().startswith("-----BEGIN PRIVATE KEY-----")

--- a/pkgs/standards/swarmauri_keyprovider_local/swarmauri_keyprovider_local/LocalKeyProvider.py
+++ b/pkgs/standards/swarmauri_keyprovider_local/swarmauri_keyprovider_local/LocalKeyProvider.py
@@ -19,19 +19,37 @@ def _b64u(b: bytes) -> str:
     return base64.urlsafe_b64encode(b).rstrip(b"=").decode("ascii")
 
 
-def _pem_pub(priv) -> bytes:
-    return priv.public_key().public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    )
+def _serialize_keypair(priv, spec: KeySpec) -> tuple[bytes, Optional[bytes]]:
+    """Serialize a private key and its public counterpart according to ``spec``."""
 
-
-def _pem_priv(priv) -> bytes:
-    return priv.private_bytes(
-        serialization.Encoding.PEM,
-        serialization.PrivateFormat.PKCS8,
-        serialization.NoEncryption(),
+    encoding = (
+        serialization.Encoding[spec.encoding]
+        if spec.encoding
+        else serialization.Encoding.PEM
     )
+    public_format = (
+        serialization.PublicFormat[spec.public_format]
+        if spec.public_format
+        else serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    public = priv.public_key().public_bytes(encoding=encoding, format=public_format)
+
+    material: Optional[bytes] = None
+    if spec.export_policy != ExportPolicy.PUBLIC_ONLY:
+        private_format = (
+            serialization.PrivateFormat[spec.private_format]
+            if spec.private_format
+            else serialization.PrivateFormat.PKCS8
+        )
+        if spec.encryption and spec.encryption != "NoEncryption":
+            raise ValueError(f"Unsupported encryption: {spec.encryption}")
+        material = priv.private_bytes(
+            encoding,
+            private_format,
+            serialization.NoEncryption(),
+        )
+
+    return material, public
 
 
 class LocalKeyProvider(KeyProviderBase):
@@ -79,8 +97,7 @@ class LocalKeyProvider(KeyProviderBase):
                 sk = ec.generate_private_key(ec.SECP256R1())
             else:
                 raise ValueError(f"Unsupported asymmetric alg: {spec.alg}")
-            material = _pem_priv(sk)
-            public = _pem_pub(sk)
+            material, public = _serialize_keypair(sk, spec)
 
         ref = KeyRef(
             kid=kid,

--- a/pkgs/standards/swarmauri_keyprovider_local/tests/unit/test_local_provider_unit.py
+++ b/pkgs/standards/swarmauri_keyprovider_local/tests/unit/test_local_provider_unit.py
@@ -13,7 +13,30 @@ async def test_create_ed25519_jwk() -> None:
         alg=KeyAlg.ED25519,
         uses=(KeyUse.SIGN, KeyUse.VERIFY),
         export_policy=ExportPolicy.PUBLIC_ONLY,
+        encoding="PEM",
+        private_format="PKCS8",
+        public_format="SubjectPublicKeyInfo",
+        encryption="NoEncryption",
     )
     ref = await kp.create_key(spec)
     jwk = await kp.get_public_jwk(ref.kid)
     assert jwk["kty"] == "OKP" and jwk["crv"] == "Ed25519"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_with_encoding_formats() -> None:
+    kp = LocalKeyProvider()
+    spec = KeySpec(
+        klass=KeyClass.asymmetric,
+        alg=KeyAlg.ED25519,
+        uses=(KeyUse.SIGN, KeyUse.VERIFY),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+        encoding="PEM",
+        private_format="PKCS8",
+        public_format="SubjectPublicKeyInfo",
+        encryption="NoEncryption",
+    )
+    ref = await kp.create_key(spec)
+    assert ref.public.startswith(b"-----BEGIN PUBLIC KEY-----")
+    assert ref.material and ref.material.startswith(b"-----BEGIN PRIVATE KEY-----")


### PR DESCRIPTION
## Summary
- honor KeySpec encoding, format, and encryption options when generating key material
- verify key providers can handle detailed KeySpec configurations

## Testing
- `uv run --package swarmauri_keyprovider_local --directory standards/swarmauri_keyprovider_local ruff format .`
- `uv run --package swarmauri_keyprovider_local --directory standards/swarmauri_keyprovider_local ruff check . --fix`
- `uv run --package swarmauri_keyprovider_file --directory standards/swarmauri_keyprovider_file ruff format .`
- `uv run --package swarmauri_keyprovider_file --directory standards/swarmauri_keyprovider_file ruff check . --fix`
- `uv run --package swarmauri_keyprovider_local --directory standards/swarmauri_keyprovider_local pytest`
- `uv run --package swarmauri_keyprovider_file --directory standards/swarmauri_keyprovider_file pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac63fef4508326bfe84c675a3654be