### PR TITLE
Handle base64 oct keys in JWE helpers

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7516.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7516.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 from typing import Any, Final, Mapping
 
 from .deps import JWAAlg, JweCrypto
@@ -13,16 +14,31 @@ RFC7516_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc7516"
 _crypto = JweCrypto()
 
 
+def _normalize_oct_key(key: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Return *key* with its ``"k"`` decoded from base64url if needed."""
+    k = key.get("k")
+    if isinstance(k, str):
+        try:
+            k_bytes = base64.urlsafe_b64decode(k + "==")
+        except Exception:
+            return key
+        new_key = dict(key)
+        new_key["k"] = k_bytes
+        return new_key
+    return key
+
+
 def encrypt_jwe(plaintext: str, key: Mapping[str, Any]) -> str:
     """Encrypt *plaintext* for *key* and return the compact JWE string."""
     if not settings.enable_rfc7516:
         raise RuntimeError(f"RFC 7516 support disabled: {RFC7516_SPEC_URL}")
+    norm_key = _normalize_oct_key(key)
     return asyncio.run(
         _crypto.encrypt_compact(
             payload=plaintext,
             alg=JWAAlg.DIR,
             enc=JWAAlg.A256GCM,
-            key=key,
+            key=norm_key,
         )
     )
 
@@ -31,7 +47,8 @@ def decrypt_jwe(token: str, key: Mapping[str, Any]) -> str:
     """Decrypt *token* with *key* and return the plaintext string."""
     if not settings.enable_rfc7516:
         raise RuntimeError(f"RFC 7516 support disabled: {RFC7516_SPEC_URL}")
-    res = asyncio.run(_crypto.decrypt_compact(token, dir_key=key.get("k")))
+    norm_key = _normalize_oct_key(key)
+    res = asyncio.run(_crypto.decrypt_compact(token, dir_key=norm_key.get("k")))
     return res.plaintext.decode()
 
 


### PR DESCRIPTION
## Summary
- normalize symmetric JWKs in JWE helpers by decoding base64 `k` values
- drop jwcrypto dependency in RFC 7520 example tests by generating keys with stdlib

## Testing
- `uv run --package auto_authn --directory standards pytest auto_authn/tests/unit/test_rfc7520_examples.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ac640d15b48326b424d5e85dfc986c