### PR TITLE
feat(auto_authn): tolerate case-insensitive WebAuthn algs

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8812.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8812.py
@@ -10,7 +10,7 @@ See RFC 8812: https://www.rfc-editor.org/rfc/rfc8812
 
 from __future__ import annotations
 
-from typing import Final
+from typing import Final, FrozenSet
 
 from .runtime_cfg import settings
 
@@ -18,7 +18,7 @@ RFC8812_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc8812"
 
 # Algorithms registered for WebAuthn. Using ``frozenset`` prevents accidental
 # mutation of the registry at runtime.
-WEBAUTHN_ALGORITHMS: Final[frozenset[str]] = frozenset(
+WEBAUTHN_ALGORITHMS: Final[FrozenSet[str]] = frozenset(
     {
         "RS256",
         "RS384",
@@ -38,15 +38,16 @@ WEBAUTHN_ALGORITHMS: Final[frozenset[str]] = frozenset(
 def is_webauthn_algorithm(alg: str, *, enabled: bool | None = None) -> bool:
     """Return ``True`` if *alg* is registered for WebAuthn per :rfc:`8812`.
 
-    When the feature is disabled the check always returns ``True`` to allow
-    deployments to accept non-registered algorithms.
+    Algorithm identifiers are compared case-insensitively to better tolerate
+    input from external sources. When the feature is disabled the check always
+    returns ``True`` to allow deployments to accept non-registered algorithms.
     """
 
     if enabled is None:
         enabled = settings.enable_rfc8812
     if not enabled:
         return True
-    return alg in WEBAUTHN_ALGORITHMS
+    return alg.upper() in WEBAUTHN_ALGORITHMS
 
 
 __all__ = ["is_webauthn_algorithm", "WEBAUTHN_ALGORITHMS", "RFC8812_SPEC_URL"]


### PR DESCRIPTION
## Summary
- normalize WebAuthn algorithm validation to be case-insensitive
- tighten typing on WEBAUTHN_ALGORITHMS

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc8812_webauthn_algorithms.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ac641793c88326bef4e18a099f1950