### PR TITLE
refactor: replace PyJWT usage in RFC9101 helpers

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc9101.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc9101.py
@@ -9,66 +9,16 @@ See RFC 9101: https://www.rfc-editor.org/rfc/rfc9101
 
 from __future__ import annotations
 
-from typing import Any, Dict, Final, Iterable, Tuple
+from typing import Any, Dict, Final, Iterable
 import asyncio
 import json
-from base64 import urlsafe_b64decode, urlsafe_b64encode
 
-from .deps import (
-    ExportPolicy,
-    JWAAlg,
-    JWTTokenService,
-    KeyAlg,
-    KeyClass,
-    KeySpec,
-    KeyUse,
-    LocalKeyProvider,
-)
+from .deps import JWAAlg, JwsSignerVerifier
 
 from .runtime_cfg import settings
 
 RFC9101_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc9101"
-
-
-def _svc_for_secret(secret: str, algorithm: str) -> Tuple[JWTTokenService, str]:
-    if algorithm != "HS256":
-        raise ValueError("Only HS256 is supported")
-    kp = LocalKeyProvider()
-    spec = KeySpec(
-        klass=KeyClass.symmetric,
-        alg=KeyAlg.HMAC_SHA256,
-        uses=(KeyUse.SIGN, KeyUse.VERIFY),
-        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
-        label="request_obj",
-    )
-    ref = asyncio.run(kp.import_key(spec, secret.encode()))
-
-    async def jwks() -> dict:
-        k = urlsafe_b64encode(secret.encode()).rstrip(b"=").decode()
-        return {
-            "keys": [
-                {
-                    "kty": "oct",
-                    "alg": "HS256",
-                    "k": k,
-                    "kid": f"{ref.kid}.{ref.version}",
-                }
-            ]
-        }
-
-    kp.jwks = jwks  # type: ignore[assignment]
-    return JWTTokenService(kp), ref.kid
-
-
-def _token_alg(token: str) -> str | None:
-    """Return the ``alg`` value from a compact JWT without verification."""
-    try:
-        header_b64, _payload, _sig = token.split(".")
-        padded = header_b64 + "=" * (-len(header_b64) % 4)
-        header = json.loads(urlsafe_b64decode(padded))
-    except Exception:
-        return None
-    return header.get("alg")
+_signer = JwsSignerVerifier()
 
 
 def create_request_object(
@@ -83,9 +33,11 @@ def create_request_object(
     """
     if not settings.enable_rfc9101:
         raise RuntimeError(f"RFC 9101 support disabled: {RFC9101_SPEC_URL}")
-    svc, kid = _svc_for_secret(secret, algorithm)
     alg = JWAAlg(algorithm)
-    return asyncio.run(svc.mint(params, alg=alg, kid=kid, lifetime_s=None))
+    key = {"kind": "raw", "key": secret}
+    return asyncio.run(
+        _signer.sign_compact(payload=params, alg=alg, key=key, typ="JWT")
+    )
 
 
 def parse_request_object(
@@ -101,17 +53,17 @@ def parse_request_object(
     if not settings.enable_rfc9101:
         raise RuntimeError(f"RFC 9101 support disabled: {RFC9101_SPEC_URL}")
 
-    alg = _token_alg(token)
-    if alg is None:
-        raise ValueError("Could not determine JWT algorithm")
-    if algorithms is not None and alg not in set(algorithms):
-        raise ValueError(f"Unsupported JWT algorithm: {alg}")
-
-    svc, _kid = _svc_for_secret(secret, alg)
-    claims = asyncio.run(svc.verify(token, audience=None, issuer=None, leeway_s=60))
-    claims.pop("iat", None)
-    claims.pop("nbf", None)
-    return claims
+    alg_allowlist = None
+    if algorithms is not None:
+        alg_allowlist = [JWAAlg(a) for a in algorithms]
+    result = asyncio.run(
+        _signer.verify_compact(
+            token,
+            hmac_keys=[{"kind": "raw", "key": secret}],
+            alg_allowlist=alg_allowlist,
+        )
+    )
+    return json.loads(result.payload.decode())
 
 
 __all__ = ["create_request_object", "parse_request_object", "RFC9101_SPEC_URL"]


### PR DESCRIPTION
## Summary
- replace PyJWT-based JWTTokenService with internal JwsSignerVerifier for RFC9101 request objects
- drop PyJWT dependency from auto_authn RFC9101 helpers

## Testing
- `uv run --package auto_authn --directory standards/auto_authn ruff format auto_authn/v2/rfc9101.py`
- `uv run --package auto_authn --directory standards/auto_authn ruff check auto_authn/v2/rfc9101.py --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc9101_jwt_secured_authorization_request.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac641c5e9c8326937505354a083410