### PR TITLE
Refactor JWT key management tests

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/crypto.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/crypto.py
@@ -45,16 +45,41 @@ _DEFAULT_KEY_DIR = pathlib.Path(os.getenv("JWT_ED25519_KEY_DIR", "runtime_secret
 # patch this path, so keep the name `_DEFAULT_KEY_PATH` for compatibility.
 _DEFAULT_KEY_PATH = _DEFAULT_KEY_DIR / "jwt_ed25519.kid"
 
+
 @lru_cache(maxsize=1)
 def _provider() -> FileKeyProvider:
     return FileKeyProvider(_DEFAULT_KEY_DIR)
+
+
+def _generate_keypair(path: pathlib.Path) -> Tuple[str, bytes, bytes]:
+    """Create a new Ed25519 key pair and store its identifier at *path*."""
+
+    async def _create() -> Tuple[str, bytes, bytes]:
+        kp = _provider()
+        spec = KeySpec(
+            klass=KeyClass.asymmetric,
+            alg=KeyAlg.ED25519,
+            uses=(KeyUse.SIGN, KeyUse.VERIFY),
+            export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+            label=path.stem,
+        )
+        ref = await kp.create_key(spec)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(ref.kid)
+        os.chmod(path, 0o600)
+        return ref.kid, ref.material or b"", ref.public or b""
+
+    return asyncio.run(_create())
 
 
 async def _ensure_key() -> Tuple[str, bytes, bytes]:
     kp = _provider()
     if _DEFAULT_KEY_PATH.exists():
         kid = _DEFAULT_KEY_PATH.read_text().strip()
-        ref = await kp.get_key(kid, include_secret=True)
+        try:
+            ref = await kp.get_key(kid, include_secret=True)
+        except Exception as exc:  # pragma: no cover - defensive
+            raise ValueError("invalid JWT signing key reference") from exc
     else:
         spec = KeySpec(
             klass=KeyClass.asymmetric,
@@ -66,6 +91,9 @@ async def _ensure_key() -> Tuple[str, bytes, bytes]:
         ref = await kp.create_key(spec)
         _DEFAULT_KEY_PATH.parent.mkdir(parents=True, exist_ok=True)
         _DEFAULT_KEY_PATH.write_text(ref.kid)
+    alg = ref.tags.get("alg") if ref.tags else None
+    if alg != KeyAlg.ED25519.value:
+        raise RuntimeError("JWT signing key is not Ed25519")
     priv = ref.material or b""
     pub = ref.public or b""
     return ref.kid, priv, pub

--- a/pkgs/standards/auto_authn/tests/conftest.py
+++ b/pkgs/standards/auto_authn/tests/conftest.py
@@ -4,6 +4,7 @@ Shared test configuration and fixtures for auto_authn test suite.
 
 import asyncio
 import os
+import shutil
 import tempfile
 import uuid
 from datetime import datetime, timezone, timedelta
@@ -172,11 +173,8 @@ def temp_key_file():
 
     yield temp_kid
 
-    if temp_kid.exists():
-        temp_kid.unlink()
-    for f in temp_dir.glob("*"):
-        f.unlink()
-    temp_dir.rmdir()
+    if temp_dir.exists():
+        shutil.rmtree(temp_dir, ignore_errors=True)
     crypto_module._DEFAULT_KEY_DIR = original_dir
     crypto_module._DEFAULT_KEY_PATH = original_path
     crypto_module._provider.cache_clear()

--- a/pkgs/standards/auto_authn/tests/unit/test_crypto.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_crypto.py
@@ -4,6 +4,7 @@ Unit tests for auto_authn.v2.crypto module.
 Tests password hashing, JWT key management, and security functions.
 """
 
+import asyncio
 from unittest.mock import patch
 
 import pytest
@@ -17,6 +18,12 @@ from auto_authn.v2.crypto import (
     public_key,
     _generate_keypair,
     _load_keypair,
+    _provider,
+    KeySpec,
+    KeyClass,
+    KeyAlg,
+    KeyUse,
+    ExportPolicy,
 )
 
 
@@ -82,11 +89,12 @@ class TestJWTKeyCrypto:
         """Test that key generation creates valid Ed25519 key pair."""
         key_path = tmp_path / "test_key.pem"
 
-        priv_pem, pub_pem = _generate_keypair(key_path)
+        kid, priv_pem, pub_pem = _generate_keypair(key_path)
 
         # Verify file was created with correct permissions
         assert key_path.exists()
         assert oct(key_path.stat().st_mode)[-3:] == "600"
+        assert key_path.read_text().strip() == kid
 
         # Verify keys are valid Ed25519 format
         private_key = serialization.load_pem_private_key(priv_pem, password=None)
@@ -101,7 +109,7 @@ class TestJWTKeyCrypto:
         key_path = tmp_path / "existing_key.pem"
 
         # First generate a key
-        original_priv, original_pub = _generate_keypair(key_path)
+        kid, original_priv, original_pub = _generate_keypair(key_path)
 
         # Mock the default path to use our test file
         with patch("auto_authn.v2.crypto._DEFAULT_KEY_PATH", key_path):
@@ -109,8 +117,9 @@ class TestJWTKeyCrypto:
             _load_keypair.cache_clear()
 
             # Load the key pair
-            loaded_priv, loaded_pub = _load_keypair()
+            loaded_kid, loaded_priv, loaded_pub = _load_keypair()
 
+            assert loaded_kid == kid
             assert loaded_priv == original_priv
             assert loaded_pub == original_pub
 
@@ -123,10 +132,11 @@ class TestJWTKeyCrypto:
             _load_keypair.cache_clear()
 
             # This should generate new keys
-            priv_pem, pub_pem = _load_keypair()
+            kid, priv_pem, pub_pem = _load_keypair()
 
             # Verify file was created
             assert key_path.exists()
+            assert key_path.read_text().strip() == kid
 
             # Verify keys are valid
             private_key = serialization.load_pem_private_key(priv_pem, password=None)
@@ -141,11 +151,12 @@ class TestJWTKeyCrypto:
             _load_keypair.cache_clear()
 
             # First call should generate/load keys
-            priv1, pub1 = _load_keypair()
+            kid1, priv1, pub1 = _load_keypair()
 
             # Second call should return cached results
-            priv2, pub2 = _load_keypair()
+            kid2, priv2, pub2 = _load_keypair()
 
+            assert kid1 == kid2
             assert priv1 is priv2  # Same object reference (cached)
             assert pub1 is pub2
 
@@ -206,52 +217,45 @@ class TestJWTKeyCrypto:
 
     def test_non_ed25519_key_raises_error(self, tmp_path):
         """Test that non-Ed25519 keys raise appropriate error."""
-        from cryptography.hazmat.primitives.asymmetric import rsa
+        key_path = tmp_path / "rsa_key.kid"
 
-        key_path = tmp_path / "rsa_key.pem"
+        async def _create_rsa() -> str:
+            kp = _provider()
+            spec = KeySpec(
+                klass=KeyClass.asymmetric,
+                alg=KeyAlg.RSA_PSS_SHA256,
+                uses=(KeyUse.SIGN, KeyUse.VERIFY),
+                export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+                label="rsa_key",
+            )
+            ref = await kp.create_key(spec)
+            return ref.kid
 
-        # Generate RSA key instead of Ed25519
-        rsa_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-        rsa_pem = rsa_key.private_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PrivateFormat.PKCS8,
-            encryption_algorithm=serialization.NoEncryption(),
-        )
-
-        key_path.write_bytes(rsa_pem)
+        kid = asyncio.run(_create_rsa())
+        key_path.write_text(kid)
 
         with patch("auto_authn.v2.crypto._DEFAULT_KEY_PATH", key_path):
-            # Clear the cache
             _load_keypair.cache_clear()
 
             with pytest.raises(RuntimeError, match="JWT signing key is not Ed25519"):
                 _load_keypair()
 
-    def test_env_key_path_override(self, monkeypatch, tmp_path):
-        """Test that JWT_ED25519_PRIV_PATH overrides the default key path."""
-        # Generate a key and write to temporary path
-        private = Ed25519PrivateKey.generate()
-        pem_priv = private.private_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PrivateFormat.PKCS8,
-            encryption_algorithm=serialization.NoEncryption(),
-        )
-        key_path = tmp_path / "override_key.pem"
-        key_path.write_bytes(pem_priv)
-
+    def test_env_key_dir_override(self, monkeypatch, tmp_path):
+        """Test that JWT_ED25519_KEY_DIR overrides the default key directory."""
         import auto_authn.v2.crypto as crypto
         import importlib
 
-        monkeypatch.setenv("JWT_ED25519_PRIV_PATH", str(key_path))
+        monkeypatch.setenv("JWT_ED25519_KEY_DIR", str(tmp_path))
 
         try:
             crypto = importlib.reload(crypto)
             crypto._load_keypair.cache_clear()
 
-            assert crypto._DEFAULT_KEY_PATH == key_path
-            assert crypto.signing_key() == pem_priv
+            kid, priv, _ = crypto._load_keypair()
+            assert crypto._DEFAULT_KEY_PATH == tmp_path / "jwt_ed25519.kid"
+            assert crypto.signing_key() == priv
         finally:
-            monkeypatch.delenv("JWT_ED25519_PRIV_PATH", raising=False)
+            monkeypatch.delenv("JWT_ED25519_KEY_DIR", raising=False)
             importlib.reload(crypto)
 
 


### PR DESCRIPTION
## Summary
- add FileKeyProvider-backed `_generate_keypair` and validation for Ed25519 keys
- update crypto tests for new key provider workflow and env override
- fix temporary key cleanup in tests

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_crypto.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac64077ac8832696a776f41d7b1da6