### PR TITLE
Replace PyJWT with internal utilities in auto_authn tests

### DIFF
--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7521_assertion_framework.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7521_assertion_framework.py
@@ -7,9 +7,9 @@ import time
 from unittest.mock import patch
 
 import pytest
-from jwt.exceptions import InvalidTokenError
 
 from auto_authn.v2 import encode_jwt
+from auto_authn.v2.errors import InvalidTokenError
 from auto_authn.v2.rfc7521 import (
     RFC7521_SPEC_URL,
     validate_jwt_assertion,

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7523_jwt_profile.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7523_jwt_profile.py
@@ -7,9 +7,9 @@ import time
 from unittest.mock import patch
 
 import pytest
-from jwt.exceptions import InvalidTokenError
 
 from auto_authn.v2 import encode_jwt
+from auto_authn.v2.errors import InvalidTokenError
 from auto_authn.v2.rfc7523 import (
     RFC7523_SPEC_URL,
     validate_client_jwt_bearer,

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc8705_compliance.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc8705_compliance.py
@@ -14,7 +14,7 @@ from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
-from jwt.exceptions import InvalidTokenError
+from auto_authn.v2.errors import InvalidTokenError
 
 import auto_authn.v2.runtime_cfg as runtime_cfg
 from auto_authn.v2.jwtoken import JWTCoder

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc9068_jwt_profile.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc9068_jwt_profile.py
@@ -9,9 +9,9 @@ when the feature flag is disabled.
 import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ed25519
-from jwt.exceptions import InvalidTokenError
 
 from auto_authn.v2 import runtime_cfg
+from auto_authn.v2.errors import InvalidTokenError
 from auto_authn.v2.jwtoken import JWTCoder
 from auto_authn.v2.rfc9068 import add_rfc9068_claims, validate_rfc9068_claims
 


### PR DESCRIPTION
## Summary
- remove PyJWT dependency from auto_authn tests by using swarmauri's InvalidTokenError
- add helper to craft `alg='none'` JWTs for RFC 8725 checks

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc9126_pushed_authorization_requests.py`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc8725_jwt_best_practices.py`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc8705_compliance.py`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc7523_jwt_profile.py`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc9068_jwt_profile.py`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc7521_assertion_framework.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac6803f8c083269faa409802e4cf37