### PR TITLE
Use internal InvalidTokenError in RFC7521 tests

### DIFF
--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7521_assertion_framework.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7521_assertion_framework.py
@@ -7,7 +7,7 @@ import time
 from unittest.mock import patch
 
 import pytest
-from jwt.exceptions import InvalidTokenError
+from auto_authn.v2.errors import InvalidTokenError
 
 from auto_authn.v2 import encode_jwt
 from auto_authn.v2.rfc7521 import (


### PR DESCRIPTION
## Summary
- Replace PyJWT InvalidTokenError with auto_authn.v2.errors.InvalidTokenError in RFC7521 tests

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc7521_assertion_framework.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ac69198fc483268dc5f835e43e34cc