### PR TITLE
refactor: use internal InvalidTokenError

### DIFF
--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7523_jwt_profile.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7523_jwt_profile.py
@@ -7,9 +7,9 @@ import time
 from unittest.mock import patch
 
 import pytest
-from jwt.exceptions import InvalidTokenError
 
 from auto_authn.v2 import encode_jwt
+from auto_authn.v2.errors import InvalidTokenError
 from auto_authn.v2.rfc7523 import (
     RFC7523_SPEC_URL,
     validate_client_jwt_bearer,


### PR DESCRIPTION
## Summary
- avoid importing PyJWT in RFC7523 tests
- rely on auto_authn's InvalidTokenError for validation

## Testing
- `uv run --package auto_authn --directory standards/auto_authn ruff format .`
- `uv run --package auto_authn --directory standards/auto_authn ruff check . --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc7523_jwt_profile.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac691e20748326a6612e246f89a0bb