### PR TITLE
refactor: remove PyJWT from RFC8725 tests

### DIFF
--- a/pkgs/standards/auto_authn/tests/unit/test_rfc8725_jwt_best_practices.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc8725_jwt_best_practices.py
@@ -4,11 +4,12 @@ Spec URL: https://www.rfc-editor.org/rfc/rfc8725
 """
 
 from datetime import datetime, timedelta, timezone
+import base64
+import json
 
-import jwt
 import pytest
-from jwt import InvalidTokenError
 
+from auto_authn.v2.errors import InvalidTokenError
 from auto_authn.v2.jwtoken import JWTCoder
 from auto_authn.v2.rfc8725 import RFC8725_SPEC_URL, validate_jwt_best_practices
 from auto_authn.v2.runtime_cfg import settings
@@ -33,9 +34,18 @@ def test_rejects_none_algorithm(monkeypatch):
         "tid": "tenant",
         "iss": "https://issuer",
         "aud": "audience",
-        "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
+        "exp": int((datetime.now(timezone.utc) + timedelta(minutes=5)).timestamp()),
     }
-    token = jwt.encode(payload, key="", algorithm="none")
+    header = {"alg": "none", "typ": "JWT"}
+
+    def _b64(obj: dict) -> str:
+        return (
+            base64.urlsafe_b64encode(json.dumps(obj, separators=(",", ":")).encode())
+            .decode()
+            .rstrip("=")
+        )
+
+    token = f"{_b64(header)}.{_b64(payload)}."
     with pytest.raises(InvalidTokenError):
         validate_jwt_best_practices(token)
 


### PR DESCRIPTION
## Summary
- replace PyJWT usage in RFC8725 tests with manual JWT construction
- rely on auto_authn's InvalidTokenError instead of jwt.InvalidTokenError

## Testing
- `uv run --package auto_authn --directory standards/auto_authn ruff check . --fix`
- `uv run --package auto_authn --directory standards pytest auto_authn/tests/unit/test_rfc8725_jwt_best_practices.py`
- `uv run --package auto_authn --directory standards pytest auto_authn/tests/unit/test_rfc7662_token_introspection.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac69213ba48326bc5be2f82c54bec0