### PR TITLE
Replace PyJWT InvalidTokenError in RFC8705 tests

### DIFF
--- a/pkgs/standards/auto_authn/tests/unit/test_rfc8705_compliance.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc8705_compliance.py
@@ -14,7 +14,7 @@ from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
-from jwt.exceptions import InvalidTokenError
+from auto_authn.v2.errors import InvalidTokenError
 
 import auto_authn.v2.runtime_cfg as runtime_cfg
 from auto_authn.v2.jwtoken import JWTCoder


### PR DESCRIPTION
## Summary
- use auto_authn's InvalidTokenError in RFC8705 compliance tests instead of PyJWT
- ensure tests run without external jwt dependency

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc8705_compliance.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac69250ac48326977a1607dbea6039