### PR TITLE
Replace PyJWT usage in RFC8725 tests

### DIFF
--- a/pkgs/standards/auto_authn/tests/unit/test_rfc8725_jwt_best_practices.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc8725_jwt_best_practices.py
@@ -4,10 +4,12 @@ Spec URL: https://www.rfc-editor.org/rfc/rfc8725
 """
 
 from datetime import datetime, timedelta, timezone
+import base64
+import json
 
-import jwt
 import pytest
-from jwt import InvalidTokenError
+
+from auto_authn.v2.errors import InvalidTokenError
 
 from auto_authn.v2.jwtoken import JWTCoder
 from auto_authn.v2.rfc8725 import RFC8725_SPEC_URL, validate_jwt_best_practices
@@ -33,9 +35,18 @@ def test_rejects_none_algorithm(monkeypatch):
         "tid": "tenant",
         "iss": "https://issuer",
         "aud": "audience",
-        "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
+        "exp": int((datetime.now(timezone.utc) + timedelta(minutes=5)).timestamp()),
     }
-    token = jwt.encode(payload, key="", algorithm="none")
+    header = {"alg": "none", "typ": "JWT"}
+
+    def to_b64(obj: dict) -> str:
+        return (
+            base64.urlsafe_b64encode(json.dumps(obj, separators=(",", ":")).encode())
+            .rstrip(b"=")
+            .decode()
+        )
+
+    token = f"{to_b64(header)}.{to_b64(payload)}."
     with pytest.raises(InvalidTokenError):
         validate_jwt_best_practices(token)
 


### PR DESCRIPTION
## Summary
- avoid PyJWT in RFC8725 tests by manually crafting 'none' algorithm tokens
- use auto_authn's InvalidTokenError in place of jwt.InvalidTokenError

## Testing
- `uv run --package auto_authn --directory standards/auto_authn ruff check . --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc8725_jwt_best_practices.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac692aa4fc8326a90c9264d52cac73