### PR TITLE
fix: add missing rfc8932 and rfc8693 helpers

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8693.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8693.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 from typing import Dict, Any, Optional, Union, List
 from enum import Enum
 
+from fastapi import APIRouter, FastAPI
+
 from .runtime_cfg import settings
 from .rfc7519 import decode_jwt
 from .jwtoken import JWTCoder
@@ -20,6 +22,22 @@ RFC8693_SPEC_URL = "https://www.rfc-editor.org/rfc/rfc8693"
 
 # Token Exchange Grant Type
 TOKEN_EXCHANGE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange"
+
+
+# FastAPI router for RFC 8693 endpoints
+router = APIRouter()
+
+
+def include_rfc8693(app: FastAPI) -> None:
+    """Include RFC 8693 token exchange routes into a FastAPI app.
+
+    Routes are registered only when RFC 8693 support is enabled.
+    """
+
+    if not settings.enable_rfc8693:
+        return
+
+    app.include_router(router)
 
 
 # Standard Token Type URIs per RFC 8693 Section 3
@@ -334,4 +352,6 @@ __all__ = [
     "create_delegation_token",
     "TOKEN_EXCHANGE_GRANT_TYPE",
     "RFC8693_SPEC_URL",
+    "include_rfc8693",
+    "router",
 ]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8932.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8932.py
@@ -19,6 +19,33 @@ from fastapi import APIRouter, HTTPException, status
 from .runtime_cfg import settings
 from .rfc8414 import ISSUER, JWKS_PATH
 
+# Supported encrypted DNS transports per RFC 8932 recommendations
+ALLOWED_ENCRYPTED_DNS = {"DoT", "DoH"}
+
+
+def enforce_encrypted_dns(protocol: str) -> str:
+    """Validate that the provided DNS transport uses encryption.
+
+    Args:
+        protocol: DNS transport identifier (e.g., "DoT" or "DoH").
+
+    Returns:
+        The validated protocol string.
+
+    Raises:
+        NotImplementedError: If RFC 8932 support is disabled.
+        ValueError: If an unencrypted transport is supplied.
+    """
+
+    if not settings.enable_rfc8932:
+        raise NotImplementedError("RFC 8932 support is disabled")
+
+    if protocol not in ALLOWED_ENCRYPTED_DNS:
+        raise ValueError("Protocol must be an encrypted DNS transport")
+
+    return protocol
+
+
 RFC8932_SPEC_URL = "https://www.rfc-editor.org/rfc/rfc8932"
 
 router = APIRouter()
@@ -316,6 +343,7 @@ def get_capability_matrix() -> Dict[str, Dict[str, Any]]:
 
 
 __all__ = [
+    "enforce_encrypted_dns",
     "get_enhanced_authorization_server_metadata",
     "enhanced_authorization_server_metadata",
     "validate_metadata_consistency",


### PR DESCRIPTION
## Summary
- add `enforce_encrypted_dns` to validate encrypted DNS transports
- add `include_rfc8693` FastAPI router helper for token exchange

## Testing
- `uv run --package auto_authn --directory standards pytest auto_authn/tests/unit/test_rfc6750_bearer_token.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac6ad0d2948326978f747d9d2bfc0b