### PR TITLE
feat(auto_authn): gate RFC8693 token exchange

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8693.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8693.py
@@ -222,8 +222,12 @@ def exchange_token(
         TokenExchangeResponse with the new token
 
     Raises:
+        RuntimeError: If RFC 8693 support is disabled
         ValueError: If token exchange fails
     """
+    if not settings.enable_rfc8693:
+        raise RuntimeError("RFC 8693 support disabled")
+
     # Validate subject token
     subject_claims = validate_subject_token(
         request.subject_token, request.subject_token_type
@@ -281,6 +285,9 @@ def create_impersonation_token(
     Returns:
         TokenExchangeResponse with impersonation token
     """
+    if not settings.enable_rfc8693:
+        raise RuntimeError("RFC 8693 support disabled")
+
     request = TokenExchangeRequest(
         grant_type=TOKEN_EXCHANGE_GRANT_TYPE,
         subject_token=subject_token,
@@ -311,6 +318,9 @@ def create_delegation_token(
     Returns:
         TokenExchangeResponse with delegation token
     """
+    if not settings.enable_rfc8693:
+        raise RuntimeError("RFC 8693 support disabled")
+
     request = TokenExchangeRequest(
         grant_type=TOKEN_EXCHANGE_GRANT_TYPE,
         subject_token=subject_token,

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc8693_token_exchange.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc8693_token_exchange.py
@@ -342,6 +342,45 @@ def test_create_delegation_token():
 
 
 @pytest.mark.unit
+def test_exchange_token_disabled():
+    """RFC 8693: exchange_token should honor feature flag."""
+    subject_jwt = encode_jwt(sub="user123", exp=int(time.time()) + 3600)
+    request = TokenExchangeRequest(
+        grant_type=TOKEN_EXCHANGE_GRANT_TYPE,
+        subject_token=subject_jwt,
+        subject_token_type=TokenType.ACCESS_TOKEN.value,
+    )
+
+    with patch.object(settings, "enable_rfc8693", False):
+        with pytest.raises(RuntimeError, match="RFC 8693 support disabled"):
+            exchange_token(request, issuer="https://auth.example.com")
+
+
+@pytest.mark.unit
+def test_create_impersonation_token_disabled():
+    """RFC 8693: create_impersonation_token should honor feature flag."""
+    subject_jwt = encode_jwt(sub="user123", exp=int(time.time()) + 3600)
+    actor_jwt = encode_jwt(sub="admin456", exp=int(time.time()) + 3600)
+
+    with patch.object(settings, "enable_rfc8693", False):
+        with pytest.raises(RuntimeError, match="RFC 8693 support disabled"):
+            create_impersonation_token(
+                subject_token=subject_jwt,
+                actor_token=actor_jwt,
+            )
+
+
+@pytest.mark.unit
+def test_create_delegation_token_disabled():
+    """RFC 8693: create_delegation_token should honor feature flag."""
+    subject_jwt = encode_jwt(sub="user123", exp=int(time.time()) + 3600)
+
+    with patch.object(settings, "enable_rfc8693", False):
+        with pytest.raises(RuntimeError, match="RFC 8693 support disabled"):
+            create_delegation_token(subject_token=subject_jwt)
+
+
+@pytest.mark.unit
 def test_token_type_enum():
     """RFC 8693: Token type enum values."""
     assert (


### PR DESCRIPTION
## Summary
- enforce RFC 8693 feature flag in token exchange helpers
- cover RFC 8693 feature flag behavior with unit tests

## Testing
- `uv run --directory . --package auto_authn ruff format auto_authn/v2/rfc8693.py tests/unit/test_rfc8693_token_exchange.py`
- `uv run --directory . --package auto_authn ruff check auto_authn/v2/rfc8693.py tests/unit/test_rfc8693_token_exchange.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_68ac6b03f814832684421d0a453beebf