### PR TITLE
feat: add RFC 8693 token exchange endpoint

### DIFF
--- a/pkgs/standards/auto_authn/tests/i9n/test_rfc8693_token_exchange_endpoint.py
+++ b/pkgs/standards/auto_authn/tests/i9n/test_rfc8693_token_exchange_endpoint.py
@@ -1,0 +1,46 @@
+"""Integration tests for RFC 8693 token exchange endpoint.
+
+See RFC 8693: https://www.rfc-editor.org/rfc/rfc8693
+"""
+
+import time
+
+import pytest
+from fastapi import status
+from httpx import AsyncClient
+
+from auto_authn.v2 import encode_jwt
+from auto_authn.v2.rfc8693 import TOKEN_EXCHANGE_GRANT_TYPE, TokenType
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_token_exchange_endpoint(
+    async_client: AsyncClient, enable_rfc8693
+) -> None:
+    """Server should exchange tokens when RFC 8693 is enabled."""
+    subject_token = encode_jwt(sub="user123", exp=int(time.time()) + 3600)
+    payload = {
+        "grant_type": TOKEN_EXCHANGE_GRANT_TYPE,
+        "subject_token": subject_token,
+        "subject_token_type": TokenType.ACCESS_TOKEN.value,
+    }
+    response = await async_client.post("/token/exchange", data=payload)
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert "access_token" in data
+    assert data["token_type"].lower() == "bearer"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_token_exchange_endpoint_disabled(async_client: AsyncClient) -> None:
+    """Endpoint should return 404 when RFC 8693 is disabled."""
+    subject_token = encode_jwt(sub="user123", exp=int(time.time()) + 3600)
+    payload = {
+        "grant_type": TOKEN_EXCHANGE_GRANT_TYPE,
+        "subject_token": subject_token,
+        "subject_token_type": TokenType.ACCESS_TOKEN.value,
+    }
+    response = await async_client.post("/token/exchange", data=payload)
+    assert response.status_code == status.HTTP_404_NOT_FOUND


### PR DESCRIPTION
## Summary
- add feature-flagged `/token/exchange` endpoint implementing RFC 8693 token exchange
- cover RFC 8693 token exchange endpoint with integration tests

## Testing
- `uv run --directory pkgs/standards --package auto_authn ruff format auto_authn/auto_authn/v2/rfc8693.py auto_authn/tests/i9n/test_rfc8693_token_exchange_endpoint.py`
- `uv run --directory pkgs/standards --package auto_authn ruff check auto_authn/auto_authn/v2/rfc8693.py auto_authn/tests/i9n/test_rfc8693_token_exchange_endpoint.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_68ac6ce3bd7c832681c9fa71fed73d01