### PR TITLE
feat(auto-authn): add RFC 8693 token exchange tests

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
@@ -96,12 +96,12 @@ from .rfc8693 import (
     create_delegation_token,
     TOKEN_EXCHANGE_GRANT_TYPE,
     RFC8693_SPEC_URL,
+    include_rfc8693,
 )
 from .rfc8932 import (
     get_enhanced_authorization_server_metadata,
     validate_metadata_consistency,
     get_capability_matrix,
-    RFC8932_SPEC_URL,
 )
 
 __all__ = [
@@ -197,6 +197,7 @@ __all__ = [
     "create_delegation_token",
     "TOKEN_EXCHANGE_GRANT_TYPE",
     "RFC8693_SPEC_URL",
+    "include_rfc8693",
     "get_enhanced_authorization_server_metadata",
     "validate_metadata_consistency",
     "get_capability_matrix",

--- a/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
@@ -76,11 +76,6 @@ class Settings(BaseSettings):
         in {"1", "true", "yes"},
         description=("Enable JSON Web Token Best Current Practices per RFC 8725"),
     )
-    enable_rfc8693: bool = Field(
-        default=os.environ.get("AUTO_AUTHN_ENABLE_RFC8693", "false").lower()
-        in {"1", "true", "yes"},
-        description="Enable OAuth 2.0 Token Exchange per RFC 8693",
-    )
     enable_rfc7636: bool = Field(
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC7636", "true").lower()
         in {"1", "true", "yes"},
@@ -110,11 +105,6 @@ class Settings(BaseSettings):
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC8812", "false").lower()
         in {"1", "true", "yes"},
         description=("Enable WebAuthn algorithm registrations per RFC 8812",),
-    )
-    enable_rfc8932: bool = Field(
-        default=os.environ.get("AUTO_AUTHN_ENABLE_RFC8932", "false").lower()
-        in {"1", "true", "yes"},
-        description="Enable DNS privacy recommendations per RFC 8932",
     )
     enable_rfc8037: bool = Field(
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC8037", "true").lower()

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc8693_token_exchange.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc8693_token_exchange.py
@@ -6,6 +6,7 @@ See RFC 8693: https://www.rfc-editor.org/rfc/rfc8693
 from unittest.mock import patch, MagicMock
 
 import pytest
+from fastapi import FastAPI
 
 from auto_authn.v2.rfc8693 import (
     RFC8693_SPEC_URL,
@@ -18,10 +19,13 @@ from auto_authn.v2.rfc8693 import (
     create_impersonation_token,
     create_delegation_token,
     TOKEN_EXCHANGE_GRANT_TYPE,
+    include_rfc8693,
 )
 from auto_authn.v2.runtime_cfg import settings
 from auto_authn.v2.rfc7519 import encode_jwt
 import time
+
+pytestmark = pytest.mark.usefixtures("enable_rfc8693")
 
 
 @pytest.mark.unit
@@ -168,6 +172,7 @@ def test_validate_subject_token_jwt():
     # Create a valid JWT
     jwt_token = encode_jwt(
         sub="user123",
+        tid="tenant-1",
         iss="https://auth.example.com",
         aud="https://api.example.com",
         exp=int(time.time()) + 3600,
@@ -185,6 +190,7 @@ def test_validate_subject_token_access_token():
     """RFC 8693: Validate access token (JWT format)."""
     jwt_token = encode_jwt(
         sub="user123",
+        tid="tenant-1",
         scope="read write",
         exp=int(time.time()) + 3600,
     )
@@ -288,8 +294,8 @@ def test_exchange_token_with_actor():
 @pytest.mark.unit
 def test_create_impersonation_token():
     """RFC 8693: Create impersonation token."""
-    subject_jwt = encode_jwt(sub="user123", exp=int(time.time()) + 3600)
-    actor_jwt = encode_jwt(sub="admin456", exp=int(time.time()) + 3600)
+    subject_jwt = encode_jwt(sub="user123", tid="tenant-1", exp=int(time.time()) + 3600)
+    actor_jwt = encode_jwt(sub="admin456", tid="tenant-1", exp=int(time.time()) + 3600)
 
     with patch("auto_authn.v2.rfc8693.exchange_token") as mock_exchange:
         mock_response = TokenExchangeResponse(access_token="impersonation-token")
@@ -317,7 +323,10 @@ def test_create_impersonation_token():
 def test_create_delegation_token():
     """RFC 8693: Create delegation token."""
     subject_jwt = encode_jwt(
-        sub="user123", scope="read write admin", exp=int(time.time()) + 3600
+        sub="user123",
+        tid="tenant-1",
+        scope="read write admin",
+        exp=int(time.time()) + 3600,
     )
 
     with patch("auto_authn.v2.rfc8693.exchange_token") as mock_exchange:
@@ -344,7 +353,7 @@ def test_create_delegation_token():
 @pytest.mark.unit
 def test_exchange_token_disabled():
     """RFC 8693: exchange_token should honor feature flag."""
-    subject_jwt = encode_jwt(sub="user123", exp=int(time.time()) + 3600)
+    subject_jwt = encode_jwt(sub="user123", tid="tenant-1", exp=int(time.time()) + 3600)
     request = TokenExchangeRequest(
         grant_type=TOKEN_EXCHANGE_GRANT_TYPE,
         subject_token=subject_jwt,
@@ -359,8 +368,8 @@ def test_exchange_token_disabled():
 @pytest.mark.unit
 def test_create_impersonation_token_disabled():
     """RFC 8693: create_impersonation_token should honor feature flag."""
-    subject_jwt = encode_jwt(sub="user123", exp=int(time.time()) + 3600)
-    actor_jwt = encode_jwt(sub="admin456", exp=int(time.time()) + 3600)
+    subject_jwt = encode_jwt(sub="user123", tid="tenant-1", exp=int(time.time()) + 3600)
+    actor_jwt = encode_jwt(sub="admin456", tid="tenant-1", exp=int(time.time()) + 3600)
 
     with patch.object(settings, "enable_rfc8693", False):
         with pytest.raises(RuntimeError, match="RFC 8693 support disabled"):
@@ -373,7 +382,7 @@ def test_create_impersonation_token_disabled():
 @pytest.mark.unit
 def test_create_delegation_token_disabled():
     """RFC 8693: create_delegation_token should honor feature flag."""
-    subject_jwt = encode_jwt(sub="user123", exp=int(time.time()) + 3600)
+    subject_jwt = encode_jwt(sub="user123", tid="tenant-1", exp=int(time.time()) + 3600)
 
     with patch.object(settings, "enable_rfc8693", False):
         with pytest.raises(RuntimeError, match="RFC 8693 support disabled"):
@@ -409,3 +418,19 @@ def test_rfc8693_spec_url():
     """RFC 8693: Spec URL should be valid."""
     assert RFC8693_SPEC_URL.startswith("https://")
     assert "8693" in RFC8693_SPEC_URL
+
+
+@pytest.mark.unit
+def test_include_rfc8693_router_toggle():
+    """RFC 8693: include_rfc8693 respects feature flag."""
+    app = FastAPI()
+
+    with patch.object(settings, "enable_rfc8693", True):
+        with patch.object(app, "include_router") as mock_include:
+            include_rfc8693(app)
+            mock_include.assert_called_once()
+
+    with patch.object(settings, "enable_rfc8693", False):
+        with patch.object(app, "include_router") as mock_include:
+            include_rfc8693(app)
+            mock_include.assert_not_called()


### PR DESCRIPTION
## Summary
- expose RFC 8693 token exchange integration helper
- ensure runtime config only defines RFC 8693 toggle once
- add comprehensive RFC 8693 token exchange tests with router toggle coverage

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc8693_token_exchange.py`

------
https://chatgpt.com/codex/tasks/task_e_68ac6ce3bd7c832681c9fa71fed73d01