### PR TITLE
fix: add missing RFC helpers

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8693.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8693.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 from typing import Dict, Any, Optional, Union, List
 from enum import Enum
 
+from fastapi import APIRouter, FastAPI
+
 from .runtime_cfg import settings
 from .rfc7519 import decode_jwt
 from .jwtoken import JWTCoder
@@ -20,6 +22,18 @@ RFC8693_SPEC_URL = "https://www.rfc-editor.org/rfc/rfc8693"
 
 # Token Exchange Grant Type
 TOKEN_EXCHANGE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange"
+
+
+router = APIRouter()
+
+
+def include_rfc8693(app: FastAPI) -> None:
+    """Attach the RFC 8693 router to *app* if enabled."""
+
+    if settings.enable_rfc8693 and not any(
+        route.path == "/token/exchange" for route in app.routes
+    ):
+        app.include_router(router)
 
 
 # Standard Token Type URIs per RFC 8693 Section 3
@@ -334,4 +348,6 @@ __all__ = [
     "create_delegation_token",
     "TOKEN_EXCHANGE_GRANT_TYPE",
     "RFC8693_SPEC_URL",
+    "include_rfc8693",
+    "router",
 ]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8932.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8932.py
@@ -24,6 +24,33 @@ RFC8932_SPEC_URL = "https://www.rfc-editor.org/rfc/rfc8932"
 router = APIRouter()
 
 
+ENCRYPTED_DNS_TRANSPORTS = {"DoT", "DoH"}
+
+
+def enforce_encrypted_dns(transport: str) -> str:
+    """Validate that DNS queries use encrypted transports.
+
+    RFC 8932 \u00a75.1.1 recommends that operators ensure DNS queries are
+    sent over encrypted transports such as DNS over TLS (DoT) or DNS over
+    HTTPS (DoH).
+
+    Args:
+        transport: The DNS transport protocol to validate.
+
+    Returns:
+        The validated transport string.
+
+    Raises:
+        NotImplementedError: If RFC 8932 support is disabled.
+        ValueError: If an unencrypted transport is provided.
+    """
+    if not settings.enable_rfc8932:
+        raise NotImplementedError("RFC 8932 is disabled")
+    if transport not in ENCRYPTED_DNS_TRANSPORTS:
+        raise ValueError("unencrypted DNS transport")
+    return transport
+
+
 def get_enhanced_authorization_server_metadata() -> Dict[str, Any]:
     """Generate enhanced OAuth 2.0 Authorization Server Metadata.
 
@@ -316,6 +343,7 @@ def get_capability_matrix() -> Dict[str, Dict[str, Any]]:
 
 
 __all__ = [
+    "enforce_encrypted_dns",
     "get_enhanced_authorization_server_metadata",
     "enhanced_authorization_server_metadata",
     "validate_metadata_consistency",


### PR DESCRIPTION
## Summary
- implement enforce_encrypted_dns and export in RFC 8932 module
- provide include_rfc8693 helper and router stub

## Testing
- `uv run --package auto_authn --directory standards pytest auto_authn/tests/unit/test_rfc9126_pushed_authorization_requests.py`
- `uv run --package auto_authn --directory standards pytest auto_authn/tests/unit/test_rfc8932_dns_privacy.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac6bf847608326b53c4f2ea5170a53