### PR TITLE
fix: ensure DNS privacy and conditional RFC inclusions

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/app.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/app.py
@@ -23,6 +23,7 @@ import fastapi
 from autoapi.v2 import get_schema  # convenience helper for /methodz
 from .routers.auth_flows import router as flows_router
 from .routers.crud import crud_api as crud_api
+from .runtime_cfg import settings
 from .rfc8414 import include_rfc8414
 from .rfc8628 import include_rfc8628
 from .rfc9126 import include_rfc9126
@@ -43,11 +44,16 @@ app = fastapi.FastAPI(
 # Mount routers
 app.include_router(crud_api.router)  # /authn/<model> CRUD (AutoAPI)
 app.include_router(flows_router)  # /register, /login, etc.
-include_rfc8628(app)
-include_rfc9126(app)
-include_rfc7009(app)
-include_rfc8693(app)
-include_rfc8414(app)
+if settings.enable_rfc8628:
+    include_rfc8628(app)
+if settings.enable_rfc9126:
+    include_rfc9126(app)
+if settings.enable_rfc7009:
+    include_rfc7009(app)
+if settings.enable_rfc8693:
+    include_rfc8693(app)
+if settings.enable_rfc8414:
+    include_rfc8414(app)
 
 
 # --------------------------------------------------------------------

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8693.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8693.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from typing import Dict, Any, Optional, Union, List
 from enum import Enum
+from fastapi import APIRouter, FastAPI
 
 from .runtime_cfg import settings
 from .rfc7519 import decode_jwt
@@ -20,6 +21,18 @@ RFC8693_SPEC_URL = "https://www.rfc-editor.org/rfc/rfc8693"
 
 # Token Exchange Grant Type
 TOKEN_EXCHANGE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange"
+
+# Router placeholder for potential token exchange endpoints
+router = APIRouter()
+
+
+def include_rfc8693(app: FastAPI) -> None:
+    """Include RFC 8693 routes on a FastAPI app."""
+
+    if not settings.enable_rfc8693:
+        raise NotImplementedError("RFC 8693 support is disabled")
+
+    app.include_router(router)
 
 
 # Standard Token Type URIs per RFC 8693 Section 3
@@ -334,4 +347,5 @@ __all__ = [
     "create_delegation_token",
     "TOKEN_EXCHANGE_GRANT_TYPE",
     "RFC8693_SPEC_URL",
+    "include_rfc8693",
 ]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8932.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8932.py
@@ -23,6 +23,21 @@ RFC8932_SPEC_URL = "https://www.rfc-editor.org/rfc/rfc8932"
 
 router = APIRouter()
 
+# Supported encrypted DNS protocols
+ENCRYPTED_DNS_PROTOCOLS = {"DoT", "DoH"}
+
+
+def enforce_encrypted_dns(protocol: str) -> str:
+    """Validate that only encrypted DNS protocols are used."""
+
+    if not settings.enable_rfc8932:
+        raise NotImplementedError("DNS privacy enforcement is disabled")
+
+    if protocol not in ENCRYPTED_DNS_PROTOCOLS:
+        raise ValueError("Only encrypted DNS protocols are allowed")
+
+    return protocol
+
 
 def get_enhanced_authorization_server_metadata() -> Dict[str, Any]:
     """Generate enhanced OAuth 2.0 Authorization Server Metadata.
@@ -322,4 +337,5 @@ __all__ = [
     "get_capability_matrix",
     "router",
     "RFC8932_SPEC_URL",
+    "enforce_encrypted_dns",
 ]


### PR DESCRIPTION
## Summary
- enforce encrypted DNS protocols and expose helper in RFC8932 module
- add RFC8693 router inclusion hook and enable conditional router mounting via settings
- guard optional RFC routers in app initialization

## Testing
- `uv run --package auto_authn --directory standards/auto_authn ruff format auto_authn/v2/app.py auto_authn/v2/rfc8693.py auto_authn/v2/rfc8932.py`
- `uv run --package auto_authn --directory standards/auto_authn ruff check auto_authn/v2/app.py auto_authn/v2/rfc8693.py auto_authn/v2/rfc8932.py --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc9101_jwt_secured_authorization_request.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ac6bf3f6e88326ba05f4543dcf190b