### PR TITLE
fix: handle optional grant types and tenant id

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/jwtoken.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/jwtoken.py
@@ -103,7 +103,7 @@ class JWTCoder:
         self,
         *,
         sub: str,
-        tid: str,
+        tid: Optional[str] = None,
         ttl: timedelta = _ACCESS_TTL,
         typ: str = "access",
         issuer: Optional[str] = None,
@@ -114,12 +114,13 @@ class JWTCoder:
         now = datetime.now(timezone.utc)
         payload: Dict[str, Any] = {
             "sub": sub,
-            "tid": tid,
             "typ": typ,
             "iat": int(now.timestamp()),
             "exp": int((now + ttl).timestamp()),
             **extra,
         }
+        if tid is not None:
+            payload["tid"] = tid
         if settings.enable_rfc8705:
             if cert_thumbprint is None:
                 raise ValueError(
@@ -149,7 +150,7 @@ class JWTCoder:
         self,
         *,
         sub: str,
-        tid: str,
+        tid: Optional[str] = None,
         ttl: timedelta = _ACCESS_TTL,
         typ: str = "access",
         issuer: Optional[str] = None,

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8932.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8932.py
@@ -143,14 +143,14 @@ def get_enhanced_authorization_server_metadata() -> Dict[str, Any]:
         enhanced_metadata["device_authorization_endpoint"] = (
             f"{ISSUER}/device_authorization"
         )
-        enhanced_metadata["grant_types_supported"].append(
+        base_metadata["grant_types_supported"].append(
             "urn:ietf:params:oauth:grant-type:device_code"
         )
 
     # RFC 8693 - Token Exchange
     if settings.enable_rfc8693:
         enhanced_metadata["token_exchange_endpoint"] = f"{ISSUER}/token/exchange"
-        enhanced_metadata["grant_types_supported"].append(
+        base_metadata["grant_types_supported"].append(
             "urn:ietf:params:oauth:grant-type:token-exchange"
         )
         enhanced_metadata["token_types_supported"] = [
@@ -163,7 +163,7 @@ def get_enhanced_authorization_server_metadata() -> Dict[str, Any]:
     # RFC 8705 - OAuth 2.0 Mutual-TLS Client Authentication
     if settings.enable_rfc8705:
         enhanced_metadata["tls_client_certificate_bound_access_tokens"] = True
-        enhanced_metadata["token_endpoint_auth_methods_supported"].extend(
+        base_metadata["token_endpoint_auth_methods_supported"].extend(
             [
                 "tls_client_auth",
                 "self_signed_tls_client_auth",


### PR DESCRIPTION
## Summary
- avoid KeyError when adding grant types in enhanced metadata
- allow JWTCoder.sign to omit tenant ID

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest` *(fails: 27 failed, 319 passed, 72 deselected)*

------
https://chatgpt.com/codex/tasks/task_e_68ac711ec91c8326b2bb1c14e23ca1a2