### PR TITLE
refactor: clean up rfc8693 and rfc8932

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8693.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8693.py
@@ -9,13 +9,9 @@ See RFC 8693: https://www.rfc-editor.org/rfc/rfc8693
 
 from __future__ import annotations
 
-from typing import Dict, Any, Optional, Union, List
+from typing import Any, Dict, List, Optional, Union
 from enum import Enum
-from fastapi import APIRouter, FastAPI
-
 from fastapi import APIRouter, FastAPI, Form, HTTPException, status
-
-from fastapi import APIRouter, FastAPI
 
 from .runtime_cfg import settings
 from .rfc7519 import decode_jwt
@@ -25,35 +21,6 @@ RFC8693_SPEC_URL = "https://www.rfc-editor.org/rfc/rfc8693"
 
 # Token Exchange Grant Type
 TOKEN_EXCHANGE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange"
-
-# Router placeholder for potential token exchange endpoints
-router = APIRouter()
-
-
-def include_rfc8693(app: FastAPI) -> None:
-    """Include RFC 8693 routes on a FastAPI app."""
-
-    if not settings.enable_rfc8693:
-        raise NotImplementedError("RFC 8693 support is disabled")
-
-    app.include_router(router)
-
-
-# FastAPI router for RFC 8693 endpoints
-router = APIRouter()
-
-
-def include_rfc8693(app: FastAPI) -> None:
-    """Include RFC 8693 token exchange routes into a FastAPI app.
-
-    Routes are registered only when RFC 8693 support is enabled.
-    """
-
-    if not settings.enable_rfc8693:
-        return
-
-    app.include_router(router)
-
 
 router = APIRouter()
 

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8932.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8932.py
@@ -13,68 +13,26 @@ See related: RFC 8414 (OAuth 2.0 Authorization Server Metadata)
 from __future__ import annotations
 
 
-from typing import Dict, Any, List
+from typing import Any, Dict, List
 from fastapi import APIRouter, HTTPException, status
 
 from .runtime_cfg import settings
 from .rfc8414 import ISSUER, JWKS_PATH
 
-# Supported encrypted DNS transports per RFC 8932 recommendations
-ALLOWED_ENCRYPTED_DNS = {"DoT", "DoH"}
-
-
-def enforce_encrypted_dns(protocol: str) -> str:
-    """Validate that the provided DNS transport uses encryption.
-
-    Args:
-        protocol: DNS transport identifier (e.g., "DoT" or "DoH").
-
-    Returns:
-        The validated protocol string.
-
-    Raises:
-        NotImplementedError: If RFC 8932 support is disabled.
-        ValueError: If an unencrypted transport is supplied.
-    """
-
-    if not settings.enable_rfc8932:
-        raise NotImplementedError("RFC 8932 support is disabled")
-
-    if protocol not in ALLOWED_ENCRYPTED_DNS:
-        raise ValueError("Protocol must be an encrypted DNS transport")
-
-    return protocol
-
-
 RFC8932_SPEC_URL = "https://www.rfc-editor.org/rfc/rfc8932"
 
 router = APIRouter()
 
-# Supported encrypted DNS protocols
-ENCRYPTED_DNS_PROTOCOLS = {"DoT", "DoH"}
-
-
-def enforce_encrypted_dns(protocol: str) -> str:
-    """Validate that only encrypted DNS protocols are used."""
-
-    if not settings.enable_rfc8932:
-        raise NotImplementedError("DNS privacy enforcement is disabled")
-
-    if protocol not in ENCRYPTED_DNS_PROTOCOLS:
-        raise ValueError("Only encrypted DNS protocols are allowed")
-
-    return protocol
-
-
+# Supported encrypted DNS transports per RFC 8932 recommendations
 ENCRYPTED_DNS_TRANSPORTS = {"DoT", "DoH"}
 
 
 def enforce_encrypted_dns(transport: str) -> str:
     """Validate that DNS queries use encrypted transports.
 
-    RFC 8932 \u00a75.1.1 recommends that operators ensure DNS queries are
-    sent over encrypted transports such as DNS over TLS (DoT) or DNS over
-    HTTPS (DoH).
+    RFC 8932 \u00a75.1.1 recommends that operators ensure DNS queries are sent
+    over encrypted transports such as DNS over TLS (DoT) or DNS over HTTPS
+    (DoH).
 
     Args:
         transport: The DNS transport protocol to validate.
@@ -86,6 +44,7 @@ def enforce_encrypted_dns(transport: str) -> str:
         NotImplementedError: If RFC 8932 support is disabled.
         ValueError: If an unencrypted transport is provided.
     """
+
     if not settings.enable_rfc8932:
         raise NotImplementedError("RFC 8932 is disabled")
     if transport not in ENCRYPTED_DNS_TRANSPORTS:


### PR DESCRIPTION
## Summary
- remove duplicate router include logic in RFC 8693 token exchange module
- consolidate RFC 8932 DNS enforcement helpers

## Testing
- `uv run --directory standards/auto_authn --package auto_authn ruff check . --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc8693_token_exchange.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac774c5d3c83268d0803b561982d14