### PR TITLE
refactor: replace PyJWT with JwsSignerVerifier

### DIFF
--- a/pkgs/standards/swarmauri_tokens_jwt/pyproject.toml
+++ b/pkgs/standards/swarmauri_tokens_jwt/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
-    "pyjwt[crypto]>=2.9.0",
+    "swarmauri_signing_jws",
 ]
 
 [project.optional-dependencies]

--- a/pkgs/standards/swarmauri_tokens_jwt/tests/unit/test_rfc7515_jws.py
+++ b/pkgs/standards/swarmauri_tokens_jwt/tests/unit/test_rfc7515_jws.py
@@ -1,5 +1,5 @@
 import base64
-import jwt
+import json
 import pytest
 from swarmauri_tokens_jwt import JWTTokenService
 from swarmauri_core.crypto.types import (
@@ -78,5 +78,7 @@ class DummyKeyProvider(IKeyProvider):
 async def test_rfc7515_header_alg() -> None:
     svc = JWTTokenService(DummyKeyProvider())
     token = await svc.mint({}, alg=JWAAlg.HS256, kid="sym")
-    header = jwt.get_unverified_header(token)
+    b64_hdr = token.split(".")[0]
+    pad = "=" * ((4 - len(b64_hdr) % 4) % 4)
+    header = json.loads(base64.urlsafe_b64decode(b64_hdr + pad))
     assert header["alg"] == JWAAlg.HS256.value


### PR DESCRIPTION
## Summary
- replace PyJWT usage in JWTTokenService with swarmauri JwsSignerVerifier
- drop external PyJWT dependency and add swarmauri_signing_jws
- adjust unit tests to parse JWT headers without PyJWT

## Testing
- `uv run --package swarmauri_tokens_jwt --directory standards/swarmauri_tokens_jwt ruff format .`
- `uv run --package swarmauri_tokens_jwt --directory standards/swarmauri_tokens_jwt ruff check . --fix`
- `uv run --package swarmauri_tokens_jwt --directory standards/swarmauri_tokens_jwt pytest`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc9126_pushed_authorization_requests.py`

------
https://chatgpt.com/codex/tasks/task_e_68ac7737096c832686f5eb77f032d04d