### PR TITLE
Validate WebAuthn algorithms accept only string identifiers

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8812.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8812.py
@@ -35,18 +35,21 @@ WEBAUTHN_ALGORITHMS: Final[FrozenSet[str]] = frozenset(
 )
 
 
-def is_webauthn_algorithm(alg: str, *, enabled: bool | None = None) -> bool:
+def is_webauthn_algorithm(alg: object, *, enabled: bool | None = None) -> bool:
     """Return ``True`` if *alg* is registered for WebAuthn per :rfc:`8812`.
 
     Algorithm identifiers are compared case-insensitively to better tolerate
     input from external sources. When the feature is disabled the check always
     returns ``True`` to allow deployments to accept non-registered algorithms.
+    Non-string inputs are rejected to avoid attribute errors during validation.
     """
 
     if enabled is None:
         enabled = settings.enable_rfc8812
     if not enabled:
         return True
+    if not isinstance(alg, str):
+        return False
     return alg.upper() in WEBAUTHN_ALGORITHMS
 
 

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc8812_webauthn_algorithms.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc8812_webauthn_algorithms.py
@@ -54,3 +54,18 @@ def test_disabled_allows_any_alg(monkeypatch):
     monkeypatch.setattr(runtime_cfg.settings, "enable_rfc8812", False)
     assert is_webauthn_algorithm("HS256")
     assert is_webauthn_algorithm("unknown")
+
+
+@pytest.mark.unit
+def test_non_string_algorithm_rejected(monkeypatch):
+    """Non-string algorithm identifiers are rejected when enabled."""
+    monkeypatch.setattr(runtime_cfg.settings, "enable_rfc8812", True)
+    assert not is_webauthn_algorithm(None)  # type: ignore[arg-type]
+    assert not is_webauthn_algorithm(123)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_case_insensitive(monkeypatch):
+    """Algorithm comparison is case-insensitive."""
+    monkeypatch.setattr(runtime_cfg.settings, "enable_rfc8812", True)
+    assert is_webauthn_algorithm("es256")


### PR DESCRIPTION
## Summary
- handle non-string values in `is_webauthn_algorithm` to avoid attribute errors
- add tests covering non-string inputs and case-insensitive matching for WebAuthn algorithms

## Testing
- `uv run --package auto_authn --directory standards/auto_authn ruff check auto_authn/v2/rfc8812.py tests/unit/test_rfc8812_webauthn_algorithms.py --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc8812_webauthn_algorithms.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac773f83a88326973ab6d113aa7449