### PR TITLE
Support custom iat handling in JWT encoding

### DIFF
--- a/pkgs/standards/swarmauri_tokens_jwt/swarmauri_tokens_jwt/JWTTokenService.py
+++ b/pkgs/standards/swarmauri_tokens_jwt/swarmauri_tokens_jwt/JWTTokenService.py
@@ -47,11 +47,15 @@ class JWTTokenService(TokenServiceBase):
         subject: Optional[str] = None,
         audience: Optional[str | list[str]] = None,
         scope: Optional[str] = None,
+        include_iat: bool = True,
+        include_nbf: bool = True,
     ) -> str:
         now = int(time.time())
         payload = dict(claims)
-        payload.setdefault("iat", now)
-        payload.setdefault("nbf", now)
+        if include_iat:
+            payload.setdefault("iat", now)
+        if include_nbf:
+            payload.setdefault("nbf", now)
         if lifetime_s:
             payload.setdefault("exp", now + int(lifetime_s))
         if issuer or self._iss:
@@ -117,7 +121,7 @@ class JWTTokenService(TokenServiceBase):
         hdr = jwt.get_unverified_header(token)
         key = _key_resolver(hdr, {})
 
-        options = {"verify_aud": audience is not None}
+        options = {"verify_aud": audience is not None, "verify_iat": False}
         return jwt.decode(
             token,
             key=key,


### PR DESCRIPTION
## Summary
- allow omitting default `iat` claim when encoding JWTs
- disable PyJWT issued-at checks to enable custom validation
- update RFC 7519 helper to sign raw claims

## Testing
- `uv run --package swarmauri_tokens_jwt --directory standards/swarmauri_tokens_jwt ruff format .`
- `uv run --package swarmauri_tokens_jwt --directory standards/swarmauri_tokens_jwt ruff check . --fix`
- `uv run --package auto_authn --directory standards/auto_authn ruff format .`
- `uv run --package auto_authn --directory standards/auto_authn ruff check auto_authn/v2/rfc7519.py --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc8523_jwt_client_auth.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac7751d59483268c1f032ba165630f