### PR TITLE
chore(auto_authn): enforce token parameter in introspection

### DIFF
--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7662_token_introspection.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7662_token_introspection.py
@@ -71,7 +71,4 @@ async def test_introspection_requires_token_parameter(enable_rfc7662):
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.post("/introspect", data={})
-    assert resp.status_code in {
-        status.HTTP_400_BAD_REQUEST,
-        status.HTTP_422_UNPROCESSABLE_ENTITY,
-    }
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST


### PR DESCRIPTION
## Summary
- require `token` form field for `/introspect`
- test missing `token` returns HTTP 400

## Testing
- `uv run --package auto_authn --directory standards/auto_authn ruff check auto_authn/v2/routers/auth_flows.py tests/unit/test_rfc7662_token_introspection.py --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc7662_token_introspection.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac775b00788326ab49b5c43c3bdbaf