### PR TITLE
fix(auto_authn): support object subject in RFC7952 SETs

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7519.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7519.py
@@ -18,7 +18,8 @@ def encode_jwt(**claims) -> str:
     """Encode *claims* as a JWT string."""
     if not settings.enable_rfc7519:
         raise RuntimeError(f"RFC 7519 support disabled: {RFC7519_SPEC_URL}")
-    return JWTCoder.default().sign(**claims)
+    sub = claims.pop("sub", "")
+    return JWTCoder.default().sign(sub=sub, **claims)
 
 
 def decode_jwt(token: str) -> dict:


### PR DESCRIPTION
## Summary
- allow non-string `sub` claims in Security Event Tokens by patching PyJWT validator
- decode SETs without exp verification and perform custom expiration checks
- make `encode_jwt` tolerate missing `sub` claim

## Testing
- `uv run --package auto_authn --directory standards/auto_authn ruff check auto_authn/v2/rfc7952.py auto_authn/v2/rfc7519.py --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc7952_security_event_token.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac7755f6188326bd99733990fe8739