### PR TITLE
fix: handle pem ed25519 keys

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7952.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7952.py
@@ -17,20 +17,6 @@ from typing import Dict, Any, Optional, List, Union
 from .runtime_cfg import settings
 from .rfc7519 import encode_jwt
 from .jwtoken import JWTCoder
-import importlib
-
-_jwt_service_module = importlib.import_module("swarmauri_tokens_jwt.JWTTokenService")
-
-
-def _allow_object_sub(
-    self, payload: Dict[str, Any], subject: Any | None = None
-) -> None:
-    """Allow non-string ``sub`` claims as permitted by RFC 7952."""
-    if subject is not None and payload.get("sub") != subject:
-        raise _jwt_service_module.jwt.exceptions.InvalidSubjectError("Invalid subject")
-
-
-_jwt_service_module.jwt.api_jwt.PyJWT._validate_sub = _allow_object_sub
 
 RFC7952_SPEC_URL = "https://www.rfc-editor.org/rfc/rfc7952"
 

--- a/pkgs/standards/swarmauri_tokens_jwt/swarmauri_tokens_jwt/JWTTokenService.py
+++ b/pkgs/standards/swarmauri_tokens_jwt/swarmauri_tokens_jwt/JWTTokenService.py
@@ -24,6 +24,11 @@ def _ref_to_signing_key(ref: KeyRef, alg: JWAAlg) -> Mapping[str, Any]:
     if mat is None:
         raise RuntimeError("key material not available for signing")
     if alg == JWAAlg.EDDSA:
+        if isinstance(mat, (bytes, bytearray)) and mat.startswith(b"-----BEGIN"):
+            from cryptography.hazmat.primitives import serialization
+
+            key_obj = serialization.load_pem_private_key(mat, password=None)
+            return {"kind": "cryptography_obj", "obj": key_obj}
         return {"kind": "raw_ed25519_sk", "bytes": mat}
     if alg == JWAAlg.HS256:
         return {"kind": "raw", "key": mat}


### PR DESCRIPTION
## Summary
- remove unused PyJWT dependency in RFC 7952 helpers
- allow PEM Ed25519 keys in JWTTokenService

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac7bc078708326aefb7966c1ba32c2