### PR TITLE
Fix JWT handling and introspection

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7952.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7952.py
@@ -17,20 +17,20 @@ from typing import Dict, Any, Optional, List, Union
 from .runtime_cfg import settings
 from .rfc7519 import encode_jwt
 from .jwtoken import JWTCoder
-import importlib
 
-_jwt_service_module = importlib.import_module("swarmauri_tokens_jwt.JWTTokenService")
+try:  # pragma: no cover - optional dependency
+    import jwt
 
+    def _allow_object_sub(
+        self, payload: Dict[str, Any], subject: Any | None = None
+    ) -> None:
+        """Allow non-string ``sub`` claims as permitted by RFC 7952."""
+        if subject is not None and payload.get("sub") != subject:
+            raise jwt.exceptions.InvalidSubjectError("Invalid subject")
 
-def _allow_object_sub(
-    self, payload: Dict[str, Any], subject: Any | None = None
-) -> None:
-    """Allow non-string ``sub`` claims as permitted by RFC 7952."""
-    if subject is not None and payload.get("sub") != subject:
-        raise _jwt_service_module.jwt.exceptions.InvalidSubjectError("Invalid subject")
-
-
-_jwt_service_module.jwt.api_jwt.PyJWT._validate_sub = _allow_object_sub
+    jwt.api_jwt.PyJWT._validate_sub = _allow_object_sub  # type: ignore[attr-defined]
+except (ModuleNotFoundError, AttributeError):
+    pass
 
 RFC7952_SPEC_URL = "https://www.rfc-editor.org/rfc/rfc7952"
 

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8523.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8523.py
@@ -14,6 +14,7 @@ from typing import Dict, Iterable, Set, Union, Optional, Any
 
 from .runtime_cfg import settings
 from .rfc7523 import validate_client_jwt_bearer
+from .errors import InvalidTokenError
 
 RFC8523_SPEC_URL = "https://www.rfc-editor.org/rfc/rfc8523"
 REQUIRED_CLAIMS: Set[str] = {"iss", "sub", "aud", "exp", "iat", "jti"}
@@ -64,7 +65,7 @@ def validate_enhanced_jwt_bearer(
     current_time = int(time.time())
     iat = claims.get("iat")
     if not isinstance(iat, int):
-        raise ValueError("'iat' claim must be an integer timestamp")
+        raise InvalidTokenError("'iat' claim must be an integer timestamp")
 
     # Check if token is too old
     token_age = current_time - iat
@@ -73,7 +74,7 @@ def validate_enhanced_jwt_bearer(
 
     # Check if token is from the future (with clock skew tolerance)
     if iat > current_time + clock_skew_seconds:
-        raise ValueError("JWT 'iat' claim is in the future")
+        raise InvalidTokenError("JWT 'iat' claim is in the future")
 
     # Validate JWT ID for replay protection
     jti = claims.get("jti")


### PR DESCRIPTION
## Summary
- allow RFC7952 to load without optional PyJWT dependency
- support PEM encoded Ed25519 keys when signing JWTs
- raise InvalidTokenError for invalid or future `iat` in RFC8523
- handle introspection requests even when RFC7662 disabled

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest` *(fails: see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7bc299e083269b3238e8d1fcfdd0