### PR TITLE
Encode HMAC secret for RFC 9101 helpers

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc9101.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc9101.py
@@ -33,7 +33,7 @@ async def create_request_object(
     if not settings.enable_rfc9101:
         raise RuntimeError(f"RFC 9101 support disabled: {RFC9101_SPEC_URL}")
     alg = JWAAlg(algorithm)
-    key = {"kind": "raw", "key": secret}
+    key = {"kind": "raw", "key": secret.encode()}
     return await _signer.sign_compact(payload=params, alg=alg, key=key, typ="JWT")
 
 
@@ -55,7 +55,7 @@ async def parse_request_object(
         alg_allowlist = [JWAAlg(a) for a in algorithms]
     result = await _signer.verify_compact(
         token,
-        hmac_keys=[{"kind": "raw", "key": secret}],
+        hmac_keys=[{"kind": "raw", "key": secret.encode()}],
         alg_allowlist=alg_allowlist,
     )
     return json.loads(result.payload.decode())


### PR DESCRIPTION
## Summary
- Encode JWT request object secret to bytes before signing and verifying

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc9101_jwt_secured_authorization_request.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac7f8bb6a08326b42a657ebee73d59