### PR TITLE
Use encode_jwt in token exchange tests

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8693.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8693.py
@@ -14,8 +14,7 @@ from enum import Enum
 from fastapi import APIRouter, FastAPI, Form, HTTPException, status
 
 from .runtime_cfg import settings
-from .rfc7519 import decode_jwt
-from .jwtoken import JWTCoder
+from .rfc7519 import decode_jwt, encode_jwt
 
 RFC8693_SPEC_URL = "https://www.rfc-editor.org/rfc/rfc8693"
 
@@ -249,9 +248,6 @@ def exchange_token(
     if request.actor_token and request.actor_token_type:
         validate_subject_token(request.actor_token, request.actor_token_type)
 
-    # Create new token based on request
-    jwt_coder = JWTCoder.default()
-
     # Extract subject from original token
     subject_id = subject_claims.get("sub", "unknown")
     tenant_id = subject_claims.get("tid", "default")
@@ -259,8 +255,8 @@ def exchange_token(
     # Determine scope - use requested scope or inherit from subject token
     scope = request.scope or subject_claims.get("scope", "")
 
-    # Create new access token
-    access_token = jwt_coder.sign(
+    # Create new access token using swarmauri JWT utilities
+    access_token = encode_jwt(
         sub=subject_id,
         tid=tenant_id,
         scopes=scope.split() if scope else [],


### PR DESCRIPTION
## Summary
- Refactor token exchange logic to sign tokens with swarmauri's `encode_jwt`
- Adjust RFC 8693 tests to patch `encode_jwt` instead of `JWTCoder`

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc8693_token_exchange.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac7f795ca88326820e8892204de64b