### PR TITLE
refactor: replace PyJWT with swarmauri signer

### DIFF
--- a/pkgs/standards/swarmauri_middleware_auth/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_auth/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "swarmauri_base",
     "swarmauri_standard",
     "fastapi",
-    "PyJWT",
+    "swarmauri_signing_jws",
 ]
 
 [tool.uv.sources]


### PR DESCRIPTION
## Summary
- refactor AuthMiddleware to verify tokens via swarmauri_signing_jws instead of PyJWT
- add InvalidTokenError and update tests to generate tokens with JwsSignerVerifier
- drop PyJWT dependency in favor of swarmauri_signing_jws

## Testing
- `uv run --package swarmauri_middleware_auth --directory standards/swarmauri_middleware_auth pytest tests/unit/test_AuthMiddleware.py`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc8812_webauthn_algorithms.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac7f81c0008326b4fde6e18dd1d184