### PR TITLE
Handle JWT tokens in introspection

### DIFF
--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7662_token_introspection.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7662_token_introspection.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 
 from auto_authn.v2.routers.auth_flows import router
 from auto_authn.v2.fastapi_deps import get_async_db
+from auto_authn.v2.jwtoken import JWTCoder
 
 
 # RFC 7662 specification excerpt for reference within tests
@@ -27,7 +28,7 @@ RFC 7662 - OAuth 2.0 Token Introspection
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_introspection_endpoint_returns_active_field(enable_rfc7662, monkeypatch):
+async def test_introspection_endpoint_returns_active_field(enable_rfc7662):
     """RFC 7662 §2.2: Response must include an 'active' boolean."""
     app = FastAPI()
     app.include_router(router)
@@ -37,23 +38,19 @@ async def test_introspection_endpoint_returns_active_field(enable_rfc7662, monke
 
     app.dependency_overrides[get_async_db] = override_db
 
-    async def fake_auth(db, token):
-        class P:
-            id = uuid4()
-            tenant_id = uuid4()
-
-        return P(), "api_key"
-
-    monkeypatch.setattr(
-        "auto_authn.v2.routers.auth_flows._api_backend.authenticate", fake_auth
-    )
+    jwt_coder = JWTCoder.default()
+    sub = uuid4()
+    tid = uuid4()
+    token = await jwt_coder.async_sign(sub=str(sub), tid=str(tid))
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.post("/introspect", data={"token": "dummy"})
+        resp = await client.post("/introspect", data={"token": token})
     assert resp.status_code == status.HTTP_200_OK
     body = resp.json()
     assert body.get("active") is True
+    assert body.get("sub") == str(sub)
+    assert body.get("tid") == str(tid)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- decode JWT tokens in RFC7662 introspection using JWTCoder
- test JWT-based introspection workflow
- resolve stale setting by referencing runtime_cfg.settings dynamically

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc7520_examples.py tests/unit/test_rfc7662_token_introspection.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac7f6f3e088326bee4c394d2477ce1