### PR TITLE
feat(auto_authn): support jwt token introspection

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/routers/auth_flows.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/routers/auth_flows.py
@@ -37,6 +37,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from ..crypto import hash_pw
 from ..jwtoken import JWTCoder
 from ..backends import PasswordBackend, ApiKeyBackend, AuthError
+from ..errors import InvalidTokenError
 from ..fastapi_deps import get_async_db
 from ..orm.tables import Tenant, User
 from ..runtime_cfg import settings
@@ -280,12 +281,21 @@ async def introspect(request: Request, db: AsyncSession = Depends(get_async_db))
     if not token:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, "token parameter required")
     try:
-        principal, kind = await _api_backend.authenticate(db, token)
-    except AuthError:
-        return IntrospectOut(active=False)
+        payload = await _jwt.async_decode(token)
+    except InvalidTokenError:
+        try:
+            principal, kind = await _api_backend.authenticate(db, token)
+        except AuthError:
+            return IntrospectOut(active=False)
+        return IntrospectOut(
+            active=True,
+            sub=str(principal.id),
+            tid=str(principal.tenant_id),
+            kind=kind,
+        )
     return IntrospectOut(
         active=True,
-        sub=str(principal.id),
-        tid=str(principal.tenant_id),
-        kind=kind,
+        sub=payload.get("sub"),
+        tid=payload.get("tid"),
+        kind=payload.get("typ"),
     )


### PR DESCRIPTION
## Summary
- decode JWTs in token introspection before falling back to API key lookup
- add unit test for JWT token introspection

## Testing
- `uv run --package auto_authn --directory standards/auto_authn ruff check . --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc7662_token_introspection.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac818ecbcc8326a78d55fb91054dec