### PR TITLE
Fix RFC feature flags to survive runtime_cfg reloads

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7662.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7662.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, Final
 
-from .runtime_cfg import settings
+from . import runtime_cfg
 
 RFC7662_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc7662"
 
@@ -35,7 +35,7 @@ def introspect_token(token: str) -> Dict[str, Any]:
     RuntimeError
         If RFC 7662 support is disabled via settings.
     """
-    if not settings.enable_rfc7662:
+    if not runtime_cfg.settings.enable_rfc7662:
         raise RuntimeError(f"RFC 7662 support is disabled: {RFC7662_SPEC_URL}")
     return _ACTIVE_TOKENS.get(token, {"active": False})
 

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8693.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8693.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, List, Optional, Union
 from enum import Enum
 from fastapi import APIRouter, FastAPI, Form, HTTPException, status
 
-from .runtime_cfg import settings
+from . import runtime_cfg
 from .rfc7519 import decode_jwt
 from .jwtoken import JWTCoder
 
@@ -28,7 +28,7 @@ router = APIRouter()
 def include_rfc8693(app: FastAPI) -> None:
     """Attach the RFC 8693 router to *app* if enabled."""
 
-    if settings.enable_rfc8693 and not any(
+    if runtime_cfg.settings.enable_rfc8693 and not any(
         route.path == "/token/exchange" for route in app.routes
     ):
         app.include_router(router)
@@ -174,7 +174,7 @@ def validate_token_exchange_request(
         RuntimeError: If RFC 8693 support is disabled
         ValueError: If validation fails
     """
-    if not settings.enable_rfc8693:
+    if not runtime_cfg.settings.enable_rfc8693:
         raise RuntimeError("RFC 8693 support disabled")
 
     request = TokenExchangeRequest(
@@ -237,7 +237,7 @@ def exchange_token(
         RuntimeError: If RFC 8693 support is disabled
         ValueError: If token exchange fails
     """
-    if not settings.enable_rfc8693:
+    if not runtime_cfg.settings.enable_rfc8693:
         raise RuntimeError("RFC 8693 support disabled")
 
     # Validate subject token
@@ -291,7 +291,7 @@ async def token_exchange_endpoint(
 ):
     """RFC 8693 token exchange endpoint."""
 
-    if not settings.enable_rfc8693:
+    if not runtime_cfg.settings.enable_rfc8693:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "token exchange disabled")
 
     request = validate_token_exchange_request(
@@ -325,7 +325,7 @@ def create_impersonation_token(
     Returns:
         TokenExchangeResponse with impersonation token
     """
-    if not settings.enable_rfc8693:
+    if not runtime_cfg.settings.enable_rfc8693:
         raise RuntimeError("RFC 8693 support disabled")
 
     request = TokenExchangeRequest(
@@ -358,7 +358,7 @@ def create_delegation_token(
     Returns:
         TokenExchangeResponse with delegation token
     """
-    if not settings.enable_rfc8693:
+    if not runtime_cfg.settings.enable_rfc8693:
         raise RuntimeError("RFC 8693 support disabled")
 
     request = TokenExchangeRequest(

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8705.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8705.py
@@ -18,7 +18,7 @@ from .errors import InvalidTokenError
 from cryptography import x509
 from cryptography.hazmat.primitives import serialization
 
-from .runtime_cfg import settings
+from . import runtime_cfg
 
 RFC8705_SPEC_URL = "https://www.rfc-editor.org/rfc/rfc8705"
 
@@ -56,7 +56,7 @@ def validate_certificate_binding(
     function returns without performing validation.
     """
     if enabled is None:
-        enabled = settings.enable_rfc8705
+        enabled = runtime_cfg.settings.enable_rfc8705
     if not enabled:
         return
     cnf = payload.get("cnf")

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8812.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8812.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from typing import Final, FrozenSet
 
-from .runtime_cfg import settings
+from . import runtime_cfg
 
 RFC8812_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc8812"
 
@@ -45,7 +45,7 @@ def is_webauthn_algorithm(alg: object, *, enabled: bool | None = None) -> bool:
     """
 
     if enabled is None:
-        enabled = settings.enable_rfc8812
+        enabled = runtime_cfg.settings.enable_rfc8812
     if not enabled:
         return True
     if not isinstance(alg, str):

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc9101.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc9101.py
@@ -14,7 +14,7 @@ import json
 
 from .deps import JWAAlg, JwsSignerVerifier
 
-from .runtime_cfg import settings
+from . import runtime_cfg
 
 RFC9101_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc9101"
 _signer = JwsSignerVerifier()
@@ -30,7 +30,7 @@ async def create_request_object(
     RuntimeError
         If RFC 9101 support is disabled via ``settings.enable_rfc9101``.
     """
-    if not settings.enable_rfc9101:
+    if not runtime_cfg.settings.enable_rfc9101:
         raise RuntimeError(f"RFC 9101 support disabled: {RFC9101_SPEC_URL}")
     alg = JWAAlg(algorithm)
     key = {"kind": "raw", "key": secret.encode()}
@@ -47,7 +47,7 @@ async def parse_request_object(
     RuntimeError
         If RFC 9101 support is disabled via ``settings.enable_rfc9101``.
     """
-    if not settings.enable_rfc9101:
+    if not runtime_cfg.settings.enable_rfc9101:
         raise RuntimeError(f"RFC 9101 support disabled: {RFC9101_SPEC_URL}")
 
     alg_allowlist = None

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc9126.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc9126.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, Final, Tuple
 
 from fastapi import APIRouter, FastAPI, HTTPException, Request, status
 
-from .runtime_cfg import settings
+from . import runtime_cfg
 
 # In-memory storage mapping request_uri -> (params, expiry)
 _PAR_STORE: Dict[str, Tuple[Dict[str, Any], datetime]] = {}
@@ -64,7 +64,7 @@ def reset_par_store() -> None:
 async def pushed_authorization_request(request: Request):
     """Endpoint for RFC 9126 pushed authorization requests."""
 
-    if not settings.enable_rfc9126:
+    if not runtime_cfg.settings.enable_rfc9126:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "PAR disabled")
     form = await request.form()
     request_uri = store_par_request(dict(form))
@@ -74,7 +74,7 @@ async def pushed_authorization_request(request: Request):
 def include_rfc9126(app: FastAPI) -> None:
     """Attach the RFC 9126 router to *app* if enabled."""
 
-    if settings.enable_rfc9126 and not any(
+    if runtime_cfg.settings.enable_rfc9126 and not any(
         route.path == "/par" for route in app.routes
     ):
         app.include_router(router)

--- a/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
@@ -269,4 +269,4 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=None)
 
 
-settings = Settings()
+settings = globals().get("settings", Settings())


### PR DESCRIPTION
## Summary
- access runtime settings through runtime_cfg module across RFC helpers
- preserve Settings instance on runtime_cfg reload to keep feature flags stable

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc8693_token_exchange.py tests/unit/test_rfc7662_token_introspection.py tests/unit/test_rfc7662_unit.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac8248df608326928135deb4f6af5e