### PR TITLE
Ensure runtime config reload updates settings

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
@@ -269,4 +269,11 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=None)
 
 
-settings = globals().get("settings", Settings())
+_existing = globals().get("settings")
+if _existing is None:
+    settings = Settings()
+else:
+    _new = Settings()
+    for field, value in _new.model_dump().items():
+        setattr(_existing, field, value)
+    settings = _existing


### PR DESCRIPTION
## Summary
- refresh existing settings object on reload to honor updated environment variables

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc7520_examples.py -q`
- `uv run --package auto_authn --directory standards/auto_authn pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac869d22308326a95cf9dcbbddfc93