### PR TITLE
feat(auto_authn): expand OIDC discovery metadata

### DIFF
--- a/pkgs/standards/auto_authn/tests/unit/test_openid_configuration.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_openid_configuration.py
@@ -1,0 +1,15 @@
+import pytest
+from fastapi import status
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_openid_configuration_contains_required_fields(async_client) -> None:
+    resp = await async_client.get("/.well-known/openid-configuration")
+    assert resp.status_code == status.HTTP_200_OK
+    data = resp.json()
+    assert data["authorization_endpoint"].endswith("/authorize")
+    assert data["userinfo_endpoint"].endswith("/userinfo")
+    assert "code" in data["response_types_supported"]
+    assert "id_token" in data["response_types_supported"]
+    assert data["id_token_signing_alg_values_supported"] == ["RS256"]


### PR DESCRIPTION
## Summary
- enrich OIDC discovery with authorization and user info endpoints
- advertise code and id_token response types and RS256 signing
- cover discovery fields with unit tests

## Testing
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff format .`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68ac89b2e2c08326b00563744bd3af53