### PR TITLE
docs: demonstrate RFC workflows for auto_authn v2

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/README.md
+++ b/pkgs/standards/auto_authn/auto_authn/v2/README.md
@@ -1,0 +1,95 @@
+# Auto Authn v2 Server
+
+This server provides a FastAPI implementation of the Auto AuthN identity provider. It exposes OAuth2/OpenID Connect compliant endpoints.
+
+## Deployment
+
+1. **Install** the package and its optional extras:
+   ```bash
+   pip install auto_authn[sqlite]  # or auto_authn[postgres]
+   ```
+2. **Run** the application with Uvicorn:
+   ```bash
+   uvicorn auto_authn.v2.app:app --reload
+   ```
+3. **Configure** runtime settings via environment variables:
+   - `DATABASE_URL` – database connection string (e.g. `sqlite+aiosqlite:///./authn.db`).
+   - `AUTHN_ISSUER` – issuer URL used in discovery documents.
+
+## Administration
+
+- `GET /healthz` returns service liveness status.
+- `GET /methodz` exposes build metadata for operational checks.
+- `GET /.well-known/openid-configuration` publishes OIDC discovery data.
+- `GET /.well-known/jwks.json` exposes the JSON Web Key Set for token verification.
+
+## Usage
+
+### Health check
+
+```python
+from fastapi.testclient import TestClient
+from auto_authn.v2.app import app
+
+client = TestClient(app)
+assert client.get("/healthz").json() == {"status": "alive"}
+```
+
+### Password grant (RFC 6749)
+
+```python
+import uuid
+from fastapi.testclient import TestClient
+from auto_authn.v2.app import app
+
+client = TestClient(app)
+
+slug = f"tenant-{uuid.uuid4().hex[:6]}"
+client.post(
+    "/tenant",
+    json={"slug": slug, "name": "Example", "email": "ops@example.com"},
+)
+client.post(
+    "/register",
+    json={
+        "tenant_slug": slug,
+        "username": "alice",
+        "email": "alice@example.com",
+        "password": "SecretPwd123",
+    },
+)
+tokens = client.post(
+    "/token",
+    data={
+        "grant_type": "password",
+        "username": "alice",
+        "password": "SecretPwd123",
+    },
+).json()
+```
+
+### Refresh token (RFC 6749)
+
+```python
+refreshed = client.post(
+    "/token/refresh", json={"refresh_token": tokens["refresh_token"]}
+).json()
+```
+
+### Token revocation (RFC 7009)
+
+```python
+import os
+from importlib import reload
+from fastapi.testclient import TestClient
+import auto_authn.v2.app as app_module
+
+os.environ["AUTO_AUTHN_ENABLE_RFC7009"] = "1"
+reload(app_module)
+
+client = TestClient(app_module.app)
+client.post("/revoke", data={"token": "deadbeef"})
+```
+
+The snippets demonstrate programmatic access to the server and showcase RFC-compliant
+workflows using FastAPI's `TestClient` for testing or integration purposes.

--- a/pkgs/standards/auto_authn/pyproject.toml
+++ b/pkgs/standards/auto_authn/pyproject.toml
@@ -56,6 +56,7 @@ markers = [
     "xfail: Expected failures",
     "acceptance: Acceptance tests",
     "perf: Performance tests that measure execution time and resource usage",
+    "example: Usage examples from documentation",
 ]
 timeout = 300
 log_cli = true

--- a/pkgs/standards/auto_authn/tests/examples/test_readme_usage.py
+++ b/pkgs/standards/auto_authn/tests/examples/test_readme_usage.py
@@ -1,0 +1,80 @@
+import os
+import uuid
+import importlib
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.mark.example
+def test_health_endpoint_in_readme():
+    from auto_authn.v2.app import app
+
+    client = TestClient(app)
+    assert client.get("/healthz").json() == {"status": "alive"}
+
+
+@pytest.mark.example
+def test_password_grant_flow_in_readme():
+    from auto_authn.v2.app import app
+
+    client = TestClient(app)
+    slug = f"tenant-{uuid.uuid4().hex[:6]}"
+    client.post(
+        "/tenant",
+        json={"slug": slug, "name": "Example", "email": "ops@example.com"},
+    )
+    client.post(
+        "/register",
+        json={
+            "tenant_slug": slug,
+            "username": "alice",
+            "email": "alice@example.com",
+            "password": "SecretPwd123",
+        },
+    )
+    tokens = client.post(
+        "/token",
+        data={
+            "grant_type": "password",
+            "username": "alice",
+            "password": "SecretPwd123",
+        },
+    ).json()
+    assert "access_token" in tokens and "refresh_token" in tokens
+
+
+@pytest.mark.example
+def test_refresh_token_flow_in_readme():
+    from auto_authn.v2.app import app
+
+    client = TestClient(app)
+    slug = f"tenant-{uuid.uuid4().hex[:6]}"
+    client.post(
+        "/tenant",
+        json={"slug": slug, "name": "Example", "email": "ops@example.com"},
+    )
+    tokens = client.post(
+        "/register",
+        json={
+            "tenant_slug": slug,
+            "username": "alice",
+            "email": "alice@example.com",
+            "password": "SecretPwd123",
+        },
+    ).json()
+    refreshed = client.post(
+        "/token/refresh", json={"refresh_token": tokens["refresh_token"]}
+    ).json()
+    assert "access_token" in refreshed
+
+
+@pytest.mark.example
+def test_token_revocation_flow_in_readme():
+    os.environ["AUTO_AUTHN_ENABLE_RFC7009"] = "1"
+    import auto_authn.v2.app as app_module
+
+    importlib.reload(app_module)
+    client = TestClient(app_module.app)
+    resp = client.post("/revoke", data={"token": "deadbeef"})
+    assert resp.status_code == 200 and resp.json() == {}


### PR DESCRIPTION
## Summary
- document RFC 6749 password grant, refresh token, and RFC 7009 revocation workflows
- cover README examples with `example`-marked tests

## Testing
- `uv run --package auto_authn --directory pkgs/standards/auto_authn ruff format .`
- `uv run --package auto_authn --directory pkgs/standards/auto_authn ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68ac8736f0c883268140daaa2ca8387d