### PR TITLE
feat(auto_authn): add RS256 ID token support

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/__init__.py
@@ -104,6 +104,8 @@ from .rfc8932 import (
     get_capability_matrix,
 )
 
+from .oidc_id_token import mint_id_token, verify_id_token
+
 __all__ = [
     "create_code_verifier",
     "create_code_challenge",
@@ -202,4 +204,6 @@ __all__ = [
     "validate_metadata_consistency",
     "get_capability_matrix",
     "RFC8932_SPEC_URL",
+    "mint_id_token",
+    "verify_id_token",
 ]

--- a/pkgs/standards/auto_authn/auto_authn/v2/app.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/app.py
@@ -102,10 +102,10 @@ async def oidc_config():
 @app.get(JWKS_PATH, include_in_schema=False)
 async def jwks():
     """Return public key in RFC 7517 JWK Set format."""
-    from .crypto import _provider, _ensure_key
+    from .oidc_id_token import ensure_rsa_jwt_key, rsa_key_provider
 
-    kid, _, _ = await _ensure_key()
-    kp = _provider()
+    kid, _, _ = await ensure_rsa_jwt_key()
+    kp = rsa_key_provider()
     key_dict = await kp.get_public_jwk(kid)
     key_dict.setdefault("kid", f"{kid}.1")
     return {"keys": [key_dict]}

--- a/pkgs/standards/auto_authn/auto_authn/v2/oidc_id_token.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/oidc_id_token.py
@@ -1,0 +1,124 @@
+"""Helpers for minting and verifying OIDC ID Tokens.
+
+This module issues ID Tokens as JWTs signed with RS256 using the
+``JWTTokenService`` infrastructure.  It stores the signing key on disk via
+``FileKeyProvider`` similar to the Ed25519 helpers in :mod:`crypto` but backed by
+an RSA key pair.  Only the minimal set of claims required by the OpenID Connect
+Core specification are handled here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import pathlib
+from datetime import timedelta
+from functools import lru_cache
+from typing import Any, Iterable, Mapping, Tuple
+
+from .deps import (
+    ExportPolicy,
+    FileKeyProvider,
+    JWAAlg,
+    JWTTokenService,
+    KeyAlg,
+    KeyClass,
+    KeySpec,
+    KeyUse,
+)
+
+# ---------------------------------------------------------------------------
+# Signing key management
+# ---------------------------------------------------------------------------
+
+# Location of the RSA key identifier used for ID Token signing.
+_RSA_KEY_PATH = pathlib.Path(
+    os.getenv("JWT_RS256_KEY_PATH", "runtime_secrets/jwt_rs256.kid")
+)
+
+
+@lru_cache(maxsize=1)
+def _provider() -> FileKeyProvider:
+    """Return a cached ``FileKeyProvider`` rooted at the key directory."""
+    return FileKeyProvider(_RSA_KEY_PATH.parent)
+
+
+async def _ensure_key() -> Tuple[str, bytes, bytes]:
+    """Ensure an RSA signing key exists and return ``(kid, priv, pub)``."""
+    kp = _provider()
+    if _RSA_KEY_PATH.exists():
+        kid = _RSA_KEY_PATH.read_text().strip()
+        ref = await kp.get_key(kid, include_secret=True)
+    else:
+        spec = KeySpec(
+            klass=KeyClass.asymmetric,
+            alg=KeyAlg.RSA_PSS_SHA256,
+            uses=(KeyUse.SIGN, KeyUse.VERIFY),
+            export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+            label="jwt_rs256",
+        )
+        ref = await kp.create_key(spec)
+        _RSA_KEY_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _RSA_KEY_PATH.write_text(ref.kid)
+    priv = ref.material or b""
+    pub = ref.public or b""
+    return ref.kid, priv, pub
+
+
+@lru_cache(maxsize=1)
+def _service() -> Tuple[JWTTokenService, str]:
+    """Return a ``JWTTokenService`` bound to the RSA signing key."""
+    kid, _, _ = asyncio.run(_ensure_key())
+    svc = JWTTokenService(_provider())
+    return svc, kid
+
+
+# ---------------------------------------------------------------------------
+# ID Token helpers
+# ---------------------------------------------------------------------------
+
+
+def mint_id_token(
+    *,
+    sub: str,
+    aud: Iterable[str] | str,
+    nonce: str,
+    issuer: str,
+    ttl: timedelta = timedelta(minutes=5),
+    **extra: Mapping[str, Any] | Any,
+) -> str:
+    """Mint an ID Token for *sub* and *aud* with the given *nonce*.
+
+    The token is signed with RS256 and includes the standard claims required by
+    OIDC: ``iss``, ``sub``, ``aud``, ``exp``, ``iat``, and ``nonce``.
+    Additional claims may be supplied via ``extra``.
+    """
+
+    svc, kid = _service()
+    claims: dict[str, Any] = {"nonce": nonce}
+    if extra:
+        claims.update(extra)  # type: ignore[arg-type]
+    return asyncio.run(
+        svc.mint(
+            claims,
+            alg=JWAAlg.RS256,
+            kid=kid,
+            lifetime_s=int(ttl.total_seconds()),
+            issuer=issuer,
+            subject=sub,
+            audience=aud,
+        )
+    )
+
+
+def verify_id_token(token: str, *, issuer: str, audience: Iterable[str] | str) -> dict:
+    """Verify *token* and return its claims if valid."""
+    svc, _ = _service()
+    return asyncio.run(svc.verify(token, issuer=issuer, audience=audience))
+
+
+# Exported helpers for JWKS publication
+rsa_key_provider = _provider
+ensure_rsa_jwt_key = _ensure_key
+
+__all__ = ["mint_id_token", "verify_id_token", "rsa_key_provider", "ensure_rsa_jwt_key"]

--- a/pkgs/standards/auto_authn/tests/conftest.py
+++ b/pkgs/standards/auto_authn/tests/conftest.py
@@ -177,14 +177,20 @@ def temp_key_file():
     temp_kid = temp_dir / "jwt_ed25519.kid"
 
     import auto_authn.v2.crypto as crypto_module
+    import auto_authn.v2.oidc_id_token as oidc_module
 
     original_dir = crypto_module._DEFAULT_KEY_DIR
     original_path = crypto_module._DEFAULT_KEY_PATH
+    original_rsa_path = oidc_module._RSA_KEY_PATH
 
     crypto_module._DEFAULT_KEY_DIR = temp_dir
     crypto_module._DEFAULT_KEY_PATH = temp_kid
     crypto_module._provider.cache_clear()
     crypto_module._load_keypair.cache_clear()
+
+    oidc_module._RSA_KEY_PATH = temp_dir / "jwt_rs256.kid"
+    oidc_module._provider.cache_clear()
+    oidc_module._service.cache_clear()
 
     yield temp_kid
 
@@ -194,6 +200,9 @@ def temp_key_file():
     crypto_module._DEFAULT_KEY_PATH = original_path
     crypto_module._provider.cache_clear()
     crypto_module._load_keypair.cache_clear()
+    oidc_module._RSA_KEY_PATH = original_rsa_path
+    oidc_module._provider.cache_clear()
+    oidc_module._service.cache_clear()
 
 
 @pytest.fixture

--- a/pkgs/standards/auto_authn/tests/i9n/test_oidc_endpoints.py
+++ b/pkgs/standards/auto_authn/tests/i9n/test_oidc_endpoints.py
@@ -133,7 +133,7 @@ class TestOIDCDiscoveryEndpoint:
         # Check signing algorithms
         signing_algs = discovery_doc["id_token_signing_alg_values_supported"]
         assert isinstance(signing_algs, list), "Signing algorithms should be a list"
-        assert "EdDSA" in signing_algs, "Must support EdDSA algorithm"
+        assert "RS256" in signing_algs, "Must support RS256 algorithm"
 
     @pytest.mark.asyncio
     async def test_discovery_with_custom_issuer(self, async_client):
@@ -203,29 +203,24 @@ class TestJWKSEndpoint:
                 continue
             assert field in key, f"JWK must contain '{field}' field"
 
-        # Key type should be appropriate for Ed25519
-        assert key["kty"] in ["OKP"], f"Unexpected key type: {key['kty']}"
+        # Key type should be RSA for ID tokens
+        assert key["kty"] in ["RSA"], f"Unexpected key type: {key['kty']}"
 
         # Should have a key ID for rotation
         assert key["kid"], "Key should have a non-empty key ID"
 
     @pytest.mark.asyncio
-    async def test_jwk_ed25519_specific_fields(self, async_client):
-        """Test Ed25519 specific JWK fields."""
+    async def test_jwk_rsa_specific_fields(self, async_client):
+        """Test RSA specific JWK fields."""
         response = await async_client.get("/.well-known/jwks.json")
         jwks_doc = response.json()
 
         key = jwks_doc["keys"][0]
 
-        # Ed25519 keys should have specific fields
-        if key["kty"] == "OKP":
-            assert "crv" in key, "OKP key must have 'crv' (curve) field"
-            assert key["crv"] == "Ed25519", (
-                f"Expected Ed25519 curve, got: {key.get('crv')}"
-            )
-            assert "x" in key, "Ed25519 key must have 'x' field (public key)"
-
-            # Should not have private key material in public JWKS
+        # RSA keys should have modulus and exponent
+        if key["kty"] == "RSA":
+            assert "n" in key and "e" in key, "RSA key must include 'n' and 'e'"
+            # Should not expose private parameters
             assert "d" not in key, "Public JWKS should not contain private key material"
 
     @pytest.mark.asyncio
@@ -274,8 +269,7 @@ class TestJWKSEndpoint:
             assert isinstance(kid, str), "Key ID should be a string"
             assert len(kid) > 0, "Key ID should not be empty"
 
-            # For Ed25519 keys, might follow a specific pattern
-            # This is implementation-specific but we can check it's reasonable
+            # Key ID format is implementation-specific; ensure it's non-trivial
             assert len(kid) >= 3, "Key ID should be at least 3 characters"
 
     @pytest.mark.asyncio
@@ -285,13 +279,10 @@ class TestJWKSEndpoint:
         response = await async_client.get("/.well-known/jwks.json")
         jwks_doc = response.json()
 
-        # Should have at least one key
+        # Should have at least one key and it should be RSA
         assert len(jwks_doc["keys"]) >= 1
-
-        # The key should be valid Ed25519 format
         key = jwks_doc["keys"][0]
-        assert key["kty"] == "OKP"
-        assert key["crv"] == "Ed25519"
+        assert key["kty"] == "RSA"
 
 
 @pytest.mark.integration
@@ -319,16 +310,9 @@ class TestOIDCEndpointIntegration:
         # Signing algorithms in discovery should match key types in JWKS
         signing_algs = discovery_doc["id_token_signing_alg_values_supported"]
 
-        if "EdDSA" in signing_algs:
-            # Should have Ed25519 keys in JWKS
-            ed25519_keys = [
-                key
-                for key in jwks_doc["keys"]
-                if key.get("kty") == "OKP" and key.get("crv") == "Ed25519"
-            ]
-            assert len(ed25519_keys) > 0, (
-                "Should have Ed25519 keys if EdDSA is supported"
-            )
+        if "RS256" in signing_algs:
+            rsa_keys = [key for key in jwks_doc["keys"] if key.get("kty") == "RSA"]
+            assert len(rsa_keys) > 0, "Should have RSA keys if RS256 is supported"
 
     @pytest.mark.asyncio
     async def test_oidc_endpoints_security_headers(self, async_client):
@@ -415,30 +399,19 @@ class TestOIDCCompliance:
             assert "kty" in key, "Each JWK must have 'kty' parameter"
 
     @pytest.mark.asyncio
-    async def test_ed25519_key_rfc8037_compliance(self, async_client):
-        """Test that Ed25519 keys comply with RFC 8037 (CFRG Elliptic Curve Keys)."""
+    async def test_rsa_key_structure(self, async_client):
+        """Ensure RSA keys expose required parameters."""
         response = await async_client.get("/.well-known/jwks.json")
         jwks_doc = response.json()
 
-        # Find Ed25519 keys
-        ed25519_keys = [
-            key
-            for key in jwks_doc["keys"]
-            if key.get("kty") == "OKP" and key.get("crv") == "Ed25519"
-        ]
+        rsa_keys = [key for key in jwks_doc["keys"] if key.get("kty") == "RSA"]
 
-        assert len(ed25519_keys) > 0, "Should have at least one Ed25519 key"
+        assert len(rsa_keys) > 0, "Should have at least one RSA key"
 
-        for key in ed25519_keys:
-            # RFC 8037 Section 2 - OKP Key Type
-            assert key["kty"] == "OKP", "Ed25519 keys must have kty=OKP"
-            assert key["crv"] == "Ed25519", "Must specify Ed25519 curve"
-            assert "x" in key, "Must have 'x' parameter (public key)"
-
-            # x parameter should be base64url-encoded
-            x_value = key["x"]
-            assert isinstance(x_value, str), "'x' parameter must be a string"
-            assert len(x_value) > 0, "'x' parameter must not be empty"
+        for key in rsa_keys:
+            assert "n" in key and "e" in key, (
+                "RSA keys must include modulus and exponent"
+            )
 
     @pytest.mark.asyncio
     async def test_content_type_compliance(self, async_client):

--- a/pkgs/standards/auto_authn/tests/unit/test_oidc_id_token.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_oidc_id_token.py
@@ -1,0 +1,27 @@
+import base64
+import json
+
+import pytest
+
+from auto_authn.v2.oidc_id_token import mint_id_token, verify_id_token
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("temp_key_file")
+def test_mint_and_verify_id_token():
+    token = mint_id_token(
+        sub="user1",
+        aud="client1",
+        nonce="n-0S6_WzA2Mj",
+        issuer="https://example.com",
+    )
+    header_b64, payload_b64, _ = token.split(".")
+    header = json.loads(base64.urlsafe_b64decode(header_b64 + "=="))
+    assert header["alg"] == "RS256"
+
+    claims = verify_id_token(token, issuer="https://example.com", audience="client1")
+    assert claims["sub"] == "user1"
+    assert claims["aud"] == "client1"
+    assert claims["iss"] == "https://example.com"
+    assert claims["nonce"] == "n-0S6_WzA2Mj"
+    assert "exp" in claims and "iat" in claims

--- a/pkgs/standards/swarmauri_signing_jws/swarmauri_signing_jws/JwsSignerVerifier.py
+++ b/pkgs/standards/swarmauri_signing_jws/swarmauri_signing_jws/JwsSignerVerifier.py
@@ -67,9 +67,9 @@ def _jwk_to_pub_for_signer(jwk: Mapping[str, Any]) -> Any:
 
 
 _RSA_RS = {
-    JWAAlg.RS256: "RSA-PKCS1v15-SHA256",
-    JWAAlg.RS384: "RSA-PKCS1v15-SHA384",
-    JWAAlg.RS512: "RSA-PKCS1v15-SHA512",
+    JWAAlg.RS256: "RS256",
+    JWAAlg.RS384: "RS384",
+    JWAAlg.RS512: "RS512",
 }
 _RSA_PS = {
     JWAAlg.PS256: "RSA-PSS-SHA256",


### PR DESCRIPTION
## Summary
- support RSA/RS256 ID token minting and verification
- expose RS256 key material via JWKS and update OIDC tests
- align JWS signer with RS256 algorithm names

## Testing
- `uv run --package swarmauri_signing_jws --directory standards/swarmauri_signing_jws pytest`
- `uv run --package auto_authn --directory standards/auto_authn pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac8af1aaa88326baa5cb848812338e