### PR TITLE
feat(auto_authn): add dynamic client registration

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/app.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/app.py
@@ -28,6 +28,7 @@ from .rfc8628 import include_rfc8628
 from .rfc9126 import include_rfc9126
 from .rfc7009 import include_rfc7009
 from .rfc8693 import include_rfc8693
+from .rfc7591 import include_rfc7591
 
 
 # --------------------------------------------------------------------
@@ -51,6 +52,8 @@ if settings.enable_rfc7009:
     include_rfc7009(app)
 if settings.enable_rfc8693:
     include_rfc8693(app)
+if settings.enable_rfc7591:
+    include_rfc7591(app)
 if settings.enable_rfc8414:
     include_rfc8414(app)
 
@@ -85,12 +88,11 @@ async def methodz():
 
 @app.get("/.well-known/openid-configuration", include_in_schema=False)
 async def oidc_config():
-    return {
+    config = {
         "issuer": ISSUER,
         "authorization_endpoint": f"{ISSUER}/authorize",
         "token_endpoint": f"{ISSUER}/token",
         "userinfo_endpoint": f"{ISSUER}/userinfo",
-        "registration_endpoint": f"{ISSUER}/register",
         "scopes_supported": ["openid", "profile", "email", "address", "phone"],
         "claims_supported": [
             "sub",
@@ -103,13 +105,14 @@ async def oidc_config():
             "phone_number",
             "phone_number_verified",
         ],
-        "response_types_supported": ["token"],
-        "jwks_uri": f"{ISSUER}{JWKS_PATH}",
-        "scopes_supported": ["openid", "profile", "email"],
         "response_types_supported": ["code", "id_token"],
+        "jwks_uri": f"{ISSUER}{JWKS_PATH}",
         "subject_types_supported": ["public"],
         "id_token_signing_alg_values_supported": ["RS256"],
     }
+    if settings.enable_rfc7591:
+        config["registration_endpoint"] = f"{ISSUER}/clients"
+    return config
 
 
 @app.get(JWKS_PATH, include_in_schema=False)

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8932.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8932.py
@@ -67,7 +67,6 @@ def get_enhanced_authorization_server_metadata() -> Dict[str, Any]:
         "authorization_endpoint": f"{ISSUER}/authorize",
         "token_endpoint": f"{ISSUER}/token",
         "jwks_uri": f"{ISSUER}{JWKS_PATH}",
-        "registration_endpoint": f"{ISSUER}/register",
         "scopes_supported": [
             "openid",
             "profile",
@@ -124,6 +123,8 @@ def get_enhanced_authorization_server_metadata() -> Dict[str, Any]:
         ],
         "code_challenge_methods_supported": ["S256"],
     }
+    if settings.enable_rfc7591:
+        base_metadata["registration_endpoint"] = f"{ISSUER}/clients"
 
     # Enhanced metadata extensions
     enhanced_metadata = {}

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7591_client_registration_endpoint.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7591_client_registration_endpoint.py
@@ -1,20 +1,39 @@
-"""Tests for missing OAuth2 Dynamic Client Registration endpoint (RFC 7591)."""
+"""Tests for OAuth2 Dynamic Client Registration endpoint (RFC 7591)."""
 
 import pytest
 from fastapi import FastAPI, status
 from httpx import ASGITransport, AsyncClient
 
-from auto_authn.v2.routers.auth_flows import router
+from auto_authn.v2.rfc7591 import include_rfc7591
+from auto_authn.v2.runtime_cfg import settings
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_rfc7591_client_registration_not_implemented() -> None:
-    """Posting RFC 7591 client metadata to `/register` yields validation error."""
+async def test_rfc7591_client_registration_endpoint(monkeypatch) -> None:
+    """Posting RFC 7591 client metadata to `/clients` registers the client."""
     app = FastAPI()
-    app.include_router(router)
+    monkeypatch.setattr(settings, "enable_rfc7591", True)
+    include_rfc7591(app)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         payload = {"redirect_uris": ["https://client.example/cb"]}
-        resp = await client.post("/register", json=payload)
-    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        resp = await client.post("/clients", json=payload)
+    assert resp.status_code == status.HTTP_201_CREATED
+    data = resp.json()
+    assert data["redirect_uris"] == payload["redirect_uris"]
+    assert "client_id" in data and "client_secret" in data
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_rfc7591_client_registration_disabled(monkeypatch) -> None:
+    """When disabled, the registration endpoint is unavailable."""
+    app = FastAPI()
+    monkeypatch.setattr(settings, "enable_rfc7591", False)
+    include_rfc7591(app)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        payload = {"redirect_uris": ["https://client.example/cb"]}
+        resp = await client.post("/clients", json=payload)
+    assert resp.status_code == status.HTTP_404_NOT_FOUND

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7592_client_management_endpoint.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7592_client_management_endpoint.py
@@ -4,16 +4,18 @@ import pytest
 from fastapi import FastAPI, status
 from httpx import ASGITransport, AsyncClient
 
-from auto_authn.v2.routers.auth_flows import router
+from auto_authn.v2.rfc7591 import include_rfc7591
+from auto_authn.v2.runtime_cfg import settings
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_rfc7592_client_management_not_implemented() -> None:
+async def test_rfc7592_client_management_not_implemented(monkeypatch) -> None:
     """Attempts to manage clients return 404 as the endpoints are absent."""
     app = FastAPI()
-    app.include_router(router)
+    monkeypatch.setattr(settings, "enable_rfc7591", True)
+    include_rfc7591(app)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.get("/register/some-client-id")
+        resp = await client.get("/clients/some-client-id")
     assert resp.status_code == status.HTTP_404_NOT_FOUND


### PR DESCRIPTION
## Summary
- add RFC 7591 dynamic client registration endpoint at `/clients`
- expose registration endpoint in OIDC discovery metadata when enabled
- test client registration and absence of management endpoints

## Testing
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff format auto_authn/v2/app.py`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check . --fix`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn pytest` *(fails: no such table: authn.users, missing DB setup in example tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8c8ac698832699e65c56859b270e