### PR TITLE
feat(auto_authn): enrich OIDC discovery metadata

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/app.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/app.py
@@ -109,13 +109,21 @@ async def oidc_config():
         "token id_token",
         "code token id_token",
     ]
-    return {
+    config = {
         "issuer": ISSUER,
         "authorization_endpoint": f"{ISSUER}/authorize",
         "token_endpoint": f"{ISSUER}/token",
         "userinfo_endpoint": f"{ISSUER}/userinfo",
-
         "jwks_uri": f"{ISSUER}{JWKS_PATH}",
+        "scopes_supported": scopes,
+        "claims_supported": claims,
+        "response_types_supported": response_types,
+        "grant_types_supported": ["authorization_code", "refresh_token"],
+        "token_endpoint_auth_methods_supported": [
+            "client_secret_basic",
+            "client_secret_post",
+        ],
+        "code_challenge_methods_supported": ["S256", "plain"],
         "subject_types_supported": ["public"],
         "id_token_signing_alg_values_supported": ["RS256"],
     }

--- a/pkgs/standards/auto_authn/tests/unit/test_openid_configuration.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_openid_configuration.py
@@ -14,3 +14,8 @@ async def test_openid_configuration_contains_required_fields(async_client) -> No
     assert "token" in data["response_types_supported"]
     assert "id_token" in data["response_types_supported"]
     assert data["id_token_signing_alg_values_supported"] == ["RS256"]
+    assert "openid" in data["scopes_supported"]
+    assert "sub" in data["claims_supported"]
+    assert "authorization_code" in data["grant_types_supported"]
+    assert "client_secret_basic" in data["token_endpoint_auth_methods_supported"]
+    assert "S256" in data["code_challenge_methods_supported"]


### PR DESCRIPTION
## Summary
- expand OpenID discovery document to advertise scopes, claims, grant types, token auth methods, and PKCE methods
- test that OIDC discovery endpoint returns complete metadata

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac9114fc8883269e84c60efe4e8541