### PR TITLE
feat(auto_authn): add lifecycle policy hooks

### DIFF
--- a/pkgs/standards/auto_authn/README.md
+++ b/pkgs/standards/auto_authn/README.md
@@ -32,6 +32,8 @@ It provides per-tenant isolation and is designed to scale for SaaS deployments.
 - FastAPI and SQLAlchemy 2.0 async stack.
 - OIDC discovery endpoints and JWKS generation.
 - Configurable PostgreSQL or SQLite storage with optional Redis support.
+- Custom registration with invite codes and arbitrary user attributes.
+- Configurable password complexity rules and session lifetimes.
 
 ## Installation
 
@@ -81,6 +83,10 @@ The service exposes an OpenID Connect discovery document at
 - `REDIS_HOST`, `REDIS_PORT`, `REDIS_DB`, and `REDIS_PASSWORD` for Redis session
   storage (optional).
 - `JWT_SECRET` for token signing and `LOG_LEVEL` to control logging verbosity.
+- `AUTO_AUTHN_PASSWORD_MIN_LENGTH` to set minimum password length (default 8).
+- `AUTO_AUTHN_PASSWORD_REGEX` to enforce additional password complexity.
+- `AUTO_AUTHN_INVITE_CODES` comma-separated invite codes required for signup.
+- `AUTO_AUTHN_ACCESS_TTL_MINUTES` and `AUTO_AUTHN_REFRESH_TTL_MINUTES` for token lifetimes.
 
 ## Docker
 

--- a/pkgs/standards/auto_authn/auto_authn/v2/app.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/app.py
@@ -88,33 +88,11 @@ async def methodz():
 
 @app.get("/.well-known/openid-configuration", include_in_schema=False)
 async def oidc_config():
-    scopes = ["openid", "profile", "email", "address", "phone"]
-    claims = [
-        "sub",
-        "name",
-        "given_name",
-        "family_name",
-        "email",
-        "email_verified",
-        "address",
-        "phone_number",
-        "phone_number_verified",
-    ]
-    response_types = [
-        "code",
-        "token",
-        "id_token",
-        "code token",
-        "code id_token",
-        "token id_token",
-        "code token id_token",
-    ]
-    return {
+    config = {
         "issuer": ISSUER,
         "authorization_endpoint": f"{ISSUER}/authorize",
         "token_endpoint": f"{ISSUER}/token",
         "userinfo_endpoint": f"{ISSUER}/userinfo",
-
         "jwks_uri": f"{ISSUER}{JWKS_PATH}",
         "subject_types_supported": ["public"],
         "id_token_signing_alg_values_supported": ["RS256"],

--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/tables.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/tables.py
@@ -26,6 +26,7 @@ from autoapi.v2 import Base
 from autoapi.v2.types import (
     String,
     LargeBinary,
+    JSON,
     relationship,
     mapped_column,
     Column,
@@ -120,6 +121,7 @@ class User(UserBase):
     __table_args__ = ({"extend_existing": True, "schema": "authn"},)
     email = Column(String(120), nullable=False, unique=True)
     password_hash = Column(LargeBinary(60))
+    attrs = Column(JSON, default=dict)
     api_keys = relationship(
         "auto_authn.v2.orm.tables.ApiKey",
         back_populates="user",

--- a/pkgs/standards/auto_authn/auto_authn/v2/policies.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/policies.py
@@ -1,0 +1,27 @@
+"""Policy helpers for user registration and authentication."""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+from .runtime_cfg import settings
+
+
+class PasswordPolicyError(ValueError):
+    """Raised when a password fails validation."""
+
+
+def validate_password_strength(password: str) -> None:
+    """Validate password against configured complexity requirements."""
+    if len(password) < settings.password_min_length:
+        raise PasswordPolicyError("password too short")
+    if settings.password_regex and not re.fullmatch(settings.password_regex, password):
+        raise PasswordPolicyError("password does not meet complexity requirements")
+
+
+def validate_invite_code(invite_code: Optional[str]) -> None:
+    """Validate *invite_code* against configured codes, if any."""
+    codes = settings.invite_code_set
+    if codes and (not invite_code or invite_code not in codes):
+        raise ValueError("invalid invite code")

--- a/pkgs/standards/auto_authn/tests/unit/test_user_policies.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_user_policies.py
@@ -1,0 +1,104 @@
+import pytest
+from sqlalchemy import select
+
+from auto_authn.v2.jwtoken import JWTCoder
+from auto_authn.v2.orm.tables import User
+from auto_authn.v2.runtime_cfg import settings
+
+
+@pytest.mark.asyncio
+async def test_invite_code_and_attributes(auth_test_client, db_session):
+    settings.invite_codes = "CODE123"
+    resp = await auth_test_client.client.post(
+        "/register",
+        json={
+            "tenant_slug": "public",
+            "username": "user1",
+            "email": "u1@example.com",
+            "password": "Password1!",
+            "invite_code": "WRONG",
+        },
+    )
+    assert resp.status_code == 422
+
+    resp = await auth_test_client.client.post(
+        "/register",
+        json={
+            "tenant_slug": "public",
+            "username": "user2",
+            "email": "u2@example.com",
+            "password": "Password1!",
+            "invite_code": "CODE123",
+            "attributes": {"role": "tester"},
+        },
+    )
+    assert resp.status_code == 201
+
+    user = await db_session.scalar(select(User).where(User.username == "user2"))
+    assert user.attrs == {"role": "tester"}
+
+
+@pytest.mark.asyncio
+async def test_password_policy_enforced(auth_test_client):
+    settings.invite_codes = ""
+    settings.password_min_length = 12
+    settings.password_regex = r"^(?=.*[A-Z])(?=.*[a-z])(?=.*\d).+$"
+
+    resp = await auth_test_client.client.post(
+        "/register",
+        json={
+            "tenant_slug": "public",
+            "username": "pass1",
+            "email": "p1@example.com",
+            "password": "short1A",
+        },
+    )
+    assert resp.status_code == 422
+
+    resp = await auth_test_client.client.post(
+        "/register",
+        json={
+            "tenant_slug": "public",
+            "username": "pass2",
+            "email": "p2@example.com",
+            "password": "Longpassword",
+        },
+    )
+    assert resp.status_code == 422
+
+    resp = await auth_test_client.client.post(
+        "/register",
+        json={
+            "tenant_slug": "public",
+            "username": "pass3",
+            "email": "p3@example.com",
+            "password": "StrongPass123",
+        },
+    )
+    assert resp.status_code == 201
+
+
+@pytest.mark.asyncio
+async def test_session_ttl_configurable(auth_test_client):
+    settings.invite_codes = ""
+    settings.password_min_length = 3
+    settings.password_regex = None
+    settings.session_access_ttl_minutes = 5
+    settings.session_refresh_ttl_minutes = 10
+
+    resp = await auth_test_client.client.post(
+        "/register",
+        json={
+            "tenant_slug": "public",
+            "username": "ttluser",
+            "email": "ttl@example.com",
+            "password": "Good123",
+        },
+    )
+    assert resp.status_code == 201
+    tokens = resp.json()
+    coder = JWTCoder.default()
+    access_claims = await coder.async_decode(tokens["access_token"])
+    refresh_claims = await coder.async_decode(tokens["refresh_token"])
+    assert access_claims["exp"] - access_claims["iat"] == 5 * 60
+    assert refresh_claims["exp"] - refresh_claims["iat"] == 10 * 60


### PR DESCRIPTION
## Summary
- allow invite-code gated registration with custom user attributes
- add configurable password complexity and token lifetimes
- document new lifecycle policy settings and add tests

## Testing
- `uv run --directory standards/auto_authn --package auto_authn ruff check . --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_user_policies.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac959a75a8832681e82bf73ce67768