### PR TITLE
feat(auto_authn): implement OIDC client registration endpoint

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/app.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/app.py
@@ -109,18 +109,20 @@ async def oidc_config():
         "token id_token",
         "code token id_token",
     ]
-    return {
+    config = {
         "issuer": ISSUER,
         "authorization_endpoint": f"{ISSUER}/authorize",
         "token_endpoint": f"{ISSUER}/token",
         "userinfo_endpoint": f"{ISSUER}/userinfo",
-
         "jwks_uri": f"{ISSUER}{JWKS_PATH}",
+        "scopes_supported": scopes,
+        "response_types_supported": response_types,
         "subject_types_supported": ["public"],
         "id_token_signing_alg_values_supported": ["RS256"],
+        "claims_supported": claims,
     }
     if settings.enable_rfc7591:
-        config["registration_endpoint"] = f"{ISSUER}/clients"
+        config["registration_endpoint"] = f"{ISSUER}/register"
     return config
 
 

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8932.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8932.py
@@ -124,7 +124,7 @@ def get_enhanced_authorization_server_metadata() -> Dict[str, Any]:
         "code_challenge_methods_supported": ["S256"],
     }
     if settings.enable_rfc7591:
-        base_metadata["registration_endpoint"] = f"{ISSUER}/clients"
+        base_metadata["registration_endpoint"] = f"{ISSUER}/register"
 
     # Enhanced metadata extensions
     enhanced_metadata = {}

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7591_client_registration_endpoint.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7591_client_registration_endpoint.py
@@ -11,14 +11,14 @@ from auto_authn.v2.runtime_cfg import settings
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_rfc7591_client_registration_endpoint(monkeypatch) -> None:
-    """Posting RFC 7591 client metadata to `/clients` registers the client."""
+    """Posting RFC 7591 client metadata to `/register` registers the client."""
     app = FastAPI()
     monkeypatch.setattr(settings, "enable_rfc7591", True)
     include_rfc7591(app)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        payload = {"redirect_uris": ["https://client.example/cb"]}
-        resp = await client.post("/clients", json=payload)
+        payload = {"redirect_uris": ["http://127.0.0.1/cb"]}
+        resp = await client.post("/register", json=payload)
     assert resp.status_code == status.HTTP_201_CREATED
     data = resp.json()
     assert data["redirect_uris"] == payload["redirect_uris"]
@@ -34,6 +34,6 @@ async def test_rfc7591_client_registration_disabled(monkeypatch) -> None:
     include_rfc7591(app)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        payload = {"redirect_uris": ["https://client.example/cb"]}
-        resp = await client.post("/clients", json=payload)
+        payload = {"redirect_uris": ["http://127.0.0.1/cb"]}
+        resp = await client.post("/register", json=payload)
     assert resp.status_code == status.HTTP_404_NOT_FOUND

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7591_dynamic_client_registration.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7591_dynamic_client_registration.py
@@ -16,11 +16,11 @@ def test_register_client_when_enabled() -> None:
 
     with patch.object(rfc7591.settings, "enable_rfc7591", True):
         rfc7591.reset_client_registry()
-        client = rfc7591.register_client({"redirect_uris": ["https://a.example/cb"]})
+        client = rfc7591.register_client({"redirect_uris": ["http://127.0.0.1/cb"]})
         assert "client_id" in client
         stored = rfc7591.get_client(client["client_id"])
         assert stored is not None
-        assert stored["redirect_uris"] == ["https://a.example/cb"]
+        assert stored["redirect_uris"] == ["http://127.0.0.1/cb"]
 
 
 def test_register_client_disabled_raises() -> None:

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7592_client_management_endpoint.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7592_client_management_endpoint.py
@@ -17,5 +17,5 @@ async def test_rfc7592_client_management_not_implemented(monkeypatch) -> None:
     include_rfc7591(app)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.get("/clients/some-client-id")
+        resp = await client.get("/register/some-client-id")
     assert resp.status_code == status.HTTP_404_NOT_FOUND


### PR DESCRIPTION
## Summary
- align dynamic client registration with OIDC by using POST /register and validating redirect URIs
- surface registration_endpoint and supported values in discovery metadata
- adjust tests to target new registration flow

## Testing
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff format .`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check . --fix`
- `uv run --package auto_authn --directory pkgs/standards/auto_authn pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac9116904c8326b63f9156c450cc0a