### PR TITLE
feat: RS256 ID tokens include access and code hashes

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/oidc_id_token.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/oidc_id_token.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import asyncio
 import os
 import pathlib
+import base64
+from hashlib import sha256
 from datetime import timedelta
 from functools import lru_cache
 from typing import Any, Iterable, Mapping, Tuple
@@ -78,6 +80,14 @@ def _service() -> Tuple[JWTTokenService, str]:
 # ---------------------------------------------------------------------------
 
 
+def oidc_hash(value: str) -> str:
+    """Return the OIDC token hash for *value* per Core §3.3.2.11."""
+
+    digest = sha256(value.encode("ascii")).digest()
+    half = digest[: len(digest) // 2]
+    return base64.urlsafe_b64encode(half).decode("ascii").rstrip("=")
+
+
 def mint_id_token(
     *,
     sub: str,
@@ -121,4 +131,10 @@ def verify_id_token(token: str, *, issuer: str, audience: Iterable[str] | str) -
 rsa_key_provider = _provider
 ensure_rsa_jwt_key = _ensure_key
 
-__all__ = ["mint_id_token", "verify_id_token", "rsa_key_provider", "ensure_rsa_jwt_key"]
+__all__ = [
+    "mint_id_token",
+    "verify_id_token",
+    "oidc_hash",
+    "rsa_key_provider",
+    "ensure_rsa_jwt_key",
+]

--- a/pkgs/standards/auto_authn/tests/unit/test_authorize_id_token_hashes.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_authorize_id_token_hashes.py
@@ -1,0 +1,92 @@
+import uuid
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from fastapi import status
+
+from auto_authn.v2.crypto import hash_pw
+from auto_authn.v2.orm.tables import Client, Tenant, User
+from auto_authn.v2.oidc_id_token import oidc_hash, verify_id_token
+from auto_authn.v2.rfc8414 import ISSUER
+from auto_authn.v2.routers.auth_flows import AUTH_CODES
+
+
+@pytest.mark.usefixtures("temp_key_file")
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_authorize_includes_at_hash(async_client, db_session):
+    tenant_id = uuid.uuid4()
+    tenant = Tenant(id=tenant_id, name="T1", email="t1@example.com")
+    client = Client(
+        id="client1",
+        tenant_id=tenant_id,
+        client_secret_hash=hash_pw("secret"),
+        redirect_uris="https://client.example/cb",
+    )
+    user = User(
+        id=uuid.uuid4(),
+        tenant_id=tenant_id,
+        username="alice",
+        email="alice@example.com",
+        password_hash=hash_pw("password"),
+    )
+    db_session.add_all([tenant, client, user])
+    await db_session.commit()
+
+    params = {
+        "response_type": "token id_token",
+        "client_id": "client1",
+        "redirect_uri": "https://client.example/cb",
+        "scope": "openid",
+        "nonce": "n",
+        "username": "alice",
+        "password": "password",
+    }
+    resp = await async_client.get("/authorize", params=params, follow_redirects=False)
+    assert resp.status_code == status.HTTP_307_TEMPORARY_REDIRECT
+    query = parse_qs(urlparse(resp.headers["location"]).query)
+    access = query["access_token"][0]
+    id_token = query["id_token"][0]
+    claims = verify_id_token(id_token, issuer=ISSUER, audience="client1")
+    assert claims["at_hash"] == oidc_hash(access)
+
+
+@pytest.mark.usefixtures("temp_key_file")
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_authorize_includes_c_hash(async_client, db_session):
+    tenant_id = uuid.uuid4()
+    tenant = Tenant(id=tenant_id, name="T2", email="t2@example.com")
+    client = Client(
+        id="client2",
+        tenant_id=tenant_id,
+        client_secret_hash=hash_pw("secret"),
+        redirect_uris="https://client.example/cb",
+    )
+    user = User(
+        id=uuid.uuid4(),
+        tenant_id=tenant_id,
+        username="bob",
+        email="bob@example.com",
+        password_hash=hash_pw("password"),
+    )
+    db_session.add_all([tenant, client, user])
+    await db_session.commit()
+
+    params = {
+        "response_type": "code id_token",
+        "client_id": "client2",
+        "redirect_uri": "https://client.example/cb",
+        "scope": "openid",
+        "nonce": "n",
+        "username": "bob",
+        "password": "password",
+    }
+    resp = await async_client.get("/authorize", params=params, follow_redirects=False)
+    assert resp.status_code == status.HTTP_307_TEMPORARY_REDIRECT
+    query = parse_qs(urlparse(resp.headers["location"]).query)
+    code = query["code"][0]
+    id_token = query["id_token"][0]
+    claims = verify_id_token(id_token, issuer=ISSUER, audience="client2")
+    assert claims["c_hash"] == oidc_hash(code)
+    AUTH_CODES.clear()


### PR DESCRIPTION
## Summary
- use mint_id_token to sign ID Tokens with RS256
- embed at_hash and c_hash claims in ID Tokens when access tokens or authorization codes are issued
- test authorize endpoint for at_hash and c_hash behavior

## Testing
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff format .`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check . --fix` *(fails: unused variables in app.py)*
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check auto_authn/v2/routers/auth_flows.py auto_authn/v2/oidc_id_token.py tests/unit/test_authorize_id_token_hashes.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_68ac97f5cf0c83268897a9461eb166b9