### PR TITLE
feat(auto_authn): enforce HTTPS redirect URIs for dynamic registration

### DIFF
--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7591_client_registration_endpoint.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7591_client_registration_endpoint.py
@@ -23,6 +23,8 @@ async def test_rfc7591_client_registration_endpoint(monkeypatch) -> None:
     data = resp.json()
     assert data["redirect_uris"] == payload["redirect_uris"]
     assert "client_id" in data and "client_secret" in data
+    assert data["grant_types"] == ["authorization_code"]
+    assert data["response_types"] == ["code"]
 
 
 @pytest.mark.unit
@@ -37,3 +39,17 @@ async def test_rfc7591_client_registration_disabled(monkeypatch) -> None:
         payload = {"redirect_uris": ["https://client.example/cb"]}
         resp = await client.post("/clients", json=payload)
     assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_rfc7591_redirect_uris_must_use_https(monkeypatch) -> None:
+    """Non-HTTPS redirect URIs for non-localhost are rejected."""
+    app = FastAPI()
+    monkeypatch.setattr(settings, "enable_rfc7591", True)
+    include_rfc7591(app)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        payload = {"redirect_uris": ["http://evil.example/cb"]}
+        resp = await client.post("/clients", json=payload)
+    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY


### PR DESCRIPTION
## Summary
- validate redirect_uris for dynamic client registration to require HTTPS (localhost exceptions)
- default grant_types and response_types for new clients
- test dynamic registration redirect URI enforcement

## Testing
- `uv run --directory standards/auto_authn --package auto_authn ruff format .`
- `uv run --directory standards/auto_authn --package auto_authn ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68ac99ff77ac832697256e8c398cf163