### PR TITLE
feat(auto_authn): add rs256 jwa support

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7518.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7518.py
@@ -8,6 +8,8 @@ See RFC 7518: https://www.rfc-editor.org/rfc/rfc7518
 
 from typing import Final
 
+from swarmauri_core.crypto.types import JWAAlg
+
 from .runtime_cfg import settings
 from .rfc8812 import WEBAUTHN_ALGORITHMS
 
@@ -18,10 +20,15 @@ def supported_algorithms() -> list[str]:
     """Return algorithms supported for JOSE operations."""
     if not settings.enable_rfc7518:
         raise RuntimeError(f"RFC 7518 support disabled: {RFC7518_SPEC_URL}")
-    algs = ["EdDSA"]
+
+    algs = {alg.value for alg in JWAAlg}
     if settings.enable_rfc8812:
-        algs.extend(sorted(WEBAUTHN_ALGORITHMS))
-    return algs
+        algs.update(WEBAUTHN_ALGORITHMS)
+    else:
+        # Ensure RS256 is always available even when WebAuthn algorithms are
+        # disabled. This is required for OpenID Connect ID Token compliance.
+        algs.add(JWAAlg.RS256.value)
+    return sorted(algs)
 
 
 __all__ = ["supported_algorithms", "RFC7518_SPEC_URL"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7800.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7800.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, Final, Mapping
 
 from .runtime_cfg import settings
 from .rfc7638 import jwk_thumbprint
+
 RFC7800_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc7800"
 
 

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7518_jwa.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7518_jwa.py
@@ -5,3 +5,7 @@ from auto_authn.v2 import supported_algorithms
 
 def test_supported_algorithms_contains_eddsa() -> None:
     assert "EdDSA" in supported_algorithms()
+
+
+def test_supported_algorithms_contains_rs256() -> None:
+    assert "RS256" in supported_algorithms()


### PR DESCRIPTION
## Summary
- expose all JWA algorithms and guarantee RS256 availability
- test that supported algorithms include EdDSA and RS256

## Testing
- `uv run --package auto_authn --directory pkgs/standards/auto_authn ruff format .`
- `uv run --package auto_authn --directory pkgs/standards/auto_authn ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68ac99cf959c8326953af7cde3466f65