### PR TITLE
feat: add OIDC userinfo endpoint

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/app.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/app.py
@@ -29,6 +29,7 @@ from .rfc9126 import include_rfc9126
 from .rfc7009 import include_rfc7009
 from .rfc8693 import include_rfc8693
 from .rfc7591 import include_rfc7591
+from .oidc_userinfo import include_oidc_userinfo
 
 
 # --------------------------------------------------------------------
@@ -54,6 +55,7 @@ if settings.enable_rfc8693:
     include_rfc8693(app)
 if settings.enable_rfc7591:
     include_rfc7591(app)
+include_oidc_userinfo(app)
 if settings.enable_rfc8414:
     include_rfc8414(app)
 

--- a/pkgs/standards/auto_authn/auto_authn/v2/oidc_userinfo.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/oidc_userinfo.py
@@ -1,0 +1,51 @@
+"""UserInfo endpoint for OpenID Connect 1.0.
+
+This module implements the `/userinfo` endpoint as described in the
+OpenID Connect Core specification.  It is **not** tied to an RFC so it
+lives in the OIDC namespace instead of an `rfcXXXX` module.
+
+The endpoint returns a minimal set of claims about the authenticated
+user.  Currently the returned claims are a subset of those advertised in
+the discovery document.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from fastapi import FastAPI
+
+from .fastapi_deps import get_current_principal
+from .orm.tables import User
+
+router = APIRouter()
+
+
+@router.get("/userinfo")
+async def userinfo(user: User = Depends(get_current_principal)) -> dict[str, str]:
+    """Return claims about the authenticated user.
+
+    The caller must present a valid access token in the `Authorization`
+    header.  For now, the response includes only a subset of standard
+    claims.
+    """
+
+    return {
+        "sub": str(user.id),
+        "name": user.username,
+        "email": user.email,
+    }
+
+
+# ---------------------------------------------------------------------------
+# FastAPI integration
+# ---------------------------------------------------------------------------
+
+
+def include_oidc_userinfo(app: FastAPI) -> None:
+    """Attach the UserInfo endpoint to *app* if not already present."""
+
+    if not any(route.path == "/userinfo" for route in app.routes):
+        app.include_router(router)
+
+
+__all__ = ["router", "include_oidc_userinfo"]


### PR DESCRIPTION
## Summary
- add `oidc_userinfo` module implementing OIDC UserInfo endpoint
- register UserInfo route in auth service app

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_authorize_id_token_hashes.py::test_authorize_includes_at_hash -q` *(fails: AttributeError 'str' object has no attribute 'hex')*


------
https://chatgpt.com/codex/tasks/task_e_68ac9adcda588326825b8dd911bb9287