### PR TITLE
feat(auto_authn): expand discovery metadata

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/app.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/app.py
@@ -125,6 +125,12 @@ async def oidc_config():
         claims_supported=claims,
         response_types_supported=response_types,
         grant_types_supported=["authorization_code", "refresh_token"],
+        token_endpoint_auth_methods_supported=[
+            "client_secret_basic",
+            "client_secret_post",
+        ],
+        response_modes_supported=["query", "fragment", "form_post"],
+        code_challenge_methods_supported=["S256"],
     )
     if settings.enable_rfc7591:
         config["registration_endpoint"] = f"{ISSUER}/clients"

--- a/pkgs/standards/auto_authn/tests/unit/test_openid_configuration.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_openid_configuration.py
@@ -19,3 +19,4 @@ async def test_openid_configuration_contains_required_fields(async_client) -> No
     assert "authorization_code" in data["grant_types_supported"]
     assert "client_secret_basic" in data["token_endpoint_auth_methods_supported"]
     assert "S256" in data["code_challenge_methods_supported"]
+    assert "query" in data["response_modes_supported"]


### PR DESCRIPTION
## Summary
- advertise supported client auth methods and response modes in OIDC discovery
- cover new metadata in unit test

## Testing
- `uv run --directory standards/auto_authn --package auto_authn ruff format .`
- `uv run --directory standards/auto_authn --package auto_authn ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68ac9e72457c832681e7dc26a44f1c38