### PR TITLE
Validate openid scope in authorize endpoint

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/routers/auth_flows.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/routers/auth_flows.py
@@ -202,6 +202,8 @@ async def authorize(
         )
     if "id_token" in rts and not nonce:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, {"error": "invalid_request"})
+    if "openid" not in scope.split():
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, {"error": "invalid_scope"})
     client = await db.get(Client, client_id)
     if client is None or redirect_uri not in (client.redirect_uris or "").split():
         raise HTTPException(status.HTTP_400_BAD_REQUEST, {"error": "invalid_request"})

--- a/pkgs/standards/auto_authn/tests/unit/test_authorize_requires_openid_scope.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_authorize_requires_openid_scope.py
@@ -1,0 +1,42 @@
+import uuid
+
+import pytest
+from fastapi import status
+
+from auto_authn.v2.crypto import hash_pw
+from auto_authn.v2.orm.tables import Client, Tenant, User
+
+
+@pytest.mark.usefixtures("temp_key_file")
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_authorize_requires_openid_scope(async_client, db_session):
+    tenant_id = uuid.uuid4()
+    tenant = Tenant(id=tenant_id, name="T1", email="t1@example.com")
+    client = Client(
+        id="client1",
+        tenant_id=tenant_id,
+        client_secret_hash=hash_pw("secret"),
+        redirect_uris="https://client.example/cb",
+    )
+    user = User(
+        id=uuid.uuid4(),
+        tenant_id=tenant_id,
+        username="alice",
+        email="alice@example.com",
+        password_hash=hash_pw("password"),
+    )
+    db_session.add_all([tenant, client, user])
+    await db_session.commit()
+
+    params = {
+        "response_type": "code",
+        "client_id": "client1",
+        "redirect_uri": "https://client.example/cb",
+        "scope": "profile",
+        "username": "alice",
+        "password": "password",
+    }
+    resp = await async_client.get("/authorize", params=params, follow_redirects=False)
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+    assert resp.json()["error"] == "invalid_scope"


### PR DESCRIPTION
## Summary
- ensure /authorize rejects requests missing `openid` in scope
- add unit test for mandatory OpenID scope

## Testing
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff format .`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check . --fix`

------
https://chatgpt.com/codex/tasks/task_e_68ac9e76c4348326bfd731a30b6cb95e