### PR TITLE
feat(auto_authn): add OIDC discovery and JWKS rotation

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/app.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/app.py
@@ -23,7 +23,7 @@ from autoapi.v2 import get_schema  # convenience helper for /methodz
 from .routers.auth_flows import router as flows_router
 from .routers.crud import crud_api as crud_api
 from .runtime_cfg import settings
-from .rfc8414 import JWKS_PATH, ISSUER, include_rfc8414
+from .rfc8414 import include_rfc8414
 from .rfc8628 import include_rfc8628
 from .rfc9126 import include_rfc9126
 from .rfc7009 import include_rfc7009
@@ -81,72 +81,6 @@ async def methodz():
         "openapi_bytes": len(schema.json().encode()),
         "python": sys.version.split()[0],
     }
-
-
-# --------------------------------------------------------------------
-# OIDC discovery + JWKS
-# --------------------------------------------------------------------
-
-
-@app.get("/.well-known/openid-configuration", include_in_schema=False)
-async def oidc_config():
-    scopes = ["openid", "profile", "email", "address", "phone"]
-    claims = [
-        "sub",
-        "name",
-        "given_name",
-        "family_name",
-        "email",
-        "email_verified",
-        "address",
-        "phone_number",
-        "phone_number_verified",
-    ]
-    response_types = [
-        "code",
-        "token",
-        "id_token",
-        "code token",
-        "code id_token",
-        "token id_token",
-        "code token id_token",
-    ]
-    config = {
-        "issuer": ISSUER,
-        "authorization_endpoint": f"{ISSUER}/authorize",
-        "token_endpoint": f"{ISSUER}/token",
-        "userinfo_endpoint": f"{ISSUER}/userinfo",
-        "jwks_uri": f"{ISSUER}{JWKS_PATH}",
-        "subject_types_supported": ["public"],
-        "id_token_signing_alg_values_supported": ["RS256"],
-    }
-    config.update(
-        scopes_supported=scopes,
-        claims_supported=claims,
-        response_types_supported=response_types,
-        grant_types_supported=["authorization_code", "refresh_token"],
-        token_endpoint_auth_methods_supported=[
-            "client_secret_basic",
-            "client_secret_post",
-        ],
-        response_modes_supported=["query", "fragment", "form_post"],
-        code_challenge_methods_supported=["S256"],
-    )
-    if settings.enable_rfc7591:
-        config["registration_endpoint"] = f"{ISSUER}/clients"
-    return config
-
-
-@app.get(JWKS_PATH, include_in_schema=False)
-async def jwks():
-    """Return public key in RFC 7517 JWK Set format."""
-    from .oidc_id_token import ensure_rsa_jwt_key, rsa_key_provider
-
-    kid, _, _ = await ensure_rsa_jwt_key()
-    kp = rsa_key_provider()
-    key_dict = await kp.get_public_jwk(kid)
-    key_dict.setdefault("kid", f"{kid}.1")
-    return {"keys": [key_dict]}
 
 
 async def _startup() -> None:

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8414.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8414.py
@@ -10,9 +10,12 @@ See RFC 8414: https://www.rfc-editor.org/rfc/rfc8414
 
 from __future__ import annotations
 
+import json
 import os
+from functools import lru_cache
+from typing import Any, Final
+
 from fastapi import APIRouter, FastAPI, HTTPException, status
-from typing import Final
 
 from .runtime_cfg import settings
 
@@ -25,13 +28,27 @@ JWKS_PATH = "/.well-known/jwks.json"
 ISSUER = os.getenv("AUTHN_ISSUER", "https://authn.example.com")
 
 
-@router.get("/.well-known/oauth-authorization-server", include_in_schema=False)
-async def authorization_server_metadata():
-    """Return OAuth 2.0 Authorization Server Metadata per RFC 8414."""
-    if not settings.enable_rfc8414:
-        raise HTTPException(
-            status.HTTP_404_NOT_FOUND, f"RFC 8414 disabled: {RFC8414_SPEC_URL}"
-        )
+# ---------------------------------------------------------------------------
+# Discovery document helpers
+# ---------------------------------------------------------------------------
+def _settings_signature() -> str:
+    """Return a stable JSON signature of current settings."""
+    return json.dumps(settings.model_dump(), sort_keys=True)
+
+
+def _build_openid_config() -> dict[str, Any]:
+    scopes = ["openid", "profile", "email", "address", "phone"]
+    claims = [
+        "sub",
+        "name",
+        "given_name",
+        "family_name",
+        "email",
+        "email_verified",
+        "address",
+        "phone_number",
+        "phone_number_verified",
+    ]
     response_types = [
         "code",
         "token",
@@ -41,22 +58,82 @@ async def authorization_server_metadata():
         "token id_token",
         "code token id_token",
     ]
-    return {
+    config: dict[str, Any] = {
         "issuer": ISSUER,
         "authorization_endpoint": f"{ISSUER}/authorize",
         "token_endpoint": f"{ISSUER}/token",
+        "userinfo_endpoint": f"{ISSUER}/userinfo",
         "jwks_uri": f"{ISSUER}{JWKS_PATH}",
-        "scopes_supported": ["openid", "profile", "email", "address", "phone"],
+        "subject_types_supported": ["public"],
+        "id_token_signing_alg_values_supported": ["RS256"],
+        "scopes_supported": scopes,
+        "claims_supported": claims,
         "response_types_supported": response_types,
+        "grant_types_supported": ["authorization_code", "refresh_token"],
+        "token_endpoint_auth_methods_supported": [
+            "client_secret_basic",
+            "client_secret_post",
+        ],
+        "response_modes_supported": ["query", "fragment", "form_post"],
+        "code_challenge_methods_supported": ["S256"],
     }
+    if settings.enable_rfc7591:
+        config["registration_endpoint"] = f"{ISSUER}/clients"
+    return config
+
+
+@lru_cache(maxsize=1)
+def _cached_openid_config(sig: str) -> dict[str, Any]:
+    return _build_openid_config()
+
+
+def refresh_discovery_cache() -> None:
+    """Clear cached discovery metadata."""
+    _cached_openid_config.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+@router.get("/.well-known/oauth-authorization-server", include_in_schema=False)
+async def authorization_server_metadata():
+    """Return OAuth 2.0 Authorization Server Metadata per RFC 8414."""
+    if not settings.enable_rfc8414:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND, f"RFC 8414 disabled: {RFC8414_SPEC_URL}"
+        )
+    return _cached_openid_config(_settings_signature())
+
+
+@router.get("/.well-known/openid-configuration", include_in_schema=False)
+async def openid_configuration():
+    """Return OpenID Connect discovery metadata."""
+    return _cached_openid_config(_settings_signature())
+
+
+@router.get(JWKS_PATH, include_in_schema=False)
+async def jwks():
+    """Publish all public keys in RFC 7517 JWKS format."""
+    from .oidc_id_token import ensure_rsa_jwt_key, rsa_key_provider
+
+    await ensure_rsa_jwt_key()
+    kp = rsa_key_provider()
+    return await kp.jwks()
 
 
 def include_rfc8414(app: FastAPI) -> None:
-    """Attach the RFC 8414 router to *app* if enabled."""
+    """Attach discovery routes to *app* if enabled."""
     if settings.enable_rfc8414 and not any(
-        route.path == "/.well-known/oauth-authorization-server" for route in app.routes
+        route.path == "/.well-known/openid-configuration" for route in app.routes
     ):
         app.include_router(router)
 
 
-__all__ = ["router", "JWKS_PATH", "ISSUER", "include_rfc8414", "RFC8414_SPEC_URL"]
+__all__ = [
+    "router",
+    "JWKS_PATH",
+    "ISSUER",
+    "include_rfc8414",
+    "RFC8414_SPEC_URL",
+    "refresh_discovery_cache",
+]

--- a/pkgs/standards/auto_authn/tests/unit/test_jwks_rotation.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_jwks_rotation.py
@@ -1,0 +1,19 @@
+import pytest
+from fastapi import status
+
+from auto_authn.v2.oidc_id_token import rotate_rsa_jwt_key
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_jwks_rotation_publishes_new_key(async_client, temp_key_file) -> None:
+    resp = await async_client.get("/.well-known/jwks.json")
+    assert resp.status_code == status.HTTP_200_OK
+    before = resp.json()["keys"]
+
+    await rotate_rsa_jwt_key()
+
+    resp = await async_client.get("/.well-known/jwks.json")
+    assert resp.status_code == status.HTTP_200_OK
+    after = resp.json()["keys"]
+    assert len(after) == len(before) + 1

--- a/pkgs/standards/auto_authn/tests/unit/test_openid_configuration.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_openid_configuration.py
@@ -8,8 +8,12 @@ async def test_openid_configuration_contains_required_fields(async_client) -> No
     resp = await async_client.get("/.well-known/openid-configuration")
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
+    from auto_authn.v2.rfc8414 import JWKS_PATH, ISSUER
+
+    assert data["issuer"] == ISSUER
     assert data["authorization_endpoint"].endswith("/authorize")
     assert data["userinfo_endpoint"].endswith("/userinfo")
+    assert data["jwks_uri"].endswith(JWKS_PATH)
     assert "code" in data["response_types_supported"]
     assert "token" in data["response_types_supported"]
     assert "id_token" in data["response_types_supported"]


### PR DESCRIPTION
## Summary
- build OpenID discovery handler and JWKS publishing under RFC 8414 module
- add RSA key rotation helper and expose through JWKS endpoint
- test JWKS key rotation and discovery metadata fields

## Testing
- `uv run --directory standards/auto_authn --package auto_authn ruff format .`
- `uv run --directory standards/auto_authn --package auto_authn ruff check . --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest` *(fails: AssertionError, etc.)*
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_openid_configuration.py tests/unit/test_jwks_rotation.py`


------
https://chatgpt.com/codex/tasks/task_e_68aca13c89008326b4ee7d9768ef46d7