### PR TITLE
feat(auto_authn): add session-aware logout

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/README.md
+++ b/pkgs/standards/auto_authn/auto_authn/v2/README.md
@@ -76,6 +76,12 @@ refreshed = client.post(
 ).json()
 ```
 
+### RP-initiated logout
+
+```python
+client.post("/logout", json={"id_token_hint": tokens["id_token"]})
+```
+
 ### Token revocation (RFC 7009)
 
 ```python


### PR DESCRIPTION
## Summary
- handle sessions via http-only cookies on register and login
- add RP-initiated logout endpoint that validates id_token_hint
- document new logout flow and test session cleanup

## Testing
- `uv run --package auto_authn --directory . ruff format .`
- `uv run --package auto_authn --directory . ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68aca16754748326823dc82f0fa07e00