### PR TITLE
fix: require openid scope on authorize

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/routers/auth_flows.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/routers/auth_flows.py
@@ -202,6 +202,9 @@ async def authorize(
         )
     if "id_token" in rts and not nonce:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, {"error": "invalid_request"})
+    scopes = set(scope.split())
+    if "openid" not in scopes:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, {"error": "invalid_scope"})
     client = await db.get(Client, client_id)
     if client is None or redirect_uri not in (client.redirect_uris or "").split():
         raise HTTPException(status.HTTP_400_BAD_REQUEST, {"error": "invalid_request"})


### PR DESCRIPTION
## Summary
- ensure /authorize validates that requested scopes include `openid`
- add regression test for missing `openid` scope

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aca11602008326a7ba31c847e7a7e1