### PR TITLE
Advertise OIDC registration and management endpoints

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7591.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7591.py
@@ -85,7 +85,7 @@ def register_client(metadata: dict, *, enabled: bool | None = None) -> dict:
     return data
 
 
-@router.post("/clients", status_code=status.HTTP_201_CREATED)
+@router.post("/register", status_code=status.HTTP_201_CREATED)
 async def register_client_endpoint(body: ClientMetadata) -> dict:
     """HTTP endpoint implementing OAuth 2.0 Dynamic Client Registration."""
 
@@ -111,7 +111,7 @@ def include_rfc7591(app: FastAPI) -> None:
     """Attach the RFC 7591 router to *app* if enabled."""
 
     if settings.enable_rfc7591 and not any(
-        route.path == "/clients" for route in app.routes
+        route.path == "/register" for route in app.routes
     ):
         app.include_router(router)
 

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8414.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8414.py
@@ -78,7 +78,19 @@ def _build_openid_config() -> dict[str, Any]:
         "code_challenge_methods_supported": ["S256"],
     }
     if settings.enable_rfc7591:
-        config["registration_endpoint"] = f"{ISSUER}/clients"
+        config["registration_endpoint"] = f"{ISSUER}/register"
+    if settings.enable_rfc7009:
+        config["revocation_endpoint"] = f"{ISSUER}/revoke"
+        config["revocation_endpoint_auth_methods_supported"] = [
+            "client_secret_basic",
+            "client_secret_post",
+        ]
+    if settings.enable_rfc7662:
+        config["introspection_endpoint"] = f"{ISSUER}/introspect"
+        config["introspection_endpoint_auth_methods_supported"] = [
+            "client_secret_basic",
+            "client_secret_post",
+        ]
     return config
 
 

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8932.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8932.py
@@ -124,7 +124,7 @@ def get_enhanced_authorization_server_metadata() -> Dict[str, Any]:
         "code_challenge_methods_supported": ["S256"],
     }
     if settings.enable_rfc7591:
-        base_metadata["registration_endpoint"] = f"{ISSUER}/clients"
+        base_metadata["registration_endpoint"] = f"{ISSUER}/register"
 
     # Enhanced metadata extensions
     enhanced_metadata = {}

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7591_client_registration_endpoint.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7591_client_registration_endpoint.py
@@ -11,14 +11,14 @@ from auto_authn.v2.runtime_cfg import settings
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_rfc7591_client_registration_endpoint(monkeypatch) -> None:
-    """Posting RFC 7591 client metadata to `/clients` registers the client."""
+    """Posting RFC 7591 client metadata to `/register` registers the client."""
     app = FastAPI()
     monkeypatch.setattr(settings, "enable_rfc7591", True)
     include_rfc7591(app)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         payload = {"redirect_uris": ["https://client.example/cb"]}
-        resp = await client.post("/clients", json=payload)
+        resp = await client.post("/register", json=payload)
     assert resp.status_code == status.HTTP_201_CREATED
     data = resp.json()
     assert data["redirect_uris"] == payload["redirect_uris"]
@@ -37,7 +37,7 @@ async def test_rfc7591_client_registration_disabled(monkeypatch) -> None:
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         payload = {"redirect_uris": ["https://client.example/cb"]}
-        resp = await client.post("/clients", json=payload)
+        resp = await client.post("/register", json=payload)
     assert resp.status_code == status.HTTP_404_NOT_FOUND
 
 
@@ -51,5 +51,5 @@ async def test_rfc7591_redirect_uris_must_use_https(monkeypatch) -> None:
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         payload = {"redirect_uris": ["http://evil.example/cb"]}
-        resp = await client.post("/clients", json=payload)
+        resp = await client.post("/register", json=payload)
     assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7592_client_management_endpoint.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7592_client_management_endpoint.py
@@ -17,5 +17,5 @@ async def test_rfc7592_client_management_not_implemented(monkeypatch) -> None:
     include_rfc7591(app)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.get("/clients/some-client-id")
+        resp = await client.get("/register/some-client-id")
     assert resp.status_code == status.HTTP_404_NOT_FOUND


### PR DESCRIPTION
## Summary
- move dynamic client registration to `/register`
- expose revocation and introspection endpoints in discovery metadata
- update tests to use new registration path

## Testing
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff format .`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68acab8bf99c8326ac9b0d6a06bfc1cd