### PR TITLE
feat(authn): add JWE ID token option

### DIFF
--- a/pkgs/standards/auto_authn/README.md
+++ b/pkgs/standards/auto_authn/README.md
@@ -81,6 +81,8 @@ The service exposes an OpenID Connect discovery document at
 - `REDIS_HOST`, `REDIS_PORT`, `REDIS_DB`, and `REDIS_PASSWORD` for Redis session
   storage (optional).
 - `JWT_SECRET` for token signing and `LOG_LEVEL` to control logging verbosity.
+- `AUTO_AUTHN_ID_TOKEN_JWE_KEY` to enable JWE-encrypted ID Tokens using a
+  base64url-encoded symmetric key.
 
 ## Docker
 

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8414.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8414.py
@@ -67,6 +67,9 @@ def _build_openid_config() -> dict[str, Any]:
         "response_modes_supported": ["query", "fragment", "form_post"],
         "code_challenge_methods_supported": ["S256"],
     }
+    if settings.id_token_jwe_key:
+        config["id_token_encryption_alg_values_supported"] = ["dir"]
+        config["id_token_encryption_enc_values_supported"] = ["A256GCM"]
     if settings.enable_rfc7591:
         config["registration_endpoint"] = f"{ISSUER}/register"
     if settings.enable_rfc7009:

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8932.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8932.py
@@ -97,6 +97,9 @@ def get_enhanced_authorization_server_metadata() -> Dict[str, Any]:
     }
     if settings.enable_rfc7591:
         base_metadata["registration_endpoint"] = f"{ISSUER}/register"
+    if settings.id_token_jwe_key:
+        base_metadata["id_token_encryption_alg_values_supported"] = ["dir"]
+        base_metadata["id_token_encryption_enc_values_supported"] = ["A256GCM"]
 
     # Enhanced metadata extensions
     enhanced_metadata = {}

--- a/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
@@ -77,9 +77,15 @@ class Settings(BaseSettings):
         description=("Enable OAuth 2.0 Mutual-TLS client authentication per RFC 8705"),
     )
     enable_rfc8725: bool = Field(
-        default=os.environ.get("AUTO_AUTHN_ENABLE_RFC8725", "false").lower()
+        default=os.environ.get("AUTO_AUTHN_ENABLE_RFC8725", "true").lower()
         in {"1", "true", "yes"},
         description=("Enable JSON Web Token Best Current Practices per RFC 8725"),
+    )
+    id_token_jwe_key: str | None = Field(
+        default=os.environ.get("AUTO_AUTHN_ID_TOKEN_JWE_KEY"),
+        description=(
+            "Base64URL-encoded symmetric key enabling JWE encryption of ID Tokens"
+        ),
     )
     enable_rfc7636: bool = Field(
         default=os.environ.get("AUTO_AUTHN_ENABLE_RFC7636", "true").lower()

--- a/pkgs/standards/auto_authn/tests/unit/test_oidc_id_token_encryption.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_oidc_id_token_encryption.py
@@ -1,0 +1,27 @@
+import asyncio
+import base64
+
+from auto_authn.v2.oidc_id_token import mint_id_token, verify_id_token
+from auto_authn.v2.runtime_cfg import settings
+from auto_authn.v2.rfc8414 import openid_configuration, refresh_discovery_cache
+
+
+# Mark as unit test according to existing pattern
+
+
+def test_encrypted_id_token(monkeypatch):
+    key = base64.urlsafe_b64encode(b"0" * 32).rstrip(b"=").decode()
+    monkeypatch.setattr(settings, "id_token_jwe_key", key)
+    refresh_discovery_cache()
+    token = mint_id_token(
+        sub="alice",
+        aud="client",
+        nonce="n",
+        issuer="https://issuer",
+    )
+    assert token.count(".") == 4
+    claims = verify_id_token(token, issuer="https://issuer", audience="client")
+    assert claims["sub"] == "alice"
+    cfg = asyncio.run(openid_configuration())
+    assert cfg["id_token_encryption_alg_values_supported"] == ["dir"]
+    assert cfg["id_token_encryption_enc_values_supported"] == ["A256GCM"]


### PR DESCRIPTION
## Summary
- reject unsigned ID tokens and enable RFC8725 checks by default
- allow optional JWE encryption of ID tokens and surface supported algs in discovery
- document new AUTO_AUTHN_ID_TOKEN_JWE_KEY setting

## Testing
- `uv run --directory . --package auto_authn ruff format .`
- `uv run --directory . --package auto_authn ruff check . --fix`
- `uv run --package auto_authn --directory . pytest` *(fails: assert 401 == 400, assert 6 == (4 + 1), assert not True)*

------
https://chatgpt.com/codex/tasks/task_e_68acaeba0c848326bf11617de74b246d