### PR TITLE
feat(auto_authn): optional ID token encryption and stricter JWT defaults

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/runtime_cfg.py
@@ -63,6 +63,15 @@ class Settings(BaseSettings):
     # ─────── Other global settings ───────
     jwt_secret: str = Field(os.environ.get("JWT_SECRET", "insecure-dev-secret"))
     log_level: str = Field(os.environ.get("LOG_LEVEL", "INFO"))
+    id_token_encryption_key: str = Field(
+        default=os.environ.get("AUTO_AUTHN_ID_TOKEN_ENC_KEY", "0" * 32),
+        description="Symmetric key for ID Token encryption",
+    )
+    enable_id_token_encryption: bool = Field(
+        default=os.environ.get("AUTO_AUTHN_ENABLE_ID_TOKEN_ENCRYPTION", "false").lower()
+        in {"1", "true", "yes"},
+        description="Encrypt ID Tokens using JWE when enabled",
+    )
     require_tls: bool = Field(
         default=os.environ.get("AUTO_AUTHN_REQUIRE_TLS", "true").lower()
         in {"1", "true", "yes"},
@@ -77,7 +86,7 @@ class Settings(BaseSettings):
         description=("Enable OAuth 2.0 Mutual-TLS client authentication per RFC 8705"),
     )
     enable_rfc8725: bool = Field(
-        default=os.environ.get("AUTO_AUTHN_ENABLE_RFC8725", "false").lower()
+        default=os.environ.get("AUTO_AUTHN_ENABLE_RFC8725", "true").lower()
         in {"1", "true", "yes"},
         description=("Enable JSON Web Token Best Current Practices per RFC 8725"),
     )

--- a/pkgs/standards/auto_authn/tests/unit/test_oidc_id_token_encryption.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_oidc_id_token_encryption.py
@@ -1,0 +1,24 @@
+import pytest
+
+import auto_authn.v2.rfc8414 as rfc8414
+from auto_authn.v2.oidc_id_token import mint_id_token, verify_id_token
+from auto_authn.v2.runtime_cfg import settings
+
+
+@pytest.mark.unit
+def test_id_token_encryption_and_metadata(monkeypatch):
+    monkeypatch.setattr(settings, "enable_id_token_encryption", True)
+    monkeypatch.setattr(settings, "id_token_encryption_key", "0" * 32)
+    rfc8414.refresh_discovery_cache()
+    token = mint_id_token(
+        sub="user",
+        aud="client",
+        nonce="n",
+        issuer="https://issuer",
+    )
+    assert token.count(".") == 4
+    claims = verify_id_token(token, issuer="https://issuer", audience="client")
+    assert claims["sub"] == "user"
+    config = rfc8414._build_openid_config()  # noqa: SLF001
+    assert config["id_token_encryption_alg_values_supported"] == ["dir"]
+    assert config["id_token_encryption_enc_values_supported"] == ["A256GCM"]


### PR DESCRIPTION
## Summary
- default to RFC8725 best practices to reject `alg=none`
- add settings for optional JWE-encrypted ID Tokens and advertise supported algorithms
- deduplicate JWKS keys and test ID Token encryption flow

## Testing
- `uv run --package auto_authn --directory pkgs/standards/auto_authn --with nest-asyncio pytest tests/unit/test_oidc_id_token_encryption.py tests/unit/test_jwks_rotation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68acaeba0c848326bf11617de74b246d