### PR TITLE
feat(auto_authn): support response_mode

### DIFF
--- a/pkgs/standards/auto_authn/tests/unit/test_authorize_response_modes.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_authorize_response_modes.py
@@ -1,0 +1,97 @@
+import uuid
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from fastapi import status
+
+from auto_authn.v2.crypto import hash_pw
+from auto_authn.v2.orm.tables import Client, Tenant, User
+
+
+async def _setup(db_session):
+    tenant_id = uuid.uuid4()
+    tenant = Tenant(id=tenant_id, name="T", email="t@example.com", slug="t")
+    client_id = uuid.uuid4()
+    client = Client(
+        id=client_id,
+        tenant_id=tenant_id,
+        client_secret_hash=hash_pw("secret"),
+        redirect_uris="https://client.example/cb",
+    )
+    user = User(
+        id=uuid.uuid4(),
+        tenant_id=tenant_id,
+        username="alice",
+        email="alice@example.com",
+        password_hash=hash_pw("password"),
+    )
+    db_session.add_all([tenant, client, user])
+    await db_session.commit()
+    return str(client_id)
+
+
+@pytest.mark.usefixtures("temp_key_file")
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_authorize_response_mode_query(async_client, db_session):
+    client_id = await _setup(db_session)
+    params = {
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": "https://client.example/cb",
+        "scope": "openid",
+        "username": "alice",
+        "password": "password",
+        "state": "xyz",
+        "response_mode": "query",
+    }
+    resp = await async_client.get("/authorize", params=params, follow_redirects=False)
+    assert resp.status_code == status.HTTP_307_TEMPORARY_REDIRECT
+    qs = parse_qs(urlparse(resp.headers["location"]).query)
+    assert "code" in qs
+    assert qs.get("state", [None])[0] == "xyz"
+
+
+@pytest.mark.usefixtures("temp_key_file")
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_authorize_response_mode_fragment(async_client, db_session):
+    client_id = await _setup(db_session)
+    params = {
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": "https://client.example/cb",
+        "scope": "openid",
+        "username": "alice",
+        "password": "password",
+        "state": "abc",
+        "response_mode": "fragment",
+    }
+    resp = await async_client.get("/authorize", params=params, follow_redirects=False)
+    assert resp.status_code == status.HTTP_307_TEMPORARY_REDIRECT
+    frag = urlparse(resp.headers["location"]).fragment
+    qs = parse_qs(frag)
+    assert "code" in qs
+    assert qs.get("state", [None])[0] == "abc"
+
+
+@pytest.mark.usefixtures("temp_key_file")
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_authorize_response_mode_form_post(async_client, db_session):
+    client_id = await _setup(db_session)
+    params = {
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": "https://client.example/cb",
+        "scope": "openid",
+        "username": "alice",
+        "password": "password",
+        "state": "form",
+        "response_mode": "form_post",
+    }
+    resp = await async_client.get("/authorize", params=params, follow_redirects=False)
+    assert resp.status_code == status.HTTP_200_OK
+    assert '<form method="post" action="https://client.example/cb">' in resp.text
+    assert 'name="code"' in resp.text
+    assert 'name="state"' in resp.text


### PR DESCRIPTION
## Summary
- handle `response_mode` in `/authorize` with query, fragment, and form_post modes
- add tests covering each response mode

## Testing
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff format .`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68acaec726208326800f37b81ce1dd2a