### PR TITLE
refactor: move oidc discovery out of rfc module

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/app.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/app.py
@@ -24,6 +24,7 @@ from .routers.auth_flows import router as flows_router
 from .routers.crud import crud_api as crud_api
 from .runtime_cfg import settings
 from .rfc8414 import include_rfc8414
+from .oidc_discovery import include_oidc_discovery
 from .rfc8628 import include_rfc8628
 from .rfc9126 import include_rfc9126
 from .rfc7009 import include_rfc7009
@@ -58,6 +59,7 @@ if settings.enable_rfc7591:
 include_oidc_userinfo(app)
 if settings.enable_rfc8414:
     include_rfc8414(app)
+    include_oidc_discovery(app)
 
 
 # --------------------------------------------------------------------

--- a/pkgs/standards/auto_authn/auto_authn/v2/crypto.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/crypto.py
@@ -129,7 +129,7 @@ async def rotate_ed25519_jwt_key() -> str:
     _DEFAULT_KEY_PATH.write_text(ref.kid)
     _load_keypair.cache_clear()
     try:  # refresh discovery metadata if available
-        from .rfc8414 import refresh_discovery_cache
+        from .oidc_discovery import refresh_discovery_cache
 
         refresh_discovery_cache()
     except Exception:  # pragma: no cover - best effort

--- a/pkgs/standards/auto_authn/auto_authn/v2/oidc_discovery.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/oidc_discovery.py
@@ -1,0 +1,137 @@
+"""OpenID Connect discovery endpoints.
+
+Provides `.well-known/openid-configuration` and JWKS publication for the
+AutoAPI AuthN service. These features are OIDC-specific and therefore live in
+an `oidc_*` module rather than an `rfcXXXX` module.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from functools import lru_cache
+from typing import Any
+
+from fastapi import APIRouter, FastAPI
+
+from .runtime_cfg import settings
+
+router = APIRouter()
+
+# Default paths and issuer used for constructing metadata.
+JWKS_PATH = "/.well-known/jwks.json"
+ISSUER = os.getenv("AUTHN_ISSUER", "https://authn.example.com")
+
+
+# ---------------------------------------------------------------------------
+# Discovery document helpers
+# ---------------------------------------------------------------------------
+def _settings_signature() -> str:
+    """Return a stable JSON signature of current settings."""
+    return json.dumps(settings.model_dump(), sort_keys=True)
+
+
+def _build_openid_config() -> dict[str, Any]:
+    scopes = ["openid", "profile", "email"]
+    claims = ["sub", "name", "email"]
+    response_types = [
+        "code",
+        "token",
+        "id_token",
+        "code token",
+        "code id_token",
+        "token id_token",
+        "code token id_token",
+    ]
+    config: dict[str, Any] = {
+        "issuer": ISSUER,
+        "authorization_endpoint": f"{ISSUER}/authorize",
+        "token_endpoint": f"{ISSUER}/token",
+        "userinfo_endpoint": f"{ISSUER}/userinfo",
+        "jwks_uri": f"{ISSUER}{JWKS_PATH}",
+        "subject_types_supported": ["public"],
+        "id_token_signing_alg_values_supported": ["RS256"],
+        "scopes_supported": scopes,
+        "claims_supported": claims,
+        "response_types_supported": response_types,
+        "grant_types_supported": ["authorization_code", "refresh_token"],
+        "token_endpoint_auth_methods_supported": [
+            "client_secret_basic",
+            "client_secret_post",
+        ],
+        "response_modes_supported": ["query", "fragment", "form_post"],
+        "code_challenge_methods_supported": ["S256"],
+    }
+    if settings.enable_id_token_encryption:
+        config["id_token_encryption_alg_values_supported"] = ["dir"]
+        config["id_token_encryption_enc_values_supported"] = ["A256GCM"]
+    if settings.enable_rfc7591:
+        config["registration_endpoint"] = f"{ISSUER}/register"
+    if settings.enable_rfc7009:
+        config["revocation_endpoint"] = f"{ISSUER}/revoke"
+        config["revocation_endpoint_auth_methods_supported"] = [
+            "client_secret_basic",
+            "client_secret_post",
+        ]
+    if settings.enable_rfc7662:
+        config["introspection_endpoint"] = f"{ISSUER}/introspect"
+        config["introspection_endpoint_auth_methods_supported"] = [
+            "client_secret_basic",
+            "client_secret_post",
+        ]
+    return config
+
+
+@lru_cache(maxsize=1)
+def _cached_openid_config(sig: str) -> dict[str, Any]:
+    return _build_openid_config()
+
+
+def refresh_discovery_cache() -> None:
+    """Clear cached discovery metadata."""
+    _cached_openid_config.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+@router.get("/.well-known/openid-configuration", include_in_schema=False)
+async def openid_configuration():
+    """Return OpenID Connect discovery metadata."""
+    return _cached_openid_config(_settings_signature())
+
+
+@router.get(JWKS_PATH, include_in_schema=False)
+async def jwks():
+    """Publish all public keys in RFC 7517 JWKS format."""
+    from .oidc_id_token import ensure_rsa_jwt_key, rsa_key_provider
+    from .crypto import _ensure_key as ensure_ed25519_key, _provider as ed25519_provider
+
+    await ensure_rsa_jwt_key()
+    await ensure_ed25519_key()
+    rsa = await rsa_key_provider().jwks()
+    ed = await ed25519_provider().jwks()
+    combined = {k.get("kid"): k for k in [*rsa.get("keys", []), *ed.get("keys", [])]}
+    return {"keys": list(combined.values())}
+
+
+# ---------------------------------------------------------------------------
+# FastAPI integration
+# ---------------------------------------------------------------------------
+
+
+def include_oidc_discovery(app: FastAPI) -> None:
+    """Attach OIDC discovery routes to *app* if not already present."""
+    if not any(
+        route.path == "/.well-known/openid-configuration" for route in app.routes
+    ):
+        app.include_router(router)
+
+
+__all__ = [
+    "router",
+    "JWKS_PATH",
+    "ISSUER",
+    "include_oidc_discovery",
+    "refresh_discovery_cache",
+]

--- a/pkgs/standards/auto_authn/auto_authn/v2/oidc_id_token.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/oidc_id_token.py
@@ -170,7 +170,7 @@ async def rotate_rsa_jwt_key() -> str:
     _RSA_KEY_PATH.write_text(ref.kid)
     _service.cache_clear()
     try:  # refresh discovery metadata if available
-        from .rfc8414 import refresh_discovery_cache
+        from .oidc_discovery import refresh_discovery_cache
 
         refresh_discovery_cache()
     except Exception:  # pragma: no cover - best effort

--- a/pkgs/standards/auto_authn/auto_authn/v2/oidc_userinfo.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/oidc_userinfo.py
@@ -22,7 +22,7 @@ from .deps import JWAAlg
 router = APIRouter()
 
 
-@router.get("/userinfo")
+@router.get("/userinfo", response_model=None)
 async def userinfo(
     request: Request, user: User = Depends(get_current_principal)
 ) -> Response | dict[str, str]:

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8414.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8414.py
@@ -10,91 +10,20 @@ See RFC 8414: https://www.rfc-editor.org/rfc/rfc8414
 
 from __future__ import annotations
 
-import json
-import os
-from functools import lru_cache
-from typing import Any, Final
+from typing import Final
 
 from fastapi import APIRouter, FastAPI, HTTPException, status
 
 from .runtime_cfg import settings
+from .oidc_discovery import (
+    _cached_openid_config,
+    _settings_signature,
+    refresh_discovery_cache,
+)
 
 RFC8414_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc8414"
 
 router = APIRouter()
-
-# Default paths and issuer used for constructing metadata.
-JWKS_PATH = "/.well-known/jwks.json"
-ISSUER = os.getenv("AUTHN_ISSUER", "https://authn.example.com")
-
-
-# ---------------------------------------------------------------------------
-# Discovery document helpers
-# ---------------------------------------------------------------------------
-def _settings_signature() -> str:
-    """Return a stable JSON signature of current settings."""
-    return json.dumps(settings.model_dump(), sort_keys=True)
-
-
-def _build_openid_config() -> dict[str, Any]:
-    scopes = ["openid", "profile", "email"]
-    claims = ["sub", "name", "email"]
-    response_types = [
-        "code",
-        "token",
-        "id_token",
-        "code token",
-        "code id_token",
-        "token id_token",
-        "code token id_token",
-    ]
-    config: dict[str, Any] = {
-        "issuer": ISSUER,
-        "authorization_endpoint": f"{ISSUER}/authorize",
-        "token_endpoint": f"{ISSUER}/token",
-        "userinfo_endpoint": f"{ISSUER}/userinfo",
-        "jwks_uri": f"{ISSUER}{JWKS_PATH}",
-        "subject_types_supported": ["public"],
-        "id_token_signing_alg_values_supported": ["RS256"],
-        "scopes_supported": scopes,
-        "claims_supported": claims,
-        "response_types_supported": response_types,
-        "grant_types_supported": ["authorization_code", "refresh_token"],
-        "token_endpoint_auth_methods_supported": [
-            "client_secret_basic",
-            "client_secret_post",
-        ],
-        "response_modes_supported": ["query", "fragment", "form_post"],
-        "code_challenge_methods_supported": ["S256"],
-    }
-    if settings.enable_id_token_encryption:
-        config["id_token_encryption_alg_values_supported"] = ["dir"]
-        config["id_token_encryption_enc_values_supported"] = ["A256GCM"]
-    if settings.enable_rfc7591:
-        config["registration_endpoint"] = f"{ISSUER}/register"
-    if settings.enable_rfc7009:
-        config["revocation_endpoint"] = f"{ISSUER}/revoke"
-        config["revocation_endpoint_auth_methods_supported"] = [
-            "client_secret_basic",
-            "client_secret_post",
-        ]
-    if settings.enable_rfc7662:
-        config["introspection_endpoint"] = f"{ISSUER}/introspect"
-        config["introspection_endpoint_auth_methods_supported"] = [
-            "client_secret_basic",
-            "client_secret_post",
-        ]
-    return config
-
-
-@lru_cache(maxsize=1)
-def _cached_openid_config(sig: str) -> dict[str, Any]:
-    return _build_openid_config()
-
-
-def refresh_discovery_cache() -> None:
-    """Clear cached discovery metadata."""
-    _cached_openid_config.cache_clear()
 
 
 # ---------------------------------------------------------------------------
@@ -110,38 +39,16 @@ async def authorization_server_metadata():
     return _cached_openid_config(_settings_signature())
 
 
-@router.get("/.well-known/openid-configuration", include_in_schema=False)
-async def openid_configuration():
-    """Return OpenID Connect discovery metadata."""
-    return _cached_openid_config(_settings_signature())
-
-
-@router.get(JWKS_PATH, include_in_schema=False)
-async def jwks():
-    """Publish all public keys in RFC 7517 JWKS format."""
-    from .oidc_id_token import ensure_rsa_jwt_key, rsa_key_provider
-    from .crypto import _ensure_key as ensure_ed25519_key, _provider as ed25519_provider
-
-    await ensure_rsa_jwt_key()
-    await ensure_ed25519_key()
-    rsa = await rsa_key_provider().jwks()
-    ed = await ed25519_provider().jwks()
-    combined = {k.get("kid"): k for k in [*rsa.get("keys", []), *ed.get("keys", [])]}
-    return {"keys": list(combined.values())}
-
-
 def include_rfc8414(app: FastAPI) -> None:
     """Attach discovery routes to *app* if enabled."""
     if settings.enable_rfc8414 and not any(
-        route.path == "/.well-known/openid-configuration" for route in app.routes
+        route.path == "/.well-known/oauth-authorization-server" for route in app.routes
     ):
         app.include_router(router)
 
 
 __all__ = [
     "router",
-    "JWKS_PATH",
-    "ISSUER",
     "include_rfc8414",
     "RFC8414_SPEC_URL",
     "refresh_discovery_cache",

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8932.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8932.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, List
 from fastapi import APIRouter, HTTPException, status
 
 from .runtime_cfg import settings
-from .rfc8414 import ISSUER, JWKS_PATH
+from .oidc_discovery import ISSUER, JWKS_PATH
 
 RFC8932_SPEC_URL = "https://www.rfc-editor.org/rfc/rfc8932"
 

--- a/pkgs/standards/auto_authn/auto_authn/v2/routers/auth_flows.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/routers/auth_flows.py
@@ -56,7 +56,7 @@ from ..rfc7636_pkce import verify_code_challenge
 from ..rfc8628 import DEVICE_CODES, DeviceGrantForm
 from autoapi.v2.error import IntegrityError
 from ..oidc_id_token import mint_id_token, oidc_hash, verify_id_token
-from ..rfc8414 import ISSUER
+from ..oidc_discovery import ISSUER
 from ..rfc8252 import is_native_redirect_uri
 
 router = APIRouter()
@@ -311,7 +311,7 @@ async def authorize(
         params.append(("access_token", access))
         params.append(("token_type", "bearer"))
     if "id_token" in rts:
-        from ..rfc8414 import ISSUER
+        from ..oidc_discovery import ISSUER
 
         extra_claims: dict[str, str] = {
             "tid": str(user.tenant_id),

--- a/pkgs/standards/auto_authn/tests/conftest.py
+++ b/pkgs/standards/auto_authn/tests/conftest.py
@@ -156,10 +156,12 @@ def enable_rfc8414():
     """Enable RFC 8414 authorization server metadata for tests."""
     from auto_authn.v2.runtime_cfg import settings
     from auto_authn.v2.rfc8414 import include_rfc8414
+    from auto_authn.v2.oidc_discovery import include_oidc_discovery
 
     original = settings.enable_rfc8414
     settings.enable_rfc8414 = True
     include_rfc8414(app)
+    include_oidc_discovery(app)
     try:
         yield
     finally:

--- a/pkgs/standards/auto_authn/tests/unit/test_authorize_id_token_hashes.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_authorize_id_token_hashes.py
@@ -8,7 +8,7 @@ import nest_asyncio
 from auto_authn.v2.crypto import hash_pw
 from auto_authn.v2.orm.tables import Client, Tenant, User
 from auto_authn.v2.oidc_id_token import oidc_hash, verify_id_token
-from auto_authn.v2.rfc8414 import ISSUER
+from auto_authn.v2.oidc_discovery import ISSUER
 from auto_authn.v2.routers.auth_flows import AUTH_CODES
 
 nest_asyncio.apply()

--- a/pkgs/standards/auto_authn/tests/unit/test_oidc_id_token_encryption.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_oidc_id_token_encryption.py
@@ -1,6 +1,6 @@
 import pytest
 
-import auto_authn.v2.rfc8414 as rfc8414
+import auto_authn.v2.oidc_discovery as oidc_discovery
 from auto_authn.v2.oidc_id_token import mint_id_token, verify_id_token
 from auto_authn.v2.runtime_cfg import settings
 
@@ -9,7 +9,7 @@ from auto_authn.v2.runtime_cfg import settings
 def test_id_token_encryption_and_metadata(monkeypatch):
     monkeypatch.setattr(settings, "enable_id_token_encryption", True)
     monkeypatch.setattr(settings, "id_token_encryption_key", "0" * 32)
-    rfc8414.refresh_discovery_cache()
+    oidc_discovery.refresh_discovery_cache()
     token = mint_id_token(
         sub="user",
         aud="client",
@@ -19,6 +19,6 @@ def test_id_token_encryption_and_metadata(monkeypatch):
     assert token.count(".") == 4
     claims = verify_id_token(token, issuer="https://issuer", audience="client")
     assert claims["sub"] == "user"
-    config = rfc8414._build_openid_config()  # noqa: SLF001
+    config = oidc_discovery._build_openid_config()  # noqa: SLF001
     assert config["id_token_encryption_alg_values_supported"] == ["dir"]
     assert config["id_token_encryption_enc_values_supported"] == ["A256GCM"]

--- a/pkgs/standards/auto_authn/tests/unit/test_openid_configuration.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_openid_configuration.py
@@ -8,7 +8,7 @@ async def test_openid_configuration_contains_required_fields(async_client) -> No
     resp = await async_client.get("/.well-known/openid-configuration")
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
-    from auto_authn.v2.rfc8414 import JWKS_PATH, ISSUER
+    from auto_authn.v2.oidc_discovery import JWKS_PATH, ISSUER
 
     assert data["issuer"] == ISSUER
     assert data["authorization_endpoint"].endswith("/authorize")


### PR DESCRIPTION
## Summary
- move OpenID Connect discovery and JWKS routes into dedicated `oidc_discovery` module
- update imports and app wiring to use new `oidc_discovery`
- adjust userinfo endpoint decorator for compatibility

## Testing
- `uv run --directory standards/auto_authn --package auto_authn ruff format .`
- `uv run --directory standards/auto_authn --package auto_authn ruff check . --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest` *(fails: 12 failed, 354 passed)*


------
https://chatgpt.com/codex/tasks/task_e_68acb6961ec083269cfd9bad09f45e71