### PR TITLE
refactor: move metadata defaults into RFC module

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/oidc_discovery.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/oidc_discovery.py
@@ -8,19 +8,15 @@ an `oidc_*` module rather than an `rfcXXXX` module.
 from __future__ import annotations
 
 import json
-import os
 from functools import lru_cache
 from typing import Any
 
 from fastapi import APIRouter, FastAPI
 
+from .rfc8414_metadata import ISSUER, JWKS_PATH
 from .runtime_cfg import settings
 
 router = APIRouter()
-
-# Default paths and issuer used for constructing metadata.
-JWKS_PATH = "/.well-known/jwks.json"
-ISSUER = os.getenv("AUTHN_ISSUER", "https://authn.example.com")
 
 
 # ---------------------------------------------------------------------------

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8414_metadata.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8414_metadata.py
@@ -1,0 +1,15 @@
+"""RFC-defined defaults for authorization server metadata.
+
+These constants collect the well-known JWKS path and issuer base URL.
+OIDC modules should import from here rather than redefining these defaults.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Final
+
+JWKS_PATH: Final[str] = "/.well-known/jwks.json"
+ISSUER: Final[str] = os.getenv("AUTHN_ISSUER", "https://authn.example.com")
+
+__all__ = ["JWKS_PATH", "ISSUER"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc8932.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc8932.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, List
 from fastapi import APIRouter, HTTPException, status
 
 from .runtime_cfg import settings
-from .oidc_discovery import ISSUER, JWKS_PATH
+from .rfc8414_metadata import ISSUER, JWKS_PATH
 
 RFC8932_SPEC_URL = "https://www.rfc-editor.org/rfc/rfc8932"
 

--- a/pkgs/standards/auto_authn/auto_authn/v2/routers/auth_flows.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/routers/auth_flows.py
@@ -56,7 +56,7 @@ from ..rfc7636_pkce import verify_code_challenge
 from ..rfc8628 import DEVICE_CODES, DeviceGrantForm
 from autoapi.v2.error import IntegrityError
 from ..oidc_id_token import mint_id_token, oidc_hash, verify_id_token
-from ..oidc_discovery import ISSUER
+from ..rfc8414_metadata import ISSUER
 from ..rfc8252 import is_native_redirect_uri
 
 router = APIRouter()
@@ -311,7 +311,7 @@ async def authorize(
         params.append(("access_token", access))
         params.append(("token_type", "bearer"))
     if "id_token" in rts:
-        from ..oidc_discovery import ISSUER
+        from ..rfc8414_metadata import ISSUER
 
         extra_claims: dict[str, str] = {
             "tid": str(user.tenant_id),

--- a/pkgs/standards/auto_authn/tests/unit/test_authorize_id_token_hashes.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_authorize_id_token_hashes.py
@@ -8,7 +8,7 @@ import nest_asyncio
 from auto_authn.v2.crypto import hash_pw
 from auto_authn.v2.orm.tables import Client, Tenant, User
 from auto_authn.v2.oidc_id_token import oidc_hash, verify_id_token
-from auto_authn.v2.oidc_discovery import ISSUER
+from auto_authn.v2.rfc8414_metadata import ISSUER
 from auto_authn.v2.routers.auth_flows import AUTH_CODES
 
 nest_asyncio.apply()

--- a/pkgs/standards/auto_authn/tests/unit/test_openid_configuration.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_openid_configuration.py
@@ -8,7 +8,7 @@ async def test_openid_configuration_contains_required_fields(async_client) -> No
     resp = await async_client.get("/.well-known/openid-configuration")
     assert resp.status_code == status.HTTP_200_OK
     data = resp.json()
-    from auto_authn.v2.oidc_discovery import JWKS_PATH, ISSUER
+    from auto_authn.v2.rfc8414_metadata import JWKS_PATH, ISSUER
 
     assert data["issuer"] == ISSUER
     assert data["authorization_endpoint"].endswith("/authorize")


### PR DESCRIPTION
## Summary
- centralize JWKS_PATH and ISSUER defaults in rfc8414_metadata
- update discovery, auth flows, and RFC 8932 to import from rfc module
- adjust unit tests to use new constants location

## Testing
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff format .`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68acc9f59e3483268233d348d5d7b54a