### PR TITLE
feat(auto_authn): integrate token revocation and introspection

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7009.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7009.py
@@ -27,10 +27,16 @@ def revoke_token(token: str) -> None:
     """Revoke *token* by adding it to the registry.
 
     No-op if ``settings.enable_rfc7009`` is ``False``.
+    Also removes the token from the RFC 7662 introspection registry
+    when enabled.
     """
     if not settings.enable_rfc7009:
         return
     _REVOKED_TOKENS.add(token)
+    if settings.enable_rfc7662:
+        from .rfc7662 import unregister_token
+
+        unregister_token(token)
 
 
 def is_revoked(token: str) -> bool:

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc7662.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc7662.py
@@ -27,6 +27,11 @@ def register_token(token: str, claims: Dict[str, Any] | None = None) -> None:
     _ACTIVE_TOKENS[token] = data
 
 
+def unregister_token(token: str) -> None:
+    """Remove *token* from the active registry if present."""
+    _ACTIVE_TOKENS.pop(token, None)
+
+
 def introspect_token(token: str) -> Dict[str, Any]:
     """Return the RFC 7662 introspection response for *token*.
 
@@ -37,6 +42,10 @@ def introspect_token(token: str) -> Dict[str, Any]:
     """
     if not runtime_cfg.settings.enable_rfc7662:
         raise RuntimeError(f"RFC 7662 support is disabled: {RFC7662_SPEC_URL}")
+    from .rfc7009 import is_revoked  # avoid circular import at module load time
+
+    if is_revoked(token):
+        return {"active": False}
     return _ACTIVE_TOKENS.get(token, {"active": False})
 
 
@@ -45,4 +54,10 @@ def reset_tokens() -> None:
     _ACTIVE_TOKENS.clear()
 
 
-__all__ = ["register_token", "introspect_token", "reset_tokens", "RFC7662_SPEC_URL"]
+__all__ = [
+    "register_token",
+    "unregister_token",
+    "introspect_token",
+    "reset_tokens",
+    "RFC7662_SPEC_URL",
+]


### PR DESCRIPTION
## Summary
- track issued tokens for RFC 7662 introspection and remove them when revoked
- reject revoked JWTs during verification
- expose a spec-compliant introspection endpoint

## Testing
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff format .`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68acb5afd8548326aea6822c1d1bc056