### PR TITLE
feat: add OIDC userinfo endpoint

### DIFF
--- a/pkgs/standards/auto_authn/tests/unit/test_openid_userinfo_endpoint.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_openid_userinfo_endpoint.py
@@ -1,19 +1,83 @@
-"""Tests for missing OpenID Connect UserInfo endpoint."""
+"""Tests for OpenID Connect UserInfo endpoint."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from fastapi import FastAPI, status
-from httpx import ASGITransport, AsyncClient
+from fastapi import status
 
-from auto_authn.v2.routers.auth_flows import router
+from auto_authn.v2.app import app
+from auto_authn.v2.fastapi_deps import get_current_principal
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_openid_userinfo_endpoint_missing() -> None:
-    """`/userinfo` should return 404 because the endpoint is not implemented."""
-    app = FastAPI()
-    app.include_router(router)
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.get("/userinfo")
-    assert resp.status_code == status.HTTP_404_NOT_FOUND
+async def test_userinfo_requires_access_token(async_client):
+    resp = await async_client.get("/userinfo")
+    assert resp.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_userinfo_returns_claims_json(async_client):
+    user = MagicMock(
+        id=1,
+        username="alice",
+        email="alice@example.com",
+        address="1 Main St",
+        phone="123",
+    )
+
+    async def override_get_current_principal(*args, **kwargs):
+        return user
+
+    app.dependency_overrides[get_current_principal] = override_get_current_principal
+
+    mock_coder = MagicMock()
+    mock_coder.async_decode = AsyncMock(
+        return_value={"scope": "profile email address phone"}
+    )
+
+    headers = {"Authorization": "Bearer token"}
+    with patch("auto_authn.v2.oidc_userinfo.JWTCoder.default", return_value=mock_coder):
+        resp = await async_client.get("/userinfo", headers=headers)
+
+    app.dependency_overrides.pop(get_current_principal, None)
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json() == {
+        "sub": "1",
+        "name": "alice",
+        "email": "alice@example.com",
+        "address": "1 Main St",
+        "phone_number": "123",
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_userinfo_signed_jwt(async_client):
+    user = MagicMock(id=1, username="bob", email="bob@example.com")
+
+    async def override_get_current_principal(*args, **kwargs):
+        return user
+
+    app.dependency_overrides[get_current_principal] = override_get_current_principal
+
+    mock_coder = MagicMock()
+    mock_coder.async_decode = AsyncMock(return_value={"scope": ""})
+    mock_svc = MagicMock()
+    mock_svc.mint = AsyncMock(return_value="signed")
+
+    headers = {"Authorization": "Bearer token", "Accept": "application/jwt"}
+    with (
+        patch("auto_authn.v2.oidc_userinfo.JWTCoder.default", return_value=mock_coder),
+        patch("auto_authn.v2.oidc_userinfo._svc", return_value=(mock_svc, "kid1")),
+    ):
+        resp = await async_client.get("/userinfo", headers=headers)
+
+    app.dependency_overrides.pop(get_current_principal, None)
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.headers["content-type"] == "application/jwt"
+    assert resp.text == "signed"
+    mock_svc.mint.assert_awaited_once()


### PR DESCRIPTION
## Summary
- require valid access token for `/userinfo`
- support JSON and JWS responses with scope-based claims
- add unit tests for UserInfo endpoint

## Testing
- `uv run --directory standards/auto_authn --package auto_authn ruff format .`
- `uv run --directory standards/auto_authn --package auto_authn ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68acc961b71c8326952189608f61f0ea