### PR TITLE
refactor: apply column spec patterns to v3 tables

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/tables/audit.py
+++ b/pkgs/standards/autoapi/autoapi/v3/tables/audit.py
@@ -4,7 +4,7 @@ from uuid import UUID
 
 from . import Base
 from ..mixins import GUIDPk, Timestamped
-from ..specs import acol, IO, S
+from ..specs import IO, F, acol, S
 from ..types import DateTime, Integer, String, PgUUID
 
 
@@ -13,26 +13,32 @@ class Change(Base, GUIDPk, Timestamped):
 
     seq: int = acol(
         storage=S(Integer, primary_key=True),
+        field=F(),
         io=IO(out_verbs=("read", "list")),
     )
     at: dt.datetime = acol(
         storage=S(DateTime, default=dt.datetime.utcnow),
+        field=F(),
         io=IO(out_verbs=("read", "list")),
     )
     actor_id: UUID | None = acol(
         storage=S(PgUUID, nullable=True),
+        field=F(),
         io=IO(out_verbs=("read", "list")),
     )
     table_name: str = acol(
         storage=S(String),
+        field=F(),
         io=IO(out_verbs=("read", "list")),
     )
     row_id: UUID | None = acol(
         storage=S(PgUUID, nullable=True),
+        field=F(),
         io=IO(out_verbs=("read", "list")),
     )
     action: str = acol(
         storage=S(String),
+        field=F(),
         io=IO(out_verbs=("read", "list")),
     )
 

--- a/pkgs/standards/autoapi/autoapi/v3/tables/client.py
+++ b/pkgs/standards/autoapi/autoapi/v3/tables/client.py
@@ -15,9 +15,11 @@ class Client(Base, GUIDPk, Timestamped, TenantBound, ActiveToggle):
     # ---------------------------------------------------------------- columns --
     client_secret_hash: bytes = acol(
         storage=S(LargeBinary(60), nullable=False),
+        field=F(),
         io=IO(in_verbs=("create",)),
     )
     redirect_uris: str = acol(
         storage=S(String, nullable=False),
         field=F(constraints={"max_length": 1000}),
+        io=IO(),
     )

--- a/pkgs/standards/autoapi/autoapi/v3/tables/group.py
+++ b/pkgs/standards/autoapi/autoapi/v3/tables/group.py
@@ -2,13 +2,17 @@
 
 from ._base import Base
 from ..mixins import GUIDPk, Timestamped, TenantBound, Principal
-from ..specs import acol, S
+from ..specs import IO, F, acol, S
 from ..types import String
 
 
 class Group(Base, GUIDPk, Timestamped, TenantBound, Principal):
     __tablename__ = "groups"
-    name: str = acol(storage=S(String))
+    name: str = acol(
+        storage=S(String),
+        field=F(),
+        io=IO(),
+    )
 
 
 __all__ = ["Group"]

--- a/pkgs/standards/autoapi/autoapi/v3/tables/org.py
+++ b/pkgs/standards/autoapi/autoapi/v3/tables/org.py
@@ -2,14 +2,18 @@
 
 from ._base import Base
 from ..mixins import GUIDPk, Timestamped, TenantBound, Principal
-from ..specs import acol, S
+from ..specs import IO, F, acol, S
 from ..types import String
 
 
 class Org(Base, GUIDPk, Timestamped, TenantBound, Principal):
     __tablename__ = "orgs"
     __abstract__ = True
-    name: str = acol(storage=S(String))
+    name: str = acol(
+        storage=S(String),
+        field=F(),
+        io=IO(),
+    )
 
 
 __all__ = ["Org"]

--- a/pkgs/standards/autoapi/autoapi/v3/tables/rbac.py
+++ b/pkgs/standards/autoapi/autoapi/v3/tables/rbac.py
@@ -1,6 +1,7 @@
 from uuid import UUID
 
-from ..specs import acol, S
+
+from ..specs import IO, F, acol, S
 from ..specs.storage_spec import ForeignKeySpec
 from ..types import Integer, String, PgUUID
 
@@ -17,9 +18,15 @@ from ..mixins import (
 # ───────── RBAC core ──────────────────────────────────────────────────
 class Role(Base, GUIDPk, Timestamped, TenantBound):
     __tablename__ = "roles"
-    slug: str = acol(storage=S(String, unique=True))
+    slug: str = acol(
+        storage=S(String, unique=True),
+        field=F(),
+        io=IO(),
+    )
     global_mask: int = acol(
         storage=S(Integer, default=0),
+        field=F(),
+        io=IO(),
     )
 
 
@@ -27,16 +34,32 @@ class RolePerm(Base, GUIDPk, Timestamped, TenantBound, RelationEdge, MaskableEdg
     __tablename__ = "role_perms"
     role_id: UUID = acol(
         storage=S(PgUUID, fk=ForeignKeySpec("roles.id")),
+        field=F(),
+        io=IO(),
     )
-    target_table: str = acol(storage=S(String))
-    target_id: str = acol(storage=S(String))  # row or sentinel
+    target_table: str = acol(
+        storage=S(String),
+        field=F(),
+        io=IO(),
+    )
+    target_id: str = acol(
+        storage=S(String),
+        field=F(),
+        io=IO(),
+    )  # row or sentinel
 
 
 class RoleGrant(Base, GUIDPk, Timestamped, TenantBound, RelationEdge):
     __tablename__ = "role_grants"
-    principal_id: UUID = acol(storage=S(PgUUID))  # FK to principal row
+    principal_id: UUID = acol(
+        storage=S(PgUUID),
+        field=F(),
+        io=IO(),
+    )  # FK to principal row
     role_id: UUID = acol(
         storage=S(PgUUID, fk=ForeignKeySpec("roles.id")),
+        field=F(),
+        io=IO(),
     )
 
 

--- a/pkgs/standards/autoapi/autoapi/v3/tables/status.py
+++ b/pkgs/standards/autoapi/autoapi/v3/tables/status.py
@@ -71,6 +71,7 @@ class StatusEnum(Base, Timestamped):
 
     id: int = acol(
         storage=S(Integer, primary_key=True, autoincrement=True),
+        field=F(),
         io=IO(out_verbs=("read", "list")),
     )
     code: Status = acol(
@@ -84,6 +85,7 @@ class StatusEnum(Base, Timestamped):
     )
     label: str = acol(
         storage=S(String, nullable=False),
+        field=F(),
         io=IO(out_verbs=("read", "list")),
     )
 

--- a/pkgs/standards/autoapi/autoapi/v3/tables/user.py
+++ b/pkgs/standards/autoapi/autoapi/v3/tables/user.py
@@ -9,7 +9,7 @@ from ..mixins import (
     AsyncCapable,
     ActiveToggle,
 )
-from ..specs import acol, F, S
+from ..specs import IO, acol, F, S
 from ..types import String
 
 
@@ -21,6 +21,7 @@ class User(
     username: str = acol(
         storage=S(String, nullable=False),
         field=F(constraints={"max_length": 80}),
+        io=IO(),
     )
 
 


### PR DESCRIPTION
## Summary
- adopt explicit storage, field, and IO specs across AutoAPI v3 table models
- ensure RBAC tables import UUID and leverage spec-based column definitions

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest` *(fails: 36 failed, 579 passed)*


------
https://chatgpt.com/codex/tasks/task_e_68acd2c3f71083269e10b8e0b7ef56ef