### PR TITLE
refactor: split auto_authn orm tables

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/__init__.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/__init__.py
@@ -1,0 +1,3 @@
+"""ORM table models for auto_authn."""
+
+from .tables import *  # noqa: F401,F403

--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/api_key.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/api_key.py
@@ -1,0 +1,23 @@
+"""API key model for the authentication service."""
+
+from __future__ import annotations
+
+from autoapi.v2.tables import ApiKey as ApiKeyBase
+from autoapi.v2.types import UniqueConstraint, relationship
+from autoapi.v2.mixins import UserMixin
+
+
+class ApiKey(ApiKeyBase, UserMixin):
+    __table_args__ = (
+        UniqueConstraint("digest"),
+        {"extend_existing": True, "schema": "authn"},
+    )
+
+    user = relationship(
+        "auto_authn.v2.orm.tables.User",
+        back_populates="api_keys",
+        lazy="joined",  # optional: eager load to avoid N+1
+    )
+
+
+__all__ = ["ApiKey"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/auth_code.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/auth_code.py
@@ -1,0 +1,40 @@
+"""Authorization code model."""
+
+from __future__ import annotations
+
+from autoapi.v2 import Base
+from autoapi.v2.mixins import Timestamped
+from autoapi.v2.types import Column, ForeignKey, JSON, PgUUID, String, TZDateTime
+
+
+class AuthCode(Base, Timestamped):
+    __tablename__ = "auth_codes"
+    __table_args__ = ({"schema": "authn"},)
+
+    code = Column(String(128), primary_key=True)
+    user_id = Column(
+        PgUUID(as_uuid=True),
+        ForeignKey("authn.users.id"),
+        nullable=False,
+        index=True,
+    )
+    tenant_id = Column(
+        PgUUID(as_uuid=True),
+        ForeignKey("authn.tenants.id"),
+        nullable=False,
+        index=True,
+    )
+    client_id = Column(
+        PgUUID(as_uuid=True),
+        ForeignKey("authn.clients.id"),
+        nullable=False,
+    )
+    redirect_uri = Column(String(1000), nullable=False)
+    code_challenge = Column(String, nullable=True)
+    nonce = Column(String, nullable=True)
+    scope = Column(String, nullable=True)
+    expires_at = Column(TZDateTime, nullable=False)
+    claims = Column(JSON, nullable=True)
+
+
+__all__ = ["AuthCode"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/auth_session.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/auth_session.py
@@ -1,0 +1,35 @@
+"""Authentication session model."""
+
+from __future__ import annotations
+
+import datetime as dt
+
+from autoapi.v2 import Base
+from autoapi.v2.mixins import Timestamped
+from autoapi.v2.types import Column, ForeignKey, PgUUID, String, TZDateTime
+
+
+class AuthSession(Base, Timestamped):
+    __tablename__ = "sessions"
+    __table_args__ = ({"schema": "authn"},)
+
+    id = Column(String(64), primary_key=True)
+    user_id = Column(
+        PgUUID(as_uuid=True),
+        ForeignKey("authn.users.id"),
+        nullable=False,
+        index=True,
+    )
+    tenant_id = Column(
+        PgUUID(as_uuid=True),
+        ForeignKey("authn.tenants.id"),
+        nullable=False,
+        index=True,
+    )
+    username = Column(String(120), nullable=False)
+    auth_time = Column(
+        TZDateTime, default=lambda: dt.datetime.now(dt.timezone.utc), nullable=False
+    )
+
+
+__all__ = ["AuthSession"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/client.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/client.py
@@ -1,0 +1,48 @@
+"""Client model for the authentication service."""
+
+from __future__ import annotations
+
+import re
+import uuid
+from typing import Final
+
+from autoapi.v2.tables import Client as ClientBase
+
+from ..crypto import hash_pw
+from ..rfc8252 import validate_native_redirect_uri
+from ..runtime_cfg import settings
+
+_CLIENT_ID_RE: Final[re.Pattern[str]] = re.compile(r"^[A-Za-z0-9\-_]{8,64}$")
+
+
+class Client(ClientBase):
+    __table_args__ = ({"schema": "authn"},)
+
+    @classmethod
+    def new(
+        cls,
+        tenant_id: uuid.UUID,
+        client_id: str,
+        client_secret: str,
+        redirects: list[str],
+    ):
+        if not _CLIENT_ID_RE.fullmatch(client_id):
+            raise ValueError("invalid client_id format")
+        if settings.enforce_rfc8252:
+            for uri in redirects:
+                validate_native_redirect_uri(uri)
+        secret_hash = hash_pw(client_secret)
+        return cls(
+            tenant_id=tenant_id,
+            id=client_id,
+            client_secret_hash=secret_hash,
+            redirect_uris=" ".join(redirects),
+        )
+
+    def verify_secret(self, plain: str) -> bool:
+        from ..crypto import verify_pw  # local import to avoid cycle
+
+        return verify_pw(plain, self.client_secret_hash)
+
+
+__all__ = ["Client", "_CLIENT_ID_RE"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/device_code.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/device_code.py
@@ -1,0 +1,46 @@
+"""Device code model."""
+
+from __future__ import annotations
+
+from autoapi.v2 import Base
+from autoapi.v2.mixins import Timestamped
+from autoapi.v2.types import (
+    Boolean,
+    Column,
+    ForeignKey,
+    Integer,
+    PgUUID,
+    String,
+    TZDateTime,
+)
+
+
+class DeviceCode(Base, Timestamped):
+    __tablename__ = "device_codes"
+    __table_args__ = ({"schema": "authn"},)
+
+    device_code = Column(String(128), primary_key=True)
+    user_code = Column(String(32), nullable=False, index=True)
+    client_id = Column(
+        PgUUID(as_uuid=True),
+        ForeignKey("authn.clients.id"),
+        nullable=False,
+    )
+    expires_at = Column(TZDateTime, nullable=False)
+    interval = Column(Integer, nullable=False)
+    authorized = Column(Boolean, default=False, nullable=False)
+    user_id = Column(
+        PgUUID(as_uuid=True),
+        ForeignKey("authn.users.id"),
+        nullable=True,
+        index=True,
+    )
+    tenant_id = Column(
+        PgUUID(as_uuid=True),
+        ForeignKey("authn.tenants.id"),
+        nullable=True,
+        index=True,
+    )
+
+
+__all__ = ["DeviceCode"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/pushed_authorization_request.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/pushed_authorization_request.py
@@ -1,0 +1,19 @@
+"""Pushed authorization request model."""
+
+from __future__ import annotations
+
+from autoapi.v2 import Base
+from autoapi.v2.mixins import Timestamped
+from autoapi.v2.types import Column, JSON, String, TZDateTime
+
+
+class PushedAuthorizationRequest(Base, Timestamped):
+    __tablename__ = "par_requests"
+    __table_args__ = ({"schema": "authn"},)
+
+    request_uri = Column(String(255), primary_key=True)
+    params = Column(JSON, nullable=False)
+    expires_at = Column(TZDateTime, nullable=False)
+
+
+__all__ = ["PushedAuthorizationRequest"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/revoked_token.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/revoked_token.py
@@ -1,0 +1,17 @@
+"""Revoked token model."""
+
+from __future__ import annotations
+
+from autoapi.v2 import Base
+from autoapi.v2.mixins import Timestamped
+from autoapi.v2.types import Column, String
+
+
+class RevokedToken(Base, Timestamped):
+    __tablename__ = "revoked_tokens"
+    __table_args__ = ({"schema": "authn"},)
+
+    token = Column(String(512), primary_key=True)
+
+
+__all__ = ["RevokedToken"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/service.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/service.py
@@ -1,0 +1,23 @@
+"""Service model for the authentication service."""
+
+from __future__ import annotations
+
+from autoapi.v2 import Base
+from autoapi.v2.mixins import GUIDPk, Timestamped, TenantBound, Principal, ActiveToggle
+from autoapi.v2.types import Column, String, relationship
+
+
+class Service(Base, GUIDPk, Timestamped, TenantBound, Principal, ActiveToggle):
+    """Machine principal representing an automated service."""
+
+    __tablename__ = "services"
+    __table_args__ = ({"schema": "authn"},)
+    name = Column(String(120), unique=True, nullable=False)
+    service_keys = relationship(
+        "auto_authn.v2.orm.tables.ServiceKey",
+        back_populates="service",
+        cascade="all, delete-orphan",
+    )
+
+
+__all__ = ["Service"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/service_key.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/service_key.py
@@ -1,0 +1,29 @@
+"""Service key model for the authentication service."""
+
+from __future__ import annotations
+
+from autoapi.v2.tables import ApiKey as ApiKeyBase
+from autoapi.v2.types import Column, ForeignKey, PgUUID, UniqueConstraint, relationship
+
+
+class ServiceKey(ApiKeyBase):
+    __tablename__ = "service_keys"
+    __table_args__ = (
+        UniqueConstraint("digest"),
+        {"extend_existing": True, "schema": "authn"},
+    )
+    service_id = Column(
+        PgUUID(as_uuid=True),
+        ForeignKey("authn.services.id"),
+        index=True,
+        nullable=False,
+    )
+
+    service = relationship(
+        "auto_authn.v2.orm.tables.Service",
+        back_populates="service_keys",
+        lazy="joined",
+    )
+
+
+__all__ = ["ServiceKey"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/tables.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/tables.py
@@ -1,304 +1,34 @@
-"""
-autoapi_authn.v2.orm.tables
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-Canonical SQLAlchemy models for the authentication service.
-
-* Tenant  – logical partition; owner of users, clients, keys.
-* Client  – OIDC / OAuth2 relying party registration.
-* User    – human principal with bcrypt-hashed password.
-* ApiKey  – machine credential (digest stored, raw secret shown once).
-
-All models inherit GUIDPk, Timestamped, and (where relevant) TenantBound
-from *autoapi.v2.mixins* so they automatically gain:
-    • UUID primary keys
-    • created_at / updated_at audit stamps
-    • row-level security filters via TenantBound
-"""
+"""Aggregated ORM table exports for backward compatibility."""
 
 from __future__ import annotations
 
-import datetime as dt
-import re
-import uuid
-from typing import Annotated, Final
-
 from autoapi.v2 import Base
-from autoapi.v2.types import (
-    String,
-    LargeBinary,
-    relationship,
-    mapped_column,
-    Column,
-    PgUUID,
-    ForeignKey,
-    UniqueConstraint,
-    JSON,
-    Boolean,
-    Integer,
-    TZDateTime,
-)
-from autoapi.v2.tables import (
-    Tenant as TenantBase,
-    Client as ClientBase,
-    User as UserBase,
-    ApiKey as ApiKeyBase,
-)
-from autoapi.v2.mixins import (
-    GUIDPk,
-    Bootstrappable,
-    Timestamped,
-    TenantBound,
-    Principal,
-    ActiveToggle,
-    UserMixin,
-)
-from ..crypto import hash_pw  # bcrypt helper shared across package
-from ..rfc8252 import validate_native_redirect_uri
-from ..runtime_cfg import settings
 
-
-# ────────────────────────────────────────────────────────────────────
-# Utility type alias for 36-char UUID strings
-_UUID = Annotated[str, mapped_column(String(36), default=lambda: str(uuid.uuid4()))]
-
-# Regular-expression for a valid client_id (RFC 6749 allows many forms)
-_CLIENT_ID_RE: Final[re.Pattern[str]] = re.compile(r"^[A-Za-z0-9\-_]{8,64}$")
-
-
-class Tenant(TenantBase, Bootstrappable):
-    # __mapper_args__ = {"concrete": True}
-    __table_args__ = (
-        {
-            "extend_existing": True,
-            "schema": "authn",
-        },
-    )
-    name = Column(String, nullable=False, unique=True)
-    email = Column(String, nullable=False, unique=True)
-    DEFAULT_ROWS = [
-        {
-            "id": uuid.UUID("FFFFFFFF-0000-0000-0000-000000000000"),
-            "email": "tenant@example.com",
-            "name": "Public",
-            "slug": "public",
-        }
-    ]
-
-
-# --------------------------------------------------------------------
-class Client(ClientBase):  # Tenant FK via mix-in
-    __table_args__ = ({"schema": "authn"},)
-
-    # ----------------------------------------------------------------
-    @classmethod
-    def new(
-        cls,
-        tenant_id: uuid.UUID,
-        client_id: str,
-        client_secret: str,
-        redirects: list[str],
-    ):
-        if not _CLIENT_ID_RE.fullmatch(client_id):
-            raise ValueError("invalid client_id format")
-        if settings.enforce_rfc8252:
-            for uri in redirects:
-                validate_native_redirect_uri(uri)
-        secret_hash = hash_pw(client_secret)
-        return cls(
-            tenant_id=tenant_id,
-            id=client_id,
-            client_secret_hash=secret_hash,
-            redirect_uris=" ".join(redirects),
-        )
-
-    def verify_secret(self, plain: str) -> bool:
-        from ..crypto import verify_pw  # local import to avoid cycle
-
-        return verify_pw(plain, self.client_secret_hash)
-
-
-# --------------------------------------------------------------------
-class User(UserBase):
-    """Human principal with authentication credentials."""
-
-    __table_args__ = ({"extend_existing": True, "schema": "authn"},)
-    email = Column(String(120), nullable=False, unique=True)
-    password_hash = Column(LargeBinary(60))
-    api_keys = relationship(
-        "auto_authn.v2.orm.tables.ApiKey",
-        back_populates="user",
-        cascade="all, delete-orphan",
-    )
-
-    # ----------------------------------------------------------------
-    @classmethod
-    def new(cls, tenant_id: uuid.UUID, username: str, email: str, password: str):
-        return cls(
-            tenant_id=tenant_id,
-            username=username,
-            email=email,
-        )
-
-    def verify_password(self, plain: str) -> bool:
-        from ..crypto import verify_pw
-
-        return verify_pw(plain, self.password_hash)
-
-
-class Service(Base, GUIDPk, Timestamped, TenantBound, Principal, ActiveToggle):
-    """Machine principal representing an automated service."""
-
-    __tablename__ = "services"
-    __table_args__ = ({"schema": "authn"},)
-    name = Column(String(120), unique=True, nullable=False)
-    service_keys = relationship(
-        "auto_authn.v2.orm.tables.ServiceKey",
-        back_populates="service",
-        cascade="all, delete-orphan",
-    )
-
-
-class ApiKey(ApiKeyBase, UserMixin):
-    __table_args__ = (
-        UniqueConstraint("digest"),
-        {"extend_existing": True, "schema": "authn"},
-    )
-
-    user = relationship(
-        "auto_authn.v2.orm.tables.User",
-        back_populates="api_keys",
-        lazy="joined",  # optional: eager load to avoid N+1
-    )
-
-
-class ServiceKey(ApiKeyBase):
-    __tablename__ = "service_keys"
-    __table_args__ = (
-        UniqueConstraint("digest"),
-        {"extend_existing": True, "schema": "authn"},
-    )
-    service_id = Column(
-        PgUUID(as_uuid=True),
-        ForeignKey("authn.services.id"),
-        index=True,
-        nullable=False,
-    )
-
-    service = relationship(
-        "auto_authn.v2.orm.tables.Service",
-        back_populates="service_keys",
-        lazy="joined",
-    )
-
-
-class AuthSession(Base, Timestamped):
-    __tablename__ = "sessions"
-    __table_args__ = ({"schema": "authn"},)
-
-    id = Column(String(64), primary_key=True)
-    user_id = Column(
-        PgUUID(as_uuid=True),
-        ForeignKey("authn.users.id"),
-        nullable=False,
-        index=True,
-    )
-    tenant_id = Column(
-        PgUUID(as_uuid=True),
-        ForeignKey("authn.tenants.id"),
-        nullable=False,
-        index=True,
-    )
-    username = Column(String(120), nullable=False)
-    auth_time = Column(
-        TZDateTime, default=lambda: dt.datetime.now(dt.timezone.utc), nullable=False
-    )
-
-
-class AuthCode(Base, Timestamped):
-    __tablename__ = "auth_codes"
-    __table_args__ = ({"schema": "authn"},)
-
-    code = Column(String(128), primary_key=True)
-    user_id = Column(
-        PgUUID(as_uuid=True),
-        ForeignKey("authn.users.id"),
-        nullable=False,
-        index=True,
-    )
-    tenant_id = Column(
-        PgUUID(as_uuid=True),
-        ForeignKey("authn.tenants.id"),
-        nullable=False,
-        index=True,
-    )
-    client_id = Column(
-        PgUUID(as_uuid=True),
-        ForeignKey("authn.clients.id"),
-        nullable=False,
-    )
-    redirect_uri = Column(String(1000), nullable=False)
-    code_challenge = Column(String, nullable=True)
-    nonce = Column(String, nullable=True)
-    scope = Column(String, nullable=True)
-    expires_at = Column(TZDateTime, nullable=False)
-    claims = Column(JSON, nullable=True)
-
-
-class DeviceCode(Base, Timestamped):
-    __tablename__ = "device_codes"
-    __table_args__ = ({"schema": "authn"},)
-
-    device_code = Column(String(128), primary_key=True)
-    user_code = Column(String(32), nullable=False, index=True)
-    client_id = Column(
-        PgUUID(as_uuid=True),
-        ForeignKey("authn.clients.id"),
-        nullable=False,
-    )
-    expires_at = Column(TZDateTime, nullable=False)
-    interval = Column(Integer, nullable=False)
-    authorized = Column(Boolean, default=False, nullable=False)
-    user_id = Column(
-        PgUUID(as_uuid=True),
-        ForeignKey("authn.users.id"),
-        nullable=True,
-        index=True,
-    )
-    tenant_id = Column(
-        PgUUID(as_uuid=True),
-        ForeignKey("authn.tenants.id"),
-        nullable=True,
-        index=True,
-    )
-
-
-class RevokedToken(Base, Timestamped):
-    __tablename__ = "revoked_tokens"
-    __table_args__ = ({"schema": "authn"},)
-
-    token = Column(String(512), primary_key=True)
-
-
-class PushedAuthorizationRequest(Base, Timestamped):
-    __tablename__ = "par_requests"
-    __table_args__ = ({"schema": "authn"},)
-
-    request_uri = Column(String(255), primary_key=True)
-    params = Column(JSON, nullable=False)
-    expires_at = Column(TZDateTime, nullable=False)
+from .api_key import ApiKey
+from .auth_code import AuthCode
+from .auth_session import AuthSession
+from .client import Client, _CLIENT_ID_RE
+from .device_code import DeviceCode
+from .pushed_authorization_request import PushedAuthorizationRequest
+from .revoked_token import RevokedToken
+from .service import Service
+from .service_key import ServiceKey
+from .tenant import Tenant
+from .user import User
 
 
 __all__ = [
-    "ApiKey",
-    "ServiceKey",
-    "User",
-    "Service",
+    "Base",
     "Tenant",
     "Client",
+    "User",
+    "Service",
+    "ApiKey",
+    "ServiceKey",
     "AuthSession",
     "AuthCode",
     "DeviceCode",
     "RevokedToken",
     "PushedAuthorizationRequest",
+    "_CLIENT_ID_RE",
 ]

--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/tenant.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/tenant.py
@@ -1,0 +1,31 @@
+"""Tenant model for the authentication service."""
+
+from __future__ import annotations
+
+import uuid
+
+from autoapi.v2.tables import Tenant as TenantBase
+from autoapi.v2.types import Column, String
+from autoapi.v2.mixins import Bootstrappable
+
+
+class Tenant(TenantBase, Bootstrappable):
+    __table_args__ = (
+        {
+            "extend_existing": True,
+            "schema": "authn",
+        },
+    )
+    name = Column(String, nullable=False, unique=True)
+    email = Column(String, nullable=False, unique=True)
+    DEFAULT_ROWS = [
+        {
+            "id": uuid.UUID("FFFFFFFF-0000-0000-0000-000000000000"),
+            "email": "tenant@example.com",
+            "name": "Public",
+            "slug": "public",
+        }
+    ]
+
+
+__all__ = ["Tenant"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/user.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/user.py
@@ -1,0 +1,37 @@
+"""User model for the authentication service."""
+
+from __future__ import annotations
+
+import uuid
+
+from autoapi.v2.tables import User as UserBase
+from autoapi.v2.types import Column, LargeBinary, String, relationship
+
+
+class User(UserBase):
+    """Human principal with authentication credentials."""
+
+    __table_args__ = ({"extend_existing": True, "schema": "authn"},)
+    email = Column(String(120), nullable=False, unique=True)
+    password_hash = Column(LargeBinary(60))
+    api_keys = relationship(
+        "auto_authn.v2.orm.tables.ApiKey",
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
+
+    @classmethod
+    def new(cls, tenant_id: uuid.UUID, username: str, email: str, password: str):
+        return cls(
+            tenant_id=tenant_id,
+            username=username,
+            email=email,
+        )
+
+    def verify_password(self, plain: str) -> bool:
+        from ..crypto import verify_pw
+
+        return verify_pw(plain, self.password_hash)
+
+
+__all__ = ["User"]


### PR DESCRIPTION
## Summary
- split auto_authn ORM tables into dedicated modules
- re-export table classes for backward compatibility

## Testing
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff format .`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68acd38415dc8326bdddc0bd7c62b7d3