### PR TITLE
refactor: migrate auto_authn ORM models to AutoAPI v3

### DIFF
--- a/docs/docs/concept/auto_authn_v2_overview.md
+++ b/docs/docs/concept/auto_authn_v2_overview.md
@@ -1,0 +1,76 @@
+# auto_authn.v2 Overview
+
+## Router Endpoint Modules
+- `rfc7591.py` – client registration endpoint
+- `rfc9126.py` – pushed authorization request endpoint
+- `rfc8628.py` – device authorization endpoint
+- `rfc8932.py` – enhanced authorization server metadata endpoint
+- `rfc8414.py` – OAuth 2.0 authorization server metadata endpoint
+- `rfc7009.py` – token revocation endpoint
+- `rfc8693.py` – token exchange endpoint
+- `oidc_userinfo.py` – OpenID Connect `/userinfo` endpoint
+- `oidc_discovery.py` – OpenID discovery endpoints
+- `routers/auth_flows.py` – aggregates authentication and authorization routers
+- `routers/authn/__init__.py` – authentication routes (register/login/logout)
+- `routers/authz/__init__.py` – authorization routes (token, introspection, etc.)
+- `routers/crud.py` – AutoAPI-generated CRUD router for ORM models
+
+## Schema Modules
+- `routers/schemas.py` – request/response models for auth flows
+- `rfc7591.py` – `ClientMetadata` for dynamic client registration
+- `rfc8628.py` – `DeviceAuthIn`, `DeviceAuthOut`, and `DeviceGrantForm`
+- `rfc9396.py` – `AuthorizationDetail` for rich authorization requests
+- `rfc8693.py` – `TokenType`, `TokenExchangeRequest`, and `TokenExchangeResponse`
+- `orm/` modules – SQLAlchemy models (`Tenant`, `User`, `Client`, `Service`, `ApiKey`, `ServiceKey`, `AuthSession`, `AuthCode`, `DeviceCode`, `RevokedToken`, `PushedAuthorizationRequest`)
+
+### Persistence vs. Virtual Schemas
+- **Persistent**: ORM models from `orm/` (listed above)
+- **Virtual**: Pydantic/in-memory classes such as `RegisterIn`, `TokenPair`, `ClientMetadata`, `DeviceAuthIn`, `DeviceAuthOut`, `DeviceGrantForm`, `AuthorizationDetail`, `TokenType`, `TokenExchangeRequest`, and `TokenExchangeResponse`
+
+## Crypto Modules
+- `crypto.py` – bcrypt password hashing and Ed25519 key management
+- `rfc7515.py` – JSON Web Signature helpers
+- `rfc7516.py` – JSON Web Encryption helpers
+- `rfc7517.py` – loading signing and public JWKs
+- `rfc7518.py` – supported JOSE algorithms list
+- `rfc7519.py` – JWT encode/decode wrappers
+- `rfc7638.py` – JWK thumbprint generation and verification
+- `rfc7800.py` – confirmation claim and proof-of-possession utilities
+- `rfc8291.py` – AES-128-GCM encryption/decryption for push messages
+- `rfc8037.py` – EdDSA signing and verification helpers
+- `rfc8705.py` – certificate thumbprint and binding validation
+- `rfc9449_dpop.py` – DPoP proof creation and verification
+
+## ORM Tables, Columns, and Operations
+| Table | Acols (stored columns) | Vcols (virtual/relationships) | Default Ops | Additional Ops | Hook Context |
+|-------|------------------------|-------------------------------|-------------|----------------|--------------|
+| `Tenant` | `id`, `slug`, `created_at`, `updated_at`, `name`, `email` | — | create, read, update, delete, list | — | — |
+| `User` | `id`, `created_at`, `updated_at`, `tenant_id`, `username`, `email`, `password_hash`, `is_active` | `api_keys` relationship | create, read, update, delete, list | register, login | `hash_pw` pre-create/pre-update for password hashing |
+| `Client` | `id`, `created_at`, `updated_at`, `tenant_id`, `client_secret_hash`, `redirect_uris`, `is_active` | — | create, read, update, delete, list | dynamic client registration (`rfc7591`) | optional `hash_client_secret` hook |
+| `Service` | `id`, `created_at`, `updated_at`, `tenant_id`, `is_active`, `name` | `service_keys` relationship | create, read, update, delete, list | — | `encrypt_service_key` if needed |
+| `ApiKey` | `id`, `created_at`, `last_used_at`, `valid_from`, `valid_to`, `label`, `digest`, `user_id` | `user` relationship | create, read, update, delete, list | generate/return raw key | pre-create `generate_api_key`, post-create `return_raw_key` |
+| `ServiceKey` | same as `ApiKey` plus `service_id` | `service` relationship | create, read, update, delete, list | — | similar hooks as `ApiKey` |
+| `AuthSession` | `id`, `user_id`, `tenant_id`, `username`, `auth_time`, `created_at`, `updated_at` | — | create, read, update, delete, list | — | — |
+| `AuthCode` | `code`, `user_id`, `tenant_id`, `client_id`, `redirect_uri`, `code_challenge`, `nonce`, `scope`, `expires_at`, `claims`, `created_at`, `updated_at` | — | create, read, update, delete, list | — | — |
+| `DeviceCode` | `device_code`, `user_code`, `client_id`, `expires_at`, `interval`, `authorized`, `user_id`, `tenant_id`, `created_at`, `updated_at` | — | create, read, update, delete, list | device authorization | `issue_device_code`, `notify_user_agent` hooks when persisted |
+| `RevokedToken` | `token`, `created_at`, `updated_at` | — | create, read, update, delete, list | revoke | `store_revoked_token` pre-create |
+| `PushedAuthorizationRequest` | `request_uri`, `params`, `expires_at`, `created_at`, `updated_at` | — | create, read, update, delete, list | pushed authorization request | `persist_par_request` pre-create |
+
+### Notes on Operations
+- **op_alias**: no explicit overrides; CRUD uses default verbs.
+- **schema_ctx**: use when virtual fields (e.g., `password`) cannot map directly to persistent columns.
+- **Lifecycle hooks**: attach callables like `_pwd_backend.verify`, `_jwt.encode`, or custom crypto/providers to appropriate `pre_*` or `post_*` phases.
+
+## Hook Context Examples
+| Endpoint | Lifecycle Hook | Purpose |
+|----------|----------------|---------|
+| `POST /register` | `pre_create` → `hash_pw` | Hash incoming password before persisting `User` record |
+| `POST /login` | `pre_read` → `_pwd_backend.verify` | Verify password before issuing tokens |
+| CRUD `ApiKey` | `pre_create` → `generate_api_key`, `post_create` → `return_raw_key` | Create digest and return plaintext key |
+| `POST /token` | `pre_read`/`post_create` → `_pwd_backend.verify`, `_jwt.encode` | Validate client secrets and sign issued tokens |
+| `POST /revoke` | `pre_create` → `store_revoked_token` | Persist revoked tokens to `RevokedToken` table |
+| `POST /device_authorization` | `pre_create`/`post_create` → `issue_device_code`, `notify_user_agent` | Generate and optionally persist device/user codes |
+| `POST /par` | `pre_create` → `persist_par_request` | Store pushed authorization request |
+| `POST /token/exchange` | `post_create` → `_jwt.encode` | Sign exchanged tokens |
+| `GET /userinfo` | `post_read` → `_jwt.encode` (optional) | Optionally sign the userinfo response |
+

--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/api_key.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/api_key.py
@@ -2,9 +2,18 @@
 
 from __future__ import annotations
 
-from autoapi.v2.tables import ApiKey as ApiKeyBase
-from autoapi.v2.types import UniqueConstraint, relationship
-from autoapi.v2.mixins import UserMixin
+import hashlib
+import secrets
+
+from autoapi.v3.tables import ApiKey as ApiKeyBase
+from autoapi.v3.types import UniqueConstraint, relationship
+from autoapi.v3.mixins import UserMixin
+from autoapi.v3.specs import IO, vcol
+from autoapi.v3 import hook_ctx
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .user import User
 
 
 class ApiKey(ApiKeyBase, UserMixin):
@@ -13,11 +22,38 @@ class ApiKey(ApiKeyBase, UserMixin):
         {"extend_existing": True, "schema": "authn"},
     )
 
-    user = relationship(
+    _user = relationship(
         "auto_authn.v2.orm.tables.User",
-        back_populates="api_keys",
+        back_populates="_api_keys",
         lazy="joined",  # optional: eager load to avoid N+1
     )
+
+    user: "User" = vcol(
+        read_producer=lambda obj, _ctx: obj._user,
+        io=IO(out_verbs=("read", "list")),
+    )
+
+    @hook_ctx(ops="create", phase="PRE_HANDLER")
+    async def _generate_digest(cls, ctx):
+        payload = ctx.get("payload") or {}
+        token = secrets.token_urlsafe(32)
+        payload["digest"] = hashlib.sha256(token.encode()).hexdigest()
+        ctx["raw_key"] = token
+
+    @hook_ctx(ops="create", phase="POST_RESPONSE")
+    async def _return_raw_key(cls, ctx):
+        raw = ctx.get("raw_key")
+        result = ctx.get("result")
+        if not raw or result is None:
+            return
+        if hasattr(result, "model_dump"):
+            data = result.model_dump()
+        elif hasattr(result, "dict") and callable(result.dict):
+            data = result.dict()  # type: ignore[call-arg]
+        else:
+            data = dict(result)
+        data["raw_key"] = raw
+        ctx["result"] = data
 
 
 __all__ = ["ApiKey"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/auth_session.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/auth_session.py
@@ -4,32 +4,56 @@ from __future__ import annotations
 
 import datetime as dt
 
-from autoapi.v2 import Base
-from autoapi.v2.mixins import Timestamped
-from autoapi.v2.types import Column, ForeignKey, PgUUID, String, TZDateTime
+from autoapi.v3.tables import Base
+from autoapi.v3.mixins import TenantMixin, Timestamped, UserMixin
+from autoapi.v3.specs import S, acol
+from autoapi.v3.types import String, TZDateTime
+from autoapi.v3 import op_ctx, hook_ctx
+from fastapi import HTTPException
 
 
-class AuthSession(Base, Timestamped):
+class AuthSession(Base, Timestamped, UserMixin, TenantMixin):
     __tablename__ = "sessions"
     __table_args__ = ({"schema": "authn"},)
 
-    id = Column(String(64), primary_key=True)
-    user_id = Column(
-        PgUUID(as_uuid=True),
-        ForeignKey("authn.users.id"),
-        nullable=False,
-        index=True,
+    id: str = acol(storage=S(String(64), primary_key=True))
+    username: str = acol(storage=S(String(120), nullable=False))
+    auth_time: dt.datetime = acol(
+        storage=S(
+            TZDateTime, nullable=False, default=lambda: dt.datetime.now(dt.timezone.utc)
+        )
     )
-    tenant_id = Column(
-        PgUUID(as_uuid=True),
-        ForeignKey("authn.tenants.id"),
-        nullable=False,
-        index=True,
-    )
-    username = Column(String(120), nullable=False)
-    auth_time = Column(
-        TZDateTime, default=lambda: dt.datetime.now(dt.timezone.utc), nullable=False
-    )
+
+    @hook_ctx(ops="login", phase="PRE_HANDLER")
+    async def _verify_credentials(cls, ctx):
+        from .user import User
+
+        payload = ctx.get("payload") or {}
+        db = ctx.get("db")
+        username = payload.get("username")
+        password = payload.get("password")
+        if db is None or not username or not password:
+            raise HTTPException(status_code=400, detail="missing credentials")
+
+        users = await User.handlers.list.core(
+            {"db": db, "payload": {"filters": {"username": username}}}
+        )
+        user = users.items[0] if getattr(users, "items", None) else None
+        if user is None or not user.verify_password(password):
+            raise HTTPException(status_code=400, detail="invalid credentials")
+
+        payload.pop("password", None)
+        payload["user_id"] = user.id
+        payload["tenant_id"] = user.tenant_id
+        payload["username"] = user.username
+
+    @op_ctx(alias="login", target="create", arity="collection")
+    def login(cls, ctx):
+        pass
+
+    @op_ctx(alias="logout", target="delete", arity="member")
+    def logout(cls, ctx, obj):
+        return obj
 
 
 __all__ = ["AuthSession"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/device_code.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/device_code.py
@@ -2,45 +2,53 @@
 
 from __future__ import annotations
 
-from autoapi.v2 import Base
-from autoapi.v2.mixins import Timestamped
-from autoapi.v2.types import (
-    Boolean,
-    Column,
-    ForeignKey,
-    Integer,
-    PgUUID,
-    String,
-    TZDateTime,
-)
+import datetime as dt
+import uuid
+
+from autoapi.v3.tables import Base
+from autoapi.v3.mixins import Timestamped
+from autoapi.v3.specs import S, acol
+from autoapi.v3.specs.storage_spec import ForeignKeySpec
+from autoapi.v3.types import Boolean, Integer, PgUUID, String, TZDateTime
+from autoapi.v3 import op_ctx
 
 
 class DeviceCode(Base, Timestamped):
     __tablename__ = "device_codes"
     __table_args__ = ({"schema": "authn"},)
 
-    device_code = Column(String(128), primary_key=True)
-    user_code = Column(String(32), nullable=False, index=True)
-    client_id = Column(
-        PgUUID(as_uuid=True),
-        ForeignKey("authn.clients.id"),
-        nullable=False,
+    device_code: str = acol(storage=S(String(128), primary_key=True))
+    user_code: str = acol(storage=S(String(32), nullable=False, index=True))
+    client_id: uuid.UUID = acol(
+        storage=S(
+            PgUUID(as_uuid=True),
+            fk=ForeignKeySpec(target="authn.clients.id"),
+            nullable=False,
+        )
     )
-    expires_at = Column(TZDateTime, nullable=False)
-    interval = Column(Integer, nullable=False)
-    authorized = Column(Boolean, default=False, nullable=False)
-    user_id = Column(
-        PgUUID(as_uuid=True),
-        ForeignKey("authn.users.id"),
-        nullable=True,
-        index=True,
+    expires_at: dt.datetime = acol(storage=S(TZDateTime, nullable=False))
+    interval: int = acol(storage=S(Integer, nullable=False))
+    authorized: bool = acol(storage=S(Boolean, nullable=False, default=False))
+    user_id: uuid.UUID | None = acol(
+        storage=S(
+            PgUUID(as_uuid=True),
+            fk=ForeignKeySpec(target="authn.users.id"),
+            nullable=True,
+            index=True,
+        )
     )
-    tenant_id = Column(
-        PgUUID(as_uuid=True),
-        ForeignKey("authn.tenants.id"),
-        nullable=True,
-        index=True,
+    tenant_id: uuid.UUID | None = acol(
+        storage=S(
+            PgUUID(as_uuid=True),
+            fk=ForeignKeySpec(target="authn.tenants.id"),
+            nullable=True,
+            index=True,
+        )
     )
+
+    @op_ctx(alias="device_authorization", target="create", arity="collection")
+    def device_authorization(cls, ctx):
+        pass
 
 
 __all__ = ["DeviceCode"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/pushed_authorization_request.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/pushed_authorization_request.py
@@ -2,18 +2,26 @@
 
 from __future__ import annotations
 
-from autoapi.v2 import Base
-from autoapi.v2.mixins import Timestamped
-from autoapi.v2.types import Column, JSON, String, TZDateTime
+import datetime as dt
+
+from autoapi.v3.tables import Base
+from autoapi.v3.mixins import Timestamped
+from autoapi.v3.specs import S, acol
+from autoapi.v3.types import JSON, String, TZDateTime
+from autoapi.v3 import op_ctx
 
 
 class PushedAuthorizationRequest(Base, Timestamped):
     __tablename__ = "par_requests"
     __table_args__ = ({"schema": "authn"},)
 
-    request_uri = Column(String(255), primary_key=True)
-    params = Column(JSON, nullable=False)
-    expires_at = Column(TZDateTime, nullable=False)
+    request_uri: str = acol(storage=S(String(255), primary_key=True))
+    params: dict = acol(storage=S(JSON, nullable=False))
+    expires_at: dt.datetime = acol(storage=S(TZDateTime, nullable=False))
+
+    @op_ctx(alias="par", target="create", arity="collection")
+    def par(cls, ctx):
+        pass
 
 
 __all__ = ["PushedAuthorizationRequest"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/revoked_token.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/revoked_token.py
@@ -2,16 +2,22 @@
 
 from __future__ import annotations
 
-from autoapi.v2 import Base
-from autoapi.v2.mixins import Timestamped
-from autoapi.v2.types import Column, String
+from autoapi.v3.tables import Base
+from autoapi.v3.mixins import Timestamped
+from autoapi.v3.specs import S, acol
+from autoapi.v3.types import String
+from autoapi.v3 import op_ctx
 
 
 class RevokedToken(Base, Timestamped):
     __tablename__ = "revoked_tokens"
     __table_args__ = ({"schema": "authn"},)
 
-    token = Column(String(512), primary_key=True)
+    token: str = acol(storage=S(String(512), primary_key=True))
+
+    @op_ctx(alias="revoke", target="create", arity="collection")
+    def revoke(cls, ctx):
+        pass
 
 
 __all__ = ["RevokedToken"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/service.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/service.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
-from autoapi.v2 import Base
-from autoapi.v2.mixins import GUIDPk, Timestamped, TenantBound, Principal, ActiveToggle
-from autoapi.v2.types import Column, String, relationship
+from autoapi.v3.tables import Base
+from autoapi.v3.mixins import GUIDPk, Timestamped, TenantBound, Principal, ActiveToggle
+from autoapi.v3.types import String, relationship
+from autoapi.v3.specs import IO, S, acol, vcol
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .service_key import ServiceKey
 
 
 class Service(Base, GUIDPk, Timestamped, TenantBound, Principal, ActiveToggle):
@@ -12,11 +17,15 @@ class Service(Base, GUIDPk, Timestamped, TenantBound, Principal, ActiveToggle):
 
     __tablename__ = "services"
     __table_args__ = ({"schema": "authn"},)
-    name = Column(String(120), unique=True, nullable=False)
-    service_keys = relationship(
+    name: str = acol(storage=S(String(120), unique=True, nullable=False))
+    _service_keys = relationship(
         "auto_authn.v2.orm.tables.ServiceKey",
-        back_populates="service",
+        back_populates="_service",
         cascade="all, delete-orphan",
+    )
+    service_keys: list["ServiceKey"] = vcol(
+        read_producer=lambda obj, _ctx: obj._service_keys,
+        io=IO(out_verbs=("read", "list")),
     )
 
 

--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/service_key.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/service_key.py
@@ -2,8 +2,19 @@
 
 from __future__ import annotations
 
-from autoapi.v2.tables import ApiKey as ApiKeyBase
-from autoapi.v2.types import Column, ForeignKey, PgUUID, UniqueConstraint, relationship
+import hashlib
+import secrets
+
+from autoapi.v3.tables import ApiKey as ApiKeyBase
+from autoapi.v3.types import PgUUID, UniqueConstraint, relationship
+from autoapi.v3.specs import IO, S, acol, vcol
+from autoapi.v3.specs.storage_spec import ForeignKeySpec
+from autoapi.v3 import hook_ctx
+from uuid import UUID
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .service import Service
 
 
 class ServiceKey(ApiKeyBase):
@@ -12,18 +23,46 @@ class ServiceKey(ApiKeyBase):
         UniqueConstraint("digest"),
         {"extend_existing": True, "schema": "authn"},
     )
-    service_id = Column(
-        PgUUID(as_uuid=True),
-        ForeignKey("authn.services.id"),
-        index=True,
-        nullable=False,
+    service_id: UUID = acol(
+        storage=S(
+            PgUUID(as_uuid=True),
+            fk=ForeignKeySpec(target="authn.services.id"),
+            index=True,
+            nullable=False,
+        )
     )
 
-    service = relationship(
+    _service = relationship(
         "auto_authn.v2.orm.tables.Service",
-        back_populates="service_keys",
+        back_populates="_service_keys",
         lazy="joined",
     )
+    service: "Service" = vcol(
+        read_producer=lambda obj, _ctx: obj._service,
+        io=IO(out_verbs=("read", "list")),
+    )
+
+    @hook_ctx(ops="create", phase="PRE_HANDLER")
+    async def _generate_digest(cls, ctx):
+        payload = ctx.get("payload") or {}
+        token = secrets.token_urlsafe(32)
+        payload["digest"] = hashlib.sha256(token.encode()).hexdigest()
+        ctx["raw_key"] = token
+
+    @hook_ctx(ops="create", phase="POST_RESPONSE")
+    async def _return_raw_key(cls, ctx):
+        raw = ctx.get("raw_key")
+        result = ctx.get("result")
+        if not raw or result is None:
+            return
+        if hasattr(result, "model_dump"):
+            data = result.model_dump()
+        elif hasattr(result, "dict") and callable(result.dict):
+            data = result.dict()  # type: ignore[call-arg]
+        else:
+            data = dict(result)
+        data["raw_key"] = raw
+        ctx["result"] = data
 
 
 __all__ = ["ServiceKey"]

--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/tables.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/tables.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from autoapi.v2 import Base
+from autoapi.v3.tables import Base
 
 from .api_key import ApiKey
 from .auth_code import AuthCode

--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/tenant.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/tenant.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import uuid
 
-from autoapi.v2.tables import Tenant as TenantBase
-from autoapi.v2.types import Column, String
-from autoapi.v2.mixins import Bootstrappable
+from autoapi.v3.tables import Tenant as TenantBase
+from autoapi.v3.mixins import Bootstrappable
+from autoapi.v3.specs import acol, S
+from autoapi.v3.types import String
 
 
 class Tenant(TenantBase, Bootstrappable):
@@ -16,8 +17,8 @@ class Tenant(TenantBase, Bootstrappable):
             "schema": "authn",
         },
     )
-    name = Column(String, nullable=False, unique=True)
-    email = Column(String, nullable=False, unique=True)
+    name: str = acol(storage=S(String, nullable=False, unique=True))
+    email: str = acol(storage=S(String, nullable=False, unique=True))
     DEFAULT_ROWS = [
         {
             "id": uuid.UUID("FFFFFFFF-0000-0000-0000-000000000000"),

--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/user.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/user.py
@@ -4,21 +4,44 @@ from __future__ import annotations
 
 import uuid
 
-from autoapi.v2.tables import User as UserBase
-from autoapi.v2.types import Column, LargeBinary, String, relationship
+from autoapi.v3.tables import User as UserBase
+from autoapi.v3 import op_ctx, hook_ctx
+from autoapi.v3.types import LargeBinary, String, relationship
+from autoapi.v3.specs import IO, S, acol, vcol
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .api_key import ApiKey
 
 
 class User(UserBase):
     """Human principal with authentication credentials."""
 
     __table_args__ = ({"extend_existing": True, "schema": "authn"},)
-    email = Column(String(120), nullable=False, unique=True)
-    password_hash = Column(LargeBinary(60))
-    api_keys = relationship(
+    email: str = acol(storage=S(String(120), nullable=False, unique=True))
+    password_hash: bytes | None = acol(storage=S(LargeBinary(60)))
+    _api_keys = relationship(
         "auto_authn.v2.orm.tables.ApiKey",
-        back_populates="user",
+        back_populates="_user",
         cascade="all, delete-orphan",
     )
+    api_keys: list["ApiKey"] = vcol(
+        read_producer=lambda obj, _ctx: obj._api_keys,
+        io=IO(out_verbs=("read", "list")),
+    )
+
+    @hook_ctx(ops=("create", "update"), phase="PRE_HANDLER")
+    async def _hash_password(cls, ctx):
+        payload = ctx.get("payload") or {}
+        plain = payload.pop("password", None)
+        if plain:
+            from ..crypto import hash_pw
+
+            payload["password_hash"] = hash_pw(plain)
+
+    @op_ctx(alias="register", target="create", arity="collection")
+    def register(cls, ctx):
+        pass
 
     @classmethod
     def new(cls, tenant_id: uuid.UUID, username: str, email: str, password: str):

--- a/pkgs/standards/auto_authn/auto_authn/v2/rfc9126.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/rfc9126.py
@@ -12,14 +12,15 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, Final, Tuple
+from typing import Any, Dict, Final
 
-from fastapi import APIRouter, FastAPI, HTTPException, Request, status
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request, status
+from sqlalchemy import delete
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from . import runtime_cfg
-
-# In-memory storage mapping request_uri -> (params, expiry)
-_PAR_STORE: Dict[str, Tuple[Dict[str, Any], datetime]] = {}
+from .fastapi_deps import get_async_db
+from .orm.tables import PushedAuthorizationRequest
 
 router = APIRouter()
 
@@ -28,46 +29,57 @@ DEFAULT_PAR_EXPIRY = 90  # seconds
 RFC9126_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc9126"
 
 
-def store_par_request(
-    params: Dict[str, Any], expires_in: int = DEFAULT_PAR_EXPIRY
+async def store_par_request(
+    params: Dict[str, Any],
+    db: AsyncSession,
+    expires_in: int = DEFAULT_PAR_EXPIRY,
 ) -> str:
-    """Store *params* and return a unique ``request_uri``.
+    """Store *params* and return a unique ``request_uri``."""
 
-    Parameters expire after *expires_in* seconds.
-    """
     request_uri = f"urn:ietf:params:oauth:request_uri:{uuid.uuid4()}"
-    _PAR_STORE[request_uri] = (
-        params,
-        datetime.now(tz=timezone.utc) + timedelta(seconds=expires_in),
+    expires_at = datetime.now(tz=timezone.utc) + timedelta(seconds=expires_in)
+    await PushedAuthorizationRequest.handlers.par.core(
+        {
+            "db": db,
+            "payload": {
+                "request_uri": request_uri,
+                "params": params,
+                "expires_at": expires_at,
+            },
+        }
     )
     return request_uri
 
 
-def get_par_request(request_uri: str) -> Dict[str, Any] | None:
+async def get_par_request(request_uri: str, db: AsyncSession) -> Dict[str, Any] | None:
     """Retrieve parameters for *request_uri* if present and not expired."""
-    record = _PAR_STORE.get(request_uri)
-    if not record:
+
+    obj = await db.get(PushedAuthorizationRequest, request_uri)
+    if not obj:
         return None
-    params, expiry = record
-    if datetime.now(tz=timezone.utc) > expiry:
-        del _PAR_STORE[request_uri]
+    if datetime.now(tz=timezone.utc) > obj.expires_at:
+        await PushedAuthorizationRequest.handlers.delete.core({"db": db, "obj": obj})
         return None
-    return params
+    return obj.params
 
 
-def reset_par_store() -> None:
+async def reset_par_store(db: AsyncSession) -> None:
     """Clear stored pushed authorization requests (test helper)."""
-    _PAR_STORE.clear()
+
+    await db.execute(delete(PushedAuthorizationRequest))
+    await db.commit()
 
 
 @router.post("/par", status_code=status.HTTP_201_CREATED)
-async def pushed_authorization_request(request: Request):
+async def pushed_authorization_request(
+    request: Request, db: AsyncSession = Depends(get_async_db)
+):
     """Endpoint for RFC 9126 pushed authorization requests."""
 
     if not runtime_cfg.settings.enable_rfc9126:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "PAR disabled")
     form = await request.form()
-    request_uri = store_par_request(dict(form))
+    request_uri = await store_par_request(dict(form), db)
     return {"request_uri": request_uri, "expires_in": DEFAULT_PAR_EXPIRY}
 
 

--- a/pkgs/standards/auto_authn/auto_authn/v2/routers/authn/login.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/routers/authn/login.py
@@ -1,19 +1,18 @@
 from __future__ import annotations
 
-from datetime import datetime
 import secrets
 
-from fastapi import Depends, HTTPException, Request, status
+from fastapi import Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ...oidc_id_token import mint_id_token
 from ...rfc8414_metadata import ISSUER
 from ...fastapi_deps import get_async_db
-from ...backends import AuthError
+from ...orm.tables import AuthSession
 
 from ..schemas import CredsIn, TokenPair
-from ..shared import _require_tls, _jwt, _pwd_backend, SESSIONS
+from ..shared import _require_tls, _jwt, SESSIONS
 
 from . import router
 
@@ -23,29 +22,40 @@ async def login(
     body: CredsIn, request: Request, db: AsyncSession = Depends(get_async_db)
 ):
     _require_tls(request)
+    session_id = secrets.token_urlsafe(16)
     try:
-        user = await _pwd_backend.authenticate(db, body.identifier, body.password)
-    except AuthError:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "invalid credentials")
+        session = await AuthSession.handlers.login.core(
+            {
+                "db": db,
+                "payload": {
+                    "id": session_id,
+                    "username": body.identifier,
+                    "password": body.password,
+                },
+            }
+        )
+    except HTTPException:
+        raise
 
     access, refresh = await _jwt.async_sign_pair(
-        sub=str(user.id), tid=str(user.tenant_id), scope="openid profile email"
+        sub=str(session.user_id),
+        tid=str(session.tenant_id),
+        scope="openid profile email",
     )
-    session_id = secrets.token_urlsafe(16)
-    SESSIONS[session_id] = {
-        "sub": str(user.id),
-        "tid": str(user.tenant_id),
-        "username": user.username,
-        "auth_time": datetime.utcnow(),
+    SESSIONS[session.id] = {
+        "sub": str(session.user_id),
+        "tid": str(session.tenant_id),
+        "username": session.username,
+        "auth_time": session.auth_time,
     }
     id_token = mint_id_token(
-        sub=str(user.id),
+        sub=str(session.user_id),
         aud=ISSUER,
         nonce=secrets.token_urlsafe(8),
         issuer=ISSUER,
-        sid=session_id,
+        sid=session.id,
     )
     pair = TokenPair(access_token=access, refresh_token=refresh, id_token=id_token)
     response = JSONResponse(pair.model_dump())
-    response.set_cookie("sid", session_id, httponly=True, samesite="lax")
+    response.set_cookie("sid", session.id, httponly=True, samesite="lax")
     return response

--- a/pkgs/standards/auto_authn/tests/conftest.py
+++ b/pkgs/standards/auto_authn/tests/conftest.py
@@ -169,20 +169,20 @@ def enable_rfc8414():
 
 
 @pytest.fixture
-def enable_rfc9126():
+def enable_rfc9126(db_session):
     """Enable RFC 9126 pushed authorization requests for tests."""
     from auto_authn.v2.runtime_cfg import settings
     from auto_authn.v2.rfc9126 import reset_par_store, include_rfc9126
 
     original = settings.enable_rfc9126
     settings.enable_rfc9126 = True
-    reset_par_store()
+    asyncio.get_event_loop().run_until_complete(reset_par_store(db_session))
     include_rfc9126(app)
     try:
         yield
     finally:
         settings.enable_rfc9126 = original
-        reset_par_store()
+        asyncio.get_event_loop().run_until_complete(reset_par_store(db_session))
 
 
 @pytest.fixture

--- a/pkgs/standards/auto_authn/tests/i9n/test_rfc8628.py
+++ b/pkgs/standards/auto_authn/tests/i9n/test_rfc8628.py
@@ -33,7 +33,7 @@ async def test_device_authorization_endpoint(async_client: AsyncClient) -> None:
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_device_token_polling(async_client: AsyncClient) -> None:
+async def test_device_token_polling(async_client: AsyncClient, db_session) -> None:
     """Token endpoint should poll until the device code is approved."""
     auth_resp = await async_client.post(
         "/device_authorization", data={"client_id": "test-client"}
@@ -50,7 +50,7 @@ async def test_device_token_polling(async_client: AsyncClient) -> None:
 
     from auto_authn.v2.rfc8628 import approve_device_code
 
-    approve_device_code(device_code, sub="user", tid="tenant")
+    await approve_device_code(device_code, sub="user", tid="tenant", db=db_session)
     success = await async_client.post("/token", data=payload)
     assert success.status_code == status.HTTP_200_OK
     data = success.json()


### PR DESCRIPTION
## Summary
- migrate auto_authn v2 ORM models to autoapi v3 using acol/vcol specs
- expose relationships via vcol and forward-reference typing helpers
- expose RFC-specific operations via op_ctx on authn models
- attach lifecycle hooks via hook_ctx for credential hashing, key generation, and login verification

## Testing
- `uv run --package auto_authn --directory pkgs/standards/auto_authn ruff format auto_authn/v2/orm/api_key.py auto_authn/v2/orm/service_key.py auto_authn/v2/orm/user.py auto_authn/v2/orm/auth_session.py auto_authn/v2/orm/client.py`
- `uv run --package auto_authn --directory pkgs/standards/auto_authn ruff check auto_authn/v2/orm/api_key.py auto_authn/v2/orm/service_key.py auto_authn/v2/orm/user.py auto_authn/v2/orm/auth_session.py auto_authn/v2/orm/client.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_68acd8de44d48326bf264342f7434289