### PR TITLE
fix(auto_kms): annotate key wrapping columns

### DIFF
--- a/pkgs/standards/auto_kms/auto_kms/tables/key.py
+++ b/pkgs/standards/auto_kms/auto_kms/tables/key.py
@@ -146,12 +146,12 @@ class Key(Base):
     )
 
     # ---- Key Wrapping virtual columns ----
-    key_material_b64: str = vcol(
+    key_material_b64: Mapped[str] = vcol(
         field=F(required_in=("wrap",)),
         io=IO(in_verbs=("wrap",), out_verbs=("unwrap",)),
     )
 
-    wrapped_key_b64: str = vcol(
+    wrapped_key_b64: Mapped[str] = vcol(
         field=F(required_in=("unwrap",)),
         io=IO(in_verbs=("unwrap",), out_verbs=("wrap",)),
     )
@@ -160,7 +160,6 @@ class Key(Base):
     @hook_ctx(ops="create", phase="POST_HANDLER")
     async def _seed_primary_version(cls, ctx):
         import secrets
-        import base64
         from swarmauri_core.crypto.types import (
             ExportPolicy,
             KeyType,

--- a/pkgs/standards/auto_kms/auto_kms/tables/key_version.py
+++ b/pkgs/standards/auto_kms/auto_kms/tables/key_version.py
@@ -7,7 +7,6 @@ from fastapi import HTTPException
 from sqlalchemy.orm import Mapped
 
 from autoapi.v3.decorators import hook_ctx
-from autoapi.v3.mixins import GUIDPk, Timestamped
 from autoapi.v3.specs import IO, F, S, acol
 from autoapi.v3.specs.io_spec import Pair
 from autoapi.v3.specs.storage_spec import ForeignKeySpec


### PR DESCRIPTION
## Summary
- use SQLAlchemy's `Mapped` annotation for key wrapping fields
- remove unused mixin imports in `KeyVersion`

## Testing
- `uv run --directory standards/auto_kms --package auto_kms ruff format .`
- `uv run --directory standards/auto_kms --package auto_kms ruff check . --fix`
- `uv run --directory standards/auto_kms --package auto_kms pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae818737248326b5ab53229d3b85ab