### PR TITLE
Rename Paramiko plugin entrypoint

### DIFF
--- a/pkgs/standards/auto_kms/auto_kms/app.py
+++ b/pkgs/standards/auto_kms/auto_kms/app.py
@@ -45,8 +45,8 @@ async def _stash_ctx(ctx):
             {
                 "plugins": {"mode": "fallback"},
                 "cryptos": {
-                    "default_crypto": "paramiko_sa",
-                    "adapters": {"paramiko_sa": {}},
+                    "default_crypto": "paramiko_crypto",
+                    "adapters": {"paramiko_crypto": {}},
                 },
             }
         )

--- a/pkgs/standards/swarmauri_crypto_paramiko/pyproject.toml
+++ b/pkgs/standards/swarmauri_crypto_paramiko/pyproject.toml
@@ -65,7 +65,7 @@ dev = [
 ParamikoCrypto = "swarmauri_crypto_paramiko:ParamikoCrypto"
 
 [project.entry-points."peagen.plugins.cryptos"]
-paramiko_sa = "swarmauri_crypto_paramiko:ParamikoCrypto"
+paramiko_crypto = "swarmauri_crypto_paramiko:ParamikoCrypto"
 
 
 


### PR DESCRIPTION
## Summary
- rename peagen crypto entrypoint from `paramiko_sa` to `paramiko_crypto`
- update AutoKMS default crypto config to use `paramiko_crypto`

## Testing
- `uv run --directory pkgs/standards/auto_kms --package auto_kms ruff format .`
- `uv run --directory pkgs/standards/auto_kms --package auto_kms ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_crypto_paramiko --package swarmauri_crypto_paramiko ruff format .`
- `uv run --directory pkgs/standards/swarmauri_crypto_paramiko --package swarmauri_crypto_paramiko ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68ae818ce7a083269d62a06b0b21b7a9