### PR TITLE
feat: add KMS unwrap support

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/kms.py
+++ b/pkgs/standards/peagen/peagen/gateway/kms.py
@@ -41,3 +41,40 @@ async def wrap_key_with_kms(key: str) -> str:
     except Exception:
         # Fail open – loggers in calling code can capture details if desired.
         return key
+
+
+async def unwrap_key_with_kms(wrapped: str) -> str:
+    """Return KMS-unwrapped ``wrapped`` if a KMS endpoint is configured.
+
+    Parameters
+    ----------
+    wrapped:
+        The wrapped key material to unwrap.
+
+    Returns
+    -------
+    str
+        The unwrapped key returned by the KMS or the original value when no
+        KMS is configured or the request fails.
+    """
+
+    kms_url = settings.kms_unwrap_url
+    if not kms_url:
+        return wrapped
+
+    payload: dict[str, Any] = {"wrapped_key_b64": wrapped}
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(kms_url, json=payload)
+            resp.raise_for_status()
+            data = resp.json()
+            raw = data.get("key_material_b64")
+            if raw is None:
+                return wrapped
+            try:
+                return base64.b64decode(raw.encode()).decode()
+            except Exception:
+                return wrapped
+    except Exception:
+        # Fail open – loggers in calling code can capture details if desired.
+        return wrapped

--- a/pkgs/standards/peagen/peagen/gateway/runtime_cfg.py
+++ b/pkgs/standards/peagen/peagen/gateway/runtime_cfg.py
@@ -68,6 +68,7 @@ class Settings(BaseSettings):
     jwt_secret: str = Field(os.environ.get("JWT_SECRET", "insecure-dev-secret"))
     log_level: str = Field(os.environ.get("LOG_LEVEL", "INFO"))
     kms_wrap_url: Optional[str] = Field(default=os.environ.get("KMS_WRAP_URL"))
+    kms_unwrap_url: Optional[str] = Field(default=os.environ.get("KMS_UNWRAP_URL"))
 
     model_config = SettingsConfigDict(env_file=None)
 

--- a/pkgs/standards/peagen/tests/unit/test_kms_unwrap_keys.py
+++ b/pkgs/standards/peagen/tests/unit/test_kms_unwrap_keys.py
@@ -1,0 +1,61 @@
+import base64
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from peagen.gateway.kms import unwrap_key_with_kms
+from peagen.gateway.runtime_cfg import settings
+
+
+@pytest.mark.asyncio
+async def test_unwrap_no_url(monkeypatch):
+    monkeypatch.setattr(settings, "kms_unwrap_url", None)
+    result = await unwrap_key_with_kms("wrapped")
+    assert result == "wrapped"
+
+
+@pytest.mark.asyncio
+async def test_unwrap_success(monkeypatch):
+    monkeypatch.setattr(settings, "kms_unwrap_url", "http://kms")
+
+    unwrapped = "secret"
+    encoded = base64.b64encode(unwrapped.encode()).decode()
+
+    class DummyClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def post(self, url, json):
+            assert url == "http://kms"
+            assert json == {"wrapped_key_b64": "wrapped"}
+            return SimpleNamespace(
+                raise_for_status=lambda: None,
+                json=lambda: {"key_material_b64": encoded},
+            )
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: DummyClient())
+    result = await unwrap_key_with_kms("wrapped")
+    assert result == unwrapped
+
+
+@pytest.mark.asyncio
+async def test_unwrap_failure(monkeypatch):
+    monkeypatch.setattr(settings, "kms_unwrap_url", "http://kms")
+
+    class DummyClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def post(self, url, json):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: DummyClient())
+    result = await unwrap_key_with_kms("wrapped")
+    assert result == "wrapped"


### PR DESCRIPTION
## Summary
- support unwrapping keys via KMS with new `unwrap_key_with_kms`
- add `KMS_UNWRAP_URL` runtime config
- test unwrap key behavior

## Testing
- `uv run --directory . --package peagen ruff check peagen/gateway/kms.py peagen/gateway/runtime_cfg.py tests/unit/test_kms_unwrap_keys.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_68ae9cf537c08326b7237e7175921603