### PR TITLE
chore: type mixin columns with mapped

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/mixins/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/mixins/__init__.py
@@ -93,7 +93,7 @@ class TenantMixin:
     """
 
     @declared_attr
-    def tenant_id(cls):
+    def tenant_id(cls) -> Mapped[UUID]:
         schema = getattr(cls, "__tenant_table_schema__", None) or _infer_schema(cls)
         spec = ColumnSpec(
             storage=S(
@@ -120,7 +120,7 @@ class UserMixin:
     """
 
     @declared_attr
-    def user_id(cls):
+    def user_id(cls) -> Mapped[UUID]:
         schema = getattr(cls, "__user_table_schema__", None) or _infer_schema(cls)
         spec = ColumnSpec(
             storage=S(
@@ -144,7 +144,7 @@ class OrgMixin:
     """
 
     @declared_attr
-    def org_id(cls):
+    def org_id(cls) -> Mapped[UUID]:
         schema = getattr(cls, "__org_table_schema__", None) or _infer_schema(cls)
         spec = ColumnSpec(
             storage=S(
@@ -166,7 +166,7 @@ class Principal:  # concrete table marker
 
 # ────────── bounded scopes  ----------------------------------
 class OwnerBound:
-    owner_id: UUID = acol(
+    owner_id: Mapped[UUID] = acol(
         spec=ColumnSpec(
             storage=S(
                 type_=PgUUID(as_uuid=True),
@@ -184,7 +184,7 @@ class OwnerBound:
 
 
 class UserBound:  # membership rows
-    user_id: UUID = acol(
+    user_id: Mapped[UUID] = acol(
         spec=ColumnSpec(
             storage=S(
                 type_=PgUUID(as_uuid=True),
@@ -295,7 +295,7 @@ class Versioned:
 @declarative_mixin
 class Contained:
     @declared_attr
-    def parent_id(cls):
+    def parent_id(cls) -> Mapped[UUID]:
         if not hasattr(cls, "parent_table"):
             raise AttributeError("subclass must set parent_table")
         spec = ColumnSpec(
@@ -318,7 +318,7 @@ class TreeNode:
     """
 
     @declared_attr
-    def parent_id(cls):
+    def parent_id(cls) -> Mapped[UUID | None]:
         spec = ColumnSpec(
             storage=S(
                 type_=PgUUID(as_uuid=True),

--- a/pkgs/standards/autoapi/autoapi/v3/mixins/ownable.py
+++ b/pkgs/standards/autoapi/autoapi/v3/mixins/ownable.py
@@ -7,7 +7,7 @@ from typing import Any, Mapping
 from uuid import UUID
 
 from sqlalchemy.dialects.postgresql import UUID as PgUUID
-from sqlalchemy.orm import declared_attr
+from sqlalchemy.orm import Mapped, declared_attr
 
 from ..columns import acol
 from ..config.constants import (
@@ -126,7 +126,7 @@ class Ownable:
     __autoapi_owner_policy__: OwnerPolicy = OwnerPolicy.CLIENT_SET
 
     @declared_attr
-    def owner_id(cls):
+    def owner_id(cls) -> Mapped[UUID]:
         pol = getattr(cls, AUTOAPI_OWNER_POLICY_ATTR, OwnerPolicy.CLIENT_SET)
         schema = _infer_schema(cls, default="public")
 

--- a/pkgs/standards/autoapi/autoapi/v3/mixins/tenant_bound.py
+++ b/pkgs/standards/autoapi/autoapi/v3/mixins/tenant_bound.py
@@ -17,7 +17,7 @@ from ..config.constants import (
 from ..runtime.errors import create_standardized_error
 from ..specs import ColumnSpec, F, IO, S
 from ..specs.storage_spec import ForeignKeySpec
-from ..types import PgUUID, declared_attr
+from ..types import Mapped, PgUUID, declared_attr
 
 
 log = logging.getLogger(__name__)
@@ -73,7 +73,7 @@ class TenantBound(_RowBound):
     # tenant_id column (Schema-Aware; PgUUID(as_uuid=True))
     # -------------------------------------------------------------------
     @declared_attr
-    def tenant_id(cls):
+    def tenant_id(cls) -> Mapped[UUID]:
         pol = getattr(cls, AUTOAPI_TENANT_POLICY_ATTR, TenantPolicy.CLIENT_SET)
         schema = _infer_schema(cls, default="public")
 


### PR DESCRIPTION
## Summary
- type mixin columns with Mapped
- annotate declared attributes for tenant and owner mixins
- ensure hierarchical mixins return Mapped columns

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68ae9d4c8cf48326a80018cf85665501