### PR TITLE
Use Mapped annotations for autoapi v3 tables

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/tables/apikey.py
+++ b/pkgs/standards/autoapi/autoapi/v3/tables/apikey.py
@@ -6,6 +6,7 @@ from hashlib import sha256
 from secrets import token_urlsafe
 
 from fastapi import HTTPException
+from sqlalchemy.orm import Mapped
 
 from ..specs import acol, F, IO, S
 from ..types import (
@@ -36,12 +37,12 @@ class ApiKey(
     __tablename__ = "api_keys"
     __abstract__ = True
 
-    label: str = acol(
+    label: Mapped[str] = acol(
         storage=S(String, nullable=False),
         field=F(constraints={"max_length": 120}),
     )
 
-    digest: str = acol(
+    digest: Mapped[str] = acol(
         storage=S(String, nullable=False, unique=True),
         field=F(constraints={"max_length": 64}),
         io=IO(out_verbs=("read", "list")),

--- a/pkgs/standards/autoapi/autoapi/v3/tables/audit.py
+++ b/pkgs/standards/autoapi/autoapi/v3/tables/audit.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from . import Base
 from ..mixins import GUIDPk, Timestamped
+from sqlalchemy.orm import Mapped
 from ..specs import IO, F, acol, S
 from ..types import DateTime, Integer, String, PgUUID
 
@@ -11,32 +12,32 @@ from ..types import DateTime, Integer, String, PgUUID
 class Change(Base, GUIDPk, Timestamped):
     __tablename__ = "changes"
 
-    seq: int = acol(
+    seq: Mapped[int] = acol(
         storage=S(Integer, primary_key=True),
         field=F(),
         io=IO(out_verbs=("read", "list")),
     )
-    at: dt.datetime = acol(
+    at: Mapped[dt.datetime] = acol(
         storage=S(DateTime, default=dt.datetime.utcnow),
         field=F(),
         io=IO(out_verbs=("read", "list")),
     )
-    actor_id: UUID | None = acol(
+    actor_id: Mapped[UUID | None] = acol(
         storage=S(PgUUID, nullable=True),
         field=F(),
         io=IO(out_verbs=("read", "list")),
     )
-    table_name: str = acol(
+    table_name: Mapped[str] = acol(
         storage=S(String),
         field=F(),
         io=IO(out_verbs=("read", "list")),
     )
-    row_id: UUID | None = acol(
+    row_id: Mapped[UUID | None] = acol(
         storage=S(PgUUID, nullable=True),
         field=F(),
         io=IO(out_verbs=("read", "list")),
     )
-    action: str = acol(
+    action: Mapped[str] = acol(
         storage=S(String),
         field=F(),
         io=IO(out_verbs=("read", "list")),

--- a/pkgs/standards/autoapi/autoapi/v3/tables/client.py
+++ b/pkgs/standards/autoapi/autoapi/v3/tables/client.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 
+from sqlalchemy.orm import Mapped
+
 from ..specs import acol, IO, S, F
 from ..types import String, LargeBinary
 
@@ -13,12 +15,12 @@ class Client(Base, GUIDPk, Timestamped, TenantBound, ActiveToggle):
     __tablename__ = "clients"
     __abstract__ = True
     # ---------------------------------------------------------------- columns --
-    client_secret_hash: bytes = acol(
+    client_secret_hash: Mapped[bytes] = acol(
         storage=S(LargeBinary(60), nullable=False),
         field=F(),
         io=IO(in_verbs=("create",)),
     )
-    redirect_uris: str = acol(
+    redirect_uris: Mapped[str] = acol(
         storage=S(String, nullable=False),
         field=F(constraints={"max_length": 1000}),
         io=IO(),

--- a/pkgs/standards/autoapi/autoapi/v3/tables/group.py
+++ b/pkgs/standards/autoapi/autoapi/v3/tables/group.py
@@ -2,13 +2,14 @@
 
 from ._base import Base
 from ..mixins import GUIDPk, Timestamped, TenantBound, Principal
+from sqlalchemy.orm import Mapped
 from ..specs import IO, F, acol, S
 from ..types import String
 
 
 class Group(Base, GUIDPk, Timestamped, TenantBound, Principal):
     __tablename__ = "groups"
-    name: str = acol(
+    name: Mapped[str] = acol(
         storage=S(String),
         field=F(),
         io=IO(),

--- a/pkgs/standards/autoapi/autoapi/v3/tables/org.py
+++ b/pkgs/standards/autoapi/autoapi/v3/tables/org.py
@@ -2,6 +2,7 @@
 
 from ._base import Base
 from ..mixins import GUIDPk, Timestamped, TenantBound, Principal
+from sqlalchemy.orm import Mapped
 from ..specs import IO, F, acol, S
 from ..types import String
 
@@ -9,7 +10,7 @@ from ..types import String
 class Org(Base, GUIDPk, Timestamped, TenantBound, Principal):
     __tablename__ = "orgs"
     __abstract__ = True
-    name: str = acol(
+    name: Mapped[str] = acol(
         storage=S(String),
         field=F(),
         io=IO(),

--- a/pkgs/standards/autoapi/autoapi/v3/tables/rbac.py
+++ b/pkgs/standards/autoapi/autoapi/v3/tables/rbac.py
@@ -1,6 +1,9 @@
 from uuid import UUID
 
 
+
+from sqlalchemy.orm import Mapped
+
 from ..specs import IO, F, acol, S
 from ..specs.storage_spec import ForeignKeySpec
 from ..types import Integer, String, PgUUID
@@ -18,12 +21,12 @@ from ..mixins import (
 # ───────── RBAC core ──────────────────────────────────────────────────
 class Role(Base, GUIDPk, Timestamped, TenantBound):
     __tablename__ = "roles"
-    slug: str = acol(
+    slug: Mapped[str] = acol(
         storage=S(String, unique=True),
         field=F(),
         io=IO(),
     )
-    global_mask: int = acol(
+    global_mask: Mapped[int] = acol(
         storage=S(Integer, default=0),
         field=F(),
         io=IO(),
@@ -32,17 +35,17 @@ class Role(Base, GUIDPk, Timestamped, TenantBound):
 
 class RolePerm(Base, GUIDPk, Timestamped, TenantBound, RelationEdge, MaskableEdge):
     __tablename__ = "role_perms"
-    role_id: UUID = acol(
+    role_id: Mapped[UUID] = acol(
         storage=S(PgUUID, fk=ForeignKeySpec("roles.id")),
         field=F(),
         io=IO(),
     )
-    target_table: str = acol(
+    target_table: Mapped[str] = acol(
         storage=S(String),
         field=F(),
         io=IO(),
     )
-    target_id: str = acol(
+    target_id: Mapped[str] = acol(
         storage=S(String),
         field=F(),
         io=IO(),
@@ -51,12 +54,12 @@ class RolePerm(Base, GUIDPk, Timestamped, TenantBound, RelationEdge, MaskableEdg
 
 class RoleGrant(Base, GUIDPk, Timestamped, TenantBound, RelationEdge):
     __tablename__ = "role_grants"
-    principal_id: UUID = acol(
+    principal_id: Mapped[UUID] = acol(
         storage=S(PgUUID),
         field=F(),
         io=IO(),
     )  # FK to principal row
-    role_id: UUID = acol(
+    role_id: Mapped[UUID] = acol(
         storage=S(PgUUID, fk=ForeignKeySpec("roles.id")),
         field=F(),
         io=IO(),

--- a/pkgs/standards/autoapi/autoapi/v3/tables/status.py
+++ b/pkgs/standards/autoapi/autoapi/v3/tables/status.py
@@ -20,6 +20,7 @@ from enum import StrEnum
 
 from ..specs import acol, F, IO, S
 from ..types import String, SAEnum, Integer
+from sqlalchemy.orm import Mapped
 
 from ._base import Base
 from ..mixins import Timestamped  # created_at / updated_at
@@ -69,12 +70,12 @@ class StatusEnum(Base, Timestamped):
 
     __tablename__ = "status_enums"
 
-    id: int = acol(
+    id: Mapped[int] = acol(
         storage=S(Integer, primary_key=True, autoincrement=True),
         field=F(),
         io=IO(out_verbs=("read", "list")),
     )
-    code: Status = acol(
+    code: Mapped[Status] = acol(
         storage=S(
             SAEnum(Status, name="status_code_enum"),
             nullable=False,
@@ -83,7 +84,7 @@ class StatusEnum(Base, Timestamped):
         field=F(py_type=Status),
         io=IO(out_verbs=("read", "list")),
     )
-    label: str = acol(
+    label: Mapped[str] = acol(
         storage=S(String, nullable=False),
         field=F(),
         io=IO(out_verbs=("read", "list")),

--- a/pkgs/standards/autoapi/autoapi/v3/tables/user.py
+++ b/pkgs/standards/autoapi/autoapi/v3/tables/user.py
@@ -9,6 +9,7 @@ from ..mixins import (
     AsyncCapable,
     ActiveToggle,
 )
+from sqlalchemy.orm import Mapped
 from ..specs import IO, acol, F, S
 from ..types import String
 
@@ -18,7 +19,7 @@ class User(
 ):
     __tablename__ = "users"
     __abstract__ = True
-    username: str = acol(
+    username: Mapped[str] = acol(
         storage=S(String, nullable=False),
         field=F(constraints={"max_length": 80}),
         io=IO(),


### PR DESCRIPTION
## Summary
- annotate autoapi v3 table models with SQLAlchemy's `Mapped` generic
- ensure status table and RBAC models use typed `Mapped` columns

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68ae9d50a98083269a7cd8a622ddcb03