### PR TITLE
feat: upgrade peagen ORM to autoapi v3

### DIFF
--- a/pkgs/standards/peagen/peagen/orm/__init__.py
+++ b/pkgs/standards/peagen/peagen/orm/__init__.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 
 from typing import FrozenSet
 
-# from autoapi.v2.tables import Role, RoleGrant, RolePerm
-from autoapi.v2.tables import Status, Base
+# from autoapi.v3.tables import Role, RoleGrant, RolePerm
+from autoapi.v3.tables import Status, Base
 
 # Import table classes. Ensure Tenant is imported before Pool so bootstrapping
 # default rows inserts the default tenant prior to default pools.

--- a/pkgs/standards/peagen/peagen/orm/abuse_record.py
+++ b/pkgs/standards/peagen/peagen/orm/abuse_record.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from sqlalchemy import Column, String, Integer, Boolean
-
-from autoapi.v2.tables import Base, User
-from autoapi.v2.mixins import GUIDPk, Timestamped, Ownable
-from sqlalchemy.orm import relationship
+from autoapi.v3.tables import Base, User
+from autoapi.v3.types import Boolean, Integer, String, Mapped, relationship
+from autoapi.v3.mixins import GUIDPk, Timestamped, Ownable
+from autoapi.v3.specs import S, acol
 
 
 class AbuseRecord(Base, GUIDPk, Timestamped, Ownable):
@@ -17,11 +16,10 @@ class AbuseRecord(Base, GUIDPk, Timestamped, Ownable):
     """
 
     __tablename__ = "abuse_records"
-    __table_args__= ({"schema": "peagen"},)
+    __table_args__ = ({"schema": "peagen"},)
 
-    ip = Column(String, nullable=False, unique=True, index=True)
-    count = Column(Integer, nullable=False, default=0)
-    banned = Column(Boolean, nullable=False, default=False)
+    ip: Mapped[str] = acol(storage=S(String, nullable=False, unique=True, index=True))
+    count: Mapped[int] = acol(storage=S(Integer, nullable=False, default=0))
+    banned: Mapped[bool] = acol(storage=S(Boolean, nullable=False, default=False))
 
-    # relationships
-    owner = relationship(User, lazy="selectin")
+    owner: Mapped[User] = relationship(User, lazy="selectin")

--- a/pkgs/standards/peagen/peagen/orm/analysis_result.py
+++ b/pkgs/standards/peagen/peagen/orm/analysis_result.py
@@ -1,24 +1,32 @@
 from __future__ import annotations
 
-from autoapi.v2.types import Column, Text, JSON, PgUUID, ForeignKey, relationship
-from autoapi.v2.tables import Base
-from autoapi.v2.mixins import GUIDPk, Timestamped, Ownable, TenantBound
-
+from autoapi.v3.tables import Base
+from autoapi.v3.types import JSON, PgUUID, Text, ForeignKey, Mapped, relationship
+from autoapi.v3.mixins import GUIDPk, Timestamped, Ownable, TenantBound
+from autoapi.v3.specs import S, acol
+from typing import TYPE_CHECKING
 
 from .users import User
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .eval_result import EvalResult
 
 
 class AnalysisResult(Base, GUIDPk, Timestamped, TenantBound, Ownable):
     __tablename__ = "analysis_results"
-    __table_args__= ({"schema": "peagen"},)
-    eval_result_id = Column(
-        PgUUID(as_uuid=True), ForeignKey("peagen.eval_results.id", ondelete="CASCADE")
+    __table_args__ = ({"schema": "peagen"},)
+    eval_result_id: Mapped[PgUUID] = acol(
+        storage=S(
+            PgUUID(as_uuid=True),
+            fk=ForeignKey("peagen.eval_results.id", ondelete="CASCADE"),
+        )
     )
-    summary = Column(Text)
-    data = Column(JSON, default=dict, nullable=False)
-    owner = relationship(User, lazy="selectin")
-    eval_result = relationship("EvalResult", back_populates="analyses", lazy="selectin")
+    summary: Mapped[str | None] = acol(storage=S(Text))
+    data: Mapped[dict] = acol(storage=S(JSON, default=dict, nullable=False))
+    owner: Mapped[User] = relationship(User, lazy="selectin")
+    eval_result: Mapped["EvalResult"] = relationship(
+        "EvalResult", back_populates="analyses", lazy="selectin"
+    )
 
 
 __all__ = ["AnalysisResult"]
-    

--- a/pkgs/standards/peagen/peagen/orm/doe_spec.py
+++ b/pkgs/standards/peagen/peagen/orm/doe_spec.py
@@ -1,34 +1,33 @@
 from __future__ import annotations
 
-from autoapi.v2.types import (
-    Column,
-    String,
-    Text,
-    JSON,
-    UniqueConstraint,
-    ForeignKey,
-    PgUUID,
-    relationship,
-)
-from autoapi.v2.tables import Base
-from autoapi.v2.mixins import GUIDPk, Timestamped, TenantBound, Ownable
+from autoapi.v3.tables import Base
+from autoapi.v3.types import JSON, String, Text, UniqueConstraint, Mapped, relationship
+from autoapi.v3.mixins import GUIDPk, Timestamped, TenantBound, Ownable
+from autoapi.v3.specs import S, acol
+from typing import TYPE_CHECKING
 
-from .tenants import Tenant
 from .users import User
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .project_payload import ProjectPayload
 
 
 class DoeSpec(Base, GUIDPk, Timestamped, TenantBound, Ownable):
     __tablename__ = "doe_specs"
-    __table_args__= (UniqueConstraint("tenant_id", "name"), {"schema": "peagen"},)
+    __table_args__ = (
+        UniqueConstraint("tenant_id", "name"),
+        {"schema": "peagen"},
+    )
 
- 
-    name = Column(String, nullable=False)
-    schema_version = Column(String, nullable=False, default="1.1.0")
-    description = Column(Text, nullable=True)
-    spec = Column(JSON, nullable=False)
+    name: Mapped[str] = acol(storage=S(String, nullable=False))
+    schema_version: Mapped[str] = acol(
+        storage=S(String, nullable=False, default="1.1.0")
+    )
+    description: Mapped[str | None] = acol(storage=S(Text, nullable=True))
+    spec: Mapped[dict] = acol(storage=S(JSON, nullable=False))
 
-    owner = relationship(User, lazy="selectin")
-    project_payloads = relationship(
+    owner: Mapped[User] = relationship(User, lazy="selectin")
+    project_payloads: Mapped[list["ProjectPayload"]] = relationship(
         "ProjectPayload",
         back_populates="doe_spec",
         cascade="all, delete-orphan",

--- a/pkgs/standards/peagen/peagen/orm/evolve_spec.py
+++ b/pkgs/standards/peagen/peagen/orm/evolve_spec.py
@@ -1,31 +1,27 @@
 from __future__ import annotations
 
-from autoapi.v2.types import (
-    Column,
-    String,
-    Text,
-    JSON,
-    UniqueConstraint,
-    ForeignKey,
-    PgUUID,
-    relationship,
-)
-from autoapi.v2.tables import Base
-from autoapi.v2.mixins import GUIDPk, Timestamped, TenantBound, Ownable
+from autoapi.v3.tables import Base
+from autoapi.v3.types import JSON, String, Text, UniqueConstraint, Mapped, relationship
+from autoapi.v3.mixins import GUIDPk, Timestamped, TenantBound, Ownable
+from autoapi.v3.specs import S, acol
 
-from .tenants import Tenant
 from .users import User
 
 
 class EvolveSpec(Base, GUIDPk, Timestamped, TenantBound, Ownable):
     __tablename__ = "evolve_specs"
-    __table_args__= (UniqueConstraint("tenant_id", "name"),{"schema": "peagen"},)
-    name = Column(String, nullable=False)
-    schema_version = Column(String, nullable=False, default="1.0.0")
-    description = Column(Text, nullable=True)
-    spec = Column(JSON, nullable=False)
+    __table_args__ = (
+        UniqueConstraint("tenant_id", "name"),
+        {"schema": "peagen"},
+    )
+    name: Mapped[str] = acol(storage=S(String, nullable=False))
+    schema_version: Mapped[str] = acol(
+        storage=S(String, nullable=False, default="1.0.0")
+    )
+    description: Mapped[str | None] = acol(storage=S(Text, nullable=True))
+    spec: Mapped[dict] = acol(storage=S(JSON, nullable=False))
 
-    owner = relationship(User, lazy="selectin")
+    owner: Mapped[User] = relationship(User, lazy="selectin")
 
 
 __all__ = ["EvolveSpec"]

--- a/pkgs/standards/peagen/peagen/orm/mixins.py
+++ b/pkgs/standards/peagen/peagen/orm/mixins.py
@@ -1,24 +1,27 @@
 from __future__ import annotations
 
-from autoapi.v2.types import (
-    Column,
+from autoapi.v3.types import (
     ForeignKey,
     PgUUID,
     String,
+    Mapped,
     declarative_mixin,
     declared_attr,
     relationship,
 )
+from autoapi.v3.specs import S, acol
 
 
 @declarative_mixin
 class RepositoryMixin:
     """Mixin providing a required ``repository_id`` foreign key."""
 
-    repository_id = Column(
-        PgUUID(as_uuid=True),
-        ForeignKey("peagen.repositories.id"),
-        nullable=False,
+    repository_id: Mapped[PgUUID] = acol(
+        storage=S(
+            PgUUID(as_uuid=True),
+            fk=ForeignKey("peagen.repositories.id"),
+            nullable=False,
+        )
     )
 
 
@@ -26,13 +29,19 @@ class RepositoryMixin:
 class RepositoryRefMixin:
     """Mixin holding an optional reference to a repository and ref."""
 
-    repository_id = Column(
-        PgUUID(as_uuid=True),
-        ForeignKey("peagen.repositories.id", ondelete="CASCADE"),
-        nullable=True,
+    repository_id: Mapped[PgUUID | None] = acol(
+        storage=S(
+            PgUUID(as_uuid=True),
+            fk=ForeignKey("peagen.repositories.id", ondelete="CASCADE"),
+            nullable=True,
+        )
     )
-    repo = Column(String, nullable=False)  # e.g. "github.com/acme/app"
-    ref = Column(String, nullable=False)  # e.g. "main" / SHA / tag
+    repo: Mapped[str] = acol(
+        storage=S(String, nullable=False)
+    )  # e.g. "github.com/acme/app"
+    ref: Mapped[str] = acol(
+        storage=S(String, nullable=False)
+    )  # e.g. "main" / SHA / tag
 
     @declared_attr
     def repository(cls):

--- a/pkgs/standards/peagen/peagen/orm/orgs.py
+++ b/pkgs/standards/peagen/peagen/orm/orgs.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
-from autoapi.v2.tables import Org as OrgBase
+from autoapi.v3.tables import Org as OrgBase
+
 
 class Org(OrgBase):
     # __mapper_args__ = {"concrete": True}
-    __table_args__ = ({
-        "extend_existing": True,
-        "schema": "peagen",
-    },)
+    __table_args__ = (
+        {
+            "extend_existing": True,
+            "schema": "peagen",
+        },
+    )
 
 
 __all__ = ["Org"]

--- a/pkgs/standards/peagen/peagen/orm/peagen_toml_spec.py
+++ b/pkgs/standards/peagen/peagen/orm/peagen_toml_spec.py
@@ -1,32 +1,28 @@
 from __future__ import annotations
 
-from autoapi.v2.types import (
-    Column,
-    String,
-    Text,
-    JSON,
-    UniqueConstraint,
-    ForeignKey,
-    PgUUID,
-    relationship,
-)
-from autoapi.v2.tables import Base
-from autoapi.v2.mixins import GUIDPk, Timestamped, TenantBound, Ownable
+from autoapi.v3.tables import Base
+from autoapi.v3.types import JSON, String, Text, UniqueConstraint, Mapped, relationship
+from autoapi.v3.mixins import GUIDPk, Timestamped, TenantBound, Ownable
+from autoapi.v3.specs import S, acol
 
-from .tenants import Tenant
 from .users import User
 
 
 class PeagenTomlSpec(Base, GUIDPk, Timestamped, TenantBound, Ownable):
     __tablename__ = "peagen_toml_specs"
-    __table_args__= (UniqueConstraint("tenant_id", "name"),{"schema": "peagen"},)
-      
-    name = Column(String, nullable=False)
-    schema_version = Column(String, nullable=False, default="1.0.0")
-    raw_toml = Column(Text, nullable=False)
-    parsed = Column(JSON, nullable=False, default=dict)
+    __table_args__ = (
+        UniqueConstraint("tenant_id", "name"),
+        {"schema": "peagen"},
+    )
 
-    owner = relationship(User, lazy="selectin")
+    name: Mapped[str] = acol(storage=S(String, nullable=False))
+    schema_version: Mapped[str] = acol(
+        storage=S(String, nullable=False, default="1.0.0")
+    )
+    raw_toml: Mapped[str] = acol(storage=S(Text, nullable=False))
+    parsed: Mapped[dict] = acol(storage=S(JSON, nullable=False, default=dict))
+
+    owner: Mapped[User] = relationship(User, lazy="selectin")
 
 
 __all__ = ["PeagenTomlSpec"]

--- a/pkgs/standards/peagen/peagen/orm/project_payload.py
+++ b/pkgs/standards/peagen/peagen/orm/project_payload.py
@@ -1,39 +1,50 @@
 from __future__ import annotations
 
-from autoapi.v2.types import (
-    Column,
+from autoapi.v3.tables import Base
+from autoapi.v3.types import (
+    JSON,
     String,
     Text,
-    JSON,
     UniqueConstraint,
-    ForeignKey,
     PgUUID,
+    ForeignKey,
+    Mapped,
     relationship,
 )
-from autoapi.v2.tables import Base
-from autoapi.v2.mixins import GUIDPk, Timestamped, TenantBound, Ownable
+from autoapi.v3.mixins import GUIDPk, Timestamped, TenantBound, Ownable
+from autoapi.v3.specs import S, acol
+from typing import TYPE_CHECKING
 
-from .tenants import Tenant
 from .users import User
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .doe_spec import DoeSpec
 
 
 class ProjectPayload(Base, GUIDPk, Timestamped, TenantBound, Ownable):
     __tablename__ = "project_payloads"
 
-    __table_args__= (UniqueConstraint("tenant_id", "name"),{"schema": "peagen"},)
-    
-    doe_spec_id = Column(
-        PgUUID(as_uuid=True),
-        ForeignKey("peagen.doe_specs.id", ondelete="SET NULL"),
-        nullable=True,
+    __table_args__ = (
+        UniqueConstraint("tenant_id", "name"),
+        {"schema": "peagen"},
     )
-    name = Column(String, nullable=False)
-    schema_version = Column(String, nullable=False, default="1.0.0")
-    description = Column(Text, nullable=True)
-    payload = Column(JSON, nullable=False)
 
-    owner = relationship(User, lazy="selectin")
-    doe_spec = relationship(
+    doe_spec_id: Mapped[PgUUID | None] = acol(
+        storage=S(
+            PgUUID(as_uuid=True),
+            fk=ForeignKey("peagen.doe_specs.id", ondelete="SET NULL"),
+            nullable=True,
+        )
+    )
+    name: Mapped[str] = acol(storage=S(String, nullable=False))
+    schema_version: Mapped[str] = acol(
+        storage=S(String, nullable=False, default="1.0.0")
+    )
+    description: Mapped[str | None] = acol(storage=S(Text, nullable=True))
+    payload: Mapped[dict] = acol(storage=S(JSON, nullable=False))
+
+    owner: Mapped[User] = relationship(User, lazy="selectin")
+    doe_spec: Mapped["DoeSpec" | None] = relationship(
         "DoeSpec", back_populates="project_payloads", lazy="selectin"
     )
 

--- a/pkgs/standards/peagen/peagen/orm/raw_blobs.py
+++ b/pkgs/standards/peagen/peagen/orm/raw_blobs.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
-from autoapi.v2.tables import Base
-from autoapi.v2.types import Column, String, Integer
-from autoapi.v2.mixins import GUIDPk, Timestamped, BlobRef
+from autoapi.v3.tables import Base
+from autoapi.v3.types import Integer, String, Mapped
+from autoapi.v3.mixins import GUIDPk, Timestamped, BlobRef
+from autoapi.v3.specs import S, acol
 
 
 class RawBlob(Base, GUIDPk, Timestamped, BlobRef):
     __tablename__ = "raw_blobs"
-    __table_args__= ({"schema": "peagen"},)
-    mime_type = Column(String, nullable=False)
-    size = Column(Integer, nullable=False)
+    __table_args__ = ({"schema": "peagen"},)
+    mime_type: Mapped[str] = acol(storage=S(String, nullable=False))
+    size: Mapped[int] = acol(storage=S(Integer, nullable=False))
 
 
 __all__ = ["RawBlob"]

--- a/pkgs/standards/peagen/peagen/orm/repositories.py
+++ b/pkgs/standards/peagen/peagen/orm/repositories.py
@@ -2,17 +2,34 @@
 from __future__ import annotations
 
 from urllib.parse import urlparse
-from typing import Any, Dict, Mapping, Optional
+from typing import Any, Mapping, Optional, TYPE_CHECKING
 
-from autoapi.v2.tables import Base
-from autoapi.v2.types import (
-    Column, String, UniqueConstraint, relationship, HookProvider, Field,
+from autoapi.v3.tables import Base
+from autoapi.v3.types import (
+    String,
+    UniqueConstraint,
+    relationship,
+    HookProvider,
+    Field,
+    Mapped,
 )
-from autoapi.v2.mixins import (
-    GUIDPk, Timestamped, TenantBound, TenantPolicy, Ownable, OwnerPolicy, StatusMixin,
+from autoapi.v3.mixins import (
+    GUIDPk,
+    Timestamped,
+    TenantBound,
+    TenantPolicy,
+    Ownable,
+    OwnerPolicy,
+    StatusMixin,
 )
-from autoapi.v2.hooks import Phase
-from autoapi.v2.jsonrpc_models import create_standardized_error
+from autoapi.v3.runtime.errors import create_standardized_error
+from autoapi.v3.specs import S, acol
+from autoapi.v3 import hook_ctx
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .secrets import RepoSecret
+    from .keys import DeployKey
+    from .tasks import Task
 
 
 class Repository(
@@ -24,21 +41,30 @@ class Repository(
     # Only request-extra we allow: caller's GitHub PAT (write-only)
     __autoapi_request_extras__ = {
         "*": {
-            "github_pat": (str | None, Field(default=None, description="GitHub PAT (write-only)")),
+            "github_pat": (
+                str | None,
+                Field(default=None, description="GitHub PAT (write-only)"),
+            ),
         }
     }
 
     __autoapi_owner_policy__: OwnerPolicy = OwnerPolicy.STRICT_SERVER
     __autoapi_tenant_policy__: TenantPolicy = TenantPolicy.STRICT_SERVER
 
-    name = Column(String, nullable=False)
-    url = Column(String, unique=True, nullable=False)
-    default_branch = Column(String, default="main")
-    commit_sha = Column(String(length=40), nullable=True)
+    name: Mapped[str] = acol(storage=S(String, nullable=False))
+    url: Mapped[str] = acol(storage=S(String, unique=True, nullable=False))
+    default_branch: Mapped[str] = acol(storage=S(String, default="main"))
+    commit_sha: Mapped[str | None] = acol(storage=S(String(length=40), nullable=True))
 
-    secrets = relationship("RepoSecret", back_populates="repository", cascade="all, delete-orphan")
-    deploy_keys = relationship("DeployKey", back_populates="repository", cascade="all, delete-orphan")
-    tasks = relationship("Task", back_populates="repository", cascade="all, delete-orphan")
+    secrets: Mapped[list["RepoSecret"]] = relationship(
+        "RepoSecret", back_populates="repository", cascade="all, delete-orphan"
+    )
+    deploy_keys: Mapped[list["DeployKey"]] = relationship(
+        "DeployKey", back_populates="repository", cascade="all, delete-orphan"
+    )
+    tasks: Mapped[list["Task"]] = relationship(
+        "Task", back_populates="repository", cascade="all, delete-orphan"
+    )
 
     # ─────────────── helpers ───────────────
 
@@ -77,7 +103,7 @@ class Repository(
 
     # ─────────────── PRE_HANDLER (provision remotes) ───────────────
 
-    @classmethod
+    @hook_ctx(ops="create", phase="PRE_HANDLER")
     async def _pre_handler_provision(cls, ctx):
         """
         Before DB create: ensure both remotes exist and are linked
@@ -90,20 +116,28 @@ class Repository(
         gh_pat = (p.get("github_pat") or "").strip()
 
         if not slug:
-            http_exc, *_ = create_standardized_error(400, message="url must include owner/name")
+            http_exc, *_ = create_standardized_error(
+                400, message="url must include owner/name"
+            )
             raise http_exc
         if not gh_pat:
-            http_exc, *_ = create_standardized_error(400, message="github_pat is required")
+            http_exc, *_ = create_standardized_error(
+                400, message="github_pat is required"
+            )
             raise http_exc
 
         # Optional description from name
         desc = (p.get("name") or "").strip()
 
         try:
-            result = await gsc.ensure_repo_and_mirror(slug=slug, github_pat=gh_pat, description=desc)
+            result = await gsc.ensure_repo_and_mirror(
+                slug=slug, github_pat=gh_pat, description=desc
+            )
         except Exception as exc:
             # Map provisioning failure to 502 (bad upstream)
-            http_exc, *_ = create_standardized_error(502, message=f"remote provisioning failed: {exc}")
+            http_exc, *_ = create_standardized_error(
+                502, message=f"remote provisioning failed: {exc}"
+            )
             raise http_exc
         finally:
             # scrub the PAT as soon as possible
@@ -118,7 +152,7 @@ class Repository(
             "created": result.get("created"),
         }
 
-    @classmethod
+    @hook_ctx(ops="create", phase="POST_RESPONSE")
     async def _post_response_attach(cls, ctx):
         summary = ctx.get("__repo_init__")
         if not summary:
@@ -130,11 +164,7 @@ class Repository(
 
     # ─────────────── register hooks ───────────────
 
-    @classmethod
-    def __autoapi_register_hooks__(cls, api) -> None:
-        # Run provisioning before the DB handler; attach a tiny summary after
-        api.register_hook(Phase.PRE_HANDLER,   model=cls, op="create")(cls._pre_handler_provision)
-        api.register_hook(Phase.POST_RESPONSE, model=cls, op="create")(cls._post_response_attach)
+    # hooks registered via @hook_ctx
 
 
 __all__ = ["Repository"]

--- a/pkgs/standards/peagen/peagen/orm/secrets.py
+++ b/pkgs/standards/peagen/peagen/orm/secrets.py
@@ -1,22 +1,28 @@
 from __future__ import annotations
 
-from autoapi.v2.types import (
-    Column,
+from autoapi.v3.tables import Base
+from autoapi.v3.types import (
     String,
     UniqueConstraint,
     CheckConstraint,
     HookProvider,
     relationship,
+    Mapped,
 )
-from autoapi.v2.tables import Base
-from autoapi.v2.mixins import GUIDPk, OrgMixin, Timestamped, UserMixin
+from autoapi.v3.mixins import GUIDPk, OrgMixin, Timestamped, UserMixin
+from autoapi.v3.specs import S, acol
+from autoapi.v3 import hook_ctx
+from typing import TYPE_CHECKING
 from peagen.orm.mixins import RepositoryMixin
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .repositories import Repository
 
 
 class _SecretCoreMixin:
-    name = Column(String(128), nullable=False)
-    data = Column(String, nullable=False)
-    desc = Column(String, nullable=True)
+    name: Mapped[str] = acol(storage=S(String(128), nullable=False))
+    data: Mapped[str] = acol(storage=S(String, nullable=False))
+    desc: Mapped[str | None] = acol(storage=S(String, nullable=True))
     __table_args__ = (
         CheckConstraint("length(name) > 0", name="chk_name_nonempty"),
         {"schema": "peagen"},
@@ -43,13 +49,15 @@ class RepoSecret(
     Base, GUIDPk, _SecretCoreMixin, RepositoryMixin, Timestamped, HookProvider
 ):
     __tablename__ = "repo_secrets"
-    repository = relationship("Repository", back_populates="secrets")
+    repository: Mapped["Repository"] = relationship(
+        "Repository", back_populates="secrets"
+    )
     __table_args__ = (
         UniqueConstraint("repository_id", "name"),
         *_SecretCoreMixin.__table_args__,
     )
 
-    @classmethod
+    @hook_ctx(ops="create", phase="POST_COMMIT")
     async def _post_create(cls, ctx):
         from peagen.gateway import log
 
@@ -58,7 +66,7 @@ class RepoSecret(
         log.info("Secret stored successfully: %s", params.name)
         ctx["result"] = {"ok": True}
 
-    @classmethod
+    @hook_ctx(ops="delete", phase="POST_COMMIT")
     async def _post_delete(cls, ctx):
         from peagen.gateway import log
 
@@ -66,17 +74,7 @@ class RepoSecret(
         params = ctx["env"].params
         log.info("Secret deleted: %s", params.name)
 
-    @classmethod
-    def __autoapi_register_hooks__(cls, api) -> None:
-        from autoapi.v2 import Phase, get_schema
-
-        cls._SRead = get_schema(cls, "read")
-        api.register_hook(Phase.POST_COMMIT, model="RepoSecret", op="create")(
-            cls._post_create
-        )
-        api.register_hook(Phase.POST_COMMIT, model="RepoSecret", op="delete")(
-            cls._post_delete
-        )
+        # hooks registered via @hook_ctx
 
 
 __all__ = ["UserSecret", "OrgSecret", "RepoSecret"]

--- a/pkgs/standards/peagen/peagen/orm/tasks.py
+++ b/pkgs/standards/peagen/peagen/orm/tasks.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import json
 from enum import Enum, auto
 
-from autoapi.v2.types import (
+from autoapi.v3.tables import Base
+from autoapi.v3.types import (
     JSON,
-    Column,
     String,
     PgEnum,
     PgUUID,
@@ -13,16 +13,22 @@ from autoapi.v2.types import (
     ForeignKey,
     relationship,
     HookProvider,
+    Mapped,
 )
-from autoapi.v2.tables import Base
-from autoapi.v2.mixins import (
+from autoapi.v3.mixins import (
     GUIDPk,
     Timestamped,
     TenantBound,
     Ownable,
     StatusMixin,
 )
+from autoapi.v3.specs import S, acol
+from autoapi.v3 import hook_ctx
+from typing import TYPE_CHECKING
 from peagen.orm.mixins import RepositoryRefMixin
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .works import Work
 
 
 class Action(str, Enum):
@@ -53,21 +59,29 @@ class Task(
 ):
     __tablename__ = "tasks"
     __table_args__ = ({"schema": "peagen"},)
-    action = Column(PgEnum(Action, name="task_action"), nullable=False)
-    pool_id = Column(
-        PgUUID(as_uuid=True), ForeignKey("peagen.pools.id"), nullable=False
+    action: Mapped[Action] = acol(
+        storage=S(PgEnum(Action, name="task_action"), nullable=False)
     )
-    config_toml = Column(String)
-    spec_kind = Column(PgEnum(SpecKind, name="task_spec_kind"), nullable=True)
-    spec_uuid = Column(PgUUID(as_uuid=True), nullable=True)
-    args = Column(JSON, nullable=False, default=dict)
-    labels = Column(JSON, nullable=False, default=dict)
-    note = Column(String)
-    schema_version = Column(Integer, nullable=False, default=3)
+    pool_id: Mapped[PgUUID] = acol(
+        storage=S(
+            PgUUID(as_uuid=True), fk=ForeignKey("peagen.pools.id"), nullable=False
+        )
+    )
+    config_toml: Mapped[str | None] = acol(storage=S(String))
+    spec_kind: Mapped[SpecKind | None] = acol(
+        storage=S(PgEnum(SpecKind, name="task_spec_kind"), nullable=True)
+    )
+    spec_uuid: Mapped[PgUUID | None] = acol(
+        storage=S(PgUUID(as_uuid=True), nullable=True)
+    )
+    args: Mapped[dict] = acol(storage=S(JSON, nullable=False, default=dict))
+    labels: Mapped[dict] = acol(storage=S(JSON, nullable=False, default=dict))
+    note: Mapped[str | None] = acol(storage=S(String))
+    schema_version: Mapped[int] = acol(storage=S(Integer, nullable=False, default=3))
 
-    works = relationship("Work", back_populates="task")
+    works: Mapped[list["Work"]] = relationship("Work", back_populates="task")
 
-    @classmethod
+    @hook_ctx(ops="create", phase="PRE_TX_BEGIN")
     async def _pre_create(cls, ctx):
         from peagen.gateway import log, queue
         from peagen.gateway.schedule_helpers import get_live_workers_by_pool
@@ -111,7 +125,7 @@ class Task(
                 log.warning("no worker advertising '%s' found", action)
         ctx["task_in"] = tc
 
-    @classmethod
+    @hook_ctx(ops="create", phase="POST_COMMIT")
     async def _post_create(cls, ctx):
         from peagen.defaults import READY_QUEUE, TASK_TTL
         from peagen.gateway import log, queue
@@ -119,7 +133,9 @@ class Task(
         from peagen.gateway.schedule_helpers import _save_task
 
         log.info("entering post_task_create")
-        created = cls._SRead.model_validate(ctx["result"], from_attributes=True)
+        created = cls.schemas.read.out.model_validate(
+            ctx["result"], from_attributes=True
+        )
         submitted = ctx["task_in"]
         wire = submitted.model_copy(update={"id": created.id})
         await queue.rpush(
@@ -128,11 +144,11 @@ class Task(
         )
         await queue.sadd("pools", wire.pool_id)
         await _publish_queue_length(queue, wire.pool_id)
-        await _save_task(queue, cls._SRead.model_validate(wire.model_dump()))
+        await _save_task(queue, cls.schemas.read.out.model_validate(wire.model_dump()))
         await _publish_task(wire.model_dump())
         log.info("task %s queued in %s (ttl=%s)", created.id, wire.pool_id, TASK_TTL)
 
-    @classmethod
+    @hook_ctx(ops="update", phase="PRE_TX_BEGIN")
     async def _pre_update(cls, ctx):
         from peagen.gateway import log, queue
         from peagen.gateway.schedule_helpers import _load_task
@@ -147,7 +163,7 @@ class Task(
         ctx["cached_task"] = cached
         ctx["changes"] = upd.model_dump(exclude_unset=True)
 
-    @classmethod
+    @hook_ctx(ops="update", phase="POST_COMMIT")
     async def _post_update(cls, ctx):
         from peagen.gateway import log, queue
         from peagen.gateway._publish import _publish_task
@@ -164,7 +180,7 @@ class Task(
                 await _finalize_parent_tasks(queue, cid)
         log.info("task %s updated (%s)", task.id, ", ".join(changes))
 
-    @classmethod
+    @hook_ctx(ops="read", phase="PRE_TX_BEGIN")
     async def _pre_read(cls, ctx):
         from peagen.gateway import log, queue
         from peagen.gateway.schedule_helpers import _load_task
@@ -176,7 +192,7 @@ class Task(
             ctx["cached_task"] = hit
             ctx["skip_db"] = True
 
-    @classmethod
+    @hook_ctx(ops="read", phase="POST_HANDLER")
     async def _post_read(cls, ctx):
         from peagen.gateway import log
 
@@ -184,28 +200,7 @@ class Task(
         if ctx.get("skip_db") and ctx.get("cached_task"):
             ctx["result"] = ctx["cached_task"]
 
-    @classmethod
-    def __autoapi_register_hooks__(cls, api) -> None:
-        from autoapi.v2 import Phase, get_schema
-
-        cls._SCreate = get_schema(cls, "create")
-        cls._SRead = get_schema(cls, "read")
-        cls._SUpdate = get_schema(cls, "update")
-        model_name = cls.__name__
-        api.register_hook(Phase.PRE_TX_BEGIN, model=model_name, op="create")(
-            cls._pre_create
-        )
-        api.register_hook(Phase.PRE_TX_BEGIN, model=model_name, op="update")(
-            cls._pre_update
-        )
-        api.register_hook(Phase.PRE_TX_BEGIN, model=model_name, op="read")(cls._pre_read)
-        api.register_hook(Phase.POST_COMMIT, model=model_name, op="create")(
-            cls._post_create
-        )
-        api.register_hook(Phase.POST_COMMIT, model=model_name, op="update")(
-            cls._post_update
-        )
-        api.register_hook(Phase.POST_HANDLER, model=model_name, op="read")(cls._post_read)
+        # hooks registered via @hook_ctx
 
 
 __all__ = ["Action", "SpecKind", "Task"]

--- a/pkgs/standards/peagen/peagen/orm/tenants.py
+++ b/pkgs/standards/peagen/peagen/orm/tenants.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from autoapi.v2.tables import Tenant as TenantBase
-from autoapi.v2.mixins import Bootstrappable
-from autoapi.v2.mixins.upsertable import Upsertable
+from autoapi.v3.tables import Tenant as TenantBase
+from autoapi.v3.mixins import Bootstrappable, Upsertable
 from peagen.defaults import (
     DEFAULT_TENANT_ID,
     DEFAULT_TENANT_SLUG,
@@ -11,10 +10,12 @@ from peagen.defaults import (
 
 class Tenant(TenantBase, Bootstrappable, Upsertable):
     # __mapper_args__ = {"concrete": True}
-    __table_args__ = ({
-        "extend_existing": True,
-        "schema": "peagen",
-    },)
+    __table_args__ = (
+        {
+            "extend_existing": True,
+            "schema": "peagen",
+        },
+    )
     DEFAULT_ROWS = [
         {
             "id": DEFAULT_TENANT_ID,
@@ -23,5 +24,6 @@ class Tenant(TenantBase, Bootstrappable, Upsertable):
     ]
 
     __upsert_keys__ = ("slug",)
+
 
 __all__ = ["Tenant"]

--- a/pkgs/standards/peagen/peagen/orm/user_repositories.py
+++ b/pkgs/standards/peagen/peagen/orm/user_repositories.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from autoapi.v2.tables import Base
-from autoapi.v2.mixins import GUIDPk, UserMixin
+from autoapi.v3.tables import Base
+from autoapi.v3.mixins import GUIDPk, UserMixin
 
 from .mixins import RepositoryMixin
 
@@ -10,6 +10,7 @@ class UserRepository(Base, GUIDPk, RepositoryMixin, UserMixin):
     """Edge capturing any per-repository permission or ownership the user may have."""
 
     __tablename__ = "user_repositories"
-    __table_args__= ({"schema": "peagen"},)
+    __table_args__ = ({"schema": "peagen"},)
+
 
 __all__ = ["UserRepository"]

--- a/pkgs/standards/peagen/peagen/orm/users.py
+++ b/pkgs/standards/peagen/peagen/orm/users.py
@@ -1,22 +1,18 @@
 from __future__ import annotations
 
-from autoapi.v2.tables import User as UserBase
-from autoapi.v2.mixins import Bootstrappable, Upsertable, uuid_example
-from autoapi.v2.types import Column, PgUUID, uuid4
+from autoapi.v3.tables import User as UserBase
+from autoapi.v3.mixins import Bootstrappable, Upsertable, uuid_example
+from autoapi.v3.types import PgUUID, Mapped, uuid4
+from autoapi.v3.specs import S, F, acol
+
 
 class User(UserBase, Bootstrappable, Upsertable):
     __table_args__ = ({"extend_existing": True, "schema": "peagen"},)
 
-    id = Column(
-        PgUUID(as_uuid=True),
-        primary_key=True,
-        default=uuid4,
-        info=dict(
-            autoapi={
-                "default_factory": uuid4,
-                "examples": [uuid_example],
-            }
-        ),
+    id: Mapped[PgUUID] = acol(
+        storage=S(PgUUID(as_uuid=True), primary_key=True, default=uuid4),
+        field=F(constraints={"examples": [uuid_example]}),
     )
+
 
 __all__ = ["User"]

--- a/pkgs/standards/peagen/peagen/orm/workers.py
+++ b/pkgs/standards/peagen/peagen/orm/workers.py
@@ -1,21 +1,21 @@
 from __future__ import annotations
 
-
-from autoapi.v2.types import (
+from autoapi.v3.tables import Base
+from autoapi.v3.types import (
     JSON,
-    Column,
-    ForeignKey,
     PgUUID,
     UUID,
     String,
     MutableDict,
+    ForeignKey,
     relationship,
     HookProvider,
     AllowAnonProvider,
+    Mapped,
 )
-from autoapi.v2.tables import Base
-
-from autoapi.v2.mixins import GUIDPk, Timestamped
+from autoapi.v3.mixins import GUIDPk, Timestamped
+from autoapi.v3.specs import S, acol
+from autoapi.v3 import hook_ctx
 from peagen.defaults import DEFAULT_POOL_ID, WORKER_KEY, WORKER_TTL
 
 from .pools import Pool
@@ -27,27 +27,31 @@ class Worker(Base, GUIDPk, Timestamped, HookProvider, AllowAnonProvider):
 
     __autoapi_allow_anon__ = {"create"}
 
-    pool_id = Column(
-        PgUUID(as_uuid=True),
-        ForeignKey("peagen.pools.id"),
-        nullable=False,
-        default=DEFAULT_POOL_ID,
+    pool_id: Mapped[PgUUID] = acol(
+        storage=S(
+            PgUUID(as_uuid=True),
+            fk=ForeignKey("peagen.pools.id"),
+            nullable=False,
+            default=DEFAULT_POOL_ID,
+        )
     )
-    url = Column(String, nullable=False, info=dict(no_update=True))
-    advertises = Column(
-        MutableDict.as_mutable(JSON),  # or JSON
-        default=lambda: {},  # ✔ correct for SQLAlchemy
-        nullable=True,
-        info=dict(no_update=True),
+    url: Mapped[str] = acol(storage=S(String, nullable=False))
+    advertises: Mapped[dict | None] = acol(
+        storage=S(
+            MutableDict.as_mutable(JSON),
+            default=lambda: {},
+            nullable=True,
+        )
     )
-    handlers = Column(
-        MutableDict.as_mutable(JSON),  # or JSON
-        default=lambda: {},  # ✔ correct for SQLAlchemy
-        nullable=True,
-        info=dict(no_update=True),
+    handlers: Mapped[dict | None] = acol(
+        storage=S(
+            MutableDict.as_mutable(JSON),
+            default=lambda: {},
+            nullable=True,
+        )
     )
 
-    pool = relationship(Pool, backref="workers")
+    pool: Mapped[Pool] = relationship(Pool, backref="workers")
 
     # ─── internal helpers -------------------------------------------------
     @staticmethod
@@ -87,7 +91,7 @@ class Worker(Base, GUIDPk, Timestamped, HookProvider, AllowAnonProvider):
             raise RPCException(code=-32602, message="pool at capacity")
 
     # ─── AutoAPI hook callbacks ------------------------------------------
-    @classmethod
+    @hook_ctx(ops="create", phase="PRE_TX_BEGIN")
     async def _pre_create_policy_gate(cls, ctx):
         from peagen.gateway import log
 
@@ -106,22 +110,26 @@ class Worker(Base, GUIDPk, Timestamped, HookProvider, AllowAnonProvider):
         policy, count = await ctx["db"].run_sync(_get_policy_and_count)
         cls._check_pool_policy(policy or {}, ip, count)
 
-    @classmethod
+    @hook_ctx(ops="create", phase="POST_RESPONSE")
     async def _post_create_cache_pool(cls, ctx):
         from peagen.gateway import log, queue
 
-        created = cls._SRead.model_validate(ctx["result"], from_attributes=True)
+        created = cls.schemas.read.out.model_validate(
+            ctx["result"], from_attributes=True
+        )
         log.info("worker %s joined pool_id %s", created.id, created.pool_id)
         try:
             await queue.sadd(f"pool_id:{created.pool_id}:members", str(created.id))
         except Exception as exc:  # noqa: BLE001
             log.error("failure to add member to pool queue. err: %s", exc)
 
-    @classmethod
+    @hook_ctx(ops="create", phase="POST_RESPONSE")
     async def _post_create_cache_worker(cls, ctx):
         from peagen.gateway import log, queue
 
-        created = cls._SRead.model_validate(ctx["result"], from_attributes=True)
+        created = cls.schemas.read.out.model_validate(
+            ctx["result"], from_attributes=True
+        )
         try:
             key = WORKER_KEY.format(str(created.id))
             await queue.hset(key, cls._as_redis_hash(created))
@@ -136,11 +144,13 @@ class Worker(Base, GUIDPk, Timestamped, HookProvider, AllowAnonProvider):
         except Exception as exc:  # noqa: BLE001
             log.error("failure to _publish_event for: `Worker.create` err: %s", exc)
 
-    @classmethod
+    @hook_ctx(ops="create", phase="POST_COMMIT")
     async def _post_create_auto_register(cls, ctx):
         from peagen.gateway import authn_adapter, log
 
-        created = cls._SRead.model_validate(ctx["result"], from_attributes=True)
+        created = cls.schemas.read.out.model_validate(
+            ctx["result"], from_attributes=True
+        )
         try:
             base = authn_adapter.base_url
 
@@ -170,7 +180,7 @@ class Worker(Base, GUIDPk, Timestamped, HookProvider, AllowAnonProvider):
             log.error("auto-registration failed: %s", exc)
             ctx["raw_worker_key"] = None
 
-    @classmethod
+    @hook_ctx(ops="create", phase="POST_RESPONSE")
     async def _post_create_inject_key(cls, ctx):
         from peagen.gateway import log
 
@@ -189,9 +199,9 @@ class Worker(Base, GUIDPk, Timestamped, HookProvider, AllowAnonProvider):
         elif hasattr(res, "model_dump"):  # Pydantic model
             out = res.model_dump(mode="json")
         else:  # ORM instance
-            out = cls._SRead.model_validate(res, from_attributes=True).model_dump(
-                mode="json"
-            )
+            out = cls.schemas.read.out.model_validate(
+                res, from_attributes=True
+            ).model_dump(mode="json")
 
         # Inject the key into the response payload only (not persisted)
         out["api_key"] = raw
@@ -201,7 +211,7 @@ class Worker(Base, GUIDPk, Timestamped, HookProvider, AllowAnonProvider):
         if resp is not None:
             resp.result = out
 
-    @classmethod
+    @hook_ctx(ops="update", phase="PRE_TX_BEGIN")
     async def _pre_update_policy_gate(cls, ctx):
         from peagen.gateway import log
 
@@ -226,7 +236,7 @@ class Worker(Base, GUIDPk, Timestamped, HookProvider, AllowAnonProvider):
         policy, count = await ctx["db"].run_sync(_get_policy_and_count)
         cls._check_pool_policy(policy or {}, ip, count)
 
-    @classmethod
+    @hook_ctx(ops="update", phase="PRE_TX_BEGIN")
     async def _pre_update(cls, ctx):
         from peagen.gateway import log, queue
         from peagen.transport.jsonrpc import RPCException
@@ -239,13 +249,15 @@ class Worker(Base, GUIDPk, Timestamped, HookProvider, AllowAnonProvider):
             raise RPCException(code=-32602, message="unknown worker; pool_id required")
         ctx["worker_id"] = worker_id
 
-    @classmethod
+    @hook_ctx(ops="update", phase="POST_RESPONSE")
     async def _post_update_cache_pool(cls, ctx):
         from peagen.gateway import log, queue
 
         worker_id = ctx["worker_id"]
         try:
-            updated = cls._SRead.model_validate(ctx["result"], from_attributes=True)
+            updated = cls.schemas.read.out.model_validate(
+                ctx["result"], from_attributes=True
+            )
             if updated.pool_id:
                 await queue.sadd(f"pool_id:{updated.pool_id}:members", worker_id)
             log.info("cached member `%s` in `%s`", worker_id, updated.pool_id)
@@ -257,14 +269,16 @@ class Worker(Base, GUIDPk, Timestamped, HookProvider, AllowAnonProvider):
                 exc,
             )
 
-    @classmethod
+    @hook_ctx(ops="update", phase="POST_RESPONSE")
     async def _post_update_cache_worker(cls, ctx):
         from peagen.gateway import log, queue
         from peagen.gateway._publish import _publish_event
 
         worker_id = ctx["worker_id"]
         try:
-            updated = cls._SRead.model_validate(ctx["result"], from_attributes=True)
+            updated = cls.schemas.read.out.model_validate(
+                ctx["result"], from_attributes=True
+            )
             key = WORKER_KEY.format(worker_id)
             await queue.hset(key, {"updated_at": str(updated.updated_at)})
             await queue.expire(key, WORKER_TTL)
@@ -276,13 +290,13 @@ class Worker(Base, GUIDPk, Timestamped, HookProvider, AllowAnonProvider):
         except Exception as exc:  # noqa: BLE001
             log.error("failure to _publish_event for: `Worker.update` err: %s", exc)
 
-    @classmethod
+    @hook_ctx(ops="list", phase="POST_HANDLER")
     async def _post_list(cls, ctx):
         from peagen.gateway import log
 
         log.info("entering post_workers_list")
 
-    @classmethod
+    @hook_ctx(ops="delete", phase="POST_HANDLER")
     async def _post_delete(cls, ctx):
         from peagen.gateway import log, queue
         from peagen.gateway._publish import _publish_event
@@ -299,42 +313,7 @@ class Worker(Base, GUIDPk, Timestamped, HookProvider, AllowAnonProvider):
         except Exception as exc:  # noqa: BLE001
             log.info("failure to _publish_event for: `Worker.delete` err: %s", exc)
 
-    @classmethod
-    def __autoapi_register_hooks__(cls, api) -> None:
-        from autoapi.v2 import Phase, get_schema
-
-        cls._SRead = get_schema(cls, "read")
-        api.register_hook(Phase.PRE_TX_BEGIN, model="Worker", op="create")(
-            cls._pre_create_policy_gate
-        )
-        api.register_hook(Phase.POST_RESPONSE, model="Worker", op="create")(
-            cls._post_create_cache_pool
-        )
-        api.register_hook(Phase.POST_RESPONSE, model="Worker", op="create")(
-            cls._post_create_cache_worker
-        )
-        api.register_hook(Phase.POST_COMMIT, model="Worker", op="create")(
-            cls._post_create_auto_register
-        )
-        api.register_hook(Phase.POST_RESPONSE, model="Worker", op="create")(
-            cls._post_create_inject_key
-        )
-        api.register_hook(Phase.PRE_TX_BEGIN, model="Worker", op="update")(
-            cls._pre_update_policy_gate
-        )
-        api.register_hook(Phase.PRE_TX_BEGIN, model="Worker", op="update")(
-            cls._pre_update
-        )
-        api.register_hook(Phase.POST_RESPONSE, model="Worker", op="update")(
-            cls._post_update_cache_pool
-        )
-        api.register_hook(Phase.POST_RESPONSE, model="Worker", op="update")(
-            cls._post_update_cache_worker
-        )
-        api.register_hook(Phase.POST_HANDLER, model="Worker", op="list")(cls._post_list)
-        api.register_hook(Phase.POST_HANDLER, model="Worker", op="delete")(
-            cls._post_delete
-        )
+        # hooks registered via @hook_ctx
 
 
 __all__ = ["Worker"]


### PR DESCRIPTION
## Summary
- migrate peagen ORM models to autoapi v3 with mapped columns
- replace __autoapi_register_hooks__ with hook_ctx decorators
- update imports to autoapi.v3 across ORM

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68ae9e7dcc608326961b5a09ac450fb7