### PR TITLE
feat: wrap private keys via KMS hooks

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_kms_unwrap_keys.py
+++ b/pkgs/standards/peagen/tests/unit/test_kms_unwrap_keys.py
@@ -1,11 +1,13 @@
 import base64
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
+import sys
 
 import httpx
 import pytest
 
 from peagen.gateway.kms import unwrap_key_with_kms
 from peagen.gateway.runtime_cfg import settings
+from peagen.orm.keys import DeployKey, GPGKey, PublicKey
 
 
 @pytest.mark.asyncio
@@ -59,3 +61,70 @@ async def test_unwrap_failure(monkeypatch):
     monkeypatch.setattr(httpx, "AsyncClient", lambda: DummyClient())
     result = await unwrap_key_with_kms("wrapped")
     assert result == "wrapped"
+
+
+@pytest.mark.asyncio
+async def test_public_key_unwrap(monkeypatch):
+    called = {}
+
+    async def fake_unwrap(key: str) -> str:
+        called["key"] = key
+        return "plain"
+
+    gw_pkg = ModuleType("peagen.gateway")
+    gw_pkg.__path__ = []
+    sys.modules["peagen.gateway"] = gw_pkg
+    kms_mod = ModuleType("peagen.gateway.kms")
+    kms_mod.unwrap_key_with_kms = fake_unwrap
+    sys.modules["peagen.gateway.kms"] = kms_mod
+
+    ctx = {"result": {"public_key": "pub", "private_key": "wrapped"}}
+    await PublicKey._post_read(ctx)
+    assert called["key"] == "wrapped"
+    assert ctx["result"]["private_key"] == "plain"
+    assert ctx["result"]["public_key"] == "pub"
+
+
+@pytest.mark.asyncio
+async def test_gpg_key_unwrap(monkeypatch):
+    called = {}
+
+    async def fake_unwrap(key: str) -> str:
+        called["key"] = key
+        return "plain"
+
+    gw_pkg = ModuleType("peagen.gateway")
+    gw_pkg.__path__ = []
+    sys.modules["peagen.gateway"] = gw_pkg
+    kms_mod = ModuleType("peagen.gateway.kms")
+    kms_mod.unwrap_key_with_kms = fake_unwrap
+    sys.modules["peagen.gateway.kms"] = kms_mod
+
+    ctx = {"result": {"gpg_key": "gpg", "private_key": "wrapped"}}
+    await GPGKey._post_read(ctx)
+    assert called["key"] == "wrapped"
+    assert ctx["result"]["private_key"] == "plain"
+    assert ctx["result"]["gpg_key"] == "gpg"
+
+
+@pytest.mark.asyncio
+async def test_deploy_key_unwrap(monkeypatch):
+    called = {}
+
+    async def fake_unwrap(key: str) -> str:
+        called["key"] = key
+        return "plain"
+
+    gw_pkg = ModuleType("peagen.gateway")
+    gw_pkg.__path__ = []
+    gw_pkg.log = SimpleNamespace(info=lambda *a, **k: None)
+    sys.modules["peagen.gateway"] = gw_pkg
+    kms_mod = ModuleType("peagen.gateway.kms")
+    kms_mod.unwrap_key_with_kms = fake_unwrap
+    sys.modules["peagen.gateway.kms"] = kms_mod
+
+    ctx = {"result": {"public_key": "pub", "private_key": "wrapped"}}
+    await DeployKey._post_read(ctx)
+    assert called["key"] == "wrapped"
+    assert ctx["result"]["private_key"] == "plain"
+    assert ctx["result"]["public_key"] == "pub"

--- a/pkgs/standards/peagen/tests/unit/test_kms_wrap_keys.py
+++ b/pkgs/standards/peagen/tests/unit/test_kms_wrap_keys.py
@@ -21,11 +21,12 @@ async def test_public_key_wrap(monkeypatch):
     kms_mod.wrap_key_with_kms = fake_wrap
     sys.modules["peagen.gateway.kms"] = kms_mod
 
-    params = SimpleNamespace(public_key="pub")
+    params = SimpleNamespace(public_key="pub", private_key="priv")
     ctx = {"env": SimpleNamespace(params=params)}
     await PublicKey._pre_create(ctx)
-    assert called["key"] == "pub"
-    assert params.public_key == "wrapped"
+    assert called["key"] == "priv"
+    assert params.private_key == "wrapped"
+    assert params.public_key == "pub"
 
 
 @pytest.mark.asyncio
@@ -43,11 +44,12 @@ async def test_gpg_key_wrap(monkeypatch):
     kms_mod.wrap_key_with_kms = fake_wrap
     sys.modules["peagen.gateway.kms"] = kms_mod
 
-    params = SimpleNamespace(gpg_key="gpg")
+    params = SimpleNamespace(gpg_key="gpg", private_key="priv")
     ctx = {"env": SimpleNamespace(params=params)}
     await GPGKey._pre_create(ctx)
-    assert called["key"] == "gpg"
-    assert params.gpg_key == "wrapped"
+    assert called["key"] == "priv"
+    assert params.private_key == "wrapped"
+    assert params.gpg_key == "gpg"
 
 
 @pytest.mark.asyncio
@@ -73,9 +75,10 @@ async def test_deploy_key_wrap(monkeypatch):
     sys.modules["peagen.gateway.kms"] = kms_mod
     monkeypatch.setattr("pgpy.PGPKey", DummyPGPKey)
 
-    params = SimpleNamespace(public_key="pub")
+    params = SimpleNamespace(public_key="pub", private_key="priv")
     ctx = {"env": SimpleNamespace(params=params)}
     await DeployKey._pre_create(ctx)
-    assert called["key"] == "pub"
-    assert params.public_key == "wrapped"
+    assert called["key"] == "priv"
+    assert params.private_key == "wrapped"
+    assert params.public_key == "pub"
     assert ctx["fingerprint"] == "FP"


### PR DESCRIPTION
## Summary
- add `private_key` column to key ORM models
- wrap private keys on create and unwrap on read via KMS hooks
- update unit tests for new wrap/unwrap behavior

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format .`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68aea6170f4883269befa14bca4e7698