### PR TITLE
chore(auto-authn): migrate to autoapi v3

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/app.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/app.py
@@ -19,7 +19,7 @@ import sys
 
 import fastapi
 
-from autoapi.v2 import get_schema  # convenience helper for /methodz
+from autoapi.v3 import get_schema  # convenience helper for /methodz
 from .routers.auth_flows import router as flows_router
 from .routers.crud import crud_api as crud_api
 from .runtime_cfg import settings

--- a/pkgs/standards/auto_authn/auto_authn/v2/hooks.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/hooks.py
@@ -6,7 +6,7 @@ log = logging.getLogger(__name__)
 
 
 def register_inject_hook(api):
-    from autoapi.v2.hooks import Phase
+    from autoapi.v3.hooks import Phase
 
     @api.register_hook(Phase.PRE_TX_BEGIN)
     async def _authn_inject_principal(ctx):

--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/user.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/user.py
@@ -51,7 +51,7 @@ class User(UserBase):
         from ..routers.shared import _jwt, _require_tls, SESSIONS
         from .auth_session import AuthSession
         from .tenant import Tenant
-        from autoapi.v2.error import IntegrityError
+        from autoapi.v3.error import IntegrityError
 
         request = ctx.get("request")
         _require_tls(request)

--- a/pkgs/standards/auto_authn/auto_authn/v2/providers/local_adapter.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/providers/local_adapter.py
@@ -2,12 +2,12 @@
 auto_authn.providers.local_adapter
 ───────────────────
 Concrete implementation of the ``AuthNProvider`` ABC declared by
-``autoapi.v2.authn_abc``.  It merely **adapts** the public helpers that already
+``autoapi.v3.authn_abc``.  It merely **adapts** the public helpers that already
 exist in *auto_authn* so that AutoAPI can consume them automatically.
 
 Usage
 -----
->>> from autoapi.v2 import AutoAPI
+>>> from autoapi.v3 import AutoAPI
 >>> from auto_authn.provider import AuthNAdapter
 >>> api = AutoAPI(get_async_db=get_db, authn=AuthNAdapter())
 """
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from fastapi import Request
 
-from autoapi.v2.types.authn_abc import AuthNProvider
+from autoapi.v3.types.authn_abc import AuthNProvider
 from ..hooks import register_inject_hook  # injects tenant_id / owner_id
 from ..fastapi_deps import get_principal
 from ..principal_ctx import principal_var  # noqa: F401  # ensure ContextVar is initialised

--- a/pkgs/standards/auto_authn/auto_authn/v2/providers/remote_adapter.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/providers/remote_adapter.py
@@ -9,7 +9,7 @@ import httpx
 from fastapi import HTTPException, Request, Security, status
 from fastapi.security import APIKeyHeader
 
-from autoapi.v2.types.authn_abc import AuthNProvider
+from autoapi.v3.types.authn_abc import AuthNProvider
 from ..principal_ctx import principal_var
 
 

--- a/pkgs/standards/auto_authn/auto_authn/v2/routers/crud.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/routers/crud.py
@@ -17,7 +17,7 @@ The resulting ``crud_api`` exposes resource operations under namespaces like
 Notes
 -----
 *   All mix-ins (GUIDPk, Timestamped, TenantBound, etc.) live in
-    *autoapi.v2.mixins* and are imported **only** by `tables.py`.
+    *autoapi.v3.mixins* and are imported **only** by `tables.py`.
 *   Importing this module has the side-effect of importing
     `autoapi_authn.orm.tables`, so every model class is registered with
     the declarative base **before** AutoAPI introspects the metadata.
@@ -25,7 +25,7 @@ Notes
 
 from __future__ import annotations
 
-from autoapi.v2 import AutoAPI, Base
+from autoapi.v3 import AutoAPI, Base
 from auto_authn.v2.orm.tables import (
     Tenant,
     User,

--- a/pkgs/standards/auto_authn/tests/unit/test_hooks.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_hooks.py
@@ -9,7 +9,7 @@ from types import SimpleNamespace
 import pytest
 
 from auto_authn.v2.hooks import register_inject_hook
-from autoapi.v2.hooks import Phase
+from autoapi.v3.hooks import Phase
 
 
 class DummyAPI:


### PR DESCRIPTION
## Summary
- update auto_authn modules to use autoapi v3
- adjust hook test to match new autoapi version

## Testing
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff format .`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68aeab44996483268ca6040a7ac2b456