### PR TITLE
refactor: migrate autoapi tests to v3

### DIFF
--- a/pkgs/standards/autoapi/tests/conftest.py
+++ b/pkgs/standards/autoapi/tests/conftest.py
@@ -2,11 +2,9 @@ from typing import AsyncIterator, Iterator
 
 import pytest
 import pytest_asyncio
-from autoapi.v2 import AutoAPI, Base
-from autoapi.v2.mixins import BulkCapable, GUIDPk
-from autoapi.v3.autoapi import AutoAPI as AutoAPIv3
-from autoapi.v3.tables import Base as Base3
-from autoapi.v3.specs import IO, S, F, acol
+from autoapi.v3 import AutoAPI, Base
+from autoapi.v3.mixins import BulkCapable, GUIDPk
+from autoapi.v3.specs import F, IO, S, acol
 from autoapi.v3.specs.storage_spec import StorageTransform
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
@@ -208,9 +206,9 @@ def sample_item_data():
 
 @pytest_asyncio.fixture()
 async def api_client_v3():
-    Base3.metadata.clear()
+    Base.metadata.clear()
 
-    class Widget(Base3):
+    class Widget(Base):
         __tablename__ = "widgets"
         __allow_unmapped__ = True
 
@@ -251,7 +249,7 @@ async def api_client_v3():
 
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     async with engine.begin() as conn:
-        await conn.run_sync(Base3.metadata.create_all)
+        await conn.run_sync(Base.metadata.create_all)
     AsyncSessionLocal = async_sessionmaker(
         bind=engine, class_=AsyncSession, expire_on_commit=False
     )
@@ -261,7 +259,7 @@ async def api_client_v3():
             yield session
 
     app = FastAPI()
-    api = AutoAPIv3(app=app, get_async_db=get_async_db)
+    api = AutoAPI(app=app, get_async_db=get_async_db)
     api.include_model(Widget, prefix="")
     api.mount_jsonrpc()
     api.attach_diagnostics()

--- a/pkgs/standards/autoapi/tests/i9n/test_acronym_route_name.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_acronym_route_name.py
@@ -1,7 +1,8 @@
 import pytest
-from autoapi.v2 import Base
-from autoapi.v2.mixins import GUIDPk
 from sqlalchemy import Column, String
+
+from autoapi.v3 import Base
+from autoapi.v3.mixins import GUIDPk
 
 
 @pytest.mark.i9n

--- a/pkgs/standards/autoapi/tests/i9n/test_allow_anon.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_allow_anon.py
@@ -1,14 +1,14 @@
 from fastapi import FastAPI, HTTPException, Security
 from fastapi.testclient import TestClient
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from sqlalchemy import Column, String, ForeignKey, create_engine
-from sqlalchemy.pool import StaticPool
+from sqlalchemy import Column, ForeignKey, String, create_engine
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 
-from autoapi.v2 import AutoAPI, Base
-from autoapi.v2.mixins import GUIDPk
-from autoapi.v2.types import AuthNProvider
+from autoapi.v3 import AutoAPI, Base
+from autoapi.v3.mixins import GUIDPk
+from autoapi.v3.types.authn_abc import AuthNProvider
 
 
 class DummyAuth(AuthNProvider):

--- a/pkgs/standards/autoapi/tests/i9n/test_apikey_generation.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_apikey_generation.py
@@ -2,8 +2,8 @@ import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
-from autoapi.v2 import AutoAPI, Base
-from autoapi.v2.tables import ApiKey
+from autoapi.v3 import AutoAPI, Base
+from autoapi.v3.tables import ApiKey
 
 
 class ConcreteApiKey(ApiKey):

--- a/pkgs/standards/autoapi/tests/i9n/test_authn_provider_integration.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_authn_provider_integration.py
@@ -6,11 +6,11 @@ from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
-from autoapi.v2 import AutoAPI, Base
-from autoapi.v2.cfgs import AUTH_CONTEXT_KEY
-from autoapi.v2.hooks import Phase
-from autoapi.v2.mixins import GUIDPk
-from autoapi.v2.types import AuthNProvider
+from autoapi.v3 import AutoAPI, Base
+from autoapi.v3.mixins import GUIDPk
+from autoapi.v3.types.authn_abc import AuthNProvider
+
+AUTH_CONTEXT_KEY = "auth_context"
 
 
 class HookedAuth(AuthNProvider):
@@ -28,7 +28,7 @@ class HookedAuth(AuthNProvider):
         return {"sub": "user", "tid": "tenant"}
 
     def register_inject_hook(self, api) -> None:  # pragma: no cover - runtime wiring
-        @api.register_hook(Phase.PRE_TX_BEGIN)
+        @api.register_hook("PRE_TX_BEGIN")
         async def _capture(ctx):  # pragma: no cover - executed in tests
             self.ctx_principal = ctx.get(AUTH_CONTEXT_KEY)
 

--- a/pkgs/standards/autoapi/tests/i9n/test_column_metadata_runtime.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_column_metadata_runtime.py
@@ -8,8 +8,9 @@ from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import Column, DateTime, String
 
-from autoapi.v2 import Base, get_schema
-from autoapi.v2.mixins import GUIDPk
+from autoapi.v3 import Base
+from autoapi.v3.mixins import GUIDPk
+from autoapi.v3.schema import _build_schema
 
 
 @pytest.mark.i9n
@@ -66,9 +67,9 @@ async def test_write_only_field_runtime_behavior(create_test_api):
             except StopIteration:
                 pass
 
-    create_schema = get_schema(WriteOnlyModel, "create")
-    read_schema = get_schema(WriteOnlyModel, "read")
-    update_schema = get_schema(WriteOnlyModel, "update")
+    create_schema = _build_schema(WriteOnlyModel, verb="create")
+    read_schema = _build_schema(WriteOnlyModel, verb="read")
+    update_schema = _build_schema(WriteOnlyModel, verb="update")
 
     assert "secret" in create_schema.model_fields
     assert "secret" in update_schema.model_fields
@@ -113,9 +114,9 @@ async def test_read_only_field_runtime_behavior(create_test_api):
         assert res.status_code == 200
         assert res.json()["code"] == ro_value
 
-    create_schema = get_schema(ReadOnlyModel, "create")
-    read_schema = get_schema(ReadOnlyModel, "read")
-    update_schema = get_schema(ReadOnlyModel, "update")
+    create_schema = _build_schema(ReadOnlyModel, verb="create")
+    read_schema = _build_schema(ReadOnlyModel, verb="read")
+    update_schema = _build_schema(ReadOnlyModel, verb="update")
 
     assert "code" not in create_schema.model_fields
     assert "code" in read_schema.model_fields
@@ -155,9 +156,9 @@ async def test_default_factory_field_runtime_behavior(create_test_api):
         assert res.status_code == 200
         assert res.json()["created_at"] == created
 
-    create_schema = get_schema(FactoryModel, "create")
+    create_schema = _build_schema(FactoryModel, verb="create")
     field = create_schema.model_fields["created_at"]
     assert field.default_factory is not None
     assert not field.is_required()
-    assert "created_at" in get_schema(FactoryModel, "read").model_fields
-    assert "created_at" in get_schema(FactoryModel, "update").model_fields
+    assert "created_at" in _build_schema(FactoryModel, verb="read").model_fields
+    assert "created_at" in _build_schema(FactoryModel, verb="update").model_fields

--- a/pkgs/standards/autoapi/tests/i9n/test_core_access.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_core_access.py
@@ -11,10 +11,11 @@ Tests cover:
 
 import pytest
 import pytest_asyncio
-from autoapi.v2 import AutoAPI, Base
-from autoapi.v2.mixins import GUIDPk
-from sqlalchemy import Column, String, Integer
 from fastapi import HTTPException
+from sqlalchemy import Column, Integer, String
+
+from autoapi.v3 import AutoAPI, Base
+from autoapi.v3.mixins import GUIDPk
 
 
 class CoreTestUser(Base, GUIDPk):

--- a/pkgs/standards/autoapi/tests/i9n/test_error_mappings.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_error_mappings.py
@@ -5,16 +5,16 @@ Tests error mappings between RPC and HTTP, and verifies parity between error res
 """
 
 import pytest
-from autoapi.v2.jsonrpc_models import (
-    _HTTP_TO_RPC,
-    _RPC_TO_HTTP,
+from fastapi import HTTPException
+from autoapi.v3.runtime.errors import (
     ERROR_MESSAGES,
     HTTP_ERROR_MESSAGES,
+    _HTTP_TO_RPC,
+    _RPC_TO_HTTP,
     _http_exc_to_rpc,
     _rpc_error_to_http,
     create_standardized_error,
 )
-from fastapi import HTTPException
 
 
 @pytest.mark.i9n

--- a/pkgs/standards/autoapi/tests/i9n/test_healthz_methodz_hookz.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_healthz_methodz_hookz.py
@@ -5,7 +5,6 @@ Tests that healthz, methodz and hookz endpoints are properly attached and behave
 """
 
 import pytest
-from autoapi.v2 import Phase
 
 
 @pytest.mark.i9n
@@ -84,15 +83,15 @@ async def test_hookz_endpoint_comprehensive(api_client):
     """Test hookz endpoint attachment, behavior, and response format."""
     client, api, _ = api_client
 
-    @api.register_hook(Phase.POST_RESPONSE)
+    @api.register_hook("POST_RESPONSE")
     def first_hook(ctx):
         pass
 
-    @api.register_hook(Phase.POST_RESPONSE)
+    @api.register_hook("POST_RESPONSE")
     def second_hook(ctx):
         pass
 
-    @api.register_hook(Phase.POST_RESPONSE, model="Item", op="create")
+    @api.register_hook("POST_RESPONSE", model="Item", op="create")
     def item_hook(ctx):
         pass
 
@@ -107,8 +106,8 @@ async def test_hookz_endpoint_comprehensive(api_client):
     assert isinstance(data, dict)
 
     expected_global_hooks = [
-        f"autoapi.v2.hooks.{first_hook.__qualname__}",
-        f"autoapi.v2.hooks.{second_hook.__qualname__}",
+        f"autoapi.v3.hooks.{first_hook.__qualname__}",
+        f"autoapi.v3.hooks.{second_hook.__qualname__}",
     ]
     for method, phases in data.items():
         assert isinstance(method, str)
@@ -117,7 +116,7 @@ async def test_hookz_endpoint_comprehensive(api_client):
 
     assert "Item.create" in data
     assert data["Item.create"]["POST_RESPONSE"] == expected_global_hooks + [
-        f"autoapi.v2.hooks.{item_hook.__qualname__}",
+        f"autoapi.v3.hooks.{item_hook.__qualname__}",
     ]
     assert "Tenant.create" in data
     assert data["Tenant.create"]["POST_RESPONSE"] == expected_global_hooks

--- a/pkgs/standards/autoapi/tests/i9n/test_info_schema_keys.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_info_schema_keys.py
@@ -7,11 +7,12 @@ Each key is tested individually using DummyModel instances.
 
 import pytest
 from datetime import datetime
-from sqlalchemy import Column, String, Integer, DateTime
+from sqlalchemy import Column, DateTime, Integer, String
 from sqlalchemy.ext.hybrid import hybrid_property
 
-from autoapi.v2.mixins import GUIDPk
-from autoapi.v2 import Base, get_schema
+from autoapi.v3 import Base
+from autoapi.v3.mixins import GUIDPk
+from autoapi.v3.schema import _build_schema, check
 
 
 class DummyModelDisableOn(Base, GUIDPk):
@@ -107,9 +108,9 @@ async def test_disable_on_key(create_test_api):
     create_test_api(DummyModelDisableOn)
 
     # Get schemas for different verbs
-    create_schema = get_schema(DummyModelDisableOn, "create")
-    update_schema = get_schema(DummyModelDisableOn, "update")
-    read_schema = get_schema(DummyModelDisableOn, "read")
+    create_schema = _build_schema(DummyModelDisableOn, verb="create")
+    update_schema = _build_schema(DummyModelDisableOn, verb="update")
+    read_schema = _build_schema(DummyModelDisableOn, verb="read")
 
     # name should be in create and read schemas
     assert "name" in create_schema.model_fields
@@ -131,8 +132,8 @@ async def test_write_only_key(create_test_api):
     create_test_api(DummyModelWriteOnly)
 
     # Get schemas for different verbs
-    create_schema = get_schema(DummyModelWriteOnly, "create")
-    read_schema = get_schema(DummyModelWriteOnly, "read")
+    create_schema = _build_schema(DummyModelWriteOnly, verb="create")
+    read_schema = _build_schema(DummyModelWriteOnly, verb="read")
 
     # secret should be in create schema (write operation)
     assert "secret" in create_schema.model_fields
@@ -152,9 +153,9 @@ async def test_read_only_key(create_test_api):
     create_test_api(DummyModelReadOnly)
 
     # Get schemas for different verbs
-    create_schema = get_schema(DummyModelReadOnly, "create")
-    update_schema = get_schema(DummyModelReadOnly, "update")
-    read_schema = get_schema(DummyModelReadOnly, "read")
+    create_schema = _build_schema(DummyModelReadOnly, verb="create")
+    update_schema = _build_schema(DummyModelReadOnly, verb="update")
+    read_schema = _build_schema(DummyModelReadOnly, verb="read")
 
     # computed_field should be in read schema
     assert "computed_field" in read_schema.model_fields
@@ -176,7 +177,7 @@ async def test_default_factory_key(create_test_api):
     create_test_api(DummyModelDefaultFactory)
 
     # Get create schema
-    create_schema = get_schema(DummyModelDefaultFactory, "create")
+    create_schema = _build_schema(DummyModelDefaultFactory, verb="create")
 
     # timestamp field should be present
     assert "timestamp" in create_schema.model_fields
@@ -200,7 +201,7 @@ async def test_examples_key(create_test_api):
     create_test_api(DummyModelExamples)
 
     # Get create schema
-    create_schema = get_schema(DummyModelExamples, "create")
+    create_schema = _build_schema(DummyModelExamples, verb="create")
 
     # Check that fields have examples
     name_field = create_schema.model_fields["name"]
@@ -219,8 +220,8 @@ async def test_hybrid_key(create_test_api):
     create_test_api(DummyModelHybrid)
 
     # Get schemas for different verbs
-    create_schema = get_schema(DummyModelHybrid, "create")
-    read_schema = get_schema(DummyModelHybrid, "read")
+    create_schema = _build_schema(DummyModelHybrid, verb="create")
+    read_schema = _build_schema(DummyModelHybrid, verb="read")
 
     # full_name should be in schemas because hybrid=True
     assert "full_name" in create_schema.model_fields
@@ -238,7 +239,7 @@ async def test_py_type_key(create_test_api):
     create_test_api(DummyModelPyType)
 
     # Get read schema
-    read_schema = get_schema(DummyModelPyType, "read")
+    read_schema = _build_schema(DummyModelPyType, verb="read")
 
     # computed_value should be present due to hybrid=True
     assert "computed_value" in read_schema.model_fields
@@ -254,8 +255,6 @@ async def test_py_type_key(create_test_api):
 @pytest.mark.asyncio
 async def test_info_schema_validation():
     """Test that invalid info schema keys raise errors."""
-    from autoapi.v2.info_schema import check
-
     # Valid metadata should not raise error
     valid_meta = {"disable_on": ["update"], "write_only": True, "examples": ["test"]}
     check(valid_meta, "test_field", "TestModel")  # Should not raise
@@ -302,9 +301,9 @@ async def test_combined_info_schema_keys(create_test_api):
     create_test_api(DummyModelCombined)
 
     # Get schemas
-    create_schema = get_schema(DummyModelCombined, "create")
-    update_schema = get_schema(DummyModelCombined, "update")
-    read_schema = get_schema(DummyModelCombined, "read")
+    create_schema = _build_schema(DummyModelCombined, verb="create")
+    update_schema = _build_schema(DummyModelCombined, verb="update")
+    read_schema = _build_schema(DummyModelCombined, verb="read")
 
     # secret should be in create (write_only=True allows writes, disable_on excludes update)
     assert "secret" in create_schema.model_fields

--- a/pkgs/standards/autoapi/tests/i9n/test_mixins.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_mixins.py
@@ -8,28 +8,29 @@ import pytest
 from datetime import datetime, timedelta
 from sqlalchemy import Column, String
 
-from autoapi.v2.mixins import GUIDPk
-from autoapi.v2.mixins import (
-    Timestamped,
-    Created,
-    LastUsed,
+from autoapi.v3 import Base
+from autoapi.v3.mixins import (
     ActiveToggle,
-    SoftDelete,
-    Versioned,
-    BulkCapable,
-    Replaceable,
     AsyncCapable,
     Audited,
-    Streamable,
-    Slugged,
-    StatusMixin,
-    ValidityWindow,
-    Monetary,
+    BulkCapable,
+    Created,
     ExtRef,
+    GUIDPk,
+    LastUsed,
     MetaJSON,
+    Monetary,
     RelationEdge,
+    Replaceable,
+    Slugged,
+    SoftDelete,
+    StatusMixin,
+    Streamable,
+    Timestamped,
+    ValidityWindow,
+    Versioned,
 )
-from autoapi.v2 import Base, get_schema
+from autoapi.v3.schema import _build_schema
 
 
 class DummyModelTimestamped(Base, GUIDPk, Timestamped):
@@ -144,9 +145,9 @@ async def test_timestamped_mixin(create_test_api):
     create_test_api(DummyModelTimestamped)
 
     # Get schemas
-    create_schema = get_schema(DummyModelTimestamped, "create")
-    read_schema = get_schema(DummyModelTimestamped, "read")
-    update_schema = get_schema(DummyModelTimestamped, "update")
+    create_schema = _build_schema(DummyModelTimestamped, verb="create")
+    read_schema = _build_schema(DummyModelTimestamped, verb="read")
+    update_schema = _build_schema(DummyModelTimestamped, verb="update")
 
     # created_at and updated_at should be in read schema
     assert "created_at" in read_schema.model_fields
@@ -171,8 +172,8 @@ async def test_created_mixin(create_test_api):
     create_test_api(DummyModelCreated)
 
     # Get schemas
-    create_schema = get_schema(DummyModelCreated, "create")
-    read_schema = get_schema(DummyModelCreated, "read")
+    create_schema = _build_schema(DummyModelCreated, verb="create")
+    read_schema = _build_schema(DummyModelCreated, verb="read")
 
     # created_at should be in read schema
     assert "created_at" in read_schema.model_fields
@@ -188,7 +189,7 @@ async def test_last_used_mixin(create_test_api):
     create_test_api(DummyModelLastUsed)
 
     # Get schemas
-    read_schema = get_schema(DummyModelLastUsed, "read")
+    read_schema = _build_schema(DummyModelLastUsed, verb="read")
 
     # last_used_at should be in read schema
     assert "last_used_at" in read_schema.model_fields
@@ -212,8 +213,8 @@ async def test_active_toggle_mixin(create_test_api):
     create_test_api(DummyModelActiveToggle)
 
     # Get schemas
-    create_schema = get_schema(DummyModelActiveToggle, "create")
-    read_schema = get_schema(DummyModelActiveToggle, "read")
+    create_schema = _build_schema(DummyModelActiveToggle, verb="create")
+    read_schema = _build_schema(DummyModelActiveToggle, verb="read")
 
     # is_active should be in schemas
     assert "is_active" in create_schema.model_fields
@@ -231,7 +232,7 @@ async def test_soft_delete_mixin(create_test_api):
     create_test_api(DummyModelSoftDelete)
 
     # Get schemas
-    read_schema = get_schema(DummyModelSoftDelete, "read")
+    read_schema = _build_schema(DummyModelSoftDelete, verb="read")
 
     # deleted_at should be in read schema
     assert "deleted_at" in read_schema.model_fields
@@ -244,8 +245,8 @@ async def test_versioned_mixin(create_test_api):
     create_test_api(DummyModelVersioned)
 
     # Get schemas
-    create_schema = get_schema(DummyModelVersioned, "create")
-    read_schema = get_schema(DummyModelVersioned, "read")
+    create_schema = _build_schema(DummyModelVersioned, verb="create")
+    read_schema = _build_schema(DummyModelVersioned, verb="read")
 
     # revision and prev_id should be in schemas
     assert "revision" in read_schema.model_fields
@@ -278,8 +279,8 @@ async def test_replaceable_mixin(create_test_api):
     create_test_api(DummyModelReplaceable)
 
     # Get schemas
-    create_schema = get_schema(DummyModelReplaceable, "create")
-    read_schema = get_schema(DummyModelReplaceable, "read")
+    create_schema = _build_schema(DummyModelReplaceable, verb="create")
+    read_schema = _build_schema(DummyModelReplaceable, verb="read")
 
     # Should have basic fields
     assert "name" in create_schema.model_fields
@@ -299,7 +300,7 @@ async def test_async_capable_mixin(create_test_api):
     create_test_api(DummyModelAsyncCapable)
 
     # Get schemas
-    read_schema = get_schema(DummyModelAsyncCapable, "read")
+    read_schema = _build_schema(DummyModelAsyncCapable, verb="read")
 
     # AsyncCapable is a marker mixin - doesn't add fields
     expected_fields = {"id", "name"}
@@ -314,8 +315,8 @@ async def test_slugged_mixin(create_test_api):
     create_test_api(DummyModelSlugged)
 
     # Get schemas
-    create_schema = get_schema(DummyModelSlugged, "create")
-    read_schema = get_schema(DummyModelSlugged, "read")
+    create_schema = _build_schema(DummyModelSlugged, verb="create")
+    read_schema = _build_schema(DummyModelSlugged, verb="read")
 
     # slug should be in schemas
     assert "slug" in create_schema.model_fields
@@ -329,8 +330,8 @@ async def test_status_mixin(create_test_api):
     create_test_api(DummyModelStatusMixin)
 
     # Get schemas
-    create_schema = get_schema(DummyModelStatusMixin, "create")
-    read_schema = get_schema(DummyModelStatusMixin, "read")
+    create_schema = _build_schema(DummyModelStatusMixin, verb="create")
+    read_schema = _build_schema(DummyModelStatusMixin, verb="read")
 
     # status should be in schemas
     assert "status" in create_schema.model_fields
@@ -348,8 +349,8 @@ async def test_validity_window_mixin(create_test_api):
     create_test_api(DummyModelValidityWindow)
 
     # Get schemas
-    create_schema = get_schema(DummyModelValidityWindow, "create")
-    read_schema = get_schema(DummyModelValidityWindow, "read")
+    create_schema = _build_schema(DummyModelValidityWindow, verb="create")
+    read_schema = _build_schema(DummyModelValidityWindow, verb="read")
 
     # validity fields should be in schemas
     assert "valid_from" in create_schema.model_fields
@@ -383,8 +384,8 @@ async def test_monetary_mixin(create_test_api):
     create_test_api(DummyModelMonetary)
 
     # Get schemas
-    create_schema = get_schema(DummyModelMonetary, "create")
-    read_schema = get_schema(DummyModelMonetary, "read")
+    create_schema = _build_schema(DummyModelMonetary, verb="create")
+    read_schema = _build_schema(DummyModelMonetary, verb="read")
 
     # monetary fields should be in schemas
     assert "currency" in create_schema.model_fields
@@ -404,8 +405,8 @@ async def test_ext_ref_mixin(create_test_api):
     create_test_api(DummyModelExtRef)
 
     # Get schemas
-    create_schema = get_schema(DummyModelExtRef, "create")
-    read_schema = get_schema(DummyModelExtRef, "read")
+    create_schema = _build_schema(DummyModelExtRef, verb="create")
+    read_schema = _build_schema(DummyModelExtRef, verb="read")
 
     # external_id should be in schemas
     assert "external_id" in create_schema.model_fields
@@ -420,8 +421,8 @@ async def test_meta_json_mixin(create_test_api):
     create_test_api(DummyModelMetaJSON)
 
     # Get schemas
-    create_schema = get_schema(DummyModelMetaJSON, "create")
-    read_schema = get_schema(DummyModelMetaJSON, "read")
+    create_schema = _build_schema(DummyModelMetaJSON, verb="create")
+    read_schema = _build_schema(DummyModelMetaJSON, verb="read")
 
     # meta should be in schemas
     assert "meta" in create_schema.model_fields
@@ -455,7 +456,7 @@ async def test_marker_mixins(create_test_api):
     for model in marker_models:
         create_test_api(model)
 
-        read_schema = get_schema(model, "read")
+        read_schema = _build_schema(model, verb="read")
 
         # Should only have id and name fields (no extra fields from marker mixins)
         expected_fields = {"id", "name"}
@@ -477,8 +478,8 @@ async def test_multiple_mixins_combination(create_test_api):
     create_test_api(DummyMultipleMixins)
 
     # Get schemas
-    create_schema = get_schema(DummyMultipleMixins, "create")
-    read_schema = get_schema(DummyMultipleMixins, "read")
+    create_schema = _build_schema(DummyMultipleMixins, verb="create")
+    read_schema = _build_schema(DummyMultipleMixins, verb="read")
 
     # Should have fields from all mixins
     # From ActiveToggle

--- a/pkgs/standards/autoapi/tests/i9n/test_nested_routing_depth.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_nested_routing_depth.py
@@ -1,7 +1,7 @@
 import pytest
 import pytest_asyncio
-from autoapi.v2 import AutoAPI, Base
-from autoapi.v2.mixins import GUIDPk
+from autoapi.v3 import AutoAPI, Base
+from autoapi.v3.mixins import GUIDPk
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import Column, ForeignKey, String

--- a/pkgs/standards/autoapi/tests/i9n/test_owner_tenant_policy.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_owner_tenant_policy.py
@@ -1,17 +1,16 @@
 from fastapi import FastAPI, HTTPException, Security
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from fastapi.testclient import TestClient
+import uuid
 from sqlalchemy import Column, String, create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
-import uuid
 
-from autoapi.v2 import AutoAPI, Base
-from autoapi.v2.mixins import GUIDPk
-from autoapi.v2.mixins.ownable import Ownable, OwnerPolicy
-from autoapi.v2.mixins.tenant_bound import TenantBound, TenantPolicy
-from autoapi.v2.types import AuthNProvider
-from autoapi.v2.hooks import Phase
+from autoapi.v3 import AutoAPI, Base
+from autoapi.v3.mixins import GUIDPk
+from autoapi.v3.mixins.ownable import Ownable, OwnerPolicy
+from autoapi.v3.mixins.tenant_bound import TenantBound, TenantPolicy
+from autoapi.v3.types.authn_abc import AuthNProvider
 
 
 class DummyAuth(AuthNProvider):
@@ -27,7 +26,7 @@ class DummyAuth(AuthNProvider):
         return {"user_id": self.user_id, "tenant_id": self.tenant_id}
 
     def register_inject_hook(self, api) -> None:
-        @api.register_hook(Phase.PRE_TX_BEGIN)
+        @api.register_hook("PRE_TX_BEGIN")
         async def _inject(ctx):
             p = getattr(ctx["request"].state, "principal", None)
             if not p:

--- a/pkgs/standards/autoapi/tests/i9n/test_request_extras.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_request_extras.py
@@ -1,14 +1,16 @@
 import pytest
 import pytest_asyncio
-from autoapi.v2 import AutoAPI, Base, get_schema
-from autoapi.v2.mixins import GUIDPk
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
+from pydantic import Field
 from sqlalchemy import Column, String, create_engine
-from sqlalchemy.pool import StaticPool
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import Session, sessionmaker
-from pydantic import Field
+from sqlalchemy.pool import StaticPool
+
+from autoapi.v3 import AutoAPI, Base
+from autoapi.v3.mixins import GUIDPk
+from autoapi.v3.schema import _build_schema
 
 
 @pytest_asyncio.fixture()
@@ -62,8 +64,8 @@ async def api_client_with_extras(db_mode):
 @pytest.mark.asyncio
 async def test_request_extras_schema(api_client_with_extras):
     _, _, Widget = api_client_with_extras
-    create_schema = get_schema(Widget, "create")
-    update_schema = get_schema(Widget, "update")
+    create_schema = _build_schema(Widget, verb="create")
+    update_schema = _build_schema(Widget, verb="update")
     assert {"token", "create_note"} <= set(create_schema.model_fields)
     assert {"token", "update_flag"} <= set(update_schema.model_fields)
 

--- a/pkgs/standards/autoapi/tests/i9n/test_request_extras_provider.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_request_extras_provider.py
@@ -1,10 +1,10 @@
 import pytest
 
-from autoapi.v2 import Base
-from autoapi.v2.types import Column, String, Field, RequestExtrasProvider
-from autoapi.v2.mixins import GUIDPk
-from autoapi.v2.impl.schema import _schema
-from autoapi.v2.types.request_extras_provider import list_request_extras_providers
+from autoapi.v3 import Base
+from autoapi.v3.mixins import GUIDPk
+from autoapi.v3.schema import _build_schema
+from autoapi.v3.types import Column, Field, RequestExtrasProvider, String
+from autoapi.v3.types.request_extras_provider import list_request_extras_providers
 
 
 @pytest.mark.i9n
@@ -19,8 +19,8 @@ async def test_request_extras_provider_in_schema():
             "create": {"extra": (int | None, Field(None, exclude=True))}
         }
 
-    SCreate = _schema(Widget, verb="create")
-    SRead = _schema(Widget, verb="read")
+    SCreate = _build_schema(Widget, verb="create")
+    SRead = _build_schema(Widget, verb="read")
 
     assert "extra" in SCreate.model_fields
     assert "extra" not in SRead.model_fields

--- a/pkgs/standards/autoapi/tests/i9n/test_response_extras_provider.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_response_extras_provider.py
@@ -1,10 +1,10 @@
 import pytest
 
-from autoapi.v2 import Base
-from autoapi.v2.types import Column, String, Field, ResponseExtrasProvider
-from autoapi.v2.mixins import GUIDPk
-from autoapi.v2.impl.schema import _schema
-from autoapi.v2.types.response_extras_provider import list_response_extras_providers
+from autoapi.v3 import Base
+from autoapi.v3.mixins import GUIDPk
+from autoapi.v3.schema import _build_schema
+from autoapi.v3.types import Column, Field, ResponseExtrasProvider, String
+from autoapi.v3.types.response_extras_provider import list_response_extras_providers
 
 
 @pytest.mark.i9n
@@ -17,6 +17,6 @@ async def test_response_extras_provider_in_schema():
         name = Column(String, nullable=False)
         __autoapi_response_extras__ = {"read": {"extra": (int | None, Field(None))}}
 
-    SRead = _schema(Widget, verb="read")
+    SRead = _build_schema(Widget, verb="read")
     assert "extra" in SRead.model_fields
     assert Widget in list_response_extras_providers()

--- a/pkgs/standards/autoapi/tests/i9n/test_schema.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_schema.py
@@ -1,5 +1,5 @@
 import pytest
-from autoapi.v2 import get_schema
+from autoapi.v3.schema import _build_schema
 
 
 @pytest.mark.i9n
@@ -7,11 +7,11 @@ from autoapi.v2 import get_schema
 async def test_schema_generation(api_client):
     client, _, Item = api_client
 
-    create_model = get_schema(Item, "create")
-    read_model = get_schema(Item, "read")
-    update_model = get_schema(Item, "update")
-    delete_model = get_schema(Item, "delete")
-    list_model = get_schema(Item, "list")
+    create_model = _build_schema(Item, verb="create")
+    read_model = _build_schema(Item, verb="read")
+    update_model = _build_schema(Item, verb="update")
+    delete_model = _build_schema(Item, verb="delete")
+    list_model = _build_schema(Item, verb="list")
 
     assert create_model.__name__ == "ItemCreate"
     assert read_model.__name__ == "ItemRead"

--- a/pkgs/standards/autoapi/tests/i9n/test_transactional.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_transactional.py
@@ -1,6 +1,6 @@
 import pytest
 import uuid
-from autoapi.v2.transactional import transactional
+from autoapi.v3.compat.transactional import transactional
 
 
 @pytest.mark.i9n

--- a/pkgs/standards/autoapi/tests/i9n/test_verb_alias_policy.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_verb_alias_policy.py
@@ -2,8 +2,8 @@
 
 import pytest
 
-from autoapi.v2.mixins import GUIDPk
-from autoapi.v2 import Base
+from autoapi.v3 import Base
+from autoapi.v3.mixins import GUIDPk
 
 
 @pytest.mark.i9n


### PR DESCRIPTION
## Summary
- migrate autoapi tests from v2 to v3
- replace Phase enum usage with string-based hooks
- switch schema helpers to `_build_schema`

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68aeab2c751c8326ace47ab3f840b9f1