### PR TITLE
refactor: route Mapped imports through autoapi types

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/auth_code.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/auth_code.py
@@ -9,9 +9,8 @@ from autoapi.v3.tables import Base
 from autoapi.v3.mixins import TenantMixin, Timestamped, UserMixin
 from autoapi.v3.specs import S, acol
 from autoapi.v3.specs.storage_spec import ForeignKeySpec
-from autoapi.v3.types import JSON, PgUUID, String, TZDateTime
+from autoapi.v3.types import JSON, PgUUID, String, TZDateTime, Mapped
 from autoapi.v3 import op_ctx
-from sqlalchemy.orm import Mapped
 from fastapi import HTTPException, status
 
 from ..rfc8414_metadata import ISSUER

--- a/pkgs/standards/auto_kms/auto_kms/tables/key.py
+++ b/pkgs/standards/auto_kms/auto_kms/tables/key.py
@@ -6,7 +6,7 @@ from uuid import UUID, uuid4
 from typing import List, Optional, TYPE_CHECKING
 
 from sqlalchemy import String, Integer, Enum as SAEnum
-from sqlalchemy.orm import Mapped, relationship
+from autoapi.v3.types import Mapped, relationship
 
 from autoapi.v3.tables import Base
 from autoapi.v3.specs import acol, vcol, S, F, IO

--- a/pkgs/standards/auto_kms/auto_kms/tables/key_version.py
+++ b/pkgs/standards/auto_kms/auto_kms/tables/key_version.py
@@ -4,7 +4,6 @@ import secrets
 from uuid import UUID, uuid4
 
 from fastapi import HTTPException
-from sqlalchemy.orm import Mapped
 
 from autoapi.v3.decorators import hook_ctx
 from autoapi.v3.specs import IO, F, S, acol
@@ -18,6 +17,7 @@ from autoapi.v3.types import (
     SAEnum,
     UniqueConstraint,
     relationship,
+    Mapped,
 )
 from swarmauri_core.crypto.types import ExportPolicy, KeyType, KeyUse
 

--- a/pkgs/standards/autoapi/autoapi/v3/mixins/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/mixins/__init__.py
@@ -24,8 +24,8 @@ from ..types import (
     Boolean,
     UUID,
     uuid4,
+    Mapped,
 )
-from sqlalchemy.orm import Mapped
 from ..config.constants import CTX_AUTH_KEY, CTX_USER_ID_KEY
 
 

--- a/pkgs/standards/autoapi/autoapi/v3/mixins/ownable.py
+++ b/pkgs/standards/autoapi/autoapi/v3/mixins/ownable.py
@@ -6,8 +6,7 @@ from enum import Enum
 from typing import Any, Mapping
 from uuid import UUID
 
-from sqlalchemy.dialects.postgresql import UUID as PgUUID
-from sqlalchemy.orm import Mapped, declared_attr
+from ..types import PgUUID, Mapped, declared_attr
 
 from ..columns import acol
 from ..config.constants import (

--- a/pkgs/standards/autoapi/autoapi/v3/tables/_base.py
+++ b/pkgs/standards/autoapi/autoapi/v3/tables/_base.py
@@ -37,7 +37,7 @@ def _infer_py_type(cls, name: str, spec: Any) -> Optional[type]:
 
     # Mapped[T] → T (then unwrap Optional)
     try:
-        from sqlalchemy.orm import Mapped
+        from ..types import Mapped
 
         if get_origin(ann) is Mapped:
             inner = get_args(ann)[0]

--- a/pkgs/standards/autoapi/autoapi/v3/tables/apikey.py
+++ b/pkgs/standards/autoapi/autoapi/v3/tables/apikey.py
@@ -6,7 +6,6 @@ from hashlib import sha256
 from secrets import token_urlsafe
 
 from fastapi import HTTPException
-from sqlalchemy.orm import Mapped
 
 from ..specs import acol, F, IO, S
 from ..types import (
@@ -14,6 +13,7 @@ from ..types import (
     HookProvider,
     Field,
     ResponseExtrasProvider,
+    Mapped,
 )
 from ._base import Base
 from ..mixins import (

--- a/pkgs/standards/autoapi/autoapi/v3/tables/audit.py
+++ b/pkgs/standards/autoapi/autoapi/v3/tables/audit.py
@@ -4,9 +4,8 @@ from uuid import UUID
 
 from . import Base
 from ..mixins import GUIDPk, Timestamped
-from sqlalchemy.orm import Mapped
 from ..specs import IO, F, acol, S
-from ..types import DateTime, Integer, String, PgUUID
+from ..types import DateTime, Integer, String, PgUUID, Mapped
 
 
 class Change(Base, GUIDPk, Timestamped):

--- a/pkgs/standards/autoapi/autoapi/v3/tables/client.py
+++ b/pkgs/standards/autoapi/autoapi/v3/tables/client.py
@@ -2,10 +2,8 @@
 from __future__ import annotations
 
 
-from sqlalchemy.orm import Mapped
-
 from ..specs import acol, IO, S, F
-from ..types import String, LargeBinary
+from ..types import LargeBinary, Mapped, String
 
 from ._base import Base
 from ..mixins import ActiveToggle, GUIDPk, Timestamped, TenantBound

--- a/pkgs/standards/autoapi/autoapi/v3/tables/group.py
+++ b/pkgs/standards/autoapi/autoapi/v3/tables/group.py
@@ -2,9 +2,8 @@
 
 from ._base import Base
 from ..mixins import GUIDPk, Timestamped, TenantBound, Principal
-from sqlalchemy.orm import Mapped
 from ..specs import IO, F, acol, S
-from ..types import String
+from ..types import Mapped, String
 
 
 class Group(Base, GUIDPk, Timestamped, TenantBound, Principal):

--- a/pkgs/standards/autoapi/autoapi/v3/tables/org.py
+++ b/pkgs/standards/autoapi/autoapi/v3/tables/org.py
@@ -2,9 +2,8 @@
 
 from ._base import Base
 from ..mixins import GUIDPk, Timestamped, TenantBound, Principal
-from sqlalchemy.orm import Mapped
 from ..specs import IO, F, acol, S
-from ..types import String
+from ..types import Mapped, String
 
 
 class Org(Base, GUIDPk, Timestamped, TenantBound, Principal):

--- a/pkgs/standards/autoapi/autoapi/v3/tables/rbac.py
+++ b/pkgs/standards/autoapi/autoapi/v3/tables/rbac.py
@@ -1,12 +1,9 @@
 from uuid import UUID
 
 
-
-from sqlalchemy.orm import Mapped
-
 from ..specs import IO, F, acol, S
 from ..specs.storage_spec import ForeignKeySpec
-from ..types import Integer, String, PgUUID
+from ..types import Integer, String, PgUUID, Mapped
 
 from . import Base
 from ..mixins import (

--- a/pkgs/standards/autoapi/autoapi/v3/tables/status.py
+++ b/pkgs/standards/autoapi/autoapi/v3/tables/status.py
@@ -19,8 +19,7 @@ from __future__ import annotations
 from enum import StrEnum
 
 from ..specs import acol, F, IO, S
-from ..types import String, SAEnum, Integer
-from sqlalchemy.orm import Mapped
+from ..types import Integer, Mapped, SAEnum, String
 
 from ._base import Base
 from ..mixins import Timestamped  # created_at / updated_at

--- a/pkgs/standards/autoapi/autoapi/v3/tables/user.py
+++ b/pkgs/standards/autoapi/autoapi/v3/tables/user.py
@@ -9,9 +9,8 @@ from ..mixins import (
     AsyncCapable,
     ActiveToggle,
 )
-from sqlalchemy.orm import Mapped
 from ..specs import IO, acol, F, S
-from ..types import String
+from ..types import Mapped, String
 
 
 class User(


### PR DESCRIPTION
## Summary
- centralize ORM type imports via `autoapi.v3.types`
- adjust auto_authn and auto_kms to use `Mapped` from `autoapi`
- pull autoapi v3 tables and mixins off direct SQLAlchemy usage

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff format .`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check . --fix`
- `uv run --directory pkgs/standards/auto_kms --package auto_kms ruff format .`
- `uv run --directory pkgs/standards/auto_kms --package auto_kms ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68aeab17d79c8326a8a61da232abfb28