### PR TITLE
feat(autoapi): expose bound schema helper

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/__init__.py
@@ -58,7 +58,7 @@ from .bindings import (
 from .runtime.executor import _invoke
 
 # ── Schemas ────────────────────────────────────────────────────────────────────
-from .schema import _build_schema, _build_list_params
+from .schema import _build_schema, _build_list_params, get_schema
 
 # ── Transport & Diagnostics (optional) ─────────────────────────────────────────
 from .transport.jsonrpc import build_jsonrpc_router
@@ -112,6 +112,7 @@ __all__ += [
     # Schemas
     "_build_schema",
     "_build_list_params",
+    "get_schema",
     # Transport / Diagnostics
     "build_jsonrpc_router",
     "mount_diagnostics",

--- a/pkgs/standards/autoapi/autoapi/v3/schema/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/__init__.py
@@ -1,6 +1,7 @@
 # autoapi/v3/schema/__init__.py
 from .builder import _build_schema, _build_list_params
 from .utils import namely_model
+from .get_schema import get_schema
 from .col_info import (
     VALID_KEYS,
     VALID_VERBS,
@@ -15,6 +16,7 @@ __all__ = [
     "_build_schema",
     "_build_list_params",
     "namely_model",
+    "get_schema",
     "VALID_KEYS",
     "VALID_VERBS",
     "WRITE_VERBS",

--- a/pkgs/standards/autoapi/autoapi/v3/schema/get_schema.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/get_schema.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Literal, Optional, Type
+
+from pydantic import BaseModel
+
+
+def get_schema(
+    orm_cls: type,
+    op: str,
+    *,
+    kind: Literal["in", "out"] = "out",
+) -> Optional[Type[BaseModel]]:
+    """Return the bound schema for ``orm_cls``.
+
+    Parameters
+    ----------
+    orm_cls:
+        ORM model that has been bound via :func:`autoapi.v3.bindings.build_schemas`.
+    op:
+        Operation alias whose schema should be returned.
+    kind:
+        Either ``"in"`` for request schemas or ``"out"`` for response schemas.
+
+    Returns
+    -------
+    Optional[Type[BaseModel]]
+        The requested schema class if available, otherwise ``None`` when the
+        operation uses raw payloads.
+
+    Raises
+    ------
+    KeyError
+        If the model has not been bound or the operation/kind is unknown.
+    """
+    ns = getattr(orm_cls, "schemas", None)
+    if ns is None:
+        raise KeyError(
+            f"{orm_cls.__name__} has no bound schemas; did you include the model?",
+        )
+
+    alias_ns = getattr(ns, op, None)
+    if alias_ns is None:
+        raise KeyError(f"Unknown op '{op}' for {orm_cls.__name__}")
+
+    kind = kind.lower()
+    if kind not in {"in", "out"}:
+        raise ValueError("kind must be 'in' or 'out'")
+
+    attr = "in_" if kind == "in" else "out"
+    if not hasattr(alias_ns, attr):
+        raise KeyError(
+            f"Schema kind '{kind}' not found for op '{op}' on {orm_cls.__name__}",
+        )
+    return getattr(alias_ns, attr)
+
+
+__all__ = ["get_schema"]


### PR DESCRIPTION
## Summary
- add utility to fetch bound schemas per operation and direction
- export get_schema via autoapi.v3

## Testing
- `uv run --package autoapi --directory . ruff format .`
- `uv run --package autoapi --directory . ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68aebb033d5c8326a3338b56b71b838d