### PR TITLE
chore(peagen): update autoapi imports to v3

### DIFF
--- a/pkgs/standards/peagen/peagen/cli/commands/init.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/init.py
@@ -353,7 +353,7 @@ def remote_init_repo(
     upstream_url = f"https://github.com/{owner}/{name}.git"
 
     # Build RPC params using the GitHub URL
-    from autoapi.v2 import get_schema
+    from autoapi.v3 import get_schema
 
     SCreate = get_schema(Repository, "create")
     SRead = get_schema(Repository, "read")

--- a/pkgs/standards/peagen/peagen/cli/commands/secrets.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/secrets.py
@@ -17,7 +17,7 @@ from typing import List, Optional
 
 import typer
 from autoapi_client import AutoAPIClient
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.orm import RepoSecret
 from peagen.core import secrets_core
 

--- a/pkgs/standards/peagen/peagen/cli/commands/task.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/task.py
@@ -9,7 +9,7 @@ import time
 
 import typer
 from autoapi_client import AutoAPIClient
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.orm import Status, Task
 from peagen.cli.task_helpers import get_task, build_task, submit_task
 

--- a/pkgs/standards/peagen/peagen/cli/task_helpers.py
+++ b/pkgs/standards/peagen/peagen/cli/task_helpers.py
@@ -5,7 +5,7 @@ import uuid
 from typing import Any, Dict, Optional
 
 from autoapi_client import AutoAPIClient
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.orm import Status, Task, Action, SpecKind
 
 

--- a/pkgs/standards/peagen/peagen/core/control_core.py
+++ b/pkgs/standards/peagen/peagen/core/control_core.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Iterable
 
 from peagen.orm import Status, Task
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 
 SUpdate = get_schema(Task, "update")
 

--- a/pkgs/standards/peagen/peagen/core/keys_core.py
+++ b/pkgs/standards/peagen/peagen/core/keys_core.py
@@ -18,7 +18,7 @@ import os
 import anyio
 import httpx
 from autoapi_client import AutoAPIClient
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen._utils.config_loader import (
     load_peagen_toml,
     resolve_cfg,

--- a/pkgs/standards/peagen/peagen/core/publickey_core.py
+++ b/pkgs/standards/peagen/peagen/core/publickey_core.py
@@ -16,7 +16,7 @@ from typing import Any, Optional
 import httpx
 
 from autoapi_client import AutoAPIClient  # ← new client
-from autoapi.v2 import get_schema  # ← schema helper
+from autoapi.v3 import get_schema  # ← schema helper
 from peagen.orm import PublicKey  # ORM resource
 
 from peagen.defaults import DEFAULT_GATEWAY, DEFAULT_SUPER_USER_ID

--- a/pkgs/standards/peagen/peagen/core/secrets_core.py
+++ b/pkgs/standards/peagen/peagen/core/secrets_core.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import List, Optional
 
 from autoapi_client import AutoAPIClient
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.orm import RepoSecret, Worker
 
 from peagen.plugins.secret_drivers import AutoGpgDriver

--- a/pkgs/standards/peagen/peagen/core/task_core.py
+++ b/pkgs/standards/peagen/peagen/core/task_core.py
@@ -8,7 +8,7 @@ import httpx
 from typing import Any, Dict
 
 from autoapi_client import AutoAPIClient
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.orm import Task
 
 from peagen.defaults import DEFAULT_GATEWAY, RPC_TIMEOUT

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -19,7 +19,7 @@ import uuid
 
 
 # ─────────── Peagen internals ──────────────────────────────────────────
-from autoapi.v2 import AutoAPI, Phase, get_schema
+from autoapi.v3 import AutoAPI, Phase, get_schema
 from auto_authn.v2.providers import RemoteAuthNAdapter
 from fastapi import FastAPI, Request
 

--- a/pkgs/standards/peagen/peagen/gateway/schedule_helpers.py
+++ b/pkgs/standards/peagen/peagen/gateway/schedule_helpers.py
@@ -17,8 +17,8 @@ import json
 import time
 from typing import Any, Dict, List, Optional, Protocol
 
-from autoapi.v2 import get_schema
-from autoapi.v2.tables.status import Status
+from autoapi.v3 import get_schema
+from autoapi.v3.tables.status import Status
 from autoapi_client import AutoAPIClient
 
 from peagen.defaults import READY_QUEUE, TASK_KEY, TASK_TTL, WORKER_KEY, WORKER_TTL

--- a/pkgs/standards/peagen/peagen/handlers/analysis_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/analysis_handler.py
@@ -18,7 +18,7 @@ from contextlib import suppress
 from pathlib import Path
 from typing import Any, Dict, List
 
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.orm import Task
 from peagen.core.analysis_core import analyze_runs
 from peagen._utils.config_loader import resolve_cfg

--- a/pkgs/standards/peagen/peagen/handlers/control_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/control_handler.py
@@ -16,8 +16,8 @@ from __future__ import annotations
 
 from typing import Iterable
 
-from autoapi.v2 import get_schema
-from autoapi.v2.tables.task import Task  # SQLAlchemy model row
+from autoapi.v3 import get_schema
+from autoapi.v3.tables.task import Task  # SQLAlchemy model row
 
 from peagen.core import control_core
 from peagen.plugins.queues import QueueBase

--- a/pkgs/standards/peagen/peagen/handlers/doe_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/doe_handler.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 import yaml
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.orm import Task, Status, Action
 
 from peagen.core.git_repo_core import (

--- a/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/doe_process_handler.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 import yaml
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.orm import Task, Status, Action
 
 from peagen.defaults import ROOT_DIR

--- a/pkgs/standards/peagen/peagen/handlers/eval_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/eval_handler.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Any, Dict, Optional
 
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.orm import Task
 
 from peagen.core.eval_core import evaluate_workspace

--- a/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/evolve_handler.py
@@ -20,7 +20,7 @@ import yaml
 from pathlib import Path
 from typing import Any, Dict, List
 
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.orm import Task, Status, Action
 from peagen.core.git_repo_core import (
     repo_lock,

--- a/pkgs/standards/peagen/peagen/handlers/extras_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/extras_handler.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, List
 
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.orm import Task
 from peagen.core.extras_core import generate_schemas
 

--- a/pkgs/standards/peagen/peagen/handlers/fetch_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/fetch_handler.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.orm import Task
 from peagen.core.fetch_core import fetch_many
 

--- a/pkgs/standards/peagen/peagen/handlers/init_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/init_handler.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict
 
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.orm import Task
 from peagen.core import init_core
 

--- a/pkgs/standards/peagen/peagen/handlers/keys_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/keys_handler.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 import anyio
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.core import keys_core
 from peagen.defaults import DEFAULT_GATEWAY
 from peagen.orm import Task

--- a/pkgs/standards/peagen/peagen/handlers/migrate_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/migrate_handler.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict
 
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.orm import Task
 
 from peagen.core.migrate_core import (

--- a/pkgs/standards/peagen/peagen/handlers/mutate_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/mutate_handler.py
@@ -19,7 +19,7 @@ from contextlib import suppress
 from pathlib import Path
 from typing import Any, Dict
 
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.orm import Task
 from peagen.core.mutate_core import mutate_workspace
 from peagen._utils.config_loader import resolve_cfg

--- a/pkgs/standards/peagen/peagen/handlers/process_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/process_handler.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict
 
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.orm import Task
 
 from peagen._utils.config_loader import resolve_cfg

--- a/pkgs/standards/peagen/peagen/handlers/secrets_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/secrets_handler.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict
 
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.orm import Task
 
 from peagen.core import secrets_core

--- a/pkgs/standards/peagen/peagen/handlers/sort_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/sort_handler.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict
 
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.orm import Task
 
 from peagen._utils.config_loader import resolve_cfg

--- a/pkgs/standards/peagen/peagen/handlers/templates_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/templates_handler.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.orm import Task
 
 from peagen._utils import maybe_clone_repo

--- a/pkgs/standards/peagen/peagen/handlers/validate_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/validate_handler.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Dict, Any
 
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.orm import Task
 from peagen.core.validate_core import validate_artifact
 

--- a/pkgs/standards/peagen/peagen/worker/base.py
+++ b/pkgs/standards/peagen/peagen/worker/base.py
@@ -15,7 +15,7 @@ from peagen.defaults import DEFAULT_GATEWAY, DEFAULT_POOL_ID, DEFAULT_POOL_NAME
 
 # ─── AutoAPI & client ────────────────────────────────────────────────
 from autoapi_client import AutoAPIClient
-from autoapi.v2 import get_schema
+from autoapi.v3 import get_schema
 from peagen.orm import Worker, Work, Status  # Status enum for updates
 
 

--- a/pkgs/standards/peagen/tests/i9n/test_worker_crud.py
+++ b/pkgs/standards/peagen/tests/i9n/test_worker_crud.py
@@ -14,7 +14,7 @@ import pytest
 
 # ❶ ------------------------------------------------------------------------
 # Runtime wiring
-from autoapi.v2 import get_schema  # your AutoAutoAPI import
+from autoapi.v3 import get_schema  # your AutoAutoAPI import
 from peagen.orm import Worker  # ORM class
 from peagen.defaults import DEFAULT_POOL_ID
 from autoapi_client import AutoAPIClient  # JSON-RPC helper


### PR DESCRIPTION
## Summary
- switch peagen modules from autoapi.v2 to autoapi.v3

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68aebcd40ec88326a01b84e0e168c75c