### PR TITLE
Refactor key wrap/unwrap to require crypto APIs

### DIFF
--- a/pkgs/core/swarmauri_core/crypto/ICrypto.py
+++ b/pkgs/core/swarmauri_core/crypto/ICrypto.py
@@ -128,6 +128,7 @@ class ICrypto(ABC):
         dek: Optional[bytes] = None,
         wrap_alg: Optional[Alg] = None,
         nonce: Optional[bytes] = None,
+        aad: Optional[bytes] = None,
     ) -> WrappedKey:
         """
         Protect a DEK under a KEK.
@@ -137,6 +138,7 @@ class ICrypto(ABC):
           dek      : raw DEK bytes to wrap. If None, provider MAY generate a new DEK.
           wrap_alg : wrapping algorithm identifier; provider MAY default if None.
           nonce    : optional per-wrap nonce/IV (algorithm-specific).
+          aad      : optional additional authenticated data bound to the wrap.
 
         Returns:
           WrappedKey: opaque blob + metadata to later recover the DEK.
@@ -148,9 +150,18 @@ class ICrypto(ABC):
         ...
 
     @abstractmethod
-    async def unwrap(self, kek: KeyRef, wrapped: WrappedKey) -> bytes:
+    async def unwrap(
+        self,
+        kek: KeyRef,
+        wrapped: WrappedKey,
+        *,
+        aad: Optional[bytes] = None,
+    ) -> bytes:
         """
         Recover a DEK from 'wrapped' using KEK 'kek'.
+
+        Parameters:
+          aad : optional additional authenticated data to validate.
 
         Returns:
           bytes: the raw DEK.

--- a/pkgs/core/swarmauri_core/crypto/types.py
+++ b/pkgs/core/swarmauri_core/crypto/types.py
@@ -197,6 +197,7 @@ class WrappedKey:
     Result of wrapping a DEK with a KEK.
     - wrap_alg: e.g., "AES-KW" / "AES-KWP" / "RSA-OAEP"
     - nonce: optional for schemes that use IVs (not AES-KW)
+    - tag: optional authentication tag for AEAD-based wrapping
     """
 
     kek_kid: KeyId
@@ -204,6 +205,7 @@ class WrappedKey:
     wrap_alg: Alg
     wrapped: bytes
     nonce: Optional[bytes] = None
+    tag: Optional[bytes] = None
 
 
 # -----------------------------


### PR DESCRIPTION
## Summary
- remove encrypt/decrypt fallbacks in key wrapping operations
- extend ICrypto interface with aad-aware wrap/unwrap methods
- allow WrappedKey to carry an authentication tag

## Testing
- `uv run --directory pkgs/standards/auto_kms --package auto_kms ruff check . --fix`
- `uv run --directory pkgs/core --package swarmauri-core ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68aec3be8b148326af7cdbaaafbd926f