### PR TITLE
feat: allow multi-resource type registration

### DIFF
--- a/pkgs/base/swarmauri_base/DynamicBase.py
+++ b/pkgs/base/swarmauri_base/DynamicBase.py
@@ -586,16 +586,18 @@ class DynamicBase(BaseModel):
     @classmethod
     def register_type(
         cls,
-        resource_type: Optional[Union[Type[T], List[Type[T]]]] = None,
+        resource_type: Optional[
+            Union[Type[T], List[Type[T]], Tuple[Type[T], ...]]
+        ] = None,
         type_name: Optional[str] = None,
     ):
         """
         Decorator to register a subtype under one or more base models in the unified registry.
 
         Parameters:
-            resource_type (Optional[Union[Type[T], List[Type[T]]]]):
-                The base model(s) under which to register the subtype. If None, all direct base classes (except DynamicBase)
-                are used.
+            resource_type (Optional[Union[Type[T], List[Type[T]], Tuple[Type[T], ...]]]):
+                The base model(s) under which to register the subtype. If ``None``, all
+                direct base classes (except ``DynamicBase``) are used.
             type_name (Optional[str]): An optional custom type name for the subtype.
 
         Returns:
@@ -608,10 +610,10 @@ class DynamicBase(BaseModel):
                 resource_types = [
                     base for base in subclass.__bases__ if base is not cls
                 ]
-            elif not isinstance(resource_type, list):
-                resource_types = [resource_type]
+            elif isinstance(resource_type, (list, tuple)):
+                resource_types = list(resource_type)
             else:
-                resource_types = resource_type
+                resource_types = [resource_type]
 
             for rt in resource_types:
                 if not issubclass(subclass, rt):

--- a/pkgs/base/tests/unit/DynamicBase_multi_resource_unit_test.py
+++ b/pkgs/base/tests/unit/DynamicBase_multi_resource_unit_test.py
@@ -1,0 +1,29 @@
+"""Unit tests for registering to multiple resource types."""
+
+import pytest
+
+from swarmauri_base.DynamicBase import DynamicBase
+
+
+@DynamicBase.register_model()
+class ResourceTypeA(DynamicBase):
+    """Dummy base model A."""
+
+
+@DynamicBase.register_model()
+class ResourceTypeB(DynamicBase):
+    """Dummy base model B."""
+
+
+@DynamicBase.register_type(resource_type=(ResourceTypeA, ResourceTypeB))
+class MultiResource(ResourceTypeA, ResourceTypeB):
+    """Model registered to two resource types."""
+
+
+@pytest.mark.unit
+def test_register_multiple_resource_types():
+    """Ensure a model registers under each specified resource type."""
+    reg_a = DynamicBase._registry["ResourceTypeA"]["subtypes"]
+    reg_b = DynamicBase._registry["ResourceTypeB"]["subtypes"]
+    assert reg_a["MultiResource"] is MultiResource
+    assert reg_b["MultiResource"] is MultiResource


### PR DESCRIPTION
## Summary
- enable `register_type` to accept multiple resource types via tuples or lists
- test multi-resource registration support in `DynamicBase`

## Testing
- `uv run --package swarmauri-base --directory base ruff format .`
- `uv run --package swarmauri-base --directory base ruff check . --fix`
- `uv run --package swarmauri-base --directory base pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aec7ecb5d88326bdfdc239954b89e0