### PR TITLE
feat: enforce key wrap and unwrap

### DIFF
--- a/pkgs/base/swarmauri_base/crypto/CryptoBase.py
+++ b/pkgs/base/swarmauri_base/crypto/CryptoBase.py
@@ -53,6 +53,7 @@ class CryptoBase(ICrypto, ComponentBase):
         dek: Optional[bytes] = None,
         wrap_alg: Optional[Alg] = None,
         nonce: Optional[bytes] = None,
+        aad: Optional[bytes] = None,
     ) -> WrappedKey:
         raise NotImplementedError("wrap() must be implemented by subclass")
 

--- a/pkgs/core/swarmauri_core/crypto/ICrypto.py
+++ b/pkgs/core/swarmauri_core/crypto/ICrypto.py
@@ -128,6 +128,7 @@ class ICrypto(ABC):
         dek: Optional[bytes] = None,
         wrap_alg: Optional[Alg] = None,
         nonce: Optional[bytes] = None,
+        aad: Optional[bytes] = None,
     ) -> WrappedKey:
         """
         Protect a DEK under a KEK.
@@ -137,6 +138,7 @@ class ICrypto(ABC):
           dek      : raw DEK bytes to wrap. If None, provider MAY generate a new DEK.
           wrap_alg : wrapping algorithm identifier; provider MAY default if None.
           nonce    : optional per-wrap nonce/IV (algorithm-specific).
+          aad      : optional associated data to bind/authenticate.
 
         Returns:
           WrappedKey: opaque blob + metadata to later recover the DEK.

--- a/pkgs/core/swarmauri_core/crypto/types.py
+++ b/pkgs/core/swarmauri_core/crypto/types.py
@@ -195,8 +195,10 @@ class AEADCiphertext:
 class WrappedKey:
     """
     Result of wrapping a DEK with a KEK.
-    - wrap_alg: e.g., "AES-KW" / "AES-KWP" / "RSA-OAEP"
+    - wrap_alg: e.g., "AES-KW" / "AES-KWP" / "RSA-OAEP" / "AES-256-GCM"
     - nonce: optional for schemes that use IVs (not AES-KW)
+    - tag: authentication tag for AEAD-based wrap algorithms
+    - aad: optional associated data bound to the wrapped key
     """
 
     kek_kid: KeyId
@@ -204,6 +206,8 @@ class WrappedKey:
     wrap_alg: Alg
     wrapped: bytes
     nonce: Optional[bytes] = None
+    tag: Optional[bytes] = None
+    aad: Optional[bytes] = None
 
 
 # -----------------------------

--- a/pkgs/standards/auto_kms/auto_kms/app.py
+++ b/pkgs/standards/auto_kms/auto_kms/app.py
@@ -7,6 +7,7 @@ from .tables.key import Key
 from .tables.key_version import KeyVersion
 
 from swarmauri_crypto_paramiko import ParamikoCrypto
+from swarmauri_secret_autogpg import AutoGpgSecretDrive
 
 import os
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
@@ -40,6 +41,12 @@ async def _stash_ctx(ctx):
     except NameError:
         CRYPTO = ParamikoCrypto()
     ctx["crypto"] = CRYPTO
+    global SECRETS
+    try:
+        SECRETS
+    except NameError:
+        SECRETS = AutoGpgSecretDrive()
+    ctx["secrets"] = SECRETS
 
 
 # Construct AutoAPI with api-level hooks; custom ops return raw dicts so no finalize hook needed

--- a/pkgs/standards/swarmauri_crypto_composite/swarmauri_crypto_composite/CompositeCrypto.py
+++ b/pkgs/standards/swarmauri_crypto_composite/swarmauri_crypto_composite/CompositeCrypto.py
@@ -93,9 +93,10 @@ class CompositeCrypto(ICrypto, ComponentBase):
         dek: Optional[bytes] = None,
         wrap_alg: Optional[Alg] = None,
         nonce: Optional[bytes] = None,
+        aad: Optional[bytes] = None,
     ) -> WrappedKey:
         return await self._pick("wrap", wrap_alg).wrap(
-            kek, dek=dek, wrap_alg=wrap_alg, nonce=nonce
+            kek, dek=dek, wrap_alg=wrap_alg, nonce=nonce, aad=aad
         )
 
     async def unwrap(self, kek: KeyRef, wrapped: WrappedKey) -> bytes:

--- a/pkgs/standards/swarmauri_crypto_ecdh_es_a128kw/swarmauri_crypto_ecdh_es_a128kw/ECDHESA128KWCrypto.py
+++ b/pkgs/standards/swarmauri_crypto_ecdh_es_a128kw/swarmauri_crypto_ecdh_es_a128kw/ECDHESA128KWCrypto.py
@@ -62,6 +62,7 @@ class ECDHESA128KWCrypto(CryptoBase):
         dek: Optional[bytes] = None,
         wrap_alg: Optional[Alg] = None,
         nonce: Optional[bytes] = None,
+        aad: Optional[bytes] = None,
     ) -> WrappedKey:
         wrap_alg = (wrap_alg or _WRAP_ALG).upper()
         if wrap_alg != _WRAP_ALG:

--- a/pkgs/standards/swarmauri_crypto_nacl_pkcs11/swarmauri_crypto_nacl_pkcs11/NaClPkcs11Crypto.py
+++ b/pkgs/standards/swarmauri_crypto_nacl_pkcs11/swarmauri_crypto_nacl_pkcs11/NaClPkcs11Crypto.py
@@ -149,6 +149,7 @@ class NaClPkcs11Crypto(CryptoBase):
         dek: Optional[bytes] = None,
         wrap_alg: Optional[Alg] = None,
         nonce: Optional[bytes] = None,
+        aad: Optional[bytes] = None,
     ) -> WrappedKey:
         alg = wrap_alg or _WRAP_ALG
         if alg != _WRAP_ALG:

--- a/pkgs/standards/swarmauri_crypto_pgp/swarmauri_crypto_pgp/PGPCrypto.py
+++ b/pkgs/standards/swarmauri_crypto_pgp/swarmauri_crypto_pgp/PGPCrypto.py
@@ -311,6 +311,7 @@ class PGPCrypto(CryptoBase):
         dek: Optional[bytes] = None,
         wrap_alg: Optional[Alg] = None,
         nonce: Optional[bytes] = None,
+        aad: Optional[bytes] = None,
     ) -> WrappedKey:
         wrap_alg = wrap_alg or _WRAP_ALG
         if wrap_alg != _WRAP_ALG:

--- a/pkgs/standards/swarmauri_crypto_rust/python/swarmauri_crypto_rust/RustCrypto.py
+++ b/pkgs/standards/swarmauri_crypto_rust/python/swarmauri_crypto_rust/RustCrypto.py
@@ -179,6 +179,7 @@ class RustCrypto(CryptoBase):
         dek: Optional[bytes] = None,
         wrap_alg: Optional[Alg] = None,
         nonce: Optional[bytes] = None,
+        aad: Optional[bytes] = None,
     ) -> CoreWrappedKey:
         wrap_alg = wrap_alg or _WRAP_ALG
         if wrap_alg != _WRAP_ALG:

--- a/pkgs/standards/swarmauri_crypto_sodium/swarmauri_crypto_sodium/SodiumCrypto.py
+++ b/pkgs/standards/swarmauri_crypto_sodium/swarmauri_crypto_sodium/SodiumCrypto.py
@@ -307,6 +307,7 @@ class SodiumCrypto(CryptoBase):
         dek: Optional[bytes] = None,
         wrap_alg: Optional[Alg] = None,
         nonce: Optional[bytes] = None,
+        aad: Optional[bytes] = None,
     ) -> WrappedKey:
         wrap_alg = (wrap_alg or _WRAP_ALG).upper()
         if wrap_alg != _WRAP_ALG:


### PR DESCRIPTION
## Summary
- remove encrypt/decrypt fallback in key wrap/unwrap
- extend crypto interfaces and types with AAD support
- implement AES-GCM key wrap/unwrap in ParamikoCrypto

## Testing
- `uv run --directory pkgs/core --package swarmauri_core ruff format .`
- `uv run --directory pkgs/core --package swarmauri_core ruff check . --fix`
- `uv run --directory pkgs/base --package swarmauri_base ruff format .`
- `uv run --directory pkgs/base --package swarmauri_base ruff check . --fix`
- `uv run --directory pkgs/standards/auto_kms --package auto_kms ruff format .`
- `uv run --directory pkgs/standards/auto_kms --package auto_kms ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_crypto_paramiko --package swarmauri_crypto_paramiko ruff format .`
- `uv run --directory pkgs/standards/swarmauri_crypto_paramiko --package swarmauri_crypto_paramiko ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_crypto_pgp --package swarmauri_crypto_pgp ruff format .`
- `uv run --directory pkgs/standards/swarmauri_crypto_pgp --package swarmauri_crypto_pgp ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_crypto_composite --package swarmauri_crypto_composite ruff format .`
- `uv run --directory pkgs/standards/swarmauri_crypto_composite --package swarmauri_crypto_composite ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_crypto_nacl_pkcs11 --package swarmauri_crypto_nacl_pkcs11 ruff format .`
- `uv run --directory pkgs/standards/swarmauri_crypto_nacl_pkcs11 --package swarmauri_crypto_nacl_pkcs11 ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_crypto_ecdh_es_a128kw --package swarmauri_crypto_ecdh_es_a128kw ruff format .`
- `uv run --directory pkgs/standards/swarmauri_crypto_ecdh_es_a128kw --package swarmauri_crypto_ecdh_es_a128kw ruff check . --fix`
- `uv run --directory pkgs/core --package swarmauri_core pytest`
- `uv run --directory pkgs/base --package swarmauri_base pytest`
- `uv run --directory pkgs/standards/auto_kms --package auto_kms pytest`
- `uv run --directory pkgs/standards/swarmauri_crypto_paramiko --package swarmauri_crypto_paramiko pytest`
- `uv run --directory pkgs/standards/swarmauri_crypto_pgp --package swarmauri_crypto_pgp pytest`
- `uv run --directory pkgs/standards/swarmauri_crypto_composite --package swarmauri_crypto_composite pytest`
- `uv run --directory pkgs/standards/swarmauri_crypto_nacl_pkcs11 --package swarmauri_crypto_nacl_pkcs11 pytest`
- `uv run --directory pkgs/standards/swarmauri_crypto_ecdh_es_a128kw --package swarmauri_crypto_ecdh_es_a128kw pytest`
- `uv run --directory pkgs/standards/swarmauri_crypto_rust --package swarmauri_crypto_rust ruff format .` (failed: workspace configuration)
- `uv run --directory pkgs/standards/swarmauri_crypto_rust --package swarmauri_crypto_rust ruff check . --fix` (failed: workspace configuration)
- `uv run --directory pkgs/standards/swarmauri_crypto_rust --package swarmauri_crypto_rust pytest` (failed: workspace configuration)
- `uv run --directory pkgs/standards/swarmauri_crypto_sodium --package swarmauri_crypto_sodium ruff format .` (failed: build error)
- `uv run --directory pkgs/standards/swarmauri_crypto_sodium --package swarmauri_crypto_sodium ruff check . --fix` (failed: build error)
- `uv run --directory pkgs/standards/swarmauri_crypto_sodium --package swarmauri_crypto_sodium pytest` (failed: build error)


------
https://chatgpt.com/codex/tasks/task_e_68aec3bf7638832681801649159de6c6