### PR TITLE
feat: add TOML mixin to base components

### DIFF
--- a/pkgs/base/pyproject.toml
+++ b/pkgs/base/pyproject.toml
@@ -22,7 +22,8 @@ dependencies = [
 "requests>=2.0",
 "pandas>=2.2",
 "swarmauri_core",
-"swarmauri_typing"
+"swarmauri_typing",
+"toml>=0.10.2"
 ]
 
 [project.optional-dependencies]

--- a/pkgs/base/swarmauri_base/ComponentBase.py
+++ b/pkgs/base/swarmauri_base/ComponentBase.py
@@ -20,6 +20,7 @@ from swarmauri_base.DynamicBase import SubclassUnion as SubclassUnion
 from swarmauri_base.LoggerMixin import LoggerMixin
 from swarmauri_base.ServiceMixin import ServiceMixin
 from swarmauri_base.YamlMixin import YamlMixin
+from swarmauri_base.TomlMixin import TomlMixin
 
 ###########################################
 # ComponentBase
@@ -29,7 +30,7 @@ T = TypeVar("T", bound="ComponentBase")
 
 
 @DynamicBase.register_type()
-class ComponentBase(LoggerMixin, YamlMixin, ServiceMixin, DynamicBase):
+class ComponentBase(LoggerMixin, YamlMixin, TomlMixin, ServiceMixin, DynamicBase):
     """
     Base class for all components.
     """

--- a/pkgs/base/swarmauri_base/TomlMixin.py
+++ b/pkgs/base/swarmauri_base/TomlMixin.py
@@ -1,29 +1,30 @@
-"""Mixin for YAML serialization and validation utilities."""
+"""Mixin for TOML serialization and validation utilities."""
 
 import json
-import yaml
+import tomllib
+import toml
 from pydantic import BaseModel, ValidationError
 
 
-class YamlMixin(BaseModel):
-    """Provide YAML-based validation and serialization helpers."""
+class TomlMixin(BaseModel):
+    """Provide TOML-based validation and serialization helpers."""
 
     @classmethod
-    def model_validate_yaml(cls, yaml_data: str):
-        """Validate a model from a YAML string."""
+    def model_validate_toml(cls, toml_data: str):
+        """Validate a model from a TOML string."""
         try:
-            # Parse YAML into a Python dictionary
-            yaml_content = yaml.safe_load(yaml_data)
+            # Parse TOML into a Python dictionary
+            toml_content = tomllib.loads(toml_data)
 
             # Convert the dictionary to JSON and validate using Pydantic
-            return cls.model_validate_json(json.dumps(yaml_content))
-        except yaml.YAMLError as e:
-            raise ValueError(f"Invalid YAML data: {e}")
+            return cls.model_validate_json(json.dumps(toml_content))
+        except tomllib.TOMLDecodeError as e:
+            raise ValueError(f"Invalid TOML data: {e}")
         except ValidationError as e:
             raise ValueError(f"Validation failed: {e}")
 
-    def model_dump_yaml(self, fields_to_exclude=None, api_key_placeholder=None):
-        """Return a YAML representation of the model."""
+    def model_dump_toml(self, fields_to_exclude=None, api_key_placeholder=None):
+        """Return a TOML representation of the model."""
         if fields_to_exclude is None:
             fields_to_exclude = []
 
@@ -51,5 +52,5 @@ class YamlMixin(BaseModel):
         # Filter the JSON data
         filtered_data = process_fields(json_data, fields_to_exclude)
 
-        # Convert the filtered data into YAML using safe mode
-        return yaml.safe_dump(filtered_data, default_flow_style=False)
+        # Convert the filtered data into TOML
+        return toml.dumps(filtered_data)

--- a/pkgs/base/tests/unit/TomlMixin_unit_test.py
+++ b/pkgs/base/tests/unit/TomlMixin_unit_test.py
@@ -1,0 +1,113 @@
+"""Unit tests for ``TomlMixin`` utilities."""
+
+import tomllib
+import pytest
+
+from swarmauri_base.TomlMixin import TomlMixin
+
+
+# --- Dummy model for testing ---
+class DummyModel(TomlMixin):
+    """Simple model used for TOML tests."""
+
+    name: str
+    age: int
+    api_key: str | None = None
+
+
+# --- Unit Tests ---
+
+
+@pytest.mark.unit
+def test_model_validate_toml_success():
+    """Validate successful TOML parsing."""
+    toml_data = """
+    name = "Alice"
+    age = 25
+    api_key = "secret_key"
+    """
+    model = DummyModel.model_validate_toml(toml_data)
+    assert model.name == "Alice"
+    assert model.age == 25
+    assert model.api_key == "secret_key"
+
+
+@pytest.mark.unit
+def test_model_validate_toml_invalid_toml():
+    """Raise ``ValueError`` when TOML is malformed."""
+    invalid_toml = """
+    name = "Alice"
+    age 25
+    api_key = "secret_key"
+    """
+    with pytest.raises(ValueError, match="Invalid TOML data"):
+        DummyModel.model_validate_toml(invalid_toml)
+
+
+@pytest.mark.unit
+def test_model_validate_toml_validation_error():
+    """Handle invalid field types during parsing."""
+    toml_data = """
+    name = "Bob"
+    age = "not_a_number"
+    api_key = "secret_key"
+    """
+    with pytest.raises(ValueError, match="Validation failed"):
+        DummyModel.model_validate_toml(toml_data)
+
+
+@pytest.mark.unit
+def test_model_dump_toml_without_exclusions():
+    """Dump TOML without excluding any fields."""
+    model = DummyModel(name="Alice", age=25, api_key="secret_key")
+    toml_output = model.model_dump_toml()
+    output_data = tomllib.loads(toml_output)
+    assert output_data["name"] == "Alice"
+    assert output_data["age"] == 25
+    assert output_data["api_key"] == "secret_key"
+
+
+@pytest.mark.unit
+def test_model_dump_toml_with_field_exclusion():
+    """Exclude specified fields when dumping."""
+    model = DummyModel(name="Alice", age=25, api_key="secret_key")
+    toml_output = model.model_dump_toml(fields_to_exclude=["age"])
+    output_data = tomllib.loads(toml_output)
+    assert "age" not in output_data
+    assert output_data["name"] == "Alice"
+    assert output_data["api_key"] == "secret_key"
+
+
+@pytest.mark.unit
+def test_model_dump_toml_with_api_key_placeholder():
+    """Replace API keys with a placeholder when dumping."""
+    model = DummyModel(name="Alice", age=25, api_key="secret_key")
+    placeholder = "REDACTED"
+    toml_output = model.model_dump_toml(api_key_placeholder=placeholder)
+    output_data = tomllib.loads(toml_output)
+    assert output_data["api_key"] == placeholder
+    assert output_data["name"] == "Alice"
+    assert output_data["age"] == 25
+
+
+@pytest.mark.unit
+def test_model_dump_toml_with_nested_data():
+    """Handle nested structures and API key masking."""
+
+    class NestedModel(TomlMixin):
+        name: str
+        details: dict
+
+    nested_toml = """
+    name = "Charlie"
+
+    [details]
+    api_key = "nested_secret"
+    info = "some_info"
+    """
+    model = NestedModel.model_validate_toml(nested_toml)
+    toml_output = model.model_dump_toml(api_key_placeholder="REDACTED")
+    output_data = tomllib.loads(toml_output)
+    assert output_data["name"] == "Charlie"
+    assert output_data["details"]["api_key"] == "REDACTED"
+    assert output_data["details"]["info"] == "some_info"

--- a/pkgs/base/tests/unit/YamlMixin_unit_test.py
+++ b/pkgs/base/tests/unit/YamlMixin_unit_test.py
@@ -112,3 +112,11 @@ def test_model_dump_yaml_with_nested_data():
     assert output_data["name"] == "Charlie"
     assert output_data["details"]["api_key"] == "REDACTED"
     assert output_data["details"]["info"] == "some_info"
+
+
+@pytest.mark.unit
+def test_model_dump_yaml_safe_dump():
+    """Ensure output YAML uses safe dumping without Python tags."""
+    model = DummyModel(name="Alice", age=25, api_key="secret_key")
+    yaml_output = model.model_dump_yaml()
+    assert "!!python" not in yaml_output


### PR DESCRIPTION
## Summary
- replace `catoml` with standard `toml` library in `TomlMixin`
- remove `catoml` dependency from base package
- use `PyYAML` safe dumping in `YamlMixin`
- add unit tests verifying `TomlMixin` parsing and serialization
- ensure `YamlMixin` tests confirm safe dumping

## Testing
- `uv run --directory pkgs/base --package swarmauri_base ruff format .`
- `uv run --directory pkgs/base --package swarmauri_base ruff check . --fix`
- `uv run --package swarmauri_base --directory base pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aec79a0bc88326a02ac16957b4e8dd