### PR TITLE
fix: correct MatrixBase resource type

### DIFF
--- a/pkgs/base/swarmauri_base/matrices/MatrixBase.py
+++ b/pkgs/base/swarmauri_base/matrices/MatrixBase.py
@@ -22,10 +22,10 @@ class MatrixBase(IMatrix, ComponentBase):
     Attributes
     ----------
     resource : Optional[str]
-        The resource type of this component, defaults to MATRICE
+        The resource type of this component, defaults to MATRIX
     """
 
-    resource: Optional[str] = Field(default=ResourceTypes.MATRICE.value)
+    resource: Optional[str] = Field(default=ResourceTypes.MATRIX.value)
 
     def __getitem__(self, key: Index) -> Union["IMatrix", IVector, T]:
         """


### PR DESCRIPTION
## Summary
- fix MatrixBase resource default to ResourceTypes.MATRIX
- update MatrixBase docs to reflect Matrix resource type

## Testing
- `uv run --directory base --package swarmauri_base ruff format .`
- `uv run --directory base --package swarmauri_base ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68aecbcd73748326aaace38c94b479e3