### PR TITLE
feat(autoapi): re-export app alias from deps

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/__init__.py
@@ -70,12 +70,13 @@ from .system.dbschema import ensure_schemas, register_sqlite_attach, bootstrap_d
 # ── Config constants (defaults used by REST) ───────────────────────────────────
 from .config.constants import DEFAULT_HTTP_METHODS
 from .autoapi import AutoAPI
+from .deps import app
 
 from .tables import Base
 
 __all__: list[str] = []
 
-__all__ += ["AutoAPI", "Base"]
+__all__ += ["AutoAPI", "Base", "app"]
 
 __all__ += [
     # OpSpec core

--- a/pkgs/standards/autoapi/autoapi/v3/deps/fastapi.py
+++ b/pkgs/standards/autoapi/autoapi/v3/deps/fastapi.py
@@ -1,6 +1,7 @@
 # ── FastAPI Imports ─────────────────────────────────────────────────────
 from fastapi import (
     APIRouter,
+    FastAPI,
     Security,
     Depends,
     Request,
@@ -10,10 +11,13 @@ from fastapi import (
     HTTPException,
 )
 
+app = FastAPI
+
 
 # ── Public Exports ───────────────────────────────────────────────────────
 __all__ = [
     "APIRouter",
+    "FastAPI",
     "Security",
     "Depends",
     "Request",
@@ -21,4 +25,5 @@ __all__ = [
     "Path",
     "Body",
     "HTTPException",
+    "app",
 ]

--- a/pkgs/standards/autoapi/tests/unit/test_app_reexport.py
+++ b/pkgs/standards/autoapi/tests/unit/test_app_reexport.py
@@ -1,0 +1,6 @@
+from autoapi.v3 import app
+from fastapi import FastAPI
+
+
+def test_app_reexport():
+    assert app is FastAPI


### PR DESCRIPTION
## Summary
- expose FastAPI as `app` in deps and re-export at `autoapi.v3`
- cover `app` re-export with unit test

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff check autoapi/v3/deps/fastapi.py autoapi/v3/__init__.py tests/unit/test_app_reexport.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_app_reexport.py`
- `uv run --package autoapi --directory standards/autoapi pytest` *(fails: ImportError: cannot import name '_http_exc_to_rpc')*

------
https://chatgpt.com/codex/tasks/task_e_68aecee678ec8326a4befa485edbab61