### PR TITLE
Require nonce for unwrap schema

### DIFF
--- a/pkgs/standards/auto_kms/auto_kms/tables/key.py
+++ b/pkgs/standards/auto_kms/auto_kms/tables/key.py
@@ -122,7 +122,7 @@ class Key(Base):
     )
 
     nonce_b64: Optional[str] = vcol(
-        field=F(required_in=("decrypt",), allow_null_in=("encrypt", "wrap", "unwrap")),
+        field=F(required_in=("decrypt", "unwrap"), allow_null_in=("encrypt", "wrap")),
         io=IO(in_verbs=("encrypt", "decrypt", "unwrap"), out_verbs=("encrypt", "wrap")),
     )
 


### PR DESCRIPTION
## Summary
- mark `nonce_b64` field as required for unwrap operations in `Key` schema

## Testing
- `uv run --package auto_kms --directory standards/auto_kms ruff format .`
- `uv run --package auto_kms --directory standards/auto_kms ruff check . --fix`
- `uv run --package auto_kms --directory standards/auto_kms pytest tests/unit/test_key_wrap_unwrap_schema.py`
- `uv run --package auto_kms --directory standards/auto_kms pytest` *(fails: 13 failed, 72 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68aeda90458c83268128b54df35aa046