### PR TITLE
Fix AutoAPI initialization for JWKS rotation test

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/routers/crud.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/routers/crud.py
@@ -25,7 +25,7 @@ Notes
 
 from __future__ import annotations
 
-from autoapi.v3 import AutoAPI, Base
+from autoapi.v3 import AutoAPI
 from auto_authn.v2.orm.tables import (
     Tenant,
     User,
@@ -35,15 +35,23 @@ from auto_authn.v2.orm.tables import (
     ServiceKey,
     AuthSession,
 )
+from fastapi import APIRouter
 from ..db import get_async_db  # same module as before
 
 # ----------------------------------------------------------------------
 # 3.  Build AutoAPI instance & router
 # ----------------------------------------------------------------------
 crud_api = AutoAPI(
-    base=Base,
-    include={Tenant, User, Client, ApiKey, Service, ServiceKey, AuthSession},
     get_async_db=get_async_db,
 )
+
+crud_api.include_models(
+    [Tenant, User, Client, ApiKey, Service, ServiceKey, AuthSession]
+)
+
+router = APIRouter()
+for r in crud_api.routers.values():
+    router.include_router(r)
+crud_api.router = router
 
 __all__ = ["crud_api"]


### PR DESCRIPTION
## Summary
- construct AutoAPI without deprecated `base` and `include` args
- aggregate model routers so FastAPI app can mount CRUD endpoints

## Testing
- `uv run --package auto_authn --directory standards/auto_authn ruff check . --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_jwks_rotation.py::test_jwks_rotation_publishes_new_key -q`


------
https://chatgpt.com/codex/tasks/task_e_68aedaeb04a08326b1e00fba8633f322