### PR TITLE
fix auto_authn models test configuration

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/api_key.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/api_key.py
@@ -23,9 +23,11 @@ class ApiKey(ApiKeyBase, UserMixin):
     )
 
     _user = relationship(
-        "auto_authn.v2.orm.tables.User",
+        "auto_authn.v2.orm.user.User",
         back_populates="_api_keys",
         lazy="joined",  # optional: eager load to avoid N+1
+        primaryjoin="ApiKey.user_id == User.id",
+        foreign_keys="ApiKey.user_id",
     )
 
     user: "User" = vcol(

--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/service.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/service.py
@@ -19,9 +19,11 @@ class Service(Base, GUIDPk, Timestamped, TenantBound, Principal, ActiveToggle):
     __table_args__ = ({"schema": "authn"},)
     name: str = acol(storage=S(String(120), unique=True, nullable=False))
     _service_keys = relationship(
-        "auto_authn.v2.orm.tables.ServiceKey",
+        "auto_authn.v2.orm.service_key.ServiceKey",
         back_populates="_service",
         cascade="all, delete-orphan",
+        primaryjoin="Service.id == ServiceKey.service_id",
+        foreign_keys="ServiceKey.service_id",
     )
     service_keys: list["ServiceKey"] = vcol(
         read_producer=lambda obj, _ctx: obj._service_keys,

--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/service_key.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/service_key.py
@@ -33,9 +33,11 @@ class ServiceKey(ApiKeyBase):
     )
 
     _service = relationship(
-        "auto_authn.v2.orm.tables.Service",
+        "auto_authn.v2.orm.service.Service",
         back_populates="_service_keys",
         lazy="joined",
+        primaryjoin="ServiceKey.service_id == Service.id",
+        foreign_keys="ServiceKey.service_id",
     )
     service: "Service" = vcol(
         read_producer=lambda obj, _ctx: obj._service,

--- a/pkgs/standards/auto_authn/auto_authn/v2/orm/user.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/orm/user.py
@@ -25,9 +25,11 @@ class User(UserBase):
     email: str = acol(storage=S(String(120), nullable=False, unique=True))
     password_hash: bytes | None = acol(storage=S(LargeBinary(60)))
     _api_keys = relationship(
-        "auto_authn.v2.orm.tables.ApiKey",
+        "auto_authn.v2.orm.api_key.ApiKey",
         back_populates="_user",
         cascade="all, delete-orphan",
+        primaryjoin="User.id == ApiKey.user_id",
+        foreign_keys="ApiKey.user_id",
     )
     api_keys: list["ApiKey"] = vcol(
         read_producer=lambda obj, _ctx: obj._api_keys,

--- a/pkgs/standards/auto_authn/auto_authn/v2/routers/crud.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/routers/crud.py
@@ -25,7 +25,8 @@ Notes
 
 from __future__ import annotations
 
-from autoapi.v3 import AutoAPI, Base
+from fastapi import APIRouter
+from autoapi.v3 import AutoAPI
 from auto_authn.v2.orm.tables import (
     Tenant,
     User,
@@ -40,10 +41,12 @@ from ..db import get_async_db  # same module as before
 # ----------------------------------------------------------------------
 # 3.  Build AutoAPI instance & router
 # ----------------------------------------------------------------------
-crud_api = AutoAPI(
-    base=Base,
-    include={Tenant, User, Client, ApiKey, Service, ServiceKey, AuthSession},
-    get_async_db=get_async_db,
+router = APIRouter()
+crud_api = AutoAPI(app=router, get_async_db=get_async_db)
+crud_api.include_models(
+    [Tenant, User, Client, ApiKey, Service, ServiceKey, AuthSession]
 )
+# Backwards compatibility: expose aggregated router as attribute
+crud_api.router = router  # type: ignore[attr-defined]
 
 __all__ = ["crud_api"]


### PR DESCRIPTION
## Summary
- fix AutoAPI setup using APIRouter and include models
- add explicit relationship joins for ApiKey, User, and Service models

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_models.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aedb02082c832685dbbea73a75bd76