### PR TITLE
refactor: update userinfo tests and crud setup

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/v2/oidc_userinfo.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/oidc_userinfo.py
@@ -23,16 +23,16 @@ from fastapi import (
 
 from .fastapi_deps import get_current_principal
 from .jwtoken import JWTCoder, InvalidTokenError, _svc
-from .orm.tables import User
 from .rfc6750 import extract_bearer_token
 from .deps import JWAAlg
+from .typing import Principal
 
 router = APIRouter()
 
 
 @router.get("/userinfo", response_model=None)
 async def userinfo(
-    request: Request, user: User = Depends(get_current_principal)
+    request: Request, user: Principal = Depends(get_current_principal)
 ) -> Response | dict[str, str]:
     """Return claims about the authenticated user.
 

--- a/pkgs/standards/auto_authn/auto_authn/v2/routers/crud.py
+++ b/pkgs/standards/auto_authn/auto_authn/v2/routers/crud.py
@@ -25,7 +25,8 @@ Notes
 
 from __future__ import annotations
 
-from autoapi.v3 import AutoAPI, Base
+from autoapi.v3 import AutoAPI
+from autoapi.v3.transport.rest import build_rest_router
 from auto_authn.v2.orm.tables import (
     Tenant,
     User,
@@ -40,10 +41,11 @@ from ..db import get_async_db  # same module as before
 # ----------------------------------------------------------------------
 # 3.  Build AutoAPI instance & router
 # ----------------------------------------------------------------------
-crud_api = AutoAPI(
-    base=Base,
-    include={Tenant, User, Client, ApiKey, Service, ServiceKey, AuthSession},
-    get_async_db=get_async_db,
+crud_api = AutoAPI(get_async_db=get_async_db)
+crud_api.include_models(
+    [Tenant, User, Client, ApiKey, Service, ServiceKey, AuthSession],
+    mount_router=False,
 )
+crud_api.router = build_rest_router(crud_api, base_prefix="/authn")
 
 __all__ = ["crud_api"]


### PR DESCRIPTION
## Summary
- align AutoAPI crud router with new v3 interface
- relax userinfo endpoint principal type
- adjust UserInfo tests for new validation behavior

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_openid_userinfo_endpoint.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aedb2d198c8326b7f9873804c6b303