### PR TITLE
Fix RFC 8252 native redirect test

### DIFF
--- a/pkgs/standards/auto_authn/tests/unit/test_rfc8252_native_app_redirects.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc8252_native_app_redirects.py
@@ -85,8 +85,10 @@ def test_client_new_allows_public_redirect_when_disabled(monkeypatch) -> None:
     monkeypatch.setenv("AUTO_AUTHN_ENFORCE_RFC8252", "0")
     importlib.reload(runtime_cfg)
     import auto_authn.v2.orm.tables as orm_tables
+    import auto_authn.v2.orm.client as orm_client
 
     monkeypatch.setattr(orm_tables, "settings", runtime_cfg.settings)
+    monkeypatch.setattr(orm_client, "settings", runtime_cfg.settings)
     tenant_id = uuid.uuid4()
     client = Client.new(
         tenant_id,
@@ -98,3 +100,4 @@ def test_client_new_allows_public_redirect_when_disabled(monkeypatch) -> None:
     monkeypatch.setenv("AUTO_AUTHN_ENFORCE_RFC8252", "1")
     importlib.reload(runtime_cfg)
     monkeypatch.setattr(orm_tables, "settings", runtime_cfg.settings)
+    monkeypatch.setattr(orm_client, "settings", runtime_cfg.settings)


### PR DESCRIPTION
## Summary
- patch `test_client_new_allows_public_redirect_when_disabled` so Client uses updated runtime settings

## Testing
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff format tests/unit/test_rfc8252_native_app_redirects.py`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check tests/unit/test_rfc8252_native_app_redirects.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_68aedb56983c8326a7e25137a952a02e