### PR TITLE
fix: correct get_async_db import in rfc8707 resource indicator tests

### DIFF
--- a/pkgs/standards/auto_authn/tests/unit/test_rfc8707_resource_indicators.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc8707_resource_indicators.py
@@ -12,7 +12,8 @@ from fastapi import FastAPI, status
 from httpx import ASGITransport, AsyncClient
 
 from auto_authn.v2.runtime_cfg import settings
-from auto_authn.v2.routers.auth_flows import router, _jwt, get_async_db
+from auto_authn.v2.routers.auth_flows import router, _jwt
+from auto_authn.v2.fastapi_deps import get_async_db
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- fix import path for get_async_db in RFC 8707 resource indicator tests

## Testing
- `uv run --package auto_authn --directory pkgs/standards/auto_authn ruff format .`
- `uv run --package auto_authn --directory pkgs/standards/auto_authn ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68aedb883adc83268e0ee5250bb6174d