### PR TITLE
fix: robust JWT header decoding in tests

### DIFF
--- a/pkgs/standards/auto_authn/tests/unit/test_jwtoken.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_jwtoken.py
@@ -404,9 +404,12 @@ class TestJWTCoder:
         tid = str(uuid4())
         token = coder.sign(sub=sub, tid=tid)
 
-        # Decode header to check algorithm without PyJWT
+        # Decode header to check algorithm without PyJWT.  The JWT segment may
+        # omit padding so we add it back before decoding to avoid "incorrect
+        # padding" errors on tokens whose header length is not divisible by 4.
         header_b64 = token.split(".")[0]
-        header = json.loads(base64.urlsafe_b64decode(header_b64 + "==").decode())
+        padding = "=" * (-len(header_b64) % 4)
+        header = json.loads(base64.urlsafe_b64decode(header_b64 + padding).decode())
         assert header["alg"] == _ALG  # Should be "EdDSA"
 
     def test_multiple_coders_independence(self):


### PR DESCRIPTION
## Summary
- ensure JWT algorithm test decodes base64 headers with proper padding to avoid errors

## Testing
- `uv run --package auto_authn --directory standards/auto_authn ruff format tests/unit/test_jwtoken.py`
- `uv run --package auto_authn --directory standards/auto_authn ruff check tests/unit/test_jwtoken.py --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_jwtoken.py`


------
https://chatgpt.com/codex/tasks/task_e_68aee482963c83269c92dc0b2ce441bc