### PR TITLE
fix(autoapi): restore http/rpc conversion aliases

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/runtime/errors.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/errors.py
@@ -312,6 +312,19 @@ def rpc_error_to_http(
     return http_exc
 
 
+# Backward compatibility shims
+def _http_exc_to_rpc(exc: HTTPException) -> tuple[int, str, Any | None]:
+    """Alias for :func:`http_exc_to_rpc` to preserve older import paths."""
+    return http_exc_to_rpc(exc)
+
+
+def _rpc_error_to_http(
+    rpc_code: int, message: str | None = None, data: Any | None = None
+) -> HTTPException:
+    """Alias for :func:`rpc_error_to_http` to preserve older import paths."""
+    return rpc_error_to_http(rpc_code, message, data)
+
+
 # ───────────────────── Exception → Standardized error ─────────────────────────
 
 
@@ -490,6 +503,8 @@ __all__ = [
     # conversions
     "http_exc_to_rpc",
     "rpc_error_to_http",
+    "_http_exc_to_rpc",
+    "_rpc_error_to_http",
     "create_standardized_error",
     "create_standardized_error_from_status",
     "to_rpc_error_payload",


### PR DESCRIPTION
## Summary
- add backwards compatibility aliases for http/rpc error conversion helpers

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `uv run --directory pkgs/standards/autoapi --package autoapi python - <<'PY'
from autoapi.v3.runtime.errors import _http_exc_to_rpc, _rpc_error_to_http
print(_http_exc_to_rpc, _rpc_error_to_http)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68aef2a0cc148326b50643ce883dd5a5