### PR TITLE
Bind routers to AutoAPI.router

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/model.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/model.py
@@ -68,7 +68,7 @@ def _ensure_model_namespaces(model: type) -> None:
     # rpc: callables to be registered/mounted elsewhere as JSON-RPC methods
     if not hasattr(model, "rpc"):
         model.rpc = SimpleNamespace()
-    # rest: .router (FastAPI/APIRouter or compatible) – built in rest binding
+    # rest: .router (FastAPI Router or compatible) – built in rest binding
     if not hasattr(model, "rest"):
         model.rest = SimpleNamespace(router=None)
     # basic table metadata for convenience (introspective only; NEVER used for HTTP paths)

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
@@ -11,19 +11,12 @@ from typing import Any, Awaitable, Callable, Dict, Mapping, Optional, Sequence, 
 from typing import get_origin as _get_origin, get_args as _get_args
 
 try:
-    from fastapi import (
-        APIRouter,
-        Request,
-        Body,
-        Depends,
-        HTTPException,
-        Query,
-        Response,
-    )
+    from ..types import Router, Request, Body, Depends, HTTPException, Response
+    from fastapi import Query
     from fastapi import status as _status
 except Exception:  # pragma: no cover
     # Minimal shims so the module can be imported without FastAPI
-    class APIRouter:  # type: ignore
+    class Router:  # type: ignore
         def __init__(self, *a, **kw):
             self.routes = []
 
@@ -853,7 +846,7 @@ def _make_member_endpoint(
 # ───────────────────────────────────────────────────────────────────────────────
 
 
-def _build_router(model: type, specs: Sequence[OpSpec]) -> APIRouter:
+def _build_router(model: type, specs: Sequence[OpSpec]) -> Router:
     resource = _resource_name(model)
 
     # Router-level deps: extra deps + auth dep (transport-only; never part of runtime plan)
@@ -864,7 +857,7 @@ def _build_router(model: type, specs: Sequence[OpSpec]) -> APIRouter:
     if auth_dep:
         extra_router_deps += _normalize_deps([auth_dep])
 
-    router = APIRouter(dependencies=extra_router_deps or None)
+    router = Router(dependencies=extra_router_deps or None)
 
     pk_param = "item_id"
     db_dep = (
@@ -967,7 +960,7 @@ def build_router_and_attach(
     model: type, specs: Sequence[OpSpec], *, only_keys: Optional[Sequence[_Key]] = None
 ) -> None:
     """
-    Build an APIRouter for the model and attach it to `model.rest.router`.
+    Build a Router for the model and attach it to `model.rest.router`.
     For simplicity and correctness with FastAPI, we **rebuild the entire router**
     on each call (FastAPI does not support removing individual routes cleanly).
     """

--- a/pkgs/standards/autoapi/autoapi/v3/deps/fastapi.py
+++ b/pkgs/standards/autoapi/autoapi/v3/deps/fastapi.py
@@ -11,12 +11,15 @@ from fastapi import (
     HTTPException,
 )
 
+Router = APIRouter
+
 app = FastAPI
 
 
 # ── Public Exports ───────────────────────────────────────────────────────
 __all__ = [
     "APIRouter",
+    "Router",
     "FastAPI",
     "Security",
     "Depends",

--- a/pkgs/standards/autoapi/autoapi/v3/system/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/system/__init__.py
@@ -2,7 +2,7 @@
 """
 AutoAPI v3 – System/Diagnostics helpers.
 
-- mount_diagnostics(api, *, get_db=None, get_async_db=None) -> APIRouter
+- mount_diagnostics(api, *, get_db=None, get_async_db=None) -> Router
 """
 
 from __future__ import annotations

--- a/pkgs/standards/autoapi/autoapi/v3/system/diagnostics.py
+++ b/pkgs/standards/autoapi/autoapi/v3/system/diagnostics.py
@@ -30,11 +30,11 @@ from typing import (
 )
 
 try:
-    from fastapi import APIRouter, Request, Depends
+    from ...types import Router, Request, Depends
     from fastapi.responses import JSONResponse
 except Exception:  # pragma: no cover
     # Lightweight shims so the module is importable without FastAPI
-    class APIRouter:  # type: ignore
+    class Router:  # type: ignore
         def __init__(self, *a, **kw):
             self.routes = []
 
@@ -270,15 +270,15 @@ def mount_diagnostics(
     *,
     get_db: Optional[Callable[..., Any]] = None,
     get_async_db: Optional[Callable[..., Awaitable[Any]]] = None,
-) -> APIRouter:
+) -> Router:
     """
-    Create & return an APIRouter that exposes:
+    Create & return a Router that exposes:
       GET /healthz
       GET /methodz
       GET /hookz
       GET /planz
     """
-    router = APIRouter()
+    router = Router()
 
     # Prefer async DB getter if provided
     dep = get_async_db or get_db

--- a/pkgs/standards/autoapi/autoapi/v3/transport/jsonrpc/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/transport/jsonrpc/__init__.py
@@ -5,7 +5,7 @@ AutoAPI v3 – JSON-RPC transport.
 Public helper:
   - build_jsonrpc_router(
         api, *, get_db=None, get_async_db=None, tags=("rpc",)
-    ) -> APIRouter
+    ) -> Router
 
 Usage:
     from autoapi.v3.transport.jsonrpc import build_jsonrpc_router

--- a/pkgs/standards/autoapi/autoapi/v3/transport/rest/aggregator.py
+++ b/pkgs/standards/autoapi/autoapi/v3/transport/rest/aggregator.py
@@ -1,6 +1,6 @@
 # autoapi/v3/transport/rest/aggregator.py
 """
-Aggregates per-model REST routers into a single APIRouter.
+Aggregates per-model REST routers into a single Router.
 
 This does not build endpoints by itself — it simply collects the routers that
 `autoapi.v3.bindings.rest` attached to each model at `model.rest.router`.
@@ -26,10 +26,10 @@ from __future__ import annotations
 from typing import Any, Mapping, Optional, Sequence
 
 try:
-    from fastapi import APIRouter, Depends
+    from ...types import Router, Depends
 except Exception:  # pragma: no cover
     # Minimal shim to keep importable without FastAPI
-    class APIRouter:  # type: ignore
+    class Router:  # type: ignore
         def __init__(self, *a, dependencies: Optional[Sequence[Any]] = None, **kw):
             self.routes = []
             self.includes = []
@@ -38,7 +38,7 @@ except Exception:  # pragma: no cover
         def add_api_route(self, path: str, endpoint, methods: Sequence[str], **opts):
             self.routes.append((path, methods, endpoint, opts))
 
-        def include_router(self, router: "APIRouter", *, prefix: str = "", **opts):
+        def include_router(self, router: "Router", *, prefix: str = "", **opts):
             self.includes.append((router, prefix, opts))
 
     def Depends(fn):  # type: ignore
@@ -80,9 +80,9 @@ def build_rest_router(
     models: Optional[Sequence[type]] = None,
     base_prefix: str = "",
     dependencies: Optional[Sequence[Any]] = None,
-) -> APIRouter:
+) -> Router:
     """
-    Build a top-level APIRouter that includes each model's router under `base_prefix`.
+    Build a top-level Router that includes each model's router under `base_prefix`.
 
     Args:
         api: your AutoAPI facade (or any object with `.models` dict).
@@ -91,9 +91,9 @@ def build_rest_router(
         dependencies: additional router-level dependencies (Depends(...) or callables).
 
     Returns:
-        APIRouter ready to be mounted on your FastAPI app.
+        Router ready to be mounted on your FastAPI app.
     """
-    root = APIRouter(dependencies=_normalize_deps(dependencies))
+    root = Router(dependencies=_normalize_deps(dependencies))
     prefix = _norm_prefix(base_prefix)
 
     for model in _iter_models(api, models):
@@ -114,7 +114,7 @@ def mount_rest(
     models: Optional[Sequence[type]] = None,
     base_prefix: str = "",
     dependencies: Optional[Sequence[Any]] = None,
-) -> APIRouter:
+) -> Router:
     """
     Convenience helper: build the aggregated router and include it on `app`.
 

--- a/pkgs/standards/autoapi/autoapi/v3/types/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/types/__init__.py
@@ -50,6 +50,7 @@ from ..deps.pydantic import (
 
 from ..deps.fastapi import (
     APIRouter,
+    Router,
     Security,
     Depends,
     Request,
@@ -145,6 +146,7 @@ __all__: list[str] = [
     "Request",
     "Response",
     "APIRouter",
+    "Router",
     "Security",
     "Depends",
     "Path",


### PR DESCRIPTION
## Summary
- expose an aggregate APIRouter on `AutoAPI` to collect routers
- mount JSON-RPC and diagnostics routers onto the aggregate router and host app
- always bind model routers to `AutoAPI.router` during inclusion
- alias FastAPI's `APIRouter` as `Router` and re-export via `autoapi.v3.types`
- update v3 modules to import `Router` from `autoapi.v3.types`

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68aef077ad30832696e6e8e31dc413cf