### PR TITLE
Fix diagnostics import in AutoAPI

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/system/diagnostics.py
+++ b/pkgs/standards/autoapi/autoapi/v3/system/diagnostics.py
@@ -30,7 +30,7 @@ from typing import (
 )
 
 try:
-    from ...types import Router, Request, Depends
+    from ..types import Router, Request, Depends
     from fastapi.responses import JSONResponse
 except Exception:  # pragma: no cover
     # Lightweight shims so the module is importable without FastAPI


### PR DESCRIPTION
## Summary
- correct relative import in autoapi diagnostics to include Depends

## Testing
- `uv run --package auto_kms --directory standards/auto_kms pytest tests/unit/test_ctx_providers.py`


------
https://chatgpt.com/codex/tasks/task_e_68aef6987b48832687b6b9472c6f2a45