### PR TITLE
Remove deprecated base parameter from AutoAPI tests

### DIFF
--- a/pkgs/standards/autoapi/tests/conftest.py
+++ b/pkgs/standards/autoapi/tests/conftest.py
@@ -73,13 +73,10 @@ def create_test_api(sync_db_session):
     """Factory fixture to create AutoAPI instances for testing individual models."""
     engine, get_sync_db = sync_db_session
 
-    def _create_api(model_class, base=None):
+    def _create_api(model_class):
         """Create AutoAPI instance with a single model for testing."""
-        if base is None:
-            base = Base
-
         # Clear metadata to avoid conflicts
-        base.metadata.clear()
+        Base.metadata.clear()
 
         api = AutoAPI(get_db=get_sync_db)
         api.include_model(model_class)
@@ -94,13 +91,10 @@ async def create_test_api_async(async_db_session):
     """Factory fixture to create async AutoAPI instances for testing individual models."""
     engine, get_async_db = async_db_session
 
-    def _create_api_async(model_class, base=None):
+    def _create_api_async(model_class):
         """Create async AutoAPI instance with a single model for testing."""
-        if base is None:
-            base = Base
-
         # Clear metadata to avoid conflicts
-        base.metadata.clear()
+        Base.metadata.clear()
 
         api = AutoAPI(get_async_db=get_async_db)
         api.include_model(model_class)
@@ -162,7 +156,8 @@ async def api_client(db_mode):
             async with AsyncSessionLocal() as session:
                 yield session
 
-        api = AutoAPI(base=Base, include={Tenant, Item}, get_async_db=get_async_db)
+        api = AutoAPI(get_async_db=get_async_db)
+        api.include_models([Tenant, Item])
         await api.initialize_async()
 
     else:
@@ -178,7 +173,8 @@ async def api_client(db_mode):
             with SessionLocal() as session:
                 yield session
 
-        api = AutoAPI(base=Base, include={Tenant, Item}, get_db=get_sync_db)
+        api = AutoAPI(get_db=get_sync_db)
+        api.include_models([Tenant, Item])
         api.initialize_sync()
 
     fastapi_app = app()

--- a/pkgs/standards/autoapi/tests/i9n/test_allow_anon.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_allow_anon.py
@@ -51,7 +51,8 @@ def _build_client():
         with SessionLocal() as session:
             yield session
 
-    api = AutoAPI(base=Base, include={Tenant, Item}, get_db=get_db, authn=DummyAuth())
+    api = AutoAPI(get_db=get_db, authn=DummyAuth())
+    api.include_models([Tenant, Item])
     app = FastAPI()
     app.include_router(api.router)
     api.initialize_sync()
@@ -83,7 +84,8 @@ def _build_client_attr():
         with SessionLocal() as session:
             yield session
 
-    api = AutoAPI(base=Base, include={Tenant, Item}, get_db=get_db, authn=DummyAuth())
+    api = AutoAPI(get_db=get_db, authn=DummyAuth())
+    api.include_models([Tenant, Item])
     app = FastAPI()
     app.include_router(api.router)
     api.initialize_sync()

--- a/pkgs/standards/autoapi/tests/i9n/test_core_access.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_core_access.py
@@ -30,8 +30,8 @@ def sync_api(sync_db_session):
     """Create sync AutoAPI instance with TestUser model."""
     engine, get_sync_db = sync_db_session
     Base.metadata.clear()
-
-    api = AutoAPI(base=Base, include={CoreTestUser}, get_db=get_sync_db)
+    api = AutoAPI(get_db=get_sync_db)
+    api.include_model(CoreTestUser)
     api.initialize_sync()
     return api, get_sync_db
 
@@ -41,8 +41,8 @@ async def async_api(async_db_session):
     """Create async AutoAPI instance with TestUser model."""
     engine, get_async_db = async_db_session
     Base.metadata.clear()
-
-    api = AutoAPI(base=Base, include={CoreTestUser}, get_async_db=get_async_db)
+    api = AutoAPI(get_async_db=get_async_db)
+    api.include_model(CoreTestUser)
     await api.initialize_async()
     return api, get_async_db
 
@@ -494,7 +494,8 @@ class TestCoreRawEdgeCases:
         Base.metadata.clear()
 
         # Create API with only async_db, no sync get_db
-        api = AutoAPI(base=Base, include={CoreTestUser}, get_async_db=get_async_db)
+        api = AutoAPI(get_async_db=get_async_db)
+        api.include_model(CoreTestUser)
         await api.initialize_async()
 
         user_data = {"name": "No GetDB", "email": "nogetdb@example.com"}

--- a/pkgs/standards/autoapi/tests/i9n/test_nested_routing_depth.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_nested_routing_depth.py
@@ -36,17 +36,13 @@ async def three_level_api_client(db_mode, sync_db_session, async_db_session):
 
     if db_mode == "async":
         _, get_async_db = async_db_session
-        api = AutoAPI(
-            base=Base,
-            include={Company, Department, Employee},
-            get_async_db=get_async_db,
-        )
+        api = AutoAPI(get_async_db=get_async_db)
+        api.include_models([Company, Department, Employee])
         await api.initialize_async()
     else:
         _, get_sync_db = sync_db_session
-        api = AutoAPI(
-            base=Base, include={Company, Department, Employee}, get_db=get_sync_db
-        )
+        api = AutoAPI(get_db=get_sync_db)
+        api.include_models([Company, Department, Employee])
         api.initialize_sync()
 
     app = FastAPI()

--- a/pkgs/standards/autoapi/tests/i9n/test_owner_tenant_policy.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_owner_tenant_policy.py
@@ -71,7 +71,8 @@ def _client_for_owner(
             yield session
 
     authn = DummyAuth(user_id, tenant_id)
-    api = AutoAPI(base=Base, include={User, Item}, get_db=get_db, authn=authn)
+    api = AutoAPI(get_db=get_db, authn=authn)
+    api.include_models([User, Item])
     authn.register_inject_hook(api)
     app = FastAPI()
     app.include_router(api.router)
@@ -131,7 +132,8 @@ def _client_for_tenant(
             yield session
 
     authn = DummyAuth(user_id, tenant_id)
-    api = AutoAPI(base=Base, include={Tenant, Item}, get_db=get_db, authn=authn)
+    api = AutoAPI(get_db=get_db, authn=authn)
+    api.include_models([Tenant, Item])
     authn.register_inject_hook(api)
     app = FastAPI()
     app.include_router(api.router)

--- a/pkgs/standards/autoapi/tests/i9n/test_request_extras.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_request_extras.py
@@ -36,7 +36,8 @@ async def api_client_with_extras(db_mode):
             async with AsyncSessionLocal() as session:
                 yield session
 
-        api = AutoAPI(base=Base, include={Widget}, get_async_db=get_async_db)
+        api = AutoAPI(get_async_db=get_async_db)
+        api.include_model(Widget)
         await api.initialize_async()
     else:
         engine = create_engine(
@@ -50,7 +51,8 @@ async def api_client_with_extras(db_mode):
             with SessionLocal() as session:
                 yield session
 
-        api = AutoAPI(base=Base, include={Widget}, get_db=get_sync_db)
+        api = AutoAPI(get_db=get_sync_db)
+        api.include_model(Widget)
         api.initialize_sync()
 
     app = FastAPI()

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -33,7 +33,6 @@ from peagen.errors import MigrationFailureError, NoWorkerAvailableError
 
 # peagen/gateway/__init__.py
 from peagen.orm import (
-    Base,
     DeployKey,
     PublicKey,
     GPGKey,
@@ -82,9 +81,9 @@ authn_adapter = RemoteAuthNAdapter(
     cache_size=settings.authn_cache_size,
 )
 
-api = AutoAPI(
-    base=Base,
-    include={
+api = AutoAPI(get_async_db=get_async_db)
+api.include_models(
+    [
         Tenant,
         User,
         Org,
@@ -102,10 +101,9 @@ api = AutoAPI(
         Task,
         Work,
         RawBlob,
-    },
-    get_async_db=get_async_db,
-    authn=authn_adapter,
+    ]
 )
+api.set_auth(authn=authn_adapter)
 
 
 @api.register_hook(Phase.PRE_TX_BEGIN)


### PR DESCRIPTION
## Summary
- update AutoAPI test fixtures and integration tests to drop the obsolete `base` argument
- register models via `include_model`/`include_models` and rely on metadata-driven table creation
- update peagen gateway to construct AutoAPI without `base`, registering models with `include_models` and configuring auth via `set_auth`

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68aef7bea6148326a052ece39ca264e6