### PR TITLE
Propagate storage defaults in ColumnSpec

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/specs/column_spec.py
+++ b/pkgs/standards/autoapi/autoapi/v3/specs/column_spec.py
@@ -32,6 +32,8 @@ class ColumnSpec(MappedColumn):
                 nullable=s.nullable,
                 unique=s.unique,
                 index=s.index,
+                default=s.default,
+                autoincrement=s.autoincrement,
                 server_default=s.server_default,
                 onupdate=s.onupdate,
                 comment=s.comment,


### PR DESCRIPTION
## Summary
- ensure ColumnSpec forwards default and autoincrement so GUID primary keys generate

## Testing
- `uv run --package autoapi --directory standards pytest autoapi/tests/i9n/test_field_spec_effects.py`


------
https://chatgpt.com/codex/tasks/task_e_68af0d371cdc8326afc9df7db5b071f1