### PR TITLE
fix: update healthz methodz hookz tests

### DIFF
--- a/pkgs/standards/autoapi/tests/conftest.py
+++ b/pkgs/standards/autoapi/tests/conftest.py
@@ -178,6 +178,7 @@ async def api_client(db_mode):
         api.initialize_sync()
 
     fastapi_app = app()
+    api.attach_diagnostics(prefix="")
     fastapi_app.include_router(api.router)
     transport = ASGITransport(app=fastapi_app)
 


### PR DESCRIPTION
## Summary
- ensure diagnostic endpoints are attached in api_client fixture
- adapt tests to new methodz response format and hook registration

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format tests/i9n/test_healthz_methodz_hookz.py tests/conftest.py`
- `uv run --package autoapi --directory standards/autoapi ruff check tests/i9n/test_healthz_methodz_hookz.py tests/conftest.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_healthz_methodz_hookz.py`


------
https://chatgpt.com/codex/tasks/task_e_68af0d3b545c832685f29784ea20ebad