### PR TITLE
fix autoapi hook ctx test with explicit ids

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/core/crud.py
+++ b/pkgs/standards/autoapi/autoapi/v3/core/crud.py
@@ -114,6 +114,7 @@ def _filter_in_values(
     for k, v in data.items():
         sp = specs.get(k)
         if sp is None:
+            out[k] = v
             continue
         io = getattr(sp, "io", None)
         allowed = True

--- a/pkgs/standards/autoapi/tests/i9n/test_hook_ctx_v3_i9n.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_hook_ctx_v3_i9n.py
@@ -4,6 +4,7 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy import Column, String, create_engine, func, select
 from sqlalchemy.pool import StaticPool
 from sqlalchemy.orm import sessionmaker
+from uuid import uuid4
 
 from autoapi.v3.autoapi import AutoAPI
 from autoapi.v3.tables import Base
@@ -82,7 +83,7 @@ async def test_hook_ctx_request_response_schema_i9n():
             ctx["response"].result["hook"] = True
 
     client, _, _ = create_client(Item)
-    res = await client.post("/item", json={"name": "a"})
+    res = await client.post("/item", json={"id": str(uuid4()), "name": "a"})
     assert res.status_code == 201
     assert res.json()["hook"] is True
     await client.aclose()
@@ -111,7 +112,7 @@ async def test_hook_ctx_columns_i9n():
             ctx["response"].result["cols"] = ctx["cols"]
 
     client, _, _ = create_client(Item)
-    res = await client.post("/item", json={"name": "x"})
+    res = await client.post("/item", json={"id": str(uuid4()), "name": "x"})
     assert set(res.json()["cols"]) == {"id", "name"}
     await client.aclose()
 
@@ -136,7 +137,7 @@ async def test_hook_ctx_defaults_resolution_i9n():
             ctx["payload"].setdefault("name", "default")
 
     client, _, _ = create_client(Item)
-    res = await client.post("/item", json={})
+    res = await client.post("/item", json={"id": str(uuid4())})
     assert res.status_code == 201
     assert res.json()["name"] == "default"
     await client.aclose()
@@ -165,7 +166,7 @@ async def test_hook_ctx_internal_model_i9n():
             ctx["response"].result["model"] = ctx["model_name"]
 
     client, _, _ = create_client(Item)
-    res = await client.post("/item", json={"name": "a"})
+    res = await client.post("/item", json={"id": str(uuid4()), "name": "a"})
     assert res.json()["model"] == "Item"
     await client.aclose()
 
@@ -218,7 +219,7 @@ async def test_hook_ctx_storage_sqlalchemy_i9n():
             ctx["response"].result["count"] = ctx["count"]
 
     client, _, _ = create_client(Item)
-    res = await client.post("/item", json={"name": "a"})
+    res = await client.post("/item", json={"id": str(uuid4()), "name": "a"})
     assert res.json()["count"] == 1
     await client.aclose()
 
@@ -242,7 +243,7 @@ async def test_hook_ctx_rest_call_i9n():
             ctx["response"].result["phase"] = "rest"
 
     client, _, _ = create_client(Item)
-    res = await client.post("/item", json={"name": "a"})
+    res = await client.post("/item", json={"id": str(uuid4()), "name": "a"})
     assert res.json()["phase"] == "rest"
     await client.aclose()
 
@@ -267,7 +268,8 @@ async def test_hook_ctx_rpc_method_i9n():
 
     client, _, _ = create_client(Item)
     res = await client.post(
-        "/rpc", json={"method": "Item.create", "params": {"name": "a"}}
+        "/rpc",
+        json={"method": "Item.create", "params": {"id": str(uuid4()), "name": "a"}},
     )
     assert res.json()["result"]["phase"] == "rpc"
     await client.aclose()
@@ -293,7 +295,9 @@ async def test_hook_ctx_core_crud_i9n():
 
     client, api, SessionLocal = create_client(Item)
     with SessionLocal() as session:
-        result = await api.core.Item.create({"name": "x"}, db=session)
+        result = await api.core.Item.create(
+            {"id": str(uuid4()), "name": "x"}, db=session
+        )
     assert result["via"] == "core"
     await client.aclose()
 
@@ -347,7 +351,7 @@ async def test_hook_ctx_atomz_i9n():
             ctx["response"].result["captured"] = ctx["captured"]
 
     client, _, _ = create_client(Item)
-    res = await client.post("/item", json={"name": "alpha"})
+    res = await client.post("/item", json={"id": str(uuid4()), "name": "alpha"})
     assert res.json()["captured"] == "alpha"
     await client.aclose()
 


### PR DESCRIPTION
## Summary
- ensure CRUD filtering retains unspecified columns
- include explicit `id` values in AutoAPI hook context tests

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_hook_ctx_v3_i9n.py`

------
https://chatgpt.com/codex/tasks/task_e_68af0d414f4c8326af7a0b38311c3efe