### PR TITLE
fix opspec default id assignment

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/specs/column_spec.py
+++ b/pkgs/standards/autoapi/autoapi/v3/specs/column_spec.py
@@ -32,6 +32,8 @@ class ColumnSpec(MappedColumn):
                 nullable=s.nullable,
                 unique=s.unique,
                 index=s.index,
+                default=s.default,
+                autoincrement=s.autoincrement,
                 server_default=s.server_default,
                 onupdate=s.onupdate,
                 comment=s.comment,


### PR DESCRIPTION
## Summary
- propagate default and autoincrement settings from StorageSpec to SQLAlchemy column

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_opspec_effects_i9n_test.py`


------
https://chatgpt.com/codex/tasks/task_e_68af0d85f9dc8326a63551a1407d9a4b