### PR TITLE
Fix AutoAPI info schema key tests

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/schema/col_info.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/col_info.py
@@ -8,7 +8,7 @@ This module centralizes:
   • Small helpers to decide input/output exposure per verb
 
 It does **not** import SQLAlchemy – callers pass plain dicts extracted from
-`Column.info` (or hybrid_property `.info`) so this remains framework-agnostic.
+`Column.info` so this remains framework-agnostic.
 
 Typical usage in the schema builder:
     meta_src = getattr(col, "info", {}) or {}
@@ -54,8 +54,7 @@ VALID_KEYS: frozenset[str] = frozenset(
         "read_only",  # (bool | Iterable[str] | Mapping[str,bool])
         "default_factory",  # (callable) → Field(default_factory=…)
         "examples",  # (Any)    → Field(..., examples=…)
-        "hybrid",  # (bool)   opt-in for @hybrid_property
-        "py_type",  # (type)   explicit Python type for hybrids/unknowns
+        "py_type",  # (type)   explicit Python type for unknowns
     }
 )
 
@@ -172,7 +171,6 @@ def normalize(
       - read_only  → bool | frozenset[str] | dict[str,bool]
       - write_only → bool
       - default_factory → callable | None
-      - hybrid → bool
       - py_type → type | None
       - examples → as-is
       - no_create/no_update → bool (legacy)
@@ -220,11 +218,6 @@ def normalize(
     out["default_factory"] = df
 
     out["examples"] = meta.get("examples", None)
-
-    hy = meta.get("hybrid", False)
-    if not isinstance(hy, bool):
-        raise _err_ctx(model, attr, f"hybrid must be bool, got {type(hy)!r}")
-    out["hybrid"] = hy
 
     py_t = meta.get("py_type", None)
     if py_t is not None and not isinstance(py_t, type):


### PR DESCRIPTION
## Summary
- ensure schema builder raises on `hybrid` properties
- drop `hybrid` key from column metadata validation
- update info schema tests to cover remaining keys and error behavior

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_info_schema_keys.py`


------
https://chatgpt.com/codex/tasks/task_e_68af0d4a2c4083268f97f3eb10f7b452