### PR TITLE
Expose optional tenant name filter in AutoAPI tests

### DIFF
--- a/pkgs/standards/autoapi/tests/conftest.py
+++ b/pkgs/standards/autoapi/tests/conftest.py
@@ -134,7 +134,16 @@ async def api_client(db_mode):
 
     class Tenant(Base, GUIDPk):
         __tablename__ = "tenants"
-        name = Column(String, nullable=False)
+        name = acol(
+            storage=S(type_=String, nullable=False),
+            field=F(py_type=str),
+            io=IO(
+                in_verbs=("create", "update", "replace"),
+                out_verbs=("read", "list"),
+                mutable_verbs=("create", "update", "replace"),
+                filter_ops=("eq",),
+            ),
+        )
 
     class Item(Base, GUIDPk, BulkCapable):
         __tablename__ = "items"


### PR DESCRIPTION
## Summary
- define ColumnSpec for `Tenant.name` in AutoAPI integration fixtures so list filters appear in OpenAPI
- verify `/tenant` filter remains optional

## Testing
- `uv run --package autoapi --directory standards pytest autoapi/tests/i9n/test_list_filters_optional.py`


------
https://chatgpt.com/codex/tasks/task_e_68af0d6126048326bd44e44f6c19541c