### PR TITLE
autoapi: expose default equality list filters

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/schema/builder.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/builder.py
@@ -538,6 +538,9 @@ def _build_list_params(model: type) -> Type[BaseModel]:
             spec = spec_map.get(c.name) if isinstance(spec_map, Mapping) else None
             io = getattr(spec, "io", None)
             ops_raw = set(getattr(io, "filter_ops", ()) or [])
+            if not ops_raw:
+                # Allow basic equality filtering by default on scalar columns
+                ops_raw = {"eq"}
             ops = {_canon.get(op, op) for op in ops_raw}
             if "eq" in ops:
                 cols[c.name] = (py_t | None, Field(None))


### PR DESCRIPTION
## Summary
- expose scalar columns as optional list filters when no filter ops are defined

## Testing
- `uv run --package autoapi --directory standards pytest autoapi/tests/i9n/test_list_filters_optional.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68af13a5daa08326aa455db86a29548d