### PR TITLE
Use autoapi types in mixins test

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_mixins.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_mixins.py
@@ -6,7 +6,7 @@ Tests all mixins and their expected behavior using individual DummyModel instanc
 
 import pytest
 from datetime import datetime, timedelta
-from sqlalchemy import Column, String
+from autoapi.v3.types import Column, String
 
 from autoapi.v3 import Base
 from autoapi.v3.mixins import (


### PR DESCRIPTION
## Summary
- use `Column` and `String` exports from `autoapi.v3.types` in mixins integration test

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_mixins.py`


------
https://chatgpt.com/codex/tasks/task_e_68af1716fdec8326b070fab4b055dfdd