### PR TITLE
Align AutoAPI diagnostics tests with v3 responses

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/__init__.py
@@ -70,13 +70,15 @@ from .system.dbschema import ensure_schemas, register_sqlite_attach, bootstrap_d
 # ── Config constants (defaults used by REST) ───────────────────────────────────
 from .config.constants import DEFAULT_HTTP_METHODS
 from .autoapi import AutoAPI
-from .deps import app
-
+from .deps import App
 from .tables import Base
+
+# Backwards compatibility: lowercase alias
+app = App
 
 __all__: list[str] = []
 
-__all__ += ["AutoAPI", "Base", "app"]
+__all__ += ["AutoAPI", "Base", "App", "app"]
 
 __all__ += [
     # OpSpec core

--- a/pkgs/standards/autoapi/tests/conftest.py
+++ b/pkgs/standards/autoapi/tests/conftest.py
@@ -2,7 +2,9 @@ from typing import AsyncIterator, Iterator
 
 import pytest
 import pytest_asyncio
-from autoapi.v3 import AutoAPI, Base, app
+from autoapi.v3.autoapi import AutoAPI
+from autoapi.v3.tables import Base
+from autoapi.v3.deps import App
 from autoapi.v3.mixins import BulkCapable, GUIDPk
 from autoapi.v3.specs import F, IO, S, acol
 from autoapi.v3.specs.storage_spec import StorageTransform
@@ -154,7 +156,7 @@ async def api_client(db_mode):
         def __autoapi_nested_paths__(cls):
             return "/tenant/{tenant_id}"
 
-    fastapi_app = app()
+    fastapi_app = App()
 
     if db_mode == "async":
         engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=True)
@@ -189,6 +191,7 @@ async def api_client(db_mode):
         api.initialize_sync()
 
     api.mount_jsonrpc()
+    api.attach_diagnostics(prefix="")
     fastapi_app.include_router(api.router)
     transport = ASGITransport(app=fastapi_app)
 
@@ -266,7 +269,7 @@ async def api_client_v3():
         async with AsyncSessionLocal() as session:
             yield session
 
-    fastapi_app = app()
+    fastapi_app = App()
     api = AutoAPI(app=fastapi_app, get_async_db=get_async_db)
     api.include_model(Widget, prefix="")
     api.mount_jsonrpc()


### PR DESCRIPTION
## Summary
- export FastAPI `App` alias in `autoapi.v3` and keep lowercase `app` for compatibility
- update integration tests to use `App` and new methodz/hookz response formats
- attach diagnostics router in test fixture

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_healthz_methodz_hookz.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af187841008326960be8e5245a1ec5