### PR TITLE
Fix acronym route test and standardize FastAPI export

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/__init__.py
@@ -70,13 +70,13 @@ from .system.dbschema import ensure_schemas, register_sqlite_attach, bootstrap_d
 # ── Config constants (defaults used by REST) ───────────────────────────────────
 from .config.constants import DEFAULT_HTTP_METHODS
 from .autoapi import AutoAPI
-from .deps import app
+from .deps import App
 
 from .tables import Base
 
 __all__: list[str] = []
 
-__all__ += ["AutoAPI", "Base", "app"]
+__all__ += ["AutoAPI", "Base", "App"]
 
 __all__ += [
     # OpSpec core

--- a/pkgs/standards/autoapi/tests/conftest.py
+++ b/pkgs/standards/autoapi/tests/conftest.py
@@ -2,7 +2,7 @@ from typing import AsyncIterator, Iterator
 
 import pytest
 import pytest_asyncio
-from autoapi.v3 import AutoAPI, Base, app
+from autoapi.v3 import AutoAPI, Base, App
 from autoapi.v3.mixins import BulkCapable, GUIDPk
 from autoapi.v3.specs import F, IO, S, acol
 from autoapi.v3.specs.storage_spec import StorageTransform
@@ -154,7 +154,7 @@ async def api_client(db_mode):
         def __autoapi_nested_paths__(cls):
             return "/tenant/{tenant_id}"
 
-    fastapi_app = app()
+    fastapi_app = App()
 
     if db_mode == "async":
         engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=True)
@@ -266,7 +266,7 @@ async def api_client_v3():
         async with AsyncSessionLocal() as session:
             yield session
 
-    fastapi_app = app()
+    fastapi_app = App()
     api = AutoAPI(app=fastapi_app, get_async_db=get_async_db)
     api.include_model(Widget, prefix="")
     api.mount_jsonrpc()

--- a/pkgs/standards/autoapi/tests/i9n/test_acronym_route_name.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_acronym_route_name.py
@@ -1,8 +1,7 @@
 import pytest
-from sqlalchemy import Column, String
-
 from autoapi.v3 import Base
 from autoapi.v3.mixins import GUIDPk
+from autoapi.v3.types import Column, String
 
 
 @pytest.mark.i9n

--- a/pkgs/standards/autoapi/tests/unit/test_app_reexport.py
+++ b/pkgs/standards/autoapi/tests/unit/test_app_reexport.py
@@ -1,6 +1,6 @@
-from autoapi.v3 import app
+from autoapi.v3 import App
 from fastapi import FastAPI
 
 
 def test_app_reexport():
-    assert app is FastAPI
+    assert App is FastAPI


### PR DESCRIPTION
## Summary
- expose FastAPI as `App` and drop lowercase `app` export
- update imports and tests to use `App`
- ensure acronym route name test uses type exports

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_acronym_route_name.py tests/unit/test_app_reexport.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af197d55508326ac1c30a93caa0e6d