### PR TITLE
fix allow anon test to use v3 types exports

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/deps/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/deps/__init__.py
@@ -14,6 +14,7 @@ from .pydantic import *  # noqa: F403, F401
 
 # Re-export all FastAPI dependencies
 from .fastapi import *  # noqa: F403, F401
+from .fastapi import App as app  # noqa: F401
 
 # Note: starlette.py is reserved for future Starlette-specific imports
 # if we need to import directly from Starlette rather than through FastAPI


### PR DESCRIPTION
## Summary
- update allow anon integration test to import from `autoapi.v3.types`
- expose `app` alias from `autoapi.v3.deps` for backward compatibility

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_allow_anon.py --confcutdir=tests/i9n`


------
https://chatgpt.com/codex/tasks/task_e_68af19870b8483269b15878dde82cf51