### PR TITLE
test: use autoapi type exports

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_hook_ctx_v3_i9n.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_hook_ctx_v3_i9n.py
@@ -1,12 +1,13 @@
 import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
-from sqlalchemy import Column, String, create_engine, func, select
+from sqlalchemy import create_engine, func, select
 from sqlalchemy.pool import StaticPool
 from sqlalchemy.orm import sessionmaker
 from uuid import uuid4
 
 from autoapi.v3.autoapi import AutoAPI
+from autoapi.v3.types import Column, String
 from autoapi.v3.tables import Base
 from autoapi.v3.mixins import GUIDPk
 from autoapi.v3.decorators import hook_ctx


### PR DESCRIPTION
## Summary
- ensure AutoAPI integration test imports Column and String from `autoapi.v3.types`

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_hook_ctx_v3_i9n.py --confcutdir=tests/i9n` *(fails: ImportError: cannot import name 'app' from 'autoapi.v3.deps')*

------
https://chatgpt.com/codex/tasks/task_e_68af19cedc6483268425560a6be2a997