### PR TITLE
Use type exports for transactional tests

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/__init__.py
@@ -70,13 +70,13 @@ from .system.dbschema import ensure_schemas, register_sqlite_attach, bootstrap_d
 # ── Config constants (defaults used by REST) ───────────────────────────────────
 from .config.constants import DEFAULT_HTTP_METHODS
 from .autoapi import AutoAPI
-from .deps import app
+from .types import App
 
 from .tables import Base
 
 __all__: list[str] = []
 
-__all__ += ["AutoAPI", "Base", "app"]
+__all__ += ["AutoAPI", "Base", "App"]
 
 __all__ += [
     # OpSpec core

--- a/pkgs/standards/autoapi/autoapi/v3/compat/transactional.py
+++ b/pkgs/standards/autoapi/autoapi/v3/compat/transactional.py
@@ -117,7 +117,7 @@ def transactional(  # noqa: D401 (compat docstring in v2)
 
         # Register on the model's registry and (re)bind the model
         reg = get_registry(model)
-        reg.set(alias, sp)  # idempotent replace per-alias
+        reg.add(sp)  # idempotent add/replace per spec
         bind_model(model)  # builds schemas/hooks/handlers/rpc/rest
 
         # Ensure router is mounted under the API (prefix '' so our absolute path_suffix is used verbatim)

--- a/pkgs/standards/autoapi/tests/conftest.py
+++ b/pkgs/standards/autoapi/tests/conftest.py
@@ -2,7 +2,8 @@ from typing import AsyncIterator, Iterator
 
 import pytest
 import pytest_asyncio
-from autoapi.v3 import AutoAPI, Base, app
+from autoapi.v3 import AutoAPI, Base
+from autoapi.v3.types import App
 from autoapi.v3.mixins import BulkCapable, GUIDPk
 from autoapi.v3.specs import F, IO, S, acol
 from autoapi.v3.specs.storage_spec import StorageTransform
@@ -154,7 +155,7 @@ async def api_client(db_mode):
         def __autoapi_nested_paths__(cls):
             return "/tenant/{tenant_id}"
 
-    fastapi_app = app()
+    fastapi_app = App()
 
     if db_mode == "async":
         engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=True)
@@ -266,7 +267,7 @@ async def api_client_v3():
         async with AsyncSessionLocal() as session:
             yield session
 
-    fastapi_app = app()
+    fastapi_app = App()
     api = AutoAPI(app=fastapi_app, get_async_db=get_async_db)
     api.include_model(Widget, prefix="")
     api.mount_jsonrpc()

--- a/pkgs/standards/autoapi/tests/i9n/test_transactional.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_transactional.py
@@ -1,5 +1,6 @@
+import inspect
 import pytest
-import uuid
+from autoapi.v3.types import UUID
 from autoapi.v3.compat.transactional import transactional
 
 
@@ -8,18 +9,17 @@ from autoapi.v3.compat.transactional import transactional
 async def test_transaction_decorator(api_client):
     client, api, Item = api_client
 
-    def fail(params, db):
-        obj = Item(tenant_id=uuid.UUID(params["tenant_id"]), name=params["name"])
+    async def fail(payload, db):
+        obj = Item(tenant_id=UUID(payload["tenant_id"]), name=payload["name"])
         db.add(obj)
-        db.flush()
-        if params.get("fail"):
+        flush_result = db.flush()
+        if inspect.isawaitable(flush_result):
+            await flush_result
+        if payload.get("fail"):
             raise ValueError("boom")
         return {"id": obj.id}
 
     fail = transactional(api, fail)
-
-    api.rpc["Item.fail"] = fail
-    api._method_ids["Item.fail"] = None
 
     t = await client.post("/tenant", json={"name": "tx"})
     tid = t.json()["id"]
@@ -27,7 +27,7 @@ async def test_transaction_decorator(api_client):
     bad = await client.post(
         "/rpc",
         json={
-            "method": "Item.fail",
+            "method": "Txn.fail",
             "params": {"tenant_id": tid, "name": "a", "fail": True},
         },
     )
@@ -38,7 +38,7 @@ async def test_transaction_decorator(api_client):
 
     ok = await client.post(
         "/rpc",
-        json={"method": "Item.fail", "params": {"tenant_id": tid, "name": "b"}},
+        json={"method": "Txn.fail", "params": {"tenant_id": tid, "name": "b"}},
     )
     assert ok.json()["result"]["id"]
     lst2 = await client.get("/item")


### PR DESCRIPTION
## Summary
- re-export App from autoapi.v3.types
- fix transactional decorator registration
- update transactional test to use UUID type export and async-safe flush

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_transactional.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68af1a58c9588326b0ca825ad5386f7a