### PR TITLE
refactor: use autoapi types in bindings test

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/deps/sqlalchemy.py
+++ b/pkgs/standards/autoapi/autoapi/v3/deps/sqlalchemy.py
@@ -37,6 +37,7 @@ from sqlalchemy.orm import (
     remote,
     column_property,
     Session,
+    InstrumentedAttribute,
 )
 
 # ── SQLAlchemy Extensions ────────────────────────────────────────────────
@@ -90,6 +91,7 @@ __all__ = [
     "remote",
     "column_property",
     "Session",
+    "InstrumentedAttribute",
     # Extensions
     "MutableDict",
     "MutableList",

--- a/pkgs/standards/autoapi/autoapi/v3/types/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/types/__init__.py
@@ -37,6 +37,7 @@ from ..deps.sqlalchemy import (
     remote,
     column_property,
     Session,
+    InstrumentedAttribute,
     # Extensions
     MutableDict,
     MutableList,
@@ -138,6 +139,7 @@ __all__: list[str] = [
     "relationship",
     "remote",
     "Session",
+    "InstrumentedAttribute",
     # sqlalchemy.ext.mutable (from deps.sqlalchemy)
     "MutableDict",
     "MutableList",

--- a/pkgs/standards/autoapi/tests/i9n/test_bindings_modules.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_bindings_modules.py
@@ -1,10 +1,13 @@
 import inspect
-from types import SimpleNamespace
 
 import pytest
-from sqlalchemy import Integer, String
-from sqlalchemy.orm.attributes import InstrumentedAttribute
 from autoapi.v3.tables import Base
+from autoapi.v3.types import (
+    InstrumentedAttribute,
+    Integer,
+    SimpleNamespace,
+    String,
+)
 
 from autoapi.v3.bindings import (
     api as api_binding,


### PR DESCRIPTION
## Summary
- use `autoapi.v3.types` exports in `test_bindings_modules`
- re-export `InstrumentedAttribute` through `autoapi.v3.types`

## Testing
- `uv run --package autoapi --directory standards ruff format autoapi/autoapi/v3/deps/sqlalchemy.py autoapi/autoapi/v3/types/__init__.py autoapi/tests/i9n/test_bindings_modules.py`
- `uv run --package autoapi --directory standards ruff check autoapi/autoapi/v3/deps/sqlalchemy.py autoapi/autoapi/v3/types/__init__.py autoapi/tests/i9n/test_bindings_modules.py --fix`
- `uv run --package autoapi --directory standards pytest autoapi/tests/i9n/test_bindings_modules.py`


------
https://chatgpt.com/codex/tasks/task_e_68af1ff299908326af8c58685ccafcf7