### PR TITLE
Align column metadata runtime test with v3 types exports

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/__init__.py
@@ -70,7 +70,7 @@ from .system.dbschema import ensure_schemas, register_sqlite_attach, bootstrap_d
 # ── Config constants (defaults used by REST) ───────────────────────────────────
 from .config.constants import DEFAULT_HTTP_METHODS
 from .autoapi import AutoAPI
-from .deps import App
+from .deps import App, FastAPI
 from .tables import Base
 
 


### PR DESCRIPTION
## Summary
- Import FastAPI via deps to avoid undefined name in AutoAPI v3
- Use autoapi.v3.types exports in column metadata runtime tests
- Expect default-factory fields to refresh on update and validate behavior

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_column_metadata_runtime.py -q --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_68af2000eff88326bb0bb9dccac95c0c