### PR TITLE
Use PHASES export from autoapi.v3.types

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/__init__.py
@@ -72,6 +72,7 @@ from .config.constants import DEFAULT_HTTP_METHODS
 from .autoapi import AutoAPI
 from .deps import App
 from .tables import Base
+from fastapi import FastAPI
 
 
 def app() -> FastAPI:  # pragma: no cover - thin wrapper

--- a/pkgs/standards/autoapi/autoapi/v3/types/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/types/__init__.py
@@ -81,6 +81,8 @@ from .response_extras_provider import (
 from .op_verb_alias_provider import OpVerbAliasProvider, list_verb_alias_providers
 from .op_config_provider import OpConfigProvider
 
+from ..opspec.types import PHASES
+
 
 # ── Public Re-exports (Backwards Compatibility) ──────────────────────────
 __all__: list[str] = [
@@ -156,4 +158,5 @@ __all__: list[str] = [
     "Path",
     "Body",
     "HTTPException",
+    "PHASES",
 ]

--- a/pkgs/standards/autoapi/tests/i9n/test_v3_opspec_attributes.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_v3_opspec_attributes.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import sessionmaker
 
 from autoapi.v3.bindings.model import bind
 from autoapi.v3.decorators import hook_ctx
-from autoapi.v3.opspec.types import PHASES
+from autoapi.v3.types import PHASES
 from autoapi.v3.runtime import system as runtime_system
 from autoapi.v3.runtime.executor import _Ctx
 from autoapi.v3.runtime.kernel import build_phase_chains


### PR DESCRIPTION
## Summary
- import PHASES from `autoapi.v3.types` in v3 opspec attribute tests
- re-export `PHASES` from `autoapi.v3.types` and fix missing `FastAPI` import

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format autoapi/v3/types/__init__.py tests/i9n/test_v3_opspec_attributes.py autoapi/v3/__init__.py`
- `uv run --directory standards/autoapi --package autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_v3_opspec_attributes.py`


------
https://chatgpt.com/codex/tasks/task_e_68af228136408326b6fe151a53af3fee