### PR TITLE
refactor: use autoapi type exports in rest ops test

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_v3_default_rest_ops.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_v3_default_rest_ops.py
@@ -2,9 +2,9 @@ import pytest
 import pytest_asyncio
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
-from sqlalchemy import Integer, String
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-from sqlalchemy.orm import Mapped
+
+from autoapi.v3.types import Integer, Mapped, String
 
 from autoapi.v3.autoapi import AutoAPI as AutoAPIv3
 from autoapi.v3.specs import F, IO, S, acol


### PR DESCRIPTION
## Summary
- import Integer, String, and Mapped from `autoapi.v3.types` in default REST ops test

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format tests/i9n/test_v3_default_rest_ops.py`
- `uv run --package autoapi --directory standards/autoapi ruff check tests/i9n/test_v3_default_rest_ops.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_v3_default_rest_ops.py`

------
https://chatgpt.com/codex/tasks/task_e_68af228b2ea88326856c59dd4e5dc359