### PR TITLE
Use autoapi.v3.types in storage spec integration test

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_storage_spec_integration.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_storage_spec_integration.py
@@ -1,6 +1,6 @@
 import pytest
 from autoapi.v3.core import crud
-from sqlalchemy import String
+from autoapi.v3.types import String
 
 
 @pytest.mark.i9n


### PR DESCRIPTION
## Summary
- fix storage spec integration test to import SQLAlchemy String via autoapi.v3.types exports

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix` *(fails: F821 Undefined name `FastAPI`)*
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check tests/i9n/test_storage_spec_integration.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_storage_spec_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_68af22ecb8948326b2c17d9743a9852c