### PR TITLE
test: use autoapi types exports in schema ctx attributes test

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_schema_ctx_attributes_integration.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_schema_ctx_attributes_integration.py
@@ -1,9 +1,8 @@
 import pytest
 import pytest_asyncio
-from pydantic import BaseModel
+from autoapi.v3.types import BaseModel, Column, Integer, String
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
-from sqlalchemy import Column, Integer, String
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from autoapi.v3 import AutoAPI, Base, schema_ctx


### PR DESCRIPTION
## Summary
- use re-exported BaseModel and SQLAlchemy types from autoapi.v3.types in schema ctx attributes integration test

## Testing
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff format .`
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff check tests/i9n/test_schema_ctx_attributes_integration.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_schema_ctx_attributes_integration.py`

------
https://chatgpt.com/codex/tasks/task_e_68af23058384832687556ab113200735