### PR TITLE
use App alias from autoapi.v3.types in schema ctx tests

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/__init__.py
@@ -70,13 +70,11 @@ from .system.dbschema import ensure_schemas, register_sqlite_attach, bootstrap_d
 # ── Config constants (defaults used by REST) ───────────────────────────────────
 from .config.constants import DEFAULT_HTTP_METHODS
 from .autoapi import AutoAPI
-from .deps import app
-
 from .tables import Base
 
 __all__: list[str] = []
 
-__all__ += ["AutoAPI", "Base", "app"]
+__all__ += ["AutoAPI", "Base"]
 
 __all__ += [
     # OpSpec core

--- a/pkgs/standards/autoapi/tests/conftest.py
+++ b/pkgs/standards/autoapi/tests/conftest.py
@@ -2,7 +2,8 @@ from typing import AsyncIterator, Iterator
 
 import pytest
 import pytest_asyncio
-from autoapi.v3 import AutoAPI, Base, app
+from autoapi.v3 import AutoAPI, Base
+from autoapi.v3.types import App
 from autoapi.v3.mixins import BulkCapable, GUIDPk
 from autoapi.v3.specs import F, IO, S, acol
 from autoapi.v3.specs.storage_spec import StorageTransform
@@ -154,7 +155,7 @@ async def api_client(db_mode):
         def __autoapi_nested_paths__(cls):
             return "/tenant/{tenant_id}"
 
-    fastapi_app = app()
+    fastapi_app = App()
 
     if db_mode == "async":
         engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=True)
@@ -266,7 +267,7 @@ async def api_client_v3():
         async with AsyncSessionLocal() as session:
             yield session
 
-    fastapi_app = app()
+    fastapi_app = App()
     api = AutoAPI(app=fastapi_app, get_async_db=get_async_db)
     api.include_model(Widget, prefix="")
     api.mount_jsonrpc()

--- a/pkgs/standards/autoapi/tests/i9n/test_schema_ctx_attributes_integration.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_schema_ctx_attributes_integration.py
@@ -1,10 +1,9 @@
 import pytest
 import pytest_asyncio
-from pydantic import BaseModel
-from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
-from sqlalchemy import Column, Integer, String
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from autoapi.v3.types import App, BaseModel, Column, Integer, String
 
 from autoapi.v3 import AutoAPI, Base, schema_ctx
 from autoapi.v3.core import crud
@@ -41,7 +40,7 @@ async def schema_ctx_client():
         async with sessionmaker() as session:
             yield session
 
-    app = FastAPI()
+    app = App()
     api = AutoAPI(app=app, get_async_db=get_async_db)
     api.include_model(Widget, prefix="")
     api.mount_jsonrpc()


### PR DESCRIPTION
## Summary
- import FastAPI-related and SQLAlchemy types via `autoapi.v3.types`
- build test fixtures using `App` alias instead of the deprecated `app`
- drop obsolete `app` import from `autoapi.v3.__init__`

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_schema_ctx_attributes_integration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af1b8c87d0832699636aea07247fce