### PR TITLE
refactor: use App alias for FastAPI

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/__init__.py
@@ -72,16 +72,17 @@ from .config.constants import DEFAULT_HTTP_METHODS
 from .autoapi import AutoAPI
 
 from .tables import Base
+from .types import App
 
 
-def app() -> FastAPI:  # pragma: no cover - thin wrapper
+def app() -> App:  # pragma: no cover - thin wrapper
     """Return a new FastAPI application instance."""
-    return FastAPI()
+    return App()
 
 
 __all__: list[str] = []
 
-__all__ += ["AutoAPI", "Base"]
+__all__ += ["AutoAPI", "Base", "App"]
 
 __all__ += [
     # OpSpec core

--- a/pkgs/standards/autoapi/tests/i9n/test_apikey_generation.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_apikey_generation.py
@@ -1,5 +1,5 @@
 import pytest
-from fastapi import FastAPI
+from autoapi.v3.types import App
 from httpx import ASGITransport, AsyncClient
 
 from autoapi.v3 import AutoAPI, Base
@@ -20,7 +20,7 @@ async def test_api_key_creation_requires_valid_payload(sync_db_session):
     _, get_sync_db = sync_db_session
     Base.metadata.clear()
 
-    app = FastAPI()
+    app = App()
     api = AutoAPI(app=app, get_db=get_sync_db)
     api.include_models([ConcreteApiKey])
     api.initialize_sync()

--- a/pkgs/standards/autoapi/tests/i9n/test_authn_provider_integration.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_authn_provider_integration.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, HTTPException, Request, Security
+from autoapi.v3.types import App, HTTPException, Request, Security
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
@@ -60,7 +60,7 @@ def _build_client_with_auth():
             yield session
 
     auth = HookedAuth()
-    app = FastAPI()
+    app = App()
     api = AutoAPI(app=app, get_db=get_db)
     api.set_auth(authn=auth.get_principal)
     auth.register_inject_hook(api)

--- a/pkgs/standards/autoapi/tests/i9n/test_column_metadata_runtime.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_column_metadata_runtime.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 
 import pytest
-from fastapi import FastAPI
+from autoapi.v3.types import App
 from httpx import ASGITransport, AsyncClient
 
 from autoapi.v3 import Base
@@ -23,7 +23,7 @@ async def test_write_only_field_runtime_behavior(create_test_api):
         secret = Column(String, info={"autoapi": {"write_only": True}})
 
     api = create_test_api(WriteOnlyModel)
-    app = FastAPI()
+    app = App()
     app.include_router(api.router)
 
     async with AsyncClient(
@@ -64,7 +64,7 @@ async def test_read_only_field_runtime_behavior(create_test_api):
         code = Column(String, default="RO", info={"autoapi": {"read_only": True}})
 
     api = create_test_api(ReadOnlyModel)
-    app = FastAPI()
+    app = App()
     app.include_router(api.router)
 
     async with AsyncClient(
@@ -113,7 +113,7 @@ async def test_default_factory_field_runtime_behavior(create_test_api):
         )
 
     api = create_test_api(FactoryModel)
-    app = FastAPI()
+    app = App()
     app.include_router(api.router)
 
     async with AsyncClient(

--- a/pkgs/standards/autoapi/tests/i9n/test_field_spec_effects.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_field_spec_effects.py
@@ -2,7 +2,7 @@ from types import SimpleNamespace
 
 import pytest
 import pytest_asyncio
-from fastapi import FastAPI
+from autoapi.v3.types import App
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -43,7 +43,7 @@ async def fs_app():
         )
 
     Base.metadata.create_all(engine)
-    app = FastAPI()
+    app = App()
     api = AutoAPI(app=app, get_db=get_db)
     api.include_model(FSItem)
     transport = ASGITransport(app=app)

--- a/pkgs/standards/autoapi/tests/i9n/test_hook_ctx_v3_i9n.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_hook_ctx_v3_i9n.py
@@ -1,5 +1,5 @@
 import pytest
-from fastapi import FastAPI
+from autoapi.v3.types import App
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import create_engine, func, select
 from sqlalchemy.pool import StaticPool
@@ -31,7 +31,7 @@ def create_client(model_cls):
         with SessionLocal() as session:
             yield session
 
-    app = FastAPI()
+    app = App()
     api = AutoAPI(app=app, get_db=get_db)
     api.include_model(model_cls)
     api.mount_jsonrpc()

--- a/pkgs/standards/autoapi/tests/i9n/test_iospec_attributes.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_iospec_attributes.py
@@ -1,6 +1,6 @@
 import pytest
 from types import SimpleNamespace
-from fastapi import FastAPI
+from autoapi.v3.types import App
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Mapped, sessionmaker
@@ -134,7 +134,7 @@ def test_openapi_reflects_io_verbs():
     sp_create = OpSpec(alias="create", target="create")
     sp_read = OpSpec(alias="read", target="read")
     router = _build_router(Widget, [sp_create, sp_read])
-    app = FastAPI()
+    app = App()
     app.include_router(router)
     spec = app.openapi()
 
@@ -205,7 +205,7 @@ def test_rest_call_respects_aliases():
             io=IO(in_verbs=("create",), out_verbs=("read",)),
         )
 
-    api = AutoAPI(app=FastAPI(), get_db=get_db)
+    api = AutoAPI(app=App(), get_db=get_db)
     api.include_model(Thing)
     Base.metadata.create_all(engine)
     client = TestClient(api.app)
@@ -275,7 +275,7 @@ async def test_core_crud_helpers_operate():
             io=IO(in_verbs=("create",), out_verbs=("read",)),
         )
 
-    api = AutoAPI(app=FastAPI(), get_db=get_db)
+    api = AutoAPI(app=App(), get_db=get_db)
     api.include_model(Thing)
     Base.metadata.create_all(engine)
 

--- a/pkgs/standards/autoapi/tests/i9n/test_iospec_integration.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_iospec_integration.py
@@ -1,6 +1,6 @@
 import pytest
 import pytest_asyncio
-from fastapi import FastAPI
+from autoapi.v3.types import App
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import sessionmaker
@@ -53,7 +53,7 @@ async def widget_setup():
     # functional regardless of prior global state.
     Widget.__table__.create(bind=engine)
 
-    app = FastAPI()
+    app = App()
     api = AutoAPI(app=app, get_db=get_db)
     api.include_model(Widget, prefix="/widget")
     api.mount_jsonrpc(prefix="/rpc")

--- a/pkgs/standards/autoapi/tests/i9n/test_nested_routing_depth.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_nested_routing_depth.py
@@ -2,7 +2,7 @@ import pytest
 import pytest_asyncio
 from autoapi.v3 import AutoAPI, Base
 from autoapi.v3.mixins import GUIDPk
-from fastapi import FastAPI
+from autoapi.v3.types import App
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import Column, ForeignKey, String
 
@@ -45,7 +45,7 @@ async def three_level_api_client(db_mode, sync_db_session, async_db_session):
         api.include_models([Company, Department, Employee])
         api.initialize_sync()
 
-    app = FastAPI()
+    app = App()
     app.include_router(api.router)
     transport = ASGITransport(app=app)
     client = AsyncClient(transport=transport, base_url="http://test")

--- a/pkgs/standards/autoapi/tests/i9n/test_op_ctx_core_crud_order.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_op_ctx_core_crud_order.py
@@ -1,5 +1,5 @@
 import pytest
-from fastapi import FastAPI
+from autoapi.v3.types import App
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import Column, String
 
@@ -11,7 +11,7 @@ from autoapi.v3.core import crud
 
 def setup_api(model_cls, get_db):
     Base.metadata.clear()
-    app = FastAPI()
+    app = App()
     api = AutoAPI(app=app, get_db=get_db)
     api.include_model(model_cls, prefix="")
     api.initialize_sync()

--- a/pkgs/standards/autoapi/tests/i9n/test_opspec_effects_i9n_test.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_opspec_effects_i9n_test.py
@@ -1,7 +1,7 @@
 import asyncio
 
 import pytest
-from fastapi import FastAPI
+from autoapi.v3.types import App
 from sqlalchemy import String, create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -105,7 +105,7 @@ def test_internal_model_opspec_binding():
 @pytest.mark.i9n
 def test_openapi_includes_path():
     bind(Gadget)
-    app = FastAPI()
+    app = App()
     app.include_router(Gadget.rest.router)
     schema = app.openapi()
     assert "/gadget" in schema["paths"]
@@ -129,7 +129,7 @@ def test_rest_routes_bound():
 
     Gadget.__autoapi_get_db__ = staticmethod(get_db)  # type: ignore[attr-defined]
     bind(Gadget)
-    app = FastAPI()
+    app = App()
     app.include_router(Gadget.rest.router)
     paths = {route.path for route in app.router.routes}
     assert "/gadget" in paths

--- a/pkgs/standards/autoapi/tests/i9n/test_owner_tenant_policy.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_owner_tenant_policy.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, HTTPException, Request, Security
+from autoapi.v3.types import App, HTTPException, Request, Security
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from fastapi.testclient import TestClient
 import pytest
@@ -100,7 +100,7 @@ def _client_for_owner(
     api.set_auth(authn=authn.get_principal)
     authn.register_inject_hook(api)
     api.include_models([User, Item])
-    app = FastAPI()
+    app = App()
     app.include_router(api.router)
     api.initialize_sync()
     return TestClient(app)
@@ -169,7 +169,7 @@ def _client_for_tenant(
     api.set_auth(authn=authn.get_principal)
     authn.register_inject_hook(api)
     api.include_models([Tenant, Item])
-    app = FastAPI()
+    app = App()
     app.include_router(api.router)
     api.initialize_sync()
     return TestClient(app)

--- a/pkgs/standards/autoapi/tests/i9n/test_request_extras.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_request_extras.py
@@ -1,6 +1,6 @@
 import pytest
 import pytest_asyncio
-from fastapi import FastAPI
+from autoapi.v3.types import App
 from httpx import ASGITransport, AsyncClient
 from pydantic import Field
 from sqlalchemy import Column, String, create_engine
@@ -60,7 +60,7 @@ async def api_client_with_extras(db_mode):
         api.include_model(Widget)
         api.initialize_sync()
 
-    app = FastAPI()
+    app = App()
     app.include_router(api.router)
     transport = ASGITransport(app=app)
     client = AsyncClient(transport=transport, base_url="http://test")

--- a/pkgs/standards/autoapi/tests/i9n/test_rest_fallback_serialization.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_rest_fallback_serialization.py
@@ -1,6 +1,6 @@
 import pytest
 import pytest_asyncio
-from fastapi import FastAPI
+from autoapi.v3.types import App
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import Integer, String
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
@@ -41,7 +41,7 @@ async def client_and_model():
         async with session_maker() as session:
             yield session
 
-    app = FastAPI()
+    app = App()
     api = AutoAPIv3(app=app, get_async_db=get_async_db)
     api.include_model(Widget, prefix="")
     # Remove output schemas to trigger fallback serialization

--- a/pkgs/standards/autoapi/tests/i9n/test_rest_row_serialization.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_rest_row_serialization.py
@@ -1,6 +1,6 @@
 import pytest
 import pytest_asyncio
-from fastapi import FastAPI
+from autoapi.v3.types import App
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import Integer, String, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
@@ -42,7 +42,7 @@ async def client_and_model():
         async with session_maker() as session:
             yield session
 
-    app = FastAPI()
+    app = App()
     api = AutoAPIv3(app=app, get_async_db=get_async_db)
     api.include_model(Widget, prefix="")
     # Remove output schemas to trigger fallback serialization

--- a/pkgs/standards/autoapi/tests/i9n/test_row_result_serialization.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_row_result_serialization.py
@@ -1,6 +1,6 @@
 import pytest
 import pytest_asyncio
-from fastapi import FastAPI
+from autoapi.v3.types import App
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import Integer, String, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
@@ -55,7 +55,7 @@ async def client():
     crud.read = row_read  # type: ignore
     crud.list = row_list  # type: ignore
 
-    app = FastAPI()
+    app = App()
     api = AutoAPIv3(app=app, get_async_db=get_async_db)
     api.include_model(Widget, prefix="")
     transport = ASGITransport(app=app)

--- a/pkgs/standards/autoapi/tests/i9n/test_schema_ctx_op_ctx_integration.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_schema_ctx_op_ctx_integration.py
@@ -1,7 +1,7 @@
 import pytest
 import pytest_asyncio
 from pydantic import BaseModel
-from fastapi import FastAPI
+from autoapi.v3.types import App
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import Column, String
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
@@ -44,7 +44,7 @@ async def widget_client():
         async with sessionmaker() as session:
             yield session
 
-    app = FastAPI()
+    app = App()
     api = AutoAPI(app=app, get_async_db=get_async_db)
     api.include_model(Widget, prefix="")
     api.mount_jsonrpc()

--- a/pkgs/standards/autoapi/tests/i9n/test_schema_ctx_spec_integration.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_schema_ctx_spec_integration.py
@@ -1,6 +1,6 @@
 import pytest
 import pytest_asyncio
-from fastapi import FastAPI
+from autoapi.v3.types import App
 from httpx import ASGITransport, AsyncClient
 from pydantic import BaseModel
 from sqlalchemy import Integer, String
@@ -75,7 +75,7 @@ async def schema_ctx_client():
         async with SessionLocal() as session:
             yield session
 
-    app = FastAPI()
+    app = App()
     api = AutoAPIv3(app=app, get_async_db=get_async_db)
     api.include_model(Widget, prefix="")
     api.mount_jsonrpc()

--- a/pkgs/standards/autoapi/tests/i9n/test_v3_bulk_rest_endpoints.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_v3_bulk_rest_endpoints.py
@@ -1,7 +1,7 @@
 import pytest
 import pytest_asyncio
 from typing import Iterator
-from fastapi import FastAPI
+from autoapi.v3.types import App
 from httpx import AsyncClient, ASGITransport
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -34,7 +34,7 @@ async def v3_client() -> Iterator[tuple[AsyncClient, type]]:
         with SessionLocal() as session:
             yield session
 
-    app = FastAPI()
+    app = App()
     api = AutoAPI(app=app, get_db=get_db)
     api.include_model(Widget)
 

--- a/pkgs/standards/autoapi/tests/i9n/test_v3_default_rest_ops.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_v3_default_rest_ops.py
@@ -1,6 +1,6 @@
 import pytest
 import pytest_asyncio
-from fastapi import FastAPI
+from autoapi.v3.types import App
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
@@ -51,7 +51,7 @@ async def client_and_model():
         async with session_maker() as session:
             yield session
 
-    app = FastAPI()
+    app = App()
     api = AutoAPIv3(app=app, get_async_db=get_async_db)
     api.include_model(Gadget, prefix="")
     transport = ASGITransport(app=app)

--- a/pkgs/standards/autoapi/tests/i9n/test_v3_default_rpc_ops.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_v3_default_rpc_ops.py
@@ -1,6 +1,6 @@
 import pytest
 import pytest_asyncio
-from fastapi import FastAPI
+from autoapi.v3.types import App
 from httpx import AsyncClient, ASGITransport
 from sqlalchemy import Integer, String
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
@@ -51,7 +51,7 @@ async def client_and_model():
         async with session_maker() as session:
             yield session
 
-    app = FastAPI()
+    app = App()
     api = AutoAPIv3(app=app, get_async_db=get_async_db)
     api.include_model(Gadget, prefix="")
     api.mount_jsonrpc(prefix="/rpc")

--- a/pkgs/standards/autoapi/tests/i9n/test_v3_opspec_attributes.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_v3_opspec_attributes.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 
 import pytest
-from fastapi import FastAPI
+from autoapi.v3.types import App
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import String, create_engine
 from sqlalchemy.orm import sessionmaker
@@ -116,7 +116,7 @@ def test_openapi_includes_path():
         )
 
     bind(Gadget)
-    app = FastAPI()
+    app = App()
     app.include_router(Gadget.rest.router)
     schema = app.openapi()
     assert "/gadget" in schema["paths"]
@@ -163,7 +163,7 @@ async def test_rest_routes_bound():
 
     Gadget.__autoapi_get_db__ = staticmethod(get_db)  # type: ignore[attr-defined]
     bind(Gadget)
-    app = FastAPI()
+    app = App()
     app.include_router(Gadget.rest.router)
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://test"

--- a/pkgs/standards/autoapi/tests/unit/test_app_reexport.py
+++ b/pkgs/standards/autoapi/tests/unit/test_app_reexport.py
@@ -1,6 +1,6 @@
 from autoapi.v3 import App
-from fastapi import FastAPI
+from autoapi.v3.deps.fastapi import App as FastAPIApp
 
 
 def test_app_reexport():
-    assert App is FastAPI
+    assert App is FastAPIApp

--- a/pkgs/standards/autoapi/tests/unit/test_include_models_base_prefix.py
+++ b/pkgs/standards/autoapi/tests/unit/test_include_models_base_prefix.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI
+from autoapi.v3.types import App
 
 from autoapi.v3.autoapi import AutoAPI
 from autoapi.v3.tables import Base
@@ -7,7 +7,7 @@ from autoapi.v3.types import Column, String
 
 
 def test_include_models_base_prefix_avoids_duplicate_segments():
-    app = FastAPI()
+    app = App()
 
     class Key(Base, GUIDPk):
         __tablename__ = "Key"

--- a/pkgs/standards/autoapi/tests/unit/test_iospec_effects.py
+++ b/pkgs/standards/autoapi/tests/unit/test_iospec_effects.py
@@ -1,6 +1,6 @@
 from types import SimpleNamespace
 
-from fastapi import FastAPI
+from autoapi.v3.types import App
 from sqlalchemy import Column
 from sqlalchemy.orm import DeclarativeBase, Mapped
 
@@ -138,7 +138,7 @@ def test_iospec_in_verbs_reflected_in_openapi() -> None:
     sp_create = OpSpec(alias="create", target="create")
     sp_read = OpSpec(alias="read", target="read")
     router = _build_router(Widget, [sp_create, sp_read])
-    app = FastAPI()
+    app = App()
     app.include_router(router)
     spec = app.openapi()
 

--- a/pkgs/standards/autoapi/tests/unit/test_op_ctx_arity_paths.py
+++ b/pkgs/standards/autoapi/tests/unit/test_op_ctx_arity_paths.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI
+from autoapi.v3.types import App
 from autoapi.v3 import op_ctx
 from autoapi.v3.decorators import collect_decorated_ops
 from autoapi.v3.bindings.rest import _build_router
@@ -54,7 +54,7 @@ def test_member_arity_openapi_has_path_param():
 
     spec = collect_decorated_ops(MemberModel)[0]
     router = _build_router(MemberModel, [spec])
-    app = FastAPI()
+    app = App()
     app.include_router(router)
     params = app.openapi()["paths"][f"/{MemberModel.__name__.lower()}/{{item_id}}/do"][
         "post"
@@ -75,7 +75,7 @@ def test_collection_arity_openapi_has_no_path_param():
 
     spec = collect_decorated_ops(CollectionModel)[0]
     router = _build_router(CollectionModel, [spec])
-    app = FastAPI()
+    app = App()
     app.include_router(router)
     operation = app.openapi()["paths"][f"/{CollectionModel.__name__.lower()}/do"][
         "post"

--- a/pkgs/standards/autoapi/tests/unit/test_opspec_effects.py
+++ b/pkgs/standards/autoapi/tests/unit/test_opspec_effects.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 
-from fastapi import FastAPI
+from autoapi.v3.types import App
 from sqlalchemy import String, create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -93,7 +93,7 @@ def test_internal_model_opspec_binding():
 
 def test_openapi_includes_path():
     bind(Gadget)
-    app = FastAPI()
+    app = App()
     app.include_router(Gadget.rest.router)
     schema = app.openapi()
     assert "/gadget" in schema["paths"]
@@ -115,7 +115,7 @@ def test_rest_routes_bound():
 
     Gadget.__autoapi_get_db__ = staticmethod(get_db)  # type: ignore[attr-defined]
     bind(Gadget)
-    app = FastAPI()
+    app = App()
     app.include_router(Gadget.rest.router)
     paths = {route.path for route in app.router.routes}
     assert "/gadget" in paths

--- a/pkgs/standards/autoapi/tests/unit/test_request_body_schema.py
+++ b/pkgs/standards/autoapi/tests/unit/test_request_body_schema.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI
+from autoapi.v3.types import App
 
 from autoapi.v3.bindings.rest import _build_router
 from autoapi.v3.opspec import OpSpec
@@ -15,7 +15,7 @@ class Widget(Base, GUIDPk):
 def test_request_body_uses_schema_model():
     sp = OpSpec(alias="create", target="create")
     router = _build_router(Widget, [sp])
-    app = FastAPI()
+    app = App()
     app.include_router(router)
     spec = app.openapi()
     path = f"/{Widget.__name__.lower()}"
@@ -35,7 +35,7 @@ def test_replace_request_body_excludes_pk():
 
     sp = OpSpec(alias="replace", target="replace")
     router = _build_router(Gadget, [sp])
-    app = FastAPI()
+    app = App()
     app.include_router(router)
     spec = app.openapi()
 

--- a/pkgs/standards/autoapi/tests/unit/test_rest_no_schema_jsonable.py
+++ b/pkgs/standards/autoapi/tests/unit/test_rest_no_schema_jsonable.py
@@ -1,6 +1,6 @@
 import pytest
 import pytest_asyncio
-from fastapi import FastAPI
+from autoapi.v3.types import App
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import Integer, String
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
@@ -51,7 +51,7 @@ async def client_and_model():
         async with session_maker() as session:
             yield session
 
-    app = FastAPI()
+    app = App()
     api = AutoAPIv3(app=app, get_async_db=get_async_db)
     api.include_model(Gadget, prefix="")
 

--- a/pkgs/standards/autoapi/tests/unit/test_v3_healthz_endpoint.py
+++ b/pkgs/standards/autoapi/tests/unit/test_v3_healthz_endpoint.py
@@ -1,6 +1,6 @@
 import pytest
 from types import SimpleNamespace
-from fastapi import FastAPI
+from autoapi.v3.types import App
 from httpx import AsyncClient, ASGITransport
 
 from autoapi.v3.system.diagnostics import mount_diagnostics
@@ -26,7 +26,7 @@ async def test_healthz_endpoint_select_case_fallback():
         return db
 
     api = SimpleNamespace(models={})
-    app = FastAPI()
+    app = App()
     app.include_router(mount_diagnostics(api, get_db=get_db), prefix="/system")
 
     async with AsyncClient(

--- a/pkgs/standards/autoapi/tests/unit/test_v3_schemas_and_decorators.py
+++ b/pkgs/standards/autoapi/tests/unit/test_v3_schemas_and_decorators.py
@@ -12,7 +12,7 @@ from autoapi.v3.decorators import collect_decorated_ops
 from autoapi.v3.bindings import build_schemas, build_hooks, build_handlers, build_rest
 
 # REST test client
-from fastapi import FastAPI
+from autoapi.v3.types import App
 from fastapi.testclient import TestClient
 
 
@@ -92,7 +92,7 @@ def test_schema_ctx_seed_and_alias_ctx_override():
 def test_rest_serialization_with_and_without_out_schema():
     _build_all(Widget)
 
-    app = FastAPI()
+    app = App()
     # Router was attached by build_rest
     app.include_router(Widget.rest.router)
     client = TestClient(app)


### PR DESCRIPTION
## Summary
- import App from autoapi.v3.types and re-export it
- switch autoapi tests to use App instead of FastAPI

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest` *(fails: sqlalchemy.orm.exc.FlushError, HTTPException, AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_68af2accbb7c83269b08ca8c287a8de7