### PR TITLE
refactor: remove app factory export

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/__init__.py
@@ -75,11 +75,6 @@ from .tables import Base
 from .types import App
 
 
-def app() -> App:  # pragma: no cover - thin wrapper
-    """Return a new FastAPI application instance."""
-    return App()
-
-
 __all__: list[str] = []
 
 __all__ += ["AutoAPI", "Base", "App"]

--- a/pkgs/standards/autoapi/tests/i9n/test_hook_lifecycle.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_hook_lifecycle.py
@@ -5,7 +5,7 @@ Tests all hook phases and their behavior across CRUD, nested CRUD, and RPC opera
 """
 
 import pytest
-from autoapi.v3 import AutoAPI, Base, app
+from autoapi.v3 import App, AutoAPI, Base
 from autoapi.v3.decorators import hook_ctx
 from autoapi.v3.mixins import BulkCapable, GUIDPk
 from httpx import ASGITransport, AsyncClient
@@ -18,7 +18,7 @@ from sqlalchemy.pool import StaticPool
 
 async def setup_client(db_mode, Tenant, Item):
     """Create an AutoAPI client for the provided models."""
-    fastapi_app = app()
+    fastapi_app = App()
 
     if db_mode == "async":
         engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)


### PR DESCRIPTION
## Summary
- remove `app()` helper from autoapi v3 API
- use `App` directly in hook lifecycle test

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff format .`
- `uv run --directory standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68af3b87d1ec8326b632d4767b2144b3