### PR TITLE
refactor: consolidate autoapi types import in test

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_column_metadata_runtime.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_column_metadata_runtime.py
@@ -3,13 +3,12 @@
 from datetime import datetime
 
 import pytest
-from autoapi.v3.types import App
 from httpx import ASGITransport, AsyncClient
 
 from autoapi.v3 import Base
 from autoapi.v3.mixins import GUIDPk
 from autoapi.v3.schema import _build_schema
-from autoapi.v3.types import Column, DateTime, String, uuid4
+from autoapi.v3.types import App, Column, DateTime, String, uuid4
 
 
 @pytest.mark.i9n


### PR DESCRIPTION
## Summary
- consolidate imports in column metadata runtime test to use autoapi.v3.types exports

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format tests/i9n/test_column_metadata_runtime.py`
- `uv run --package autoapi --directory standards/autoapi ruff check tests/i9n/test_column_metadata_runtime.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_column_metadata_runtime.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af3d36346c83269664f4901ec10a14