### PR TITLE
fix: correct io spec openapi test

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_iospec_attributes.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_iospec_attributes.py
@@ -1,6 +1,5 @@
 import pytest
-from types import SimpleNamespace
-from autoapi.v3.types import App
+from autoapi.v3.types import App, SimpleNamespace
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Mapped, sessionmaker
@@ -138,9 +137,13 @@ def test_openapi_reflects_io_verbs():
     app.include_router(router)
     spec = app.openapi()
 
-    props = spec["components"]["schemas"]["WidgetCreate"]["properties"]
-    assert "name" in props
-    assert "id" in props
+    props_create = spec["components"]["schemas"]["WidgetCreate"]["properties"]
+    assert "name" in props_create
+    assert "id" not in props_create
+
+    props_read = spec["components"]["schemas"]["WidgetRead"]["properties"]
+    assert "name" in props_read
+    assert "id" in props_read
 
 
 @pytest.mark.i9n


### PR DESCRIPTION
## Summary
- import SimpleNamespace from autoapi.v3.types
- assert ID excluded from WidgetCreate but present in WidgetRead

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_iospec_attributes.py`

------
https://chatgpt.com/codex/tasks/task_e_68af3d51794883268b959c76cd05a843