### PR TITLE
fix: include jsonrpc fields in rpc hook ctx test

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_hook_ctx_v3_i9n.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_hook_ctx_v3_i9n.py
@@ -270,7 +270,12 @@ async def test_hook_ctx_rpc_method_i9n():
     client, _, _ = create_client(Item)
     res = await client.post(
         "/rpc",
-        json={"method": "Item.create", "params": {"id": str(uuid4()), "name": "a"}},
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "Item.create",
+            "params": {"name": "a"},
+        },
     )
     assert res.json()["result"]["phase"] == "rpc"
     await client.aclose()


### PR DESCRIPTION
## Summary
- fix RPC hook context integration test by using proper JSON-RPC payload

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_hook_ctx_v3_i9n.py::test_hook_ctx_rpc_method_i9n -q`

------
https://chatgpt.com/codex/tasks/task_e_68af3d3fcbe083268dd6551fb9762cad