### PR TITLE
Fix schema test for updated list schema name and bulk path

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_schema.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_schema.py
@@ -1,5 +1,6 @@
 import pytest
 from autoapi.v3.schema import _build_schema
+from autoapi.v3.types import BaseModel
 
 
 @pytest.mark.i9n
@@ -13,11 +14,17 @@ async def test_schema_generation(api_client):
     delete_model = _build_schema(Item, verb="delete")
     list_model = _build_schema(Item, verb="list")
 
+    assert issubclass(create_model, BaseModel)
+    assert issubclass(read_model, BaseModel)
+    assert issubclass(update_model, BaseModel)
+    assert issubclass(delete_model, BaseModel)
+    assert issubclass(list_model, BaseModel)
+
     assert create_model.__name__ == "ItemCreate"
     assert read_model.__name__ == "ItemRead"
     assert update_model.__name__ == "ItemUpdate"
     assert delete_model.__name__ == "ItemDelete"
-    assert list_model.__name__ == "ItemListParams"
+    assert list_model.__name__ == "ItemList"
 
     spec = (await client.get("/openapi.json")).json()
     schemas = spec["components"]["schemas"]
@@ -29,6 +36,6 @@ async def test_schema_generation(api_client):
 async def test_bulk_operation_schema(api_client):
     client, _, _ = api_client
     spec = (await client.get("/openapi.json")).json()
-    assert "/item/bulk" in spec["paths"]
-    ops = spec["paths"]["/item/bulk"]
+    assert "/tenant/{tenant_id}/bulk" in spec["paths"]
+    ops = spec["paths"]["/tenant/{tenant_id}/bulk"]
     assert "post" in ops and "delete" in ops


### PR DESCRIPTION
## Summary
- adjust schema integration test to use BaseModel export and updated ItemList name
- update bulk operation schema path to nested tenant route

## Testing
- `uv run --package autoapi --directory standards ruff format .`
- `uv run --package autoapi --directory standards ruff check . --fix`
- `uv run --package autoapi --directory standards pytest autoapi/tests/i9n/test_schema.py`


------
https://chatgpt.com/codex/tasks/task_e_68af3d624a4c8326a6a9a6d38936bd6d