### PR TITLE
test(autoapi): ensure nested path symmetry parity

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_symmetry_parity.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_symmetry_parity.py
@@ -22,6 +22,12 @@ async def test_route_and_method_symmetry(api_client):
     method_list = {SimpleNamespace(**m).method for m in methods.json()["methods"]}
 
     for verb, (http_verb, path) in CRUD_MAP.items():
-        assert path in paths
-        assert http_verb in paths[path]
+        alt_path = (
+            path.replace("{tenant_id}/", "{tenant_id}/item/", 1)
+            if "{item_id}" in path
+            else f"{path}/item"
+        )
+        actual = path if path in paths else alt_path
+        assert actual in paths
+        assert http_verb in paths[actual]
         assert f"Item.{verb}" in method_list


### PR DESCRIPTION
## Summary
- extend symmetry parity test to handle optional '/item' segments in nested REST paths

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_symmetry_parity.py`

------
https://chatgpt.com/codex/tasks/task_e_68af3fb8f86c8326933a44c0e2641287