### PR TITLE
Fix transactional decorator integration test

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/compat/transactional.py
+++ b/pkgs/standards/autoapi/autoapi/v3/compat/transactional.py
@@ -117,7 +117,7 @@ def transactional(  # noqa: D401 (compat docstring in v2)
 
         # Register on the model's registry and (re)bind the model
         reg = get_registry(model)
-        reg.set(alias, sp)  # idempotent replace per-alias
+        reg.add(sp)  # idempotent replace per-alias
         bind_model(model)  # builds schemas/hooks/handlers/rpc/rest
 
         # Ensure router is mounted under the API (prefix '' so our absolute path_suffix is used verbatim)


### PR DESCRIPTION
## Summary
- update transactional decorator test to use AutoAPI v3 type exports and JSON-RPC calls
- adjust transactional shim to register ops via `add`

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_transactional.py`

------
https://chatgpt.com/codex/tasks/task_e_68af402a49588326a53a01c19616d58f