### PR TITLE
refactor: use v3 type exports in rest ops test

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_v3_default_rest_ops.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_v3_default_rest_ops.py
@@ -1,10 +1,9 @@
 import pytest
 import pytest_asyncio
-from autoapi.v3.types import App
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
-from autoapi.v3.types import Integer, Mapped, String
+from autoapi.v3.types import App, Integer, Mapped, String
 
 from autoapi.v3.autoapi import AutoAPI as AutoAPIv3
 from autoapi.v3.specs import F, IO, S, acol


### PR DESCRIPTION
## Summary
- group imports in v3 default REST ops test and use autoapi.v3.types exports

## Testing
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff format tests/i9n/test_v3_default_rest_ops.py`
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff check tests/i9n/test_v3_default_rest_ops.py --fix`
- `uv run --package autoapi --directory pkgs/standards/autoapi pytest tests/i9n/test_v3_default_rest_ops.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af4030cc3c83268787484533d46b6f