### PR TITLE
test(autoapi): use exported types in RPC default ops test

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_v3_default_rpc_ops.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_v3_default_rpc_ops.py
@@ -1,10 +1,8 @@
 import pytest
 import pytest_asyncio
-from autoapi.v3.types import App
+from autoapi.v3.types import App, Integer, Mapped, String
 from httpx import AsyncClient, ASGITransport
-from sqlalchemy import Integer, String
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-from sqlalchemy.orm import Mapped
 
 from autoapi.v3.autoapi import AutoAPI as AutoAPIv3
 from autoapi.v3.specs import F, IO, S, acol


### PR DESCRIPTION
## Summary
- import SQLAlchemy types from `autoapi.v3.types` in default RPC ops test

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_v3_default_rpc_ops.py::test_rpc_methods -vv`


------
https://chatgpt.com/codex/tasks/task_e_68af40365a7c8326ace9ef2f866fe976