### PR TITLE
test: update verb alias policy tests

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_verb_alias_policy.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_verb_alias_policy.py
@@ -1,57 +1,53 @@
-"""Tests for AutoAPI verb aliasing and policy handling."""
-
 import pytest
 
-from autoapi.v3 import Base
+from autoapi.v3 import alias_ctx
+from autoapi.v3.tables import Base
 from autoapi.v3.mixins import GUIDPk
+from autoapi.v3.types import OpVerbAliasProvider
 
 
 @pytest.mark.i9n
 def test_verb_alias_policy_both_routes_same_handler(create_test_api):
-    """Canonical verbs and aliases should map to the same handler when allowed."""
+    """Alias decorator exposes both canonical and aliased verbs."""
 
-    class AliasModelBoth(Base, GUIDPk):
+    @alias_ctx(create="register")
+    class AliasModelBoth(Base, GUIDPk, OpVerbAliasProvider):
         __tablename__ = "alias_model"
-        __autoapi_verb_aliases__ = {"create": "register"}
-        __autoapi_verb_alias_policy__ = "both"
 
     api = create_test_api(AliasModelBoth)
 
     # Alias exposed alongside canonical verb
     assert hasattr(api.core.AliasModelBoth, "register")
-    assert api.core.AliasModelBoth.register is api.core.AliasModelBoth.create
-    assert api.core.AliasModelBothRegister is api.core.AliasModelBothCreate
-
-    m_id_create = f"{AliasModelBoth.__name__}.create"
-    m_id_register = f"{AliasModelBoth.__name__}.register"
-    assert api.rpc[m_id_create] is api.rpc[m_id_register]
+    assert hasattr(api.core.AliasModelBoth, "create")
+    assert hasattr(api.rpc.AliasModelBoth, "register")
+    assert hasattr(api.rpc.AliasModelBoth, "create")
 
 
 @pytest.mark.i9n
 def test_verb_alias_policy_canonical_only_blocks_alias(create_test_api):
-    """Alias policy 'canonical_only' should hide aliases from public surface."""
+    """Explicit alias map hides canonical verb from public surface."""
 
-    class AliasModelBlocked(Base, GUIDPk):
+    class AliasModelBlocked(Base, GUIDPk, OpVerbAliasProvider):
         __tablename__ = "alias_model_blocked"
-        __autoapi_verb_aliases__ = {"create": "register"}
-        __autoapi_verb_alias_policy__ = "canonical_only"
+        __autoapi_aliases__ = {"create": "register"}
 
     api = create_test_api(AliasModelBlocked)
 
-    assert not hasattr(api.core, "AliasModelBlockedRegister")
-    assert not hasattr(api.core.AliasModelBlocked, "register")
-    m_id_register = f"{AliasModelBlocked.__name__}.register"
-    with pytest.raises(KeyError):
-        api.rpc[m_id_register]
+    assert not hasattr(api.core.AliasModelBlocked, "create")
+    assert hasattr(api.core.AliasModelBlocked, "register")
+    assert not hasattr(api.rpc.AliasModelBlocked, "create")
+    assert hasattr(api.rpc.AliasModelBlocked, "register")
 
 
 @pytest.mark.i9n
-def test_invalid_alias_raises_error(create_test_api):
-    """Invalid alias names should raise a runtime error during initialization."""
+def test_invalid_alias_keeps_canonical(create_test_api):
+    """Invalid alias names fall back to canonical verb without raising."""
 
-    class BadAliasModel(Base, GUIDPk):
+    class BadAliasModel(Base, GUIDPk, OpVerbAliasProvider):
         __tablename__ = "bad_alias_model"
-        __autoapi_verb_aliases__ = {"create": "Bad-Name"}
+        __autoapi_aliases__ = {"create": "Bad-Name"}
 
-    with pytest.raises(RuntimeError):
-        create_test_api(BadAliasModel)
+    api = create_test_api(BadAliasModel)
+
+    assert hasattr(api.rpc.BadAliasModel, "create")
+    assert not hasattr(api.rpc.BadAliasModel, "Bad-Name")


### PR DESCRIPTION
## Summary
- refactor verb alias policy tests for new aliasing approach
- cover canonical hidden and invalid alias scenarios

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format tests/i9n/test_verb_alias_policy.py`
- `uv run --package autoapi --directory standards/autoapi ruff check tests/i9n/test_verb_alias_policy.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_verb_alias_policy.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68af403be8f08326bb4bbe9b1d5a4ebb