### PR TITLE
fix bulk ops tests to use autoapi types

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_core_crud_bulk_ops.py
+++ b/pkgs/standards/autoapi/tests/unit/test_core_crud_bulk_ops.py
@@ -1,10 +1,10 @@
 import pytest
 from sqlalchemy import create_engine
-from sqlalchemy.orm import Session, declarative_base
+from sqlalchemy.orm import declarative_base
 
 from autoapi.v3.core import crud
 from autoapi.v3.specs import F, IO, S, acol
-from autoapi.v3.types import Integer, String
+from autoapi.v3.types import Integer, Session, String
 
 Base = declarative_base()
 
@@ -12,7 +12,7 @@ Base = declarative_base()
 class Widget(Base):
     __tablename__ = "widgets"
     id = acol(
-        storage=S(type_=Integer, primary_key=True),
+        storage=S(type_=Integer, primary_key=True, autoincrement=True),
         field=F(py_type=int),
         io=IO(out_verbs=("read", "list")),
     )


### PR DESCRIPTION
## Summary
- ensure bulk CRUD tests use autoapi type exports and autoincrement primary key

## Testing
- `uv run --package autoapi --directory standards ruff format autoapi/tests/unit/test_core_crud_bulk_ops.py`
- `uv run --package autoapi --directory standards ruff check autoapi/tests/unit/test_core_crud_bulk_ops.py --fix`
- `uv run --package autoapi --directory standards pytest autoapi/tests/unit/test_core_crud_bulk_ops.py`


------
https://chatgpt.com/codex/tasks/task_e_68af4046fed483268da99d6225f0b03e