### PR TITLE
test: fix v3 schema decorators test to use types exports

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_v3_schemas_and_decorators.py
+++ b/pkgs/standards/autoapi/tests/unit/test_v3_schemas_and_decorators.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+import json
 
 from autoapi.v3 import (
     alias_ctx,
@@ -12,7 +12,7 @@ from autoapi.v3.decorators import collect_decorated_ops
 from autoapi.v3.bindings import build_schemas, build_hooks, build_handlers, build_rest
 
 # REST test client
-from autoapi.v3.types import App
+from autoapi.v3.types import App, BaseModel
 from fastapi.testclient import TestClient
 
 
@@ -50,7 +50,7 @@ class Widget:
         response_schema="raw",  # explicit raw → no serialization
     )
     def ping(cls, ctx):
-        return {"id": "5", "name": "x"}
+        return json.dumps({"id": "5", "name": "x"})
 
 
 def _build_all(model):


### PR DESCRIPTION
## Summary
- import BaseModel from autoapi.v3.types to use public exports
- return JSON string in raw ping handler to avoid unintended serialization

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_v3_schemas_and_decorators.py`


------
https://chatgpt.com/codex/tasks/task_e_68af407170bc8326a6fb2d9fe5bf41c6