### PR TITLE
fix: stabilize info schema key tests

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_info_schema_keys.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_info_schema_keys.py
@@ -7,7 +7,7 @@ Each key is tested individually using DummyModel instances.
 """
 
 import pytest
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from functools import partial
 from typing import get_args
 from autoapi.v3.types import Column, DateTime, Integer, JSON, String, hybrid_property
@@ -52,7 +52,7 @@ class DummyModelDefaultFactory(Base, GUIDPk):
     name = Column(String)
     timestamp = Column(
         DateTime,
-        info=dict(autoapi={"default_factory": partial(datetime.now, UTC)}),
+        info=dict(autoapi={"default_factory": partial(datetime.now, timezone.utc)}),
     )
 
 


### PR DESCRIPTION
## Summary
- use `timezone.utc` in default_factory to avoid relying on Python 3.11's `UTC`
- import `timezone` alongside existing autoapi exports for test coverage

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format tests/i9n/test_info_schema_keys.py`
- `uv run --package autoapi --directory standards/autoapi ruff check tests/i9n/test_info_schema_keys.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_info_schema_keys.py`


------
https://chatgpt.com/codex/tasks/task_e_68af58cee0c4832697f6fd9946d0b3d1