### PR TITLE
test: use autoapi v3 types in mixins test

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_mixins.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_mixins.py
@@ -6,7 +6,7 @@ Tests all mixins and their expected behavior using individual DummyModel instanc
 
 import pytest
 from datetime import datetime, timedelta
-from autoapi.v3.types import Column, String
+from autoapi.v3.types import Column, String, uuid4
 
 from autoapi.v3 import Base
 from autoapi.v3.mixins import (
@@ -33,7 +33,6 @@ from autoapi.v3.mixins import (
     tzutcnow_plus_day,
 )
 from autoapi.v3.schema import _build_schema
-from autoapi.v3.types import uuid4
 
 
 class DummyModelTimestamped(Base, GUIDPk, Timestamped):


### PR DESCRIPTION
## Summary
- use `Column`, `String`, and `uuid4` from `autoapi.v3.types` in mixins integration test

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_mixins.py`


------
https://chatgpt.com/codex/tasks/task_e_68af58d2f1388326bcbfbdd8eeb1d6ba