### PR TITLE
Fix CRUD default ops test using autoapi types

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_core_crud_default_ops.py
+++ b/pkgs/standards/autoapi/tests/unit/test_core_crud_default_ops.py
@@ -14,7 +14,7 @@ Base = declarative_base()
 class Widget(Base):
     __tablename__ = "widgets"
     id = acol(
-        storage=S(type_=Integer, primary_key=True),
+        storage=S(type_=Integer, primary_key=True, autoincrement=True),
         field=F(py_type=int),
         io=IO(out_verbs=("read", "list")),
     )


### PR DESCRIPTION
## Summary
- ensure Widget primary key uses autoapi types with autoincrement in core CRUD default ops test

## Testing
- `uv run --package autoapi --directory standards ruff check autoapi/tests/unit/test_core_crud_default_ops.py --fix`
- `uv run --package autoapi --directory standards pytest autoapi/tests/unit/test_core_crud_default_ops.py`


------
https://chatgpt.com/codex/tasks/task_e_68af58f19bb883269223115748b5b4a6