### PR TITLE
Use autoapi types for RPC default ops test

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/deps/sqlalchemy.py
+++ b/pkgs/standards/autoapi/autoapi/v3/deps/sqlalchemy.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
     LargeBinary,
     UniqueConstraint,
     CheckConstraint,
+    create_engine,
     event,
 )
 
@@ -37,8 +38,11 @@ from sqlalchemy.orm import (
     remote,
     column_property,
     Session,
+    sessionmaker,
     InstrumentedAttribute,
 )
+
+from sqlalchemy.pool import StaticPool
 
 # ── SQLAlchemy Extensions ────────────────────────────────────────────────
 from sqlalchemy.ext.mutable import MutableDict, MutableList
@@ -74,6 +78,8 @@ __all__ = [
     "LargeBinary",
     "UniqueConstraint",
     "CheckConstraint",
+    "create_engine",
+    "StaticPool",
     "event",
     # PostgreSQL dialect
     "ARRAY",
@@ -91,6 +97,7 @@ __all__ = [
     "remote",
     "column_property",
     "Session",
+    "sessionmaker",
     "InstrumentedAttribute",
     # Extensions
     "MutableDict",

--- a/pkgs/standards/autoapi/autoapi/v3/types/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/types/__init__.py
@@ -20,6 +20,7 @@ from ..deps.sqlalchemy import (
     LargeBinary,
     UniqueConstraint,
     CheckConstraint,
+    create_engine,
     event,
     # PostgreSQL dialect
     ARRAY,
@@ -37,11 +38,13 @@ from ..deps.sqlalchemy import (
     remote,
     column_property,
     Session,
+    sessionmaker,
     InstrumentedAttribute,
     # Extensions
     MutableDict,
     MutableList,
     hybrid_property,
+    StaticPool,
 )
 
 from ..deps.pydantic import (
@@ -121,6 +124,7 @@ __all__: list[str] = [
     "LargeBinary",
     "UniqueConstraint",
     "CheckConstraint",
+    "create_engine",
     "event",
     # sqlalchemy.dialects.postgresql (from deps.sqlalchemy)
     "ARRAY",
@@ -139,10 +143,12 @@ __all__: list[str] = [
     "relationship",
     "remote",
     "Session",
+    "sessionmaker",
     "InstrumentedAttribute",
     # sqlalchemy.ext.mutable (from deps.sqlalchemy)
     "MutableDict",
     "MutableList",
+    "StaticPool",
     # pydantic schema support (from deps.pydantic)
     "BaseModel",
     "Field",

--- a/pkgs/standards/autoapi/tests/unit/test_rpc_default_ops.py
+++ b/pkgs/standards/autoapi/tests/unit/test_rpc_default_ops.py
@@ -1,14 +1,17 @@
 import pytest
 from collections.abc import Iterator
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy.pool import StaticPool
 
 from autoapi.v3.autoapi import AutoAPI
 from autoapi.v3.mixins import BulkCapable, GUIDPk
 from autoapi.v3.specs import IO, S, F, acol as spec_acol
 from autoapi.v3.tables import Base
-from autoapi.v3.types import Session, String
+from autoapi.v3.types import (
+    Session,
+    String,
+    StaticPool,
+    create_engine,
+    sessionmaker,
+)
 
 
 class Widget(Base, GUIDPk, BulkCapable):


### PR DESCRIPTION
## Summary
- re-export SQLAlchemy engine helpers through autoapi.v3.types
- update RPC default ops unit test to import from autoapi.v3.types

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_rpc_default_ops.py`


------
https://chatgpt.com/codex/tasks/task_e_68af59153a508326ab3298ceb49da744