### PR TITLE
Reset registry in v3 RPC ops test

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_v3_default_rpc_ops.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_v3_default_rpc_ops.py
@@ -12,6 +12,7 @@ from autoapi.v3.tables import Base as Base3
 @pytest_asyncio.fixture()
 async def client_and_model():
     Base3.metadata.clear()
+    Base3.registry.dispose()
 
     class Gadget(Base3):
         __tablename__ = "gadgets"


### PR DESCRIPTION
## Summary
- clear SQLAlchemy registry in test fixture to prevent duplicated Gadget class warnings during RPC tests

## Testing
- `uv run --package autoapi --directory standards pytest autoapi/tests/i9n/test_v3_default_rpc_ops.py -q --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_68af5a39458083268635d307cebe852c