### PR TITLE
test: verify bulk update persistence

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_core_crud_bulk_ops.py
+++ b/pkgs/standards/autoapi/tests/unit/test_core_crud_bulk_ops.py
@@ -98,6 +98,8 @@ async def test_bulk_update_modifies_rows(session):
     ]
     updated = await crud.bulk_update(Widget, updates, session)
     assert [u.name for u in updated] == ["alpha", "beta"]
+    rows = await crud.list(Widget, db=session)
+    assert [r.name for r in rows] == ["alpha", "beta"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- verify database values persist after `bulk_update`

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_core_crud_bulk_ops.py`


------
https://chatgpt.com/codex/tasks/task_e_68af5a74a9148326943042e063893e45