### PR TITLE
Use direct payload in bulk RPC tests

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_rpc_all_default_op_verbs.py
+++ b/pkgs/standards/autoapi/tests/unit/test_rpc_all_default_op_verbs.py
@@ -145,7 +145,7 @@ async def _op_bulk_update(api, db):
             {"id": rows[1]["id"], "name": "i2u"},
         ]
     }
-    result = await api.rpc.Widget.bulk_update(None, db=db, ctx={"payload": payload})
+    result = await api.rpc.Widget.bulk_update(payload, db=db)
     assert {r["name"] for r in result} == {"i1u", "i2u"}
 
 
@@ -160,7 +160,7 @@ async def _op_bulk_replace(api, db):
             {"id": rows[1]["id"], "name": "j2r"},
         ]
     }
-    result = await api.rpc.Widget.bulk_replace(None, db=db, ctx={"payload": payload})
+    result = await api.rpc.Widget.bulk_replace(payload, db=db)
     assert {r["name"] for r in result} == {"j1r", "j2r"}
 
 


### PR DESCRIPTION
## Summary
- call `bulk_update` and `bulk_replace` with payload arguments instead of ctx

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_rpc_all_default_op_verbs.py`

------
https://chatgpt.com/codex/tasks/task_e_68af5c2712888326af4de2a374d9e5c2