### PR TITLE
test: reset schema cache between tests

### DIFF
--- a/pkgs/standards/autoapi/tests/conftest.py
+++ b/pkgs/standards/autoapi/tests/conftest.py
@@ -15,6 +15,21 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from sqlalchemy.orm import Mapped, Session, sessionmaker
 
 
+@pytest.fixture(autouse=True)
+def clear_caches_and_metadata():
+    """Reset schema caches and SQLAlchemy metadata around each test."""
+    from autoapi.v2.impl import schema as v2_schema
+    from autoapi.v3.schema import builder as v3_builder
+
+    Base.metadata.clear()
+    v2_schema._SchemaCache.clear()
+    v3_builder._SchemaCache.clear()
+    yield
+    Base.metadata.clear()
+    v2_schema._SchemaCache.clear()
+    v3_builder._SchemaCache.clear()
+
+
 def pytest_addoption(parser):
     """Add command line options for database mode."""
     group = parser.getgroup("database")


### PR DESCRIPTION
## Summary
- reset schema caches and metadata before and after each test run
- restore crud functions in row result serialization test so later tests see defaults

## Testing
- `uv run --package autoapi --directory standards ruff format autoapi`
- `uv run --package autoapi --directory standards ruff check autoapi --fix`
- `uv run --package autoapi --directory standards pytest autoapi/tests/i9n/test_row_result_serialization.py`
- `uv run --package autoapi --directory standards pytest autoapi` *(fails: 23 failed, 561 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68af5b07087883268b8bb24fa05b8f7a