### PR TITLE
Clear schema cache and metadata for autoapi tests

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_op_ctx_behavior.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_op_ctx_behavior.py
@@ -22,7 +22,6 @@ def setup_api(model_cls, get_db):
 
 @pytest.mark.i9n
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="request schema coercion pending")
 async def test_op_ctx_request_response_schemas(sync_db_session):
     _, get_sync_db = sync_db_session
 

--- a/pkgs/standards/autoapi/tests/i9n/test_owner_tenant_policy.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_owner_tenant_policy.py
@@ -66,7 +66,12 @@ class DummyAuth(AuthNProvider):
 def _client_for_owner(
     policy: OwnerPolicy, user_id: uuid.UUID, tenant_id: uuid.UUID
 ) -> TestClient:
+    from autoapi.v2.impl import schema as v2_schema
+    from autoapi.v3.schema import builder as v3_builder
+
     Base.metadata.clear()
+    v2_schema._SchemaCache.clear()
+    v3_builder._SchemaCache.clear()
 
     class User(Base, GUIDPk):
         __tablename__ = "users"
@@ -103,7 +108,11 @@ def _client_for_owner(
     app = App()
     app.include_router(api.router)
     api.initialize_sync()
-    return TestClient(app)
+    client = TestClient(app)
+    v2_schema._SchemaCache.clear()
+    v3_builder._SchemaCache.clear()
+    Base.metadata.clear()
+    return client
 
 
 @pytest.mark.i9n
@@ -135,7 +144,12 @@ def test_owner_policy_runtime_switch():
 def _client_for_tenant(
     policy: TenantPolicy, user_id: uuid.UUID, tenant_id: uuid.UUID
 ) -> TestClient:
+    from autoapi.v2.impl import schema as v2_schema
+    from autoapi.v3.schema import builder as v3_builder
+
     Base.metadata.clear()
+    v2_schema._SchemaCache.clear()
+    v3_builder._SchemaCache.clear()
 
     class Tenant(Base, GUIDPk):
         __tablename__ = "tenants"
@@ -172,7 +186,11 @@ def _client_for_tenant(
     app = App()
     app.include_router(api.router)
     api.initialize_sync()
-    return TestClient(app)
+    client = TestClient(app)
+    v2_schema._SchemaCache.clear()
+    v3_builder._SchemaCache.clear()
+    Base.metadata.clear()
+    return client
 
 
 @pytest.mark.i9n

--- a/pkgs/standards/autoapi/tests/unit/test_rpc_all_default_op_verbs.py
+++ b/pkgs/standards/autoapi/tests/unit/test_rpc_all_default_op_verbs.py
@@ -48,6 +48,13 @@ class Widget(Base, GUIDPk, BulkCapable):
 
 @pytest.fixture()
 def api_and_session():
+    from autoapi.v2.impl import schema as v2_schema
+    from autoapi.v3.schema import builder as v3_builder
+
+    Base.metadata.clear()
+    v2_schema._SchemaCache.clear()
+    v3_builder._SchemaCache.clear()
+
     engine = create_engine(
         "sqlite:///:memory:",
         connect_args={"check_same_thread": False},
@@ -69,6 +76,9 @@ def api_and_session():
     finally:
         session.close()
         engine.dispose()
+        Base.metadata.clear()
+        v2_schema._SchemaCache.clear()
+        v3_builder._SchemaCache.clear()
 
 
 async def _op_create(api, db):

--- a/pkgs/standards/autoapi/tests/unit/test_rpc_default_ops.py
+++ b/pkgs/standards/autoapi/tests/unit/test_rpc_default_ops.py
@@ -31,6 +31,13 @@ class Widget(Base, GUIDPk, BulkCapable):
 
 @pytest.fixture()
 def api_and_session() -> tuple[AutoAPI, Session]:
+    from autoapi.v2.impl import schema as v2_schema
+    from autoapi.v3.schema import builder as v3_builder
+
+    Base.metadata.clear()
+    v2_schema._SchemaCache.clear()
+    v3_builder._SchemaCache.clear()
+
     engine = create_engine(
         "sqlite:///:memory:",
         connect_args={"check_same_thread": False},
@@ -52,6 +59,9 @@ def api_and_session() -> tuple[AutoAPI, Session]:
     finally:
         session.close()
         engine.dispose()
+        Base.metadata.clear()
+        v2_schema._SchemaCache.clear()
+        v3_builder._SchemaCache.clear()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- reset schema cache and SQLAlchemy metadata in autoapi RPC tests
- clear caches in owner/tenant policy helpers and remove stale xfail

## Testing
- `uv run --package autoapi --directory standards pytest autoapi/tests/unit/test_rpc_all_default_op_verbs.py`
- `uv run --package autoapi --directory standards pytest autoapi/tests/unit/test_rpc_default_ops.py`
- `uv run --package autoapi --directory standards pytest autoapi/tests/i9n/test_op_ctx_behavior.py::test_op_ctx_request_response_schemas`
- `uv run --package autoapi --directory standards pytest autoapi/tests/unit`


------
https://chatgpt.com/codex/tasks/task_e_68afcbbb852883269814cd4ee757e579