### PR TITLE
chore(autoapi): reset SQLAlchemy registry around tests

### DIFF
--- a/pkgs/standards/autoapi/tests/conftest.py
+++ b/pkgs/standards/autoapi/tests/conftest.py
@@ -21,10 +21,12 @@ def clear_caches_and_metadata():
     from autoapi.v2.impl import schema as v2_schema
     from autoapi.v3.schema import builder as v3_builder
 
+    Base.registry.dispose()
     Base.metadata.clear()
     v2_schema._SchemaCache.clear()
     v3_builder._SchemaCache.clear()
     yield
+    Base.registry.dispose()
     Base.metadata.clear()
     v2_schema._SchemaCache.clear()
     v3_builder._SchemaCache.clear()


### PR DESCRIPTION
## Summary
- ensure AutoAPI tests fully reset SQLAlchemy state by disposing the Base registry before and after each test

## Testing
- `uv run --package autoapi --directory standards pytest autoapi/tests/i9n/test_hook_lifecycle.py` *(fails: TypeError: 'NoneType' object is not subscriptable)*
- `uv run --package autoapi --directory standards pytest autoapi/tests` *(fails: multiple assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68afcf5d47e08326991fa674e361e5ec