### PR TITLE
test: isolate rpc opspec tests

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_rpc_all_default_op_verbs.py
+++ b/pkgs/standards/autoapi/tests/unit/test_rpc_all_default_op_verbs.py
@@ -9,6 +9,8 @@ from autoapi.v3.specs import IO, S, F, acol as spec_acol
 from autoapi.v3.tables import Base
 from autoapi.v3.types import String
 from autoapi.v3.opspec import OpSpec
+from autoapi.v3.schema import builder as v3_builder
+from autoapi.v3.runtime import kernel as runtime_kernel
 
 
 class Widget(Base, GUIDPk, BulkCapable):
@@ -44,6 +46,18 @@ class Widget(Base, GUIDPk, BulkCapable):
             ),
         ),
     )
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    """Ensure clean metadata and caches around each test."""
+    Base.metadata.clear()
+    v3_builder._SchemaCache.clear()
+    runtime_kernel._default_kernel = runtime_kernel.Kernel()
+    yield
+    Base.metadata.clear()
+    v3_builder._SchemaCache.clear()
+    runtime_kernel._default_kernel = runtime_kernel.Kernel()
 
 
 @pytest.fixture()

--- a/pkgs/standards/autoapi/tests/unit/test_rpc_default_ops.py
+++ b/pkgs/standards/autoapi/tests/unit/test_rpc_default_ops.py
@@ -1,6 +1,7 @@
 import pytest
 from collections.abc import Iterator
 
+
 from autoapi.v3.autoapi import AutoAPI
 from autoapi.v3.mixins import BulkCapable, GUIDPk
 from autoapi.v3.specs import IO, S, F, acol as spec_acol
@@ -12,6 +13,8 @@ from autoapi.v3.types import (
     create_engine,
     sessionmaker,
 )
+from autoapi.v3.schema import builder as v3_builder
+from autoapi.v3.runtime import kernel as runtime_kernel
 
 
 class Widget(Base, GUIDPk, BulkCapable):
@@ -27,6 +30,18 @@ class Widget(Base, GUIDPk, BulkCapable):
             mutable_verbs=("create", "update", "replace"),
         ),
     )
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    """Ensure clean metadata and caches around each test."""
+    Base.metadata.clear()
+    v3_builder._SchemaCache.clear()
+    runtime_kernel._default_kernel = runtime_kernel.Kernel()
+    yield
+    Base.metadata.clear()
+    v3_builder._SchemaCache.clear()
+    runtime_kernel._default_kernel = runtime_kernel.Kernel()
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary
- reset SQLAlchemy metadata and schema caches around RPC op tests to prevent cross-test leakage

## Testing
- `uv run --package autoapi --directory standards pytest autoapi/tests/unit/test_rpc_default_ops.py -q`
- `uv run --package autoapi --directory standards pytest autoapi/tests/unit/test_rpc_default_ops.py autoapi/tests/unit/test_rpc_all_default_op_verbs.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68afcf67af848326942056833ad5cb5d