### PR TITLE
chore(autoapi): remove obsolete xfail markers

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_op_ctx_behavior.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_op_ctx_behavior.py
@@ -22,7 +22,6 @@ def setup_api(model_cls, get_db):
 
 @pytest.mark.i9n
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="request schema coercion pending")
 async def test_op_ctx_request_response_schemas(sync_db_session):
     _, get_sync_db = sync_db_session
 
@@ -225,7 +224,6 @@ async def test_op_ctx_rest_call(sync_db_session):
 
 @pytest.mark.i9n
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="rpc dispatch error")
 async def test_op_ctx_rpc_method(sync_db_session):
     _, get_sync_db = sync_db_session
 


### PR DESCRIPTION
## Summary
- drop outdated xfail markers in op_ctx behavior tests

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_rpc_default_ops.py -q`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_op_ctx_behavior.py tests/unit/test_rpc_default_ops.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68afcf8d12b88326a69ce5264c994f73