### PR TITLE
refactor: remove autoapi v2 test references

### DIFF
--- a/pkgs/standards/autoapi/tests/conftest.py
+++ b/pkgs/standards/autoapi/tests/conftest.py
@@ -7,6 +7,8 @@ from autoapi.v3.types import App
 from autoapi.v3.mixins import BulkCapable, GUIDPk
 from autoapi.v3.specs import F, IO, S, acol
 from autoapi.v3.specs.storage_spec import StorageTransform
+from autoapi.v3.schema import builder as v3_builder
+from autoapi.v3.runtime import kernel as runtime_kernel
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import Column, ForeignKey, Integer, String, create_engine
 from sqlalchemy.pool import StaticPool
@@ -16,18 +18,15 @@ from sqlalchemy.orm import Mapped, Session, sessionmaker
 
 
 @pytest.fixture(autouse=True)
-def clear_caches_and_metadata():
-    """Reset schema caches and SQLAlchemy metadata around each test."""
-    from autoapi.v2.impl import schema as v2_schema
-    from autoapi.v3.schema import builder as v3_builder
-
+def _reset_state():
+    """Ensure clean metadata and caches around each test."""
     Base.metadata.clear()
-    v2_schema._SchemaCache.clear()
     v3_builder._SchemaCache.clear()
+    runtime_kernel._default_kernel = runtime_kernel.Kernel()
     yield
     Base.metadata.clear()
-    v2_schema._SchemaCache.clear()
     v3_builder._SchemaCache.clear()
+    runtime_kernel._default_kernel = runtime_kernel.Kernel()
 
 
 def pytest_addoption(parser):

--- a/pkgs/standards/autoapi/tests/unit/test_rpc_all_default_op_verbs.py
+++ b/pkgs/standards/autoapi/tests/unit/test_rpc_all_default_op_verbs.py
@@ -14,13 +14,6 @@ from autoapi.v3.opspec import OpSpec
 
 @pytest.fixture()
 def api_and_session() -> Iterator[tuple[AutoAPI, Session]]:
-    from autoapi.v2.impl import schema as v2_schema
-    from autoapi.v3.schema import builder as v3_builder
-
-    Base.metadata.clear()
-    v2_schema._SchemaCache.clear()
-    v3_builder._SchemaCache.clear()
-
     class Widget(Base, GUIDPk, BulkCapable):
         __tablename__ = "widgets_rpc_all_ops"
         __allow_unmapped__ = True
@@ -82,9 +75,6 @@ def api_and_session() -> Iterator[tuple[AutoAPI, Session]]:
     finally:
         session.close()
         engine.dispose()
-        Base.metadata.clear()
-        v2_schema._SchemaCache.clear()
-        v3_builder._SchemaCache.clear()
 
 
 async def _op_create(api, db):

--- a/pkgs/standards/autoapi/tests/unit/test_rpc_default_ops.py
+++ b/pkgs/standards/autoapi/tests/unit/test_rpc_default_ops.py
@@ -16,13 +16,6 @@ from autoapi.v3.types import (
 
 @pytest.fixture()
 def api_and_session() -> Iterator[tuple[AutoAPI, Session, type[Base]]]:
-    from autoapi.v2.impl import schema as v2_schema
-    from autoapi.v3.schema import builder as v3_builder
-
-    Base.metadata.clear()
-    v2_schema._SchemaCache.clear()
-    v3_builder._SchemaCache.clear()
-
     class Widget(Base, GUIDPk, BulkCapable):
         __tablename__ = "widgets_rpc_ops"
         __allow_unmapped__ = True
@@ -58,9 +51,6 @@ def api_and_session() -> Iterator[tuple[AutoAPI, Session, type[Base]]]:
     finally:
         session.close()
         engine.dispose()
-        Base.metadata.clear()
-        v2_schema._SchemaCache.clear()
-        v3_builder._SchemaCache.clear()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- reset v3 schema and kernel state before/after tests
- drop legacy AutoAPI v2 imports from tests

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest` *(fails: 21 failed, 563 passed, 1 skipped, 21 xfailed, 2 xpassed)*

------
https://chatgpt.com/codex/tasks/task_e_68afd1f7fc888326865c1e45d132f5bb