### PR TITLE
refactor: use types exports in opspec test

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_opspec_effects.py
+++ b/pkgs/standards/autoapi/tests/unit/test_opspec_effects.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 import asyncio
 
-from autoapi.v3.types import App
-from sqlalchemy import String, create_engine
-from sqlalchemy.orm import sessionmaker
+from autoapi.v3.types import App, String, create_engine, sessionmaker
 
 from autoapi.v3.bindings.model import bind
 from autoapi.v3.opspec.types import PHASES


### PR DESCRIPTION
## Summary
- use `autoapi.v3.types` for SQLAlchemy session utilities in opspec test

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format tests/unit/test_opspec_effects.py`
- `uv run --package autoapi --directory standards/autoapi ruff check tests/unit/test_opspec_effects.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_opspec_effects.py`

------
https://chatgpt.com/codex/tasks/task_e_68afd3c787208326a6526f9698156800