### PR TITLE
style: reorder imports in info schema tests

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_info_schema_keys.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_info_schema_keys.py
@@ -6,15 +6,16 @@ examples, py_type. Also verifies that hybrid properties are rejected.
 Each key is tested individually using DummyModel instances.
 """
 
-import pytest
 from datetime import datetime, timezone
 from functools import partial
 from typing import get_args
-from autoapi.v3.types import Column, DateTime, Integer, JSON, String, hybrid_property
+
+import pytest
 
 from autoapi.v3 import Base
 from autoapi.v3.mixins import GUIDPk
 from autoapi.v3.schema import _build_schema, check
+from autoapi.v3.types import Column, DateTime, Integer, JSON, String, hybrid_property
 
 
 class DummyModelDisableOn(Base, GUIDPk):


### PR DESCRIPTION
## Summary
- reorder imports in info schema tests for clarity

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_info_schema_keys.py -q`
- `uv run --package autoapi --directory standards/autoapi pytest -q` *(fails: AssertionError and others)*

------
https://chatgpt.com/codex/tasks/task_e_68afd571f7d48326b02781d2978f36e3