### PR TITLE
test: clear metadata after bindings integration

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_bindings_integration.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_bindings_integration.py
@@ -109,3 +109,15 @@ def test_col_info_reexport():
 
     assert col_info.normalize is schema_col_info.normalize
     assert col_info.VALID_KEYS == schema_col_info.VALID_KEYS
+
+
+def teardown_module() -> None:
+    """Clear global SQLAlchemy metadata after tests run.
+
+    Binding models mutates ``Base.metadata`` which leaks tables into
+    subsequent tests.  Explicitly clearing the metadata here ensures each
+    test module starts from a clean slate and avoids cross-test
+    contamination.
+    """
+
+    Base.metadata.clear()


### PR DESCRIPTION
## Summary
- clear global SQLAlchemy metadata after bindings integration tests to prevent leakage into subsequent tests

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_bindings_integration.py`
- `uv run --package autoapi --directory standards/autoapi pytest` *(fails: 20 failed, 566 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68afd874bbf88326b84da2d586d9f5e6