### PR TITLE
test: isolate iospec integration metadata

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_iospec_integration.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_iospec_integration.py
@@ -35,6 +35,7 @@ class Widget(Base, GUIDPk):
 
 @pytest_asyncio.fixture
 async def widget_setup():
+    Base.metadata.clear()
     engine = create_engine(
         "sqlite:///:memory:",
         connect_args={"check_same_thread": False},
@@ -61,6 +62,7 @@ async def widget_setup():
     client = AsyncClient(transport=transport, base_url="http://test")
     yield client, api, SessionLocal
     await client.aclose()
+    Base.metadata.clear()
 
 
 @pytest.mark.i9n


### PR DESCRIPTION
## Summary
- ensure iospec integration tests operate on a clean SQLAlchemy metadata registry

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_iospec_integration.py`
- `uv run --package autoapi --directory standards/autoapi pytest` *(fails: test_column_metadata_runtime.py::test_write_only_field_runtime_behavior, test_column_metadata_runtime.py::test_default_factory_field_runtime_behavior, test_hook_lifecycle.py::test_hook_phases_execution_order[sync], test_hook_lifecycle.py::test_hook_phases_execution_order[async], test_hook_lifecycle.py::test_hook_parity_crud_vs_rpc[sync], test_hook_lifecycle.py::test_hook_parity_crud_vs_rpc[async], test_hook_lifecycle.py::test_hook_error_handling[sync], test_hook_lifecycle.py::test_hook_error_handling[async], test_hook_lifecycle.py::test_hook_early_termination_and_cleanup[sync], test_hook_lifecycle.py::test_hook_early_termination_and_cleanup[async], test_hook_lifecycle.py::test_hook_context_modification[sync], test_hook_lifecycle.py::test_hook_context_modification[async], test_hook_lifecycle.py::test_catch_all_hooks[sync], test_hook_lifecycle.py::test_catch_all_hooks[async], test_hook_lifecycle.py::test_multiple_hooks_same_phase[sync], test_hook_lifecycle.py::test_multiple_hooks_same_phase[async])`

------
https://chatgpt.com/codex/tasks/task_e_68afd961739483268fa52eaa545def9b