### PR TITLE
test: avoid clearing metadata in apikey test

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_apikey_generation.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_apikey_generation.py
@@ -2,7 +2,7 @@ import pytest
 from autoapi.v3.types import App
 from httpx import ASGITransport, AsyncClient
 
-from autoapi.v3 import AutoAPI, Base
+from autoapi.v3 import AutoAPI
 from autoapi.v3.tables import ApiKey
 
 
@@ -11,6 +11,7 @@ class ConcreteApiKey(ApiKey):
 
     __abstract__ = False
     __resource__ = "apikey"
+    __tablename__ = "apikeys_generation"
 
 
 @pytest.mark.i9n
@@ -18,7 +19,6 @@ class ConcreteApiKey(ApiKey):
 async def test_api_key_creation_requires_valid_payload(sync_db_session):
     """Posting without required fields yields a conflict response."""
     _, get_sync_db = sync_db_session
-    Base.metadata.clear()
 
     app = App()
     api = AutoAPI(app=app, get_db=get_sync_db)


### PR DESCRIPTION
## Summary
- stop clearing global metadata in API key generation test
- give test API key table a unique name to avoid collisions

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format tests/i9n/test_apikey_generation.py`
- `uv run --package autoapi --directory standards/autoapi ruff check tests/i9n/test_apikey_generation.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_apikey_generation.py::test_api_key_creation_requires_valid_payload -q`
- `uv run --package autoapi --directory standards/autoapi pytest -q` *(fails: AssertionError: assert 'secret' in {}, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68afdb469f50832684ca29248f88f064