### PR TITLE
Bind models before building column metadata schemas

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_column_metadata_runtime.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_column_metadata_runtime.py
@@ -7,8 +7,9 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from autoapi.v3 import Base
+from autoapi.v3.bindings.model import bind
 from autoapi.v3.mixins import GUIDPk
-from autoapi.v3.schema import _build_schema
+from autoapi.v3.schema import _build_schema, builder as v3_builder
 from autoapi.v3.types import App, Column, DateTime, String, uuid4
 
 
@@ -44,6 +45,8 @@ async def test_write_only_field_runtime_behavior(create_test_api):
         assert res.status_code == 200
         assert "secret" not in res.json()
 
+    v3_builder._SchemaCache.clear()
+    bind(WriteOnlyModel)
     create_schema = _build_schema(WriteOnlyModel, verb="create")
     read_schema = _build_schema(WriteOnlyModel, verb="read")
     update_schema = _build_schema(WriteOnlyModel, verb="update")
@@ -91,6 +94,8 @@ async def test_read_only_field_runtime_behavior(create_test_api):
         assert res.status_code == 200
         assert res.json()["code"] == ro_value
 
+    v3_builder._SchemaCache.clear()
+    bind(ReadOnlyModel)
     create_schema = _build_schema(ReadOnlyModel, verb="create")
     read_schema = _build_schema(ReadOnlyModel, verb="read")
     update_schema = _build_schema(ReadOnlyModel, verb="update")
@@ -138,6 +143,8 @@ async def test_default_factory_field_runtime_behavior(create_test_api):
         new_created_at = datetime.fromisoformat(res.json()["created_at"])
         assert new_created_at > created_at
 
+    v3_builder._SchemaCache.clear()
+    bind(FactoryModel)
     create_schema = _build_schema(FactoryModel, verb="create")
     field = create_schema.model_fields["created_at"]
     assert field.default_factory is not None


### PR DESCRIPTION
## Summary
- bind models and clear schema cache in column metadata runtime tests to ensure stable schema generation

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_column_metadata_runtime.py -q`
- `uv run --package autoapi --directory standards/autoapi pytest` *(fails: tests/i9n/test_write_only_field_runtime_behavior, tests/i9n/test_default_factory_field_runtime_behavior, tests/i9n/test_hook_lifecycle.py::test_hook_phases_execution_order[sync], tests/i9n/test_hook_lifecycle.py::test_hook_phases_execution_order[async], tests/i9n/test_hook_lifecycle.py::test_hook_parity_crud_vs_rpc[sync], tests/i9n/test_hook_lifecycle.py::test_hook_parity_crud_vs_rpc[async], tests/i9n/test_hook_lifecycle.py::test_hook_error_handling[sync], tests/i9n/test_hook_lifecycle.py::test_hook_error_handling[async], tests/i9n/test_hook_lifecycle.py::test_hook_early_termination_and_cleanup[sync], tests/i9n/test_hook_lifecycle.py::test_hook_early_termination_and_cleanup[async], tests/i9n/test_hook_lifecycle.py::test_hook_context_modification[sync], tests/i9n/test_hook_lifecycle.py::test_hook_context_modification[async], tests/i9n/test_hook_lifecycle.py::test_catch_all_hooks[sync], tests/i9n/test_hook_lifecycle.py::test_catch_all_hooks[async], tests/i9n/test_hook_lifecycle.py::test_multiple_hooks_same_phase[sync], tests/i9n/test_hook_lifecycle.py::test_multiple_hooks_same_phase[async])`

------
https://chatgpt.com/codex/tasks/task_e_68afdc9196c88326aa9f67a0715a83c8