### PR TITLE
Handle dict env in owner and tenant policies

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/mixins/ownable.py
+++ b/pkgs/standards/autoapi/autoapi/v3/mixins/ownable.py
@@ -214,7 +214,11 @@ class Ownable:
 
             # write back into both env.params and payload so downstream sees the same view
             if "env" in ctx and ctx["env"] is not None:
-                ctx["env"].params = params
+                env = ctx["env"]
+                if isinstance(env, dict):
+                    env["params"] = params
+                else:
+                    env.params = params
             ctx["payload"] = params
 
         def _before_update(ctx: dict[str, Any]) -> None:
@@ -230,7 +234,11 @@ class Ownable:
                 # treat None/"" as not provided → drop it
                 params.pop("owner_id", None)
                 if "env" in ctx and ctx["env"] is not None:
-                    ctx["env"].params = params
+                    env = ctx["env"]
+                    if isinstance(env, dict):
+                        env["params"] = params
+                    else:
+                        env.params = params
                 ctx["payload"] = params
                 return
 
@@ -255,7 +263,11 @@ class Ownable:
             # normalize stored value
             params["owner_id"] = new_val
             if "env" in ctx and ctx["env"] is not None:
-                ctx["env"].params = params
+                env = ctx["env"]
+                if isinstance(env, dict):
+                    env["params"] = params
+                else:
+                    env.params = params
             ctx["payload"] = params
 
         # Attach (merge) into __autoapi_hooks__ without clobbering existing mappings

--- a/pkgs/standards/autoapi/autoapi/v3/mixins/tenant_bound.py
+++ b/pkgs/standards/autoapi/autoapi/v3/mixins/tenant_bound.py
@@ -153,7 +153,11 @@ class TenantBound(_RowBound):
                     params["tenant_id"] = _normalize_uuid(provided)
 
             if "env" in ctx and ctx["env"] is not None:
-                ctx["env"].params = params
+                env = ctx["env"]
+                if isinstance(env, dict):
+                    env["params"] = params
+                else:
+                    env.params = params
             ctx["payload"] = params
 
         def _before_update(ctx: dict[str, Any]) -> None:
@@ -167,7 +171,11 @@ class TenantBound(_RowBound):
             if _is_missing(params.get("tenant_id")):
                 params.pop("tenant_id", None)
                 if "env" in ctx and ctx["env"] is not None:
-                    ctx["env"].params = params
+                    env = ctx["env"]
+                    if isinstance(env, dict):
+                        env["params"] = params
+                    else:
+                        env.params = params
                 ctx["payload"] = params
                 return
 
@@ -183,7 +191,11 @@ class TenantBound(_RowBound):
 
             params["tenant_id"] = new_val
             if "env" in ctx and ctx["env"] is not None:
-                ctx["env"].params = params
+                env = ctx["env"]
+                if isinstance(env, dict):
+                    env["params"] = params
+                else:
+                    env.params = params
             ctx["payload"] = params
 
         hooks = {**getattr(cls, "__autoapi_hooks__", {})}

--- a/pkgs/standards/autoapi/tests/i9n/test_owner_tenant_policy.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_owner_tenant_policy.py
@@ -107,7 +107,6 @@ def _client_for_owner(
 
 
 @pytest.mark.i9n
-@pytest.mark.xfail(reason="Owner/Tenant policy integration currently unstable")
 def test_owner_policy_runtime_switch():
     user_id = uuid.uuid4()
     tenant_id = uuid.uuid4()
@@ -176,7 +175,6 @@ def _client_for_tenant(
 
 
 @pytest.mark.i9n
-@pytest.mark.xfail(reason="Owner/Tenant policy integration currently unstable")
 def test_tenant_policy_runtime_switch():
     user_id = uuid.uuid4()
     tenant_id = uuid.uuid4()


### PR DESCRIPTION
## Summary
- support dictionaries for ctx.env in Ownable and TenantBound hooks
- enable runtime owner and tenant policy tests

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_owner_tenant_policy.py`
- `uv run --package autoapi --directory standards/autoapi pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68afe77a0abc8326b320261afcdf0b73