### PR TITLE
chore(auto_authn): drop vcols causing annotation errors

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/orm/api_key.py
+++ b/pkgs/standards/auto_authn/auto_authn/orm/api_key.py
@@ -8,12 +8,7 @@ import secrets
 from autoapi.v3.tables import ApiKey as ApiKeyBase
 from autoapi.v3.types import UniqueConstraint, relationship
 from autoapi.v3.mixins import UserMixin
-from autoapi.v3.specs import IO, vcol
 from autoapi.v3 import hook_ctx
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:  # pragma: no cover
-    from .user import User
 
 
 class ApiKey(ApiKeyBase, UserMixin):
@@ -26,11 +21,6 @@ class ApiKey(ApiKeyBase, UserMixin):
         "auto_authn.orm.tables.User",
         back_populates="_api_keys",
         lazy="joined",  # optional: eager load to avoid N+1
-    )
-
-    user: "User" = vcol(
-        read_producer=lambda obj, _ctx: obj._user,
-        io=IO(out_verbs=("read", "list")),
     )
 
     @hook_ctx(ops="create", phase="PRE_HANDLER")

--- a/pkgs/standards/auto_authn/auto_authn/orm/service.py
+++ b/pkgs/standards/auto_authn/auto_authn/orm/service.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 from autoapi.v3.tables import Base
 from autoapi.v3.mixins import GUIDPk, Timestamped, TenantBound, Principal, ActiveToggle
 from autoapi.v3.types import String, relationship
-from autoapi.v3.specs import IO, S, acol, vcol
+from autoapi.v3.specs import S, acol
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .service_key import ServiceKey
+    pass
 
 
 class Service(Base, GUIDPk, Timestamped, TenantBound, Principal, ActiveToggle):
@@ -22,10 +22,6 @@ class Service(Base, GUIDPk, Timestamped, TenantBound, Principal, ActiveToggle):
         "auto_authn.orm.tables.ServiceKey",
         back_populates="_service",
         cascade="all, delete-orphan",
-    )
-    service_keys: list["ServiceKey"] = vcol(
-        read_producer=lambda obj, _ctx: obj._service_keys,
-        io=IO(out_verbs=("read", "list")),
     )
 
 

--- a/pkgs/standards/auto_authn/auto_authn/orm/service_key.py
+++ b/pkgs/standards/auto_authn/auto_authn/orm/service_key.py
@@ -7,14 +7,14 @@ import secrets
 
 from autoapi.v3.tables import ApiKey as ApiKeyBase
 from autoapi.v3.types import PgUUID, UniqueConstraint, relationship
-from autoapi.v3.specs import IO, S, acol, vcol
+from autoapi.v3.specs import S, acol
 from autoapi.v3.specs.storage_spec import ForeignKeySpec
 from autoapi.v3 import hook_ctx
 from uuid import UUID
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .service import Service
+    pass
 
 
 class ServiceKey(ApiKeyBase):
@@ -36,10 +36,6 @@ class ServiceKey(ApiKeyBase):
         "auto_authn.orm.tables.Service",
         back_populates="_service_keys",
         lazy="joined",
-    )
-    service: "Service" = vcol(
-        read_producer=lambda obj, _ctx: obj._service,
-        io=IO(out_verbs=("read", "list")),
     )
 
     @hook_ctx(ops="create", phase="PRE_HANDLER")

--- a/pkgs/standards/auto_authn/auto_authn/orm/user.py
+++ b/pkgs/standards/auto_authn/auto_authn/orm/user.py
@@ -7,7 +7,7 @@ import uuid
 from autoapi.v3.tables import User as UserBase
 from autoapi.v3 import op_ctx, hook_ctx
 from autoapi.v3.types import LargeBinary, String, relationship
-from autoapi.v3.specs import IO, S, acol, vcol
+from autoapi.v3.specs import S, acol
 from typing import TYPE_CHECKING
 
 from fastapi import HTTPException, status
@@ -15,7 +15,7 @@ from fastapi.responses import JSONResponse
 from sqlalchemy import select
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .api_key import ApiKey
+    pass
 
 
 class User(UserBase):
@@ -28,10 +28,6 @@ class User(UserBase):
         "auto_authn.orm.tables.ApiKey",
         back_populates="_user",
         cascade="all, delete-orphan",
-    )
-    api_keys: list["ApiKey"] = vcol(
-        read_producer=lambda obj, _ctx: obj._api_keys,
-        io=IO(out_verbs=("read", "list")),
     )
 
     @hook_ctx(ops=("create", "update"), phase="PRE_HANDLER")


### PR DESCRIPTION
## Summary
- remove virtual API key, service, and user references that required forward type resolution
- avoid SQLAlchemy annotation errors by simplifying auto_authn ORM models

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest` *(fails: ModuleNotFoundError: No module named 'autoapi.v3.hooks')*


------
https://chatgpt.com/codex/tasks/task_e_68afe845b6d08326b9370db96b52ef10