### PR TITLE
fix(peagen): replace ForeignKey with ForeignKeySpec

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/mixins/_RowBound.py
+++ b/pkgs/standards/autoapi/autoapi/v3/mixins/_RowBound.py
@@ -34,7 +34,8 @@ class _RowBound:
             return
 
         hook = cls._make_row_visibility_hook()
-        hooks = {**getattr(cls, "__autoapi_hooks__", {})}
+        hooks_attr = getattr(cls, "__autoapi_hooks__", {})
+        hooks = {**hooks_attr} if isinstance(hooks_attr, dict) else {}
 
         def _append(alias: str, phase: str, fn) -> None:
             phase_map = hooks.get(alias) or {}

--- a/pkgs/standards/peagen/peagen/orm/analysis_result.py
+++ b/pkgs/standards/peagen/peagen/orm/analysis_result.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from autoapi.v3.tables import Base
-from autoapi.v3.types import JSON, PgUUID, Text, ForeignKey, Mapped, relationship
+from autoapi.v3.types import JSON, PgUUID, Text, Mapped, relationship
 from autoapi.v3.mixins import GUIDPk, Timestamped, Ownable, TenantBound
 from autoapi.v3.specs import S, acol
+from autoapi.v3.specs.storage_spec import ForeignKeySpec
 from typing import TYPE_CHECKING
 
 from .users import User
@@ -18,7 +19,7 @@ class AnalysisResult(Base, GUIDPk, Timestamped, TenantBound, Ownable):
     eval_result_id: Mapped[PgUUID] = acol(
         storage=S(
             PgUUID(as_uuid=True),
-            fk=ForeignKey("peagen.eval_results.id", ondelete="CASCADE"),
+            fk=ForeignKeySpec("peagen.eval_results.id", on_delete="CASCADE"),
         )
     )
     summary: Mapped[str | None] = acol(storage=S(Text))

--- a/pkgs/standards/peagen/peagen/orm/eval_result.py
+++ b/pkgs/standards/peagen/peagen/orm/eval_result.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from autoapi.v3.tables import Base
-from autoapi.v3.types import JSON, PgUUID, String, ForeignKey, Mapped, relationship
+from autoapi.v3.types import JSON, PgUUID, String, Mapped, relationship
 from autoapi.v3.mixins import GUIDPk, Timestamped, Ownable, TenantBound
 from autoapi.v3.specs import S, acol
+from autoapi.v3.specs.storage_spec import ForeignKeySpec
 from typing import TYPE_CHECKING
 
 from .users import User
@@ -19,13 +20,13 @@ class EvalResult(Base, GUIDPk, Timestamped, TenantBound, Ownable):
     work_id: Mapped[PgUUID | None] = acol(
         storage=S(
             PgUUID(as_uuid=True),
-            fk=ForeignKey("peagen.works.id", ondelete="CASCADE"),
+            fk=ForeignKeySpec("peagen.works.id", on_delete="CASCADE"),
         )
     )
     label: Mapped[str | None] = acol(storage=S(String))
     metrics: Mapped[dict] = acol(storage=S(JSON, nullable=False))
     owner: Mapped[User] = relationship(User, lazy="selectin")
-    work: Mapped["Work" | None] = relationship(
+    work: Mapped["Work | None"] = relationship(
         "Work", back_populates="eval_results", lazy="selectin"
     )
     analyses: Mapped[list["AnalysisResult"]] = relationship(

--- a/pkgs/standards/peagen/peagen/orm/mixins.py
+++ b/pkgs/standards/peagen/peagen/orm/mixins.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from autoapi.v3.types import (
-    ForeignKey,
     PgUUID,
     String,
     Mapped,
@@ -10,6 +9,7 @@ from autoapi.v3.types import (
     relationship,
 )
 from autoapi.v3.specs import S, acol
+from autoapi.v3.specs.storage_spec import ForeignKeySpec
 
 
 @declarative_mixin
@@ -19,7 +19,7 @@ class RepositoryMixin:
     repository_id: Mapped[PgUUID] = acol(
         storage=S(
             PgUUID(as_uuid=True),
-            fk=ForeignKey("peagen.repositories.id"),
+            fk=ForeignKeySpec("peagen.repositories.id"),
             nullable=False,
         )
     )
@@ -32,7 +32,7 @@ class RepositoryRefMixin:
     repository_id: Mapped[PgUUID | None] = acol(
         storage=S(
             PgUUID(as_uuid=True),
-            fk=ForeignKey("peagen.repositories.id", ondelete="CASCADE"),
+            fk=ForeignKeySpec("peagen.repositories.id", on_delete="CASCADE"),
             nullable=True,
         )
     )

--- a/pkgs/standards/peagen/peagen/orm/project_payload.py
+++ b/pkgs/standards/peagen/peagen/orm/project_payload.py
@@ -7,12 +7,12 @@ from autoapi.v3.types import (
     Text,
     UniqueConstraint,
     PgUUID,
-    ForeignKey,
     Mapped,
     relationship,
 )
 from autoapi.v3.mixins import GUIDPk, Timestamped, TenantBound, Ownable
 from autoapi.v3.specs import S, acol
+from autoapi.v3.specs.storage_spec import ForeignKeySpec
 from typing import TYPE_CHECKING
 
 from .users import User
@@ -32,7 +32,7 @@ class ProjectPayload(Base, GUIDPk, Timestamped, TenantBound, Ownable):
     doe_spec_id: Mapped[PgUUID | None] = acol(
         storage=S(
             PgUUID(as_uuid=True),
-            fk=ForeignKey("peagen.doe_specs.id", ondelete="SET NULL"),
+            fk=ForeignKeySpec("peagen.doe_specs.id", on_delete="SET NULL"),
             nullable=True,
         )
     )
@@ -44,7 +44,7 @@ class ProjectPayload(Base, GUIDPk, Timestamped, TenantBound, Ownable):
     payload: Mapped[dict] = acol(storage=S(JSON, nullable=False))
 
     owner: Mapped[User] = relationship(User, lazy="selectin")
-    doe_spec: Mapped["DoeSpec" | None] = relationship(
+    doe_spec: Mapped["DoeSpec | None"] = relationship(
         "DoeSpec", back_populates="project_payloads", lazy="selectin"
     )
 

--- a/pkgs/standards/peagen/peagen/orm/tasks.py
+++ b/pkgs/standards/peagen/peagen/orm/tasks.py
@@ -10,7 +10,6 @@ from autoapi.v3.types import (
     PgEnum,
     PgUUID,
     Integer,
-    ForeignKey,
     relationship,
     HookProvider,
     Mapped,
@@ -23,6 +22,7 @@ from autoapi.v3.mixins import (
     StatusMixin,
 )
 from autoapi.v3.specs import S, acol
+from autoapi.v3.specs.storage_spec import ForeignKeySpec
 from autoapi.v3 import hook_ctx
 from typing import TYPE_CHECKING
 from peagen.orm.mixins import RepositoryRefMixin
@@ -64,7 +64,9 @@ class Task(
     )
     pool_id: Mapped[PgUUID] = acol(
         storage=S(
-            PgUUID(as_uuid=True), fk=ForeignKey("peagen.pools.id"), nullable=False
+            PgUUID(as_uuid=True),
+            fk=ForeignKeySpec("peagen.pools.id"),
+            nullable=False,
         )
     )
     config_toml: Mapped[str | None] = acol(storage=S(String))

--- a/pkgs/standards/peagen/peagen/orm/workers.py
+++ b/pkgs/standards/peagen/peagen/orm/workers.py
@@ -7,7 +7,6 @@ from autoapi.v3.types import (
     UUID,
     String,
     MutableDict,
-    ForeignKey,
     relationship,
     HookProvider,
     AllowAnonProvider,
@@ -15,6 +14,7 @@ from autoapi.v3.types import (
 )
 from autoapi.v3.mixins import GUIDPk, Timestamped
 from autoapi.v3.specs import S, acol
+from autoapi.v3.specs.storage_spec import ForeignKeySpec
 from autoapi.v3 import hook_ctx
 from peagen.defaults import DEFAULT_POOL_ID, WORKER_KEY, WORKER_TTL
 
@@ -30,7 +30,7 @@ class Worker(Base, GUIDPk, Timestamped, HookProvider, AllowAnonProvider):
     pool_id: Mapped[PgUUID] = acol(
         storage=S(
             PgUUID(as_uuid=True),
-            fk=ForeignKey("peagen.pools.id"),
+            fk=ForeignKeySpec("peagen.pools.id"),
             nullable=False,
             default=DEFAULT_POOL_ID,
         )

--- a/pkgs/standards/peagen/peagen/orm/works.py
+++ b/pkgs/standards/peagen/peagen/orm/works.py
@@ -5,13 +5,13 @@ from autoapi.v3.types import (
     JSON,
     PgUUID,
     Integer,
-    ForeignKey,
     relationship,
     HookProvider,
     Mapped,
 )
 from autoapi.v3.mixins import GUIDPk, Timestamped, StatusMixin
 from autoapi.v3.specs import S, acol
+from autoapi.v3.specs.storage_spec import ForeignKeySpec
 from autoapi.v3 import hook_ctx
 from typing import TYPE_CHECKING
 
@@ -26,7 +26,7 @@ class Work(Base, GUIDPk, Timestamped, StatusMixin, HookProvider):
     __table_args__ = ({"schema": "peagen"},)
     task_id: Mapped[PgUUID] = acol(
         storage=S(
-            PgUUID(as_uuid=True), fk=ForeignKey("peagen.tasks.id"), nullable=False
+            PgUUID(as_uuid=True), fk=ForeignKeySpec("peagen.tasks.id"), nullable=False
         )
     )
     result: Mapped[dict | None] = acol(storage=S(JSON, nullable=True))

--- a/pkgs/standards/peagen/tests/unit/conftest.py
+++ b/pkgs/standards/peagen/tests/unit/conftest.py
@@ -1,7 +1,17 @@
 import uuid
 import pytest
 from pydantic import BaseModel, Field
-from peagen.cli import task_helpers
+import importlib.util
+import sys
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "peagen.cli.task_helpers",
+    Path(__file__).resolve().parents[2] / "peagen" / "cli" / "task_helpers.py",
+)
+task_helpers = importlib.util.module_from_spec(spec)
+sys.modules["peagen.cli.task_helpers"] = task_helpers
+spec.loader.exec_module(task_helpers)
 
 
 class DummyTaskModel(BaseModel):


### PR DESCRIPTION
## Summary
- replace SQLAlchemy ForeignKey usage in peagen ORM models with ForeignKeySpec
- ensure RowBound mixin handles non-mapping hook definitions gracefully
- load task helper module directly in tests to avoid CLI import side effects

## Testing
- `uv run --package peagen --directory standards pytest peagen/tests/i9n/test_worker_crud.py`

------
https://chatgpt.com/codex/tasks/task_e_68afef09f7688326b4bf91446b4c979f