### PR TITLE
test(autoapi): close resources to remove warnings

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_field_spec_effects.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_field_spec_effects.py
@@ -52,6 +52,7 @@ async def fs_app():
         yield client, api, SessionLocal, FSItem
     finally:
         await client.aclose()
+        engine.dispose()
 
 
 @pytest.mark.i9n

--- a/pkgs/standards/autoapi/tests/i9n/test_hook_ctx_v3_i9n.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_hook_ctx_v3_i9n.py
@@ -39,7 +39,7 @@ def create_client(model_cls):
     Base.metadata.create_all(engine)
     transport = ASGITransport(app=app)
     client = AsyncClient(transport=transport, base_url="http://test")
-    return client, api, SessionLocal
+    return client, api, SessionLocal, engine
 
 
 # ---------------------------------------------------------------------------
@@ -60,9 +60,10 @@ async def test_hook_ctx_binding_i9n():
         async def flag(cls, ctx):
             ctx["flagged"] = True
 
-    client, api, _ = create_client(Item)
+    client, api, _, engine = create_client(Item)
     assert any(callable(h) for h in api.hooks.Item.create.PRE_HANDLER)
     await client.aclose()
+    engine.dispose()
 
 
 # ---------------------------------------------------------------------------
@@ -83,11 +84,12 @@ async def test_hook_ctx_request_response_schema_i9n():
         async def modify(cls, ctx):
             ctx["response"].result["hook"] = True
 
-    client, _, _ = create_client(Item)
+    client, _, _, engine = create_client(Item)
     res = await client.post("/item", json={"id": str(uuid4()), "name": "a"})
     assert res.status_code == 201
     assert res.json()["hook"] is True
     await client.aclose()
+    engine.dispose()
 
 
 # ---------------------------------------------------------------------------
@@ -112,10 +114,11 @@ async def test_hook_ctx_columns_i9n():
         async def expose(cls, ctx):
             ctx["response"].result["cols"] = ctx["cols"]
 
-    client, _, _ = create_client(Item)
+    client, _, _, engine = create_client(Item)
     res = await client.post("/item", json={"id": str(uuid4()), "name": "x"})
     assert set(res.json()["cols"]) == {"id", "name"}
     await client.aclose()
+    engine.dispose()
 
 
 # ---------------------------------------------------------------------------
@@ -137,11 +140,12 @@ async def test_hook_ctx_defaults_resolution_i9n():
             ctx.setdefault("payload", {})
             ctx["payload"].setdefault("name", "default")
 
-    client, _, _ = create_client(Item)
+    client, _, _, engine = create_client(Item)
     res = await client.post("/item", json={"id": str(uuid4())})
     assert res.status_code == 201
     assert res.json()["name"] == "default"
     await client.aclose()
+    engine.dispose()
 
 
 # ---------------------------------------------------------------------------
@@ -166,10 +170,11 @@ async def test_hook_ctx_internal_model_i9n():
         async def expose_model(cls, ctx):
             ctx["response"].result["model"] = ctx["model_name"]
 
-    client, _, _ = create_client(Item)
+    client, _, _, engine = create_client(Item)
     res = await client.post("/item", json={"id": str(uuid4()), "name": "a"})
     assert res.json()["model"] == "Item"
     await client.aclose()
+    engine.dispose()
 
 
 # ---------------------------------------------------------------------------
@@ -190,10 +195,11 @@ async def test_hook_ctx_openapi_json_i9n():
         async def noop(cls, ctx):
             pass
 
-    client, _, _ = create_client(Item)
+    client, _, _, engine = create_client(Item)
     res = await client.get("/openapi.json")
     assert "/item" in res.json()["paths"]
     await client.aclose()
+    engine.dispose()
 
 
 # ---------------------------------------------------------------------------
@@ -219,10 +225,11 @@ async def test_hook_ctx_storage_sqlalchemy_i9n():
         async def expose_count(cls, ctx):
             ctx["response"].result["count"] = ctx["count"]
 
-    client, _, _ = create_client(Item)
+    client, _, _, engine = create_client(Item)
     res = await client.post("/item", json={"id": str(uuid4()), "name": "a"})
     assert res.json()["count"] == 1
     await client.aclose()
+    engine.dispose()
 
 
 # ---------------------------------------------------------------------------
@@ -243,10 +250,11 @@ async def test_hook_ctx_rest_call_i9n():
         async def mark(cls, ctx):
             ctx["response"].result["phase"] = "rest"
 
-    client, _, _ = create_client(Item)
+    client, _, _, engine = create_client(Item)
     res = await client.post("/item", json={"id": str(uuid4()), "name": "a"})
     assert res.json()["phase"] == "rest"
     await client.aclose()
+    engine.dispose()
 
 
 # ---------------------------------------------------------------------------
@@ -267,7 +275,7 @@ async def test_hook_ctx_rpc_method_i9n():
         async def mark(cls, ctx):
             ctx["response"].result["phase"] = "rpc"
 
-    client, _, _ = create_client(Item)
+    client, _, _, engine = create_client(Item)
     res = await client.post(
         "/rpc",
         json={
@@ -279,6 +287,7 @@ async def test_hook_ctx_rpc_method_i9n():
     )
     assert res.json()["result"]["phase"] == "rpc"
     await client.aclose()
+    engine.dispose()
 
 
 # ---------------------------------------------------------------------------
@@ -299,13 +308,14 @@ async def test_hook_ctx_core_crud_i9n():
         async def mark(cls, ctx):
             ctx["response"].result["via"] = "core"
 
-    client, api, SessionLocal = create_client(Item)
+    client, api, SessionLocal, engine = create_client(Item)
     with SessionLocal() as session:
         result = await api.core.Item.create(
             {"id": str(uuid4()), "name": "x"}, db=session
         )
     assert result["via"] == "core"
     await client.aclose()
+    engine.dispose()
 
 
 # ---------------------------------------------------------------------------
@@ -326,12 +336,13 @@ async def test_hook_ctx_hookz_i9n():
         async def marker(cls, ctx):
             pass
 
-    client, _, _ = create_client(Item)
+    client, _, _, engine = create_client(Item)
     res = await client.get("/system/hookz")
     data = res.json()
     assert "Item" in data and "create" in data["Item"]
     assert any("marker" in s for s in data["Item"]["create"]["POST_COMMIT"])
     await client.aclose()
+    engine.dispose()
 
 
 # ---------------------------------------------------------------------------
@@ -356,10 +367,11 @@ async def test_hook_ctx_atomz_i9n():
         async def expose(cls, ctx):
             ctx["response"].result["captured"] = ctx["captured"]
 
-    client, _, _ = create_client(Item)
+    client, _, _, engine = create_client(Item)
     res = await client.post("/item", json={"id": str(uuid4()), "name": "alpha"})
     assert res.json()["captured"] == "alpha"
     await client.aclose()
+    engine.dispose()
 
 
 # ---------------------------------------------------------------------------
@@ -380,9 +392,10 @@ async def test_hook_ctx_system_steps_i9n():
         async def marker(cls, ctx):
             pass
 
-    client, _, _ = create_client(Item)
+    client, _, _, engine = create_client(Item)
     res = await client.get("/system/planz")
     data = res.json()
     steps = data["Item"]["create"]
     assert "sys:handler:crud@HANDLER" in steps
     await client.aclose()
+    engine.dispose()

--- a/pkgs/standards/autoapi/tests/i9n/test_nested_routing_depth.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_nested_routing_depth.py
@@ -48,8 +48,8 @@ async def three_level_api_client(db_mode, sync_db_session, async_db_session):
     app = App()
     app.include_router(api.router)
     transport = ASGITransport(app=app)
-    client = AsyncClient(transport=transport, base_url="http://test")
-    return client
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
 
 
 @pytest.mark.i9n

--- a/pkgs/standards/autoapi/tests/i9n/test_request_extras.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_request_extras.py
@@ -64,7 +64,14 @@ async def api_client_with_extras(db_mode):
     app.include_router(api.router)
     transport = ASGITransport(app=app)
     client = AsyncClient(transport=transport, base_url="http://test")
-    return client, api, Widget
+    try:
+        yield client, api, Widget
+    finally:
+        await client.aclose()
+        if db_mode == "async":
+            await engine.dispose()
+        else:
+            engine.dispose()
 
 
 @pytest.mark.i9n

--- a/pkgs/standards/autoapi/tests/i9n/test_schema_ctx_attributes_integration.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_schema_ctx_attributes_integration.py
@@ -48,8 +48,11 @@ async def schema_ctx_client():
     api.attach_diagnostics()
     await api.initialize_async()
 
-    client = AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
-    return client, api, Widget, sessionmaker
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        yield client, api, Widget, sessionmaker
+    await engine.dispose()
 
 
 @pytest.mark.i9n

--- a/pkgs/standards/autoapi/tests/i9n/test_schema_ctx_op_ctx_integration.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_schema_ctx_op_ctx_integration.py
@@ -50,8 +50,11 @@ async def widget_client():
     api.mount_jsonrpc()
     await api.initialize_async()
 
-    client = AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
-    return client, api, Widget
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        yield client, api, Widget
+    await engine.dispose()
 
 
 @pytest.mark.i9n

--- a/pkgs/standards/autoapi/tests/i9n/test_schema_ctx_spec_integration.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_schema_ctx_spec_integration.py
@@ -81,8 +81,11 @@ async def schema_ctx_client():
     api.mount_jsonrpc()
     api.attach_diagnostics()
     await api.initialize_async()
-    client = AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
-    return client, api, Widget, SessionLocal
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        yield client, api, Widget, SessionLocal
+    await engine.dispose()
 
 
 @pytest.mark.i9n

--- a/pkgs/standards/autoapi/tests/i9n/test_v3_bulk_rest_endpoints.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_v3_bulk_rest_endpoints.py
@@ -43,6 +43,7 @@ async def v3_client() -> Iterator[tuple[AsyncClient, type]]:
         yield client, Widget
     finally:
         await client.aclose()
+        engine.dispose()
 
 
 @pytest.mark.asyncio()

--- a/pkgs/standards/autoapi/tests/unit/test_core_crud_default_ops.py
+++ b/pkgs/standards/autoapi/tests/unit/test_core_crud_default_ops.py
@@ -55,8 +55,11 @@ class Widget(Base):
 def session():
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
-    with Session(engine) as s:
-        yield s
+    try:
+        with Session(engine) as s:
+            yield s
+    finally:
+        engine.dispose()
 
 
 @pytest.mark.asyncio

--- a/pkgs/standards/autoapi/tests/unit/test_opspec_effects.py
+++ b/pkgs/standards/autoapi/tests/unit/test_opspec_effects.py
@@ -60,7 +60,9 @@ def hooked_model():
 def _fresh_session():
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(bind=engine)
-    return sessionmaker(bind=engine)()
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    return session, engine
 
 
 # --- tests ---------------------------------------------------------------------
@@ -82,9 +84,10 @@ def test_columns_bound(gadget_model):
 
 def test_defaults_value_resolution(gadget_model):
     bind(gadget_model)
-    db = _fresh_session()
+    db, engine = _fresh_session()
     obj = asyncio.run(_core.create(gadget_model, db=db, data={}))
     assert obj.name == "anon"
+    engine.dispose()
 
 
 def test_internal_model_opspec_binding(gadget_model):
@@ -103,14 +106,15 @@ def test_openapi_includes_path(gadget_model):
 
 def test_storage_and_sqlalchemy_persist(gadget_model):
     bind(gadget_model)
-    db = _fresh_session()
+    db, engine = _fresh_session()
     asyncio.run(_core.create(gadget_model, db=db, data={"name": "stored"}))
     fetched = db.query(gadget_model).one()
     assert fetched.name == "stored"
+    engine.dispose()
 
 
 def test_rest_routes_bound(gadget_model):
-    session = _fresh_session()
+    session, engine = _fresh_session()
 
     def get_db():
         return session
@@ -121,6 +125,7 @@ def test_rest_routes_bound(gadget_model):
     app.include_router(gadget_model.rest.router)
     paths = {route.path for route in app.router.routes}
     assert "/gadget" in paths
+    engine.dispose()
 
 
 def test_rpc_method_bound(gadget_model):


### PR DESCRIPTION
## Summary
- ensure database engines and HTTPX clients are properly closed in autoapi tests
- add clean-up logic to shared test fixtures

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff format .`
- `uv run --directory standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68aff0120a94832687ce849bb7351db3