### PR TITLE
fix(test): adjust userinfo dependency override

### DIFF
--- a/pkgs/standards/auto_authn/tests/unit/test_openid_userinfo_endpoint.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_openid_userinfo_endpoint.py
@@ -27,7 +27,7 @@ async def test_userinfo_returns_claims_json(async_client):
         phone="123",
     )
 
-    async def override_get_current_principal(*args, **kwargs):
+    async def override_get_current_principal():
         return user
 
     app.dependency_overrides[get_current_principal] = override_get_current_principal
@@ -58,7 +58,7 @@ async def test_userinfo_returns_claims_json(async_client):
 async def test_userinfo_signed_jwt(async_client):
     user = MagicMock(id=1, username="bob", email="bob@example.com")
 
-    async def override_get_current_principal(*args, **kwargs):
+    async def override_get_current_principal():
         return user
 
     app.dependency_overrides[get_current_principal] = override_get_current_principal


### PR DESCRIPTION
## Summary
- avoid FastAPI treating dependency override args/kwargs as required query params in UserInfo endpoint tests by switching to parameterless overrides

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest -q tests/unit/test_openid_userinfo_endpoint.py`


------
https://chatgpt.com/codex/tasks/task_e_68aff2b36e78832685a74f36498f66f6