### PR TITLE
feat(auto_authn): add RFC7009 token revocation endpoint

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/app.py
+++ b/pkgs/standards/auto_authn/auto_authn/app.py
@@ -28,6 +28,7 @@ from .oidc_discovery import include_oidc_discovery
 from .rfc8693 import include_rfc8693
 from .rfc7591 import include_rfc7591
 from .oidc_userinfo import include_oidc_userinfo
+from .rfc7009 import include_rfc7009
 
 
 # --------------------------------------------------------------------
@@ -48,6 +49,8 @@ if settings.enable_rfc8693:
 if settings.enable_rfc7591:
     include_rfc7591(app)
 include_oidc_userinfo(app)
+if settings.enable_rfc7009:
+    include_rfc7009(app)
 if settings.enable_rfc8414:
     include_rfc8414(app)
     include_oidc_discovery(app)

--- a/pkgs/standards/auto_authn/auto_authn/rfc7009.py
+++ b/pkgs/standards/auto_authn/auto_authn/rfc7009.py
@@ -11,9 +11,13 @@ from __future__ import annotations
 
 from typing import Final, Set
 
+from fastapi import APIRouter, FastAPI, Form, HTTPException, status
+
 from .runtime_cfg import settings
 
 RFC7009_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc7009"
+
+router = APIRouter()
 
 # In-memory set storing revoked tokens for demonstration and testing purposes
 _REVOKED_TOKENS: Set[str] = set()
@@ -50,9 +54,30 @@ def reset_revocations() -> None:
     _REVOKED_TOKENS.clear()
 
 
+@router.post("/revoked_tokens/revoke")
+async def revoke(token: str = Form(...)) -> dict[str, str]:
+    """RFC 7009 token revocation endpoint."""
+    if not settings.enable_rfc7009:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND, f"RFC 7009 disabled: {RFC7009_SPEC_URL}"
+        )
+    revoke_token(token)
+    return {}
+
+
+def include_rfc7009(app: FastAPI) -> None:
+    """Attach revocation routes to *app* if enabled."""
+    if settings.enable_rfc7009 and not any(
+        route.path == "/revoked_tokens/revoke" for route in app.routes
+    ):
+        app.include_router(router)
+
+
 __all__ = [
     "revoke_token",
     "is_revoked",
     "reset_revocations",
+    "include_rfc7009",
+    "router",
     "RFC7009_SPEC_URL",
 ]

--- a/pkgs/standards/auto_authn/tests/conftest.py
+++ b/pkgs/standards/auto_authn/tests/conftest.py
@@ -123,10 +123,11 @@ def enable_rfc7662():
 def enable_rfc7009():
     """Enable RFC 7009 token revocation for tests."""
     from auto_authn.runtime_cfg import settings
-    from auto_authn.rfc7009 import reset_revocations
+    from auto_authn.rfc7009 import include_rfc7009, reset_revocations
 
     original = settings.enable_rfc7009
     settings.enable_rfc7009 = True
+    include_rfc7009(app)
     reset_revocations()
     try:
         yield


### PR DESCRIPTION
## Summary
- add FastAPI router for RFC7009 token revocation
- wire up router when feature flag enabled
- update tests to include the new router

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc7009_token_revocation.py`


------
https://chatgpt.com/codex/tasks/task_e_68aff2cd86c483268c4312a89bdb323e