### PR TITLE
fix resource indicator tests to include client credentials

### DIFF
--- a/pkgs/standards/auto_authn/tests/unit/test_rfc8707_resource_indicators.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc8707_resource_indicators.py
@@ -15,6 +15,7 @@ from auto_authn.runtime_cfg import settings
 from auto_authn.routers.auth_flows import router, _jwt
 from auto_authn.fastapi_deps import get_async_db
 
+
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_token_includes_aud_when_resource_provided(monkeypatch):
@@ -36,6 +37,8 @@ async def test_token_includes_aud_when_resource_provided(monkeypatch):
                 "grant_type": "password",
                 "username": "u",
                 "password": "p",
+                "client_id": "client",
+                "client_secret": "secret",
                 "resource": "https://rs.example",
             },
         )
@@ -60,6 +63,8 @@ async def test_invalid_resource_returns_error(monkeypatch):
                 "grant_type": "password",
                 "username": "u",
                 "password": "p",
+                "client_id": "client",
+                "client_secret": "secret",
                 "resource": "not-a-uri",
             },
         )
@@ -88,6 +93,8 @@ async def test_multiple_resources_uses_first(monkeypatch):
                 "grant_type": "password",
                 "username": "u",
                 "password": "p",
+                "client_id": "client",
+                "client_secret": "secret",
                 "resource": ["https://rs.example", "https://api.example"],
             },
         )
@@ -112,6 +119,8 @@ async def test_multiple_resources_with_invalid_returns_error(monkeypatch):
                 "grant_type": "password",
                 "username": "u",
                 "password": "p",
+                "client_id": "client",
+                "client_secret": "secret",
                 "resource": ["https://rs.example", "not-a-uri"],
             },
         )
@@ -140,6 +149,8 @@ async def test_feature_flag_disables_resource(monkeypatch):
                 "grant_type": "password",
                 "username": "u",
                 "password": "p",
+                "client_id": "client",
+                "client_secret": "secret",
                 "resource": "https://rs.example",
             },
         )


### PR DESCRIPTION
## Summary
- ensure resource indicator tests authenticate client

## Testing
- `uv run --package auto_authn --directory standards/auto_authn ruff format .`
- `uv run --package auto_authn --directory standards/auto_authn ruff check . --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc8707_resource_indicators.py`


------
https://chatgpt.com/codex/tasks/task_e_68aff2d71edc8326b8d1a11678c1a169