### PR TITLE
fix: filter WebAuthn algs when disabled

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/rfc7518.py
+++ b/pkgs/standards/auto_authn/auto_authn/rfc7518.py
@@ -25,8 +25,9 @@ def supported_algorithms() -> list[str]:
     if settings.enable_rfc8812:
         algs.update(WEBAUTHN_ALGORITHMS)
     else:
-        # Ensure RS256 is always available even when WebAuthn algorithms are
-        # disabled. This is required for OpenID Connect ID Token compliance.
+        # Remove WebAuthn-specific algorithms when RFC 8812 is disabled while
+        # retaining RS256 for OpenID Connect compatibility.
+        algs.difference_update(WEBAUTHN_ALGORITHMS)
         algs.add(JWAAlg.RS256.value)
     return sorted(algs)
 

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc8812_webauthn_algorithms.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc8812_webauthn_algorithms.py
@@ -45,7 +45,8 @@ def test_supported_algorithms_extends_when_enabled(monkeypatch):
     assert "PS256" in algs
     monkeypatch.setattr(runtime_cfg.settings, "enable_rfc8812", False)
     algs = supported_algorithms()
-    assert not any(alg in algs for alg in WEBAUTHN_ALGORITHMS)
+    assert "RS256" in algs
+    assert not any(alg in algs for alg in WEBAUTHN_ALGORITHMS - {"RS256"})
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- remove WebAuthn algorithms from supported list when RFC8812 feature disabled
- adjust tests to expect RS256 retained while others removed

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc8812_webauthn_algorithms.py`


------
https://chatgpt.com/codex/tasks/task_e_68aff2dec6288326b24ac0ef5c5e13b3