### PR TITLE
Fix ORM relationships to infer joins via primary keys

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/orm/api_key.py
+++ b/pkgs/standards/auto_authn/auto_authn/orm/api_key.py
@@ -18,7 +18,7 @@ class ApiKey(ApiKeyBase, UserMixin):
     )
 
     _user = relationship(
-        "auto_authn.orm.tables.User",
+        "auto_authn.orm.user.User",
         back_populates="_api_keys",
         lazy="joined",  # optional: eager load to avoid N+1
     )

--- a/pkgs/standards/auto_authn/auto_authn/orm/service.py
+++ b/pkgs/standards/auto_authn/auto_authn/orm/service.py
@@ -19,7 +19,7 @@ class Service(Base, GUIDPk, Timestamped, TenantBound, Principal, ActiveToggle):
     __table_args__ = ({"schema": "authn"},)
     name: str = acol(storage=S(String(120), unique=True, nullable=False))
     _service_keys = relationship(
-        "auto_authn.orm.tables.ServiceKey",
+        "auto_authn.orm.service_key.ServiceKey",
         back_populates="_service",
         cascade="all, delete-orphan",
     )

--- a/pkgs/standards/auto_authn/auto_authn/orm/service_key.py
+++ b/pkgs/standards/auto_authn/auto_authn/orm/service_key.py
@@ -6,9 +6,14 @@ import hashlib
 import secrets
 
 from autoapi.v3.tables import ApiKey as ApiKeyBase
-from autoapi.v3.types import PgUUID, UniqueConstraint, relationship
-from autoapi.v3.specs import S, acol
-from autoapi.v3.specs.storage_spec import ForeignKeySpec
+from autoapi.v3.types import (
+    PgUUID,
+    UniqueConstraint,
+    relationship,
+    mapped_column,
+    ForeignKey,
+)
+
 from autoapi.v3 import hook_ctx
 from uuid import UUID
 from typing import TYPE_CHECKING
@@ -23,17 +28,15 @@ class ServiceKey(ApiKeyBase):
         UniqueConstraint("digest"),
         {"extend_existing": True, "schema": "authn"},
     )
-    service_id: UUID = acol(
-        storage=S(
-            PgUUID(as_uuid=True),
-            fk=ForeignKeySpec(target="authn.services.id"),
-            index=True,
-            nullable=False,
-        )
+    service_id: UUID = mapped_column(
+        PgUUID(as_uuid=True),
+        ForeignKey("authn.services.id"),
+        index=True,
+        nullable=False,
     )
 
     _service = relationship(
-        "auto_authn.orm.tables.Service",
+        "auto_authn.orm.service.Service",
         back_populates="_service_keys",
         lazy="joined",
     )

--- a/pkgs/standards/auto_authn/auto_authn/orm/user.py
+++ b/pkgs/standards/auto_authn/auto_authn/orm/user.py
@@ -25,7 +25,7 @@ class User(UserBase):
     email: str = acol(storage=S(String(120), nullable=False, unique=True))
     password_hash: bytes | None = acol(storage=S(LargeBinary(60)))
     _api_keys = relationship(
-        "auto_authn.orm.tables.ApiKey",
+        "auto_authn.orm.api_key.ApiKey",
         back_populates="_user",
         cascade="all, delete-orphan",
     )

--- a/pkgs/standards/autoapi/autoapi/v3/mixins/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/mixins/__init__.py
@@ -24,6 +24,8 @@ from ..types import (
     UUID,
     uuid4,
     Mapped,
+    ForeignKey,
+    mapped_column,
 )
 from ..config.constants import CTX_AUTH_KEY, CTX_USER_ID_KEY
 
@@ -104,7 +106,15 @@ class TenantMixin:
             field=F(py_type=UUID, constraints={"examples": [uuid_example]}),
             io=CRUD_IO,
         )
-        return acol(spec=spec)
+        colspec = acol(spec=spec)
+        colspec.__set_name__(cls, "tenant_id")
+        return mapped_column(
+            PgUUID(as_uuid=True),
+            ForeignKey(f"{schema}.tenants.id"),
+            nullable=False,
+            index=True,
+            info={"autoapi": {"spec": spec}},
+        )
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -131,7 +141,15 @@ class UserMixin:
             field=F(py_type=UUID, constraints={"examples": [uuid_example]}),
             io=CRUD_IO,
         )
-        return acol(spec=spec)
+        colspec = acol(spec=spec)
+        colspec.__set_name__(cls, "user_id")
+        return mapped_column(
+            PgUUID(as_uuid=True),
+            ForeignKey(f"{schema}.users.id"),
+            nullable=False,
+            index=True,
+            info={"autoapi": {"spec": spec}},
+        )
 
 
 @declarative_mixin
@@ -155,7 +173,15 @@ class OrgMixin:
             field=F(py_type=UUID, constraints={"examples": [uuid_example]}),
             io=CRUD_IO,
         )
-        return acol(spec=spec)
+        colspec = acol(spec=spec)
+        colspec.__set_name__(cls, "org_id")
+        return mapped_column(
+            PgUUID(as_uuid=True),
+            ForeignKey(f"{schema}.orgs.id"),
+            nullable=False,
+            index=True,
+            info={"autoapi": {"spec": spec}},
+        )
 
 
 @declarative_mixin

--- a/pkgs/standards/autoapi/autoapi/v3/mixins/tenant_bound.py
+++ b/pkgs/standards/autoapi/autoapi/v3/mixins/tenant_bound.py
@@ -17,7 +17,7 @@ from ..config.constants import (
 from ..runtime.errors import create_standardized_error
 from ..specs import ColumnSpec, F, IO, S
 from ..specs.storage_spec import ForeignKeySpec
-from ..types import Mapped, PgUUID, declared_attr
+from ..types import Mapped, PgUUID, declared_attr, ForeignKey, mapped_column
 
 
 log = logging.getLogger(__name__)
@@ -98,7 +98,15 @@ class TenantBound(_RowBound):
             field=F(py_type=UUID),
             io=io,
         )
-        return acol(spec=spec)
+        colspec = acol(spec=spec)
+        colspec.__set_name__(cls, "tenant_id")
+        return mapped_column(
+            PgUUID(as_uuid=True),
+            ForeignKey(f"{schema}.tenants.id"),
+            nullable=False,
+            index=True,
+            info={"autoapi": {"spec": spec}},
+        )
 
     @declared_attr
     def __tablename__(cls):


### PR DESCRIPTION
## Summary
- ensure ORM relationships reference concrete model modules
- inject ForeignKey-based columns in mixins to allow default PK joins
- map service key `service_id` with explicit FK to services

## Testing
- `uv run --package auto_authn --directory standards/auto_authn ruff format auto_authn/orm/api_key.py auto_authn/orm/service.py auto_authn/orm/service_key.py auto_authn/orm/user.py`
- `uv run --package auto_authn --directory standards/auto_authn ruff check auto_authn/orm/api_key.py auto_authn/orm/service.py auto_authn/orm/service_key.py auto_authn/orm/user.py --fix`
- `uv run --package autoapi --directory standards/autoapi ruff format autoapi/v3/mixins/__init__.py`
- `uv run --package autoapi --directory standards/autoapi ruff check autoapi/v3/mixins/__init__.py --fix`
- `uv run --package autoapi --directory standards/autoapi ruff format autoapi/v3/mixins/tenant_bound.py`
- `uv run --package autoapi --directory standards/autoapi ruff check autoapi/v3/mixins/tenant_bound.py --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest` *(fails: 11 failed, 361 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68aff9295b3083269759c31ebd8a0d7c