### PR TITLE
Refactor auth relationships and add login routes

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/orm/api_key.py
+++ b/pkgs/standards/auto_authn/auto_authn/orm/api_key.py
@@ -4,21 +4,30 @@ from __future__ import annotations
 
 import hashlib
 import secrets
+from uuid import UUID
 
 from autoapi.v3.tables import ApiKey as ApiKeyBase
-from autoapi.v3.types import UniqueConstraint, relationship
-from autoapi.v3.mixins import UserMixin
+from autoapi.v3.types import PgUUID, UniqueConstraint, relationship
+from sqlalchemy import ForeignKey
+from sqlalchemy.orm import Mapped, mapped_column
 from autoapi.v3 import hook_ctx
 
 
-class ApiKey(ApiKeyBase, UserMixin):
+class ApiKey(ApiKeyBase):
     __table_args__ = (
         UniqueConstraint("digest"),
         {"extend_existing": True, "schema": "authn"},
     )
 
+    user_id: Mapped[UUID] = mapped_column(
+        PgUUID(as_uuid=True),
+        ForeignKey("authn.users.id"),
+        nullable=False,
+        index=True,
+    )
+
     _user = relationship(
-        "auto_authn.orm.tables.User",
+        "User",
         back_populates="_api_keys",
         lazy="joined",  # optional: eager load to avoid N+1
     )

--- a/pkgs/standards/auto_authn/auto_authn/orm/service.py
+++ b/pkgs/standards/auto_authn/auto_authn/orm/service.py
@@ -19,7 +19,7 @@ class Service(Base, GUIDPk, Timestamped, TenantBound, Principal, ActiveToggle):
     __table_args__ = ({"schema": "authn"},)
     name: str = acol(storage=S(String(120), unique=True, nullable=False))
     _service_keys = relationship(
-        "auto_authn.orm.tables.ServiceKey",
+        "ServiceKey",
         back_populates="_service",
         cascade="all, delete-orphan",
     )

--- a/pkgs/standards/auto_authn/auto_authn/orm/service_key.py
+++ b/pkgs/standards/auto_authn/auto_authn/orm/service_key.py
@@ -7,9 +7,9 @@ import secrets
 
 from autoapi.v3.tables import ApiKey as ApiKeyBase
 from autoapi.v3.types import PgUUID, UniqueConstraint, relationship
-from autoapi.v3.specs import S, acol
-from autoapi.v3.specs.storage_spec import ForeignKeySpec
 from autoapi.v3 import hook_ctx
+from sqlalchemy import ForeignKey
+from sqlalchemy.orm import Mapped, mapped_column
 from uuid import UUID
 from typing import TYPE_CHECKING
 
@@ -23,17 +23,16 @@ class ServiceKey(ApiKeyBase):
         UniqueConstraint("digest"),
         {"extend_existing": True, "schema": "authn"},
     )
-    service_id: UUID = acol(
-        storage=S(
-            PgUUID(as_uuid=True),
-            fk=ForeignKeySpec(target="authn.services.id"),
-            index=True,
-            nullable=False,
-        )
+
+    service_id: Mapped[UUID] = mapped_column(
+        PgUUID(as_uuid=True),
+        ForeignKey("authn.services.id"),
+        index=True,
+        nullable=False,
     )
 
     _service = relationship(
-        "auto_authn.orm.tables.Service",
+        "Service",
         back_populates="_service_keys",
         lazy="joined",
     )

--- a/pkgs/standards/auto_authn/auto_authn/orm/user.py
+++ b/pkgs/standards/auto_authn/auto_authn/orm/user.py
@@ -25,7 +25,7 @@ class User(UserBase):
     email: str = acol(storage=S(String(120), nullable=False, unique=True))
     password_hash: bytes | None = acol(storage=S(LargeBinary(60)))
     _api_keys = relationship(
-        "auto_authn.orm.tables.ApiKey",
+        "ApiKey",
         back_populates="_user",
         cascade="all, delete-orphan",
     )

--- a/pkgs/standards/auto_authn/auto_authn/routers/auth_flows.py
+++ b/pkgs/standards/auto_authn/auto_authn/routers/auth_flows.py
@@ -1,6 +1,60 @@
+"""Authentication flow endpoints such as /login and /logout."""
+
 from __future__ import annotations
 
-from .authz import router as router
+import secrets
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..db import get_async_db
+from ..orm.auth_session import AuthSession
+from .authz import router as authz_router
 from .shared import _jwt, _pwd_backend, AUTH_CODES, SESSIONS
 
-__all__ = ["router", "_jwt", "_pwd_backend", "AUTH_CODES", "SESSIONS"]
+router = APIRouter()
+router.include_router(authz_router)
+
+
+@router.post("/login")
+async def login(request: Request, db: AsyncSession = Depends(get_async_db)):
+    data = await request.json()
+    identifier = data.get("identifier")
+    password = data.get("password")
+    user = await _pwd_backend.authenticate(db, identifier, password)
+    session = AuthSession(
+        id=secrets.token_urlsafe(16),
+        username=user.username,
+        user_id=user.id,
+        tenant_id=user.tenant_id,
+    )
+    db.add(session)
+    auth_time = session.auth_time
+    await db.commit()
+    SESSIONS[session.id] = {
+        "sub": str(user.id),
+        "tid": str(user.tenant_id),
+        "username": user.username,
+        "auth_time": auth_time,
+    }
+    response = JSONResponse({"status": "ok"})
+    response.set_cookie("sid", session.id, httponly=True, samesite="lax")
+    return response
+
+
+@router.post("/logout")
+async def logout(request: Request, db: AsyncSession = Depends(get_async_db)):
+    payload = await request.json()
+    return await AuthSession.handlers.logout.handler(
+        {"request": request, "payload": payload, "db": db}
+    )
+
+
+__all__ = [
+    "router",
+    "_jwt",
+    "_pwd_backend",
+    "AUTH_CODES",
+    "SESSIONS",
+]


### PR DESCRIPTION
## Summary
- simplify ORM relationships to rely on default primary key joins
- add explicit ForeignKey columns for user and service associations
- expose `/login` and `/logout` endpoints for authentication flows

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest` *(fails: MissingGreenlet errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aff9295b3083269759c31ebd8a0d7c