### PR TITLE
refactor: use session.get for client lookup

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/routers/authz/rfc6749.py
+++ b/pkgs/standards/auto_authn/auto_authn/routers/authz/rfc6749.py
@@ -7,7 +7,6 @@ from typing import Any
 
 from fastapi import Depends, HTTPException, Request, status
 from fastapi.responses import JSONResponse
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from pydantic import ValidationError
 
@@ -71,7 +70,7 @@ async def token(
             status_code=status.HTTP_401_UNAUTHORIZED,
             headers={"WWW-Authenticate": "Basic"},
         )
-    client = await db.scalar(select(Client).where(Client.id == client_id))
+    client = await db.get(Client, client_id)
     if not client or not client.verify_secret(client_secret):
         return JSONResponse(
             {"error": "invalid_client"},

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc6749_token_endpoint.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc6749_token_endpoint.py
@@ -21,6 +21,9 @@ class DummyClient:
 
 
 class DummyDB:
+    async def get(self, model, key):  # pragma: no cover - trivial
+        return DummyClient()
+
     async def scalar(self, stmt):  # pragma: no cover - trivial
         return DummyClient()
 


### PR DESCRIPTION
## Summary
- resolve client lookup using AsyncSession.get
- update token endpoint unit test with dummy get method

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc6749_token_endpoint.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68affc00e3fc832682abccf3e7aaa061