### PR TITLE
refactor: annotate auto_authn columns with Mapped

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/orm/auth_session.py
+++ b/pkgs/standards/auto_authn/auto_authn/orm/auth_session.py
@@ -7,8 +7,8 @@ import datetime as dt
 from autoapi.v3.tables import Base
 from autoapi.v3.mixins import TenantMixin, Timestamped, UserMixin
 from autoapi.v3.specs import S, acol
-from autoapi.v3.types import String, TZDateTime
-from autoapi.v3 import op_ctx, hook_ctx
+from autoapi.v3.types import Mapped, String, TZDateTime
+from autoapi.v3 import hook_ctx, op_ctx
 from fastapi import HTTPException, status
 from fastapi.responses import JSONResponse, Response
 
@@ -17,9 +17,9 @@ class AuthSession(Base, Timestamped, UserMixin, TenantMixin):
     __tablename__ = "sessions"
     __table_args__ = ({"schema": "authn"},)
 
-    id: str = acol(storage=S(String(64), primary_key=True))
-    username: str = acol(storage=S(String(120), nullable=False))
-    auth_time: dt.datetime = acol(
+    id: Mapped[str] = acol(storage=S(String(64), primary_key=True))
+    username: Mapped[str] = acol(storage=S(String(120), nullable=False))
+    auth_time: Mapped[dt.datetime] = acol(
         storage=S(
             TZDateTime, nullable=False, default=lambda: dt.datetime.now(dt.timezone.utc)
         )

--- a/pkgs/standards/auto_authn/auto_authn/orm/device_code.py
+++ b/pkgs/standards/auto_authn/auto_authn/orm/device_code.py
@@ -9,7 +9,7 @@ from autoapi.v3.tables import Base
 from autoapi.v3.mixins import Timestamped
 from autoapi.v3.specs import S, acol
 from autoapi.v3.specs.storage_spec import ForeignKeySpec
-from autoapi.v3.types import Boolean, Integer, PgUUID, String, TZDateTime
+from autoapi.v3.types import Boolean, Integer, Mapped, PgUUID, String, TZDateTime
 from autoapi.v3 import op_ctx
 from fastapi import HTTPException, status
 
@@ -25,19 +25,19 @@ class DeviceCode(Base, Timestamped):
     __tablename__ = "device_codes"
     __table_args__ = ({"schema": "authn"},)
 
-    device_code: str = acol(storage=S(String(128), primary_key=True))
-    user_code: str = acol(storage=S(String(32), nullable=False, index=True))
-    client_id: uuid.UUID = acol(
+    device_code: Mapped[str] = acol(storage=S(String(128), primary_key=True))
+    user_code: Mapped[str] = acol(storage=S(String(32), nullable=False, index=True))
+    client_id: Mapped[uuid.UUID] = acol(
         storage=S(
             PgUUID(as_uuid=True),
             fk=ForeignKeySpec(target="authn.clients.id"),
             nullable=False,
         )
     )
-    expires_at: dt.datetime = acol(storage=S(TZDateTime, nullable=False))
-    interval: int = acol(storage=S(Integer, nullable=False))
-    authorized: bool = acol(storage=S(Boolean, nullable=False, default=False))
-    user_id: uuid.UUID | None = acol(
+    expires_at: Mapped[dt.datetime] = acol(storage=S(TZDateTime, nullable=False))
+    interval: Mapped[int] = acol(storage=S(Integer, nullable=False))
+    authorized: Mapped[bool] = acol(storage=S(Boolean, nullable=False, default=False))
+    user_id: Mapped[uuid.UUID | None] = acol(
         storage=S(
             PgUUID(as_uuid=True),
             fk=ForeignKeySpec(target="authn.users.id"),
@@ -45,7 +45,7 @@ class DeviceCode(Base, Timestamped):
             index=True,
         )
     )
-    tenant_id: uuid.UUID | None = acol(
+    tenant_id: Mapped[uuid.UUID | None] = acol(
         storage=S(
             PgUUID(as_uuid=True),
             fk=ForeignKeySpec(target="authn.tenants.id"),

--- a/pkgs/standards/auto_authn/auto_authn/orm/pushed_authorization_request.py
+++ b/pkgs/standards/auto_authn/auto_authn/orm/pushed_authorization_request.py
@@ -7,7 +7,7 @@ import datetime as dt
 from autoapi.v3.tables import Base
 from autoapi.v3.mixins import Timestamped
 from autoapi.v3.specs import S, acol
-from autoapi.v3.types import JSON, String, TZDateTime
+from autoapi.v3.types import JSON, Mapped, String, TZDateTime
 from autoapi.v3 import op_ctx
 from fastapi import HTTPException, status
 
@@ -19,9 +19,9 @@ class PushedAuthorizationRequest(Base, Timestamped):
     __tablename__ = "par_requests"
     __table_args__ = ({"schema": "authn"},)
 
-    request_uri: str = acol(storage=S(String(255), primary_key=True))
-    params: dict = acol(storage=S(JSON, nullable=False))
-    expires_at: dt.datetime = acol(storage=S(TZDateTime, nullable=False))
+    request_uri: Mapped[str] = acol(storage=S(String(255), primary_key=True))
+    params: Mapped[dict] = acol(storage=S(JSON, nullable=False))
+    expires_at: Mapped[dt.datetime] = acol(storage=S(TZDateTime, nullable=False))
 
     @op_ctx(alias="par", target="create", arity="collection")
     async def par(cls, ctx):

--- a/pkgs/standards/auto_authn/auto_authn/orm/revoked_token.py
+++ b/pkgs/standards/auto_authn/auto_authn/orm/revoked_token.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from autoapi.v3.tables import Base
 from autoapi.v3.mixins import Timestamped
 from autoapi.v3.specs import S, acol
-from autoapi.v3.types import String
+from autoapi.v3.types import Mapped, String
 from autoapi.v3 import op_ctx
 from fastapi import HTTPException, status
 
@@ -17,7 +17,7 @@ class RevokedToken(Base, Timestamped):
     __tablename__ = "revoked_tokens"
     __table_args__ = ({"schema": "authn"},)
 
-    token: str = acol(storage=S(String(512), primary_key=True))
+    token: Mapped[str] = acol(storage=S(String(512), primary_key=True))
 
     @op_ctx(alias="revoke", target="create", arity="collection")
     async def revoke(cls, ctx):

--- a/pkgs/standards/auto_authn/auto_authn/orm/service.py
+++ b/pkgs/standards/auto_authn/auto_authn/orm/service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from autoapi.v3.tables import Base
 from autoapi.v3.mixins import GUIDPk, Timestamped, TenantBound, Principal, ActiveToggle
-from autoapi.v3.types import String, relationship
+from autoapi.v3.types import Mapped, String, relationship
 from autoapi.v3.specs import S, acol
 from typing import TYPE_CHECKING
 
@@ -17,7 +17,7 @@ class Service(Base, GUIDPk, Timestamped, TenantBound, Principal, ActiveToggle):
 
     __tablename__ = "services"
     __table_args__ = ({"schema": "authn"},)
-    name: str = acol(storage=S(String(120), unique=True, nullable=False))
+    name: Mapped[str] = acol(storage=S(String(120), unique=True, nullable=False))
     _service_keys = relationship(
         "auto_authn.orm.tables.ServiceKey",
         back_populates="_service",

--- a/pkgs/standards/auto_authn/auto_authn/orm/service_key.py
+++ b/pkgs/standards/auto_authn/auto_authn/orm/service_key.py
@@ -6,7 +6,7 @@ import hashlib
 import secrets
 
 from autoapi.v3.tables import ApiKey as ApiKeyBase
-from autoapi.v3.types import PgUUID, UniqueConstraint, relationship
+from autoapi.v3.types import Mapped, PgUUID, UniqueConstraint, relationship
 from autoapi.v3.specs import S, acol
 from autoapi.v3.specs.storage_spec import ForeignKeySpec
 from autoapi.v3 import hook_ctx
@@ -23,7 +23,7 @@ class ServiceKey(ApiKeyBase):
         UniqueConstraint("digest"),
         {"extend_existing": True, "schema": "authn"},
     )
-    service_id: UUID = acol(
+    service_id: Mapped[UUID] = acol(
         storage=S(
             PgUUID(as_uuid=True),
             fk=ForeignKeySpec(target="authn.services.id"),

--- a/pkgs/standards/auto_authn/auto_authn/orm/tenant.py
+++ b/pkgs/standards/auto_authn/auto_authn/orm/tenant.py
@@ -7,7 +7,7 @@ import uuid
 from autoapi.v3.tables import Tenant as TenantBase
 from autoapi.v3.mixins import Bootstrappable
 from autoapi.v3.specs import acol, S
-from autoapi.v3.types import String
+from autoapi.v3.types import Mapped, String
 
 
 class Tenant(TenantBase, Bootstrappable):
@@ -17,8 +17,8 @@ class Tenant(TenantBase, Bootstrappable):
             "schema": "authn",
         },
     )
-    name: str = acol(storage=S(String, nullable=False, unique=True))
-    email: str = acol(storage=S(String, nullable=False, unique=True))
+    name: Mapped[str] = acol(storage=S(String, nullable=False, unique=True))
+    email: Mapped[str] = acol(storage=S(String, nullable=False, unique=True))
     DEFAULT_ROWS = [
         {
             "id": uuid.UUID("FFFFFFFF-0000-0000-0000-000000000000"),

--- a/pkgs/standards/auto_authn/auto_authn/orm/user.py
+++ b/pkgs/standards/auto_authn/auto_authn/orm/user.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import uuid
 
 from autoapi.v3.tables import User as UserBase
-from autoapi.v3 import op_ctx, hook_ctx
-from autoapi.v3.types import LargeBinary, String, relationship
+from autoapi.v3 import hook_ctx, op_ctx
+from autoapi.v3.types import LargeBinary, Mapped, String, relationship
 from autoapi.v3.specs import S, acol
 from typing import TYPE_CHECKING
 
@@ -22,8 +22,8 @@ class User(UserBase):
     """Human principal with authentication credentials."""
 
     __table_args__ = ({"extend_existing": True, "schema": "authn"},)
-    email: str = acol(storage=S(String(120), nullable=False, unique=True))
-    password_hash: bytes | None = acol(storage=S(LargeBinary(60)))
+    email: Mapped[str] = acol(storage=S(String(120), nullable=False, unique=True))
+    password_hash: Mapped[bytes | None] = acol(storage=S(LargeBinary(60)))
     _api_keys = relationship(
         "auto_authn.orm.tables.ApiKey",
         back_populates="_user",


### PR DESCRIPTION
## Summary
- use SQLAlchemy `Mapped` typing for all ORM column declarations in auto_authn

## Testing
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff format .`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check . --fix`
- `cd pkgs && uv run --package auto_authn --directory standards/auto_authn pytest` *(fails: 20 failed, 202 passed, 4 skipped, 77 deselected, 213 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68affdbcdd888326b2ced19b075f124e