### PR TITLE
fix: ensure SSH key provider available

### DIFF
--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "swarmauri_standard",
     "swarmauri",
     "swarmauri_prompt_j2prompttemplate",
+    "swarmauri_keyprovider_ssh",
 
     "pydantic-settings>=2.2", 
     "pydantic[email]>=2.7", # why is this necessary?
@@ -96,6 +97,7 @@ swarmauri_standard = { workspace = true }
 autoapi = { workspace = true }
 autoapi_client = { workspace = true }
 auto_authn = { workspace = true }
+swarmauri_keyprovider_ssh = { workspace = true }
 
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary
- include swarmauri_keyprovider_ssh dependency so public key CLI can generate key pairs

## Testing
- `uv run --package peagen --directory standards/peagen ruff format .`
- `uv run --package peagen --directory standards/peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_publickey_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68b001fefb408326ba6e15c8d2b9afea