### PR TITLE
fix extras CLI tests

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_extras_cli.py
+++ b/pkgs/standards/peagen/tests/unit/test_extras_cli.py
@@ -27,7 +27,6 @@ def test_extras_cli_generates_schemas(monkeypatch, tmp_path):
     result = runner.invoke(
         local_extras_app,
         [
-            "extras",
             "--repo",
             "repo",
             "--ref",
@@ -66,7 +65,7 @@ def test_extras_cli_handles_error(monkeypatch):
     runner = CliRunner()
     result = runner.invoke(
         local_extras_app,
-        ["extras", "--repo", "repo"],
+        ["--repo", "repo"],
         obj={"pool": "default"},
     )
 


### PR DESCRIPTION
## Summary
- adjust extras CLI test invocations to call default command

## Testing
- `uv run --package peagen --directory standards/peagen ruff format tests/unit/test_extras_cli.py`
- `uv run --package peagen --directory standards/peagen ruff check tests/unit/test_extras_cli.py --fix`
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_extras_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0020bf2c8832690a0cdc3214f7c05