### PR TITLE
fix alembic migration test

### DIFF
--- a/pkgs/standards/peagen/peagen/migrations/env.py
+++ b/pkgs/standards/peagen/peagen/migrations/env.py
@@ -25,12 +25,15 @@ elif pg_host and pg_db and pg_user:
 else:
     dsn = "sqlite+aiosqlite:///./gateway.db"
 
-engine = create_async_engine(
-    dsn,
-    pool_size=10,
-    max_overflow=20,
-    echo=False,
-)
+engine_kwargs = {
+    "pool_size": 10,
+    "max_overflow": 20,
+    "echo": False,
+}
+if dsn.startswith("sqlite"):
+    engine_kwargs["execution_options"] = {"schema_translate_map": {"peagen": None}}
+
+engine = create_async_engine(dsn, **engine_kwargs)
 
 config = context.config
 if config.config_file_name is not None:

--- a/pkgs/standards/peagen/tests/unit/test_alembic_integration.py
+++ b/pkgs/standards/peagen/tests/unit/test_alembic_integration.py
@@ -50,7 +50,10 @@ def test_alembic_upgrade_and_current(tmp_path):
     from peagen.orm import Base
 
     async def init_db() -> None:
-        engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+        engine = create_async_engine(
+            f"sqlite+aiosqlite:///{db_path}",
+            execution_options={"schema_translate_map": {"peagen": None}},
+        )
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
         await engine.dispose()


### PR DESCRIPTION
## Summary
- handle SQLite schema in Alembic env by translating `peagen` schema to default
- update Alembic integration test to use schema translation when initializing SQLite engine

## Testing
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_alembic_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_68b00213d6508326bbe557773ee0a805