### PR TITLE
fix plugin manager perf test cache

### DIFF
--- a/pkgs/standards/peagen/tests/perf/test_plugin_manager_perf.py
+++ b/pkgs/standards/peagen/tests/perf/test_plugin_manager_perf.py
@@ -5,6 +5,7 @@ import pytest
 
 import peagen.plugins as plugins
 from peagen.plugins import PluginManager
+from swarmauri_base.keys import KeyProviderBase
 
 
 def _reset_plugins(monkeypatch):
@@ -26,7 +27,16 @@ def test_plugin_discovery_cached(monkeypatch):
             module = "peagen.dummy"
 
             def load(self):
-                return object
+                if group == "swarmauri.key_providers":
+
+                    class Dummy(KeyProviderBase):
+                        pass
+                else:
+
+                    class Dummy:
+                        pass
+
+                return Dummy
 
         return [EP()]
 


### PR DESCRIPTION
## Summary
- make plugin manager perf test use a KeyProviderBase subclass for key_providers group

## Testing
- `uv run --package peagen --directory standards/peagen pytest tests/perf/test_plugin_manager_perf.py`


------
https://chatgpt.com/codex/tasks/task_e_68b00225d66c8326a53300a2a197d5ce