### PR TITLE
fix: expose settings in orm tables for tests

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/orm/tables.py
+++ b/pkgs/standards/auto_authn/auto_authn/orm/tables.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from autoapi.v3.tables import Base
 
+from ..runtime_cfg import settings
 from .api_key import ApiKey
 from .auth_code import AuthCode
 from .auth_session import AuthSession
@@ -31,4 +32,5 @@ __all__ = [
     "RevokedToken",
     "PushedAuthorizationRequest",
     "_CLIENT_ID_RE",
+    "settings",
 ]


### PR DESCRIPTION
## Summary
- export runtime settings in `auto_authn.orm.tables` for monkeypatching

## Testing
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff format .`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check . --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc8252_native_app_redirects.py::test_client_new_allows_public_redirect_when_disabled -q`


------
https://chatgpt.com/codex/tasks/task_e_68b007c9e1e08326915fc41916cd9324