### PR TITLE
Add login route and fix OIDC authorize flow

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/routers/auth_flows.py
+++ b/pkgs/standards/auto_authn/auto_authn/routers/auth_flows.py
@@ -1,6 +1,61 @@
 from __future__ import annotations
 
+import asyncio
+import secrets
+
+from fastapi import Depends, HTTPException, Request, status
+from fastapi.responses import JSONResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..backends import AuthError
+from ..fastapi_deps import get_async_db
+from ..oidc_id_token import mint_id_token
+from ..orm.auth_session import AuthSession
+from ..routers.schemas import CredsIn, TokenPair
+from ..rfc8414_metadata import ISSUER
 from .authz import router as router
 from .shared import _jwt, _pwd_backend, AUTH_CODES, SESSIONS
+
+
+@router.post("/login", response_model=TokenPair)
+async def login(
+    creds: CredsIn,
+    request: Request,
+    db: AsyncSession = Depends(get_async_db),
+):
+    try:
+        user = await _pwd_backend.authenticate(db, creds.identifier, creds.password)
+    except AuthError:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "invalid credentials")
+    session_id = secrets.token_urlsafe(16)
+    payload = {
+        "id": session_id,
+        "user_id": user.id,
+        "tenant_id": user.tenant_id,
+        "username": user.username,
+    }
+    session = await AuthSession.handlers.create.core({"db": db, "payload": payload})
+    access, refresh = await _jwt.async_sign_pair(
+        sub=str(user.id), tid=str(user.tenant_id), scope="openid profile email"
+    )
+    SESSIONS[session.id] = {
+        "sub": str(user.id),
+        "tid": str(user.tenant_id),
+        "username": user.username,
+        "auth_time": session.auth_time,
+    }
+    id_token = await asyncio.to_thread(
+        mint_id_token,
+        sub=str(user.id),
+        aud=ISSUER,
+        nonce=secrets.token_urlsafe(8),
+        issuer=ISSUER,
+        sid=session.id,
+    )
+    pair = {"access_token": access, "refresh_token": refresh, "id_token": id_token}
+    response = JSONResponse(pair)
+    response.set_cookie("sid", session.id, httponly=True, samesite="lax")
+    return response
+
 
 __all__ = ["router", "_jwt", "_pwd_backend", "AUTH_CODES", "SESSIONS"]

--- a/pkgs/standards/auto_authn/auto_authn/routers/authz/oidc.py
+++ b/pkgs/standards/auto_authn/auto_authn/routers/authz/oidc.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import secrets
 from datetime import datetime, timedelta
@@ -66,11 +67,7 @@ async def authorize(
     if "login" in prompts:
         session = None
     if session is None:
-        if "none" in prompts:
-            raise HTTPException(
-                status.HTTP_401_UNAUTHORIZED, {"error": "login_required"}
-            )
-        raise HTTPException(status.HTTP_401_UNAUTHORIZED, {"error": "access_denied"})
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, {"error": "login_required"})
     if max_age is not None:
         auth_time = session.get("auth_time")
         if auth_time is None or datetime.utcnow() - auth_time > timedelta(
@@ -86,7 +83,7 @@ async def authorize(
         raise HTTPException(status.HTTP_400_BAD_REQUEST, {"error": "invalid_request"})
     if code_challenge_method and code_challenge_method != "S256":
         raise HTTPException(status.HTTP_400_BAD_REQUEST, {"error": "invalid_request"})
-    mode = response_mode or "query"
+    mode = response_mode or ("fragment" if rts & {"token", "id_token"} else "query")
     if mode not in {"query", "fragment", "form_post"}:
         raise HTTPException(
             status.HTTP_400_BAD_REQUEST, {"error": "unsupported_response_mode"}
@@ -143,7 +140,8 @@ async def authorize(
             extra_claims["at_hash"] = oidc_hash(access)
         if code:
             extra_claims["c_hash"] = oidc_hash(code)
-        id_token = mint_id_token(
+        id_token = await asyncio.to_thread(
+            mint_id_token,
             sub=user_sub,
             aud=client_id,
             nonce=nonce,


### PR DESCRIPTION
## Summary
- expose `/login` endpoint to create sessions and issue tokens
- fix OIDC authorize default response mode and login-required handling
- avoid event-loop conflicts when minting and verifying ID tokens

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_authorize_id_token_hashes.py tests/unit/test_authorize_response_modes.py tests/unit/test_oidc_authorize_scope_nonce.py -q --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_68b007f8bfa48326a9e25b24fea6612c