### PR TITLE
fix: restore config after RFC8252 tests

### DIFF
--- a/pkgs/standards/auto_authn/tests/unit/test_rfc8252_native_app_redirects.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc8252_native_app_redirects.py
@@ -99,5 +99,5 @@ def test_client_new_allows_public_redirect_when_disabled(monkeypatch) -> None:
     assert client.redirect_uris == "http://example.com/callback"
     monkeypatch.setenv("AUTO_AUTHN_ENFORCE_RFC8252", "1")
     importlib.reload(runtime_cfg)
-    monkeypatch.setattr(orm_tables, "settings", runtime_cfg.settings)
-    monkeypatch.setattr(orm_client, "settings", runtime_cfg.settings)
+    orm_tables.settings = runtime_cfg.settings
+    orm_client.settings = runtime_cfg.settings


### PR DESCRIPTION
## Summary
- ensure RFC8252 native redirect tests restore runtime config

## Testing
- `uv run --package auto_authn --directory standards/auto_authn ruff format tests/unit/test_rfc8252_native_app_redirects.py`
- `uv run --package auto_authn --directory standards/auto_authn ruff check tests/unit/test_rfc8252_native_app_redirects.py --fix`
- `uv run --package auto_authn --directory standards/auto_authn ruff format .`
- `uv run --package auto_authn --directory standards/auto_authn ruff check . --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc8252_native_app_redirects.py`


------
https://chatgpt.com/codex/tasks/task_e_68b00a561b288326b6da7bacba72a6b9