### PR TITLE
test: set git user for repo init

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_init_core_init_repo.py
+++ b/pkgs/standards/peagen/tests/unit/test_init_core_init_repo.py
@@ -17,6 +17,8 @@ def test_init_repo_configures_and_pushes(
     repo = Repo.init(repo_dir)
     (repo_dir / "README.md").write_text("hi")
     repo.git.add(all=True)
+    repo.git.config("user.email", "test@example.com")
+    repo.git.config("user.name", "Test User")
     repo.git.commit("-m", "init")
 
     gh = GithubMock.return_value


### PR DESCRIPTION
## Summary
- set git user and email for tests creating repos

## Testing
- `uv run --directory standards/peagen --package peagen pytest tests/unit/test_init_core_init_repo.py`


------
https://chatgpt.com/codex/tasks/task_e_68b010fb10e48326a60387fb8d56ea3d