### PR TITLE
Fix async JWE/JWS handling in auto_authn

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/oidc_id_token.py
+++ b/pkgs/standards/auto_authn/auto_authn/oidc_id_token.py
@@ -131,7 +131,7 @@ async def mint_id_token(
     )
     if settings.enable_id_token_encryption:
         key = {"kty": "oct", "k": settings.id_token_encryption_key.encode()}
-        token = encrypt_jwe(token, key)
+        token = await encrypt_jwe(token, key)
     return token
 
 
@@ -141,7 +141,7 @@ async def verify_id_token(
     """Verify *token* and return its claims if valid."""
     if settings.enable_id_token_encryption:
         key = {"kty": "oct", "k": settings.id_token_encryption_key.encode()}
-        token = decrypt_jwe(token, key)
+        token = await decrypt_jwe(token, key)
     if _header_alg(token) in {"", "none"}:
         raise InvalidTokenError("unsigned JWTs are not accepted")
     svc, _ = await _service()

--- a/pkgs/standards/auto_authn/auto_authn/rfc7515.py
+++ b/pkgs/standards/auto_authn/auto_authn/rfc7515.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from typing import Any, Final, Mapping
 
 from .deps import JWAAlg, JwsSignerVerifier
@@ -13,21 +12,19 @@ RFC7515_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc7515"
 _signer = JwsSignerVerifier()
 
 
-def sign_jws(payload: str, key: Mapping[str, Any]) -> str:
+async def sign_jws(payload: str, key: Mapping[str, Any]) -> str:
     """Return a JWS compact serialization of *payload* using *key*."""
     if not settings.enable_rfc7515:
         raise RuntimeError(f"RFC 7515 support disabled: {RFC7515_SPEC_URL}")
     alg = JWAAlg.HS256 if key.get("kty") == "oct" else JWAAlg.EDDSA
-    return asyncio.run(_signer.sign_compact(payload=payload, alg=alg, key=key))
+    return await _signer.sign_compact(payload=payload, alg=alg, key=key)
 
 
-def verify_jws(token: str, key: Mapping[str, Any]) -> str:
+async def verify_jws(token: str, key: Mapping[str, Any]) -> str:
     """Verify *token* and return the decoded payload as a string."""
     if not settings.enable_rfc7515:
         raise RuntimeError(f"RFC 7515 support disabled: {RFC7515_SPEC_URL}")
-    result = asyncio.run(
-        _signer.verify_compact(token, jwks_resolver=lambda _k, _a: key)
-    )
+    result = await _signer.verify_compact(token, jwks_resolver=lambda _k, _a: key)
     return result.payload.decode()
 
 

--- a/pkgs/standards/auto_authn/auto_authn/rfc7516.py
+++ b/pkgs/standards/auto_authn/auto_authn/rfc7516.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import base64
 from typing import Any, Final, Mapping
 
@@ -28,27 +27,25 @@ def _normalize_oct_key(key: Mapping[str, Any]) -> Mapping[str, Any]:
     return key
 
 
-def encrypt_jwe(plaintext: str, key: Mapping[str, Any]) -> str:
+async def encrypt_jwe(plaintext: str, key: Mapping[str, Any]) -> str:
     """Encrypt *plaintext* for *key* and return the compact JWE string."""
     if not settings.enable_rfc7516:
         raise RuntimeError(f"RFC 7516 support disabled: {RFC7516_SPEC_URL}")
     norm_key = _normalize_oct_key(key)
-    return asyncio.run(
-        _crypto.encrypt_compact(
-            payload=plaintext,
-            alg=JWAAlg.DIR,
-            enc=JWAAlg.A256GCM,
-            key=norm_key,
-        )
+    return await _crypto.encrypt_compact(
+        payload=plaintext,
+        alg=JWAAlg.DIR,
+        enc=JWAAlg.A256GCM,
+        key=norm_key,
     )
 
 
-def decrypt_jwe(token: str, key: Mapping[str, Any]) -> str:
+async def decrypt_jwe(token: str, key: Mapping[str, Any]) -> str:
     """Decrypt *token* with *key* and return the plaintext string."""
     if not settings.enable_rfc7516:
         raise RuntimeError(f"RFC 7516 support disabled: {RFC7516_SPEC_URL}")
     norm_key = _normalize_oct_key(key)
-    res = asyncio.run(_crypto.decrypt_compact(token, dir_key=norm_key.get("k")))
+    res = await _crypto.decrypt_compact(token, dir_key=norm_key.get("k"))
     return res.plaintext.decode()
 
 

--- a/pkgs/standards/auto_authn/auto_authn/rfc7520.py
+++ b/pkgs/standards/auto_authn/auto_authn/rfc7520.py
@@ -16,20 +16,20 @@ from .rfc7516 import encrypt_jwe, decrypt_jwe
 RFC7520_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc7520"
 
 
-def jws_then_jwe(payload: str, key: dict) -> str:
+async def jws_then_jwe(payload: str, key: dict) -> str:
     """Sign *payload* then encrypt the resulting JWS."""
     if not settings.enable_rfc7520:
         raise RuntimeError(f"RFC 7520 support disabled: {RFC7520_SPEC_URL}")
-    jws_token = sign_jws(payload, key)
-    return encrypt_jwe(jws_token, key)
+    jws_token = await sign_jws(payload, key)
+    return await encrypt_jwe(jws_token, key)
 
 
-def jwe_then_jws(token: str, key: dict) -> str:
+async def jwe_then_jws(token: str, key: dict) -> str:
     """Decrypt a JWE then verify the contained JWS."""
     if not settings.enable_rfc7520:
         raise RuntimeError(f"RFC 7520 support disabled: {RFC7520_SPEC_URL}")
-    jws_token = decrypt_jwe(token, key)
-    return verify_jws(jws_token, key)
+    jws_token = await decrypt_jwe(token, key)
+    return await verify_jws(jws_token, key)
 
 
 __all__ = ["jws_then_jwe", "jwe_then_jws", "RFC7520_SPEC_URL"]

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7515_jws.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7515_jws.py
@@ -2,6 +2,7 @@
 
 import base64
 import secrets
+import asyncio
 
 from auto_authn import sign_jws, verify_jws
 
@@ -15,5 +16,5 @@ def test_sign_and_verify_jws() -> None:
         "k": base64.urlsafe_b64encode(secret).rstrip(b"=").decode(),
     }
     payload = "payload"
-    token = sign_jws(payload, key)
-    assert verify_jws(token, key) == payload
+    token = asyncio.run(sign_jws(payload, key))
+    assert asyncio.run(verify_jws(token, key)) == payload

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7516_jwe.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7516_jwe.py
@@ -1,5 +1,6 @@
 """Tests for RFC 7516: JSON Web Encryption (JWE)."""
 
+import asyncio
 from secrets import token_bytes
 
 from auto_authn import decrypt_jwe, encrypt_jwe
@@ -8,5 +9,5 @@ from auto_authn import decrypt_jwe, encrypt_jwe
 def test_encrypt_and_decrypt_jwe() -> None:
     key = {"kty": "oct", "k": token_bytes(32)}
     secret = "sensitive"
-    token = encrypt_jwe(secret, key)
-    assert decrypt_jwe(token, key) == secret
+    token = asyncio.run(encrypt_jwe(secret, key))
+    assert asyncio.run(decrypt_jwe(token, key)) == secret

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7520_examples.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7520_examples.py
@@ -8,6 +8,7 @@ import importlib
 
 import base64
 import secrets
+import asyncio
 
 import pytest
 
@@ -29,8 +30,8 @@ def _generate_oct_key() -> dict:
 def test_jws_then_jwe_roundtrip() -> None:
     key = _generate_oct_key()
     message = "hello"
-    token = jws_then_jwe(message, key)
-    assert jwe_then_jws(token, key) == message
+    token = asyncio.run(jws_then_jwe(message, key))
+    assert asyncio.run(jwe_then_jws(token, key)) == message
 
 
 def test_rfc7520_disabled(monkeypatch) -> None:
@@ -41,7 +42,7 @@ def test_rfc7520_disabled(monkeypatch) -> None:
     importlib.reload(rfc7520)
     key = _generate_oct_key()
     with pytest.raises(RuntimeError):
-        rfc7520.jws_then_jwe("hi", key)
+        asyncio.run(rfc7520.jws_then_jwe("hi", key))
 
 
 def test_spec_url_constant() -> None:


### PR DESCRIPTION
## Summary
- make JWE and JWS helpers async to avoid nested event loop errors
- await encryption in ID token flow and update JOSE composition helpers
- adjust unit tests for new async APIs

## Testing
- `uv run --package auto_authn --directory standards/auto_authn ruff format .`
- `uv run --package auto_authn --directory standards/auto_authn ruff check . --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b010a3102c8326bdad741b96417b86