### PR TITLE
Fix evolve CLI task assertion

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_evolve_cli.py
+++ b/pkgs/standards/peagen/tests/unit/test_evolve_cli.py
@@ -1,5 +1,6 @@
 import pytest
 from peagen.cli.task_helpers import build_task
+from peagen.orm import Action
 
 
 @pytest.mark.unit
@@ -11,5 +12,5 @@ def test_build_task_payload():
         repo="repo",
         ref="HEAD",
     )
-    assert task.action == "evolve"
+    assert task.action == Action.EVOLVE
     assert task.args == {"evolve_spec": "foo.yaml"}


### PR DESCRIPTION
## Summary
- update evolve CLI task test to expect Action enum

## Testing
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_evolve_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68b01e2b50108326bf92a53ae92e4934