### PR TITLE
chore: remove storage adapter deprecation warnings

### DIFF
--- a/pkgs/standards/swarmauri_storage_file/swarmauri_storage_file/file_storage_adapter.py
+++ b/pkgs/standards/swarmauri_storage_file/swarmauri_storage_file/file_storage_adapter.py
@@ -9,15 +9,8 @@ from __future__ import annotations
 import io
 import os
 import shutil
-import warnings
 from pathlib import Path
 from typing import BinaryIO
-
-warnings.warn(
-    "FileStorageAdapter is deprecated; use peagen.plugins.git_filters.file_filter instead",
-    DeprecationWarning,
-    stacklevel=2,
-)
 
 
 class FileStorageAdapter:

--- a/pkgs/standards/swarmauri_storage_github/swarmauri_storage_github/github_storage_adapter.py
+++ b/pkgs/standards/swarmauri_storage_github/swarmauri_storage_github/github_storage_adapter.py
@@ -1,12 +1,3 @@
-import warnings
-
-warnings.warn(
-    "GithubStorageAdapter is deprecated; use peagen.plugins.git_filters.github_filter instead",
-    DeprecationWarning,
-    stacklevel=2,
-)
-
-
 class GithubStorageAdapter:
     def __init__(self, **kwargs):
         self.kwargs = kwargs

--- a/pkgs/standards/swarmauri_storage_github_release/swarmauri_storage_github_release/gh_release_storage_adapter.py
+++ b/pkgs/standards/swarmauri_storage_github_release/swarmauri_storage_github_release/gh_release_storage_adapter.py
@@ -8,18 +8,11 @@ import io
 import os
 import shutil
 import tempfile
-import warnings
 from pathlib import Path
 from typing import BinaryIO, Optional
 
 from peagen._utils.config_loader import load_peagen_toml
 from github import Github, UnknownObjectException
-
-warnings.warn(
-    "GithubReleaseStorageAdapter is deprecated; use peagen.plugins.git_filters.gh_release_filter instead",
-    DeprecationWarning,
-    stacklevel=2,
-)
 
 
 class GithubReleaseStorageAdapter:

--- a/pkgs/standards/swarmauri_storage_minio/swarmauri_storage_minio/minio_storage_adapter.py
+++ b/pkgs/standards/swarmauri_storage_minio/swarmauri_storage_minio/minio_storage_adapter.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import io
 import os
 import shutil
-import warnings
 from pathlib import Path
 from typing import BinaryIO, Optional
 
@@ -17,12 +16,6 @@ from minio.error import S3Error
 from pydantic import SecretStr
 
 from peagen._utils.config_loader import load_peagen_toml
-
-warnings.warn(
-    "MinioStorageAdapter is deprecated; use peagen.plugins.git_filters.minio_filter instead",
-    DeprecationWarning,
-    stacklevel=2,
-)
 
 
 class MinioStorageAdapter:


### PR DESCRIPTION
## Summary
- remove deprecation warnings from storage adapter packages

## Testing
- `uv run --directory pkgs/standards/swarmauri_storage_file --package swarmauri_storage_file ruff format .`
- `uv run --directory pkgs/standards/swarmauri_storage_file --package swarmauri_storage_file ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_storage_github --package swarmauri_storage_github ruff format .`
- `uv run --directory pkgs/standards/swarmauri_storage_github --package swarmauri_storage_github ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_storage_github_release --package swarmauri_storage_github_release ruff format .`
- `uv run --directory pkgs/standards/swarmauri_storage_github_release --package swarmauri_storage_github_release ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_storage_minio --package swarmauri_storage_minio ruff format .`
- `uv run --directory pkgs/standards/swarmauri_storage_minio --package swarmauri_storage_minio ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b0222ed254832692c40f3e95416d25