### PR TITLE
feat(peagen): add file storage dependency

### DIFF
--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -47,8 +47,9 @@ dependencies = [
     "swarmauri",
     "swarmauri_prompt_j2prompttemplate",
     "swarmauri_keyprovider_ssh",
+    "swarmauri_storage_file",
 
-    "pydantic-settings>=2.2", 
+    "pydantic-settings>=2.2",
     "pydantic[email]>=2.7", # why is this necessary?
 
     # plugins —————————————————————————————————————————————————————————————————————————
@@ -98,6 +99,7 @@ autoapi = { workspace = true }
 autoapi_client = { workspace = true }
 auto_authn = { workspace = true }
 swarmauri_keyprovider_ssh = { workspace = true }
+swarmauri_storage_file = { workspace = true }
 
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary
- include swarmauri_storage_file package in peagen dependencies
- wire the file-storage adapter as a workspace source for peagen

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format .`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b021f80060832685028111a0b52cb6