### PR TITLE
feat(storage): add base interfaces for adapters

### DIFF
--- a/pkgs/base/swarmauri_base/ComponentBase.py
+++ b/pkgs/base/swarmauri_base/ComponentBase.py
@@ -123,4 +123,5 @@ class ResourceTypes(Enum):
     TRACER = "Tracer"
     TENSOR = "Tensor"
     TOKEN_SERVICE = "TokenService"
+    STORAGE_ADAPTER = "StorageAdapter"
     SST = "SST"

--- a/pkgs/base/swarmauri_base/storage/StorageAdapterBase.py
+++ b/pkgs/base/swarmauri_base/storage/StorageAdapterBase.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import os
+from typing import BinaryIO, Optional, Literal
+from pydantic import Field
+
+from swarmauri_base.ComponentBase import ComponentBase, ResourceTypes
+from swarmauri_core.storage.IStorageAdapter import IStorageAdapter
+
+
+class StorageAdapterBase(IStorageAdapter, ComponentBase):
+    """Abstract base class for storage adapters."""
+
+    resource: Optional[str] = Field(
+        default=ResourceTypes.STORAGE_ADAPTER.value, frozen=True
+    )
+    type: Literal["StorageAdapterBase"] = "StorageAdapterBase"
+
+    # ------------------------------------------------------------------
+    def upload(self, key: str, data: BinaryIO) -> str:
+        raise NotImplementedError("upload() must be implemented by subclass")
+
+    # ------------------------------------------------------------------
+    def download(self, key: str) -> BinaryIO:
+        raise NotImplementedError("download() must be implemented by subclass")
+
+    # ------------------------------------------------------------------
+    def upload_dir(self, src: str | os.PathLike, *, prefix: str = "") -> None:
+        raise NotImplementedError("upload_dir() must be implemented by subclass")
+
+    # ------------------------------------------------------------------
+    def download_dir(self, prefix: str, dest_dir: str | os.PathLike) -> None:
+        raise NotImplementedError("download_dir() must be implemented by subclass")
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_uri(cls, uri: str) -> "StorageAdapterBase":
+        raise NotImplementedError("from_uri() must be implemented by subclass")

--- a/pkgs/base/swarmauri_base/storage/__init__.py
+++ b/pkgs/base/swarmauri_base/storage/__init__.py
@@ -1,0 +1,3 @@
+from .StorageAdapterBase import StorageAdapterBase
+
+__all__ = ["StorageAdapterBase"]

--- a/pkgs/core/swarmauri_core/storage/IStorageAdapter.py
+++ b/pkgs/core/swarmauri_core/storage/IStorageAdapter.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+import os
+from typing import BinaryIO
+
+
+class IStorageAdapter(ABC):
+    """Interface for basic storage adapter operations."""
+
+    @abstractmethod
+    def upload(self, key: str, data: BinaryIO) -> str:  # pragma: no cover - interface
+        """Upload *data* under *key* and return the resulting URI."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def download(self, key: str) -> BinaryIO:  # pragma: no cover - interface
+        """Retrieve the artifact stored at *key*."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def upload_dir(
+        self, src: str | os.PathLike, *, prefix: str = ""
+    ) -> None:  # pragma: no cover - interface
+        """Recursively upload files from *src* under *prefix*."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def download_dir(
+        self, prefix: str, dest_dir: str | os.PathLike
+    ) -> None:  # pragma: no cover - interface
+        """Download all artifacts under *prefix* into *dest_dir*."""
+        raise NotImplementedError
+
+    @classmethod
+    @abstractmethod
+    def from_uri(cls, uri: str) -> "IStorageAdapter":  # pragma: no cover - interface
+        """Create an adapter instance from *uri*."""
+        raise NotImplementedError

--- a/pkgs/core/swarmauri_core/storage/__init__.py
+++ b/pkgs/core/swarmauri_core/storage/__init__.py
@@ -1,0 +1,3 @@
+from .IStorageAdapter import IStorageAdapter
+
+__all__ = ["IStorageAdapter"]

--- a/pkgs/standards/swarmauri_storage_file/swarmauri_storage_file/file_storage_adapter.py
+++ b/pkgs/standards/swarmauri_storage_file/swarmauri_storage_file/file_storage_adapter.py
@@ -12,9 +12,10 @@ import shutil
 from pathlib import Path
 from typing import BinaryIO
 
+from swarmauri_base.storage import StorageAdapterBase
 
 
-class FileStorageAdapter:
+class FileStorageAdapter(StorageAdapterBase):
     """Write and read artefacts on the local disk."""
 
     def __init__(self, output_dir: str | os.PathLike, *, prefix: str = ""):
@@ -81,8 +82,8 @@ class FileStorageAdapter:
                 rel = path.relative_to(self._root)
                 yield str(rel)
 
-    # ---------------------------------------------------------------- download_prefix
-    def download_prefix(self, prefix: str, dest_dir: str | os.PathLike) -> None:
+    # ---------------------------------------------------------------- download_dir
+    def download_dir(self, prefix: str, dest_dir: str | os.PathLike) -> None:
         """Copy all files under ``prefix`` into ``dest_dir``."""
         src_root = self._full_key(prefix)
         dest = Path(dest_dir)

--- a/pkgs/standards/swarmauri_storage_github/swarmauri_storage_github/github_storage_adapter.py
+++ b/pkgs/standards/swarmauri_storage_github/swarmauri_storage_github/github_storage_adapter.py
@@ -1,7 +1,31 @@
+from __future__ import annotations
 
-class GithubStorageAdapter:
-    def __init__(self, **kwargs):
+import os
+from typing import BinaryIO
+
+from swarmauri_base.storage import StorageAdapterBase
+
+
+class GithubStorageAdapter(StorageAdapterBase):
+    def __init__(self, **kwargs) -> None:
         self.kwargs = kwargs
 
-    def upload(self, path: str, dest: str) -> str:
-        return f"github://{dest}"
+    def upload(self, key: str, data: BinaryIO) -> str:  # pragma: no cover - stub
+        return f"github://{key}"
+
+    def download(self, key: str) -> BinaryIO:  # pragma: no cover - stub
+        raise NotImplementedError("download() not implemented")
+
+    def upload_dir(
+        self, src: str | os.PathLike, *, prefix: str = ""
+    ) -> None:  # pragma: no cover - stub
+        raise NotImplementedError("upload_dir() not implemented")
+
+    def download_dir(
+        self, prefix: str, dest_dir: str | os.PathLike
+    ) -> None:  # pragma: no cover - stub
+        raise NotImplementedError("download_dir() not implemented")
+
+    @classmethod
+    def from_uri(cls, uri: str) -> "GithubStorageAdapter":  # pragma: no cover - stub
+        return cls()

--- a/pkgs/standards/swarmauri_storage_github_release/swarmauri_storage_github_release/gh_release_storage_adapter.py
+++ b/pkgs/standards/swarmauri_storage_github_release/swarmauri_storage_github_release/gh_release_storage_adapter.py
@@ -11,10 +11,13 @@ import tempfile
 from pathlib import Path
 from typing import BinaryIO, Optional
 
+from swarmauri_base.storage import StorageAdapterBase
+
 from peagen._utils.config_loader import load_peagen_toml
 from github import Github, UnknownObjectException
 
-class GithubReleaseStorageAdapter:
+
+class GithubReleaseStorageAdapter(StorageAdapterBase):
     """Storage adapter that uses GitHub Releases to store and retrieve assets."""
 
     def __init__(
@@ -133,7 +136,7 @@ class GithubReleaseStorageAdapter:
                     key = key[len(self._prefix.rstrip("/")) + 1 :]
                 yield key
 
-    def download_prefix(self, prefix: str, dest_dir: str | os.PathLike) -> None:
+    def download_dir(self, prefix: str, dest_dir: str | os.PathLike) -> None:
         """Download all assets under *prefix* into *dest_dir*."""
         dest = Path(dest_dir)
         for rel_key in self.iter_prefix(prefix):

--- a/pkgs/standards/swarmauri_storage_minio/swarmauri_storage_minio/minio_storage_adapter.py
+++ b/pkgs/standards/swarmauri_storage_minio/swarmauri_storage_minio/minio_storage_adapter.py
@@ -11,6 +11,8 @@ import shutil
 from pathlib import Path
 from typing import BinaryIO, Optional
 
+from swarmauri_base.storage import StorageAdapterBase
+
 from minio import Minio
 from minio.error import S3Error
 from pydantic import SecretStr
@@ -18,7 +20,7 @@ from pydantic import SecretStr
 from peagen._utils.config_loader import load_peagen_toml
 
 
-class MinioStorageAdapter:
+class MinioStorageAdapter(StorageAdapterBase):
     """Simple wrapper around the MinIO client for use with Peagen."""
 
     def __init__(
@@ -119,7 +121,7 @@ class MinioStorageAdapter:
             yield key
 
     # ------------------------------------------------------------------
-    def download_prefix(self, prefix: str, dest_dir: str | os.PathLike) -> None:
+    def download_dir(self, prefix: str, dest_dir: str | os.PathLike) -> None:
         """Download everything under ``prefix`` into ``dest_dir``."""
         dest = Path(dest_dir)
         for rel_key in self.iter_prefix(prefix):


### PR DESCRIPTION
## Summary
- add IStorageAdapter core interface and StorageAdapterBase
- update file, GitHub, GitHub release, and MinIO adapters to subclass StorageAdapterBase

## Testing
- `uv run --package swarmauri_core --directory pkgs/core ruff check . --fix`
- `uv run --package swarmauri_base --directory pkgs/base ruff check . --fix`
- `uv run --package swarmauri_storage_file --directory pkgs/standards/swarmauri_storage_file ruff check . --fix`
- `uv run --package swarmauri_storage_github --directory pkgs/standards/swarmauri_storage_github ruff check . --fix`
- `uv run --package swarmauri_storage_github_release --directory pkgs/standards/swarmauri_storage_github_release ruff check . --fix`
- `uv run --package swarmauri_storage_minio --directory pkgs/standards/swarmauri_storage_minio ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b0261d09f0832693ce115623269e78