### PR TITLE
feat: add swarmauri and peagen entry points

### DIFF
--- a/pkgs/standards/swarmauri_gitfilter_file/pyproject.toml
+++ b/pkgs/standards/swarmauri_gitfilter_file/pyproject.toml
@@ -32,6 +32,9 @@ swarmauri_base = { workspace = true }
 swarmauri_standard = { workspace = true }
 swarmauri_storage_file = { workspace = true }
 
+[project.entry-points.'swarmauri.git_filters']
+FileFilter = "swarmauri_gitfilter_file.file_filter:FileFilter"
+
 [project.entry-points."peagen.plugins.git_filters"]
 file = "swarmauri_gitfilter_file.file_filter:FileFilter"
 

--- a/pkgs/standards/swarmauri_gitfilter_gh_release/pyproject.toml
+++ b/pkgs/standards/swarmauri_gitfilter_gh_release/pyproject.toml
@@ -31,6 +31,9 @@ swarmauri_core = { workspace = true }
 swarmauri_base = { workspace = true }
 swarmauri_standard = { workspace = true }
 
+[project.entry-points.'swarmauri.git_filters']
+GithubReleaseFilter = "swarmauri_gitfilter_gh_release.gh_release_filter:GithubReleaseFilter"
+
 [project.entry-points."peagen.plugins.git_filters"]
 gh_release = "swarmauri_gitfilter_gh_release.gh_release_filter:GithubReleaseFilter"
 

--- a/pkgs/standards/swarmauri_gitfilter_minio/pyproject.toml
+++ b/pkgs/standards/swarmauri_gitfilter_minio/pyproject.toml
@@ -31,6 +31,9 @@ swarmauri_core = { workspace = true }
 swarmauri_base = { workspace = true }
 swarmauri_standard = { workspace = true }
 
+[project.entry-points.'swarmauri.git_filters']
+MinioFilter = "swarmauri_gitfilter_minio.minio_filter:MinioFilter"
+
 [project.entry-points."peagen.plugins.git_filters"]
 minio = "swarmauri_gitfilter_minio.minio_filter:MinioFilter"
 

--- a/pkgs/standards/swarmauri_gitfilter_s3fs/pyproject.toml
+++ b/pkgs/standards/swarmauri_gitfilter_s3fs/pyproject.toml
@@ -31,6 +31,9 @@ swarmauri_core = { workspace = true }
 swarmauri_base = { workspace = true }
 swarmauri_standard = { workspace = true }
 
+[project.entry-points.'swarmauri.git_filters']
+S3FSFilter = "swarmauri_gitfilter_s3fs.s3fs_filter:S3FSFilter"
+
 [project.entry-points."peagen.plugins.git_filters"]
 s3 = "swarmauri_gitfilter_s3fs.s3fs_filter:S3FSFilter"
 

--- a/pkgs/standards/swarmauri_keyprovider_file/pyproject.toml
+++ b/pkgs/standards/swarmauri_keyprovider_file/pyproject.toml
@@ -65,3 +65,6 @@ build-backend = "poetry.core.masonry.api"
 
 [project.entry-points.'swarmauri.key_providers']
 FileKeyProvider = "swarmauri_keyprovider_file.FileKeyProvider:FileKeyProvider"
+
+[project.entry-points."peagen.plugins.key_providers"]
+file = "swarmauri_keyprovider_file.FileKeyProvider:FileKeyProvider"

--- a/pkgs/standards/swarmauri_keyprovider_hierarchical/pyproject.toml
+++ b/pkgs/standards/swarmauri_keyprovider_hierarchical/pyproject.toml
@@ -66,3 +66,6 @@ build-backend = "poetry.core.masonry.api"
 
 [project.entry-points.'swarmauri.key_providers']
 HierarchicalKeyProvider = "swarmauri_keyprovider_hierarchical.HierarchicalKeyProvider:HierarchicalKeyProvider"
+
+[project.entry-points."peagen.plugins.key_providers"]
+hierarchical = "swarmauri_keyprovider_hierarchical.HierarchicalKeyProvider:HierarchicalKeyProvider"

--- a/pkgs/standards/swarmauri_keyprovider_inmemory/pyproject.toml
+++ b/pkgs/standards/swarmauri_keyprovider_inmemory/pyproject.toml
@@ -61,3 +61,6 @@ build-backend = "poetry.core.masonry.api"
 
 [project.entry-points.'swarmauri.key_providers']
 InMemoryKeyProvider = "swarmauri_keyprovider_inmemory.InMemoryKeyProvider:InMemoryKeyProvider"
+
+[project.entry-points."peagen.plugins.key_providers"]
+inmemory = "swarmauri_keyprovider_inmemory.InMemoryKeyProvider:InMemoryKeyProvider"

--- a/pkgs/standards/swarmauri_keyprovider_local/pyproject.toml
+++ b/pkgs/standards/swarmauri_keyprovider_local/pyproject.toml
@@ -61,3 +61,6 @@ build-backend = "poetry.core.masonry.api"
 
 [project.entry-points.'swarmauri.key_providers']
 LocalKeyProvider = "swarmauri_keyprovider_local.LocalKeyProvider:LocalKeyProvider"
+
+[project.entry-points."peagen.plugins.key_providers"]
+local = "swarmauri_keyprovider_local.LocalKeyProvider:LocalKeyProvider"

--- a/pkgs/standards/swarmauri_keyprovider_pkcs11/pyproject.toml
+++ b/pkgs/standards/swarmauri_keyprovider_pkcs11/pyproject.toml
@@ -62,3 +62,6 @@ build-backend = "poetry.core.masonry.api"
 
 [project.entry-points.'swarmauri.key_providers']
 Pkcs11KeyProvider = "swarmauri_keyprovider_pkcs11.Pkcs11KeyProvider:Pkcs11KeyProvider"
+
+[project.entry-points."peagen.plugins.key_providers"]
+pkcs11 = "swarmauri_keyprovider_pkcs11.Pkcs11KeyProvider:Pkcs11KeyProvider"

--- a/pkgs/standards/swarmauri_keyprovider_remote_jwks/pyproject.toml
+++ b/pkgs/standards/swarmauri_keyprovider_remote_jwks/pyproject.toml
@@ -65,3 +65,6 @@ build-backend = "poetry.core.masonry.api"
 
 [project.entry-points.'swarmauri.key_providers']
 RemoteJwksKeyProvider = "swarmauri_keyprovider_remote_jwks.RemoteJwksKeyProvider:RemoteJwksKeyProvider"
+
+[project.entry-points."peagen.plugins.key_providers"]
+remote_jwks = "swarmauri_keyprovider_remote_jwks.RemoteJwksKeyProvider:RemoteJwksKeyProvider"

--- a/pkgs/standards/swarmauri_keyprovider_ssh/pyproject.toml
+++ b/pkgs/standards/swarmauri_keyprovider_ssh/pyproject.toml
@@ -62,3 +62,6 @@ build-backend = "poetry.core.masonry.api"
 
 [project.entry-points.'swarmauri.key_providers']
 SshKeyProvider = "swarmauri_keyprovider_ssh.SshKeyProvider:SshKeyProvider"
+
+[project.entry-points."peagen.plugins.key_providers"]
+ssh = "swarmauri_keyprovider_ssh.SshKeyProvider:SshKeyProvider"

--- a/pkgs/standards/swarmauri_keyproviders_mirrored/pyproject.toml
+++ b/pkgs/standards/swarmauri_keyproviders_mirrored/pyproject.toml
@@ -67,3 +67,6 @@ build-backend = "poetry.core.masonry.api"
 [project.entry-points.'swarmauri.key_providers']
 MirroredKeyProvider = "swarmauri_keyproviders_mirrored.MirroredKeyProvider:MirroredKeyProvider"
 
+[project.entry-points."peagen.plugins.key_providers"]
+mirrored = "swarmauri_keyproviders_mirrored.MirroredKeyProvider:MirroredKeyProvider"
+

--- a/pkgs/standards/swarmauri_storage_file/pyproject.toml
+++ b/pkgs/standards/swarmauri_storage_file/pyproject.toml
@@ -30,6 +30,9 @@ swarmauri_core = { workspace = true }
 swarmauri_base = { workspace = true }
 swarmauri_standard = { workspace = true }
 
+[project.entry-points.'swarmauri.storage_adapters']
+FileStorageAdapter = "swarmauri_storage_file.file_storage_adapter:FileStorageAdapter"
+
 [project.entry-points."peagen.plugins.storage_adapters"]
 file = "swarmauri_storage_file.file_storage_adapter:FileStorageAdapter"
 

--- a/pkgs/standards/swarmauri_storage_github/pyproject.toml
+++ b/pkgs/standards/swarmauri_storage_github/pyproject.toml
@@ -30,6 +30,9 @@ swarmauri_core = { workspace = true }
 swarmauri_base = { workspace = true }
 swarmauri_standard = { workspace = true }
 
+[project.entry-points.'swarmauri.storage_adapters']
+GithubStorageAdapter = "swarmauri_storage_github.github_storage_adapter:GithubStorageAdapter"
+
 [project.entry-points."peagen.plugins.storage_adapters"]
 github = "swarmauri_storage_github.github_storage_adapter:GithubStorageAdapter"
 

--- a/pkgs/standards/swarmauri_storage_github_release/pyproject.toml
+++ b/pkgs/standards/swarmauri_storage_github_release/pyproject.toml
@@ -31,6 +31,9 @@ swarmauri_core = { workspace = true }
 swarmauri_base = { workspace = true }
 swarmauri_standard = { workspace = true }
 
+[project.entry-points.'swarmauri.storage_adapters']
+GithubReleaseStorageAdapter = "swarmauri_storage_github_release.gh_release_storage_adapter:GithubReleaseStorageAdapter"
+
 [project.entry-points."peagen.plugins.storage_adapters"]
 gh_release = "swarmauri_storage_github_release.gh_release_storage_adapter:GithubReleaseStorageAdapter"
 

--- a/pkgs/standards/swarmauri_storage_minio/pyproject.toml
+++ b/pkgs/standards/swarmauri_storage_minio/pyproject.toml
@@ -31,6 +31,9 @@ swarmauri_core = { workspace = true }
 swarmauri_base = { workspace = true }
 swarmauri_standard = { workspace = true }
 
+[project.entry-points.'swarmauri.storage_adapters']
+MinioStorageAdapter = "swarmauri_storage_minio.minio_storage_adapter:MinioStorageAdapter"
+
 [project.entry-points."peagen.plugins.storage_adapters"]
 minio = "swarmauri_storage_minio.minio_storage_adapter:MinioStorageAdapter"
 


### PR DESCRIPTION
## Summary
- add swarmauri storage adapter entry points alongside peagen ones
- add swarmauri git filter entry points alongside peagen ones
- add peagen key provider entry points alongside swarmauri ones

## Testing
- `uv run --directory pkgs/standards/swarmauri_storage_file --package swarmauri_storage_file ruff format .`
- `uv run --directory pkgs/standards/swarmauri_storage_file --package swarmauri_storage_file ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_storage_github --package swarmauri_storage_github ruff format .`
- `uv run --directory pkgs/standards/swarmauri_storage_github --package swarmauri_storage_github ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_storage_github_release --package swarmauri_storage_github_release ruff format .`
- `uv run --directory pkgs/standards/swarmauri_storage_github_release --package swarmauri_storage_github_release ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_storage_minio --package swarmauri_storage_minio ruff format .`
- `uv run --directory pkgs/standards/swarmauri_storage_minio --package swarmauri_storage_minio ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_gitfilter_file --package swarmauri_gitfilter_file ruff format .`
- `uv run --directory pkgs/standards/swarmauri_gitfilter_file --package swarmauri_gitfilter_file ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_gitfilter_gh_release --package swarmauri_gitfilter_gh_release ruff format .`
- `uv run --directory pkgs/standards/swarmauri_gitfilter_gh_release --package swarmauri_gitfilter_gh_release ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_gitfilter_minio --package swarmauri_gitfilter_minio ruff format .`
- `uv run --directory pkgs/standards/swarmauri_gitfilter_minio --package swarmauri_gitfilter_minio ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_gitfilter_s3fs --package swarmauri_gitfilter_s3fs ruff format .`
- `uv run --directory pkgs/standards/swarmauri_gitfilter_s3fs --package swarmauri_gitfilter_s3fs ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_keyprovider_file --package swarmauri_keyprovider_file ruff format .`
- `uv run --directory pkgs/standards/swarmauri_keyprovider_file --package swarmauri_keyprovider_file ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_keyprovider_hierarchical --package swarmauri_keyprovider_hierarchical ruff format .`
- `uv run --directory pkgs/standards/swarmauri_keyprovider_hierarchical --package swarmauri_keyprovider_hierarchical ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_keyprovider_inmemory --package swarmauri_keyprovider_inmemory ruff format .`
- `uv run --directory pkgs/standards/swarmauri_keyprovider_inmemory --package swarmauri_keyprovider_inmemory ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_keyprovider_local --package swarmauri_keyprovider_local ruff format .`
- `uv run --directory pkgs/standards/swarmauri_keyprovider_local --package swarmauri_keyprovider_local ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_keyprovider_pkcs11 --package swarmauri_keyprovider_pkcs11 ruff format .` *(failed: unknown file type '.h' while building `pkcs11`)*
- `uv run --directory pkgs/standards/swarmauri_keyprovider_pkcs11 --package swarmauri_keyprovider_pkcs11 ruff check . --fix` *(skipped due to previous failure)*
- `uv run --directory pkgs/standards/swarmauri_keyprovider_remote_jwks --package swarmauri_keyprovider_remote_jwks ruff format .`
- `uv run --directory pkgs/standards/swarmauri_keyprovider_remote_jwks --package swarmauri_keyprovider_remote_jwks ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_keyprovider_ssh --package swarmauri_keyprovider_ssh ruff format .`
- `uv run --directory pkgs/standards/swarmauri_keyprovider_ssh --package swarmauri_keyprovider_ssh ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_keyproviders_mirrored --package swarmauri_keyproviders_mirrored ruff format .`
- `uv run --directory pkgs/standards/swarmauri_keyproviders_mirrored --package swarmauri_keyproviders_mirrored ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b02824c7488326b34e1a697166a3c6