### PR TITLE
fix: ensure dummy git filter subclass in plugin test

### DIFF
--- a/pkgs/standards/peagen/tests/perf/test_plugin_manager_perf.py
+++ b/pkgs/standards/peagen/tests/perf/test_plugin_manager_perf.py
@@ -5,6 +5,7 @@ import pytest
 
 import peagen.plugins as plugins
 from peagen.plugins import PluginManager
+from swarmauri_base.git_filters import GitFilterBase
 from swarmauri_base.keys import KeyProviderBase
 
 
@@ -30,6 +31,10 @@ def test_plugin_discovery_cached(monkeypatch):
                 if group == "swarmauri.key_providers":
 
                     class Dummy(KeyProviderBase):
+                        pass
+                elif group == "peagen.plugins.git_filters":
+
+                    class Dummy(GitFilterBase):
                         pass
                 else:
 


### PR DESCRIPTION
## Summary
- ensure dummy plugin for git_filters subclasses `GitFilterBase` in performance test

## Testing
- `uv run --package peagen --directory standards/peagen ruff format .`
- `uv run --package peagen --directory standards/peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest`
- `uv run --package peagen --directory standards/peagen pytest tests/perf/test_plugin_manager_perf.py::test_plugin_discovery_cached -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0291697008326bceb0efa05421d84