### PR TITLE
Fix plugin discovery perf test to skip unrelated groups

### DIFF
--- a/pkgs/standards/peagen/tests/perf/test_plugin_manager_perf.py
+++ b/pkgs/standards/peagen/tests/perf/test_plugin_manager_perf.py
@@ -22,6 +22,8 @@ def test_plugin_discovery_cached(monkeypatch):
 
     def fake_entry_points(group: str):
         time.sleep(0.01)
+        if group not in {"swarmauri.key_providers", "peagen.plugins.git_filters"}:
+            return []
 
         class EP:
             name = "dummy"
@@ -32,13 +34,9 @@ def test_plugin_discovery_cached(monkeypatch):
 
                     class Dummy(KeyProviderBase):
                         pass
-                elif group == "peagen.plugins.git_filters":
+                else:  # group == "peagen.plugins.git_filters"
 
                     class Dummy(GitFilterBase):
-                        pass
-                else:
-
-                    class Dummy:
                         pass
 
                 return Dummy


### PR DESCRIPTION
## Summary
- ensure fake entry point generator skips unrelated plugin groups in plugin manager perf test

## Testing
- `uv run --package peagen --directory standards/peagen pytest tests/perf/test_plugin_manager_perf.py`
- `uv run --package peagen --directory standards/peagen pytest` *(fails: Entry-point 'jwe' in group 'peagen.plugins.cryptos' must subclass CryptoBase)*

------
https://chatgpt.com/codex/tasks/task_e_68b02c0f04308326ac5c0acaae241fde