### PR TITLE
fix: ensure plugin perf test uses crypto base

### DIFF
--- a/pkgs/standards/peagen/tests/perf/test_plugin_manager_perf.py
+++ b/pkgs/standards/peagen/tests/perf/test_plugin_manager_perf.py
@@ -5,6 +5,7 @@ import pytest
 
 import peagen.plugins as plugins
 from peagen.plugins import PluginManager
+from swarmauri_base.crypto.CryptoBase import CryptoBase
 from swarmauri_base.git_filters import GitFilterBase
 from swarmauri_base.keys import KeyProviderBase
 
@@ -35,6 +36,10 @@ def test_plugin_discovery_cached(monkeypatch):
                 elif group == "peagen.plugins.git_filters":
 
                     class Dummy(GitFilterBase):
+                        pass
+                elif group == "peagen.plugins.cryptos":
+
+                    class Dummy(CryptoBase):
                         pass
                 else:
 


### PR DESCRIPTION
## Summary
- adjust plugin manager perf test to provide CryptoBase subclass for cryptos group

## Testing
- `uv run --package peagen --directory standards/peagen pytest tests/e2e/test_local_evolve.py tests/perf/test_plugin_manager_perf.py`


------
https://chatgpt.com/codex/tasks/task_e_68b02c0aaa2c8326906336bbff62c9af