### PR TITLE
chore: remove jwe crypto entry points

### DIFF
--- a/pkgs/standards/swarmauri_crypto_jwe/pyproject.toml
+++ b/pkgs/standards/swarmauri_crypto_jwe/pyproject.toml
@@ -64,9 +64,3 @@ dev = [
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
-
-[project.entry-points.'swarmauri.cryptos']
-JweCrypto = "swarmauri_crypto_jwe:JweCrypto"
-
-[project.entry-points."peagen.plugins.cryptos"]
-jwe = "swarmauri_crypto_jwe:JweCrypto"


### PR DESCRIPTION
## Summary
- remove jwe crypto entry points that don't match CryptoBase

## Testing
- `uv run --package swarmauri_crypto_jwe --directory standards/swarmauri_crypto_jwe pytest`
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_gateway_client_ip.py tests/unit/test_kms_unwrap_keys.py`


------
https://chatgpt.com/codex/tasks/task_e_68b02b913f3c832683c3d59dfdc3772c