### PR TITLE
feat: standardize storage and git filter packages

### DIFF
--- a/pkgs/standards/swarmauri_gitfilter_file/swarmauri_gitfilter_file/__init__.py
+++ b/pkgs/standards/swarmauri_gitfilter_file/swarmauri_gitfilter_file/__init__.py
@@ -1,3 +1,13 @@
 from .file_filter import FileFilter
 
 __all__ = ["FileFilter"]
+
+try:  # pragma: no cover
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError:  # pragma: no cover
+    from importlib_metadata import version, PackageNotFoundError
+
+try:  # pragma: no cover
+    __version__ = version("swarmauri_gitfilter_file")
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "0.0.0"

--- a/pkgs/standards/swarmauri_gitfilter_file/swarmauri_gitfilter_file/file_filter.py
+++ b/pkgs/standards/swarmauri_gitfilter_file/swarmauri_gitfilter_file/file_filter.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from swarmauri_base.ComponentBase import ComponentBase
+from swarmauri_base.storage import StorageAdapterBase
 from swarmauri_base.git_filters import GitFilterBase
 from swarmauri_storage_file import FileStorageAdapter
 
 
+@ComponentBase.register_type(StorageAdapterBase, "FileFilter")
 class FileFilter(FileStorageAdapter, GitFilterBase):
     """Git filter that stores files on the local filesystem."""
 

--- a/pkgs/standards/swarmauri_gitfilter_file/tests/i9n/test_i9n__init__.py
+++ b/pkgs/standards/swarmauri_gitfilter_file/tests/i9n/test_i9n__init__.py
@@ -1,0 +1,23 @@
+import importlib
+import pytest
+
+
+@pytest.mark.i9n
+def test_init_module_import():
+    module = importlib.import_module("swarmauri_gitfilter_file")
+    assert module is not None
+
+
+@pytest.mark.i9n
+def test_init_module_version():
+    module = importlib.import_module("swarmauri_gitfilter_file")
+    assert hasattr(module, "__version__")
+    assert isinstance(module.__version__, str)
+    assert module.__version__
+
+
+@pytest.mark.i9n
+def test_init_module_all_variable():
+    module = importlib.import_module("swarmauri_gitfilter_file")
+    assert hasattr(module, "__all__")
+    assert "FileFilter" in module.__all__

--- a/pkgs/standards/swarmauri_gitfilter_file/tests/unit/test_file_filter.py
+++ b/pkgs/standards/swarmauri_gitfilter_file/tests/unit/test_file_filter.py
@@ -5,3 +5,16 @@ def test_clean_smudge(tmp_path):
     filt = FileFilter(output_dir=tmp_path)
     oid = filt.clean(b"data")
     assert filt.smudge(oid) == b"data"
+
+
+def test_resource_type(tmp_path):
+    filt = FileFilter(output_dir=tmp_path)
+    assert filt.resource == "StorageAdapter"
+    assert filt.type == "FileFilter"
+
+
+def test_round_trip_serialization(tmp_path):
+    filt = FileFilter(output_dir=tmp_path)
+    data = filt.model_dump()
+    restored = FileFilter(output_dir=tmp_path, **data)
+    assert restored.type == filt.type

--- a/pkgs/standards/swarmauri_gitfilter_gh_release/swarmauri_gitfilter_gh_release/__init__.py
+++ b/pkgs/standards/swarmauri_gitfilter_gh_release/swarmauri_gitfilter_gh_release/__init__.py
@@ -1,3 +1,13 @@
 from .gh_release_filter import GithubReleaseFilter
 
 __all__ = ["GithubReleaseFilter"]
+
+try:  # pragma: no cover
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError:  # pragma: no cover
+    from importlib_metadata import version, PackageNotFoundError
+
+try:  # pragma: no cover
+    __version__ = version("swarmauri_gitfilter_gh_release")
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "0.0.0"

--- a/pkgs/standards/swarmauri_gitfilter_gh_release/swarmauri_gitfilter_gh_release/gh_release_filter.py
+++ b/pkgs/standards/swarmauri_gitfilter_gh_release/swarmauri_gitfilter_gh_release/gh_release_filter.py
@@ -11,15 +11,18 @@ from github import Github, UnknownObjectException
 from pydantic import SecretStr
 
 from peagen._utils.config_loader import load_peagen_toml
+from swarmauri_base.ComponentBase import ComponentBase
+from swarmauri_base.storage import StorageAdapterBase
 from swarmauri_base.git_filters import GitFilterBase
 
 
-class GithubReleaseFilter(GitFilterBase):
+@ComponentBase.register_type(StorageAdapterBase, "GithubReleaseFilter")
+class GithubReleaseFilter(StorageAdapterBase, GitFilterBase):
     """Git filter that uses GitHub Releases to store and retrieve assets."""
 
     def __init__(
         self,
-        token: SecretStr,
+        token: SecretStr | str,
         org: str,
         repo: str,
         tag: str,
@@ -29,8 +32,11 @@ class GithubReleaseFilter(GitFilterBase):
         draft: bool = False,
         prerelease: bool = False,
         prefix: str = "",
+        **kwargs,
     ) -> None:
-        self._client = Github(token.get_secret_value())
+        super().__init__(**kwargs)
+        token_val = token.get_secret_value() if isinstance(token, SecretStr) else token
+        self._client = Github(token_val)
         self._repo = self._client.get_organization(org).get_repo(repo)
         self._tag = tag
         self._prefix = prefix.lstrip("/")

--- a/pkgs/standards/swarmauri_gitfilter_gh_release/tests/i9n/test_i9n__init__.py
+++ b/pkgs/standards/swarmauri_gitfilter_gh_release/tests/i9n/test_i9n__init__.py
@@ -1,0 +1,23 @@
+import importlib
+import pytest
+
+
+@pytest.mark.i9n
+def test_init_module_import():
+    module = importlib.import_module("swarmauri_gitfilter_gh_release")
+    assert module is not None
+
+
+@pytest.mark.i9n
+def test_init_module_version():
+    module = importlib.import_module("swarmauri_gitfilter_gh_release")
+    assert hasattr(module, "__version__")
+    assert isinstance(module.__version__, str)
+    assert module.__version__
+
+
+@pytest.mark.i9n
+def test_init_module_all_variable():
+    module = importlib.import_module("swarmauri_gitfilter_gh_release")
+    assert hasattr(module, "__all__")
+    assert "GithubReleaseFilter" in module.__all__

--- a/pkgs/standards/swarmauri_gitfilter_minio/swarmauri_gitfilter_minio/__init__.py
+++ b/pkgs/standards/swarmauri_gitfilter_minio/swarmauri_gitfilter_minio/__init__.py
@@ -1,3 +1,13 @@
 from .minio_filter import MinioFilter
 
 __all__ = ["MinioFilter"]
+
+try:  # pragma: no cover
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError:  # pragma: no cover
+    from importlib_metadata import version, PackageNotFoundError
+
+try:  # pragma: no cover
+    __version__ = version("swarmauri_gitfilter_minio")
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "0.0.0"

--- a/pkgs/standards/swarmauri_gitfilter_minio/swarmauri_gitfilter_minio/minio_filter.py
+++ b/pkgs/standards/swarmauri_gitfilter_minio/swarmauri_gitfilter_minio/minio_filter.py
@@ -11,10 +11,13 @@ from minio.error import S3Error
 from pydantic import SecretStr
 
 from peagen._utils.config_loader import load_peagen_toml
+from swarmauri_base.ComponentBase import ComponentBase
+from swarmauri_base.storage import StorageAdapterBase
 from swarmauri_base.git_filters import GitFilterBase
 
 
-class MinioFilter(GitFilterBase):
+@ComponentBase.register_type(StorageAdapterBase, "MinioFilter")
+class MinioFilter(StorageAdapterBase, GitFilterBase):
     """Simple wrapper around the MinIO client for use with Peagen."""
 
     def __init__(
@@ -26,7 +29,9 @@ class MinioFilter(GitFilterBase):
         *,
         secure: bool = True,
         prefix: str = "",
+        **kwargs,
     ) -> None:
+        super().__init__(**kwargs)
         self._client = Minio(
             endpoint,
             access_key=access_key,

--- a/pkgs/standards/swarmauri_gitfilter_minio/tests/i9n/test_i9n__init__.py
+++ b/pkgs/standards/swarmauri_gitfilter_minio/tests/i9n/test_i9n__init__.py
@@ -1,0 +1,23 @@
+import importlib
+import pytest
+
+
+@pytest.mark.i9n
+def test_init_module_import():
+    module = importlib.import_module("swarmauri_gitfilter_minio")
+    assert module is not None
+
+
+@pytest.mark.i9n
+def test_init_module_version():
+    module = importlib.import_module("swarmauri_gitfilter_minio")
+    assert hasattr(module, "__version__")
+    assert isinstance(module.__version__, str)
+    assert module.__version__
+
+
+@pytest.mark.i9n
+def test_init_module_all_variable():
+    module = importlib.import_module("swarmauri_gitfilter_minio")
+    assert hasattr(module, "__all__")
+    assert "MinioFilter" in module.__all__

--- a/pkgs/standards/swarmauri_gitfilter_s3fs/swarmauri_gitfilter_s3fs/__init__.py
+++ b/pkgs/standards/swarmauri_gitfilter_s3fs/swarmauri_gitfilter_s3fs/__init__.py
@@ -1,3 +1,13 @@
 from .s3fs_filter import S3FSFilter
 
 __all__ = ["S3FSFilter"]
+
+try:  # pragma: no cover
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError:  # pragma: no cover
+    from importlib_metadata import version, PackageNotFoundError
+
+try:  # pragma: no cover
+    __version__ = version("swarmauri_gitfilter_s3fs")
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "0.0.0"

--- a/pkgs/standards/swarmauri_gitfilter_s3fs/swarmauri_gitfilter_s3fs/s3fs_filter.py
+++ b/pkgs/standards/swarmauri_gitfilter_s3fs/swarmauri_gitfilter_s3fs/s3fs_filter.py
@@ -9,10 +9,13 @@ import s3fs
 from pydantic import SecretStr
 
 from peagen._utils.config_loader import load_peagen_toml
+from swarmauri_base.ComponentBase import ComponentBase
+from swarmauri_base.storage import StorageAdapterBase
 from swarmauri_base.git_filters import GitFilterBase
 
 
-class S3FSFilter(GitFilterBase):
+@ComponentBase.register_type(StorageAdapterBase, "S3FSFilter")
+class S3FSFilter(StorageAdapterBase, GitFilterBase):
     """Git filter that stores artifacts in S3 via :mod:`s3fs`."""
 
     def __init__(
@@ -26,6 +29,7 @@ class S3FSFilter(GitFilterBase):
         prefix: str = "",
         **kwargs,
     ) -> None:
+        super().__init__(**kwargs)
         self._bucket = bucket
         self._prefix = prefix.lstrip("/")
 

--- a/pkgs/standards/swarmauri_gitfilter_s3fs/tests/i9n/test_i9n__init__.py
+++ b/pkgs/standards/swarmauri_gitfilter_s3fs/tests/i9n/test_i9n__init__.py
@@ -1,0 +1,23 @@
+import importlib
+import pytest
+
+
+@pytest.mark.i9n
+def test_init_module_import():
+    module = importlib.import_module("swarmauri_gitfilter_s3fs")
+    assert module is not None
+
+
+@pytest.mark.i9n
+def test_init_module_version():
+    module = importlib.import_module("swarmauri_gitfilter_s3fs")
+    assert hasattr(module, "__version__")
+    assert isinstance(module.__version__, str)
+    assert module.__version__
+
+
+@pytest.mark.i9n
+def test_init_module_all_variable():
+    module = importlib.import_module("swarmauri_gitfilter_s3fs")
+    assert hasattr(module, "__all__")
+    assert "S3FSFilter" in module.__all__

--- a/pkgs/standards/swarmauri_gitfilter_s3fs/tests/unit/test_s3fs_filter.py
+++ b/pkgs/standards/swarmauri_gitfilter_s3fs/tests/unit/test_s3fs_filter.py
@@ -1,21 +1,49 @@
 import io
 
+import pytest
 
 from swarmauri_gitfilter_s3fs import S3FSFilter
 
 
 class DummyFS:
-    def open(self, *args, **kwargs):
-        return io.BytesIO()
+    def __init__(self):
+        self.store: dict[str, bytes] = {}
+
+    def open(self, path, mode):
+        if "w" in mode:
+            fs = self
+
+            class _Buf(io.BytesIO):
+                def close(self_nonlocal):
+                    fs.store[path] = self_nonlocal.getvalue()
+                    super().close()
+
+            return _Buf()
+        if path not in self.store:
+            raise FileNotFoundError(path)
+        return io.BytesIO(self.store[path])
 
     def find(self, base):
-        return []
+        return list(self.store.keys())
 
 
-def test_from_uri(monkeypatch):
+@pytest.fixture
+def filt(monkeypatch):
     monkeypatch.setattr(
         "swarmauri_gitfilter_s3fs.s3fs_filter.s3fs.S3FileSystem",
         lambda *a, **k: DummyFS(),
     )
-    filt = S3FSFilter.from_uri("s3://bucket")
-    assert isinstance(filt, S3FSFilter)
+    return S3FSFilter.from_uri("s3://bucket")
+
+
+def test_resource_type_serialization(filt):
+    assert filt.resource == "StorageAdapter"
+    assert filt.type == "S3FSFilter"
+    data = filt.model_dump()
+    restored = S3FSFilter(bucket="bucket", **data)
+    assert restored.type == filt.type
+
+
+def test_clean_smudge(filt):
+    oid = filt.clean(b"data")
+    assert filt.smudge(oid) == b"data"

--- a/pkgs/standards/swarmauri_storage_file/swarmauri_storage_file/__init__.py
+++ b/pkgs/standards/swarmauri_storage_file/swarmauri_storage_file/__init__.py
@@ -1,3 +1,13 @@
 from .file_storage_adapter import FileStorageAdapter
 
 __all__ = ["FileStorageAdapter"]
+
+try:  # pragma: no cover
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError:  # pragma: no cover
+    from importlib_metadata import version, PackageNotFoundError
+
+try:  # pragma: no cover
+    __version__ = version("swarmauri_storage_file")
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "0.0.0"

--- a/pkgs/standards/swarmauri_storage_file/swarmauri_storage_file/file_storage_adapter.py
+++ b/pkgs/standards/swarmauri_storage_file/swarmauri_storage_file/file_storage_adapter.py
@@ -12,13 +12,16 @@ import shutil
 from pathlib import Path
 from typing import BinaryIO
 
+from swarmauri_base.ComponentBase import ComponentBase
 from swarmauri_base.storage import StorageAdapterBase
 
 
+@ComponentBase.register_type(StorageAdapterBase, "FileStorageAdapter")
 class FileStorageAdapter(StorageAdapterBase):
     """Write and read artefacts on the local disk."""
 
-    def __init__(self, output_dir: str | os.PathLike, *, prefix: str = ""):
+    def __init__(self, output_dir: str | os.PathLike, *, prefix: str = "", **kwargs):
+        super().__init__(**kwargs)
         self._root = Path(output_dir).expanduser().resolve()
         self._root.mkdir(parents=True, exist_ok=True)
         self._prefix = prefix.lstrip("/")

--- a/pkgs/standards/swarmauri_storage_file/tests/i9n/test_i9n__init__.py
+++ b/pkgs/standards/swarmauri_storage_file/tests/i9n/test_i9n__init__.py
@@ -1,0 +1,27 @@
+import importlib
+import logging
+
+import pytest
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.i9n
+def test_init_module_import():
+    module = importlib.import_module("swarmauri_storage_file")
+    assert module is not None
+
+
+@pytest.mark.i9n
+def test_init_module_version():
+    module = importlib.import_module("swarmauri_storage_file")
+    assert hasattr(module, "__version__")
+    assert isinstance(module.__version__, str)
+    assert module.__version__
+
+
+@pytest.mark.i9n
+def test_init_module_all_variable():
+    module = importlib.import_module("swarmauri_storage_file")
+    assert hasattr(module, "__all__")
+    assert "FileStorageAdapter" in module.__all__

--- a/pkgs/standards/swarmauri_storage_file/tests/unit/test_file_storage_adapter.py
+++ b/pkgs/standards/swarmauri_storage_file/tests/unit/test_file_storage_adapter.py
@@ -1,0 +1,32 @@
+import io
+
+import pytest
+
+from swarmauri_storage_file import FileStorageAdapter
+
+
+@pytest.fixture
+def adapter(tmp_path):
+    return FileStorageAdapter(output_dir=tmp_path)
+
+
+def test_ubc_resource(adapter):
+    assert adapter.resource == "StorageAdapter"
+
+
+def test_ubc_type(adapter):
+    assert adapter.type == "FileStorageAdapter"
+
+
+def test_round_trip_serialization(adapter):
+    data = adapter.model_dump()
+    restored = FileStorageAdapter(output_dir=adapter._root, **data)
+    assert restored.type == adapter.type
+
+
+def test_upload_download(adapter):
+    data = io.BytesIO(b"hello")
+    uri = adapter.upload("foo.txt", data)
+    assert uri.endswith("foo.txt")
+    out = adapter.download("foo.txt").read()
+    assert out == b"hello"

--- a/pkgs/standards/swarmauri_storage_github/swarmauri_storage_github/__init__.py
+++ b/pkgs/standards/swarmauri_storage_github/swarmauri_storage_github/__init__.py
@@ -1,3 +1,13 @@
 from .github_storage_adapter import GithubStorageAdapter
 
 __all__ = ["GithubStorageAdapter"]
+
+try:  # pragma: no cover
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError:  # pragma: no cover
+    from importlib_metadata import version, PackageNotFoundError
+
+try:  # pragma: no cover
+    __version__ = version("swarmauri_storage_github")
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "0.0.0"

--- a/pkgs/standards/swarmauri_storage_github/swarmauri_storage_github/github_storage_adapter.py
+++ b/pkgs/standards/swarmauri_storage_github/swarmauri_storage_github/github_storage_adapter.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 import os
 from typing import BinaryIO
 
+from swarmauri_base.ComponentBase import ComponentBase
 from swarmauri_base.storage import StorageAdapterBase
 
 
+@ComponentBase.register_type(StorageAdapterBase, "GithubStorageAdapter")
 class GithubStorageAdapter(StorageAdapterBase):
     def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
         self.kwargs = kwargs
 
     def upload(self, key: str, data: BinaryIO) -> str:  # pragma: no cover - stub

--- a/pkgs/standards/swarmauri_storage_github/tests/i9n/test_i9n__init__.py
+++ b/pkgs/standards/swarmauri_storage_github/tests/i9n/test_i9n__init__.py
@@ -1,0 +1,23 @@
+import importlib
+import pytest
+
+
+@pytest.mark.i9n
+def test_init_module_import():
+    module = importlib.import_module("swarmauri_storage_github")
+    assert module is not None
+
+
+@pytest.mark.i9n
+def test_init_module_version():
+    module = importlib.import_module("swarmauri_storage_github")
+    assert hasattr(module, "__version__")
+    assert isinstance(module.__version__, str)
+    assert module.__version__
+
+
+@pytest.mark.i9n
+def test_init_module_all_variable():
+    module = importlib.import_module("swarmauri_storage_github")
+    assert hasattr(module, "__all__")
+    assert "GithubStorageAdapter" in module.__all__

--- a/pkgs/standards/swarmauri_storage_github/tests/unit/test_github_storage_adapter.py
+++ b/pkgs/standards/swarmauri_storage_github/tests/unit/test_github_storage_adapter.py
@@ -1,0 +1,23 @@
+import io
+
+
+from swarmauri_storage_github import GithubStorageAdapter
+
+
+def test_ubc_resource_type():
+    adapter = GithubStorageAdapter()
+    assert adapter.resource == "StorageAdapter"
+    assert adapter.type == "GithubStorageAdapter"
+
+
+def test_round_trip_serialization():
+    adapter = GithubStorageAdapter()
+    serialized = adapter.model_dump_json()
+    restored = GithubStorageAdapter.model_validate_json(serialized)
+    assert restored.type == adapter.type
+
+
+def test_upload_returns_uri():
+    adapter = GithubStorageAdapter()
+    uri = adapter.upload("foo.txt", io.BytesIO(b"hi"))
+    assert uri == "github://foo.txt"

--- a/pkgs/standards/swarmauri_storage_github_release/swarmauri_storage_github_release/__init__.py
+++ b/pkgs/standards/swarmauri_storage_github_release/swarmauri_storage_github_release/__init__.py
@@ -1,3 +1,13 @@
 from .gh_release_storage_adapter import GithubReleaseStorageAdapter
 
 __all__ = ["GithubReleaseStorageAdapter"]
+
+try:  # pragma: no cover
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError:  # pragma: no cover
+    from importlib_metadata import version, PackageNotFoundError
+
+try:  # pragma: no cover
+    __version__ = version("swarmauri_storage_github_release")
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "0.0.0"

--- a/pkgs/standards/swarmauri_storage_github_release/swarmauri_storage_github_release/gh_release_storage_adapter.py
+++ b/pkgs/standards/swarmauri_storage_github_release/swarmauri_storage_github_release/gh_release_storage_adapter.py
@@ -11,18 +11,20 @@ import tempfile
 from pathlib import Path
 from typing import BinaryIO, Optional
 
+from swarmauri_base.ComponentBase import ComponentBase
 from swarmauri_base.storage import StorageAdapterBase
 
 from peagen._utils.config_loader import load_peagen_toml
 from github import Github, UnknownObjectException
 
 
+@ComponentBase.register_type(StorageAdapterBase, "GithubReleaseStorageAdapter")
 class GithubReleaseStorageAdapter(StorageAdapterBase):
     """Storage adapter that uses GitHub Releases to store and retrieve assets."""
 
     def __init__(
         self,
-        token: SecretStr,
+        token: SecretStr | str,
         org: str,
         repo: str,
         tag: str,
@@ -32,8 +34,11 @@ class GithubReleaseStorageAdapter(StorageAdapterBase):
         draft: bool = False,
         prerelease: bool = False,
         prefix: str = "",
+        **kwargs,
     ) -> None:
-        self._client = Github(token.get_secret_value())
+        super().__init__(**kwargs)
+        token_val = token.get_secret_value() if isinstance(token, SecretStr) else token
+        self._client = Github(token_val)
         self._repo = self._client.get_organization(org).get_repo(repo)
         self._tag = tag
         self._prefix = prefix.lstrip("/")

--- a/pkgs/standards/swarmauri_storage_github_release/tests/i9n/test_i9n__init__.py
+++ b/pkgs/standards/swarmauri_storage_github_release/tests/i9n/test_i9n__init__.py
@@ -1,0 +1,23 @@
+import importlib
+import pytest
+
+
+@pytest.mark.i9n
+def test_init_module_import():
+    module = importlib.import_module("swarmauri_storage_github_release")
+    assert module is not None
+
+
+@pytest.mark.i9n
+def test_init_module_version():
+    module = importlib.import_module("swarmauri_storage_github_release")
+    assert hasattr(module, "__version__")
+    assert isinstance(module.__version__, str)
+    assert module.__version__
+
+
+@pytest.mark.i9n
+def test_init_module_all_variable():
+    module = importlib.import_module("swarmauri_storage_github_release")
+    assert hasattr(module, "__all__")
+    assert "GithubReleaseStorageAdapter" in module.__all__

--- a/pkgs/standards/swarmauri_storage_minio/swarmauri_storage_minio/__init__.py
+++ b/pkgs/standards/swarmauri_storage_minio/swarmauri_storage_minio/__init__.py
@@ -1,3 +1,13 @@
 from .minio_storage_adapter import MinioStorageAdapter
 
 __all__ = ["MinioStorageAdapter"]
+
+try:  # pragma: no cover
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError:  # pragma: no cover
+    from importlib_metadata import version, PackageNotFoundError
+
+try:  # pragma: no cover
+    __version__ = version("swarmauri_storage_minio")
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "0.0.0"

--- a/pkgs/standards/swarmauri_storage_minio/swarmauri_storage_minio/minio_storage_adapter.py
+++ b/pkgs/standards/swarmauri_storage_minio/swarmauri_storage_minio/minio_storage_adapter.py
@@ -11,6 +11,7 @@ import shutil
 from pathlib import Path
 from typing import BinaryIO, Optional
 
+from swarmauri_base.ComponentBase import ComponentBase
 from swarmauri_base.storage import StorageAdapterBase
 
 from minio import Minio
@@ -20,6 +21,7 @@ from pydantic import SecretStr
 from peagen._utils.config_loader import load_peagen_toml
 
 
+@ComponentBase.register_type(StorageAdapterBase, "MinioStorageAdapter")
 class MinioStorageAdapter(StorageAdapterBase):
     """Simple wrapper around the MinIO client for use with Peagen."""
 
@@ -32,7 +34,9 @@ class MinioStorageAdapter(StorageAdapterBase):
         *,
         secure: bool = True,
         prefix: str = "",
+        **kwargs,
     ) -> None:
+        super().__init__(**kwargs)
         self._client = Minio(
             endpoint,
             access_key=access_key,

--- a/pkgs/standards/swarmauri_storage_minio/tests/i9n/test_i9n__init__.py
+++ b/pkgs/standards/swarmauri_storage_minio/tests/i9n/test_i9n__init__.py
@@ -1,0 +1,23 @@
+import importlib
+import pytest
+
+
+@pytest.mark.i9n
+def test_init_module_import():
+    module = importlib.import_module("swarmauri_storage_minio")
+    assert module is not None
+
+
+@pytest.mark.i9n
+def test_init_module_version():
+    module = importlib.import_module("swarmauri_storage_minio")
+    assert hasattr(module, "__version__")
+    assert isinstance(module.__version__, str)
+    assert module.__version__
+
+
+@pytest.mark.i9n
+def test_init_module_all_variable():
+    module = importlib.import_module("swarmauri_storage_minio")
+    assert hasattr(module, "__all__")
+    assert "MinioStorageAdapter" in module.__all__

--- a/pkgs/standards/swarmauri_storage_minio/tests/unit/test_minio_storage_adapter.py
+++ b/pkgs/standards/swarmauri_storage_minio/tests/unit/test_minio_storage_adapter.py
@@ -1,0 +1,82 @@
+import io
+
+import pytest
+
+from swarmauri_storage_minio import MinioStorageAdapter
+
+
+class DummyObject:
+    def __init__(self, data: bytes):
+        self._data = data
+
+    def read(self):
+        return self._data
+
+    def close(self):
+        pass
+
+    def release_conn(self):
+        pass
+
+
+class DummyClient:
+    def __init__(self, *args, **kwargs):
+        self.store = {}
+
+    def bucket_exists(self, bucket):
+        return True
+
+    def make_bucket(self, bucket):
+        pass
+
+    def put_object(self, bucket, key, data, length=-1, part_size=0):
+        self.store[key] = data.read()
+
+    def get_object(self, bucket, key):
+        if key not in self.store:
+            raise Exception("not found")
+        return DummyObject(self.store[key])
+
+    def list_objects(self, bucket, prefix="", recursive=True):
+        class Obj:
+            def __init__(self, name):
+                self.object_name = name
+
+        for k in self.store.keys():
+            if k.startswith(prefix):
+                yield Obj(k)
+
+
+@pytest.fixture
+def adapter(monkeypatch):
+    monkeypatch.setattr(
+        "swarmauri_storage_minio.minio_storage_adapter.Minio",
+        DummyClient,
+    )
+    return MinioStorageAdapter(
+        endpoint="example.com",
+        bucket="b",
+        access_key="a",
+        secret_key="s",
+    )
+
+
+def test_resource_type_serialization(adapter):
+    assert adapter.resource == "StorageAdapter"
+    assert adapter.type == "MinioStorageAdapter"
+    data = adapter.model_dump()
+    restored = MinioStorageAdapter(
+        endpoint="example.com",
+        bucket="b",
+        access_key="a",
+        secret_key="s",
+        **data,
+    )
+    assert restored.type == adapter.type
+
+
+def test_upload_download(adapter):
+    uri = adapter.upload("foo.txt", io.BytesIO(b"hi"))
+    assert uri.endswith("foo.txt")
+    data = adapter.download("foo.txt").read()
+    assert data == b"hi"


### PR DESCRIPTION
## Summary
- add version metadata to storage adapter and git filter packages
- implement type registration and initialization for adapters and filters
- introduce comprehensive tests for storage and git filter packages

## Testing
- `uv run --directory standards/swarmauri_storage_file --package swarmauri_storage_file ruff check . --fix`
- `uv run --package swarmauri_storage_file --directory standards/swarmauri_storage_file pytest`
- `uv run --directory standards/swarmauri_storage_github --package swarmauri_storage_github ruff check . --fix`
- `uv run --package swarmauri_storage_github --directory standards/swarmauri_storage_github pytest`
- `uv run --directory standards/swarmauri_storage_github_release --package swarmauri_storage_github_release ruff check . --fix`
- `uv run --package swarmauri_storage_github_release --directory standards/swarmauri_storage_github_release pytest`
- `uv run --directory standards/swarmauri_storage_minio --package swarmauri_storage_minio ruff check . --fix`
- `uv run --package swarmauri_storage_minio --directory standards/swarmauri_storage_minio pytest`
- `uv run --directory standards/swarmauri_gitfilter_file --package swarmauri_gitfilter_file ruff check . --fix`
- `uv run --package swarmauri_gitfilter_file --directory standards/swarmauri_gitfilter_file pytest`
- `uv run --directory standards/swarmauri_gitfilter_gh_release --package swarmauri_gitfilter_gh_release ruff check . --fix`
- `uv run --package swarmauri_gitfilter_gh_release --directory standards/swarmauri_gitfilter_gh_release pytest`
- `uv run --directory standards/swarmauri_gitfilter_minio --package swarmauri_gitfilter_minio ruff check . --fix`
- `uv run --package swarmauri_gitfilter_minio --directory standards/swarmauri_gitfilter_minio pytest`
- `uv run --directory standards/swarmauri_gitfilter_s3fs --package swarmauri_gitfilter_s3fs ruff check . --fix`
- `uv run --package swarmauri_gitfilter_s3fs --directory standards/swarmauri_gitfilter_s3fs pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b02ecf263c8326b487e8da87833a9d