### PR TITLE
test: verify sqlite attachments on initialization

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_sqlite_attachments.py
+++ b/pkgs/standards/autoapi/tests/unit/test_sqlite_attachments.py
@@ -1,0 +1,49 @@
+import pytest
+from autoapi.v3.autoapi import AutoAPI
+
+
+def _db_names(conn):
+    result = conn.exec_driver_sql("PRAGMA database_list")
+    return {row[1] for row in result.fetchall()}
+
+
+def test_initialize_sync_without_sqlite_attachments(sync_db_session):
+    engine, get_db = sync_db_session
+    api = AutoAPI(get_db=get_db)
+    api.initialize_sync()
+    with engine.connect() as conn:
+        assert _db_names(conn) == {"main"}
+
+
+def test_initialize_sync_with_sqlite_attachments(sync_db_session, tmp_path):
+    engine, get_db = sync_db_session
+    attach_db = tmp_path / "logs.sqlite"
+    attach_db.touch()
+    api = AutoAPI(get_db=get_db)
+    api.initialize_sync(sqlite_attachments={"logs": str(attach_db)})
+    with engine.connect() as conn:
+        assert "logs" in _db_names(conn)
+
+
+@pytest.mark.asyncio
+async def test_initialize_async_without_sqlite_attachments(async_db_session):
+    engine, get_async_db = async_db_session
+    api = AutoAPI(get_async_db=get_async_db)
+    await api.initialize_async()
+    async with engine.connect() as conn:
+        result = await conn.exec_driver_sql("PRAGMA database_list")
+        names = {row[1] for row in result.fetchall()}
+    assert names == {"main"}
+
+
+@pytest.mark.asyncio
+async def test_initialize_async_with_sqlite_attachments(async_db_session, tmp_path):
+    engine, get_async_db = async_db_session
+    attach_db = tmp_path / "logs.sqlite"
+    attach_db.touch()
+    api = AutoAPI(get_async_db=get_async_db)
+    await api.initialize_async(sqlite_attachments={"logs": str(attach_db)})
+    async with engine.connect() as conn:
+        result = await conn.exec_driver_sql("PRAGMA database_list")
+        names = {row[1] for row in result.fetchall()}
+    assert "logs" in names


### PR DESCRIPTION
## Summary
- add unit tests exercising AutoAPI.initialize_sync/async with and without sqlite attachments

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_sqlite_attachments.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0344739948326b0e246fbf930085e