### PR TITLE
fix workspace path for local ca package

### DIFF
--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -115,7 +115,7 @@ members = [
     "standards/swarmauri_signing_ecdsa",
     "standards/swarmauri_signing_ca",
     "standards/swarmauri_signing_jws",
-    "swarmauri_certs_local_ca",
+    "standards/swarmauri_certs_local_ca",
     "standards/swarmauri_certs_self_signed",
     "standards/swarmauri_tokens_jwt",
     "standards/swarmauri_tokens_sshsig",


### PR DESCRIPTION
## Summary
- fix workspace member path for local ca cert service to include standards directory

## Testing
- `uv run --project pkgs --directory pkgs/standards/swarmauri_certs_local_ca --package swarmauri_certs_local_ca ruff format .`
- `uv run --project pkgs --directory pkgs/standards/swarmauri_certs_local_ca --package swarmauri_certs_local_ca ruff check . --fix`
- `uv run --project pkgs --directory pkgs/standards/swarmauri_certs_local_ca --package swarmauri_certs_local_ca pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b035950eac832681f6d2f3beb0160b