### PR TITLE
Handle missing objects with KeyError in GitFilterBase

### DIFF
--- a/pkgs/base/swarmauri_base/git_filters/GitFilterBase.py
+++ b/pkgs/base/swarmauri_base/git_filters/GitFilterBase.py
@@ -28,7 +28,9 @@ class GitFilterBase(IGitFilter):
         oid = "sha256:" + hashlib.sha256(data).hexdigest()
         try:
             self.download(oid)
-        except FileNotFoundError:
+        except (FileNotFoundError, KeyError):
+            # Some storage backends may raise ``KeyError`` instead of ``FileNotFoundError``
+            # when an object is missing. Treat both cases as a cache miss and upload.
             self.upload(oid, io.BytesIO(data))
         return oid
 


### PR DESCRIPTION
## Summary
- handle storage backends that raise KeyError for missing objects in GitFilterBase.clean

## Testing
- `uv run --directory base --package swarmauri_base ruff format .`
- `uv run --directory base --package swarmauri_base ruff check . --fix`
- `uv run --package swarmauri_base --directory base pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b036138e5883268466e48f1e51ca75