### PR TITLE
fix: replace pkcs11 dependency with python-pkcs11

### DIFF
--- a/pkgs/standards/swarmauri_keyprovider_hierarchical/pyproject.toml
+++ b/pkgs/standards/swarmauri_keyprovider_hierarchical/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
 
 [project.optional-dependencies]
 aws = ["boto3"]
-pkcs11 = ["pkcs11"]
+pkcs11 = ["python-pkcs11>=0.7.0"]
 
 [tool.uv.sources]
 swarmauri_core = { workspace = true }

--- a/pkgs/standards/swarmauri_keyprovider_pkcs11/pyproject.toml
+++ b/pkgs/standards/swarmauri_keyprovider_pkcs11/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "cryptography",
-    "pkcs11",
+    "python-pkcs11>=0.7.0",
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_keyprovider_pkcs11/swarmauri_keyprovider_pkcs11/Pkcs11KeyProvider.py
+++ b/pkgs/standards/swarmauri_keyprovider_pkcs11/swarmauri_keyprovider_pkcs11/Pkcs11KeyProvider.py
@@ -58,7 +58,9 @@ class Pkcs11KeyProvider(KeyProviderBase):
     ) -> None:
         super().__init__()
         if not _PKCS11_OK:
-            raise ImportError("pkcs11 is required. Install with: pip install pkcs11")
+            raise ImportError(
+                "pkcs11 is required. Install with: pip install python-pkcs11"
+            )
 
         self._lib = pkcs11.lib(module_path)
         if token_label:


### PR DESCRIPTION
## Summary
- replace deprecated `pkcs11` package with `python-pkcs11`
- clarify installation instructions for pkcs11 provider
- update hierarchical key provider optional dependencies

## Testing
- `uv run --directory pkgs/standards/swarmauri_keyprovider_pkcs11 --package swarmauri_keyprovider_pkcs11 ruff check . --fix`
- `uv run --directory pkgs/standards/swarmauri_keyprovider_hierarchical --package swarmauri_keyprovider_hierarchical ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b0365f572883269691dcc222937c6f