### PR TITLE
fix: use python-pkcs11 dependency

### DIFF
--- a/pkgs/standards/swarmauri_keyprovider_pkcs11/pyproject.toml
+++ b/pkgs/standards/swarmauri_keyprovider_pkcs11/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "cryptography",
-    "pkcs11",
+    "python-pkcs11",
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_keyprovider_pkcs11/swarmauri_keyprovider_pkcs11/Pkcs11KeyProvider.py
+++ b/pkgs/standards/swarmauri_keyprovider_pkcs11/swarmauri_keyprovider_pkcs11/Pkcs11KeyProvider.py
@@ -58,7 +58,9 @@ class Pkcs11KeyProvider(KeyProviderBase):
     ) -> None:
         super().__init__()
         if not _PKCS11_OK:
-            raise ImportError("pkcs11 is required. Install with: pip install pkcs11")
+            raise ImportError(
+                "python-pkcs11 is required. Install with: pip install python-pkcs11"
+            )
 
         self._lib = pkcs11.lib(module_path)
         if token_label:


### PR DESCRIPTION
## Summary
- depend on python-pkcs11 instead of pkcs11
- clarify import error message

## Testing
- `uv run --directory pkgs/standards/swarmauri_keyprovider_pkcs11 --package swarmauri_keyprovider_pkcs11 ruff format .`
- `uv run --directory pkgs/standards/swarmauri_keyprovider_pkcs11 --package swarmauri_keyprovider_pkcs11 ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b0365f572883269691dcc222937c6f