### PR TITLE
Use httpx client and support Annotated types in tool decorator

### DIFF
--- a/pkgs/swarmauri_standard/swarmauri_standard/tools/JSONRequestsTool.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/tools/JSONRequestsTool.py
@@ -64,6 +64,9 @@ class JSONRequestsTool(ToolBase):
         ]
     )
 
+    # Reusable client for requests; allows injection of a custom transport for testing.
+    client: httpx.Client = Field(default_factory=httpx.Client, exclude=True)
+
     def get(
         self,
         url: str,
@@ -81,7 +84,7 @@ class JSONRequestsTool(ToolBase):
         Returns:
             httpx.Response: The response object from the GET request.
         """
-        response = httpx.get(url, params=params, headers=headers)
+        response = self.client.get(url, params=params, headers=headers)
         response.raise_for_status()  # Raise an HTTPStatusError for bad responses (4xx and 5xx)
         return response
 
@@ -104,7 +107,7 @@ class JSONRequestsTool(ToolBase):
         Returns:
             httpx.Response: The response object from the POST request.
         """
-        response = httpx.post(url, data=data, json=json, headers=headers)
+        response = self.client.post(url, data=data, json=json, headers=headers)
         response.raise_for_status()  # Raise an HTTPStatusError for bad responses (4xx and 5xx)
         return response
 
@@ -127,7 +130,7 @@ class JSONRequestsTool(ToolBase):
         Returns:
             httpx.Response: The response object from the PUT request.
         """
-        response = httpx.put(url, data=data, json=json, headers=headers)
+        response = self.client.put(url, data=data, json=json, headers=headers)
         response.raise_for_status()  # Raise an HTTPStatusError for bad responses (4xx and 5xx)
         return response
 
@@ -144,7 +147,7 @@ class JSONRequestsTool(ToolBase):
         Returns:
             httpx.Response: The response object from the DELETE request.
         """
-        response = httpx.delete(url, headers=headers)
+        response = self.client.delete(url, headers=headers)
         response.raise_for_status()  # Raise an HTTPStatusError for bad responses (4xx and 5xx)
         return response
 

--- a/pkgs/swarmauri_standard/tests/unit/tools/JSONRequestsTool_unit_test.py
+++ b/pkgs/swarmauri_standard/tests/unit/tools/JSONRequestsTool_unit_test.py
@@ -1,5 +1,33 @@
+import json
+import httpx
 import pytest
+
 from swarmauri_standard.tools.JSONRequestsTool import JSONRequestsTool as Tool
+
+
+def _mock_httpbin(request: httpx.Request) -> httpx.Response:
+    data = {
+        "args": dict(request.url.params),
+        "headers": dict(request.headers),
+        "origin": "0.0.0.0",
+        "url": str(request.url),
+    }
+    if request.method in {"POST", "PUT", "DELETE"}:
+        if request.content:
+            try:
+                data["json"] = json.loads(request.content.decode())
+            except json.JSONDecodeError:
+                data["json"] = None
+        else:
+            data["json"] = None
+    return httpx.Response(200, json=data)
+
+
+@pytest.fixture
+def tool():
+    transport = httpx.MockTransport(_mock_httpbin)
+    client = httpx.Client(transport=transport)
+    return Tool(client=client)
 
 
 @pytest.mark.unit
@@ -28,37 +56,28 @@ def test_serialization():
 @pytest.mark.parametrize(
     "method, url, kwargs",
     [
-        ("get", "https://httpbin.org/get", {}),
-        ("post", "https://httpbin.org/post", {"json": {"key": "value"}}),
-        ("put", "https://httpbin.org/put", {"json": {"key": "value"}}),
-        ("delete", "https://httpbin.org/delete", {}),
+        ("get", "https://example.com/get", {}),
+        ("post", "https://example.com/post", {"json": {"key": "value"}}),
+        ("put", "https://example.com/put", {"json": {"key": "value"}}),
+        ("delete", "https://example.com/delete", {}),
     ],
 )
 @pytest.mark.unit
-def test_call(method, url, kwargs):
-    tool = Tool()
-
+def test_call(method, url, kwargs, tool):
     expected_keys = {"args", "headers", "origin", "url"}
 
-    try:
-        result = tool(method, url, **kwargs)
+    result = tool(method, url, **kwargs)
 
-        assert isinstance(result, dict), (
-            f"Expected dict, but got {type(result).__name__}"
-        )
-        assert expected_keys.issubset(result.keys()), (
-            f"Expected keys {expected_keys} to be a subset of {result.keys()}"
-        )
+    assert isinstance(result, dict), f"Expected dict, but got {type(result).__name__}"
+    assert expected_keys.issubset(result.keys()), (
+        f"Expected keys {expected_keys} to be a subset of {result.keys()}"
+    )
 
-        # Check for method-specific keys
-        if method in ["post", "put", "delete"]:
-            assert "json" in result, f"Expected 'json' key for {method.upper()} method"
-            if kwargs.get("json"):
-                assert result["json"] == kwargs["json"], (
-                    f"Expected JSON payload {kwargs['json']}, but got {result['json']}"
-                )
+    if method in ["post", "put", "delete"]:
+        assert "json" in result, f"Expected 'json' key for {method.upper()} method"
+        if kwargs.get("json"):
+            assert result["json"] == kwargs["json"], (
+                f"Expected JSON payload {kwargs['json']}, but got {result['json']}"
+            )
 
-        assert result["url"] == url, f"Expected URL {url}, but got {result['url']}"
-
-    except Exception as e:
-        pytest.fail(f"{method.upper()} request failed with error: {e}")
+    assert result["url"] == url, f"Expected URL {url}, but got {result['url']}"


### PR DESCRIPTION
## Summary
- Inject reusable httpx client into JSONRequestsTool for easier testing
- Teach tool decorator to retain Annotated type hints
- Mock HTTP interactions in JSONRequestsTool unit tests

## Testing
- `uv run --package swarmauri-standard --directory swarmauri_standard ruff format .`
- `uv run --package swarmauri-standard --directory swarmauri_standard ruff check . --fix`
- `uv run --package swarmauri-standard --directory swarmauri_standard pytest tests/unit/tools/JSONRequestsTool_unit_test.py tests/unit/utils/tool_decorator_additional_test.py`


------
https://chatgpt.com/codex/tasks/task_e_68b03556b4b883268f4731ec0e5a95b5