### PR TITLE
Handle string key material when fingerprinting

### DIFF
--- a/pkgs/core/swarmauri_core/crypto/types.py
+++ b/pkgs/core/swarmauri_core/crypto/types.py
@@ -161,14 +161,16 @@ class KeyRef:
     uses: Tuple[KeyUse, ...]
     export_policy: ExportPolicy
     uri: Optional[str] = None
-    material: Optional[bytes] = None
-    public: Optional[bytes] = None
+    material: Optional[bytes | str] = None
+    public: Optional[bytes | str] = None
     tags: Dict[str, str] | None = None
     fingerprint: Optional[str] = None
 
     def __post_init__(self) -> None:
         if self.fingerprint is None:
             data = self.public or self.material or self.kid.encode("utf-8")
+            if isinstance(data, str):
+                data = data.encode("utf-8")
             object.__setattr__(self, "fingerprint", hashlib.sha256(data).hexdigest())
 
 


### PR DESCRIPTION
## Summary
- allow `KeyRef` to accept string key material or public key data, encoding to bytes before computing fingerprint

## Testing
- `uv run --package swarmauri_core --directory core pytest`
- `uv run --package swarmauri_tokens_sshcert --directory standards/swarmauri_tokens_sshcert pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0356aad10832695db097146cdd07b