### PR TITLE
Implement jwks method for PasetoV4TokenService

### DIFF
--- a/pkgs/standards/swarmauri_tokens_paseto_v4/swarmauri_tokens_paseto_v4/PasetoV4TokenService.py
+++ b/pkgs/standards/swarmauri_tokens_paseto_v4/swarmauri_tokens_paseto_v4/PasetoV4TokenService.py
@@ -269,3 +269,7 @@ class PasetoV4TokenService(TokenServiceBase):
                 raise ValueError("Audience (aud) mismatch")
 
         return payload_obj
+
+    async def jwks(self) -> dict:
+        """Return provider's JWKS."""
+        return await self._kp.jwks()


### PR DESCRIPTION
## Summary
- implement `jwks` to expose key provider JWKS in `PasetoV4TokenService`

## Testing
- `uv run --package swarmauri_tokens_paseto_v4 --directory standards/swarmauri_tokens_paseto_v4 pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b03d63e1508326b485e0ff59cbee69