### PR TITLE
Handle missing PKCS11 library in provider init

### DIFF
--- a/pkgs/experimental/swarmauri_keyprovider_pkcs11/swarmauri_keyprovider_pkcs11/Pkcs11KeyProvider.py
+++ b/pkgs/experimental/swarmauri_keyprovider_pkcs11/swarmauri_keyprovider_pkcs11/Pkcs11KeyProvider.py
@@ -62,7 +62,10 @@ class Pkcs11KeyProvider(KeyProviderBase):
                 "python-pkcs11 is required. Install with: pip install python-pkcs11"
             )
 
-        self._lib = pkcs11.lib(module_path)
+        try:
+            self._lib = pkcs11.lib(module_path)
+        except pkcs11.PKCS11Error as exc:  # pragma: no cover - init sanity
+            raise ImportError(f"failed to load PKCS#11 module: {module_path}") from exc
         if token_label:
             self._slot = next(
                 (


### PR DESCRIPTION
## Summary
- Raise ImportError when PKCS#11 module fails to load, preventing obscure errors

## Testing
- `uv run --package swarmauri_keyprovider_pkcs11 --directory experimental/swarmauri_keyprovider_pkcs11 ruff format .`
- `uv run --package swarmauri_keyprovider_pkcs11 --directory experimental/swarmauri_keyprovider_pkcs11 ruff check . --fix`
- `uv run --package swarmauri_keyprovider_pkcs11 --directory experimental/swarmauri_keyprovider_pkcs11 pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b03d75e3f88326aae5108f923ff9cb