### PR TITLE
Add swarmauri crypto rust to workspace

### DIFF
--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -99,6 +99,7 @@ members = [
     "experimental/swarmauri_keyprovider_pkcs11",
     "standards/swarmauri_crypto_paramiko",
     "standards/swarmauri_crypto_pgp",
+    "standards/swarmauri_crypto_rust",
     "standards/swarmauri_crypto_sodium",
     "standards/swarmauri_crypto_nacl_pkcs11",
     "standards/swarmauri_crypto_jwe",
@@ -278,6 +279,7 @@ auto_kms = { workspace = true }
 swarmauri_secret_autogpg = { workspace = true }
 swarmauri_crypto_paramiko = { workspace = true }
 swarmauri_crypto_pgp = { workspace = true }
+swarmauri_crypto_rust = { workspace = true }
 swarmauri_crypto_nacl_pkcs11 = { workspace = true }
 swarmauri_crypto_composite = { workspace = true }
 swarmauri_crypto_ecdh_es_a128kw = { workspace = true }

--- a/pkgs/standards/swarmauri_crypto_rust/python/swarmauri_crypto_rust/RustCrypto.py
+++ b/pkgs/standards/swarmauri_crypto_rust/python/swarmauri_crypto_rust/RustCrypto.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import secrets
 import warnings
-from typing import Any, Dict, Iterable, Literal, Optional
+from typing import Dict, Iterable, Literal, Optional
 
 from swarmauri_core.crypto.types import (
     AEADCiphertext as CoreAEADCiphertext,


### PR DESCRIPTION
## Summary
- register swarmauri_crypto_rust as a workspace member and source
- clean up unused imports in RustCrypto wrapper

## Testing
- `uv run --directory pkgs/standards/swarmauri_crypto_rust --package swarmauri_crypto_rust ruff format .`
- `uv run --directory pkgs/standards/swarmauri_crypto_rust --package swarmauri_crypto_rust ruff check . --fix`
- `cd pkgs && uv run --package swarmauri_crypto_rust --directory standards/swarmauri_crypto_rust pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b03d8b3d5c832680487de4a1669381