### PR TITLE
fix(auto_kms): add asyncpg dependency

### DIFF
--- a/pkgs/standards/auto_kms/pyproject.toml
+++ b/pkgs/standards/auto_kms/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "typer>=0.12.3",
     "uvicorn[standard]>=0.29",
     "sqlalchemy[asyncio]>=2.0.0",
+    "asyncpg>=0.29,<1.0",
     "swarmauri_secret_autogpg",
     "swarmauri_crypto_paramiko"
 ]


### PR DESCRIPTION
## Summary
- include asyncpg dependency so Auto KMS can connect to PostgreSQL

## Testing
- `uv run --package auto_kms --directory pkgs/standards/auto_kms ruff format .`
- `uv run --package auto_kms --directory pkgs/standards/auto_kms ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b059583b448326a90b4cf5b2edb8d2