### PR TITLE
feat: add postgres extras and fix hook ordering

### DIFF
--- a/pkgs/standards/autoapi/pyproject.toml
+++ b/pkgs/standards/autoapi/pyproject.toml
@@ -25,6 +25,12 @@ dependencies = [
     "greenlet>=3.2.3",
 ]
 
+[project.optional-dependencies]
+postgres = [
+    "psycopg2-binary>=2.9",
+    "asyncpg>=0.30",
+]
+
 [tool.uv.sources]
 swarmauri_core = { workspace = true }
 swarmauri_base = { workspace = true }


### PR DESCRIPTION
## Summary
- add optional Postgres dependencies to autoapi
- ensure _shadow_principal is first in PRE_TX_BEGIN hook chains

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest`
- `uv run --package peagen --directory standards/peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b05ea9c2ec8326922695c1a048abac