### PR TITLE
feat(autoapi,peagen): add postgres extras and fix gateway hook ordering

### DIFF
--- a/pkgs/standards/autoapi/pyproject.toml
+++ b/pkgs/standards/autoapi/pyproject.toml
@@ -25,6 +25,9 @@ dependencies = [
     "greenlet>=3.2.3",
 ]
 
+[project.optional-dependencies]
+postgres = ["asyncpg>=0.30.0", "psycopg2-binary>=2.9"]
+
 [tool.uv.sources]
 swarmauri_core = { workspace = true }
 swarmauri_base = { workspace = true }

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -299,11 +299,11 @@ async def _startup() -> None:
 
     # 1 – metadata validation / SQLite convenience mode
     await api.initialize_async()
-    # ensure our hook runs second after the AuthN injection hook
-    _pre = api._hook_registry.get("PRE_TX_BEGIN", {}).get(None, [])
+    # ensure our hook remains at the front of the PRE_TX_BEGIN chain
+    _pre = (getattr(api, "_api_hooks_map", {}) or {}).get("PRE_TX_BEGIN", [])
     for idx, fn in enumerate(_pre):
         if getattr(fn, "__name__", "") == "_shadow_principal":
-            _pre.insert(1, _pre.pop(idx))
+            _pre.insert(0, _pre.pop(idx))
             break
 
     # 2 – run Alembic first so the ORM never creates tables implicitly


### PR DESCRIPTION
## Summary
- expose postgres extra for asyncpg and psycopg2 drivers in autoapi
- fix peagen gateway startup to use modern AutoAPI hook map

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest`
- `uv run --package peagen --directory standards/peagen pytest` *(interrupted after completion)*

------
https://chatgpt.com/codex/tasks/task_e_68b05eab386483269a1ffd1bb4f46cad