### PR TITLE
ci: annotate container startup status

### DIFF
--- a/.github/workflows/peagen_ci.yml
+++ b/.github/workflows/peagen_ci.yml
@@ -41,48 +41,66 @@ jobs:
       PEAGEN_GIT_SHADOW_PAT:    ${{ secrets.PEAGEN_GIT_SHADOW_PAT }}
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Deploy with Docker Compose
-      id: deploy
-      run: |
-        # pre build prune always
-        sudo docker system prune -f
+      - name: Deploy with Docker Compose
+        id: deploy
+        run: |
+          # pre build prune always
+          sudo docker system prune -f
 
-        sudo -E docker compose \
-          -f infra/peagen/docker-compose.yml \
-          down auto_authn auto_kms gateway worker || true
+          sudo -E docker compose \
+            -f infra/peagen/docker-compose.yml \
+            down auto_authn auto_kms gateway worker || true
 
-        sudo -E docker compose \
-          -f infra/peagen/docker-compose.yml \
-          up -d --build --force-recreate --no-deps auto_authn auto_kms gateway worker
+          sudo -E docker compose \
+            -f infra/peagen/docker-compose.yml \
+            up -d --build --force-recreate --no-deps auto_authn auto_kms gateway worker
+
+      - name: Verify services
+        run: |
+          services="auto_authn auto_kms gateway worker"
+          failed=0
+          for svc in $services; do
+            cid=$(sudo -E docker compose -f infra/peagen/docker-compose.yml ps -q $svc)
+            status=$(sudo docker inspect -f '{{.State.Status}}' "$cid" 2>/dev/null)
+            if [ "$status" != "running" ]; then
+              log=$(sudo -E docker compose -f infra/peagen/docker-compose.yml logs --tail 10 $svc)
+              log="${log//'%'/'%25'}"
+              log="${log//$'\n'/'%0A'}"
+              log="${log//$'\r'/'%0D'}"
+              echo "::error title=$svc failed::$log"
+              failed=1
+            fi
+          done
+          if [ $failed -eq 0 ]; then
+            echo "::notice title=Services started::All containers are running"
+          else
+            exit 1
+          fi
 
 
+      # Collect logs only when *any* previous step failed (deploy or later)
+      - name: Get container logs on failure
+        if: failure()          # <- overrides the implicit success() check
+        run: |
+          echo "::group::auto_authn logs"
+          sudo -E docker compose -f infra/peagen/docker-compose.yml logs auto_authn || true
+          echo "::endgroup::"
 
+          echo "::group::auto_kms logs"
+          sudo -E docker compose -f infra/peagen/docker-compose.yml logs auto_kms || true
+          echo "::endgroup::"
 
+          echo "::group::gateway logs"
+          sudo -E docker compose -f infra/peagen/docker-compose.yml logs gateway || true
+          echo "::endgroup::"
 
+          echo "::group::worker logs"
+          sudo -E docker compose -f infra/peagen/docker-compose.yml logs worker || true
+          echo "::endgroup::"
 
-    # Collect logs only when *any* previous step failed (deploy or later)
-    - name: Get container logs on failure
-      if: failure()          # <- overrides the implicit success() check
-      run: |
-        echo "::group::auto_authn logs"
-        sudo -E docker compose -f infra/peagen/docker-compose.yml logs auto_authn || true
-        echo "::endgroup::"
-
-        echo "::group::auto_kms logs"
-        sudo -E docker compose -f infra/peagen/docker-compose.yml logs auto_kms || true
-        echo "::endgroup::"
-
-        echo "::group::gateway logs"
-        sudo -E docker compose -f infra/peagen/docker-compose.yml logs gateway || true
-        echo "::endgroup::"
-
-        echo "::group::worker logs"
-        sudo -E docker compose -f infra/peagen/docker-compose.yml logs worker || true
-        echo "::endgroup::"
-
-    - name: Tear down services
-      if: always()
-      run: |
-        sudo -E docker compose -f infra/peagen/docker-compose.yml down auto_authn auto_kms gateway worker || true
+      - name: Tear down services
+        if: always()
+        run: |
+          sudo -E docker compose -f infra/peagen/docker-compose.yml down auto_authn auto_kms gateway worker || true


### PR DESCRIPTION
## Summary
- verify peagen services start and annotate success or failure
- keep collecting docker logs on failure

## Testing
- `yamllint .github/workflows/peagen_ci.yml` *(fails: spacing and line-length warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b06001a6f88326ae21cb13ef049a14