### PR TITLE
Add Postgres extras and fix gateway hook ordering

### DIFF
--- a/pkgs/standards/autoapi/pyproject.toml
+++ b/pkgs/standards/autoapi/pyproject.toml
@@ -25,6 +25,12 @@ dependencies = [
     "greenlet>=3.2.3",
 ]
 
+[project.optional-dependencies]
+postgres = [
+    "asyncpg>=0.30.0",
+    "psycopg2-binary>=2.9.9",
+]
+
 [tool.uv.sources]
 swarmauri_core = { workspace = true }
 swarmauri_base = { workspace = true }

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -299,12 +299,6 @@ async def _startup() -> None:
 
     # 1 – metadata validation / SQLite convenience mode
     await api.initialize_async()
-    # ensure our hook runs second after the AuthN injection hook
-    _pre = api._hook_registry.get("PRE_TX_BEGIN", {}).get(None, [])
-    for idx, fn in enumerate(_pre):
-        if getattr(fn, "__name__", "") == "_shadow_principal":
-            _pre.insert(1, _pre.pop(idx))
-            break
 
     # 2 – run Alembic first so the ORM never creates tables implicitly
     if engine.url.get_backend_name() != "sqlite":


### PR DESCRIPTION
## Summary
- add `postgres` optional dependency to AutoAPI for asyncpg and psycopg2
- initialize gateway hooks without accessing internal hook registry

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest`
- `uv run --package peagen --directory standards/peagen pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b05e875b2883269c95bc84026abd1c