### PR TITLE
fix: remove AutoAPI v2 debug logs

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -318,12 +318,9 @@ async def _startup() -> None:
     READY = True
     log.info(api.router)
     log.info(api.rpc)
-    log.info(api._registered_tables)
-    log.info(api._method_ids)
-    log.info(api._schemas)
-    log.info(api._allow_anon)
-    log.info(api.methods)
+    log.info(api.models)
     log.info(api.schemas)
+    log.info(api._allow_anon)
 
     log.info("gateway ready")
 


### PR DESCRIPTION
## Summary
- avoid referencing AutoAPI v2 internals in peagen gateway logging

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b0e69693a083268c31c126c18a6884