### PR TITLE
Guard op_ctx alias handlers from context mutations

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/handlers.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/handlers.py
@@ -436,7 +436,24 @@ def _wrap_custom(model: type, sp: OpSpec, user_handler: Callable[..., Any]) -> S
 
         kw = {}
         if "ctx" in wanted:
-            kw["ctx"] = ctx
+            canonical = {
+                "create",
+                "read",
+                "update",
+                "replace",
+                "delete",
+                "list",
+                "bulk_create",
+                "bulk_update",
+                "bulk_replace",
+                "bulk_delete",
+                "clear",
+            }
+            # If the user is overriding a canonical op (alias matches a known
+            # verb and no explicit target was provided), operate on a copy of
+            # the context so any mutations are isolated from the caller.
+            should_copy = sp.alias in canonical and sp.target in (None, "custom")
+            kw["ctx"] = ctx.__class__(ctx) if should_copy else ctx
         if "db" in wanted:
             kw["db"] = db
         if "payload" in wanted:


### PR DESCRIPTION
## Summary
- prevent `op_ctx` alias handlers from mutating caller context by copying ctx when overriding canonical verbs

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_op_ctx_core_crud_integration.py -q`
- `uv run --package autoapi --directory standards/autoapi pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0f0be13d883268b9b1411e8808a98