### PR TITLE
fix: support nested resource segments in AutoAPI paths

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
@@ -1115,7 +1115,7 @@ def _build_router(model: type, specs: Sequence[OpSpec]) -> Router:
             suffix = sp.path_suffix or _default_path_suffix(sp) or ""
             if not suffix.startswith("/") and suffix:
                 suffix = "/" + suffix
-            base = nested_pref
+            base = f"{nested_pref}/{resource}" if resource else nested_pref
             if sp.arity == "member" or sp.target in {
                 "read",
                 "update",

--- a/pkgs/standards/autoapi/tests/i9n/test_nested_rest_rpc_parity.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_nested_rest_rpc_parity.py
@@ -1,0 +1,51 @@
+import pytest
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_nested_rest_rpc_parity(api_client, sample_tenant_data):
+    client, _, _ = api_client
+
+    # Create tenant to scope nested paths
+    res = await client.post("/tenant", json=sample_tenant_data)
+    assert res.status_code == 201
+    tenant_id = res.json()["id"]
+
+    # REST create does not require tenant_id in body
+    res = await client.post(f"/tenant/{tenant_id}/item", json={"name": "rest"})
+    assert res.status_code == 201, res.text
+    rest_item_id = res.json()["id"]
+
+    # REST read confirms tenant_id propagated from path
+    res = await client.get(f"/tenant/{tenant_id}/item/{rest_item_id}")
+    assert res.status_code == 200
+    assert res.json()["tenant_id"] == tenant_id
+
+    # RPC create requires tenant_id in params
+    payload = {
+        "jsonrpc": "2.0",
+        "method": "Item.create",
+        "params": {"tenant_id": tenant_id, "name": "rpc"},
+        "id": 1,
+    }
+    res = await client.post("/rpc", json=payload)
+    assert res.status_code == 200, res.text
+    rpc_item_id = res.json()["result"]["id"]
+
+    # RPC read verifies payload handling
+    payload = {
+        "jsonrpc": "2.0",
+        "method": "Item.read",
+        "params": {"tenant_id": tenant_id, "item_id": rpc_item_id},
+        "id": 2,
+    }
+    res = await client.post("/rpc", json=payload)
+    assert res.status_code == 200, res.text
+    assert res.json()["result"]["tenant_id"] == tenant_id
+
+    # OpenAPI schema for nested REST path should omit tenant_id from body
+    spec = (await client.get("/openapi.json")).json()
+    body_schema = spec["paths"]["/tenant/{tenant_id}/item"]["post"]["requestBody"][
+        "content"
+    ]["application/json"]["schema"]
+    assert "tenant_id" not in body_schema.get("properties", {})

--- a/pkgs/standards/autoapi/tests/i9n/test_nested_routing_depth.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_nested_routing_depth.py
@@ -64,7 +64,7 @@ async def test_nested_routing_depth(three_level_api_client):
 
     # Create department
     res = await client.post(
-        f"/company/{company_id}",
+        f"/company/{company_id}/department",
         json={"name": "Engineering"},
     )
     assert res.status_code == 201
@@ -72,7 +72,7 @@ async def test_nested_routing_depth(three_level_api_client):
 
     # Create employee
     res = await client.post(
-        f"/company/{company_id}/department/{department_id}",
+        f"/company/{company_id}/department/{department_id}/employee",
         json={"name": "Alice"},
     )
     assert res.status_code == 201
@@ -83,14 +83,14 @@ async def test_nested_routing_depth(three_level_api_client):
     expected = {
         "/company": {"post", "get", "delete"},
         "/company/{item_id}": {"get", "patch", "delete"},
-        "/company/{company_id}": {"post", "get", "delete"},
-        "/company/{company_id}/{item_id}": {"get", "patch", "delete"},
-        "/company/{company_id}/department/{department_id}": {
+        "/company/{company_id}/department": {"post", "get", "delete"},
+        "/company/{company_id}/department/{item_id}": {"get", "patch", "delete"},
+        "/company/{company_id}/department/{department_id}/employee": {
             "post",
             "get",
             "delete",
         },
-        "/company/{company_id}/department/{department_id}/{item_id}": {
+        "/company/{company_id}/department/{department_id}/employee/{item_id}": {
             "get",
             "patch",
             "delete",
@@ -102,12 +102,12 @@ async def test_nested_routing_depth(three_level_api_client):
             assert verb in paths[path]
 
     # Confirm nested routes resolve to correct handlers
-    res = await client.get(f"/company/{company_id}/{department_id}")
+    res = await client.get(f"/company/{company_id}/department/{department_id}")
     assert res.status_code == 200
     assert res.json()["id"] == department_id
 
     res = await client.get(
-        f"/company/{company_id}/department/{department_id}/{employee_id}"
+        f"/company/{company_id}/department/{department_id}/employee/{employee_id}"
     )
     assert res.status_code == 200
     assert res.json()["id"] == employee_id

--- a/pkgs/standards/autoapi/tests/i9n/test_schema.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_schema.py
@@ -36,6 +36,6 @@ async def test_schema_generation(api_client):
 async def test_bulk_operation_schema(api_client):
     client, _, _ = api_client
     spec = (await client.get("/openapi.json")).json()
-    assert "/tenant/{tenant_id}/bulk" in spec["paths"]
-    ops = spec["paths"]["/tenant/{tenant_id}/bulk"]
+    assert "/tenant/{tenant_id}/item/bulk" in spec["paths"]
+    ops = spec["paths"]["/tenant/{tenant_id}/item/bulk"]
     assert "post" in ops and "delete" in ops

--- a/pkgs/standards/autoapi/tests/i9n/test_symmetry_parity.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_symmetry_parity.py
@@ -2,12 +2,12 @@ import pytest
 from autoapi.v3.types import SimpleNamespace
 
 CRUD_MAP = {
-    "create": ("post", "/tenant/{tenant_id}"),
-    "list": ("get", "/tenant/{tenant_id}"),
-    "clear": ("delete", "/tenant/{tenant_id}"),
-    "read": ("get", "/tenant/{tenant_id}/{item_id}"),
-    "update": ("patch", "/tenant/{tenant_id}/{item_id}"),
-    "delete": ("delete", "/tenant/{tenant_id}/{item_id}"),
+    "create": ("post", "/tenant/{tenant_id}/item"),
+    "list": ("get", "/tenant/{tenant_id}/item"),
+    "clear": ("delete", "/tenant/{tenant_id}/item"),
+    "read": ("get", "/tenant/{tenant_id}/item/{item_id}"),
+    "update": ("patch", "/tenant/{tenant_id}/item/{item_id}"),
+    "delete": ("delete", "/tenant/{tenant_id}/item/{item_id}"),
 }
 
 


### PR DESCRIPTION
## Summary
- ensure nested REST paths include the resource name segment
- cover nested path handling and parity with RPC via integration tests

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_symmetry_parity.py tests/i9n/test_nested_routing_depth.py tests/i9n/test_schema.py tests/i9n/test_nested_rest_rpc_parity.py`

------
https://chatgpt.com/codex/tasks/task_e_68b0f178f8a48326b4c0cbbe49578669