### PR TITLE
Fix nested path handling for AutoAPI

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_error_mappings.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_error_mappings.py
@@ -190,8 +190,12 @@ async def test_error_parity_crud_vs_rpc(api_client):
     client, api, _ = api_client
 
     # Test 404 error parity
+    tenant = await client.post("/tenant", json={"name": "ghost"})
+    tid = tenant.json()["id"]
     # Try to read non-existent item via REST
-    rest_response = await client.get("/item/00000000-0000-0000-0000-000000000000")
+    rest_response = await client.get(
+        f"/tenant/{tid}/item/00000000-0000-0000-0000-000000000000"
+    )
     assert rest_response.status_code == 404
     rest_error = rest_response.json()
 
@@ -268,7 +272,9 @@ async def test_error_response_structure(api_client):
     client, api, _ = api_client
 
     # Test REST error structure
-    rest_response = await client.get("/item/invalid-uuid")
+    tenant = await client.post("/tenant", json={"name": "ghost"})
+    tid = tenant.json()["id"]
+    rest_response = await client.get(f"/tenant/{tid}/item/invalid-uuid")
     rest_error = rest_response.json()
 
     # REST errors should have detail field

--- a/pkgs/standards/autoapi/tests/i9n/test_nested_routing_depth.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_nested_routing_depth.py
@@ -64,7 +64,7 @@ async def test_nested_routing_depth(three_level_api_client):
 
     # Create department
     res = await client.post(
-        f"/company/{company_id}",
+        f"/company/{company_id}/department",
         json={"name": "Engineering"},
     )
     assert res.status_code == 201
@@ -72,7 +72,7 @@ async def test_nested_routing_depth(three_level_api_client):
 
     # Create employee
     res = await client.post(
-        f"/company/{company_id}/department/{department_id}",
+        f"/company/{company_id}/department/{department_id}/employee",
         json={"name": "Alice"},
     )
     assert res.status_code == 201
@@ -83,14 +83,14 @@ async def test_nested_routing_depth(three_level_api_client):
     expected = {
         "/company": {"post", "get", "delete"},
         "/company/{item_id}": {"get", "patch", "delete"},
-        "/company/{company_id}": {"post", "get", "delete"},
-        "/company/{company_id}/{item_id}": {"get", "patch", "delete"},
-        "/company/{company_id}/department/{department_id}": {
+        "/company/{company_id}/department": {"post", "get", "delete"},
+        "/company/{company_id}/department/{item_id}": {"get", "patch", "delete"},
+        "/company/{company_id}/department/{department_id}/employee": {
             "post",
             "get",
             "delete",
         },
-        "/company/{company_id}/department/{department_id}/{item_id}": {
+        "/company/{company_id}/department/{department_id}/employee/{item_id}": {
             "get",
             "patch",
             "delete",
@@ -102,12 +102,12 @@ async def test_nested_routing_depth(three_level_api_client):
             assert verb in paths[path]
 
     # Confirm nested routes resolve to correct handlers
-    res = await client.get(f"/company/{company_id}/{department_id}")
+    res = await client.get(f"/company/{company_id}/department/{department_id}")
     assert res.status_code == 200
     assert res.json()["id"] == department_id
 
     res = await client.get(
-        f"/company/{company_id}/department/{department_id}/{employee_id}"
+        f"/company/{company_id}/department/{department_id}/employee/{employee_id}"
     )
     assert res.status_code == 200
     assert res.json()["id"] == employee_id

--- a/pkgs/standards/autoapi/tests/i9n/test_rest_rpc_parity_v3.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_rest_rpc_parity_v3.py
@@ -1,0 +1,23 @@
+import pytest
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_rest_rpc_nested_parity(api_client, sample_tenant_data):
+    """Ensure nested REST paths map cleanly to RPC payloads."""
+    client, _, Item = api_client
+
+    # Nested REST schema should drop parent identifiers
+    assert "tenant_id" not in Item.schemas.create.in_.model_fields
+
+    # Create tenant and item via REST (path supplies tenant_id)
+    t = await client.post("/tenant", json=sample_tenant_data)
+    tid = t.json()["id"]
+    r_rest = await client.post(f"/tenant/{tid}/item", json={"name": "rest"})
+    assert r_rest.status_code == 201
+
+    # RPC call without tenant_id fails validation
+    r_bad = await client.post(
+        "/rpc", json={"method": "Item.create", "params": {"name": "oops"}}
+    )
+    assert r_bad.json()["error"] is not None

--- a/pkgs/standards/autoapi/tests/i9n/test_schema.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_schema.py
@@ -36,6 +36,6 @@ async def test_schema_generation(api_client):
 async def test_bulk_operation_schema(api_client):
     client, _, _ = api_client
     spec = (await client.get("/openapi.json")).json()
-    assert "/tenant/{tenant_id}/bulk" in spec["paths"]
-    ops = spec["paths"]["/tenant/{tenant_id}/bulk"]
+    assert "/tenant/{tenant_id}/item/bulk" in spec["paths"]
+    ops = spec["paths"]["/tenant/{tenant_id}/item/bulk"]
     assert "post" in ops and "delete" in ops

--- a/pkgs/standards/autoapi/tests/i9n/test_symmetry_parity.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_symmetry_parity.py
@@ -2,12 +2,12 @@ import pytest
 from autoapi.v3.types import SimpleNamespace
 
 CRUD_MAP = {
-    "create": ("post", "/tenant/{tenant_id}"),
-    "list": ("get", "/tenant/{tenant_id}"),
-    "clear": ("delete", "/tenant/{tenant_id}"),
-    "read": ("get", "/tenant/{tenant_id}/{item_id}"),
-    "update": ("patch", "/tenant/{tenant_id}/{item_id}"),
-    "delete": ("delete", "/tenant/{tenant_id}/{item_id}"),
+    "create": ("post", "/tenant/{tenant_id}/item"),
+    "list": ("get", "/tenant/{tenant_id}/item"),
+    "clear": ("delete", "/tenant/{tenant_id}/item"),
+    "read": ("get", "/tenant/{tenant_id}/item/{item_id}"),
+    "update": ("patch", "/tenant/{tenant_id}/item/{item_id}"),
+    "delete": ("delete", "/tenant/{tenant_id}/item/{item_id}"),
 }
 
 


### PR DESCRIPTION
## Summary
- ensure nested REST routes include the resource segment
- coerce nested path parameters to ORM types and validate nested REST vs RPC

## Testing
- `uv run --package autoapi --directory standards pytest autoapi/tests/i9n/test_symmetry_parity.py autoapi/tests/i9n/test_schema.py autoapi/tests/i9n/test_nested_routing_depth.py autoapi/tests/i9n/test_error_mappings.py autoapi/tests/i9n/test_rest_rpc_parity_v3.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0f8f870c48326b4da5ad918534f32