### PR TITLE
Fix nested REST paths and update tests

### DIFF
--- a/pkgs/standards/autoapi/tests/conftest.py
+++ b/pkgs/standards/autoapi/tests/conftest.py
@@ -167,7 +167,7 @@ async def api_client(db_mode):
 
         @classmethod
         def __autoapi_nested_paths__(cls):
-            return "/tenant/{tenant_id}"
+            return "/tenant/{tenant_id}/item"
 
     fastapi_app = App()
 

--- a/pkgs/standards/autoapi/tests/i9n/test_error_mappings.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_error_mappings.py
@@ -190,8 +190,12 @@ async def test_error_parity_crud_vs_rpc(api_client):
     client, api, _ = api_client
 
     # Test 404 error parity
+    t = await client.post("/tenant", json={"name": "ghost"})
+    tid = t.json()["id"]
     # Try to read non-existent item via REST
-    rest_response = await client.get("/item/00000000-0000-0000-0000-000000000000")
+    rest_response = await client.get(
+        f"/tenant/{tid}/item/00000000-0000-0000-0000-000000000000"
+    )
     assert rest_response.status_code == 404
     rest_error = rest_response.json()
 
@@ -200,7 +204,10 @@ async def test_error_parity_crud_vs_rpc(api_client):
         "/rpc",
         json={
             "method": "Item.read",
-            "params": {"id": "00000000-0000-0000-0000-000000000000"},
+            "params": {
+                "tenant_id": tid,
+                "id": "00000000-0000-0000-0000-000000000000",
+            },
         },
     )
     assert rpc_response.status_code == 200

--- a/pkgs/standards/autoapi/tests/i9n/test_schema.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_schema.py
@@ -36,6 +36,6 @@ async def test_schema_generation(api_client):
 async def test_bulk_operation_schema(api_client):
     client, _, _ = api_client
     spec = (await client.get("/openapi.json")).json()
-    assert "/tenant/{tenant_id}/bulk" in spec["paths"]
-    ops = spec["paths"]["/tenant/{tenant_id}/bulk"]
+    assert "/tenant/{tenant_id}/item/bulk" in spec["paths"]
+    ops = spec["paths"]["/tenant/{tenant_id}/item/bulk"]
     assert "post" in ops and "delete" in ops

--- a/pkgs/standards/autoapi/tests/i9n/test_symmetry_parity.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_symmetry_parity.py
@@ -2,12 +2,12 @@ import pytest
 from autoapi.v3.types import SimpleNamespace
 
 CRUD_MAP = {
-    "create": ("post", "/tenant/{tenant_id}"),
-    "list": ("get", "/tenant/{tenant_id}"),
-    "clear": ("delete", "/tenant/{tenant_id}"),
-    "read": ("get", "/tenant/{tenant_id}/{item_id}"),
-    "update": ("patch", "/tenant/{tenant_id}/{item_id}"),
-    "delete": ("delete", "/tenant/{tenant_id}/{item_id}"),
+    "create": ("post", "/tenant/{tenant_id}/item"),
+    "list": ("get", "/tenant/{tenant_id}/item"),
+    "clear": ("delete", "/tenant/{tenant_id}/item"),
+    "read": ("get", "/tenant/{tenant_id}/item/{item_id}"),
+    "update": ("patch", "/tenant/{tenant_id}/item/{item_id}"),
+    "delete": ("delete", "/tenant/{tenant_id}/item/{item_id}"),
 }
 
 


### PR DESCRIPTION
## Summary
- ensure Item fixture exposes nested `/tenant/{tenant_id}/item` prefix
- adjust integration tests for new nested routing structure
- verify nested routing depth and error parity with updated paths

## Testing
- `uv run --package autoapi --directory . ruff format tests/i9n/test_schema.py tests/i9n/test_symmetry_parity.py tests/i9n/test_nested_routing_depth.py tests/i9n/test_error_mappings.py tests/conftest.py`
- `uv run --package autoapi --directory . ruff check tests/i9n/test_schema.py tests/i9n/test_symmetry_parity.py tests/i9n/test_nested_routing_depth.py tests/i9n/test_error_mappings.py tests/conftest.py --fix`
- `uv run --package autoapi --directory standards pytest autoapi/tests/i9n/test_schema.py autoapi/tests/i9n/test_symmetry_parity.py autoapi/tests/i9n/test_nested_routing_depth.py autoapi/tests/i9n/test_error_mappings.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0f919130c83268e2ce6dd729c05f8