### PR TITLE
feat(autoapi): correct bulk op response schemas

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_apikey_generation.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_apikey_generation.py
@@ -17,7 +17,7 @@ class ConcreteApiKey(ApiKey):
 @pytest.mark.i9n
 @pytest.mark.asyncio
 async def test_api_key_creation_requires_valid_payload(sync_db_session):
-    """Posting without required fields yields a conflict response."""
+    """Posting without required fields yields a validation error."""
     _, get_sync_db = sync_db_session
 
     app = App()
@@ -29,4 +29,4 @@ async def test_api_key_creation_requires_valid_payload(sync_db_session):
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         res = await client.post("/apikey", json={})
 
-    assert res.status_code == 409
+    assert res.status_code == 422

--- a/pkgs/standards/autoapi/tests/unit/test_bulk_response_schema.py
+++ b/pkgs/standards/autoapi/tests/unit/test_bulk_response_schema.py
@@ -1,0 +1,43 @@
+from autoapi.v3.bindings.rest import _build_router
+from autoapi.v3.opspec import OpSpec
+from autoapi.v3.tables import Base
+from autoapi.v3.mixins import GUIDPk, BulkCapable
+from autoapi.v3.types import Column, String, App
+
+
+class Widget(Base, GUIDPk, BulkCapable):
+    __tablename__ = "widgets_bulk_schema"
+    name = Column(String, nullable=False)
+
+
+def _openapi_for(ops):
+    router = _build_router(Widget, [OpSpec(alias=a, target=t) for a, t in ops])
+    app = App()
+    app.include_router(router)
+    return app.openapi()
+
+
+def test_bulk_create_response_schema():
+    spec = _openapi_for([("bulk_create", "bulk_create")])
+    path = f"/{Widget.__name__.lower()}"
+    ref = spec["paths"][path]["post"]["responses"]["200"]["content"][
+        "application/json"
+    ]["schema"]["$ref"]
+    assert ref.endswith("WidgetBulkCreateResponse")
+    comp = spec["components"]["schemas"]["WidgetBulkCreateResponse"]
+    assert comp["type"] == "array"
+    items_ref = comp["items"]["$ref"]
+    assert items_ref.endswith("WidgetRead")
+
+
+def test_bulk_delete_response_schema():
+    spec = _openapi_for([("bulk_delete", "bulk_delete")])
+    path = f"/{Widget.__name__.lower()}"
+    ref = spec["paths"][path]["delete"]["responses"]["200"]["content"][
+        "application/json"
+    ]["schema"]["$ref"]
+    assert ref.endswith("WidgetBulkDeleteResponse")
+    comp = spec["components"]["schemas"]["WidgetBulkDeleteResponse"]
+    props = comp.get("properties", {})
+    assert "deleted" in props
+    assert props["deleted"]["type"] == "integer"


### PR DESCRIPTION
## Summary
- return list responses for bulk create/update/replace/upsert
- return deleted count for bulk delete
- test bulk OpenAPI schemas for array and delete count
- expect a 422 validation error when API key creation payload is missing

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_bulk_response_schema.py tests/i9n/test_apikey_generation.py::test_api_key_creation_requires_valid_payload -q`

------
https://chatgpt.com/codex/tasks/task_e_68b0ffe349748326b7b028fd9402dd4e