### PR TITLE
feat(autoapi): correct bulk op response schemas

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/schemas.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/schemas.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 from types import SimpleNamespace
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Type
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, Union
 
 from pydantic import BaseModel, Field, RootModel, create_model
 
@@ -73,6 +73,38 @@ def _make_bulk_rows_model(
     )
 
 
+def _make_bulk_rows_response_model(
+    model: type, verb: str, item_schema: Type[BaseModel]
+) -> Type[BaseModel]:
+    """Build a root model representing ``List[item_schema]`` for responses."""
+    name = f"{model.__name__}{_camel(verb)}Response"
+    schema = create_model(  # type: ignore[call-arg]
+        name,
+        __base__=RootModel[List[item_schema]],
+    )
+    return namely_model(
+        schema,
+        name=name,
+        doc=f"{verb} response schema for {model.__name__}",
+    )
+
+
+def _make_single_or_bulk_model(
+    model: type, verb: str, item_schema: Type[BaseModel]
+) -> Type[BaseModel]:
+    """Build a root model accepting a single item or a list of items."""
+    name = f"{model.__name__}{_camel(verb)}Request"
+    schema = create_model(  # type: ignore[call-arg]
+        name,
+        __base__=RootModel[Union[item_schema, List[item_schema]]],  # type: ignore[valid-type]
+    )
+    return namely_model(
+        schema,
+        name=name,
+        doc=f"{verb} request schema for {model.__name__}",
+    )
+
+
 def _make_bulk_ids_model(
     model: type, verb: str, pk_type: type | Any
 ) -> Type[BaseModel]:
@@ -88,6 +120,20 @@ def _make_bulk_ids_model(
         schema,
         name=name,
         doc=f"{verb} request schema for {model.__name__}",
+    )
+
+
+def _make_bulk_deleted_response_model(model: type, verb: str) -> Type[BaseModel]:
+    """Build a response schema with a ``deleted`` count."""
+    name = f"{model.__name__}{_camel(verb)}Response"
+    schema = create_model(  # type: ignore[call-arg]
+        name,
+        deleted=(int, Field(...)),
+    )
+    return namely_model(
+        schema,
+        name=name,
+        doc=f"{verb} response schema for {model.__name__}",
     )
 
 
@@ -202,7 +248,8 @@ def _default_schemas_for_spec(
 
     # Canonical targets
     if target == "create":
-        result["in_"] = _build_schema(model, verb="create")
+        item_in = _build_schema(model, verb="create")
+        result["in_"] = _make_single_or_bulk_model(model, "create", item_in)
         result["out"] = read_schema
 
     elif target == "read":
@@ -238,17 +285,29 @@ def _default_schemas_for_spec(
     elif target == "bulk_create":
         item_in = _build_schema(model, verb="create")
         result["in_"] = _make_bulk_rows_model(model, "bulk_create", item_in)
-        result["out"] = read_schema
+        result["out"] = (
+            _make_bulk_rows_response_model(model, "bulk_create", read_schema)
+            if read_schema
+            else None
+        )
 
     elif target == "bulk_update":
         item_in = _build_schema(model, verb="update")
         result["in_"] = _make_bulk_rows_model(model, "bulk_update", item_in)
-        result["out"] = read_schema
+        result["out"] = (
+            _make_bulk_rows_response_model(model, "bulk_update", read_schema)
+            if read_schema
+            else None
+        )
 
     elif target == "bulk_replace":
         item_in = _build_schema(model, verb="replace")
         result["in_"] = _make_bulk_rows_model(model, "bulk_replace", item_in)
-        result["out"] = read_schema
+        result["out"] = (
+            _make_bulk_rows_response_model(model, "bulk_replace", read_schema)
+            if read_schema
+            else None
+        )
 
     elif target == "bulk_upsert":
         # Prefer a dedicated 'upsert' item shape if available; otherwise fall back to 'replace'
@@ -256,12 +315,16 @@ def _default_schemas_for_spec(
             model, verb="replace"
         )
         result["in_"] = _make_bulk_rows_model(model, "bulk_upsert", item_in)
-        result["out"] = read_schema
+        result["out"] = (
+            _make_bulk_rows_response_model(model, "bulk_upsert", read_schema)
+            if read_schema
+            else None
+        )
 
     elif target == "bulk_delete":
         pk_name, pk_type = _pk_info(model)
         result["in_"] = _make_bulk_ids_model(model, "bulk_delete", pk_type)
-        result["out"] = read_schema
+        result["out"] = _make_bulk_deleted_response_model(model, "bulk_delete")
 
     elif target == "custom":
         # Build schemas for custom operations based on verb-specific IO specs

--- a/pkgs/standards/autoapi/tests/i9n/test_apikey_generation.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_apikey_generation.py
@@ -17,7 +17,7 @@ class ConcreteApiKey(ApiKey):
 @pytest.mark.i9n
 @pytest.mark.asyncio
 async def test_api_key_creation_requires_valid_payload(sync_db_session):
-    """Posting without required fields yields a conflict response."""
+    """Posting without required fields yields an unprocessable entity response."""
     _, get_sync_db = sync_db_session
 
     app = App()
@@ -29,4 +29,4 @@ async def test_api_key_creation_requires_valid_payload(sync_db_session):
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         res = await client.post("/apikey", json={})
 
-    assert res.status_code == 409
+    assert res.status_code == 422

--- a/pkgs/standards/autoapi/tests/unit/test_bulk_response_schema.py
+++ b/pkgs/standards/autoapi/tests/unit/test_bulk_response_schema.py
@@ -1,0 +1,55 @@
+from autoapi.v3.bindings.rest import _build_router
+from autoapi.v3.opspec import OpSpec
+from autoapi.v3.tables import Base
+from autoapi.v3.mixins import GUIDPk, BulkCapable
+from autoapi.v3.types import Column, String, App
+
+
+class Widget(Base, GUIDPk, BulkCapable):
+    __tablename__ = "widgets_bulk_schema"
+    name = Column(String, nullable=False)
+
+
+def _openapi_for(ops):
+    router = _build_router(Widget, [OpSpec(alias=a, target=t) for a, t in ops])
+    app = App()
+    app.include_router(router)
+    return app.openapi()
+
+
+def test_create_request_schema_allows_single_or_list():
+    spec = _openapi_for([("create", "create")])
+    path = f"/{Widget.__name__.lower()}"
+    schema = spec["paths"][path]["post"]["requestBody"]["content"]["application/json"][
+        "schema"
+    ]
+    union = schema.get("anyOf") or schema.get("oneOf")
+    assert union is not None
+    types = {item.get("type") for item in union}
+    assert types == {"object", "array"}
+
+
+def test_bulk_create_response_schema():
+    spec = _openapi_for([("bulk_create", "bulk_create")])
+    path = f"/{Widget.__name__.lower()}"
+    ref = spec["paths"][path]["post"]["responses"]["200"]["content"][
+        "application/json"
+    ]["schema"]["$ref"]
+    assert ref.endswith("WidgetBulkCreateResponse")
+    comp = spec["components"]["schemas"]["WidgetBulkCreateResponse"]
+    assert comp["type"] == "array"
+    items_ref = comp["items"]["$ref"]
+    assert items_ref.endswith("WidgetRead")
+
+
+def test_bulk_delete_response_schema():
+    spec = _openapi_for([("bulk_delete", "bulk_delete")])
+    path = f"/{Widget.__name__.lower()}"
+    ref = spec["paths"][path]["delete"]["responses"]["200"]["content"][
+        "application/json"
+    ]["schema"]["$ref"]
+    assert ref.endswith("WidgetBulkDeleteResponse")
+    comp = spec["components"]["schemas"]["WidgetBulkDeleteResponse"]
+    props = comp.get("properties", {})
+    assert "deleted" in props
+    assert props["deleted"]["type"] == "integer"


### PR DESCRIPTION
## Summary
- return list responses for bulk create/update/replace/upsert
- return deleted count for bulk delete
- allow create request to accept single object or array
- test bulk OpenAPI schemas for array, delete count, and request union

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b0ffe349748326b7b028fd9402dd4e