### PR TITLE
Fix RemoteAuthNAdapter usage in Peagen gateway

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -187,7 +187,7 @@ api.include_models(
         RawBlob,
     ]
 )
-api.set_auth(authn=authn_adapter)
+api.set_auth(authn=authn_adapter.get_principal)
 
 api.mount_jsonrpc(prefix="/rpc")
 api.attach_diagnostics(prefix="/system")


### PR DESCRIPTION
## Summary
- use `RemoteAuthNAdapter.get_principal` as auth dependency in gateway

## Testing
- `uv run --package peagen --directory standards/peagen pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1043651f483269e7113e6ff8a6932