### PR TITLE
feat(autoapi): support single or bulk create on same endpoint

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/handlers.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/handlers.py
@@ -477,6 +477,8 @@ def _wrap_core(model: type, target: str) -> StepFn:
         payload = _ctx_payload(ctx)
 
         if target == "create":
+            if isinstance(payload, list):
+                return await _core.bulk_create(model, payload, db=db)
             return await _core.create(model, payload, db=db)
 
         if target == "read":

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
@@ -1106,6 +1106,7 @@ def _build_router(model: type, specs: Sequence[OpSpec]) -> Router:
     # "/resource/{item_id}". FastAPI matches routes in the order they are
     # added, so sorting here prevents "bulk" from being treated as an
     # identifier.
+    specs = [sp for sp in specs if sp.target != "bulk_create"]
     specs = sorted(specs, key=lambda sp: (0 if sp.target.startswith("bulk_") else 1))
 
     for sp in specs:

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/schemas.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/schemas.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 
 import logging
 from types import SimpleNamespace
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Type
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, Union
 
-from pydantic import BaseModel, Field, RootModel, create_model
+from pydantic import BaseModel, Field, RootModel, ConfigDict, create_model
 
 from ..opspec import OpSpec
 from ..opspec.types import (
@@ -107,6 +107,44 @@ def _make_pk_model(
     )
 
 
+def _extract_example(schema: Type[BaseModel]) -> Dict[str, Any]:
+    """Build a simple example object from field examples if available."""
+    try:
+        js = schema.model_json_schema()
+    except Exception:
+        return {}
+    out: Dict[str, Any] = {}
+    for name, prop in (js.get("properties") or {}).items():
+        examples = prop.get("examples")
+        if examples:
+            out[name] = examples[0]
+    return out
+
+
+def _one_of_union_model(
+    name: str,
+    single: Type[BaseModel],
+    bulk: Type[BaseModel],
+    *,
+    doc: str,
+    examples: List[Any],
+) -> Type[BaseModel]:
+    """Create a RootModel union with `oneOf` semantics and examples."""
+    union_type = Union[single, bulk]  # type: ignore[valid-type]
+
+    class _UnionModel(RootModel[union_type]):  # type: ignore[misc]
+        model_config = ConfigDict(json_schema_extra={"examples": examples})
+
+        @classmethod
+        def __get_pydantic_json_schema__(cls, core_schema, handler):  # type: ignore[override]
+            schema = handler(core_schema)
+            if "anyOf" in schema:
+                schema["oneOf"] = schema.pop("anyOf")
+            return schema
+
+    return namely_model(_UnionModel, name=name, doc=doc)
+
+
 def _parse_str_ref(s: str) -> Tuple[str, str]:
     """
     Parse dotted schema ref "alias.in" | "alias.out".
@@ -202,8 +240,31 @@ def _default_schemas_for_spec(
 
     # Canonical targets
     if target == "create":
-        result["in_"] = _build_schema(model, verb="create")
-        result["out"] = read_schema
+        item_in = _build_schema(model, verb="create")
+        if read_schema is None:
+            result["in_"] = item_in
+            result["out"] = None
+        else:
+            bulk_in = _make_bulk_rows_model(model, "bulk_create", item_in)
+            bulk_out = _make_bulk_rows_model(model, "bulk_create", read_schema)
+            in_example = _extract_example(item_in)
+            out_example = _extract_example(read_schema)
+            in_examples = [in_example, [in_example] if in_example else []]
+            out_examples = [out_example, [out_example] if out_example else []]
+            result["in_"] = _one_of_union_model(
+                f"{model.__name__}CreateRequest",
+                item_in,
+                bulk_in,
+                doc=f"create request schema for {model.__name__}",
+                examples=in_examples,
+            )
+            result["out"] = _one_of_union_model(
+                f"{model.__name__}CreateResponse",
+                read_schema,
+                bulk_out,
+                doc=f"create response schema for {model.__name__}",
+                examples=out_examples,
+            )
 
     elif target == "read":
         pk_name, pk_type = _pk_info(model)


### PR DESCRIPTION
## Summary
- allow POST collection endpoint to accept single or list payloads
- combine create schemas with oneOf and examples for single/bulk
- avoid exposing separate bulk_create route

## Testing
- `uv run --directory . --package autoapi ruff format .`
- `uv run --directory . --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b0ffecb1f08326b8e7e9f85ff05e2c