### PR TITLE
Return 422 for invalid API key payload

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
@@ -288,14 +288,17 @@ def _validate_body(
         try:
             inst = in_model.model_validate(body)  # type: ignore[arg-type]
             return inst.model_dump(exclude_none=True)
-        except Exception:
+        except Exception as e:
             logger.debug(
                 "rest input body validation failed for %s.%s",
                 model.__name__,
                 alias,
                 exc_info=True,
             )
-            return dict(body)
+            raise HTTPException(
+                status_code=_status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=str(e),
+            )
     return dict(body)
 
 


### PR DESCRIPTION
## Summary
- raise 422 when request body fails model validation
- expect unprocessable entity on API key creation without required fields

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff format .`
- `uv run --directory standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b10b1da0e88326917e8a2efc29a9ca