### PR TITLE
Fix autoapi bulk routing and validation

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/handlers.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/handlers.py
@@ -83,10 +83,10 @@ def _ctx_get(ctx: Mapping[str, Any], key: str, default: Any = None) -> Any:
         return getattr(ctx, key, default)
 
 
-def _ctx_payload(ctx: Mapping[str, Any]) -> Mapping[str, Any]:
+def _ctx_payload(ctx: Mapping[str, Any]) -> Any:
     v = _ctx_get(ctx, "payload", None)
-    # Never let non-mapping (incl. SQLA ClauseElement) flow as payload
-    return v if isinstance(v, Mapping) else {}
+    # Accept dict or list payloads; anything else → empty mapping
+    return v if isinstance(v, (Mapping, Sequence)) else {}
 
 
 def _ctx_db(ctx: Mapping[str, Any]) -> Any:
@@ -505,19 +505,39 @@ def _wrap_core(model: type, target: str) -> StepFn:
             return await _core.clear(model, {}, db=db)
 
         if target == "bulk_create":
-            rows = payload if isinstance(payload, list) else []
+            if isinstance(payload, list):
+                rows = payload
+            elif isinstance(payload, Mapping):
+                rows = [payload]
+            else:
+                rows = []
             return await _core.bulk_create(model, rows, db=db)
 
         if target == "bulk_update":
-            rows = payload if isinstance(payload, list) else []
+            if isinstance(payload, list):
+                rows = payload
+            elif isinstance(payload, Mapping):
+                rows = [payload]
+            else:
+                rows = []
             return await _core.bulk_update(model, rows, db=db)
 
         if target == "bulk_replace":
-            rows = payload if isinstance(payload, list) else []
+            if isinstance(payload, list):
+                rows = payload
+            elif isinstance(payload, Mapping):
+                rows = [payload]
+            else:
+                rows = []
             return await _core.bulk_replace(model, rows, db=db)
 
         if target == "bulk_upsert":
-            rows = payload if isinstance(payload, list) else []
+            if isinstance(payload, list):
+                rows = payload
+            elif isinstance(payload, Mapping):
+                rows = [payload]
+            else:
+                rows = []
             return await _core.bulk_upsert(model, rows, db=db)
 
         if target == "bulk_delete":

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
@@ -1106,7 +1106,6 @@ def _build_router(model: type, specs: Sequence[OpSpec]) -> Router:
     # "/resource/{item_id}". FastAPI matches routes in the order they are
     # added, so sorting here prevents "bulk" from being treated as an
     # identifier.
-    specs = [sp for sp in specs if sp.target != "bulk_create"]
     specs = sorted(specs, key=lambda sp: (0 if sp.target.startswith("bulk_") else 1))
 
     for sp in specs:

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/schemas.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/schemas.py
@@ -287,23 +287,13 @@ def _default_schemas_for_spec(
     # Canonical targets
     if target == "create":
         item_in = _build_schema(model, verb="create")
+        result["in_"] = _make_single_or_bulk_model(model, "create", item_in)
         if read_schema is None:
-            result["in_"] = item_in
             result["out"] = None
         else:
-            bulk_in = _make_bulk_rows_model(model, "bulk_create", item_in)
-            bulk_out = _make_bulk_rows_model(model, "bulk_create", read_schema)
-            in_example = _extract_example(item_in)
+            bulk_out = _make_bulk_rows_response_model(model, "bulk_create", read_schema)
             out_example = _extract_example(read_schema)
-            in_examples = [in_example, [in_example] if in_example else []]
             out_examples = [out_example, [out_example] if out_example else []]
-            result["in_"] = _one_of_union_model(
-                f"{model.__name__}CreateRequest",
-                item_in,
-                bulk_in,
-                doc=f"create request schema for {model.__name__}",
-                examples=in_examples,
-            )
             result["out"] = _one_of_union_model(
                 f"{model.__name__}CreateResponse",
                 read_schema,

--- a/pkgs/standards/autoapi/autoapi/v3/tables/apikey.py
+++ b/pkgs/standards/autoapi/autoapi/v3/tables/apikey.py
@@ -39,7 +39,7 @@ class ApiKey(
 
     label: Mapped[str] = acol(
         storage=S(String, nullable=False),
-        field=F(constraints={"max_length": 120}),
+        field=F(constraints={"max_length": 120}, required_in=("create",)),
     )
 
     digest: Mapped[str] = acol(

--- a/pkgs/standards/autoapi/tests/i9n/test_core_access.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_core_access.py
@@ -101,7 +101,7 @@ async def test_core_and_core_raw_sync_operations(sync_api):
                     "email": f"b_{uid}@example.com",
                 },
             ]
-            created_rows = await model.bulk_create({"rows": rows}, db=db)
+            created_rows = await model.bulk_create(rows, db=db)
             ids = [r["id"] if isinstance(r, Mapping) else r.id for r in created_rows]
             assert len(ids) == 2
 
@@ -109,20 +109,14 @@ async def test_core_and_core_raw_sync_operations(sync_api):
                 {"id": ids[0], "age": 20},
                 {"id": ids[1], "age": 21},
             ]
-            payload = {"rows": upd_rows}
-            updated_rows = await model.bulk_update(
-                None, db=db, ctx={"payload": payload}
-            )
+            updated_rows = await model.bulk_update(upd_rows, db=db)
             assert {_get(u, "age") for u in updated_rows} == {20, 21}
 
             rep_rows = [
                 {"id": ids[0], "name": "A1", "email": f"a1_{uid}@example.com"},
                 {"id": ids[1], "name": "B1", "email": f"b1_{uid}@example.com"},
             ]
-            payload = {"rows": rep_rows}
-            replaced_rows = await model.bulk_replace(
-                None, db=db, ctx={"payload": payload}
-            )
+            replaced_rows = await model.bulk_replace(rep_rows, db=db)
             assert {_get(r, "name") for r in replaced_rows} == {"A1", "B1"}
 
             del_payload = {"ids": ids}


### PR DESCRIPTION
## Summary
- allow bulk handlers to accept dict or list payloads instead of using 'rows'
- preserve list payloads and unwrap RootModel inputs during RPC validation
- update core access test to call bulk operations with list payloads

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_apikey_generation.py::test_api_key_creation_requires_valid_payload tests/i9n/test_bulk_docs_client.py::test_openapi_client_create_request_allows_single_or_list tests/i9n/test_bulk_docs_client.py::test_openapi_client_bulk_create_response_schema tests/i9n/test_core_access.py::test_core_and_core_raw_sync_operations -q`


------
https://chatgpt.com/codex/tasks/task_e_68b10b19ca888326b5ce7bf713b2f311