### PR TITLE
Allow anonymous worker registration

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_allow_anon.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_allow_anon.py
@@ -8,6 +8,7 @@ from autoapi.v3.autoapi import AutoAPI
 from autoapi.v3.mixins import GUIDPk
 from autoapi.v3.tables import Base
 from autoapi.v3.types import (
+    AllowAnonProvider,
     App,
     AuthNProvider,
     Column,
@@ -137,6 +138,100 @@ def test_allow_anon_list_and_read():
     # Requests without credentials are rejected for non-whitelisted routes.
     payload = {"id": str(uuid4()), "tenant_id": tid, "name": "new"}
     assert client.post("/item", json=payload).status_code == 409
+
+
+def _build_client_create_noauth():
+    Base.metadata.clear()
+
+    class Tenant(Base, GUIDPk):
+        __tablename__ = "tenants"
+        name = Column(String, nullable=False)
+
+    class Item(Base, GUIDPk, AllowAnonProvider):
+        __tablename__ = "items"
+        tenant_id = Column(
+            PgUUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False
+        )
+        name = Column(String, nullable=False)
+
+        @classmethod
+        def __autoapi_allow_anon__(cls):
+            return {"create"}
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+
+    def get_db():
+        with SessionLocal() as session:
+            yield session
+
+    api = AutoAPI(get_db=get_db)
+    api.include_models([Tenant, Item])
+    app = App()
+    app.include_router(api.router)
+    api.initialize_sync()
+    return TestClient(app), SessionLocal, Tenant, Item
+
+
+def _build_client_create_attr_noauth():
+    Base.metadata.clear()
+
+    class Tenant(Base, GUIDPk):
+        __tablename__ = "tenants"
+        name = Column(String, nullable=False)
+
+    class Item(Base, GUIDPk, AllowAnonProvider):
+        __tablename__ = "items"
+        tenant_id = Column(
+            PgUUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False
+        )
+        name = Column(String, nullable=False)
+
+        __autoapi_allow_anon__ = {"create"}
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+
+    def get_db():
+        with SessionLocal() as session:
+            yield session
+
+    api = AutoAPI(get_db=get_db)
+    api.include_models([Tenant, Item])
+    app = App()
+    app.include_router(api.router)
+    api.initialize_sync()
+    return TestClient(app), SessionLocal, Tenant, Item
+
+
+def test_allow_anon_create_method():
+    client, SessionLocal, Tenant, Item = _build_client_create_noauth()
+    with SessionLocal() as db:
+        tenant = Tenant(id=uuid4(), name="acme")
+        db.add(tenant)
+        db.commit()
+        db.refresh(tenant)
+        payload = {"id": str(uuid4()), "tenant_id": str(tenant.id), "name": "thing"}
+    assert client.post("/item", json=payload).status_code == 201
+
+
+def test_allow_anon_create_attr_noauth():
+    client, SessionLocal, Tenant, Item = _build_client_create_attr_noauth()
+    with SessionLocal() as db:
+        tenant = Tenant(id=uuid4(), name="acme")
+        db.add(tenant)
+        db.commit()
+        db.refresh(tenant)
+        payload = {"id": str(uuid4()), "tenant_id": str(tenant.id), "name": "thing"}
+    assert client.post("/item", json=payload).status_code == 201
 
 
 def test_allow_anon_list_and_read_attr():

--- a/pkgs/standards/peagen/peagen/orm/workers.py
+++ b/pkgs/standards/peagen/peagen/orm/workers.py
@@ -25,7 +25,7 @@ class Worker(Base, GUIDPk, Timestamped, HookProvider, AllowAnonProvider):
     __tablename__ = "workers"
     __table_args__ = ({"schema": "peagen"},)
 
-    __autoapi_allow_anon__ = {"create"}
+    __autoapi_allow_anon__ = {"create"}  # allow unauthenticated worker registration
 
     pool_id: Mapped[PgUUID] = acol(
         storage=S(

--- a/pkgs/standards/peagen/tests/infra/test_worker_create_anon.py
+++ b/pkgs/standards/peagen/tests/infra/test_worker_create_anon.py
@@ -1,0 +1,61 @@
+import asyncio
+from uuid import uuid4
+
+import httpx
+import pytest
+import uvicorn
+
+from peagen.defaults import DEFAULT_POOL_ID
+
+pytestmark = pytest.mark.infra
+
+GATEWAY_RPC = "http://127.0.0.1:8000/rpc"
+
+
+async def _wait_for_gateway() -> None:
+    async with httpx.AsyncClient() as client:
+        for _ in range(50):
+            try:
+                resp = await client.post(
+                    GATEWAY_RPC,
+                    json={"jsonrpc": "2.0", "method": "Worker.list", "params": {}},
+                )
+                if resp.status_code == 200:
+                    return
+            except Exception:
+                pass
+            await asyncio.sleep(0.1)
+    raise RuntimeError("gateway not ready")
+
+
+@pytest.fixture(scope="module")
+async def running_gateway():
+    cfg = uvicorn.Config(
+        "peagen.gateway:app", host="127.0.0.1", port=8000, log_level="info"
+    )
+    server = uvicorn.Server(cfg)
+    task = asyncio.create_task(server.serve())
+    await _wait_for_gateway()
+    yield
+    server.should_exit = True
+    await task
+
+
+@pytest.mark.asyncio
+async def test_worker_create_without_auth(running_gateway) -> None:
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 0,
+        "method": "Worker.create",
+        "params": {
+            "id": str(uuid4()),
+            "pool_id": str(DEFAULT_POOL_ID),
+            "url": "http://127.0.0.1:8001",
+            "advertises": {},
+            "handlers": {},
+        },
+    }
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(GATEWAY_RPC, json=payload)
+        assert resp.status_code != 403
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- allow unauthenticated worker registration
- add test ensuring Worker.create succeeds without auth
- expand autoapi tests to cover anonymous create via class attribute or classmethod

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format tests/i9n/test_allow_anon.py`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check tests/i9n/test_allow_anon.py --fix`
- `uv run --directory pkgs/standards/autoapi --package autoapi pytest tests/i9n/test_allow_anon.py`
- `uv run --directory pkgs/standards/peagen --package peagen ruff format tests/infra/test_worker_create_anon.py`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check tests/infra/test_worker_create_anon.py --fix`
- `uv run --directory pkgs/standards/peagen --package peagen pytest -m infra tests/infra/test_worker_create_anon.py` *(fails: httpx.ConnectError: All connection attempts failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b10ba1675883268f1c5955d399ebca