### PR TITLE
fix: expose bulk create schema for autoapi

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
@@ -1105,8 +1105,11 @@ def _build_router(model: type, specs: Sequence[OpSpec]) -> Router:
     # like "/resource/bulk" aren't captured by dynamic member routes such as
     # "/resource/{item_id}". FastAPI matches routes in the order they are
     # added, so sorting here prevents "bulk" from being treated as an
-    # identifier.
-    specs = [sp for sp in specs if sp.target != "bulk_create"]
+    # identifier. When both ``create`` and ``bulk_create`` are supplied, only
+    # expose the ``create`` variant to avoid duplicate routes sharing the same
+    # path and method.
+    if any(sp.target == "create" for sp in specs):
+        specs = [sp for sp in specs if sp.target != "bulk_create"]
     specs = sorted(specs, key=lambda sp: (0 if sp.target.startswith("bulk_") else 1))
 
     for sp in specs:


### PR DESCRIPTION
## Summary
- allow create operations to accept single item or arrays in OpenAPI schema
- include `bulk_create` routes in REST router when `create` is absent

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_bulk_response_schema.py`


------
https://chatgpt.com/codex/tasks/task_e_68b10d2f867c8326bc646b118358c633