### PR TITLE
fix: avoid duplicated resource in nested paths

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
@@ -1182,7 +1182,9 @@ def _build_router(model: type, specs: Sequence[OpSpec]) -> Router:
             suffix = sp.path_suffix or _default_path_suffix(sp) or ""
             if not suffix.startswith("/") and suffix:
                 suffix = "/" + suffix
-            base = f"{nested_pref.rstrip('/')}/{resource}"
+            base = nested_pref.rstrip("/")
+            if not base.endswith(f"/{resource}"):
+                base = f"{base}/{resource}"
             if sp.arity == "member" or sp.target in {
                 "read",
                 "update",


### PR DESCRIPTION
## Summary
- ensure nested REST paths that already include the resource segment aren't duplicated

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_symmetry_parity.py -q --tb=short`
- `uv run --with pytest --with pytest-asyncio --package autoapi --directory standards/autoapi sh -c "pytest >/tmp/autoapi.log && tail -n 20 /tmp/autoapi.log"`


------
https://chatgpt.com/codex/tasks/task_e_68b11e24ac188326a10c082f45577124