### PR TITLE
fix: expose bulk create routes in autoapi

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
@@ -1155,7 +1155,8 @@ def _build_router(model: type, specs: Sequence[OpSpec]) -> Router:
     # "/resource/{item_id}". FastAPI matches routes in the order they are
     # added, so sorting here prevents "bulk" from being treated as an
     # identifier.
-    specs = [sp for sp in specs if sp.target != "bulk_create"]
+    if any(sp.target == "create" for sp in specs):
+        specs = [sp for sp in specs if sp.target != "bulk_create"]
     specs = sorted(specs, key=lambda sp: (0 if sp.target.startswith("bulk_") else 1))
 
     for sp in specs:


### PR DESCRIPTION
## Summary
- ensure `_build_router` keeps `bulk_create` specs when no standard create op is present

## Testing
- `uv run --package autoapi --directory standards pytest autoapi/tests/i9n/test_bulk_docs_client.py -q`
- `uv run --package autoapi --directory standards pytest autoapi` *(fails: 22 failed, 598 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68b11e35f79c8326b2da5fc4fdd77e7f