### PR TITLE
Dispose registry in nested routing depth test to avoid duplicate model warnings

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_nested_routing_depth.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_nested_routing_depth.py
@@ -10,6 +10,7 @@ from sqlalchemy import Column, ForeignKey, String
 @pytest_asyncio.fixture
 async def three_level_api_client(db_mode, sync_db_session, async_db_session):
     Base.metadata.clear()
+    Base.registry.dispose()
 
     class Company(Base, GUIDPk):
         __tablename__ = "companies"


### PR DESCRIPTION
## Summary
- clear SQLAlchemy's registry before redefining models in nested routing depth integration test

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_nested_routing_depth.py -q`
- `uv run --package autoapi --directory standards/autoapi pytest -q` *(fails: test_api_key_creation_requires_valid_payload, test_core_and_core_raw_sync_operations, test_nested_path_schema_and_rpc[sync], test_nested_path_schema_and_rpc[async], test_op_ctx_core_crud_order::test_op_ctx_override[clear-delete-collection-False], test_v3_default_rest_ops::test_rest_clear, test_v3_default_rpc_ops::test_rpc_methods[bulk_create], test_v3_default_rpc_ops::test_rpc_methods[bulk_update], test_v3_default_rpc_ops::test_rpc_methods[bulk_replace], test_v3_default_rpc_ops::test_rpc_methods[bulk_delete], test_rest_rpc_parity_default_ops::test_rest_rpc_parity_for_default_verbs[bulk_create-bulk_create-/item-methods7], test_rest_rpc_symmetry_for_default_verbs, test_rpc_all_default_op_verbs[_op_bulk_create], test_rpc_all_default_op_verbs[_op_bulk_update], test_rpc_all_default_op_verbs[_op_bulk_replace], test_rpc_all_default_op_verbs[_op_bulk_delete]`)

------
https://chatgpt.com/codex/tasks/task_e_68b121af9bb88326be7976c566d2e923