### PR TITLE
fix: simplify symmetry parity method extraction

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_symmetry_parity.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_symmetry_parity.py
@@ -1,5 +1,4 @@
 import pytest
-from autoapi.v3.types import SimpleNamespace
 
 CRUD_MAP = {
     "create": ("post", "/tenant/{tenant_id}/item"),
@@ -19,7 +18,7 @@ async def test_route_and_method_symmetry(api_client):
     spec = (await client.get("/openapi.json")).json()
     paths = spec["paths"]
     methods = await client.get("/methodz")
-    method_list = {SimpleNamespace(**m).method for m in methods.json()["methods"]}
+    method_list = {m["method"] for m in methods.json()["methods"]}
 
     for verb, (http_verb, path) in CRUD_MAP.items():
         assert path in paths


### PR DESCRIPTION
## Summary
- avoid SimpleNamespace when reading method list in symmetry parity test

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_symmetry_parity.py`
- `uv run --package autoapi --directory standards/autoapi pytest` *(fails: test_apikey_generation::test_api_key_creation_requires_valid_payload, test_core_access::test_core_and_core_raw_sync_operations, test_nested_path_schema_and_rpc[sync], test_nested_path_schema_and_rpc[async], test_op_ctx_core_crud_order::test_op_ctx_override[clear-delete-collection-False])*

------
https://chatgpt.com/codex/tasks/task_e_68b12203bb7483269f7d40c1d2cc29ab