### PR TITLE
refactor: ensure bulk ops expect list payloads

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/handlers.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/handlers.py
@@ -510,20 +510,24 @@ def _wrap_core(model: type, target: str) -> StepFn:
             return await _core.clear(model, {}, db=db)
 
         if target == "bulk_create":
-            rows = payload if isinstance(payload, list) else []
-            return await _core.bulk_create(model, rows, db=db)
+            if not isinstance(payload, list):
+                raise TypeError("bulk_create expects a list payload")
+            return await _core.bulk_create(model, payload, db=db)
 
         if target == "bulk_update":
-            rows = payload if isinstance(payload, list) else []
-            return await _core.bulk_update(model, rows, db=db)
+            if not isinstance(payload, list):
+                raise TypeError("bulk_update expects a list payload")
+            return await _core.bulk_update(model, payload, db=db)
 
         if target == "bulk_replace":
-            rows = payload if isinstance(payload, list) else []
-            return await _core.bulk_replace(model, rows, db=db)
+            if not isinstance(payload, list):
+                raise TypeError("bulk_replace expects a list payload")
+            return await _core.bulk_replace(model, payload, db=db)
 
         if target == "bulk_upsert":
-            rows = payload if isinstance(payload, list) else []
-            return await _core.bulk_upsert(model, rows, db=db)
+            if not isinstance(payload, list):
+                raise TypeError("bulk_upsert expects a list payload")
+            return await _core.bulk_upsert(model, payload, db=db)
 
         if target == "bulk_delete":
             ids = payload.get("ids") if isinstance(payload, Mapping) else None

--- a/pkgs/standards/autoapi/tests/i9n/test_core_access.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_core_access.py
@@ -101,7 +101,7 @@ async def test_core_and_core_raw_sync_operations(sync_api):
                     "email": f"b_{uid}@example.com",
                 },
             ]
-            created_rows = await model.bulk_create({"rows": rows}, db=db)
+            created_rows = await model.bulk_create(rows, db=db)
             ids = [r["id"] if isinstance(r, Mapping) else r.id for r in created_rows]
             assert len(ids) == 2
 
@@ -109,7 +109,7 @@ async def test_core_and_core_raw_sync_operations(sync_api):
                 {"id": ids[0], "age": 20},
                 {"id": ids[1], "age": 21},
             ]
-            payload = {"rows": upd_rows}
+            payload = upd_rows
             updated_rows = await model.bulk_update(
                 None, db=db, ctx={"payload": payload}
             )
@@ -119,7 +119,7 @@ async def test_core_and_core_raw_sync_operations(sync_api):
                 {"id": ids[0], "name": "A1", "email": f"a1_{uid}@example.com"},
                 {"id": ids[1], "name": "B1", "email": f"b1_{uid}@example.com"},
             ]
-            payload = {"rows": rep_rows}
+            payload = rep_rows
             replaced_rows = await model.bulk_replace(
                 None, db=db, ctx={"payload": payload}
             )

--- a/pkgs/standards/autoapi/tests/i9n/test_v3_default_rpc_ops.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_v3_default_rpc_ops.py
@@ -149,7 +149,7 @@ async def test_rpc_methods(verb, client_and_model):
     elif verb == "bulk_create":
         resp = await rpc(
             "Gadget.bulk_create",
-            {"rows": [{"name": "A", "age": 1}, {"name": "B", "age": 2}]},
+            [{"name": "A", "age": 1}, {"name": "B", "age": 2}],
         )
         assert resp.status_code == 200
         result = resp.json()["result"]
@@ -158,15 +158,13 @@ async def test_rpc_methods(verb, client_and_model):
     elif verb == "bulk_update":
         created = await rpc(
             "Gadget.bulk_create",
-            {"rows": [{"name": "A", "age": 1}, {"name": "B", "age": 2}]},
+            [{"name": "A", "age": 1}, {"name": "B", "age": 2}],
         )
         r = created.json()["result"]
-        payload = {
-            "rows": [
-                {"id": r[0]["id"], "name": "A2", "age": 10},
-                {"id": r[1]["id"], "name": "B2", "age": 20},
-            ]
-        }
+        payload = [
+            {"id": r[0]["id"], "name": "A2", "age": 10},
+            {"id": r[1]["id"], "name": "B2", "age": 20},
+        ]
         resp = await rpc("Gadget.bulk_update", payload, id_=2)
         assert resp.status_code == 200
         result = resp.json()["result"]
@@ -175,15 +173,13 @@ async def test_rpc_methods(verb, client_and_model):
     elif verb == "bulk_replace":
         created = await rpc(
             "Gadget.bulk_create",
-            {"rows": [{"name": "A", "age": 1}, {"name": "B", "age": 2}]},
+            [{"name": "A", "age": 1}, {"name": "B", "age": 2}],
         )
         r = created.json()["result"]
-        payload = {
-            "rows": [
-                {"id": r[0]["id"], "name": "A3", "age": 11},
-                {"id": r[1]["id"], "name": "B3", "age": 22},
-            ]
-        }
+        payload = [
+            {"id": r[0]["id"], "name": "A3", "age": 11},
+            {"id": r[1]["id"], "name": "B3", "age": 22},
+        ]
         resp = await rpc("Gadget.bulk_replace", payload, id_=2)
         assert resp.status_code == 200
         result = resp.json()["result"]
@@ -192,7 +188,7 @@ async def test_rpc_methods(verb, client_and_model):
     elif verb == "bulk_delete":
         created = await rpc(
             "Gadget.bulk_create",
-            {"rows": [{"name": "A", "age": 1}, {"name": "B", "age": 2}]},
+            [{"name": "A", "age": 1}, {"name": "B", "age": 2}],
         )
         r = created.json()["result"]
         ids = [r[0]["id"], r[1]["id"]]

--- a/pkgs/standards/autoapi/tests/unit/test_rpc_all_default_op_verbs.py
+++ b/pkgs/standards/autoapi/tests/unit/test_rpc_all_default_op_verbs.py
@@ -134,7 +134,7 @@ async def _op_clear(api, db):
 
 async def _op_bulk_create(api, db):
     result = await api.rpc.Widget.bulk_create(
-        {"rows": [{"name": "h1"}, {"name": "h2"}]},
+        [{"name": "h1"}, {"name": "h2"}],
         db=db,
     )
     assert {r["name"] for r in result} == {"h1", "h2"}
@@ -142,37 +142,33 @@ async def _op_bulk_create(api, db):
 
 async def _op_bulk_update(api, db):
     rows = await api.rpc.Widget.bulk_create(
-        {"rows": [{"name": "i1"}, {"name": "i2"}]},
+        [{"name": "i1"}, {"name": "i2"}],
         db=db,
     )
-    payload = {
-        "rows": [
-            {"id": rows[0]["id"], "name": "i1u"},
-            {"id": rows[1]["id"], "name": "i2u"},
-        ]
-    }
+    payload = [
+        {"id": rows[0]["id"], "name": "i1u"},
+        {"id": rows[1]["id"], "name": "i2u"},
+    ]
     result = await api.rpc.Widget.bulk_update(None, db=db, ctx={"payload": payload})
     assert {r["name"] for r in result} == {"i1u", "i2u"}
 
 
 async def _op_bulk_replace(api, db):
     rows = await api.rpc.Widget.bulk_create(
-        {"rows": [{"name": "j1"}, {"name": "j2"}]},
+        [{"name": "j1"}, {"name": "j2"}],
         db=db,
     )
-    payload = {
-        "rows": [
-            {"id": rows[0]["id"], "name": "j1r"},
-            {"id": rows[1]["id"], "name": "j2r"},
-        ]
-    }
+    payload = [
+        {"id": rows[0]["id"], "name": "j1r"},
+        {"id": rows[1]["id"], "name": "j2r"},
+    ]
     result = await api.rpc.Widget.bulk_replace(None, db=db, ctx={"payload": payload})
     assert {r["name"] for r in result} == {"j1r", "j2r"}
 
 
 async def _op_bulk_delete(api, db):
     rows = await api.rpc.Widget.bulk_create(
-        {"rows": [{"name": "k1"}, {"name": "k2"}]},
+        [{"name": "k1"}, {"name": "k2"}],
         db=db,
     )
     ids = [r["id"] for r in rows]


### PR DESCRIPTION
## Summary
- enforce list payloads for bulk operations
- update bulk RPC tests to send list payloads

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest --maxfail=1` *(fails: tests/i9n/test_apikey_generation.py::test_api_key_creation_requires_valid_payload)*

------
https://chatgpt.com/codex/tasks/task_e_68b123d13b8c83269125edcd7807718f