### PR TITLE
Add caching to AutoAPI diagnostics and performance tests

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/system/diagnostics.py
+++ b/pkgs/standards/autoapi/autoapi/v3/system/diagnostics.py
@@ -136,8 +136,14 @@ def _build_healthz_endpoint(dep: Optional[Callable[..., Any]]):
 
 
 def _build_methodz_endpoint(api: Any):
+    cache: Optional[Dict[str, Any]] = None
+
     async def _methodz():
         """Ordered, canonical operation list."""
+        nonlocal cache
+        if cache is not None:
+            return cache
+
         methods: List[str] = []
         for model in _model_iter(api):
             mname = getattr(model, "__name__", "Model")
@@ -161,12 +167,15 @@ def _build_methodz_endpoint(api: Any):
                     }
                 )
         methods.sort(key=lambda x: (x["model"], x["alias"]))
-        return {"methods": methods}
+        cache = {"methods": methods}
+        return cache
 
     return _methodz
 
 
 def _build_hookz_endpoint(api: Any):
+    cache: Optional[Dict[str, Dict[str, Dict[str, List[str]]]]] = None
+
     async def _hookz():
         """
         Expose hook execution order for each method.
@@ -175,6 +184,10 @@ def _build_hookz_endpoint(api: Any):
         Within each phase, hooks are listed in execution order: global (None) hooks,
         then method-specific hooks.
         """
+        nonlocal cache
+        if cache is not None:
+            return cache
+
         out: Dict[str, Dict[str, Dict[str, List[str]]]] = {}
         for model in _model_iter(api):
             mname = getattr(model, "__name__", "Model")
@@ -198,14 +211,21 @@ def _build_hookz_endpoint(api: Any):
                     model_map[alias] = phase_map
             if model_map:
                 out[mname] = model_map
-        return out
+        cache = out
+        return cache
 
     return _hookz
 
 
 def _build_planz_endpoint(api: Any):
+    cache: Optional[Dict[str, Dict[str, List[str]]]] = None
+
     async def _planz():
         """Expose the runtime step sequence for each operation."""
+        nonlocal cache
+        if cache is not None:
+            return cache
+
         out: Dict[str, Dict[str, List[str]]] = {}
         for model in _model_iter(api):
             mname = getattr(model, "__name__", "Model")
@@ -255,7 +275,8 @@ def _build_planz_endpoint(api: Any):
                 model_map[sp.alias] = seq
             if model_map:
                 out[mname] = model_map
-        return out
+        cache = out
+        return cache
 
     return _planz
 

--- a/pkgs/standards/autoapi/tests/perf/test_hookz_performance.py
+++ b/pkgs/standards/autoapi/tests/perf/test_hookz_performance.py
@@ -1,0 +1,50 @@
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from autoapi.v3.system.diagnostics import _build_hookz_endpoint
+from autoapi.v3.opspec import OpSpec
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("op_count", [1, 5, 100])
+async def test_hookz_cached_response(op_count: int) -> None:
+    """Hookz endpoint should cache computed results."""
+
+    class API:
+        pass
+
+    class Model:
+        __name__ = "Widget"
+
+    def noop(ctx):
+        return None
+
+    Model.opspecs = SimpleNamespace(
+        all=tuple(
+            OpSpec(alias=f"op{i}", target="create", table=Model)
+            for i in range(op_count)
+        )
+    )
+
+    hooks_root = SimpleNamespace()
+    for i in range(op_count):
+        alias_ns = SimpleNamespace(HANDLER=[noop])
+        setattr(hooks_root, f"op{i}", alias_ns)
+    Model.hooks = hooks_root
+
+    api = API()
+    api.models = {"Widget": Model}
+
+    endpoint = _build_hookz_endpoint(api)
+
+    start = time.perf_counter()
+    await endpoint()
+    first = time.perf_counter() - start
+
+    start = time.perf_counter()
+    await endpoint()
+    second = time.perf_counter() - start
+
+    assert second <= first

--- a/pkgs/standards/autoapi/tests/perf/test_methodz_performance.py
+++ b/pkgs/standards/autoapi/tests/perf/test_methodz_performance.py
@@ -1,0 +1,44 @@
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from autoapi.v3.system.diagnostics import _build_methodz_endpoint
+from autoapi.v3.opspec import OpSpec
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("op_count", [1, 5, 100])
+async def test_methodz_cached_response(op_count: int) -> None:
+    """Methodz endpoint should cache computed results."""
+
+    class API:
+        pass
+
+    class Model:
+        __name__ = "Widget"
+
+    def handler(ctx):
+        return None
+
+    Model.opspecs = SimpleNamespace(
+        all=tuple(
+            OpSpec(alias=f"op{i}", target="create", table=Model, handler=handler)
+            for i in range(op_count)
+        )
+    )
+
+    api = API()
+    api.models = {"Widget": Model}
+
+    endpoint = _build_methodz_endpoint(api)
+
+    start = time.perf_counter()
+    await endpoint()
+    first = time.perf_counter() - start
+
+    start = time.perf_counter()
+    await endpoint()
+    second = time.perf_counter() - start
+
+    assert second <= first

--- a/pkgs/standards/autoapi/tests/perf/test_planz_performance.py
+++ b/pkgs/standards/autoapi/tests/perf/test_planz_performance.py
@@ -1,0 +1,61 @@
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from autoapi.v3.system.diagnostics import _build_planz_endpoint
+from autoapi.v3.opspec import OpSpec
+from autoapi.v3.runtime import plan as _plan
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("op_count", [1, 5, 100])
+async def test_planz_cached_response(
+    monkeypatch: pytest.MonkeyPatch, op_count: int
+) -> None:
+    """Planz endpoint should cache computed results even for large plans."""
+
+    class API:
+        pass
+
+    class Model:
+        __name__ = "Widget"
+
+    def handler(ctx):
+        return None
+
+    Model.opspecs = SimpleNamespace(
+        all=tuple(
+            OpSpec(
+                alias=f"op{i}",
+                target="create",
+                table=Model,
+                persist="default",
+                handler=handler,
+            )
+            for i in range(op_count)
+        )
+    )
+
+    dummy_plan = object()
+    Model.runtime = SimpleNamespace(plan=dummy_plan)
+
+    def fake_flattened_order(plan, *, persist, include_system_steps, deps):
+        return [f"step{j}" for j in range(1000)]
+
+    monkeypatch.setattr(_plan, "flattened_order", fake_flattened_order)
+
+    api = API()
+    api.models = {"Widget": Model}
+
+    endpoint = _build_planz_endpoint(api)
+
+    start = time.perf_counter()
+    await endpoint()
+    first = time.perf_counter() - start
+
+    start = time.perf_counter()
+    await endpoint()
+    second = time.perf_counter() - start
+
+    assert second <= first


### PR DESCRIPTION
## Summary
- cache diagnostic endpoints for methodz, hookz, and planz so repeated calls are instant
- add performance tests covering methodz, hookz, and planz endpoints across varying operation counts

## Testing
- ✅ `uv run --package autoapi --directory pkgs/standards/autoapi ruff format .`
- ✅ `uv run --package autoapi --directory pkgs/standards/autoapi ruff check . --fix`
- ⚠️ no pytest run per user instruction


------
https://chatgpt.com/codex/tasks/task_e_68b125e9331c8326abdc493b70b727e3