### PR TITLE
Add caching to AutoAPI diagnostics and performance tests

### DIFF
--- a/pkgs/standards/autoapi/tests/perf/test_hookz_performance.py
+++ b/pkgs/standards/autoapi/tests/perf/test_hookz_performance.py
@@ -1,0 +1,52 @@
+import time
+from types import SimpleNamespace
+
+import pytest
+from autoapi.v3.system import diagnostics
+
+
+def _make_api(count: int):
+    def dummy_fn():
+        pass
+
+    class DummySpec:
+        def __init__(self, alias: str):
+            self.alias = alias
+
+    hooks_root = SimpleNamespace()
+    rpc_ns = {}
+    for i in range(count):
+        alias = f"m{i}"
+        rpc_ns[alias] = None
+        setattr(
+            hooks_root,
+            alias,
+            SimpleNamespace(HANDLER=[dummy_fn]),
+        )
+
+    class DummyModel:
+        __name__ = "Model"
+        opspecs = SimpleNamespace(all=[DummySpec(f"m{i}") for i in range(count)])
+        hooks = hooks_root
+        rpc = SimpleNamespace(**rpc_ns)
+
+    api = SimpleNamespace(models={"Model": DummyModel})
+    return api
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("count", [1, 5, 100])
+async def test_hookz_cache_performance(count: int):
+    api = _make_api(count)
+    endpoint = diagnostics._build_hookz_endpoint(api)
+
+    start = time.perf_counter()
+    await endpoint()
+    first = time.perf_counter() - start
+
+    start = time.perf_counter()
+    result = await endpoint()
+    second = time.perf_counter() - start
+
+    assert second <= first
+    assert len(result["Model"]) == count

--- a/pkgs/standards/autoapi/tests/perf/test_methodz_performance.py
+++ b/pkgs/standards/autoapi/tests/perf/test_methodz_performance.py
@@ -1,0 +1,44 @@
+import time
+from types import SimpleNamespace
+
+import pytest
+from autoapi.v3.system import diagnostics
+
+
+def _make_api(count: int):
+    class DummySpec:
+        def __init__(self, alias: str):
+            self.alias = alias
+            self.target = f"handler_{alias}"
+            self.arity = 1
+            self.persist = "default"
+            self.request_model = None
+            self.response_model = None
+            self.expose_routes = True
+            self.expose_rpc = True
+            self.tags = ()
+
+    class DummyModel:
+        __name__ = "Model"
+        opspecs = SimpleNamespace(all=[DummySpec(f"m{i}") for i in range(count)])
+
+    api = SimpleNamespace(models={"Model": DummyModel})
+    return api
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("count", [1, 5, 100])
+async def test_methodz_cache_performance(count: int):
+    api = _make_api(count)
+    endpoint = diagnostics._build_methodz_endpoint(api)
+
+    start = time.perf_counter()
+    await endpoint()
+    first = time.perf_counter() - start
+
+    start = time.perf_counter()
+    result = await endpoint()
+    second = time.perf_counter() - start
+
+    assert second <= first
+    assert len(result["methods"]) == count

--- a/pkgs/standards/autoapi/tests/perf/test_planz_performance.py
+++ b/pkgs/standards/autoapi/tests/perf/test_planz_performance.py
@@ -1,0 +1,48 @@
+import time
+from types import SimpleNamespace
+
+import pytest
+from autoapi.v3.system import diagnostics
+
+
+def _make_api(count: int):
+    class DummySpec:
+        def __init__(self, alias: str):
+            self.alias = alias
+            self.target = "handler"
+            self.persist = "default"
+
+    class DummyModel:
+        __name__ = "Model"
+        opspecs = SimpleNamespace(all=[DummySpec(f"m{i}") for i in range(count)])
+
+    api = SimpleNamespace(models={"Model": DummyModel})
+    return api
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("count", [1, 5, 100])
+async def test_planz_cache_performance(count: int, monkeypatch):
+    api = _make_api(count)
+
+    def fake_build_phase_chains(model, alias):
+        def fn():
+            return None
+
+        return {ph: [fn for _ in range(10)] for ph in diagnostics.PHASES}
+
+    monkeypatch.setattr(diagnostics, "build_phase_chains", fake_build_phase_chains)
+    endpoint = diagnostics._build_planz_endpoint(api)
+
+    start = time.perf_counter()
+    await endpoint()
+    first = time.perf_counter() - start
+
+    start = time.perf_counter()
+    result = await endpoint()
+    second = time.perf_counter() - start
+
+    assert second <= first
+    assert len(result["Model"]) == count
+    total_steps = sum(len(seq) for seq in result["Model"].values())
+    assert total_steps >= count * len(diagnostics.PHASES) * 10


### PR DESCRIPTION
## Summary
- cache AutoAPI diagnostic endpoints to speed up method, hook, and plan listings
- implement async locks to keep diagnostics non-blocking
- add performance tests for methodz, hookz, and planz endpoints

## Testing
- `uv run --package autoapi --directory . ruff format .`
- `uv run --package autoapi --directory . ruff check . --fix`

------
https://chatgpt.com/codex/tasks/task_e_68b1260f55348326b622b3a8d054031b