### PR TITLE
Add performance tests for AutoAPI diagnostics endpoints

### DIFF
--- a/pkgs/standards/autoapi/tests/perf/test_hookz_performance.py
+++ b/pkgs/standards/autoapi/tests/perf/test_hookz_performance.py
@@ -1,0 +1,42 @@
+import pytest
+from types import SimpleNamespace
+from time import perf_counter
+
+from autoapi.v3.system.diagnostics import _build_hookz_endpoint
+from autoapi.v3 import hook_ctx
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("count", [1, 5, 100])
+async def test_hookz_performance(count):
+    """Measure /system/hookz response time with varying hook counts."""
+
+    class Model:
+        __name__ = "Model"
+        hooks = SimpleNamespace()
+        rpc = SimpleNamespace(create=None)
+        opspecs = SimpleNamespace(all=())
+
+    # Generate ``count`` hooks on the POST_RESPONSE phase of "create"
+    def make_hook(idx):
+        @hook_ctx(ops="*", phase="POST_RESPONSE")
+        def _hook(cls, ctx):
+            return None
+
+        _hook.__name__ = f"hook_{idx}"
+        return _hook
+
+    hooks = [make_hook(i) for i in range(count)]
+    Model.hooks.create = SimpleNamespace(POST_RESPONSE=hooks)
+
+    class API:
+        models = {"Model": Model}
+
+    hookz = _build_hookz_endpoint(API)
+
+    start = perf_counter()
+    data = await hookz()
+    duration = perf_counter() - start
+
+    assert len(data["Model"]["create"]["POST_RESPONSE"]) == count
+    print(f"/system/hookz with {count} hooks took {duration:.6f}s")

--- a/pkgs/standards/autoapi/tests/perf/test_methodz_performance.py
+++ b/pkgs/standards/autoapi/tests/perf/test_methodz_performance.py
@@ -1,0 +1,47 @@
+import pytest
+from types import SimpleNamespace
+from time import perf_counter
+
+from autoapi.v3.system.diagnostics import _build_methodz_endpoint
+from autoapi.v3.opspec import OpSpec
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("count", [1, 5, 100])
+async def test_methodz_performance(count):
+    """Measure /system/methodz response time with varying method counts."""
+
+    class Model:
+        __name__ = "Model"
+
+    def handler(ctx):
+        return None
+
+    # Generate ``count`` OpSpec instances for the model
+    Model.opspecs = SimpleNamespace(
+        all=tuple(
+            OpSpec(
+                alias=f"op{i}",
+                target="create",
+                table=Model,
+                persist="default",
+                handler=handler,
+            )
+            for i in range(count)
+        )
+    )
+
+    class API:
+        models = {"Model": Model}
+
+    methodz = _build_methodz_endpoint(API)
+
+    start = perf_counter()
+    data = await methodz()
+    duration = perf_counter() - start
+
+    # Basic sanity checks
+    assert len(data["methods"]) == count
+
+    # Capture duration for performance tracking
+    print(f"/system/methodz with {count} methods took {duration:.6f}s")

--- a/pkgs/standards/autoapi/tests/perf/test_planz_performance.py
+++ b/pkgs/standards/autoapi/tests/perf/test_planz_performance.py
@@ -1,0 +1,52 @@
+import pytest
+from types import SimpleNamespace
+from time import perf_counter
+
+from autoapi.v3.system.diagnostics import _build_planz_endpoint
+from autoapi.v3.opspec import OpSpec
+from autoapi.v3.runtime import plan as _plan
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("count", [1, 5, 100])
+async def test_planz_performance(monkeypatch, count):
+    """Measure /system/planz response time with varying operation counts."""
+
+    class Model:
+        __name__ = "Model"
+
+    def handler(ctx):
+        return None
+
+    Model.opspecs = SimpleNamespace(
+        all=tuple(
+            OpSpec(
+                alias=f"op{i}",
+                target="create",
+                table=Model,
+                persist="default",
+                handler=handler,
+            )
+            for i in range(count)
+        )
+    )
+    dummy_plan = object()
+    Model.runtime = SimpleNamespace(plan=dummy_plan)
+
+    def fake_flattened_order(plan, *, persist, include_system_steps, deps):
+        return [f"step_{i}" for i in range(10)]
+
+    monkeypatch.setattr(_plan, "flattened_order", fake_flattened_order)
+
+    class API:
+        models = {"Model": Model}
+
+    planz = _build_planz_endpoint(API)
+
+    start = perf_counter()
+    data = await planz()
+    duration = perf_counter() - start
+
+    total_steps = sum(len(v) for v in data["Model"].values())
+    assert total_steps == count * 10
+    print(f"/system/planz with {count} operations took {duration:.6f}s")


### PR DESCRIPTION
## Summary
- add performance tests for /system/methodz and /system/hookz with varying counts
- add performance tests for /system/planz covering large operation sets

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff format .`
- `uv run --directory standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b125c59410832698a49bee69e91229