### PR TITLE
fix: support sequence payloads in autoapi RPC

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rpc.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rpc.py
@@ -68,9 +68,13 @@ def _get_phase_chains(
     return out
 
 
-def _coerce_payload(payload: Any) -> Mapping[str, Any]:
-    """
-    Accept dict-like or Pydantic models; fallback to {} for None.
+def _coerce_payload(payload: Any) -> Any:
+    """Normalize common payload shapes.
+
+    ``dict``-like and Pydantic models become plain ``dict``\ s. ``None`` becomes an
+    empty ``dict``.  Sequence payloads (used by bulk operations) pass through as
+    lists of ``dict``\ s when possible; otherwise the original sequence is
+    returned.  Any other type yields an empty ``dict``.
     """
     if payload is None:
         return {}
@@ -81,7 +85,15 @@ def _coerce_payload(payload: Any) -> Mapping[str, Any]:
             return dict(payload.__dict__)
     if isinstance(payload, Mapping):
         return dict(payload)
-    return {}  # unexpected shapes → ignore
+    if isinstance(payload, Sequence) and not isinstance(payload, (str, bytes)):
+        out: list[Any] = []
+        for item in payload:
+            if isinstance(item, Mapping):
+                out.append(dict(item))
+            else:
+                out.append(item)
+        return out
+    return {}
 
 
 def _validate_input(
@@ -187,10 +199,19 @@ def _build_rpc_callable(model: type, sp: OpSpec) -> Callable[..., Awaitable[Any]
     ) -> Any:
         # 1) normalize + validate input
         raw_payload = _coerce_payload(payload)
-        norm_payload = _validate_input(model, alias, target, raw_payload)
-        merged_payload: Dict[str, Any] = dict(raw_payload)
-        for key, value in norm_payload.items():
-            merged_payload[key] = value
+        if target.startswith("bulk_") and isinstance(raw_payload, Sequence):
+            merged_payload = []
+            for item in raw_payload:
+                if isinstance(item, Mapping):
+                    norm = _validate_input(model, alias, target, dict(item))
+                    merged_payload.append({**dict(item), **norm})
+                else:
+                    merged_payload.append(item)
+        else:
+            norm_payload = _validate_input(model, alias, target, raw_payload)
+            merged_payload = dict(raw_payload)
+            for key, value in norm_payload.items():
+                merged_payload[key] = value
 
         # 2) build executor context & phases
         base_ctx: Dict[str, Any] = dict(ctx or {})

--- a/pkgs/standards/autoapi/autoapi/v3/transport/jsonrpc/models.py
+++ b/pkgs/standards/autoapi/autoapi/v3/transport/jsonrpc/models.py
@@ -16,7 +16,7 @@ class RPCRequest(BaseModel):
 
     jsonrpc: Literal["2.0"] = "2.0"
     method: str
-    params: dict[str, Any] = Field(default_factory=dict)
+    params: dict[str, Any] | list[Any] = Field(default_factory=dict)
     id: UUID | str | int | None = Field(
         default_factory=uuid4,
         json_schema_extra=_uuid_examples,


### PR DESCRIPTION
## Summary
- handle list payloads for bulk RPC operations
- allow JSON-RPC requests to accept list params

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_rpc_all_default_op_verbs.py::test_rpc_all_default_op_verbs -vv`
- `uv run --package autoapi --directory standards/autoapi pytest` *(fails: 17 failed, 612 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68b12cbddffc8326a2cfe57779a9c680