### PR TITLE
Fix planz endpoint hook ordering

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/system/diagnostics.py
+++ b/pkgs/standards/autoapi/autoapi/v3/system/diagnostics.py
@@ -256,8 +256,14 @@ def _build_planz_endpoint(api: Any):
                     }
                     for ph in PHASES:
                         if ph == "START_TX":
+                            # PRE_HANDLER hooks run before starting the TX
+                            seq.extend(hook_labels.get("PRE_HANDLER", []))
+                            seq.extend(phase_labels.get("PRE_HANDLER", []))
                             seq.extend(phase_labels.get(ph, []))
                             seq.extend(hook_labels.get(ph, []))
+                        elif ph == "PRE_HANDLER":
+                            # handled in START_TX branch
+                            continue
                         elif ph == "HANDLER":
                             phase_list = phase_labels.get(ph, [])
                             if phase_list and phase_list[0].startswith("sys:"):


### PR DESCRIPTION
## Summary
- ensure PRE_HANDLER hooks are emitted before START_TX steps in the planz diagnostics endpoint

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_planz_endpoint.py`
- `uv run --package autoapi --directory standards/autoapi pytest` *(fails: tests/i9n/test_apikey_generation.py::test_api_key_creation_requires_valid_payload, tests/i9n/test_nested_path_schema_and_rpc.py::test_nested_path_schema_and_rpc[sync], tests/i9n/test_nested_path_schema_and_rpc.py::test_nested_path_schema_and_rpc[async], tests/i9n/test_op_ctx_core_crud_order.py::test_op_ctx_override[clear-delete-collection-False], tests/i9n/test_opspec_effects_i9n_test.py::test_columns_bound, tests/i9n/test_opspec_effects_i9n_test.py::test_defaults_value_resolution, tests/i9n/test_opspec_effects_i9n_test.py::test_storage_and_sqlalchemy_persist, tests/i9n/test_opspec_effects_i9n_test.py::test_rest_routes_bound, tests/i9n/test_v3_default_rest_ops.py::test_rest_clear, tests/i9n/test_v3_default_rpc_ops.py::test_rpc_methods[bulk_create], tests/i9n/test_v3_default_rpc_ops.py::test_rpc_methods[bulk_update], tests/i9n/test_v3_default_rpc_ops.py::test_rpc_methods[bulk_replace], tests/i9n/test_v3_default_rpc_ops.py::test_rpc_methods[bulk_delete], tests/perf/test_planz_performance.py::test_planz_performance[1], tests/perf/test_planz_performance.py::test_planz_performance[5], tests/perf/test_planz_performance.py::test_planz_performance[100])


------
https://chatgpt.com/codex/tasks/task_e_68b13265d234832692b703712c4bf566