### PR TITLE
feat(autoapi): canonical hook labels and step constants

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/runtime/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/__init__.py
@@ -2,6 +2,7 @@
 from .executor import _invoke, _Ctx
 from .kernel import Kernel, build_phase_chains, run
 from . import events, errors, context
+from .labels import STEP_KINDS, DOMAINS
 
 __all__ = [
     "_invoke",
@@ -12,4 +13,6 @@ __all__ = [
     "events",
     "errors",
     "context",
+    "STEP_KINDS",
+    "DOMAINS",
 ]

--- a/pkgs/standards/autoapi/autoapi/v3/system/diagnostics.py
+++ b/pkgs/standards/autoapi/autoapi/v3/system/diagnostics.py
@@ -57,7 +57,7 @@ except Exception:  # pragma: no cover
 from sqlalchemy import text
 from ..opspec.types import PHASES
 from ..runtime.kernel import build_phase_chains
-from ..runtime import events as _ev, plan as _plan
+from ..runtime import events as _ev, plan as _plan, labels as _lbl
 
 logger = logging.getLogger(__name__)
 
@@ -81,6 +81,11 @@ def _label_callable(fn: Any) -> str:
     n = getattr(fn, "__qualname__", getattr(fn, "__name__", repr(fn)))
     m = getattr(fn, "__module__", None)
     return f"{m}.{n}" if m else n
+
+
+def _label_hook(fn: Any, phase: str) -> str:
+    subj = _label_callable(fn).replace(".", ":")
+    return f"hook:{_lbl.DOMAINS[-1]}:{subj}@{phase}"
 
 
 async def _maybe_execute(db: Any, stmt: str):
@@ -226,7 +231,14 @@ def _build_planz_endpoint(api: Any):
                 seq: List[str] = []
                 persist = getattr(sp, "persist", "default") != "skip"
                 if compiled_plan is not None:
-                    deps: List[str] = []
+                    deps: List[str] = [
+                        _label_callable(d) if callable(d) else str(d)
+                        for d in getattr(sp, "deps", []) or []
+                    ]
+                    secdeps: List[str] = [
+                        _label_callable(d) if callable(d) else str(d)
+                        for d in getattr(sp, "secdeps", []) or []
+                    ]
                     handler = getattr(sp, "handler", None)
                     if handler is not None:
                         deps.append(_label_callable(handler))
@@ -235,10 +247,15 @@ def _build_planz_endpoint(api: Any):
                         persist=persist,
                         include_system_steps=True,
                         deps=deps,
+                        secdeps=secdeps,
                     )
+                    pre_labels: List[str] = []
                     phase_labels: Dict[str, List[str]] = {ph: [] for ph in PHASES}
                     for lbl in labels:
                         kind = getattr(lbl, "kind", None)
+                        if kind in {"secdep", "dep"}:
+                            pre_labels.append(str(lbl))
+                            continue
                         phase = (
                             lbl.anchor
                             if kind == "sys"
@@ -249,11 +266,12 @@ def _build_planz_endpoint(api: Any):
                     alias_ns = getattr(hooks_root, sp.alias, SimpleNamespace())
                     hook_labels: Dict[str, List[str]] = {
                         ph: [
-                            _label_callable(fn)
+                            _label_hook(fn, ph)
                             for fn in getattr(alias_ns, ph, []) or []
                         ]
                         for ph in PHASES
                     }
+                    seq.extend(pre_labels)
                     for ph in PHASES:
                         if ph == "START_TX":
                             seq.extend(phase_labels.get(ph, []))
@@ -274,7 +292,20 @@ def _build_planz_endpoint(api: Any):
                             seq.extend(hook_labels.get(ph, []))
                             seq.extend(phase_labels.get(ph, []))
                 else:
+                    deps: List[str] = [
+                        _label_callable(d) if callable(d) else str(d)
+                        for d in getattr(sp, "deps", []) or []
+                    ]
+                    secdeps: List[str] = [
+                        _label_callable(d) if callable(d) else str(d)
+                        for d in getattr(sp, "secdeps", []) or []
+                    ]
+                    handler = getattr(sp, "handler", None)
+                    if handler is not None:
+                        deps.append(_label_callable(handler))
                     chains = build_phase_chains(model, sp.alias)
+                    seq.extend(f"secdep:{s}" for s in secdeps)
+                    seq.extend(f"dep:{d}" for d in deps)
                     for ph in PHASES:
                         if ph == "START_TX" and persist:
                             seq.append("sys:txn:begin@START_TX")
@@ -284,7 +315,7 @@ def _build_planz_endpoint(api: Any):
                             name = getattr(step, "__name__", "")
                             if name in {"start_tx", "end_tx"}:
                                 continue
-                            seq.append(_label_callable(step))
+                            seq.append(_label_hook(step, ph))
                         if ph == "END_TX" and persist:
                             seq.append("sys:txn:commit@END_TX")
                 model_map[sp.alias] = seq

--- a/pkgs/standards/autoapi/tests/unit/test_planz_endpoint.py
+++ b/pkgs/standards/autoapi/tests/unit/test_planz_endpoint.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 from autoapi.v3.system import diagnostics as _diag
 from autoapi.v3.system.diagnostics import _build_planz_endpoint
 from autoapi.v3.opspec import OpSpec
-from autoapi.v3.runtime import plan as _plan
+from autoapi.v3.runtime import plan as _plan, labels as _lbl
 
 
 class DummyLabel:
@@ -18,6 +18,14 @@ class DummyLabel:
 
 
 def sample_hook(ctx):
+    return None
+
+
+def dep_fn(ctx):
+    return None
+
+
+def secdep_fn(ctx):
     return None
 
 
@@ -40,6 +48,8 @@ async def test_planz_endpoint_sequence(monkeypatch: pytest.MonkeyPatch):
                 table=Model,
                 persist="default",
                 handler=handler,
+                deps=(dep_fn,),
+                secdeps=(secdep_fn,),
             ),
             OpSpec(
                 alias="read",
@@ -56,10 +66,21 @@ async def test_planz_endpoint_sequence(monkeypatch: pytest.MonkeyPatch):
     dummy_plan = object()
     Model.runtime = SimpleNamespace(plan=dummy_plan)
 
-    def fake_flattened_order(plan, *, persist, include_system_steps, deps):
+    dep_label = _diag._label_callable(dep_fn)
+    secdep_label = _diag._label_callable(secdep_fn)
+    handler_label = _diag._label_callable(handler)
+
+    def fake_flattened_order(plan, *, persist, include_system_steps, deps, secdeps):
         assert plan is dummy_plan
         if persist:
-            return [DummyLabel("sys:txn:begin@START_TX", "START_TX", kind="sys")]
+            assert set(deps) == {dep_label, handler_label}
+            assert secdeps == [secdep_label]
+            return [
+                DummyLabel(f"secdep:{secdep_label}", "", kind="secdep"),
+                DummyLabel(f"dep:{dep_label}", "", kind="dep"),
+                DummyLabel(f"dep:{handler_label}", "", kind="dep"),
+                DummyLabel("sys:txn:begin@START_TX", "START_TX", kind="sys"),
+            ]
         return []
 
     monkeypatch.setattr(_plan, "flattened_order", fake_flattened_order)
@@ -72,8 +93,11 @@ async def test_planz_endpoint_sequence(monkeypatch: pytest.MonkeyPatch):
 
     assert "Model" in data
     assert "write" in data["Model"]
-    hook_label = f"{sample_hook.__module__}.{sample_hook.__qualname__}"
+    hook_label = f"hook:{_lbl.DOMAINS[-1]}:{_diag._label_callable(sample_hook).replace('.', ':')}@PRE_HANDLER"
     assert hook_label in data["Model"]["write"]
+    assert f"secdep:{secdep_label}" in data["Model"]["write"]
+    assert f"dep:{dep_label}" in data["Model"]["write"]
+    assert f"dep:{handler_label}" in data["Model"]["write"]
     assert "sys:txn:begin@START_TX" in data["Model"]["write"]
     assert "read" in data["Model"]
     assert not any("sys:txn:begin@START_TX" in s for s in data["Model"]["read"])
@@ -113,7 +137,7 @@ async def test_planz_endpoint_prefers_compiled_plan_for_atoms(
 
     calls = {"flatten": False, "chains": False}
 
-    def fake_flattened_order(plan, *, persist, include_system_steps, deps):
+    def fake_flattened_order(plan, *, persist, include_system_steps, deps, secdeps):
         calls["flatten"] = True
         return [
             DummyLabel("sys:txn:begin@START_TX", "START_TX", kind="sys"),
@@ -139,7 +163,7 @@ async def test_planz_endpoint_prefers_compiled_plan_for_atoms(
 
     assert calls["flatten"] is True
     assert calls["chains"] is False
-    hook_label = f"{sample_hook.__module__}.{sample_hook.__qualname__}"
+    hook_label = f"hook:{_lbl.DOMAINS[-1]}:{_diag._label_callable(sample_hook).replace('.', ':')}@PRE_HANDLER"
     assert data["Model"]["create"] == [
         hook_label,
         "sys:txn:begin@START_TX",


### PR DESCRIPTION
## Summary
- enforce canonical `hook:` labels with a default `wire` domain
- surface `STEP_KINDS` and `DOMAINS` constants from runtime
- include dep/secdep steps when building `/planz` diagnostics

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff format .`
- `uv run --directory standards/autoapi --package autoapi ruff check . --fix`
- `uv run --directory standards/autoapi --package autoapi pytest` *(failed: test_api_key_creation_requires_valid_payload, test_nested_path_schema_and_rpc[sync], test_nested_path_schema_and_rpc[async])*

------
https://chatgpt.com/codex/tasks/task_e_68b1330a23048326a3445d72b08d0c20