### PR TITLE
docs: add request/response examples for create and bulk ops

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/schemas.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/schemas.py
@@ -63,12 +63,14 @@ def _make_bulk_rows_model(
     Build a root model representing `List[item_schema]`.
     """
     name = f"{model.__name__}{_camel(verb)}Request"
-    schema = create_model(  # type: ignore[call-arg]
-        name,
-        __base__=RootModel[List[item_schema]],
-    )
+    example = _extract_example(item_schema)
+    examples = [[example]] if example else []
+
+    class _BulkModel(RootModel[List[item_schema]]):  # type: ignore[misc]
+        model_config = ConfigDict(json_schema_extra={"examples": examples})
+
     return namely_model(
-        schema,
+        _BulkModel,
         name=name,
         doc=f"{verb} request schema for {model.__name__}",
     )
@@ -79,12 +81,14 @@ def _make_bulk_rows_response_model(
 ) -> Type[BaseModel]:
     """Build a root model representing ``List[item_schema]`` for responses."""
     name = f"{model.__name__}{_camel(verb)}Response"
-    schema = create_model(  # type: ignore[call-arg]
-        name,
-        __base__=RootModel[List[item_schema]],
-    )
+    example = _extract_example(item_schema)
+    examples = [[example]] if example else []
+
+    class _BulkModel(RootModel[List[item_schema]]):  # type: ignore[misc]
+        model_config = ConfigDict(json_schema_extra={"examples": examples})
+
     return namely_model(
-        schema,
+        _BulkModel,
         name=name,
         doc=f"{verb} response schema for {model.__name__}",
     )
@@ -95,12 +99,15 @@ def _make_single_or_bulk_model(
 ) -> Type[BaseModel]:
     """Build a root model accepting a single item or a list of items."""
     name = f"{model.__name__}{_camel(verb)}Request"
-    schema = create_model(  # type: ignore[call-arg]
-        name,
-        __base__=RootModel[Union[item_schema, List[item_schema]]],  # type: ignore[valid-type]
-    )
+    example = _extract_example(item_schema)
+    examples = [example, [example] if example else []]
+    union_type = Union[item_schema, List[item_schema]]  # type: ignore[valid-type]
+
+    class _UnionModel(RootModel[union_type]):  # type: ignore[misc]
+        model_config = ConfigDict(json_schema_extra={"examples": examples})
+
     return namely_model(
-        schema,
+        _UnionModel,
         name=name,
         doc=f"{verb} request schema for {model.__name__}",
     )

--- a/pkgs/standards/autoapi/tests/unit/test_request_response_examples.py
+++ b/pkgs/standards/autoapi/tests/unit/test_request_response_examples.py
@@ -1,0 +1,68 @@
+from autoapi.v3.bindings.rest import _build_router
+from autoapi.v3.opspec import OpSpec
+from autoapi.v3.tables import Base
+from autoapi.v3.mixins import GUIDPk, BulkCapable
+from autoapi.v3.types import Column, String, App
+
+
+class Widget(Base, GUIDPk, BulkCapable):
+    __tablename__ = "widgets_example_schemas"
+    name = Column(String, nullable=False, info={"autoapi": {"examples": ["foo"]}})
+
+
+def _openapi_for(ops):
+    router = _build_router(Widget, [OpSpec(alias=a, target=t) for a, t in ops])
+    app = App()
+    app.include_router(router)
+    return app.openapi()
+
+
+def _resolve_schema(spec, schema):
+    if "$ref" in schema:
+        ref = schema["$ref"].split("/")[-1]
+        return spec["components"]["schemas"][ref]
+    return schema
+
+
+def test_create_request_model_examples():
+    spec = _openapi_for([("create", "create")])
+    path = f"/{Widget.__name__.lower()}"
+    schema = spec["paths"][path]["post"]["requestBody"]["content"]["application/json"][
+        "schema"
+    ]
+    schema = _resolve_schema(spec, schema)
+    assert schema["examples"][0] == {"name": "foo"}
+    assert schema["examples"][1] == [{"name": "foo"}]
+
+
+def test_create_response_model_examples():
+    spec = _openapi_for([("create", "create")])
+    path = f"/{Widget.__name__.lower()}"
+    schema = spec["paths"][path]["post"]["responses"]["201"]["content"][
+        "application/json"
+    ]["schema"]
+    schema = _resolve_schema(spec, schema)
+    single, bulk = schema["examples"]
+    assert single == {"name": "foo"}
+    assert bulk == [{"name": "foo"}]
+
+
+def test_bulk_request_model_examples():
+    spec = _openapi_for([("bulk_create", "bulk_create")])
+    path = f"/{Widget.__name__.lower()}"
+    schema = spec["paths"][path]["post"]["requestBody"]["content"]["application/json"][
+        "schema"
+    ]
+    schema = _resolve_schema(spec, schema)
+    assert schema["examples"][0] == [{"name": "foo"}]
+
+
+def test_bulk_response_model_examples():
+    spec = _openapi_for([("bulk_create", "bulk_create")])
+    path = f"/{Widget.__name__.lower()}"
+    schema = spec["paths"][path]["post"]["responses"]["200"]["content"][
+        "application/json"
+    ]["schema"]
+    schema = _resolve_schema(spec, schema)
+    example = schema["examples"][0][0]
+    assert example == {"name": "foo"}


### PR DESCRIPTION
## Summary
- include example payloads for create and bulk request/response schemas
- add tests verifying request and response examples for create and bulk endpoints

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_request_response_examples.py`
- `uv run --package autoapi --directory standards/autoapi pytest` *(fails: tests/i9n/test_apikey_generation.py::test_api_key_creation_requires_valid_payload, tests/i9n/test_bulk_docs_client.py::test_openapi_client_bulk_create_response_schema)*

------
https://chatgpt.com/codex/tasks/task_e_68b134cfa8908326a1fa020cce1b612b