### PR TITLE
fix: support bulk RPC params

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rpc.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rpc.py
@@ -146,16 +146,17 @@ def _serialize_output(model: type, alias: str, target: str, result: Any) -> Any:
         return result
 
     try:
-        if target in {
-            "list",
-            "bulk_create",
-            "bulk_update",
-            "bulk_replace",
-        } and isinstance(result, (list, tuple)):
+        if target == "list" and isinstance(result, (list, tuple)):
             return [
                 out_model.model_validate(x).model_dump(exclude_none=True, by_alias=True)
                 for x in result
             ]
+        if target in {"bulk_create", "bulk_update", "bulk_replace"} and isinstance(
+            result, (list, tuple)
+        ):
+            return out_model.model_validate(result).model_dump(
+                exclude_none=True, by_alias=True
+            )
         # Single object case
         return out_model.model_validate(result).model_dump(
             exclude_none=True, by_alias=True

--- a/pkgs/standards/autoapi/autoapi/v3/transport/jsonrpc/dispatcher.py
+++ b/pkgs/standards/autoapi/autoapi/v3/transport/jsonrpc/dispatcher.py
@@ -104,13 +104,16 @@ def _err(code: int, msg: str, id_: Any, data: Any | None = None) -> Dict[str, An
     return e
 
 
-def _normalize_params(params: Any) -> Mapping[str, Any]:
+def _normalize_params(params: Any) -> Any:
     if params is None:
         return {}
     if isinstance(params, Mapping):
         return dict(params)
-    # Positional params are not supported in AutoAPI adapters
-    raise HTTPException(status_code=400, detail="Invalid params: expected object")
+    if isinstance(params, Sequence) and not isinstance(params, (str, bytes)):
+        return list(params)
+    raise HTTPException(
+        status_code=400, detail="Invalid params: expected object or array"
+    )
 
 
 def _model_for(api: Any, name: str) -> Optional[type]:


### PR DESCRIPTION
## Summary
- allow JSON-RPC dispatcher to accept array params
- correctly serialize bulk RPC results via root Pydantic models

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_v3_default_rpc_ops.py::test_rpc_methods -vv`
- `uv run --package autoapi --directory standards/autoapi pytest` *(fails: tests/i9n/test_apikey_generation.py::test_api_key_creation_requires_valid_payload - assert 409 == 422)*

------
https://chatgpt.com/codex/tasks/task_e_68b134e703f08326a4df17e2a85450f9