### PR TITLE
feat(autoapi): add dependency fields to OpSpec

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/opspec/types.py
+++ b/pkgs/standards/autoapi/autoapi/v3/opspec/types.py
@@ -192,6 +192,8 @@ class OpSpec:
     core: Optional[StepFn] = None
     core_raw: Optional[StepFn] = None
     extra: Mapping[str, Any] = field(default_factory=dict)
+    deps: Tuple[StepFn | str, ...] = field(default_factory=tuple)
+    secdeps: Tuple[StepFn | str, ...] = field(default_factory=tuple)
 
 
 # Canonical verb set


### PR DESCRIPTION
## Summary
- allow `OpSpec` to declare `deps` and `secdeps` for runtime diagnostics

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_planz_endpoint.py -q`
- `uv run --package autoapi --directory standards/autoapi pytest` *(fails: tests/i9n/test_apikey_generation.py::test_api_key_creation_requires_valid_payload)*

------
https://chatgpt.com/codex/tasks/task_e_68b136c19a788326b50c9b04a52e6923