### PR TITLE
fix nested path schema handling

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/schema/builder.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/builder.py
@@ -25,8 +25,13 @@ from typing import (
     Tuple,
     Type,
     Union,
+    get_args,
+    get_origin,
     get_type_hints,
+    List,
 )
+
+import inspect
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, create_model
 
@@ -584,11 +589,31 @@ def _strip_parent_fields(base: Type[BaseModel], *, drop: Set[str]) -> Type[BaseM
     Preserves field types and defaults where possible.
     """
     assert issubclass(base, BaseModel), "base must be a Pydantic BaseModel subclass"
+
+    # RootModel[Union[Model, List[Model]]] – unwrap inner model so we can strip
+    # identifiers and return the cleaned schema directly.
+    if len(getattr(base, "model_fields", {})) == 1 and "root" in base.model_fields:
+        root_ann = base.model_fields["root"].annotation
+        if get_origin(root_ann) is Union:
+            item_type = None
+            for arg in get_args(root_ann):
+                origin = get_origin(arg)
+                if inspect.isclass(arg) and issubclass(arg, BaseModel):
+                    item_type = arg
+                    break
+                if origin in (list, List):
+                    sub = get_args(arg)[0]
+                    if inspect.isclass(sub) and issubclass(sub, BaseModel):
+                        item_type = sub
+                        break
+            if item_type is not None:
+                return _strip_parent_fields(item_type, drop=drop)
+
     hints = get_type_hints(base, include_extras=True)
     new_fields: Dict[str, Tuple[type, Any]] = {}
 
     for name, finfo in base.model_fields.items():  # type: ignore[attr-defined]
-        if name in (drop or ()):
+        if name in (drop or ()):  # pragma: no branch
             continue
         typ = hints.get(name, Any)
         default = (


### PR DESCRIPTION
## Summary
- unwrap root union schemas when stripping parent fields so nested routes drop injected identifiers correctly

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_nested_path_schema_and_rpc.py::test_nested_path_schema_and_rpc -q`


------
https://chatgpt.com/codex/tasks/task_e_68b137cb80908326bed366cac2763e9d