### PR TITLE
Fix API key creation error handling

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/runtime/errors.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/errors.py
@@ -381,7 +381,11 @@ def _classify_exception(
         return status.HTTP_409_CONFLICT, _stringify_exc(exc), None
 
     if (IntegrityError is not None) and isinstance(exc, IntegrityError):
-        return status.HTTP_409_CONFLICT, _stringify_exc(exc), None
+        msg = _stringify_exc(exc)
+        lower_msg = msg.lower()
+        if "not null constraint" in lower_msg or "check constraint" in lower_msg:
+            return status.HTTP_422_UNPROCESSABLE_ENTITY, msg, None
+        return status.HTTP_409_CONFLICT, msg, None
 
     if (OperationalError is not None) and isinstance(exc, OperationalError):
         return status.HTTP_503_SERVICE_UNAVAILABLE, _stringify_exc(exc), None


### PR DESCRIPTION
## Summary
- return 422 for invalid API key payloads due to constraint violations
- keep unique violations as 409 conflicts

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_apikey_generation.py::test_api_key_creation_requires_valid_payload -q`


------
https://chatgpt.com/codex/tasks/task_e_68b137afc0dc83268a78359c6f450029