### PR TITLE
fix: prioritize clear REST route

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
@@ -1159,7 +1159,9 @@ def _build_router(model: type, specs: Sequence[OpSpec]) -> Router:
     specs = sorted(
         specs,
         key=lambda sp: (
-            0
+            -1
+            if sp.target == "clear"
+            else 0
             if sp.target in {"bulk_update", "bulk_replace", "bulk_delete"}
             else 1
             if sp.target == "create"


### PR DESCRIPTION
## Summary
- ensure clear REST endpoint registered before bulk delete to avoid route conflict

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_v3_default_rest_ops.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b13a6c4ddc8326bf4b600a6db406cc