### PR TITLE
fix: ensure unique bulk response schema names

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/schema/utils.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/utils.py
@@ -8,7 +8,9 @@ from pydantic import BaseModel
 def namely_model(model: Type[BaseModel], *, name: str, doc: str) -> Type[BaseModel]:
     """Assign a unique name and docstring to a Pydantic model class."""
     model.__name__ = name
+    model.__qualname__ = name
     model.__doc__ = doc
+    model.model_rebuild(force=True)
     return model
 
 


### PR DESCRIPTION
## Summary
- ensure dynamically created Pydantic models rebuild with correct names

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_bulk_response_schema.py tests/i9n/test_bulk_docs_client.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b13a62911c83269cdaebb2a3da6465