### PR TITLE
test(autoapi): guard against missing tables

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_opspec_effects_i9n_test.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_opspec_effects_i9n_test.py
@@ -63,8 +63,8 @@ def _fresh_session():
     engine = create_engine("sqlite:///:memory:")
     # ``Base.metadata`` may have been cleared by other tests; create tables
     # explicitly from the model definitions to avoid missing table errors.
-    Gadget.__table__.create(bind=engine)
-    Hooked.__table__.create(bind=engine)
+    for model in (Gadget, Hooked):
+        model.__table__.create(bind=engine, checkfirst=True)
     return sessionmaker(bind=engine)()
 
 


### PR DESCRIPTION
## Summary
- create autoapi test tables defensively to avoid missing table errors

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_opspec_effects_i9n_test.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b13a66a4dc8326872a459ce81c2044