### PR TITLE
fix: normalize payload docstring

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rpc.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rpc.py
@@ -71,10 +71,10 @@ def _get_phase_chains(
 def _coerce_payload(payload: Any) -> Any:
     """Normalize common payload shapes.
 
-    ``dict``-like and Pydantic models become plain ``dict``\ s. ``None`` becomes an
-    empty ``dict``.  Sequence payloads (used by bulk operations) pass through as
-    lists of ``dict``\ s when possible; otherwise the original sequence is
-    returned.  Any other type yields an empty ``dict``.
+    ``dict``-like and Pydantic models become plain ``dict``s. ``None`` becomes an
+    empty ``dict``. Sequence payloads (used by bulk operations) pass through as
+    lists of ``dict``s when possible; otherwise the original sequence is
+    returned. Any other type yields an empty ``dict``.
     """
     if payload is None:
         return {}


### PR DESCRIPTION
## Summary
- fix docstring in `_coerce_payload` to avoid invalid escape sequences in rpc binding

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_v3_default_rest_ops.py`


------
https://chatgpt.com/codex/tasks/task_e_68b13c66893483268f99970c9300c006