### PR TITLE
fix: ensure autoapi opspec tests create tables

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_opspec_effects_i9n_test.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_opspec_effects_i9n_test.py
@@ -61,10 +61,9 @@ class Hooked(Base, GUIDPk):
 
 def _fresh_session():
     engine = create_engine("sqlite:///:memory:")
-    # ``Base.metadata`` may have been cleared by other tests; create tables
-    # explicitly from the model definitions to avoid missing table errors.
-    Gadget.__table__.create(bind=engine)
-    Hooked.__table__.create(bind=engine)
+    # ``Base.metadata`` may have been cleared by other tests; ensure the
+    # required tables exist for this module's models.
+    Base.metadata.create_all(bind=engine, tables=[Gadget.__table__, Hooked.__table__])
     return sessionmaker(bind=engine)()
 
 


### PR DESCRIPTION
## Summary
- avoid metadata issues by creating tables via `Base.metadata.create_all`

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_opspec_effects_i9n_test.py`

------
https://chatgpt.com/codex/tasks/task_e_68b13c61ca188326ac1a7ef6c0e716de