### PR TITLE
Allow create endpoints to accept list payloads

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
@@ -788,7 +788,14 @@ def _make_collection_endpoint(
     # --- Body-based collection endpoints: create / bulk_* ---
 
     body_model = _request_model_for(sp, model)
-    body_annotation = body_model if body_model is not None else Mapping[str, Any]
+    base_annotation = body_model if body_model is not None else Mapping[str, Any]
+    if target == "create":
+        try:
+            body_annotation = base_annotation | list[base_annotation]
+        except Exception:  # pragma: no cover - best effort
+            body_annotation = base_annotation
+    else:
+        body_annotation = base_annotation
 
     async def _endpoint(
         request: Request,

--- a/pkgs/standards/autoapi/tests/unit/test_request_body_schema.py
+++ b/pkgs/standards/autoapi/tests/unit/test_request_body_schema.py
@@ -22,7 +22,13 @@ def test_request_body_uses_schema_model():
     request_schema = spec["paths"][path]["post"]["requestBody"]["content"][
         "application/json"
     ]["schema"]
-    assert request_schema["$ref"] == "#/components/schemas/WidgetCreate"
+    if "$ref" in request_schema:
+        ref = request_schema["$ref"].split("/")[-1]
+        request_schema = spec["components"]["schemas"][ref]
+    union = request_schema.get("anyOf") or request_schema.get("oneOf")
+    assert union is not None
+    types = {item.get("type") or "object" for item in union}
+    assert types == {"object", "array"}
 
     widget_schema = spec["components"]["schemas"]["WidgetCreate"]
     assert "name" in widget_schema.get("properties", {})


### PR DESCRIPTION
## Summary
- allow REST create endpoints to accept either a single object or a list of objects
- adjust request body schema test to expect object-or-array union

## Testing
- `uv run --package autoapi --directory standards pytest` *(fails: ModuleNotFoundError: No module named 'pgpy')*

------
https://chatgpt.com/codex/tasks/task_e_68b13b4796b4832684861dddd76e309b