### PR TITLE
fix: support references in example extraction

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/schemas.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/schemas.py
@@ -168,8 +168,12 @@ def _extract_example(schema: Type[BaseModel]) -> Dict[str, Any]:
     except Exception:
         return {}
     out: Dict[str, Any] = {}
+    defs = js.get("$defs", {})
     for name, prop in (js.get("properties") or {}).items():
         examples = prop.get("examples")
+        if examples is None and "$ref" in prop:
+            ref = prop["$ref"].split("/")[-1]
+            examples = (defs.get(ref) or {}).get("examples")
         if examples:
             out[name] = examples[0]
     return out

--- a/pkgs/standards/autoapi/tests/i9n/test_request_response_examples.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_request_response_examples.py
@@ -1,0 +1,71 @@
+import pytest
+from autoapi.v3.bindings.rest import _build_router
+from autoapi.v3.opspec import OpSpec
+from autoapi.v3.tables import Base
+from autoapi.v3.mixins import GUIDPk, BulkCapable
+from autoapi.v3.types import Column, String, App
+
+pytestmark = pytest.mark.i9n
+
+
+class Widget(Base, GUIDPk, BulkCapable):
+    __tablename__ = "widgets_example_schemas"
+    name = Column(String, nullable=False, info={"autoapi": {"examples": ["foo"]}})
+
+
+def _openapi_for(ops):
+    router = _build_router(Widget, [OpSpec(alias=a, target=t) for a, t in ops])
+    app = App()
+    app.include_router(router)
+    return app.openapi()
+
+
+def _resolve_schema(spec, schema):
+    if "$ref" in schema:
+        ref = schema["$ref"].split("/")[-1]
+        return spec["components"]["schemas"][ref]
+    return schema
+
+
+def test_create_request_model_examples():
+    spec = _openapi_for([("create", "create")])
+    path = f"/{Widget.__name__.lower()}"
+    schema = spec["paths"][path]["post"]["requestBody"]["content"]["application/json"][
+        "schema"
+    ]
+    schema = _resolve_schema(spec, schema)
+    assert schema["examples"][0] == {"name": "foo"}
+    assert schema["examples"][1] == [{"name": "foo"}]
+
+
+def test_create_response_model_examples():
+    spec = _openapi_for([("create", "create")])
+    path = f"/{Widget.__name__.lower()}"
+    schema = spec["paths"][path]["post"]["responses"]["201"]["content"][
+        "application/json"
+    ]["schema"]
+    schema = _resolve_schema(spec, schema)
+    single, bulk = schema["examples"]
+    assert single == {"name": "foo"}
+    assert bulk == [{"name": "foo"}]
+
+
+def test_bulk_request_model_examples():
+    spec = _openapi_for([("bulk_create", "bulk_create")])
+    path = f"/{Widget.__name__.lower()}"
+    schema = spec["paths"][path]["post"]["requestBody"]["content"]["application/json"][
+        "schema"
+    ]
+    schema = _resolve_schema(spec, schema)
+    assert schema["examples"][0] == [{"name": "foo"}]
+
+
+def test_bulk_response_model_examples():
+    spec = _openapi_for([("bulk_create", "bulk_create")])
+    path = f"/{Widget.__name__.lower()}"
+    schema = spec["paths"][path]["post"]["responses"]["200"]["content"][
+        "application/json"
+    ]["schema"]
+    schema = _resolve_schema(spec, schema)
+    example = schema["examples"][0][0]
+    assert example == {"name": "foo"}


### PR DESCRIPTION
## Summary
- handle `$ref` resolution when extracting schema examples
- add integration tests for request/response examples

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_request_response_examples.py`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_request_response_examples.py`


------
https://chatgpt.com/codex/tasks/task_e_68b13f603a108326aa5ace32cce05725