### PR TITLE
Fix request body example schema in autoapi

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
@@ -772,7 +772,7 @@ def _make_collection_endpoint(
 
     body_model = _request_model_for(sp, model)
     base_annotation = body_model if body_model is not None else Mapping[str, Any]
-    if target == "create":
+    if target == "create" and body_model is None:
         try:
             body_annotation = base_annotation | list[base_annotation]
         except Exception:  # pragma: no cover - best effort


### PR DESCRIPTION
## Summary
- ensure create endpoints with request models preserve example schemas

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_request_response_examples.py`

------
https://chatgpt.com/codex/tasks/task_e_68b13fcd1fcc8326a0bd6cf51a08f77f