### PR TITLE
Require array payload for autoapi bulk create

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_bulk_docs_client.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_bulk_docs_client.py
@@ -9,7 +9,7 @@ from autoapi.v3.types import App, Column, String
 
 
 @pytest.mark.asyncio()
-async def test_openapi_client_create_request_allows_single_or_list() -> None:
+async def test_openapi_client_create_request_is_array() -> None:
     Base.metadata.clear()
 
     class Widget(Base, GUIDPk, BulkCapable):
@@ -31,10 +31,7 @@ async def test_openapi_client_create_request_allows_single_or_list() -> None:
     if "$ref" in schema:
         ref = schema["$ref"].split("/")[-1]
         schema = spec["components"]["schemas"][ref]
-    union = schema.get("anyOf") or schema.get("oneOf")
-    assert union is not None
-    types = {item.get("type") or "object" for item in union}
-    assert types == {"object", "array"}
+    assert schema.get("type") == "array"
 
 
 @pytest.mark.asyncio()

--- a/pkgs/standards/autoapi/tests/unit/test_bulk_response_schema.py
+++ b/pkgs/standards/autoapi/tests/unit/test_bulk_response_schema.py
@@ -17,7 +17,7 @@ def _openapi_for(ops):
     return app.openapi()
 
 
-def test_create_request_schema_allows_single_or_list():
+def test_create_request_schema_is_array():
     spec = _openapi_for([("create", "create")])
     path = f"/{Widget.__name__.lower()}"
     schema = spec["paths"][path]["post"]["requestBody"]["content"]["application/json"][
@@ -26,10 +26,7 @@ def test_create_request_schema_allows_single_or_list():
     if "$ref" in schema:
         ref = schema["$ref"].split("/")[-1]
         schema = spec["components"]["schemas"][ref]
-    union = schema.get("anyOf") or schema.get("oneOf")
-    assert union is not None
-    types = {item.get("type") or "object" for item in union}
-    assert types == {"object", "array"}
+    assert schema.get("type") == "array"
 
 
 def test_bulk_create_response_schema():

--- a/pkgs/standards/autoapi/tests/unit/test_request_body_schema.py
+++ b/pkgs/standards/autoapi/tests/unit/test_request_body_schema.py
@@ -25,10 +25,7 @@ def test_request_body_uses_schema_model():
     if "$ref" in request_schema:
         ref = request_schema["$ref"].split("/")[-1]
         request_schema = spec["components"]["schemas"][ref]
-    union = request_schema.get("anyOf") or request_schema.get("oneOf")
-    assert union is not None
-    types = {item.get("type") or "object" for item in union}
-    assert types == {"object", "array"}
+    assert request_schema.get("type") == "object"
 
     widget_schema = spec["components"]["schemas"]["WidgetCreate"]
     assert "name" in widget_schema.get("properties", {})


### PR DESCRIPTION
## Summary
- remove mixed single/bulk model
- require list payload and responses for BulkCapable create operations
- update request/response schema tests

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_bulk_docs_client.py tests/unit/test_bulk_response_schema.py tests/unit/test_request_body_schema.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1422029a483269c8f22f439e41f63