### PR TITLE
fix: allow bulk create payloads

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
@@ -16,6 +16,7 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
+    Union,
 )
 
 from typing import get_origin as _get_origin, get_args as _get_args
@@ -772,9 +773,9 @@ def _make_collection_endpoint(
 
     body_model = _request_model_for(sp, model)
     base_annotation = body_model if body_model is not None else Mapping[str, Any]
-    if target == "create" and body_model is None:
+    if target == "create":
         try:
-            body_annotation = base_annotation | list[base_annotation]
+            body_annotation = Union[base_annotation, list[base_annotation]]  # type: ignore[valid-type]
         except Exception:  # pragma: no cover - best effort
             body_annotation = base_annotation
     else:


### PR DESCRIPTION
## Summary
- allow create endpoints to accept either a single object or list payloads for bulk creation

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff check autoapi/v3/bindings/rest.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_request_body_schema.py::test_request_body_uses_schema_model -q`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_v3_default_rest_ops.py::test_rest_update -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1422304148326969d20bf7f076d46