### PR TITLE
Fix hook context test to check response keys

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_hook_lifecycle.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_hook_lifecycle.py
@@ -351,7 +351,7 @@ async def test_hook_context_modification(db_mode):
     async def enrich_response(cls, ctx):
         hook_executions.append("POST_RESPONSE")
         assert ctx["custom_data"]["verified"] is True
-        assert hasattr(ctx["response"].result, "name")
+        assert "name" in ctx["response"].result
 
     class Item(Base, GUIDPk, BulkCapable):
         __tablename__ = "items"


### PR DESCRIPTION
## Summary
- ensure hook lifecycle test checks for response key instead of attribute

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_hook_lifecycle.py::test_hook_context_modification -q`


------
https://chatgpt.com/codex/tasks/task_e_68b142fd9f188326b06a38fa6df1a6b3