### PR TITLE
fix autoapi create request schema for bulk models

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
@@ -95,6 +95,7 @@ from ..config.constants import (
 )
 from ..rest import _nested_prefix
 from ..schema.builder import _strip_parent_fields
+from ..mixins import BulkCapable
 
 logger = logging.getLogger(__name__)
 
@@ -773,7 +774,7 @@ def _make_collection_endpoint(
 
     body_model = _request_model_for(sp, model)
     base_annotation = body_model if body_model is not None else Mapping[str, Any]
-    if target == "create":
+    if target == "create" and not issubclass(model, BulkCapable):
         try:
             body_annotation = Union[base_annotation, list[base_annotation]]  # type: ignore[valid-type]
         except Exception:  # pragma: no cover - best effort


### PR DESCRIPTION
## Summary
- ensure autoapi create endpoints for BulkCapable models expect array payloads

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_bulk_docs_client.py::test_openapi_client_create_request_is_array -q --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_68b145f16a708326ae134eaa6c36bf48