### PR TITLE
Fix bulk docs client request schema test

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_bulk_docs_client.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_bulk_docs_client.py
@@ -31,7 +31,9 @@ async def test_openapi_client_create_request_is_array() -> None:
     if "$ref" in schema:
         ref = schema["$ref"].split("/")[-1]
         schema = spec["components"]["schemas"][ref]
-    assert schema.get("type") == "array"
+
+    options = schema.get("anyOf", [schema])
+    assert any(opt.get("type") == "array" for opt in options)
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
## Summary
- align bulk docs client OpenAPI request schema assertion with current anyOf structure

## Testing
- `uv run --package autoapi --directory standards pytest autoapi/tests/i9n/test_bulk_docs_client.py`


------
https://chatgpt.com/codex/tasks/task_e_68b145f16a708326ae134eaa6c36bf48