### PR TITLE
Ensure bulk operation schemas include item references

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/schemas.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/schemas.py
@@ -66,8 +66,12 @@ def _make_bulk_rows_model(
     example = _extract_example(item_schema)
     examples = [[example]] if example else []
 
+    item_ref = {"$ref": f"#/components/schemas/{item_schema.__name__}"}
+
     class _BulkModel(RootModel[List[item_schema]]):  # type: ignore[misc]
-        model_config = ConfigDict(json_schema_extra={"examples": examples})
+        model_config = ConfigDict(
+            json_schema_extra={"examples": examples, "items": item_ref}
+        )
 
     return namely_model(
         _BulkModel,
@@ -84,8 +88,12 @@ def _make_bulk_rows_response_model(
     example = _extract_example(item_schema)
     examples = [[example]] if example else []
 
+    item_ref = {"$ref": f"#/components/schemas/{item_schema.__name__}"}
+
     class _BulkModel(RootModel[List[item_schema]]):  # type: ignore[misc]
-        model_config = ConfigDict(json_schema_extra={"examples": examples})
+        model_config = ConfigDict(
+            json_schema_extra={"examples": examples, "items": item_ref}
+        )
 
     return namely_model(
         _BulkModel,

--- a/pkgs/standards/autoapi/tests/unit/test_bulk_response_schema.py
+++ b/pkgs/standards/autoapi/tests/unit/test_bulk_response_schema.py
@@ -42,6 +42,18 @@ def test_bulk_create_response_schema():
     assert items_ref.endswith("WidgetRead")
 
 
+def test_bulk_create_request_schema_has_item_ref():
+    spec = _openapi_for([("bulk_create", "bulk_create")])
+    path = f"/{Widget.__name__.lower()}"
+    ref = spec["paths"][path]["post"]["requestBody"]["content"]["application/json"][
+        "schema"
+    ]["$ref"]
+    assert ref.endswith("WidgetBulkCreateRequest")
+    comp = spec["components"]["schemas"]["WidgetBulkCreateRequest"]
+    items_ref = comp["items"]["$ref"]
+    assert items_ref.endswith("WidgetCreate")
+
+
 def test_bulk_delete_response_schema():
     spec = _openapi_for([("bulk_delete", "bulk_delete")])
     path = f"/{Widget.__name__.lower()}"


### PR DESCRIPTION
## Summary
- ensure bulk request/response schemas explicitly reference underlying item models
- add regression test for bulk create request schema

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_bulk_response_schema.py tests/unit/test_request_response_examples.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b1586d5d7c8326b74784ab3644dc71