### PR TITLE
feat(autoapi): cache planz diagnostic responses

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/system/diagnostics.py
+++ b/pkgs/standards/autoapi/autoapi/v3/system/diagnostics.py
@@ -209,8 +209,13 @@ def _build_hookz_endpoint(api: Any):
 
 
 def _build_planz_endpoint(api: Any):
+    cache: Optional[Dict[str, Dict[str, List[str]]]] = None
+
     async def _planz():
+        nonlocal cache
         """Expose the runtime step sequence for each operation."""
+        if cache is not None:
+            return cache
         out: Dict[str, Dict[str, List[str]]] = {}
         for model in _model_iter(api):
             mname = getattr(model, "__name__", "Model")
@@ -327,7 +332,8 @@ def _build_planz_endpoint(api: Any):
                 model_map[sp.alias] = seq
             if model_map:
                 out[mname] = model_map
-        return out
+        cache = out
+        return cache
 
     return _planz
 


### PR DESCRIPTION
## Summary
- add in-memory caching for `/system/planz` diagnostic endpoint
- test cached behavior and verify subsequent calls are faster

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_planz_endpoint.py tests/perf/test_planz_performance.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1598c03108326b1bc1e877b96bf4f