### PR TITLE
fix(auto_authn): expose user and tenant fields

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/orm/tenant.py
+++ b/pkgs/standards/auto_authn/auto_authn/orm/tenant.py
@@ -6,7 +6,7 @@ import uuid
 
 from autoapi.v3.tables import Tenant as TenantBase
 from autoapi.v3.mixins import Bootstrappable
-from autoapi.v3.specs import acol, S
+from autoapi.v3.specs import F, IO, S, acol, ColumnSpec
 from autoapi.v3.types import Mapped, String
 
 
@@ -17,8 +17,30 @@ class Tenant(TenantBase, Bootstrappable):
             "schema": "authn",
         },
     )
-    name: Mapped[str] = acol(storage=S(String, nullable=False, unique=True))
-    email: Mapped[str] = acol(storage=S(String, nullable=False, unique=True))
+    name: Mapped[str] = acol(
+        spec=ColumnSpec(
+            storage=S(String, nullable=False, unique=True),
+            field=F(constraints={"max_length": 120}, required_in=("create",)),
+            io=IO(
+                in_verbs=("create", "update", "replace"),
+                out_verbs=("read", "list"),
+                filter_ops=("eq", "ilike"),
+                sortable=True,
+            ),
+        )
+    )
+    email: Mapped[str] = acol(
+        spec=ColumnSpec(
+            storage=S(String, nullable=False, unique=True),
+            field=F(constraints={"max_length": 120}, required_in=("create",)),
+            io=IO(
+                in_verbs=("create", "update", "replace"),
+                out_verbs=("read", "list"),
+                filter_ops=("eq", "ilike"),
+                sortable=True,
+            ),
+        )
+    )
     DEFAULT_ROWS = [
         {
             "id": uuid.UUID("FFFFFFFF-0000-0000-0000-000000000000"),

--- a/pkgs/standards/auto_authn/tests/unit/test_bulk_schema_fields.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_bulk_schema_fields.py
@@ -1,0 +1,22 @@
+"""Verify IO verb exposure for user and tenant columns."""
+
+from auto_authn.orm.user import User
+from auto_authn.orm.tenant import Tenant
+
+
+def test_user_column_io() -> None:
+    specs = User.__autoapi_colspecs__
+    expected_in = {"create", "update", "replace"}
+    assert set(specs["username"].io.in_verbs) == expected_in
+    assert set(specs["email"].io.in_verbs) == expected_in
+    assert set(specs["password_hash"].io.in_verbs) == expected_in
+    assert set(specs["username"].io.out_verbs) >= {"read", "list"}
+    assert set(specs["email"].io.out_verbs) >= {"read", "list"}
+
+
+def test_tenant_column_io() -> None:
+    specs = Tenant.__autoapi_colspecs__
+    expected_in = {"create", "update", "replace"}
+    for col in ("name", "email"):
+        assert set(specs[col].io.in_verbs) == expected_in
+        assert set(specs[col].io.out_verbs) >= {"read", "list"}


### PR DESCRIPTION
## Summary
- wrap user and tenant column definitions in ColumnSpec to preserve IO verbs
- add tests ensuring user and tenant columns advertise create/update/replace verbs

## Testing
- `uv run --package auto_authn --directory pkgs/standards/auto_authn ruff format .`
- `uv run --package auto_authn --directory pkgs/standards/auto_authn ruff check . --fix`
- `uv run --package auto_authn --directory pkgs/standards/auto_authn pytest tests/unit/test_bulk_schema_fields.py`


------
https://chatgpt.com/codex/tasks/task_e_68b15669d7f08326b6816017d971fe8a