### PR TITLE
refactor: simplify create and bulk create binding

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/handlers.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/handlers.py
@@ -482,8 +482,6 @@ def _wrap_core(model: type, target: str) -> StepFn:
         payload = _ctx_payload(ctx)
 
         if target == "create":
-            if isinstance(payload, list):
-                return await _core.bulk_create(model, payload, db=db)
             return await _core.create(model, payload, db=db)
 
         if target == "read":

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/schemas.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/schemas.py
@@ -14,7 +14,6 @@ from ..opspec.types import (
 )  # lazy-capable schema args (runtime: we restrict forms)
 from ..schema import _build_schema, _build_list_params, namely_model
 from ..decorators import collect_decorated_schemas  # ← seed @schema_ctx declarations
-from ..mixins import BulkCapable
 
 logger = logging.getLogger(__name__)
 
@@ -260,17 +259,8 @@ def _default_schemas_for_spec(
     # Canonical targets
     if target == "create":
         item_in = _build_schema(model, verb="create")
-        if issubclass(model, BulkCapable):
-            result["in_"] = _make_bulk_rows_model(model, "create", item_in)
-            if read_schema is None:
-                result["out"] = None
-            else:
-                result["out"] = _make_bulk_rows_response_model(
-                    model, "create", read_schema
-                )
-        else:
-            result["in_"] = item_in
-            result["out"] = read_schema
+        result["in_"] = item_in
+        result["out"] = read_schema
 
     elif target == "read":
         pk_name, pk_type = _pk_info(model)

--- a/pkgs/standards/autoapi/tests/i9n/test_bulk_docs_client.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_bulk_docs_client.py
@@ -31,7 +31,7 @@ async def test_openapi_client_create_request_is_array() -> None:
     if "$ref" in schema:
         ref = schema["$ref"].split("/")[-1]
         schema = spec["components"]["schemas"][ref]
-    assert schema.get("type") == "array"
+    assert schema.get("type") == "object"
 
 
 @pytest.mark.asyncio()

--- a/pkgs/standards/autoapi/tests/unit/test_bulk_response_schema.py
+++ b/pkgs/standards/autoapi/tests/unit/test_bulk_response_schema.py
@@ -17,7 +17,7 @@ def _openapi_for(ops):
     return app.openapi()
 
 
-def test_create_request_schema_is_array():
+def test_create_request_schema_is_object():
     spec = _openapi_for([("create", "create")])
     path = f"/{Widget.__name__.lower()}"
     schema = spec["paths"][path]["post"]["requestBody"]["content"]["application/json"][
@@ -26,7 +26,7 @@ def test_create_request_schema_is_array():
     if "$ref" in schema:
         ref = schema["$ref"].split("/")[-1]
         schema = spec["components"]["schemas"][ref]
-    assert schema.get("type") == "array"
+    assert schema.get("type") == "object"
 
 
 def test_bulk_create_response_schema():
@@ -52,6 +52,21 @@ def test_bulk_create_request_schema_has_item_ref():
     comp = spec["components"]["schemas"]["WidgetBulkCreateRequest"]
     items_ref = comp["items"]["$ref"]
     assert items_ref.endswith("WidgetCreate")
+
+
+def test_create_and_bulk_create_handlers_and_schemas_bound():
+    _ = _openapi_for(
+        [
+            ("create", "create"),
+            ("bulk_create", "bulk_create"),
+        ]
+    )
+    assert hasattr(Widget.schemas, "create")
+    assert hasattr(Widget.schemas, "bulk_create")
+    assert hasattr(Widget.handlers, "create")
+    assert hasattr(Widget.handlers, "bulk_create")
+    assert hasattr(Widget.handlers.create, "core")
+    assert hasattr(Widget.handlers.bulk_create, "core")
 
 
 def test_bulk_delete_response_schema():


### PR DESCRIPTION
## Summary
- simplify v3 schema binding so create always uses single-item schemas and bulk_create uses list schemas
- remove list fallback from create handler
- update docs tests for create vs bulk_create schemas

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `uv run --directory pkgs/standards/autoapi --package autoapi pytest -q` *(fails: test_v3_bulk_rest_endpoints.py::test_bulk_delete, others)*

------
https://chatgpt.com/codex/tasks/task_e_68b165118e0483269d91cc7c00050da1