### PR TITLE
fix: remove transactional hooks from autoapi v3

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_bindings_modules.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_bindings_modules.py
@@ -78,8 +78,9 @@ def test_schemas_build_and_attach(model_cls, specs):
 def test_hooks_normalize_and_attach(model_cls, specs):
     columns_binding.build_and_attach(model_cls)
     hooks_binding.normalize_and_attach(model_cls, specs)
-    assert model_cls.hooks.create.START_TX  # default transactional step
-    assert model_cls.hooks.create.END_TX
+    # default transactional steps are no longer injected
+    assert not model_cls.hooks.create.START_TX
+    assert not model_cls.hooks.create.END_TX
 
 
 @pytest.mark.i9n

--- a/pkgs/standards/autoapi/tests/i9n/test_op_ctx_behavior.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_op_ctx_behavior.py
@@ -353,5 +353,6 @@ def test_op_ctx_system_steps(sync_db_session):
 
     _, api = setup_api(Widget, get_sync_db)
     chains = build_phase_chains(Widget, "ping")
-    assert any(fn.__name__ == "start_tx" for fn in chains["START_TX"])
-    assert any(fn.__name__ == "end_tx" for fn in chains["END_TX"])
+    # transactional system steps are managed by runtime and not bound by default
+    assert not chains["START_TX"]
+    assert not chains["END_TX"]

--- a/pkgs/standards/autoapi/tests/i9n/test_opspec_effects_i9n_test.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_opspec_effects_i9n_test.py
@@ -181,7 +181,8 @@ def test_atom_injection():
     bind(Gadget)
     chains = build_phase_chains(Gadget, "create")
     non_handler = [ph for ph in PHASES if ph != "HANDLER" and chains.get(ph)]
-    assert non_handler  # atoms or hooks provide extra steps
+    # default system steps no longer inject additional phases
+    assert not non_handler
 
 
 @pytest.mark.i9n


### PR DESCRIPTION
## Summary
- avoid nested transactions by removing default begin/commit hooks in AutoAPI v3
- mark skip-persist only for ephemeral operations

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b16e75291c8326b74b45c2396ff7b7