### PR TITLE
fix: use single example for bulk schemas

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/schemas.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/schemas.py
@@ -63,14 +63,16 @@ def _make_bulk_rows_model(
     """
     name = f"{model.__name__}{_camel(verb)}Request"
     example = _extract_example(item_schema)
-    examples = [[example]] if example else []
+    example_val = [example] if example else None
 
     item_ref = {"$ref": f"#/components/schemas/{item_schema.__name__}"}
 
+    extra = {"items": item_ref}
+    if example_val is not None:
+        extra["example"] = example_val
+
     class _BulkModel(RootModel[List[item_schema]]):  # type: ignore[misc]
-        model_config = ConfigDict(
-            json_schema_extra={"examples": examples, "items": item_ref}
-        )
+        model_config = ConfigDict(json_schema_extra=extra)
 
     return namely_model(
         _BulkModel,
@@ -85,14 +87,16 @@ def _make_bulk_rows_response_model(
     """Build a root model representing ``List[item_schema]`` for responses."""
     name = f"{model.__name__}{_camel(verb)}Response"
     example = _extract_example(item_schema)
-    examples = [[example]] if example else []
+    example_val = [example] if example else None
 
     item_ref = {"$ref": f"#/components/schemas/{item_schema.__name__}"}
 
+    extra = {"items": item_ref}
+    if example_val is not None:
+        extra["example"] = example_val
+
     class _BulkModel(RootModel[List[item_schema]]):  # type: ignore[misc]
-        model_config = ConfigDict(
-            json_schema_extra={"examples": examples, "items": item_ref}
-        )
+        model_config = ConfigDict(json_schema_extra=extra)
 
     return namely_model(
         _BulkModel,

--- a/pkgs/standards/autoapi/tests/unit/test_request_response_examples.py
+++ b/pkgs/standards/autoapi/tests/unit/test_request_response_examples.py
@@ -56,7 +56,7 @@ def test_bulk_request_model_examples():
         "schema"
     ]
     schema = _resolve_schema(spec, schema)
-    assert schema["examples"][0] == [{"name": "foo"}]
+    assert schema["example"] == [{"name": "foo"}]
 
 
 def test_bulk_response_model_examples():
@@ -66,5 +66,5 @@ def test_bulk_response_model_examples():
         "application/json"
     ]["schema"]
     schema = _resolve_schema(spec, schema)
-    example = schema["examples"][0][0]
+    example = schema["example"][0]
     assert example == {"name": "foo"}


### PR DESCRIPTION
## Summary
- ensure bulk create schemas use `example` field so swagger shows sample payloads
- adjust tests for new bulk example schema

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format autoapi/v3/bindings/schemas.py tests/unit/test_request_response_examples.py`
- `uv run --package autoapi --directory standards/autoapi ruff check autoapi/v3/bindings/schemas.py tests/unit/test_request_response_examples.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_request_response_examples.py tests/unit/test_bulk_response_schema.py`


------
https://chatgpt.com/codex/tasks/task_e_68b16ef9a7888326a113dc362f4d0007