### PR TITLE
fix: align bulk_create REST docs and routes

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_bulk_response_schema.py
+++ b/pkgs/standards/autoapi/tests/unit/test_bulk_response_schema.py
@@ -54,6 +54,18 @@ def test_bulk_create_request_schema_has_item_ref():
     assert items_ref.endswith("WidgetCreate")
 
 
+def test_create_preferred_over_bulk_create_docs():
+    spec = _openapi_for([("create", "create"), ("bulk_create", "bulk_create")])
+    path = f"/{Widget.__name__.lower()}"
+    schema = spec["paths"][path]["post"]["requestBody"]["content"]["application/json"][
+        "schema"
+    ]
+    if "$ref" in schema:
+        ref = schema["$ref"].split("/")[-1]
+        schema = spec["components"]["schemas"][ref]
+    assert schema.get("type") == "object"
+
+
 def test_create_and_bulk_create_handlers_and_schemas_bound():
     _ = _openapi_for(
         [


### PR DESCRIPTION
## Summary
- avoid registering bulk_create REST route when create exists so docs match runtime
- add tests ensuring create docs preferred and bulk_create route hidden

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_bulk_response_schema.py::test_create_preferred_over_bulk_create_docs tests/unit/test_rest_rpc_parity_default_ops.py::test_bulk_create_rest_route_hidden_when_create_present -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1ae92508c8326b24887ce4dd01cf6