### PR TITLE
feat(autoapi): default canonical verbs to CRUD

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/mixins/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/mixins/__init__.py
@@ -25,7 +25,7 @@ from ..types import (
     uuid4,
     Mapped,
 )
-from ..config.constants import CTX_AUTH_KEY, CTX_USER_ID_KEY
+from ..config.constants import CTX_AUTH_KEY, CTX_USER_ID_KEY, BULK_VERBS
 
 
 def tzutcnow() -> dt.datetime:  # default/on‑update factory
@@ -403,13 +403,31 @@ class RowLock:
 # ────────── Bulk Operations ---------------------------------------------
 @declarative_mixin
 class BulkCapable:
-    pass
+    __autoapi_defaults_mode__: str = "all"
+    __autoapi_defaults_include__: set[str] = set(
+        v for v in BULK_VERBS if v != "bulk_replace"
+    )
+    __autoapi_defaults_exclude__: set[str] = set()
+
+    def __init_subclass__(cls, **kw):
+        super().__init_subclass__(**kw)
+        inc = set(getattr(cls, "__autoapi_defaults_include__", set()))
+        inc.update(BulkCapable.__autoapi_defaults_include__)
+        cls.__autoapi_defaults_include__ = inc
 
 
 # ────────── Enable PUT METHOD ------------------------------------------
 @declarative_mixin
 class Replaceable:
-    pass  # described earlier
+    __autoapi_defaults_mode__: str = "all"
+    __autoapi_defaults_include__: set[str] = {"replace", "bulk_replace"}
+    __autoapi_defaults_exclude__: set[str] = set()
+
+    def __init_subclass__(cls, **kw):
+        super().__init_subclass__(**kw)
+        inc = set(getattr(cls, "__autoapi_defaults_include__", set()))
+        inc.update(Replaceable.__autoapi_defaults_include__)
+        cls.__autoapi_defaults_include__ = inc
 
 
 # ────────── WSS --------------------------------------------------------

--- a/pkgs/standards/autoapi/autoapi/v3/opspec/collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/opspec/collect.py
@@ -23,6 +23,7 @@ from ..config.constants import (
     AUTOAPI_OPS_ATTR,
 )
 from ..decorators import alias_map_for  # canonical→alias mapping source
+from ..types.op_config_provider import should_wire_canonical
 
 try:
     # Per-model registry (observable, triggers rebind elsewhere)
@@ -142,6 +143,8 @@ def _generate_canonical(model: type) -> List[OpSpec]:
     )
     out: List[OpSpec] = []
     for target in canon_targets:
+        if not should_wire_canonical(model, target):
+            continue
         alias = (
             target  # canonical alias matches the target (may be remapped by alias_ctx)
         )

--- a/pkgs/standards/autoapi/autoapi/v3/types/op_config_provider.py
+++ b/pkgs/standards/autoapi/autoapi/v3/types/op_config_provider.py
@@ -18,12 +18,16 @@ class OpConfigProvider(TableConfigProvider):
     __autoapi_defaults_exclude__: set[str] = set()
 
 
+DEFAULT_CANON_VERBS = {"create", "read", "update", "delete", "list", "clear"}
+
+
 def should_wire_canonical(table: Type, op: str) -> bool:
     mode = getattr(table, AUTOAPI_DEFAULTS_MODE_ATTR, "all")
-    inc = getattr(table, AUTOAPI_DEFAULTS_INCLUDE_ATTR, set())
-    exc = getattr(table, AUTOAPI_DEFAULTS_EXCLUDE_ATTR, set())
+    inc = set(getattr(table, AUTOAPI_DEFAULTS_INCLUDE_ATTR, set()))
+    exc = set(getattr(table, AUTOAPI_DEFAULTS_EXCLUDE_ATTR, set()))
     if mode == "none":
         return False
     if mode == "some":
         return op in inc
-    return op not in exc  # mode == "all"
+    allowed = (DEFAULT_CANON_VERBS | inc) - exc
+    return op in allowed  # mode == "all"


### PR DESCRIPTION
## Summary
- expose bulk and replace expectations via class attributes
- restrict default canonical verbs to create/read/update/delete/list/clear
- test mixin interactions with should_wire_canonical

## Testing
- `uv run --directory pkgs/standards --package autoapi ruff format autoapi/autoapi/v3/mixins/__init__.py autoapi/autoapi/v3/types/op_config_provider.py autoapi/tests/unit/test_should_wire_canonical.py`
- `uv run --directory pkgs/standards --package autoapi ruff check autoapi/autoapi/v3/mixins/__init__.py autoapi/autoapi/v3/types/op_config_provider.py autoapi/tests/unit/test_should_wire_canonical.py --fix`
- `cd pkgs && uv run --package autoapi --directory standards pytest autoapi/tests/unit/test_should_wire_canonical.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1c5e838708326b9ac4e02ea83b635