### PR TITLE
Ensure ColumnSpec maps are class-specific

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/specs/column_spec.py
+++ b/pkgs/standards/autoapi/autoapi/v3/specs/column_spec.py
@@ -65,8 +65,9 @@ class ColumnSpec(MappedColumn):
         parent = getattr(super(), "__set_name__", None)
         if parent:
             parent(owner, name)
-        colspecs = getattr(owner, "__autoapi_colspecs__", None)
+        colspecs = owner.__dict__.get("__autoapi_colspecs__")
         if colspecs is None:
-            colspecs = {}
+            base_specs = getattr(owner, "__autoapi_colspecs__", {})
+            colspecs = dict(base_specs)
             setattr(owner, "__autoapi_colspecs__", colspecs)
         colspecs[name] = self

--- a/pkgs/standards/autoapi/tests/unit/test_colspec_map_isolation.py
+++ b/pkgs/standards/autoapi/tests/unit/test_colspec_map_isolation.py
@@ -1,0 +1,19 @@
+from autoapi.v3.specs import ColumnSpec
+
+
+class Base:
+    base = ColumnSpec(storage=None)
+
+
+class One(Base):
+    one = ColumnSpec(storage=None)
+
+
+class Two(Base):
+    two = ColumnSpec(storage=None)
+
+
+def test_colspec_maps_are_isolated() -> None:
+    assert set(Base.__autoapi_colspecs__) == {"base"}
+    assert set(One.__autoapi_colspecs__) == {"base", "one"}
+    assert set(Two.__autoapi_colspecs__) == {"base", "two"}


### PR DESCRIPTION
## Summary
- prevent ColumnSpec.__set_name__ from reusing ancestor __autoapi_colspecs__
- add regression test for per-class ColumnSpec map isolation

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `uv run --directory pkgs/standards/autoapi --package autoapi pytest`
- `uv run --directory pkgs/standards/autoapi --package autoapi pytest tests/unit/test_colspec_map_isolation.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1ca933c408326bbdf813ebc3de39e