### PR TITLE
feat(autoapi): add clear response schema

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
@@ -469,9 +469,9 @@ def _response_model_for(sp: OpSpec, model: type) -> Any | None:
     """
     Determine the FastAPI response_model based on presence of an out schema.
     If there is no out schema, return None (raw pass-through).
-    Suppress response_model for 204 routes (delete/clear).
+    Suppress response_model for 204 routes (delete).
     """
-    if sp.target in {"delete", "clear"}:
+    if sp.target == "delete":
         return None
     alias_ns = getattr(
         getattr(model, "schemas", None) or SimpleNamespace(), sp.alias, None

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/schemas.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/schemas.py
@@ -119,12 +119,14 @@ def _make_bulk_ids_model(
     )
 
 
-def _make_bulk_deleted_response_model(model: type, verb: str) -> Type[BaseModel]:
-    """Build a response schema with a ``deleted`` count."""
+def _make_deleted_response_model(model: type, verb: str) -> Type[BaseModel]:
+    """Build a response schema with a ``deleted`` count and example."""
     name = f"{model.__name__}{_camel(verb)}Response"
+
     schema = create_model(  # type: ignore[call-arg]
         name,
-        deleted=(int, Field(...)),
+        deleted=(int, Field(..., examples=[1])),
+        __config__=ConfigDict(json_schema_extra={"examples": [{"deleted": 1}]}),
     )
     return namely_model(
         schema,
@@ -290,7 +292,7 @@ def _default_schemas_for_spec(
     elif target == "clear":
         params = _build_list_params(model)
         result["in_"] = params
-        result["out"] = read_schema
+        result["out"] = _make_deleted_response_model(model, "clear")
 
     elif target == "bulk_create":
         item_in = _build_schema(model, verb="create")
@@ -334,7 +336,7 @@ def _default_schemas_for_spec(
     elif target == "bulk_delete":
         pk_name, pk_type = _pk_info(model)
         result["in_"] = _make_bulk_ids_model(model, "bulk_delete", pk_type)
-        result["out"] = _make_bulk_deleted_response_model(model, "bulk_delete")
+        result["out"] = _make_deleted_response_model(model, "bulk_delete")
 
     elif target == "custom":
         # Build schemas for custom operations based on verb-specific IO specs

--- a/pkgs/standards/autoapi/tests/unit/test_bulk_response_schema.py
+++ b/pkgs/standards/autoapi/tests/unit/test_bulk_response_schema.py
@@ -80,3 +80,17 @@ def test_bulk_delete_response_schema():
     props = comp.get("properties", {})
     assert "deleted" in props
     assert props["deleted"]["type"] == "integer"
+
+
+def test_clear_response_schema():
+    spec = _openapi_for([("clear", "clear")])
+    path = f"/{Widget.__name__.lower()}"
+    ref = spec["paths"][path]["delete"]["responses"]["200"]["content"][
+        "application/json"
+    ]["schema"]["$ref"]
+    assert ref.endswith("WidgetClearResponse")
+    comp = spec["components"]["schemas"]["WidgetClearResponse"]
+    props = comp.get("properties", {})
+    assert "deleted" in props
+    assert props["deleted"]["type"] == "integer"
+    assert comp["examples"][0] == {"deleted": 1}


### PR DESCRIPTION
## Summary
- add dedicated deleted-count schema for clear operations
- include example response for clear in OpenAPI
- document clear response schema with tests

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `uv run --directory pkgs/standards/autoapi --package autoapi pytest tests/unit/test_bulk_response_schema.py::test_clear_response_schema`
- `uv run --directory pkgs/standards/autoapi --package autoapi pytest` *(fails: AttributeError: CoreTestUser has no core method 'replace'; assert 405 in {200, 201}; assert 422 in {200, 201}; IndexError: list index out of range; AssertionError: assert {'deleted': 0} == {'deleted': 2}; assert 405 == 200; TypeError: 'NoneType' object is not subscriptable; assert []; KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b201f4c8748326933c493fdd6254e0