### PR TITLE
feat: enable replace and bulk RPC operations

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/types/op_config_provider.py
+++ b/pkgs/standards/autoapi/autoapi/v3/types/op_config_provider.py
@@ -18,7 +18,19 @@ class OpConfigProvider(TableConfigProvider):
     __autoapi_defaults_exclude__: set[str] = set()
 
 
-DEFAULT_CANON_VERBS = {"create", "read", "update", "delete", "list", "clear"}
+DEFAULT_CANON_VERBS = {
+    "create",
+    "read",
+    "update",
+    "replace",
+    "delete",
+    "list",
+    "clear",
+    "bulk_create",
+    "bulk_update",
+    "bulk_replace",
+    "bulk_delete",
+}
 
 
 def should_wire_canonical(table: Type, op: str) -> bool:

--- a/pkgs/standards/autoapi/tests/unit/test_should_wire_canonical.py
+++ b/pkgs/standards/autoapi/tests/unit/test_should_wire_canonical.py
@@ -1,8 +1,19 @@
 from autoapi.v3.types.op_config_provider import should_wire_canonical
 from autoapi.v3.mixins import BulkCapable, Replaceable
-from autoapi.v3.config.constants import BULK_VERBS
 
-DEFAULT_VERBS = {"create", "read", "update", "delete", "list", "clear"}
+DEFAULT_VERBS = {
+    "create",
+    "read",
+    "update",
+    "replace",
+    "delete",
+    "list",
+    "clear",
+    "bulk_create",
+    "bulk_update",
+    "bulk_replace",
+    "bulk_delete",
+}
 
 
 def test_should_wire_canonical_defaults():
@@ -12,35 +23,26 @@ def test_should_wire_canonical_defaults():
     for verb in DEFAULT_VERBS:
         assert should_wire_canonical(Plain, verb)
 
-    for verb in {"replace"} | set(BULK_VERBS):
-        assert not should_wire_canonical(Plain, verb)
-
 
 def test_should_wire_canonical_bulkcapable():
     class Bulk(BulkCapable):
         pass
 
-    for verb in set(BULK_VERBS) - {"bulk_replace"}:
+    for verb in DEFAULT_VERBS:
         assert should_wire_canonical(Bulk, verb)
-
-    assert not should_wire_canonical(Bulk, "bulk_replace")
-    assert not should_wire_canonical(Bulk, "replace")
 
 
 def test_should_wire_canonical_replaceable():
     class Rep(Replaceable):
         pass
 
-    assert should_wire_canonical(Rep, "replace")
-    assert should_wire_canonical(Rep, "bulk_replace")
-    for verb in set(BULK_VERBS) - {"bulk_replace"}:
-        assert not should_wire_canonical(Rep, verb)
+    for verb in DEFAULT_VERBS:
+        assert should_wire_canonical(Rep, verb)
 
 
 def test_should_wire_canonical_bulk_and_replace():
     class Both(BulkCapable, Replaceable):
         pass
 
-    for verb in BULK_VERBS:
+    for verb in DEFAULT_VERBS:
         assert should_wire_canonical(Both, verb)
-    assert should_wire_canonical(Both, "replace")


### PR DESCRIPTION
## Summary
- make RPC binding serialize ORM objects without schemas
- wire replace and bulk operations by default
- update canonical op tests for new defaults

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_v3_default_rpc_ops.py -q`
- `uv run --package autoapi --directory standards/autoapi pytest -q` *(partial: 224 passed, 1 skipped)*


------
https://chatgpt.com/codex/tasks/task_e_68b200b9de6083268dd12b40ab7a51ac