### PR TITLE
Ensure runtime atom discovery returns full anchor info

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/runtime/events.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/events.py
@@ -128,6 +128,14 @@ def is_persist_tied(anchor: str) -> bool:
         raise ValueError(f"Unknown event anchor: {anchor!r}") from e
 
 
+def get_anchor_info(anchor: str) -> AnchorInfo:
+    """Return the full :class:`AnchorInfo` for a canonical event."""
+    try:
+        return _ANCHORS[anchor]
+    except KeyError as e:
+        raise ValueError(f"Unknown event anchor: {anchor!r}") from e
+
+
 def all_events_ordered() -> List[str]:
     """Return all canonical events in deterministic, lifecycle order."""
     return list(_EVENT_ORDER)
@@ -191,6 +199,7 @@ __all__ = [
     "is_valid_event",
     "phase_for_event",
     "is_persist_tied",
+    "get_anchor_info",
     "all_events_ordered",
     "events_for_phase",
     "prune_events_for_persist",

--- a/pkgs/standards/autoapi/tests/i9n/test_opspec_effects_i9n_test.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_opspec_effects_i9n_test.py
@@ -181,8 +181,8 @@ def test_atom_injection():
     bind(Gadget)
     chains = build_phase_chains(Gadget, "create")
     non_handler = [ph for ph in PHASES if ph != "HANDLER" and chains.get(ph)]
-    # default system steps no longer inject additional phases
-    assert not non_handler
+    # atom discovery injects steps into additional phases beyond the handler
+    assert non_handler
 
 
 @pytest.mark.i9n


### PR DESCRIPTION
## Summary
- add `get_anchor_info` helper to runtime events module so atom injection can evaluate anchors
- update opspec tests to expect atoms in non-handler phases

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_v3_opspec_attributes.py::test_atom_injection -q`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_opspec_effects_i9n_test.py::test_atom_injection -q`
- `uv run --package autoapi --directory standards/autoapi pytest -q --maxfail=1` *(fails: tests/i9n/test_core_access.py::test_core_and_core_raw_sync_operations)*

------
https://chatgpt.com/codex/tasks/task_e_68b200bf9b4c832686aaaee7467b250e