### PR TITLE
Include Replaceable mixin in RPC default verbs test

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_rpc_all_default_op_verbs.py
+++ b/pkgs/standards/autoapi/tests/unit/test_rpc_all_default_op_verbs.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from autoapi.v3.autoapi import AutoAPI
-from autoapi.v3.mixins import BulkCapable, GUIDPk
+from autoapi.v3.mixins import BulkCapable, GUIDPk, Replaceable
 from autoapi.v3.specs import IO, S, F, acol as spec_acol
 from autoapi.v3.tables import Base
 from autoapi.v3.types import Session, String
@@ -14,7 +14,7 @@ from autoapi.v3.opspec import OpSpec
 
 @pytest.fixture()
 def api_and_session() -> Iterator[tuple[AutoAPI, Session]]:
-    class Widget(Base, GUIDPk, BulkCapable):
+    class Widget(Base, GUIDPk, BulkCapable, Replaceable):
         __tablename__ = "widgets_rpc_all_ops"
         __allow_unmapped__ = True
         __autoapi_ops__ = (


### PR DESCRIPTION
## Summary
- ensure RPC all-default-op-verbs test uses Replaceable mixin so `replace`/`bulk_replace` verbs are present

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_rpc_all_default_op_verbs.py::test_rpc_all_default_op_verbs -q`
- `uv run --package autoapi --directory standards/autoapi pytest -q` *(fails: tests/i9n/test_core_access.py::test_core_and_core_raw_sync_operations, tests/i9n/test_op_ctx_core_crud_order.py::test_op_ctx_override[update-put-member-True], tests/i9n/test_v3_bulk_rest_endpoints.py::test_bulk_create, tests/i9n/test_v3_bulk_rest_endpoints.py::test_bulk_update, tests/i9n/test_v3_bulk_rest_endpoints.py::test_bulk_replace, tests/i9n/test_v3_bulk_rest_endpoints.py::test_bulk_delete, tests/i9n/test_v3_default_rest_ops.py::test_rest_replace, tests/i9n/test_v3_default_rpc_ops.py::test_rpc_methods[replace], tests/i9n/test_v3_default_rpc_ops.py::test_rpc_methods[bulk_create], tests/i9n/test_v3_default_rpc_ops.py::test_rpc_methods[bulk_update], tests/i9n/test_v3_default_rpc_ops.py::test_rpc_methods[bulk_replace], tests/i9n/test_v3_default_rpc_ops.py::test_rpc_methods[bulk_delete], tests/i9n/test_v3_opspec_attributes.py::test_atom_injection, tests/unit/test_opspec_effects.py::test_atom_injection, tests/unit/test_request_body_schema.py::test_replace_request_body_excludes_pk, tests/unit/test_rest_all_default_op_verbs.py::test_rest_default_op_verbs[replace-replace-/item/{item_id}-methods3])`

------
https://chatgpt.com/codex/tasks/task_e_68b200dfa7e483269e02329863613238