### PR TITLE
fix: ensure replace schema binding test uses replaceable mixin

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_schemas_binding.py
+++ b/pkgs/standards/autoapi/tests/unit/test_schemas_binding.py
@@ -1,10 +1,10 @@
 from autoapi.v3.bindings.model import bind
 from autoapi.v3.tables import Base
-from autoapi.v3.mixins import GUIDPk
+from autoapi.v3.mixins import GUIDPk, Replaceable
 from autoapi.v3.types import Column, String
 
 
-class Gadget(Base, GUIDPk):
+class Gadget(Base, GUIDPk, Replaceable):
     __tablename__ = "gadgets_schemas_binding"
     name = Column(String, nullable=False)
 


### PR DESCRIPTION
## Summary
- ensure schema binding test uses Replaceable mixin so replace schemas are bound

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_schemas_binding.py`
- `uv run --package autoapi --directory standards/autoapi pytest` *(fails: 13 failed, 460 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b200e52c148326b0d68db029dd05ee