### PR TITLE
feat(autoapi): expose collect_in per-field

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/schema/collect_in.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/schema/collect_in.py
@@ -54,6 +54,8 @@ def run(obj: Optional[object], ctx: Any) -> None:
         return
 
     temp = _ensure_temp(ctx)
+    if "schema_in" in temp:
+        return
     op = (getattr(ctx, "op", None) or "").lower() or None
 
     fields_sorted = sorted(specs.keys())

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/plan.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/plan.py
@@ -119,6 +119,8 @@ def build_plan(
 
     # Partition atoms into per-model vs per-field subjects
     per_field_subjects = {
+        # schema
+        ("schema", "collect_in"),
         # wire (contract → wire)
         ("wire", "build_in"),
         ("wire", "validate"),  # canonical subject (alias of validate_in)


### PR DESCRIPTION
## Summary
- treat `schema:collect_in` as a per-field atom so diagnostic plans include field names
- make `collect_in` idempotent to avoid repeated work when invoked per-field

## Testing
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff format .`
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b2033353c48326b0f61bfea3539d2b