### PR TITLE
feat(autoapi): run schema collect_out per field

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/schema/collect_out.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/schema/collect_out.py
@@ -55,6 +55,8 @@ def run(obj: Optional[object], ctx: Any) -> None:
         return
 
     temp = _ensure_temp(ctx)
+    if "schema_out" in temp:
+        return
 
     fields_sorted = sorted(specs.keys())
     entries: list[Dict[str, Any]] = []

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/plan.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/plan.py
@@ -121,6 +121,7 @@ def build_plan(
     per_field_subjects = {
         # schema
         ("schema", "collect_in"),
+        ("schema", "collect_out"),
         # wire (contract → wire)
         ("wire", "build_in"),
         ("wire", "validate"),  # canonical subject (alias of validate_in)

--- a/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_schema_collect_out.py
+++ b/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_schema_collect_out.py
@@ -23,3 +23,14 @@ def test_collect_out_registers_alias_and_sensitivity() -> None:
     assert schema["aliases"]["name"] == "alias"
     assert schema["by_field"]["name"]["sensitive"] is True
     assert "name" in schema["expose"]
+
+
+def test_collect_out_runs_only_once() -> None:
+    specs = {"name": Col()}
+    ctx = SimpleNamespace(specs=specs, temp={})
+    collect_out.run(None, ctx)
+    ctx.specs = {"other": Col()}
+    collect_out.run(None, ctx)
+    schema = ctx.temp["schema_out"]
+    assert "name" in schema["by_field"]
+    assert "other" not in schema["by_field"]

--- a/pkgs/standards/autoapi/tests/unit/test_runtime_plan.py
+++ b/pkgs/standards/autoapi/tests/unit/test_runtime_plan.py
@@ -167,6 +167,27 @@ def test_build_plan_respects_only_keys(monkeypatch):
     assert fields == ["f1"]
 
 
+def test_build_plan_treats_collect_out_per_field(monkeypatch):
+    """schema:collect_out should instantiate once per field."""
+    fake_registry = {
+        ("schema", "collect_out"): (_ev.SCHEMA_COLLECT_OUT, lambda *_: None)
+    }
+    monkeypatch.setattr(runtime_atoms, "REGISTRY", fake_registry, raising=False)
+    monkeypatch.setattr(
+        runtime_plan, "_should_instantiate", lambda *a, **k: True, raising=False
+    )
+
+    specs = {"f1": object(), "f2": object()}
+
+    class Model:
+        pass
+
+    plan = runtime_plan.build_plan(Model, specs)
+    nodes = plan.atoms_by_anchor[_ev.SCHEMA_COLLECT_OUT]
+    assert len(nodes) == 2
+    assert {n.field for n in nodes} == {"f1", "f2"}
+
+
 @pytest.mark.parametrize(
     "domain,subject,anchor,field,col",
     [


### PR DESCRIPTION
## Summary
- treat `schema:collect_out` as per-field atom
- guard `schema:collect_out` from repeated execution
- test per-field planning and idempotent collect_out

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/runtime/atoms/test_schema_collect_out.py tests/unit/test_runtime_plan.py`


------
https://chatgpt.com/codex/tasks/task_e_68b208014dec8326bc307251f4ba7775