### PR TITLE
feat(autoapi): add clear response schema

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
@@ -493,9 +493,9 @@ def _response_model_for(sp: OpSpec, model: type) -> Any | None:
     """
     Determine the FastAPI response_model based on presence of an out schema.
     If there is no out schema, return None (raw pass-through).
-    Suppress response_model for 204 routes (delete/clear).
+    Suppress response_model for delete routes which may return 204.
     """
-    if sp.target in {"delete", "clear"}:
+    if sp.target == "delete":
         return None
     alias_ns = getattr(
         getattr(model, "schemas", None) or SimpleNamespace(), sp.alias, None

--- a/pkgs/standards/autoapi/tests/i9n/test_openapi_clear_response_schema.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_openapi_clear_response_schema.py
@@ -1,0 +1,34 @@
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from autoapi.v3.autoapi import AutoAPI
+from autoapi.v3.mixins import GUIDPk
+from autoapi.v3.tables import Base
+from autoapi.v3.types import App, Column, String
+
+
+@pytest.mark.asyncio()
+async def test_openapi_clear_response_schema() -> None:
+    Base.metadata.clear()
+
+    class Widget(Base, GUIDPk):
+        __tablename__ = "widgets_openapi_clear"
+        name = Column(String, nullable=False)
+
+    app = App()
+    api = AutoAPI(app=app)
+    api.include_model(Widget)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        spec = (await client.get("/openapi.json")).json()
+
+    path = f"/{Widget.__name__.lower()}"
+    schema_ref = spec["paths"][path]["delete"]["responses"]["200"]["content"][
+        "application/json"
+    ]["schema"]["$ref"]
+    assert schema_ref.endswith("WidgetClearResponse")
+    comp = spec["components"]["schemas"]["WidgetClearResponse"]
+    assert "deleted" in comp.get("properties", {})
+    assert comp.get("examples") == [{"deleted": 0}]


### PR DESCRIPTION
## Summary
- add deleted count model and use it for clear and bulk delete responses
- include response model for clear routes in OpenAPI
- test OpenAPI clear response schema

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `uv run --directory pkgs/standards/autoapi --package autoapi pytest tests/i9n/test_v3_default_rest_ops.py::test_rest_clear tests/i9n/test_openapi_clear_response_schema.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b20e653bcc8326989ef647af58fe08