### PR TITLE
fix: apply auth security per route

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
@@ -103,7 +103,6 @@ from ..config.constants import (
     AUTOAPI_GET_ASYNC_DB_ATTR,
     AUTOAPI_GET_DB_ATTR,
     AUTOAPI_AUTH_DEP_ATTR,
-    AUTOAPI_ALLOW_ANON_ATTR,
     AUTOAPI_REST_DEPENDENCIES_ATTR,
     AUTOAPI_ALLOW_ANON_ATTR,
 )
@@ -1326,7 +1325,7 @@ def _build_router(model: type, specs: Sequence[OpSpec]) -> Router:
             route_kwargs["response_class"] = response_class
 
         secdeps: list[Any] = []
-        if auth_dep and sp.alias not in allow_anon_ops:
+        if auth_dep and sp.alias not in allow_anon and sp.target not in allow_anon:
             secdeps.append(auth_dep)
         secdeps.extend(getattr(sp, "secdeps", ()))
         route_secdeps = _normalize_secdeps(secdeps)


### PR DESCRIPTION
## Summary
- ensure AutoAPI applies auth dependencies as `Security` per operation rather than only globally

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_security_per_route.py::test_security_applied_per_route -q`
- `uv run --package autoapi --directory standards/autoapi pytest -q` *(fails: tests/i9n/test_core_access.py::test_core_and_core_raw_sync_operations, tests/i9n/test_v3_default_rpc_ops.py::test_rpc_bulk_ops, tests/unit/runtime/test_plan.py::test_build_plan_instantiates_model_and_field_atoms, tests/unit/test_planz_endpoint.py::test_planz_endpoint_sequence, tests/unit/test_planz_endpoint.py::test_planz_endpoint_prefers_compiled_plan_for_atoms)*
- `uv run --package peagen --directory standards/peagen pytest -q` *(fails: tests/e2e/test_local_evolve.py::test_local_evolve)*

------
https://chatgpt.com/codex/tasks/task_e_68b20fd1cf008326850d0a45ba6ac304