### PR TITLE
fix security per-route

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_api_level_set_auth.py
+++ b/pkgs/standards/autoapi/tests/unit/test_api_level_set_auth.py
@@ -1,0 +1,24 @@
+from autoapi.v3 import AutoAPI
+from autoapi.v3.tables import Base
+from autoapi.v3.mixins import GUIDPk
+from fastapi import FastAPI, Security
+from fastapi.security import HTTPBearer
+
+
+class Widget(Base, GUIDPk):
+    __tablename__ = "widgets_api_level_set_auth"
+    __autoapi_allow_anon__ = ["list"]
+
+
+def test_api_level_auth_dep_applied_per_route():
+    app = FastAPI()
+    api = AutoAPI(app=app)
+    api.set_auth(authn=lambda cred=Security(HTTPBearer()): cred, allow_anon=False)
+    api.include_models([Widget])
+    schema = app.openapi()
+    paths = {route.name: route.path for route in api.routers["Widget"].routes}
+    list_sec = schema["paths"][paths["Widget.list"]]["get"].get("security")
+    read_sec = schema["paths"][paths["Widget.read"]]["get"].get("security")
+    assert not list_sec
+    assert read_sec == [{"HTTPBearer": []}]
+    assert "HTTPBearer" in schema["components"]["securitySchemes"]

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -168,6 +168,11 @@ authn_adapter = RemoteAuthNAdapter(
 api = AutoAPI(
     get_async_db=get_async_db, api_hooks={"PRE_TX_BEGIN": [_shadow_principal]}
 )
+api.set_auth(
+    authn=authn_adapter.get_principal,
+    optional_authn_dep=authn_adapter.get_principal_optional,
+    allow_anon=False,
+)
 api.include_models(
     [
         Tenant,
@@ -188,11 +193,6 @@ api.include_models(
         Work,
         RawBlob,
     ]
-)
-api.set_auth(
-    authn=authn_adapter.get_principal,
-    optional_authn_dep=authn_adapter.get_principal_optional,
-    allow_anon=False,
 )
 
 api.mount_jsonrpc(prefix="/rpc")


### PR DESCRIPTION
## Summary
- ensure peagen gateway applies auth dependencies before model inclusion so OpenAPI marks protected routes individually
- add test covering AutoAPI-level auth dependency behavior

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_api_level_set_auth.py::test_api_level_auth_dep_applied_per_route -q`
- `uv run --package autoapi --directory standards/autoapi pytest` (failed: 'dict' object has no attribute 'age')
- `uv run --package peagen --directory standards/peagen pytest` (failed: Command '['peagen', 'local', '-q', 'evolve', ...] returned non-zero exit status 2)

------
https://chatgpt.com/codex/tasks/task_e_68b21224da608326b12d93fc1871a7fe