### PR TITLE
feat(auto_kms): enable bulk ops for key models

### DIFF
--- a/pkgs/standards/auto_kms/auto_kms/tables/key.py
+++ b/pkgs/standards/auto_kms/auto_kms/tables/key.py
@@ -7,6 +7,7 @@ from typing import List, Optional, TYPE_CHECKING
 
 from sqlalchemy import String, Integer, Enum as SAEnum
 from autoapi.v3.types import Mapped, relationship
+from autoapi.v3.mixins import BulkCapable, Replaceable
 
 from autoapi.v3.tables import Base
 from autoapi.v3.specs import acol, vcol, S, F, IO
@@ -47,7 +48,7 @@ class KeyStatus(str, Enum):
     disabled = "disabled"
 
 
-class Key(Base):
+class Key(Base, BulkCapable, Replaceable):
     __tablename__ = "keys"
     __resource__ = "key"
     __allow_unmapped__ = True  # allow vcol attributes

--- a/pkgs/standards/auto_kms/auto_kms/tables/key_version.py
+++ b/pkgs/standards/auto_kms/auto_kms/tables/key_version.py
@@ -6,6 +6,7 @@ from fastapi import HTTPException
 
 from autoapi.v3.decorators import hook_ctx
 from autoapi.v3.specs import IO, F, S, acol
+from autoapi.v3.mixins import BulkCapable, Replaceable
 from autoapi.v3.specs.io_spec import Pair
 from autoapi.v3.specs.storage_spec import ForeignKeySpec
 from autoapi.v3.tables import Base
@@ -25,7 +26,7 @@ from ..utils import b64d
 from .key import Key, KeyAlg
 
 
-class KeyVersion(Base):
+class KeyVersion(Base, BulkCapable, Replaceable):
     __tablename__ = "key_versions"
     __resource__ = "key_version"
     __table_args__ = (UniqueConstraint("key_id", "version"),)


### PR DESCRIPTION
## Summary
- support bulk CRUD operations for Key and KeyVersion models

## Testing
- `uv run --package auto-kms --directory pkgs/standards/auto_kms ruff check . --fix`
- `uv run --package auto-kms --directory pkgs/standards/auto_kms pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b227d996e08326a429c3470f2b3fdc