### PR TITLE
Fix bulk operation schemas and bulk_delete routing

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
@@ -1165,6 +1165,10 @@ def _build_router(model: type, specs: Sequence[OpSpec]) -> Router:
     nested_pref = re.sub(r"/{2,}", "/", raw_nested).rstrip("/") or ""
     nested_vars = re.findall(r"{(\w+)}", raw_nested)
 
+    # If bulk_delete is present, drop clear to avoid route conflicts
+    if any(sp.target == "bulk_delete" for sp in specs):
+        specs = [sp for sp in specs if sp.target != "clear"]
+
     # Register collection-level bulk routes before member routes so static paths
     # like "/resource/bulk" aren't captured by dynamic member routes such as
     # "/resource/{item_id}". FastAPI matches routes in the order they are

--- a/pkgs/standards/autoapi/tests/unit/test_rest_bulk_delete_suppresses_clear.py
+++ b/pkgs/standards/autoapi/tests/unit/test_rest_bulk_delete_suppresses_clear.py
@@ -1,0 +1,25 @@
+from autoapi.v3.bindings.rest import build_router_and_attach
+from autoapi.v3.mixins import GUIDPk
+from autoapi.v3.opspec import OpSpec
+from autoapi.v3.tables import Base
+from autoapi.v3.types import Column, String
+
+
+def test_bulk_delete_suppresses_clear_route():
+    Base.metadata.clear()
+
+    class Item(Base, GUIDPk):
+        __tablename__ = "items_bulk_delete_route"
+        name = Column(String, nullable=False)
+
+    build_router_and_attach(
+        Item,
+        [
+            OpSpec(alias="clear", target="clear"),
+            OpSpec(alias="bulk_delete", target="bulk_delete"),
+        ],
+    )
+
+    aliases = {route.name.split(".", 1)[1] for route in Item.rest.router.routes}
+    assert "bulk_delete" in aliases
+    assert "clear" not in aliases

--- a/pkgs/standards/autoapi/tests/unit/test_rpc_all_default_op_verbs.py
+++ b/pkgs/standards/autoapi/tests/unit/test_rpc_all_default_op_verbs.py
@@ -149,7 +149,7 @@ async def _op_bulk_update(api, db):
         {"id": rows[0]["id"], "name": "i1u"},
         {"id": rows[1]["id"], "name": "i2u"},
     ]
-    result = await api.rpc.Widget.bulk_update(None, db=db, ctx={"payload": payload})
+    result = await api.rpc.Widget.bulk_update(payload, db=db)
     assert {r["name"] for r in result} == {"i1u", "i2u"}
 
 
@@ -162,7 +162,7 @@ async def _op_bulk_replace(api, db):
         {"id": rows[0]["id"], "name": "j1r"},
         {"id": rows[1]["id"], "name": "j2r"},
     ]
-    result = await api.rpc.Widget.bulk_replace(None, db=db, ctx={"payload": payload})
+    result = await api.rpc.Widget.bulk_replace(payload, db=db)
     assert {r["name"] for r in result} == {"j1r", "j2r"}
 
 
@@ -172,8 +172,10 @@ async def _op_bulk_delete(api, db):
         db=db,
     )
     ids = [r["id"] for r in rows]
-    result = await api.rpc.Widget.bulk_delete({"ids": ids}, db=db)
-    assert result["deleted"] == 2
+    result = await api.rpc.Widget.bulk_delete(ids[:1], db=db)
+    assert result["deleted"] == 1
+    remaining = await api.rpc.Widget.list({}, db=db)
+    assert len(remaining) == 1 and remaining[0]["id"] == ids[1]
 
 
 OPS = [


### PR DESCRIPTION
## Summary
- add regression tests for bulk_update and bulk_replace schema arrays
- ensure RPC bulk operations accept sequence payloads and bulk_delete only removes specified ids
- verify bulk_delete route hides clear route

## Testing
- `uv run --package autoapi --directory /workspace/swarmauri-sdk/pkgs/standards/autoapi ruff format tests/unit/test_bulk_response_schema.py tests/unit/test_rpc_all_default_op_verbs.py tests/unit/test_rest_bulk_delete_suppresses_clear.py`
- `uv run --package autoapi --directory /workspace/swarmauri-sdk/pkgs/standards/autoapi ruff check tests/unit/test_bulk_response_schema.py tests/unit/test_rpc_all_default_op_verbs.py tests/unit/test_rest_bulk_delete_suppresses_clear.py --fix`
- `uv run --package autoapi --directory /workspace/swarmauri-sdk/pkgs/standards/autoapi pytest tests/unit/test_bulk_response_schema.py::test_bulk_update_request_and_response_schemas tests/unit/test_bulk_response_schema.py::test_bulk_replace_request_and_response_schemas tests/unit/test_rest_bulk_delete_suppresses_clear.py::test_bulk_delete_suppresses_clear_route tests/unit/test_rpc_all_default_op_verbs.py::test_rpc_all_default_op_verbs -q`


------
https://chatgpt.com/codex/tasks/task_e_68b22b8c97148326991bfc07c738af60