### PR TITLE
refactor: relocate schema make helpers

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/schemas.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/schemas.py
@@ -3,16 +3,24 @@ from __future__ import annotations
 
 import logging
 from types import SimpleNamespace
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Type
+from typing import Any, Dict, Optional, Sequence, Tuple, Type
 
-from pydantic import BaseModel, Field, RootModel, ConfigDict, create_model
+from pydantic import BaseModel
 
 from ..opspec import OpSpec
 from ..opspec.types import (
     SchemaRef,
     SchemaArg,
 )  # lazy-capable schema args (runtime: we restrict forms)
-from ..schema import _build_schema, _build_list_params, namely_model
+from ..schema import (
+    _build_schema,
+    _build_list_params,
+    _make_bulk_rows_model,
+    _make_bulk_rows_response_model,
+    _make_bulk_ids_model,
+    _make_deleted_response_model,
+    _make_pk_model,
+)
 from ..decorators import collect_decorated_schemas  # ← seed @schema_ctx declarations
 
 logger = logging.getLogger(__name__)
@@ -22,10 +30,6 @@ _Key = Tuple[str, str]  # (alias, target)
 # ───────────────────────────────────────────────────────────────────────────────
 # Internal helpers
 # ───────────────────────────────────────────────────────────────────────────────
-
-
-def _camel(s: str) -> str:
-    return "".join(p.capitalize() or "_" for p in s.split("_"))
 
 
 def _ensure_alias_namespace(model: type, alias: str) -> SimpleNamespace:
@@ -53,107 +57,6 @@ def _pk_info(model: type) -> Tuple[str, type | Any]:
     col = cols[0]
     py_t = getattr(getattr(col, "type", None), "python_type", Any)
     return (getattr(col, "name", "id"), py_t or Any)
-
-
-def _make_bulk_rows_model(
-    model: type, verb: str, item_schema: Type[BaseModel]
-) -> Type[BaseModel]:
-    """
-    Build a root model representing `List[item_schema]`.
-    """
-    name = f"{model.__name__}{_camel(verb)}Request"
-    example = _extract_example(item_schema)
-    examples = [[example]] if example else []
-
-    class _BulkModel(RootModel[List[item_schema]]):  # type: ignore[misc]
-        model_config = ConfigDict(json_schema_extra={"examples": examples})
-
-    return namely_model(
-        _BulkModel,
-        name=name,
-        doc=f"{verb} request schema for {model.__name__}",
-    )
-
-
-def _make_bulk_rows_response_model(
-    model: type, verb: str, item_schema: Type[BaseModel]
-) -> Type[BaseModel]:
-    """Build a root model representing ``List[item_schema]`` for responses."""
-    name = f"{model.__name__}{_camel(verb)}Response"
-    example = _extract_example(item_schema)
-    examples = [[example]] if example else []
-
-    class _BulkModel(RootModel[List[item_schema]]):  # type: ignore[misc]
-        model_config = ConfigDict(json_schema_extra={"examples": examples})
-
-    return namely_model(
-        _BulkModel,
-        name=name,
-        doc=f"{verb} response schema for {model.__name__}",
-    )
-
-
-def _make_bulk_ids_model(
-    model: type, verb: str, pk_type: type | Any
-) -> Type[BaseModel]:
-    """
-    Build a wrapper schema with an `ids: List[pk_type]` field.
-    """
-    name = f"{model.__name__}{_camel(verb)}Request"
-    schema = create_model(  # type: ignore[call-arg]
-        name,
-        ids=(List[pk_type], Field(...)),  # type: ignore[name-defined]
-    )
-    return namely_model(
-        schema,
-        name=name,
-        doc=f"{verb} request schema for {model.__name__}",
-    )
-
-
-def _make_deleted_response_model(model: type, verb: str) -> Type[BaseModel]:
-    """Build a response schema with a ``deleted`` count."""
-    name = f"{model.__name__}{_camel(verb)}Response"
-    schema = create_model(  # type: ignore[call-arg]
-        name,
-        deleted=(int, Field(..., examples=[0])),
-        __config__=ConfigDict(json_schema_extra={"examples": [{"deleted": 0}]}),
-    )
-    return namely_model(
-        schema,
-        name=name,
-        doc=f"{verb} response schema for {model.__name__}",
-    )
-
-
-def _make_pk_model(
-    model: type, verb: str, pk_name: str, pk_type: type | Any
-) -> Type[BaseModel]:
-    """Build a wrapper schema with a single primary-key field."""
-    name = f"{model.__name__}{_camel(verb)}Request"
-    schema = create_model(  # type: ignore[call-arg]
-        name,
-        **{pk_name: (pk_type, Field(...))},  # type: ignore[name-defined]
-    )
-    return namely_model(
-        schema,
-        name=name,
-        doc=f"{verb} request schema for {model.__name__}",
-    )
-
-
-def _extract_example(schema: Type[BaseModel]) -> Dict[str, Any]:
-    """Build a simple example object from field examples if available."""
-    try:
-        js = schema.model_json_schema()
-    except Exception:
-        return {}
-    out: Dict[str, Any] = {}
-    for name, prop in (js.get("properties") or {}).items():
-        examples = prop.get("examples")
-        if examples:
-            out[name] = examples[0]
-    return out
 
 
 def _parse_str_ref(s: str) -> Tuple[str, str]:

--- a/pkgs/standards/autoapi/autoapi/v3/schema/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/__init__.py
@@ -1,6 +1,13 @@
 # autoapi/v3/schema/__init__.py
 from .builder import _build_schema, _build_list_params
-from .utils import namely_model
+from .utils import (
+    namely_model,
+    _make_bulk_rows_model,
+    _make_bulk_rows_response_model,
+    _make_bulk_ids_model,
+    _make_deleted_response_model,
+    _make_pk_model,
+)
 from .get_schema import get_schema
 from .col_info import (
     VALID_KEYS,
@@ -16,6 +23,11 @@ __all__ = [
     "_build_schema",
     "_build_list_params",
     "namely_model",
+    "_make_bulk_rows_model",
+    "_make_bulk_rows_response_model",
+    "_make_bulk_ids_model",
+    "_make_deleted_response_model",
+    "_make_pk_model",
     "get_schema",
     "VALID_KEYS",
     "VALID_VERBS",

--- a/pkgs/standards/autoapi/autoapi/v3/schema/utils.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/utils.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from typing import Type
+from typing import Any, Dict, List, Type
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field, RootModel, create_model
 
 
 def namely_model(model: Type[BaseModel], *, name: str, doc: str) -> Type[BaseModel]:
@@ -17,4 +17,112 @@ def namely_model(model: Type[BaseModel], *, name: str, doc: str) -> Type[BaseMod
     return model
 
 
-__all__ = ["namely_model"]
+def _camel(s: str) -> str:
+    return "".join(p.capitalize() or "_" for p in s.split("_"))
+
+
+def _extract_example(schema: Type[BaseModel]) -> Dict[str, Any]:
+    """Build a simple example object from field examples if available."""
+    try:
+        js = schema.model_json_schema()
+    except Exception:
+        return {}
+    out: Dict[str, Any] = {}
+    for name, prop in (js.get("properties") or {}).items():
+        examples = prop.get("examples")
+        if examples:
+            out[name] = examples[0]
+    return out
+
+
+def _make_bulk_rows_model(
+    model: type, verb: str, item_schema: Type[BaseModel]
+) -> Type[BaseModel]:
+    """Build a root model representing ``List[item_schema]``."""
+    name = f"{model.__name__}{_camel(verb)}Request"
+    example = _extract_example(item_schema)
+    examples = [[example]] if example else []
+
+    class _BulkModel(RootModel[List[item_schema]]):  # type: ignore[misc]
+        model_config = ConfigDict(json_schema_extra={"examples": examples})
+
+    return namely_model(
+        _BulkModel,
+        name=name,
+        doc=f"{verb} request schema for {model.__name__}",
+    )
+
+
+def _make_bulk_rows_response_model(
+    model: type, verb: str, item_schema: Type[BaseModel]
+) -> Type[BaseModel]:
+    """Build a root model representing ``List[item_schema]`` for responses."""
+    name = f"{model.__name__}{_camel(verb)}Response"
+    example = _extract_example(item_schema)
+    examples = [[example]] if example else []
+
+    class _BulkModel(RootModel[List[item_schema]]):  # type: ignore[misc]
+        model_config = ConfigDict(json_schema_extra={"examples": examples})
+
+    return namely_model(
+        _BulkModel,
+        name=name,
+        doc=f"{verb} response schema for {model.__name__}",
+    )
+
+
+def _make_bulk_ids_model(
+    model: type, verb: str, pk_type: type | Any
+) -> Type[BaseModel]:
+    """Build a wrapper schema with an ``ids: List[pk_type]`` field."""
+    name = f"{model.__name__}{_camel(verb)}Request"
+    schema = create_model(  # type: ignore[call-arg]
+        name,
+        ids=(List[pk_type], Field(...)),  # type: ignore[name-defined]
+    )
+    return namely_model(
+        schema,
+        name=name,
+        doc=f"{verb} request schema for {model.__name__}",
+    )
+
+
+def _make_deleted_response_model(model: type, verb: str) -> Type[BaseModel]:
+    """Build a response schema with a ``deleted`` count."""
+    name = f"{model.__name__}{_camel(verb)}Response"
+    schema = create_model(  # type: ignore[call-arg]
+        name,
+        deleted=(int, Field(..., examples=[0])),
+        __config__=ConfigDict(json_schema_extra={"examples": [{"deleted": 0}]}),
+    )
+    return namely_model(
+        schema,
+        name=name,
+        doc=f"{verb} response schema for {model.__name__}",
+    )
+
+
+def _make_pk_model(
+    model: type, verb: str, pk_name: str, pk_type: type | Any
+) -> Type[BaseModel]:
+    """Build a wrapper schema with a single primary-key field."""
+    name = f"{model.__name__}{_camel(verb)}Request"
+    schema = create_model(  # type: ignore[call-arg]
+        name,
+        **{pk_name: (pk_type, Field(...))},  # type: ignore[name-defined]
+    )
+    return namely_model(
+        schema,
+        name=name,
+        doc=f"{verb} request schema for {model.__name__}",
+    )
+
+
+__all__ = [
+    "namely_model",
+    "_make_bulk_rows_model",
+    "_make_bulk_rows_response_model",
+    "_make_bulk_ids_model",
+    "_make_deleted_response_model",
+    "_make_pk_model",
+]

--- a/pkgs/standards/autoapi/tests/unit/test_rest_rpc_symmetry.py
+++ b/pkgs/standards/autoapi/tests/unit/test_rest_rpc_symmetry.py
@@ -57,7 +57,6 @@ def test_rest_rpc_symmetry_for_default_verbs():
         "delete": {"item_id", "request", "db"},
         "list": {"request", "q", "db"},
         "clear": {"request", "db"},
-        "upsert": {"request", "db", "body"},
         "bulk_create": {"request", "db", "body"},
         "bulk_update": {"request", "db", "body"},
         "bulk_replace": {"request", "db", "body"},


### PR DESCRIPTION
## Summary
- move schema make helpers into the schema utils module
- expose relocated helpers via schema package and use them in bindings
- remove duplicate mapping entry in test_rest_rpc_symmetry

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest` *(fails: AttributeError in test_core_and_core_raw_sync_operations)*

------
https://chatgpt.com/codex/tasks/task_e_68b23978dfb4832684c6c4ba3f2dde92