### PR TITLE
feat(autoapi): expose request and response schemas

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_iospec_attributes.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_iospec_attributes.py
@@ -137,11 +137,11 @@ def test_openapi_reflects_io_verbs():
     app.include_router(router)
     spec = app.openapi()
 
-    props_create = spec["components"]["schemas"]["WidgetCreate"]["properties"]
+    props_create = spec["components"]["schemas"]["WidgetCreateRequest"]["properties"]
     assert "name" in props_create
     assert "id" not in props_create
 
-    props_read = spec["components"]["schemas"]["WidgetRead"]["properties"]
+    props_read = spec["components"]["schemas"]["WidgetReadResponse"]["properties"]
     assert "name" in props_read
     assert "id" in props_read
 

--- a/pkgs/standards/autoapi/tests/i9n/test_iospec_integration.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_iospec_integration.py
@@ -111,7 +111,7 @@ async def test_orm_model_carries_io_spec(widget_setup):
 async def test_openapi_reflects_io_spec(widget_setup):
     client, _, _ = widget_setup
     spec = (await client.get("/openapi.json")).json()
-    props = spec["components"]["schemas"]["WidgetRead"]["properties"]
+    props = spec["components"]["schemas"]["WidgetReadResponse"]["properties"]
     assert "secret" in props
 
 

--- a/pkgs/standards/autoapi/tests/i9n/test_storage_spec_integration.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_storage_spec_integration.py
@@ -45,7 +45,7 @@ async def test_storage_spec_internal_orm(api_client_v3):
 async def test_storage_spec_openapi(api_client_v3):
     client, _, _, _ = api_client_v3
     spec = (await client.get("/openapi.json")).json()
-    schema = spec["components"]["schemas"]["WidgetCreate"]
+    schema = spec["components"]["schemas"]["WidgetCreateRequest"]
     assert "name" in schema["required"]
     assert "age" not in schema["required"]
 

--- a/pkgs/standards/autoapi/tests/unit/test_bulk_response_schema.py
+++ b/pkgs/standards/autoapi/tests/unit/test_bulk_response_schema.py
@@ -121,7 +121,6 @@ def test_bulk_replace_request_and_response_schemas():
     assert resp_comp["items"]["$ref"].endswith("WidgetRead")
 
 
-
 def test_bulk_upsert_request_and_response_schemas():
     spec = _openapi_for([("bulk_upsert", "bulk_upsert")])
     path = f"/{Widget.__name__.lower()}"
@@ -139,6 +138,8 @@ def test_bulk_upsert_request_and_response_schemas():
     assert resp_ref.endswith("WidgetBulkUpsertResponse")
     resp_comp = spec["components"]["schemas"]["WidgetBulkUpsertResponse"]
     assert resp_comp["items"]["$ref"].endswith("WidgetRead")
+
+
 def test_update_and_bulk_update_schema_names_do_not_collide():
     spec = _openapi_for([("update", "update"), ("bulk_update", "bulk_update")])
     base = f"/{Widget.__name__.lower()}"
@@ -147,7 +148,7 @@ def test_update_and_bulk_update_schema_names_do_not_collide():
     upd_ref = spec["paths"][update_path]["patch"]["requestBody"]["content"][
         "application/json"
     ]["schema"]["$ref"]
-    assert upd_ref.endswith("WidgetUpdate")
+    assert upd_ref.endswith("WidgetUpdateRequest")
     # bulk update schema
     bulk_ref = spec["paths"][base]["patch"]["requestBody"]["content"][
         "application/json"

--- a/pkgs/standards/autoapi/tests/unit/test_iospec_effects.py
+++ b/pkgs/standards/autoapi/tests/unit/test_iospec_effects.py
@@ -146,7 +146,7 @@ def test_iospec_in_verbs_reflected_in_openapi() -> None:
     app.include_router(router)
     spec = app.openapi()
 
-    create_props = spec["components"]["schemas"]["WidgetCreate"]["properties"]
+    create_props = spec["components"]["schemas"]["WidgetCreateRequest"]["properties"]
     assert "name" in create_props
     assert "id" not in create_props
 

--- a/pkgs/standards/autoapi/tests/unit/test_request_body_schema.py
+++ b/pkgs/standards/autoapi/tests/unit/test_request_body_schema.py
@@ -27,7 +27,7 @@ def test_request_body_uses_schema_model():
         request_schema = spec["components"]["schemas"][ref]
     assert request_schema.get("type") == "object"
 
-    widget_schema = spec["components"]["schemas"]["WidgetCreate"]
+    widget_schema = spec["components"]["schemas"]["WidgetCreateRequest"]
     assert "name" in widget_schema.get("properties", {})
 
 
@@ -42,6 +42,6 @@ def test_replace_request_body_excludes_pk():
     app.include_router(router)
     spec = app.openapi()
 
-    gadget_schema = spec["components"]["schemas"]["GadgetReplace"]
+    gadget_schema = spec["components"]["schemas"]["GadgetReplaceRequest"]
     assert "id" not in gadget_schema.get("properties", {})
     assert "id" not in gadget_schema.get("required", [])


### PR DESCRIPTION
## Summary
- ensure request and response schemas are generated for all operations
- update tests for new request/response schema naming

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `uv run --directory pkgs/standards/autoapi --package autoapi python - <<'PY'
from autoapi.v3.bindings.rest import _build_router
from autoapi.v3.tables import Base
from autoapi.v3.mixins import GUIDPk
from autoapi.v3.types import Column, String, App
from autoapi.v3.opspec import OpSpec

class Widget(Base, GUIDPk):
    __tablename__ = "widgets_openapi_demo"
    name = Column(String, nullable=False)

router = _build_router(Widget, [OpSpec(alias="create", target="create"), OpSpec(alias="read", target="read")])
app = App()
app.include_router(router)
spec = app.openapi()
print(sorted(spec["components"]["schemas"].keys()))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b244a2aae483268dc0c4b570f60f18