### PR TITLE
Handle mixed return types in core proxy bulk ops

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_core_access.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_core_access.py
@@ -120,7 +120,7 @@ async def test_core_and_core_raw_sync_operations(sync_api):
                 ],
                 db=db,
             )
-            assert all(u.age in {22, 23} for u in bulk_updated)
+            assert all(_get(u, "age") in {22, 23} for u in bulk_updated)
             bulk_replaced = await model.bulk_replace(
                 [
                     {
@@ -138,7 +138,7 @@ async def test_core_and_core_raw_sync_operations(sync_api):
                 ],
                 db=db,
             )
-            assert {u.name for u in bulk_replaced} == {"R1", "R2"}
+            assert {_get(u, "name") for u in bulk_replaced} == {"R1", "R2"}
             deleted = await model.bulk_delete(ids, db=db)
             assert deleted["deleted"] == 2
 


### PR DESCRIPTION
## Summary
- ensure core access tests account for dict and object responses in bulk operations

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_core_access.py`


------
https://chatgpt.com/codex/tasks/task_e_68b24a40c5ac832697ccbe4240a20f1e