### PR TITLE
fix: align field spec OpenAPI test with request schema naming

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_field_spec_effects.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_field_spec_effects.py
@@ -59,7 +59,7 @@ async def fs_app():
 async def test_field_spec_openapi(fs_app):
     client, _, _, _ = fs_app
     spec = (await client.get("/openapi.json")).json()
-    schema = spec["components"]["schemas"]["FSItemCreate"]
+    schema = spec["components"]["schemas"]["FSItemCreateRequest"]
     assert "name" in schema["required"]
     assert schema["properties"]["name"]["type"] == "string"
 


### PR DESCRIPTION
## Summary
- update field spec OpenAPI integration test to expect `FSItemCreateRequest`

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_field_spec_effects.py`


------
https://chatgpt.com/codex/tasks/task_e_68b24a45f18883269c72f770c133dff6