### PR TITLE
fix: isolate schema cache by name

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/schema/builder.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/builder.py
@@ -89,7 +89,9 @@ _SchemaVerb = Union[
     Literal["clear"],  # type: ignore[name-defined]
 ]
 
-_SchemaCache: Dict[Tuple[type, str, frozenset, frozenset], Type[BaseModel]] = {}
+_SchemaCache: Dict[
+    Tuple[type, str, frozenset, frozenset, str | None], Type[BaseModel]
+] = {}
 
 
 # ───────────────────────────────────────────────────────────────────────────────
@@ -251,7 +253,13 @@ def _build_schema(
         - default_factory, examples
       • __autoapi_request_extras__ / __autoapi_response_extras__ on the ORM class
     """
-    cache_key = (orm_cls, verb, frozenset(include or ()), frozenset(exclude or ()))
+    cache_key = (
+        orm_cls,
+        verb,
+        frozenset(include or ()),
+        frozenset(exclude or ()),
+        name,
+    )
     cached = _SchemaCache.get(cache_key)
     if cached is not None:
         logger.debug("schema: cache hit %s verb=%s", orm_cls.__name__, verb)


### PR DESCRIPTION
## Summary
- prevent name collisions in schema cache so single and bulk schema models are unique

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_schema.py -q --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_68b24a48da18832697c461371a963060