### PR TITLE
fix: preserve schema_ctx models in autoapi

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/schemas.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/schemas.py
@@ -447,14 +447,22 @@ def build_and_attach(
     for sp in specs:
         ns = _ensure_alias_namespace(model, sp.alias)
         in_model = getattr(ns, "in_", None)
-        if isinstance(in_model, type) and issubclass(in_model, BaseModel):
+        if (
+            isinstance(in_model, type)
+            and issubclass(in_model, BaseModel)
+            and getattr(in_model, "__autoapi_schema_decl__", None) is None
+        ):
             setattr(
                 ns,
                 "in_",
                 _alias_schema(in_model, model=model, alias=sp.alias, kind="Request"),
             )
         out_model = getattr(ns, "out", None)
-        if isinstance(out_model, type) and issubclass(out_model, BaseModel):
+        if (
+            isinstance(out_model, type)
+            and issubclass(out_model, BaseModel)
+            and getattr(out_model, "__autoapi_schema_decl__", None) is None
+        ):
             setattr(
                 ns,
                 "out",


### PR DESCRIPTION
## Summary
- avoid aliasing schema_ctx-declared schemas to keep user models

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_schema_ctx_attributes_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_68b24a4d4d8483268f796f468d374e3d