### PR TITLE
Support bulk list payloads on create endpoints

### DIFF
--- a/pkgs/standards/auto_kms/tests/unit/test_key_bulk_create.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_key_bulk_create.py
@@ -1,0 +1,37 @@
+import asyncio
+import importlib
+
+import pytest
+from fastapi.testclient import TestClient
+from autoapi.v3.tables import Base
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    db_path = tmp_path / "kms.db"
+    monkeypatch.setenv("KMS_DATABASE_URL", f"sqlite+aiosqlite:///{db_path}")
+    app = importlib.reload(importlib.import_module("auto_kms.app"))
+
+    async def init_db():
+        async with app.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+    asyncio.run(init_db())
+    try:
+        with TestClient(app.app) as c:
+            yield c
+    finally:
+        if hasattr(app, "CRYPTO"):
+            delattr(app, "CRYPTO")
+
+
+def test_bulk_create_keys(client):
+    payload = [
+        {"name": "b1", "algorithm": "AES256_GCM"},
+        {"name": "b2", "algorithm": "AES256_GCM"},
+    ]
+    res = client.post("/kms/key", json=payload)
+    assert res.status_code in {200, 201}
+    listed = client.get("/kms/key").json()
+    names = {row["name"] for row in listed}
+    assert {"b1", "b2"} <= names

--- a/pkgs/standards/auto_kms/tests/unit/test_key_default_op_verbs.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_key_default_op_verbs.py
@@ -29,7 +29,6 @@ def key_routes(tmp_path, monkeypatch):
         ("replace", "/kms/key/{item_id}", {"PUT"}),
         ("delete", "/kms/key/{item_id}", {"DELETE"}),
         ("list", "/kms/key", {"GET"}),
-        ("clear", "/kms/key", {"DELETE"}),
         ("bulk_create", "/kms/key", {"POST"}),
         ("bulk_update", "/kms/key", {"PATCH"}),
         ("bulk_replace", "/kms/key", {"PUT"}),

--- a/pkgs/standards/auto_kms/tests/unit/test_key_version_default_op_verbs.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_key_version_default_op_verbs.py
@@ -29,7 +29,6 @@ def key_version_routes(tmp_path, monkeypatch):
         ("replace", "/kms/key_version/{item_id}", {"PUT"}),
         ("delete", "/kms/key_version/{item_id}", {"DELETE"}),
         ("list", "/kms/key_version", {"GET"}),
-        ("clear", "/kms/key_version", {"DELETE"}),
         ("bulk_create", "/kms/key_version", {"POST"}),
         ("bulk_update", "/kms/key_version", {"PATCH"}),
         ("bulk_replace", "/kms/key_version", {"PUT"}),


### PR DESCRIPTION
## Summary
- allow collection endpoints to accept list payloads and dispatch to bulk operations
- test bulk key creation and adjust expected routes

## Testing
- `uv run --directory standards/autoapi --package autoapi pytest` *(fails: tests/i9n/test_core_access.py::test_core_and_core_raw_sync_operations - AttributeError: 'dict' object has no attribute 'age' ...)*
- `uv run --directory standards/auto_kms --package auto_kms pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b249b53390832681d0f2c9807c2514