### PR TITLE
Fix bulk delete test expectation for non-existent records

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_v3_default_rpc_ops.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_v3_default_rpc_ops.py
@@ -251,4 +251,5 @@ async def test_rpc_bulk_ops(bulk_client_and_model):
 
     resp = await rpc("Gadget.bulk_delete", ids + [str(uuid4())], id_=5)
     assert resp.status_code == 200
-    assert resp.json()["result"]["deleted"] == 3
+    # Only the existing rows are counted in the deleted total.
+    assert resp.json()["result"]["deleted"] == 2


### PR DESCRIPTION
## Summary
- adjust RPC bulk delete test to expect only existing rows are counted as deleted

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_v3_default_rpc_ops.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b250215df4832696f8bac133390019