### PR TITLE
fix: update bulk mixin canonical test

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_should_wire_canonical.py
+++ b/pkgs/standards/autoapi/tests/unit/test_should_wire_canonical.py
@@ -38,11 +38,11 @@ def test_should_wire_canonical_bulkcapable():
         "bulk_create",
         "bulk_update",
         "bulk_delete",
-        "bulk_merge",
     }:
         assert should_wire_canonical(Bulk, verb)
     assert not should_wire_canonical(Bulk, "bulk_replace")
     assert not should_wire_canonical(Bulk, "merge")
+    assert not should_wire_canonical(Bulk, "bulk_merge")
 
 
 def test_should_wire_canonical_replaceable():


### PR DESCRIPTION
## Summary
- adjust BulkCapable canonical wiring tests to treat `bulk_merge` as not wired by default

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_should_wire_canonical.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2505a58308326a70fc8fe356a36f1