### PR TITLE
fix: ensure merge ops use member paths

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
@@ -516,7 +516,13 @@ def _path_for_spec(
     if not suffix.startswith("/") and suffix:
         suffix = "/" + suffix
 
-    if sp.arity == "member" or sp.target in {"read", "update", "replace", "delete"}:
+    if sp.arity == "member" or sp.target in {
+        "read",
+        "update",
+        "replace",
+        "merge",
+        "delete",
+    }:
         return f"/{resource}/{{{pk_param}}}{suffix}", True
     return f"/{resource}{suffix}", False
 
@@ -1192,7 +1198,8 @@ def _make_member_endpoint(
             inspect.Parameter(
                 "body",
                 inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                annotation=Annotated[body_annotation, body_default],
+                annotation=body_annotation,
+                default=body_default,
             ),
         ]
     )
@@ -1311,6 +1318,7 @@ def _build_router(model: type, specs: Sequence[OpSpec]) -> Router:
                 "read",
                 "update",
                 "replace",
+                "merge",
                 "delete",
             }:
                 path = f"{base}/{{{pk_param}}}{suffix}"

--- a/pkgs/standards/autoapi/autoapi/v3/opspec/collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/opspec/collect.py
@@ -156,7 +156,7 @@ def _generate_canonical(model: type) -> List[OpSpec]:
                 target=target,  # ← canonical verb goes here
                 table=model,
                 arity="member"
-                if target in {"read", "update", "replace", "delete"}
+                if target in {"read", "update", "replace", "merge", "delete"}
                 else "collection",
                 # persistent by default; binder will auto START_TX/END_TX where appropriate
                 persist="default",


### PR DESCRIPTION
## Summary
- ensure REST binding treats merge operations as member routes
- avoid FastAPI body default assertion by setting body parameter default directly
- mark canonical merge OpSpec as member

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_rest_all_default_op_verbs.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2503a0ca083269ff361c279235936