### PR TITLE
Fix bulk delete count in RPC integration test

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_v3_default_rpc_ops.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_v3_default_rpc_ops.py
@@ -251,4 +251,4 @@ async def test_rpc_bulk_ops(bulk_client_and_model):
 
     resp = await rpc("Gadget.bulk_delete", ids + [str(uuid4())], id_=5)
     assert resp.status_code == 200
-    assert resp.json()["result"]["deleted"] == 3
+    assert resp.json()["result"]["deleted"] == 2


### PR DESCRIPTION
## Summary
- fix `test_rpc_bulk_ops` to expect deletion count of existing ids only

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_v3_default_rpc_ops.py::test_rpc_bulk_ops`


------
https://chatgpt.com/codex/tasks/task_e_68b25374fe448326b35f74f966113b6b