### PR TITLE
Handle union request body schemas in autoapi tests

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_request_body_schema.py
+++ b/pkgs/standards/autoapi/tests/unit/test_request_body_schema.py
@@ -25,6 +25,13 @@ def test_request_body_uses_schema_model():
     if "$ref" in request_schema:
         ref = request_schema["$ref"].split("/")[-1]
         request_schema = spec["components"]["schemas"][ref]
+    elif "anyOf" in request_schema:
+        ref = next(
+            (s["$ref"].split("/")[-1] for s in request_schema["anyOf"] if "$ref" in s),
+            None,
+        )
+        if ref is not None:
+            request_schema = spec["components"]["schemas"][ref]
     assert request_schema.get("type") == "object"
 
     widget_schema = spec["components"]["schemas"]["WidgetCreateRequest"]


### PR DESCRIPTION
## Summary
- handle `$ref` or `anyOf` when asserting request body schema

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format tests/unit/test_request_body_schema.py`
- `uv run --package autoapi --directory standards/autoapi ruff check tests/unit/test_request_body_schema.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_request_body_schema.py::test_request_body_uses_schema_model tests/unit/test_request_body_schema.py::test_replace_request_body_excludes_pk`


------
https://chatgpt.com/codex/tasks/task_e_68b253b344088326a4158f4b800bca75