### PR TITLE
Adjust parity test for clear suppression when bulk delete exists

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_rest_rpc_parity_default_ops.py
+++ b/pkgs/standards/autoapi/tests/unit/test_rest_rpc_parity_default_ops.py
@@ -57,9 +57,12 @@ def test_rest_rpc_parity_for_default_verbs(alias, target, path, methods):
     api.include_model(Item, mount_router=False)
 
     routes = _route_map(Item.rest.router)
-    assert alias in routes
-    got_path, got_methods = routes[alias]
-    assert got_path.lower() == path.lower()
-    assert got_methods == methods
+    if alias == "clear" and "bulk_delete" in routes:
+        assert alias not in routes
+    else:
+        assert alias in routes
+        got_path, got_methods = routes[alias]
+        assert got_path.lower() == path.lower()
+        assert got_methods == methods
 
     assert hasattr(api.rpc.Item, alias)


### PR DESCRIPTION
## Summary
- update REST/RPC parity test to account for clear route being dropped when bulk delete is enabled

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_rest_rpc_parity_default_ops.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b253c2c97c8326bc340b716a440d14