### PR TITLE
test: correct canonical wiring cases

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_should_wire_canonical.py
+++ b/pkgs/standards/autoapi/tests/unit/test_should_wire_canonical.py
@@ -1,4 +1,4 @@
-from autoapi.v3.mixins import BulkCapable, Replaceable
+from autoapi.v3.mixins import BulkCapable, Mergeable, Replaceable
 from autoapi.v3.opspec.canonical import should_wire_canonical
 
 NON_BULK_VERBS = {
@@ -34,15 +34,10 @@ def test_should_wire_canonical_bulkcapable():
     class Bulk(BulkCapable):
         pass
 
-    for verb in (NON_BULK_VERBS - {"merge"}) | {
-        "bulk_create",
-        "bulk_update",
-        "bulk_delete",
-        "bulk_merge",
-    }:
+    for verb in NON_BULK_VERBS | {"bulk_create", "bulk_update", "bulk_delete"}:
         assert should_wire_canonical(Bulk, verb)
-    assert not should_wire_canonical(Bulk, "bulk_replace")
-    assert not should_wire_canonical(Bulk, "merge")
+    for verb in {"bulk_replace", "merge", "bulk_merge"}:
+        assert not should_wire_canonical(Bulk, verb)
 
 
 def test_should_wire_canonical_replaceable():
@@ -56,11 +51,11 @@ def test_should_wire_canonical_replaceable():
         assert not should_wire_canonical(Rep, verb)
 
 
-def test_should_wire_canonical_bulk_and_replace():
-    class Both(BulkCapable, Replaceable):
+def test_should_wire_canonical_mergeable():
+    class Merge(Mergeable):
         pass
 
-    for verb in (NON_BULK_VERBS | BULK_VERBS) - {"merge", "bulk_merge"}:
-        assert should_wire_canonical(Both, verb)
-    assert not should_wire_canonical(Both, "merge")
-    assert not should_wire_canonical(Both, "bulk_merge")
+    for verb in NON_BULK_VERBS | {"merge", "bulk_merge"}:
+        assert should_wire_canonical(Merge, verb)
+    for verb in {"bulk_create", "bulk_update", "bulk_replace", "bulk_delete"}:
+        assert not should_wire_canonical(Merge, verb)


### PR DESCRIPTION
## Summary
- add Mergeable coverage for canonical wiring
- refine BulkCapable expectations for bulk merge

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_should_wire_canonical.py`


------
https://chatgpt.com/codex/tasks/task_e_68b255e198b883269d9af31335c62217