### PR TITLE
fix: support object principals in hooks

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/hooks.py
+++ b/pkgs/standards/auto_authn/auto_authn/hooks.py
@@ -18,8 +18,20 @@ def register_inject_hook(api):
             return  # nothing to inject
 
         injected = ctx.setdefault("__autoapi_injected_fields__", {})
-        tid = p.get("tid") or p.get("tenant_id")
-        sub = p.get("sub") or p.get("user_id")
+
+        def _lookup(obj, *names):
+            for name in names:
+                if hasattr(obj, "get"):
+                    val = obj.get(name)
+                    if val is not None:
+                        return val
+                val = getattr(obj, name, None)
+                if val is not None:
+                    return val
+            return None
+
+        tid = _lookup(p, "tid", "tenant_id")
+        sub = _lookup(p, "sub", "user_id")
         if tid is not None:
             injected["tenant_id"] = tid
         if sub is not None:

--- a/pkgs/standards/auto_authn/tests/unit/test_hooks.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_hooks.py
@@ -44,3 +44,21 @@ async def test_register_inject_hook_injects_principal():
     await api.hooks[phase](ctx)
 
     assert ctx["__autoapi_injected_fields__"] == {"tenant_id": "t1", "user_id": "u1"}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_register_inject_hook_accepts_object_principal():
+    """Hook handles principals implementing attribute access."""
+    api = DummyAPI()
+    register_inject_hook(api)
+
+    phase = PHASE.PRE_TX_BEGIN
+    request = SimpleNamespace(
+        state=SimpleNamespace(principal=SimpleNamespace(tenant_id="t1", user_id="u1"))
+    )
+    ctx = {"request": request}
+
+    await api.hooks[phase](ctx)
+
+    assert ctx["__autoapi_injected_fields__"] == {"tenant_id": "t1", "user_id": "u1"}


### PR DESCRIPTION
## Summary
- allow principal lookups on objects without `.get`
- add regression test for object principal injection

## Testing
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff format .`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b39e2fb3608326a2aa52114060da0a