### PR TITLE
refactor: move authn providers to adapters

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/adapters/__init__.py
+++ b/pkgs/standards/auto_authn/auto_authn/adapters/__init__.py
@@ -1,4 +1,4 @@
-# auto_authn/v2/providers/__init__.py
+# auto_authn/v2/adapters/__init__.py
 def __getattr__(name):
     if name == "RemoteAuthNAdapter":
         from .remote_adapter import RemoteAuthNAdapter

--- a/pkgs/standards/auto_authn/auto_authn/adapters/local_adapter.py
+++ b/pkgs/standards/auto_authn/auto_authn/adapters/local_adapter.py
@@ -1,6 +1,6 @@
 """
-auto_authn.providers.local_adapter
-───────────────────
+auto_authn.adapters.local_adapter
+──────────────────
 Concrete implementation of the ``AuthNProvider`` ABC declared by
 ``autoapi.v3.authn_abc``.  It merely **adapts** the public helpers that already
 exist in *auto_authn* so that AutoAPI can consume them automatically.
@@ -8,8 +8,8 @@ exist in *auto_authn* so that AutoAPI can consume them automatically.
 Usage
 -----
 >>> from autoapi.v3 import AutoAPI
->>> from auto_authn.provider import AuthNAdapter
->>> api = AutoAPI(get_async_db=get_db, authn=AuthNAdapter())
+>>> from auto_authn.adapters import LocalAuthNAdapter
+>>> api = AutoAPI(get_async_db=get_db, authn=LocalAuthNAdapter())
 """
 
 from __future__ import annotations

--- a/pkgs/standards/auto_authn/auto_authn/adapters/remote_adapter.py
+++ b/pkgs/standards/auto_authn/auto_authn/adapters/remote_adapter.py
@@ -1,4 +1,4 @@
-# auto_authn/v2/providers/remote_adapter.py
+# auto_authn/v2/adapters/remote_adapter.py
 from __future__ import annotations
 
 import time

--- a/pkgs/standards/auto_authn/tests/unit/test_adapters.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_adapters.py
@@ -1,4 +1,4 @@
-"""Unit tests for AuthN provider adapters.
+"""Unit tests for AuthN adapters.
 
 Verify adapter delegation and hook registration behavior."""
 
@@ -6,10 +6,10 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-import auto_authn.providers.local_adapter as local_adapter_mod
-import auto_authn.providers.remote_adapter as remote_adapter_mod
-from auto_authn.providers.local_adapter import LocalAuthNAdapter
-from auto_authn.providers.remote_adapter import RemoteAuthNAdapter
+import auto_authn.adapters.local_adapter as local_adapter_mod
+import auto_authn.adapters.remote_adapter as remote_adapter_mod
+from auto_authn.adapters.local_adapter import LocalAuthNAdapter
+from auto_authn.adapters.remote_adapter import RemoteAuthNAdapter
 
 
 @pytest.mark.unit

--- a/pkgs/standards/auto_authn/tests/unit/test_remote_adapter.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_remote_adapter.py
@@ -7,8 +7,8 @@ import httpx
 import pytest
 from fastapi import HTTPException, Request, status
 
-import auto_authn.providers.remote_adapter as remote_adapter
-from auto_authn.providers.remote_adapter import RemoteAuthNAdapter
+import auto_authn.adapters.remote_adapter as remote_adapter
+from auto_authn.adapters.remote_adapter import RemoteAuthNAdapter
 
 
 @pytest.mark.unit

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -20,7 +20,7 @@ import uuid
 
 # ─────────── Peagen internals ──────────────────────────────────────────
 from autoapi.v3 import AutoAPI, get_schema
-from auto_authn.providers import RemoteAuthNAdapter
+from auto_authn.adapters import RemoteAuthNAdapter
 from fastapi import FastAPI, Request
 
 from peagen._utils.config_loader import resolve_cfg


### PR DESCRIPTION
## Summary
- relocate auto_authn provider modules into new adapters package
- update imports in tests and peagen gateway

## Testing
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff format .`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check . --fix`
- `uv run --directory pkgs/standards/peagen --package peagen ruff format peagen/gateway/__init__.py`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check peagen/gateway/__init__.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b3f84ed2988326b0d81dd1f9dfb5bb