### PR TITLE
autoapi: add default favicon route

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/deps/fastapi.py
+++ b/pkgs/standards/autoapi/autoapi/v3/deps/fastapi.py
@@ -6,14 +6,27 @@ from fastapi import (
     Depends,
     Request,
     Response,
-    Path,
+    Path as FastAPIPath,
     Body,
     HTTPException,
 )
+from fastapi.responses import FileResponse
+from pathlib import Path as FilePath
 
 Router = APIRouter
+Path = FastAPIPath
 
-App = FastAPI
+FAVICON_PATH = FilePath(__file__).with_name("favicon.svg")
+
+
+def App(*args, **kwargs):
+    app = FastAPI(*args, **kwargs)
+
+    @app.get("/favicon.ico", include_in_schema=False)
+    async def favicon() -> FileResponse:  # pragma: no cover - simple static route
+        return FileResponse(FAVICON_PATH, media_type="image/svg+xml")
+
+    return app
 
 
 # ── Public Exports ───────────────────────────────────────────────────────

--- a/pkgs/standards/autoapi/autoapi/v3/deps/favicon.svg
+++ b/pkgs/standards/autoapi/autoapi/v3/deps/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#4f46e5"/>
+  <text x="16" y="21" font-size="18" text-anchor="middle" fill="#fff">A</text>
+</svg>

--- a/pkgs/standards/autoapi/tests/unit/test_v3_favicon_endpoint.py
+++ b/pkgs/standards/autoapi/tests/unit/test_v3_favicon_endpoint.py
@@ -1,0 +1,17 @@
+import pytest
+from autoapi.v3.types import App
+from httpx import AsyncClient, ASGITransport
+
+
+@pytest.mark.asyncio
+async def test_favicon_endpoint_serves_default_icon():
+    app = App()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        res = await client.get("/favicon.ico")
+
+    assert res.status_code == 200
+    assert res.headers.get("content-type") == "image/svg+xml"
+    assert res.content  # file has some content


### PR DESCRIPTION
## Summary
- serve packaged SVG favicon through App helper
- test favicon route renders vector icon

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b3e9e16b188326b1a00eb22f7a4aad