### PR TITLE
feat(autoapi): add v3 shortcuts aggregator

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/shortcuts.py
+++ b/pkgs/standards/autoapi/autoapi/v3/shortcuts.py
@@ -1,0 +1,22 @@
+# autoapi/autoapi/v3/shortcuts.py
+from __future__ import annotations
+
+from .app import shortcuts as app_shortcuts
+from .api import shortcuts as api_shortcuts
+from .engines import shortcuts as engines_shortcuts
+from .specs import shortcuts as specs_shortcuts
+from .table import shortcuts as table_shortcuts
+
+from .app.shortcuts import *  # noqa: F401,F403
+from .api.shortcuts import *  # noqa: F401,F403
+from .engines.shortcuts import *  # noqa: F401,F403
+from .specs.shortcuts import *  # noqa: F401,F403
+from .table.shortcuts import *  # noqa: F401,F403
+
+__all__ = [
+    *app_shortcuts.__all__,
+    *api_shortcuts.__all__,
+    *engines_shortcuts.__all__,
+    *specs_shortcuts.__all__,
+    *table_shortcuts.__all__,
+]


### PR DESCRIPTION
## Summary
- add `autoapi.v3.shortcuts` that consolidates shortcut exports

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff format autoapi/v3/shortcuts.py`
- `uv run --directory standards/autoapi --package autoapi ruff check autoapi/v3/shortcuts.py --fix`
- `uv run --directory standards/autoapi --package autoapi ruff check . --fix` *(fails: invalid-syntax in existing engines/shortcuts.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b438742ba48326bbb6019f2ba4985d