### PR TITLE
feat(autoapi): expose engine_ctx via decorators module

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/__init__.py
@@ -39,7 +39,15 @@ from .opspec import (
 )
 
 # ── Ctx-only decorators (new surface; replaces legacy opspec.decorators) ───────
-from .decorators import alias_ctx, op_ctx, hook_ctx, schema_ctx, alias, op_alias
+from .decorators import (
+    alias_ctx,
+    op_ctx,
+    hook_ctx,
+    schema_ctx,
+    alias,
+    op_alias,
+    engine_ctx,
+)
 
 # ── Bindings (model + API orchestration) ───────────────────────────────────────
 from .bindings import (
@@ -100,6 +108,7 @@ __all__ += [
     "schema_ctx",
     "alias",
     "op_alias",
+    "engine_ctx",
     # Bindings
     "bind",
     "rebind",

--- a/pkgs/standards/autoapi/autoapi/v3/decorators.py
+++ b/pkgs/standards/autoapi/autoapi/v3/decorators.py
@@ -13,6 +13,7 @@ from autoapi.v3.opspec.types import (
     SchemaArg,
 )
 from autoapi.v3.runtime.executor import _Ctx  # pipeline ctx normalizer
+from autoapi.v3.engines.decorators import engine_ctx
 
 # Try-pydantic (optional; schemas may be any class but we keep this for hints/debug)
 try:  # pragma: no cover
@@ -540,3 +541,14 @@ def collect_decorated_hooks(
                         _wrap_ctx_hook(table, func, ph)
                     )
     return mapping
+
+
+__all__ = [
+    "alias",
+    "alias_ctx",
+    "op_alias",
+    "schema_ctx",
+    "hook_ctx",
+    "engine_ctx",
+    "op_ctx",
+]


### PR DESCRIPTION
## Summary
- expose `engine_ctx` through `autoapi.v3.decorators`
- add `__all__` for decorator exports
- re-export `engine_ctx` in `autoapi.v3`

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format autoapi/v3/decorators.py autoapi/v3/__init__.py`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check autoapi/v3/decorators.py autoapi/v3/__init__.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b4387d4b508326ba176347b6156aab