### PR TITLE
test(autoapi): run resolver precedence with async postgres

### DIFF
--- a/pkgs/standards/autoapi/pyproject.toml
+++ b/pkgs/standards/autoapi/pyproject.toml
@@ -72,4 +72,6 @@ dev = [
     "pytest-timeout>=2.3.1",
     "ruff>=0.9.9",
     "pytest-benchmark>=4.0.0",
+    "asyncpg>=0.30.0",
+    "psycopg2-binary>=2.9.9",
 ]

--- a/pkgs/standards/autoapi/tests/unit/test_resolver_precedence.py
+++ b/pkgs/standards/autoapi/tests/unit/test_resolver_precedence.py
@@ -1,30 +1,15 @@
-# tests/test_resolver_precedence.py
 from types import SimpleNamespace
 
-from autoapi.v3.engines.shortcuts import (
-    mem,
-    sqlitef,
-    pga,
-    pgs,
-    prov,
-)  # :contentReference[oaicite:9]{index=9}
-from autoapi.v3.engines import resolver  # :contentReference[oaicite:10]{index=10}
+from autoapi.v3.engines.shortcuts import mem, sqlitef, pga, pgs, prov
+from autoapi.v3.engines import resolver
 
 
 def test_precedence_op_over_model_over_api_over_app(tmp_path):
     # Build four distinct Providers to track identity
-    _app_prov = prov(
-        sqlitef(str(tmp_path / "app.sqlite"))
-    )  # sync sqlite  :contentReference[oaicite:11]{index=11}
-    _api_prov = prov(
-        pgs(host="db", name="api_db")
-    )  # sync pg      :contentReference[oaicite:12]{index=12}
-    _model_prov = prov(
-        mem(async_=False)
-    )  # sync mem     :contentReference[oaicite:13]{index=13}
-    _op_prov = prov(
-        pga(host="db", name="op_db")
-    )  # async pg     :contentReference[oaicite:14]{index=14}
+    _app_prov = prov(sqlitef(str(tmp_path / "app.sqlite")))
+    _api_prov = prov(pgs(host="db", name="api_db"))
+    _model_prov = prov(mem(async_=False))
+    _op_prov = prov(pga(host="db", name="op_db"))
 
     # Fake “api” and “model” identities
     api = SimpleNamespace()
@@ -33,20 +18,16 @@ def test_precedence_op_over_model_over_api_over_app(tmp_path):
         __name__ = "Model"
 
     # Register in resolver
-    resolver.set_default(
-        sqlitef(str(tmp_path / "app.sqlite"))
-    )  # app  :contentReference[oaicite:15]{index=15}
+    resolver.set_default(sqlitef(str(tmp_path / "app.sqlite")))
     resolver.register_api(
         api, {"kind": "postgres", "async": False, "host": "db", "db": "api_db"}
-    )  # api
-    resolver.register_table(
-        Model, {"kind": "sqlite", "async": False, "mode": "memory"}
-    )  # model
+    )
+    resolver.register_table(Model, {"kind": "sqlite", "async": False, "mode": "memory"})
     resolver.register_op(
         Model,
         "create",
         {"kind": "postgres", "async": True, "host": "db", "db": "op_db"},
-    )  # op
+    )
 
     # Resolve each level
     p_app = resolver.resolve_provider()
@@ -54,14 +35,11 @@ def test_precedence_op_over_model_over_api_over_app(tmp_path):
     p_model = resolver.resolve_provider(model=Model)
     p_op = resolver.resolve_provider(model=Model, op_alias="create")
 
-    # Identity checks: we can’t compare to local prov(...) objects because resolver re-coerces,
-    # but we can assert precedence by pairwise inequality and kind/expected async-ness
-    assert p_app is not None and p_app.kind == "sync"  # sqlite file
+    # Each level should resolve to a different provider with expected sync/async kind
+    assert p_app is not None and p_app.kind == "sync"
     assert p_api is not None and p_api is not p_app and p_api.kind == "sync"
     assert p_model is not None and p_model is not p_api and p_model.kind == "sync"
-    assert (
-        p_op is not None and p_op is not p_model and p_op.kind == "async"
-    )  # op-level wins
+    assert p_op is not None and p_op is not p_model and p_op.kind == "async"
 
     # Also test acquire() end-to-end
     db, release = resolver.acquire(model=Model, op_alias="create")


### PR DESCRIPTION
## Summary
- remove asyncpg skip and tidy resolver precedence test
- include asyncpg and psycopg2-binary in dev dependencies for async postgres support

## Testing
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff format tests/unit/test_resolver_precedence.py pyproject.toml`
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff check tests/unit/test_resolver_precedence.py pyproject.toml --fix`
- `uv run --package autoapi --directory standards/autoapi pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b43e633670832686c34f3fde420ff2