### PR TITLE
refactor: reorganize schema helpers

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/__init__.py
@@ -34,20 +34,19 @@ from .opspec import (
     PHASE,
     HookPhase,
     PHASES,
-    SchemaRef,
-    SchemaArg,
 )
+from .schema.types import SchemaRef, SchemaArg
 
 # ── Ctx-only decorators (new surface; replaces legacy opspec.decorators) ───────
 from .decorators import (
     alias_ctx,
     op_ctx,
     hook_ctx,
-    schema_ctx,
     alias,
     op_alias,
     engine_ctx,
 )
+from .schema.decorators import schema_ctx
 
 # ── Bindings (model + API orchestration) ───────────────────────────────────────
 from .bindings import (

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/schemas.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/schemas.py
@@ -8,10 +8,7 @@ from typing import Any, Dict, Optional, Sequence, Tuple, Type
 from pydantic import BaseModel, create_model
 
 from ..opspec import OpSpec
-from ..opspec.types import (
-    SchemaRef,
-    SchemaArg,
-)  # lazy-capable schema args (runtime: we restrict forms)
+from ..schema.types import SchemaRef, SchemaArg  # lazy-capable schema args
 from ..schema import (
     _build_schema,
     _build_list_params,
@@ -21,8 +18,9 @@ from ..schema import (
     _make_deleted_response_model,
     _make_pk_model,
     namely_model,
+    collect_decorated_schemas,
 )
-from ..decorators import collect_decorated_schemas  # ← seed @schema_ctx declarations
+# ← seed @schema_ctx declarations
 
 logger = logging.getLogger(__name__)
 

--- a/pkgs/standards/autoapi/autoapi/v3/compat/transactional.py
+++ b/pkgs/standards/autoapi/autoapi/v3/compat/transactional.py
@@ -5,7 +5,8 @@ from typing import Any, Callable
 
 from ..bindings.api import include_model
 from ..bindings.model import bind as bind_model
-from ..opspec import OpSpec, SchemaArg, get_registry
+from ..opspec import OpSpec, get_registry
+from ..schema.types import SchemaArg
 from ..config.constants import AUTOAPI_TX_MODELS_ATTR
 
 

--- a/pkgs/standards/autoapi/autoapi/v3/config/constants.py
+++ b/pkgs/standards/autoapi/autoapi/v3/config/constants.py
@@ -63,11 +63,11 @@ DEFAULT_HTTP_METHODS: Mapping[str, Tuple[str, ...]] = {
 
 
 # ───────────────────────────────────────────────────────────────────────────────
-# ‼ Column.info["autoapi"] is deprecated and will be removed. 
+# ‼ Column.info["autoapi"] is deprecated and will be removed.
 # ‼ Support is not guaranteed.
 # Column-level configuration keys (Column.info["autoapi"])
 #   See: v3 schema builder & v3 schema.info check(meta, attr, model)
-# 
+#
 # ───────────────────────────────────────────────────────────────────────────────
 
 COL_LEVEL_CFGS: frozenset[str] = frozenset(
@@ -123,6 +123,7 @@ AUTOAPI_ALLOW_ANON_ATTR = "__autoapi_allow_anon__"  # verbs callable without aut
 AUTOAPI_DEFAULTS_MODE_ATTR = "__autoapi_defaults_mode__"  # canonical verb wiring policy
 AUTOAPI_DEFAULTS_INCLUDE_ATTR = "__autoapi_defaults_include__"  # verbs to force include
 AUTOAPI_DEFAULTS_EXCLUDE_ATTR = "__autoapi_defaults_exclude__"  # verbs to force exclude
+AUTOAPI_SCHEMA_DECLS_ATTR = "__autoapi_schema_decls__"  # declared schemas map
 
 # Aggregate of recognized model-level config attributes
 MODEL_LEVEL_CFGS: frozenset[str] = frozenset(
@@ -148,6 +149,7 @@ MODEL_LEVEL_CFGS: frozenset[str] = frozenset(
         AUTOAPI_DEFAULTS_MODE_ATTR,
         AUTOAPI_DEFAULTS_INCLUDE_ATTR,
         AUTOAPI_DEFAULTS_EXCLUDE_ATTR,
+        AUTOAPI_SCHEMA_DECLS_ATTR,
         "__resource__",  # resource name override for REST
     }
 )
@@ -211,6 +213,7 @@ __all__ = [
     "AUTOAPI_DEFAULTS_MODE_ATTR",
     "AUTOAPI_DEFAULTS_INCLUDE_ATTR",
     "AUTOAPI_DEFAULTS_EXCLUDE_ATTR",
+    "AUTOAPI_SCHEMA_DECLS_ATTR",
     "AUTOAPI_CUSTOM_OP_ATTR",
     "AUTOAPI_TX_MODELS_ATTR",
     "CTX_REQUEST_KEY",

--- a/pkgs/standards/autoapi/autoapi/v3/decorators.py
+++ b/pkgs/standards/autoapi/autoapi/v3/decorators.py
@@ -10,8 +10,9 @@ from autoapi.v3.opspec.types import (
     Arity,
     TargetOp,
     PersistPolicy,
-    SchemaArg,
 )
+from autoapi.v3.schema.types import SchemaArg
+from autoapi.v3.schema.decorators import schema_ctx
 from autoapi.v3.runtime.executor import _Ctx  # pipeline ctx normalizer
 from autoapi.v3.engines.decorators import engine_ctx
 
@@ -177,106 +178,6 @@ def op_alias(
         return table_cls
 
     return deco
-
-
-# ──────────────────────────────────────────────────────────────────────
-# schema_ctx (class decorator): register extra model-wide schemas
-# ──────────────────────────────────────────────────────────────────────
-
-
-@dataclass(frozen=True)
-class _SchemaDecl:
-    alias: str  # name under model.schemas.<alias>
-    kind: str  # "in" | "out"
-
-
-def _register_schema_decl(
-    target_model: type, alias: str, kind: str, schema_cls: type
-) -> None:
-    """
-    Store declarations directly on the model so we can attach them later during schema binding.
-    Shape: model.__autoapi_schema_decls__ = { alias: {"in": cls, "out": cls, ...}, ... }
-    """
-    if kind not in ("in", "out"):
-        raise ValueError("schema_ctx(kind=...) must be 'in' or 'out'")
-    mapping: Dict[str, Dict[str, type]] = (
-        getattr(target_model, "__autoapi_schema_decls__", None) or {}
-    )
-    bucket = dict(mapping.get(alias, {}))
-    bucket[kind] = schema_cls
-    mapping[alias] = bucket
-    setattr(target_model, "__autoapi_schema_decls__", mapping)
-
-
-def schema_ctx(*, alias: str, kind: str = "out", for_: Optional[type] = None):
-    """
-    Decorate a (Pydantic) class to register it as a named schema for a target model.
-
-    Usage 1 (nested inside the model class):
-        class Widget:
-            @schema_ctx(alias="Search", kind="in")
-            class SearchParams(BaseModel): ...
-
-            @schema_ctx(alias="Search", kind="out")
-            class SearchResult(BaseModel): ...
-
-    Usage 2 (external class, explicit target):
-        @schema_ctx(alias="Export", kind="out", for_=Widget)
-        class ExportRow(BaseModel): ...
-
-    The schema becomes addressable as:
-        SchemaRef("Search", "in")   →  model.schemas.Search.in_
-        SchemaRef("Search", "out")  →  model.schemas.Search.out
-    """
-
-    def deco(schema_cls: type):
-        if not isinstance(schema_cls, type):
-            raise TypeError("@schema_ctx must decorate a class")
-
-        # If explicit model provided, register immediately on that model
-        if for_ is not None:
-            _register_schema_decl(for_, alias, kind, schema_cls)
-
-        # Always mark the schema class so we can pick it up if it's nested in the model
-        setattr(
-            schema_cls, "__autoapi_schema_decl__", _SchemaDecl(alias=alias, kind=kind)
-        )
-        return schema_cls
-
-    return deco
-
-
-def collect_decorated_schemas(model: type) -> Dict[str, Dict[str, type]]:
-    """
-    Gather all schema declarations for a model, merging:
-      • Explicit registrations via schema_ctx(..., for_=Model)
-      • Nested class declarations inside the model (and its bases)
-    Subclass declarations override base-class ones for the same (alias, kind).
-    """
-    out: Dict[str, Dict[str, type]] = {}
-
-    # 1) Explicit registrations (MRO-merged)
-    for base in reversed(model.__mro__):
-        mapping: Dict[str, Dict[str, type]] = (
-            getattr(base, "__autoapi_schema_decls__", {}) or {}
-        )
-        for alias, kinds in mapping.items():
-            bucket = out.setdefault(alias, {})
-            bucket.update(kinds or {})
-
-    # 2) Nested classes with __autoapi_schema_decl__
-    for base in reversed(model.__mro__):
-        for name in dir(base):
-            obj = getattr(base, name, None)
-            if not inspect.isclass(obj):
-                continue
-            decl: _SchemaDecl | None = getattr(obj, "__autoapi_schema_decl__", None)
-            if not decl:
-                continue
-            bucket = out.setdefault(decl.alias, {})
-            bucket[decl.kind] = obj
-
-    return out
 
 
 # ──────────────────────────────────────────────────────────────────────

--- a/pkgs/standards/autoapi/autoapi/v3/opspec/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/opspec/__init__.py
@@ -9,7 +9,6 @@ Types:
   - TargetOp, Arity, PersistPolicy
   - HookPhase, PHASES
   - VerbAliasPolicy
-  - SchemaRef, SchemaArg
 
 Collection & Registry:
   - resolve(model)                        → list[OpSpec]
@@ -43,8 +42,6 @@ from .types import (
     HookPhase,
     PHASES,
     VerbAliasPolicy,
-    SchemaRef,
-    SchemaArg,
 )
 
 # Collector
@@ -71,8 +68,6 @@ __all__ = [
     "HookPhase",
     "PHASES",
     "VerbAliasPolicy",
-    "SchemaRef",
-    "SchemaArg",
     # collection
     "resolve",
     # registry

--- a/pkgs/standards/autoapi/autoapi/v3/opspec/types.py
+++ b/pkgs/standards/autoapi/autoapi/v3/opspec/types.py
@@ -11,9 +11,12 @@ from typing import (
     Mapping,
     Optional,
     Tuple,
-    Type,
     Union,
 )
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from ..schema.types import SchemaArg
 
 # ───────────────────────────────────────────────────────────────────────────────
 # Core aliases & enums
@@ -106,32 +109,6 @@ HookPredicate = Callable[[Any], bool]
 # Lazy-capable schema argument types
 # ───────────────────────────────────────────────────────────────────────────────
 
-try:  # pragma: no cover
-    from pydantic import BaseModel  # type: ignore
-except Exception:  # pragma: no cover
-
-    class BaseModel:  # minimal stub for typing only
-        pass
-
-
-SchemaKind = Literal["in", "out"]
-
-
-@dataclass(frozen=True, slots=True)
-class SchemaRef:
-    """Lazy reference to `model.schemas.<alias>.(in_|out)`."""
-
-    alias: str
-    kind: SchemaKind = "in"
-
-
-SchemaArg = Union[
-    Type[BaseModel],  # direct Pydantic model
-    SchemaRef,  # cross-op reference
-    str,  # "alias.in" | "alias.out"
-    Callable[[type], Type[BaseModel]],  # lambda cls: cls.schemas.create.in_
-]
-
 
 # ───────────────────────────────────────────────────────────────────────────────
 # Engine binding (optional, used by resolver precedence: op > table > api > app)
@@ -185,7 +162,6 @@ class OpSpec:
 
     # Optional per-op engine binding (DSN string or mapping spec)
     db: Optional[DBSpec] = None
-
 
     # HTTP behavior
     arity: Arity = "collection"
@@ -246,9 +222,6 @@ __all__ = [
     "Ctx",
     "StepFn",
     "HookPredicate",
-    "SchemaKind",
-    "SchemaRef",
-    "SchemaArg",
     "DBSpec",
     "OpHook",
     "OpSpec",

--- a/pkgs/standards/autoapi/autoapi/v3/schema/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/__init__.py
@@ -18,6 +18,12 @@ from .col_info import (
     should_include_in_input,
     should_include_in_output,
 )
+from .decorators import schema_ctx
+from .collect import collect_decorated_schemas
+from ._schema import Schema
+from .schema_spec import SchemaSpec
+from .shortcuts import schema, schema_spec
+from .types import SchemaRef, SchemaArg, SchemaKind
 
 __all__ = [
     "_build_schema",
@@ -36,4 +42,13 @@ __all__ = [
     "check",
     "should_include_in_input",
     "should_include_in_output",
+    "schema_ctx",
+    "collect_decorated_schemas",
+    "Schema",
+    "SchemaSpec",
+    "schema",
+    "schema_spec",
+    "SchemaRef",
+    "SchemaArg",
+    "SchemaKind",
 ]

--- a/pkgs/standards/autoapi/autoapi/v3/schema/_schema.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/_schema.py
@@ -1,0 +1,27 @@
+# autoapi/v3/schema/_schema.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Type
+
+try:  # pragma: no cover
+    from pydantic import BaseModel  # type: ignore
+except Exception:  # pragma: no cover
+
+    class BaseModel:  # minimal stub for typing only
+        pass
+
+
+from .types import SchemaKind
+
+
+@dataclass(frozen=True, slots=True)
+class Schema:
+    """Concrete schema paired with its alias and kind."""
+
+    model: Type[BaseModel]
+    kind: SchemaKind = "out"
+    alias: str | None = None
+
+
+__all__ = ["Schema"]

--- a/pkgs/standards/autoapi/autoapi/v3/schema/collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/collect.py
@@ -1,0 +1,40 @@
+# autoapi/v3/schema/collect.py
+from __future__ import annotations
+
+import inspect
+from typing import Dict
+
+from ..config.constants import AUTOAPI_SCHEMA_DECLS_ATTR
+
+from .decorators import _SchemaDecl
+
+
+def collect_decorated_schemas(model: type) -> Dict[str, Dict[str, type]]:
+    """Gather schema declarations for ``model`` across its MRO."""
+    out: Dict[str, Dict[str, type]] = {}
+
+    # Explicit registrations (MRO-merged)
+    for base in reversed(model.__mro__):
+        mapping: Dict[str, Dict[str, type]] = (
+            getattr(base, AUTOAPI_SCHEMA_DECLS_ATTR, {}) or {}
+        )
+        for alias, kinds in mapping.items():
+            bucket = out.setdefault(alias, {})
+            bucket.update(kinds or {})
+
+    # Nested classes with __autoapi_schema_decl__
+    for base in reversed(model.__mro__):
+        for name in dir(base):
+            obj = getattr(base, name, None)
+            if not inspect.isclass(obj):
+                continue
+            decl: _SchemaDecl | None = getattr(obj, "__autoapi_schema_decl__", None)
+            if not decl:
+                continue
+            bucket = out.setdefault(decl.alias, {})
+            bucket[decl.kind] = obj
+
+    return out
+
+
+__all__ = ["collect_decorated_schemas"]

--- a/pkgs/standards/autoapi/autoapi/v3/schema/decorators.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/decorators.py
@@ -1,0 +1,47 @@
+# autoapi/v3/schema/decorators.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+from ..config.constants import AUTOAPI_SCHEMA_DECLS_ATTR
+
+
+@dataclass(frozen=True)
+class _SchemaDecl:
+    alias: str  # name under model.schemas.<alias>
+    kind: str  # "in" | "out"
+
+
+def _register_schema_decl(
+    target_model: type, alias: str, kind: str, schema_cls: type
+) -> None:
+    """Store schema declarations on the model for later binding."""
+    if kind not in ("in", "out"):
+        raise ValueError("schema_ctx(kind=...) must be 'in' or 'out'")
+    mapping: Dict[str, Dict[str, type]] = (
+        getattr(target_model, AUTOAPI_SCHEMA_DECLS_ATTR, None) or {}
+    )
+    bucket = dict(mapping.get(alias, {}))
+    bucket[kind] = schema_cls
+    mapping[alias] = bucket
+    setattr(target_model, AUTOAPI_SCHEMA_DECLS_ATTR, mapping)
+
+
+def schema_ctx(*, alias: str, kind: str = "out", for_: Optional[type] = None):
+    """Register a named schema for a model."""
+
+    def deco(schema_cls: type):
+        if not isinstance(schema_cls, type):
+            raise TypeError("@schema_ctx must decorate a class")
+        if for_ is not None:
+            _register_schema_decl(for_, alias, kind, schema_cls)
+        setattr(
+            schema_cls, "__autoapi_schema_decl__", _SchemaDecl(alias=alias, kind=kind)
+        )
+        return schema_cls
+
+    return deco
+
+
+__all__ = ["schema_ctx"]

--- a/pkgs/standards/autoapi/autoapi/v3/schema/schema_spec.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/schema_spec.py
@@ -1,0 +1,20 @@
+# autoapi/v3/schema/schema_spec.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from .types import SchemaArg, SchemaKind
+
+
+@dataclass(frozen=True, slots=True)
+class SchemaSpec:
+    """Declarative description of a schema for a model."""
+
+    alias: str
+    kind: SchemaKind = "out"
+    for_: Optional[type] = None
+    schema: SchemaArg | None = None
+
+
+__all__ = ["SchemaSpec"]

--- a/pkgs/standards/autoapi/autoapi/v3/schema/shortcuts.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/shortcuts.py
@@ -1,0 +1,42 @@
+# autoapi/v3/schema/shortcuts.py
+from __future__ import annotations
+
+from typing import Optional, Type
+
+try:  # pragma: no cover
+    from pydantic import BaseModel  # type: ignore
+except Exception:  # pragma: no cover
+
+    class BaseModel:  # minimal stub for typing only
+        pass
+
+
+from ._schema import Schema
+from .schema_spec import SchemaSpec
+from .types import SchemaArg, SchemaKind
+
+
+def schema_spec(
+    alias: str,
+    *,
+    kind: SchemaKind = "out",
+    for_: Optional[type] = None,
+    schema: SchemaArg | None = None,
+) -> SchemaSpec:
+    """Factory for :class:`SchemaSpec`."""
+
+    return SchemaSpec(alias=alias, kind=kind, for_=for_, schema=schema)
+
+
+def schema(
+    model: Type[BaseModel],
+    *,
+    kind: SchemaKind = "out",
+    alias: str | None = None,
+) -> Schema:
+    """Factory for :class:`Schema`."""
+
+    return Schema(model=model, kind=kind, alias=alias)
+
+
+__all__ = ["schema_spec", "schema"]

--- a/pkgs/standards/autoapi/autoapi/v3/schema/types.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/types.py
@@ -1,0 +1,34 @@
+# autoapi/v3/schema/types.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Type, Union, Literal
+
+try:  # pragma: no cover
+    from pydantic import BaseModel  # type: ignore
+except Exception:  # pragma: no cover
+
+    class BaseModel:  # minimal stub for typing only
+        pass
+
+
+SchemaKind = Literal["in", "out"]
+
+
+@dataclass(frozen=True, slots=True)
+class SchemaRef:
+    """Lazy reference to ``model.schemas.<alias>.(in_|out)``."""
+
+    alias: str
+    kind: SchemaKind = "in"
+
+
+SchemaArg = Union[
+    Type[BaseModel],  # direct Pydantic model
+    SchemaRef,  # cross-op reference
+    str,  # "alias.in" | "alias.out"
+    Callable[[type], Type[BaseModel]],  # lambda cls: cls.schemas.create.in_
+]
+
+
+__all__ = ["SchemaKind", "SchemaRef", "SchemaArg"]


### PR DESCRIPTION
## Summary
- extract AUTOAPI_SCHEMA_DECLS_ATTR constant for schema declarations
- add Schema/SchemaSpec classes with factory shortcuts
- move schema collection into dedicated module and update bindings

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format autoapi/v3/bindings/schemas.py autoapi/v3/config/constants.py autoapi/v3/schema/__init__.py autoapi/v3/schema/decorators.py autoapi/v3/schema/_schema.py autoapi/v3/schema/collect.py autoapi/v3/schema/schema_spec.py autoapi/v3/schema/shortcuts.py`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check autoapi/v3/bindings/schemas.py autoapi/v3/config/constants.py autoapi/v3/schema/__init__.py autoapi/v3/schema/decorators.py autoapi/v3/schema/_schema.py autoapi/v3/schema/collect.py autoapi/v3/schema/schema_spec.py autoapi/v3/schema/shortcuts.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b43f2bfd3c8326bdfcfea1d97bc528