### PR TITLE
refactor(autoapi): remove autowire_collect module

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/api/_api.py
+++ b/pkgs/standards/autoapi/autoapi/v3/api/_api.py
@@ -1,14 +1,24 @@
 # autoapi/autoapi/v3/api/_api.py
 from __future__ import annotations
-from typing import Any, AsyncGenerator, ClassVar, Generator, Iterable, Optional, Sequence, Type
+from typing import (
+    Any,
+    AsyncGenerator,
+    Generator,
+)
 
 from ..engines import resolver as _resolver
-from ..engines.autowire_collect import install_from_objects
+from ..engine import install_from_objects
 from .api_spec import APISpec
+
 
 class API(APISpec):
     def __init__(self, **fastapi_kwargs: Any) -> None:
-        super().__init__(title=self.TITLE, version=self.VERSION, lifespan=self.LIFESPAN, **fastapi_kwargs)
+        super().__init__(
+            title=self.TITLE,
+            version=self.VERSION,
+            lifespan=self.LIFESPAN,
+            **fastapi_kwargs,
+        )
         if self.DB is not None:
             _resolver.set_default(self.DB)
         for mw in self.MIDDLEWARES:
@@ -16,17 +26,23 @@ class API(APISpec):
 
     def get_db(self) -> Generator[Any, None, None]:
         db, release = _resolver.acquire()
-        try: yield db
-        finally: release()
+        try:
+            yield db
+        finally:
+            release()
 
     async def get_async_db(self) -> AsyncGenerator[Any, None]:
         db, release = _resolver.acquire()
-        try: yield db
-        finally: release()
+        try:
+            yield db
+        finally:
+            release()
 
-    def install_engines(self, *, api: Any = None, models: tuple[Any, ...] | None = None) -> None:
+    def install_engines(
+        self, *, api: Any = None, models: tuple[Any, ...] | None = None
+    ) -> None:
         # If class declared APIS/MODELS, use them unless explicit args are passed.
-        apis   = (api,) if api is not None else self.APIS
+        apis = (api,) if api is not None else self.APIS
         models = models if models is not None else self.MODELS
         if apis:
             for a in apis:

--- a/pkgs/standards/autoapi/autoapi/v3/app/_app.py
+++ b/pkgs/standards/autoapi/autoapi/v3/app/_app.py
@@ -1,15 +1,25 @@
 # autoapi/autoapi/v3/app/_app.py
 from __future__ import annotations
-from typing import Any, AsyncGenerator, ClassVar, Generator, Iterable, Optional, Sequence, Type
+from typing import (
+    Any,
+    AsyncGenerator,
+    Generator,
+)
 
 from autoapi.v3.deps.fastapi import FastAPI
 from ..engines import resolver as _resolver
-from ..engines.autowire_collect import install_from_objects
+from ..engine import install_from_objects
 from .app_spec import AppSpec
+
 
 class App(AppSpec, FastAPI):
     def __init__(self, **fastapi_kwargs: Any) -> None:
-        super().__init__(title=self.TITLE, version=self.VERSION, lifespan=self.LIFESPAN, **fastapi_kwargs)
+        super().__init__(
+            title=self.TITLE,
+            version=self.VERSION,
+            lifespan=self.LIFESPAN,
+            **fastapi_kwargs,
+        )
         if self.DB is not None:
             _resolver.set_default(self.DB)
         for mw in self.MIDDLEWARES:
@@ -17,17 +27,23 @@ class App(AppSpec, FastAPI):
 
     def get_db(self) -> Generator[Any, None, None]:
         db, release = _resolver.acquire()
-        try: yield db
-        finally: release()
+        try:
+            yield db
+        finally:
+            release()
 
     async def get_async_db(self) -> AsyncGenerator[Any, None]:
         db, release = _resolver.acquire()
-        try: yield db
-        finally: release()
+        try:
+            yield db
+        finally:
+            release()
 
-    def install_engines(self, *, api: Any = None, models: tuple[Any, ...] | None = None) -> None:
+    def install_engines(
+        self, *, api: Any = None, models: tuple[Any, ...] | None = None
+    ) -> None:
         # If class declared APIS/MODELS, use them unless explicit args are passed.
-        apis   = (api,) if api is not None else self.APIS
+        apis = (api,) if api is not None else self.APIS
         models = models if models is not None else self.MODELS
         if apis:
             for a in apis:

--- a/pkgs/standards/autoapi/autoapi/v3/engine/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/engine/__init__.py
@@ -1,0 +1,6 @@
+"""Engine utilities for collecting and binding database providers."""
+
+from .collect import collect_from_objects
+from .bind import bind, install_from_objects
+
+__all__ = ["collect_from_objects", "bind", "install_from_objects"]

--- a/pkgs/standards/autoapi/autoapi/v3/engine/bind.py
+++ b/pkgs/standards/autoapi/autoapi/v3/engine/bind.py
@@ -1,0 +1,33 @@
+"""Bind collected engine configuration to the resolver."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable
+
+from ..engines.resolver import register_api, register_op, register_table, set_default
+
+
+def bind(collected: Dict[str, Any]) -> None:
+    """Bind a collected configuration mapping into the resolver."""
+    default_db = collected.get("default")
+    if default_db is not None:
+        set_default(default_db)
+
+    for api_obj, db in collected.get("api", {}).items():
+        register_api(api_obj, db)
+
+    for table_obj, db in collected.get("tables", {}).items():
+        register_table(table_obj, db)
+
+    for (model, alias), db in collected.get("ops", {}).items():
+        register_op(model, alias, db)
+
+
+def install_from_objects(
+    *, app: Any | None = None, api: Any | None = None, models: Iterable[Any] = ()
+) -> None:
+    """Collect engine config from objects and bind them to the resolver."""
+    from .collect import collect_from_objects
+
+    collected = collect_from_objects(app=app, api=api, models=models)
+    bind(collected)

--- a/pkgs/standards/autoapi/autoapi/v3/engines/decorators.py
+++ b/pkgs/standards/autoapi/autoapi/v3/engines/decorators.py
@@ -2,11 +2,11 @@
 from __future__ import annotations
 
 import inspect
-from typing import Any, Mapping, Optional
+from typing import Any, Optional
 
 # EngineSpec provides the canonical parsing; EngineCtx is the accepted input type
 # (DSN string or mapping) attached by @engine_ctx.
-from .engine_spec import EngineSpec, EngineCtx
+from .engine_spec import EngineCtx
 
 
 def _normalize(ctx: Optional[EngineCtx] = None, **kw: Any) -> EngineCtx:
@@ -31,7 +31,10 @@ def _normalize(ctx: Optional[EngineCtx] = None, **kw: Any) -> EngineCtx:
             )
         return str(dsn)
 
-    m: dict[str, Any] = {"kind": kind, "async": bool(kw.get("async_", kw.get("async", False)))}
+    m: dict[str, Any] = {
+        "kind": kind,
+        "async": bool(kw.get("async_", kw.get("async", False))),
+    }
 
     if kind == "sqlite":
         # memory modes: mode="memory" OR memory=True OR no path supplied
@@ -64,8 +67,8 @@ def engine_ctx(ctx: Optional[EngineCtx] = None, **kw: Any):
       • For App/API classes or instances: sets attribute .db = EngineCtx.
 
     Downstream:
-      • engines.autowire_collect.install_from_objects(...) discovers these and
-        registers Providers with resolver precedence: op > table(model) > api > app.
+      • engine.install_from_objects(...) discovers these and registers
+        Providers with resolver precedence: op > table(model) > api > app.
     """
     spec = _normalize(ctx, **kw)
 

--- a/pkgs/standards/autoapi/autoapi/v3/table/_table.py
+++ b/pkgs/standards/autoapi/autoapi/v3/table/_table.py
@@ -1,11 +1,12 @@
 # autoapi/autoapi/v3/table/_table.py
 from __future__ import annotations
 
-from typing import Any, ClassVar, Mapping, Optional
+from typing import Any
 
 from ..engines import resolver as _resolver
-from ..engines.autowire_collect import install_from_objects  # reuse the collector
+from ..engine import install_from_objects  # reuse the collector
 from .table_spec import TableSpec
+
 
 class Table(TableSpec):
     def __init_subclass__(cls, **kw: Any) -> None:

--- a/pkgs/standards/autoapi/tests/unit/test_decorator_and_collect.py
+++ b/pkgs/standards/autoapi/tests/unit/test_decorator_and_collect.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 from autoapi.v3.engines.decorators import (
     engine_ctx,
 )  # :contentReference[oaicite:17]{index=17}
-from autoapi.v3.engines.autowire_collect import install_from_objects
+from autoapi.v3.engine import install_from_objects
 from autoapi.v3.engines import (
     resolver,
 )  # precedence registry  :contentReference[oaicite:18]{index=18}


### PR DESCRIPTION
## Summary
- drop deprecated autowire_collect shim
- import install_from_objects from new engine utilities
- clarify decorator docs to reference engine.install_from_objects

## Testing
- `uv run --package autoapi ruff format autoapi/v3/app/_app.py autoapi/v3/api/_api.py autoapi/v3/table/_table.py autoapi/v3/engines/decorators.py tests/unit/test_decorator_and_collect.py`
- `uv run --package autoapi ruff check autoapi/v3/app/_app.py autoapi/v3/api/_api.py autoapi/v3/table/_table.py autoapi/v3/engines/decorators.py tests/unit/test_decorator_and_collect.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b43f8d0c2c8326a747f645766ef5ac