### PR TITLE
Fix autoapi constants circular import

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/config/constants.py
+++ b/pkgs/standards/autoapi/autoapi/v3/config/constants.py
@@ -19,7 +19,27 @@ from __future__ import annotations
 
 from typing import Mapping, Tuple
 
-from ..opspec.types import CANON  # canonical op registry (dict-like of targets)
+# NOTE: importing CANON from ``opspec.types`` introduces a circular dependency
+# because that module transitively imports this one via ``hook``. To keep the
+# constant values in sync without triggering the circular import at import time,
+# we inline the canonical verb tuple here. This tuple **must** match
+# ``autoapi.v3.opspec.types.CANON``.
+CANON: Tuple[str, ...] = (
+    "create",
+    "read",
+    "update",
+    "replace",
+    "merge",
+    "delete",
+    "list",
+    "clear",
+    "bulk_create",
+    "bulk_update",
+    "bulk_replace",
+    "bulk_merge",
+    "bulk_delete",
+    "custom",
+)
 
 
 # ───────────────────────────────────────────────────────────────────────────────

--- a/pkgs/standards/autoapi/autoapi/v3/opspec/types.py
+++ b/pkgs/standards/autoapi/autoapi/v3/opspec/types.py
@@ -2,8 +2,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Callable, Literal, Mapping, Optional, Tuple, Type, Union
+from typing import Any, Callable, Literal, Mapping, Optional, Tuple, Type, Union, cast
 
+from ..config.constants import CANON as CANONICAL_VERB_TUPLE
 from ..hook.types import PHASE, HookPhase, PHASES, Ctx, StepFn, HookPredicate
 from ..hook_spec import HookSpec as OpHook
 
@@ -133,22 +134,7 @@ class OpSpec:
 
 
 # Canonical verb set
-CANON: Tuple[TargetOp, ...] = (
-    "create",
-    "read",
-    "update",
-    "replace",
-    "merge",
-    "delete",
-    "list",
-    "clear",
-    "bulk_create",
-    "bulk_update",
-    "bulk_replace",
-    "bulk_merge",
-    "bulk_delete",
-    "custom",
-)
+CANON: Tuple[TargetOp, ...] = cast(Tuple[TargetOp, ...], CANONICAL_VERB_TUPLE)
 
 __all__ = [
     "PersistPolicy",


### PR DESCRIPTION
## Summary
- avoid circular import in autoapi config constants by inlining canonical verb list
- reuse canonical verb tuple in opspec types by importing it from config constants

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_rest_rpc_parity_default_ops.py::test_rest_rpc_parity_for_default_verbs -q`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_resolver_precedence.py::test_precedence_op_over_model_over_api_over_app -q` *(fails: ModuleNotFoundError: No module named 'asyncpg')*
- `uv run --package autoapi --directory standards/autoapi --with asyncpg pytest tests/unit/test_resolver_precedence.py::test_precedence_op_over_model_over_api_over_app -q`


------
https://chatgpt.com/codex/tasks/task_e_68b44402ff508326b04d9bead374bcc8