### PR TITLE
Refactor AutoAPI v3 shortcut naming for class definitions

### DIFF
--- a/pkgs/standards/autoapi/README.md
+++ b/pkgs/standards/autoapi/README.md
@@ -57,14 +57,14 @@ A high-leverage meta-framework that turns plain SQLAlchemy models into a fully-f
 ### Engine & Provider examples
 
 ```python
-from autoapi.v3.engine.shortcuts import engineSpec, prov
+from autoapi.v3.engine.shortcuts import engine_spec, prov
 from autoapi.v3.engine._engine import Engine, Provider
 
 # Build an EngineSpec from a DSN string
-spec = engineSpec("sqlite://:memory:")
+spec = engine_spec("sqlite://:memory:")
 
 # Or from keyword arguments
-spec_pg = engineSpec(kind="postgres", async_=True, host="db", name="app_db")
+spec_pg = engine_spec(kind="postgres", async_=True, host="db", name="app_db")
 
 # Lazy Provider from the spec
 provider = prov(spec)            # same as Provider(spec)

--- a/pkgs/standards/autoapi/autoapi/v3/api/shortcuts.py
+++ b/pkgs/standards/autoapi/autoapi/v3/api/shortcuts.py
@@ -7,7 +7,7 @@ from .api_spec import APISpecMixin
 from ._api import Api
 
 
-def apiSpec(
+def defineApiSpec(
     *,
     # identity
     name: str = "api",
@@ -27,10 +27,10 @@ def apiSpec(
     Build an API-spec *mixin* class with class attributes only (no instances).
     Use it directly in your class MRO:
 
-        class TenantA(apiSpec(name="tenantA", db=...)):
+        class TenantA(defineApiSpec(name="tenantA", db=...)):
             pass
 
-    or pass it to `apiSub(...)` to get a concrete API subclass.
+    or pass it to `deriveApi(...)` to get a concrete API subclass.
     """
     attrs = dict(
         NAME=name,
@@ -47,10 +47,10 @@ def apiSpec(
     return type("APISpec", (APISpecMixin,), attrs)
 
 
-def apiSub(**kw: Any) -> Type[Api]:
+def deriveApi(**kw: Any) -> Type[Api]:
     """Produce a concrete :class:`Api` subclass that inherits the spec mixin."""
-    Spec = apiSpec(**kw)
+    Spec = defineApiSpec(**kw)
     return type("APIWithSpec", (Spec, Api), {})
 
 
-__all__ = ["apiSpec", "apiSub"]
+__all__ = ["defineApiSpec", "deriveApi"]

--- a/pkgs/standards/autoapi/autoapi/v3/app/shortcuts.py
+++ b/pkgs/standards/autoapi/autoapi/v3/app/shortcuts.py
@@ -7,7 +7,7 @@ from .app_spec import AppSpecMixin
 from ._app import App
 
 
-def appSpec(
+def defineAppSpec(
     *,
     title: str = "AutoAPI",
     version: str = "0.1.0",
@@ -32,10 +32,10 @@ def appSpec(
     Build an App-spec *mixin* class with class attributes only (no instances).
     Use it directly in your class MRO:
 
-        class MyApp(appSpec(title="Svc", db=...)):
+        class MyApp(defineAppSpec(title="Svc", db=...)):
             pass
 
-    or pass it to `appSub(...)` to get a concrete App subclass.
+    or pass it to `deriveApp(...)` to get a concrete App subclass.
     """
     attrs = dict(
         TITLE=title,
@@ -56,10 +56,10 @@ def appSpec(
     return type("AppSpec", (AppSpecMixin,), attrs)
 
 
-def appSub(**kw: Any) -> Type[App]:
+def deriveApp(**kw: Any) -> Type[App]:
     """Produce a concrete :class:`App` subclass that inherits the spec mixin."""
-    Spec = appSpec(**kw)
+    Spec = defineAppSpec(**kw)
     return type("AppWithSpec", (Spec, App), {})
 
 
-__all__ = ["appSpec", "appSub"]
+__all__ = ["defineAppSpec", "deriveApp"]

--- a/pkgs/standards/autoapi/autoapi/v3/engine/shortcuts.py
+++ b/pkgs/standards/autoapi/autoapi/v3/engine/shortcuts.py
@@ -11,11 +11,11 @@ EngineCfg = Union[str, Mapping[str, object]]  # DSN string or structured mapping
 
 # ---------------------------------------------------------------------------
 # EngineSpec / Provider / Engine helpers  (ctx builder collapsed into
-# engineSpec)
+# engine_spec)
 # ---------------------------------------------------------------------------
 
 
-def engineSpec(
+def engine_spec(
     spec: Union[EngineCfg, Mapping[str, Any], str, None] = None, **kw: Any
 ) -> EngineSpec:
     """Build an :class:`EngineSpec` from a DSN string, mapping, or keyword fields."""
@@ -75,7 +75,7 @@ def prov(
     """
     if isinstance(spec, EngineSpec):
         return spec.to_provider()
-    return engineSpec(spec, **kw).to_provider()
+    return engine_spec(spec, **kw).to_provider()
 
 
 def engine(
@@ -84,7 +84,7 @@ def engine(
     """Return an Engine façade for convenience in ad-hoc flows."""
     if isinstance(spec, EngineSpec):
         return Engine(spec)
-    return Engine(engineSpec(spec, **kw))
+    return Engine(engine_spec(spec, **kw))
 
 
 # ---------------------------------------------------------------------------
@@ -159,11 +159,11 @@ def pgs(**kw: Any) -> EngineCfg:
 
 
 def provider_sqlite_memory(async_: bool = False) -> Provider:
-    return engineSpec(kind="sqlite", mode="memory", async_=async_).to_provider()
+    return engine_spec(kind="sqlite", mode="memory", async_=async_).to_provider()
 
 
 def provider_sqlite_file(path: str, async_: bool = False) -> Provider:
-    return engineSpec(kind="sqlite", path=path, async_=async_).to_provider()
+    return engine_spec(kind="sqlite", path=path, async_=async_).to_provider()
 
 
 def provider_postgres(
@@ -177,7 +177,7 @@ def provider_postgres(
     pool_size: int = 10,
     max: int = 20,
 ) -> Provider:
-    return engineSpec(
+    return engine_spec(
         kind="postgres",
         async_=async_,
         user=user,
@@ -192,7 +192,7 @@ def provider_postgres(
 
 __all__ = [
     # EngineSpec / Provider / Engine helpers
-    "engineSpec",
+    "engine_spec",
     "prov",
     "engine",
     # convenience EngineCfg helpers

--- a/pkgs/standards/autoapi/autoapi/v3/hook/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/hook/__init__.py
@@ -1,7 +1,7 @@
 from ..config.constants import HOOK_DECLS_ATTR
 from .decorators import hook_ctx
 from .types import PHASE, HookPhase, PHASES, Ctx, StepFn, HookPredicate
-from .shortcuts import hook, hookS
+from .shortcuts import hook, hook_spec
 from ._hook import Hook
 from ..hook_spec import HookSpec
 
@@ -16,6 +16,6 @@ __all__ = [
     "StepFn",
     "HookPredicate",
     "hook",
-    "hookS",
+    "hook_spec",
     "HookSpec",
 ]

--- a/pkgs/standards/autoapi/autoapi/v3/hook/shortcuts.py
+++ b/pkgs/standards/autoapi/autoapi/v3/hook/shortcuts.py
@@ -21,7 +21,7 @@ def hook(
     return Hook(phase=phase, fn=fn, ops=ops, name=name, description=description)
 
 
-def hookS(
+def hook_spec(
     phase: HookPhase,
     fn: StepFn,
     *,
@@ -41,4 +41,4 @@ def hookS(
     )
 
 
-__all__ = ["hook", "hookS"]
+__all__ = ["hook", "hook_spec"]

--- a/pkgs/standards/autoapi/autoapi/v3/table/shortcuts.py
+++ b/pkgs/standards/autoapi/autoapi/v3/table/shortcuts.py
@@ -7,7 +7,7 @@ from .table_spec import TableSpecMixin
 from ._table import Table
 
 
-def tableSpec(
+def defineTableSpec(
     *,
     # engine binding
     db: Any = None,
@@ -24,10 +24,10 @@ def tableSpec(
     Build a Table-spec *mixin* class with class attributes only (no instances).
     Use directly in your ORM class MRO:
 
-        class User(tableSpec(db=..., ops=(...)), Base, Table):
+        class User(defineTableSpec(db=..., ops=(...)), Base, Table):
             __tablename__ = "users"
 
-    or pass it to `tableSub(Model, ...)` to get a configured subclass.
+    or pass it to `deriveTable(Model, ...)` to get a configured subclass.
     """
     attrs = {
         # top-level mirrors read by collectors
@@ -47,11 +47,11 @@ def tableSpec(
     return type("TableSpec", (TableSpecMixin,), attrs)
 
 
-def tableSub(model: Type[Table], **kw: Any) -> Type[Table]:
+def deriveTable(model: Type[Table], **kw: Any) -> Type[Table]:
     """Produce a concrete ORM subclass that inherits the spec mixin."""
-    Spec = tableSpec(**kw)
+    Spec = defineTableSpec(**kw)
     name = f"{model.__name__}WithSpec"
     return type(name, (Spec, model), {})
 
 
-__all__ = ["tableSpec", "tableSub"]
+__all__ = ["defineTableSpec", "deriveTable"]

--- a/pkgs/standards/autoapi/tests/unit/test_engine_spec_and_shortcuts.py
+++ b/pkgs/standards/autoapi/tests/unit/test_engine_spec_and_shortcuts.py
@@ -2,7 +2,7 @@
 import pytest
 
 from autoapi.v3.engine.shortcuts import (
-    engineSpec,
+    engine_spec,
     engine,
     mem,
     prov,
@@ -13,8 +13,8 @@ from autoapi.v3.engine.engine_spec import (
 )  # :contentReference[oaicite:3]{index=3}
 
 
-def test_engineSpec_builds_from_kwargs_sqlite_memory_async():
-    spec = engineSpec(
+def test_engine_spec_builds_from_kwargs_sqlite_memory_async():
+    spec = engine_spec(
         kind="sqlite", mode="memory", async_=True
     )  # collapsed ctx builder
     assert isinstance(spec, EngineSpec)  # normalized
@@ -23,8 +23,8 @@ def test_engineSpec_builds_from_kwargs_sqlite_memory_async():
     )  # :contentReference[oaicite:4]{index=4}
 
 
-def test_engineSpec_builds_from_mapping_postgres_sync():
-    spec = engineSpec(
+def test_engine_spec_builds_from_mapping_postgres_sync():
+    spec = engine_spec(
         {"kind": "postgres", "async": False, "host": "db", "db": "foo"}
     )  # mapping path
     assert (


### PR DESCRIPTION
## Summary
- rename shortcut helpers that create classes to `define*`/`derive*`
- update API, Table, and App shortcut docs to reference new names
- rename engine `engineSpec` helper to `engine_spec` and hook `hookS` helper to `hook_spec`
- update engine docs and tests for new helper names

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check autoapi/v3/engine/shortcuts.py autoapi/v3/hook/shortcuts.py autoapi/v3/hook/__init__.py tests/unit/test_engine_spec_and_shortcuts.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b5c3bbe2c08326848f3e0606cdfa5e