### PR TITLE
refactor: remove Mixin suffix from autoapi v3 specs

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/api/shortcuts.py
+++ b/pkgs/standards/autoapi/autoapi/v3/api/shortcuts.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any, Sequence, Type
 
-from .api_spec import APISpecMixin
+from .api_spec import APISpec
 from ._api import Api
 
 
@@ -22,15 +22,15 @@ def defineApiSpec(
     security_deps: Sequence[Any] = (),
     deps: Sequence[Any] = (),
     models: Sequence[Any] = (),
-) -> Type[APISpecMixin]:
+) -> Type[APISpec]:
     """
-    Build an API-spec *mixin* class with class attributes only (no instances).
+    Build an API spec class with class attributes only (no instances).
     Use it directly in your class MRO:
 
         class TenantA(defineApiSpec(name="tenantA", db=...)):
             pass
 
-    or pass it to `deriveApi(...)` to get a concrete API subclass.
+    or pass it to ``deriveApi(...)`` to get a concrete :class:`Api` subclass.
     """
     attrs = dict(
         NAME=name,
@@ -44,11 +44,11 @@ def defineApiSpec(
         DEPS=tuple(deps or ()),
         MODELS=tuple(models or ()),
     )
-    return type("APISpec", (APISpecMixin,), attrs)
+    return type("APISpec", (APISpec,), attrs)
 
 
 def deriveApi(**kw: Any) -> Type[Api]:
-    """Produce a concrete :class:`Api` subclass that inherits the spec mixin."""
+    """Produce a concrete :class:`Api` subclass that inherits the spec."""
     Spec = defineApiSpec(**kw)
     return type("APIWithSpec", (Spec, Api), {})
 

--- a/pkgs/standards/autoapi/autoapi/v3/app/shortcuts.py
+++ b/pkgs/standards/autoapi/autoapi/v3/app/shortcuts.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any, Sequence, Type
 
-from .app_spec import AppSpecMixin
+from .app_spec import AppSpec
 from ._app import App
 
 
@@ -27,15 +27,15 @@ def defineAppSpec(
     # framework bits
     middlewares: Sequence[Any] = (),
     lifespan: Any = None,
-) -> Type[AppSpecMixin]:
+) -> Type[AppSpec]:
     """
-    Build an App-spec *mixin* class with class attributes only (no instances).
+    Build an App spec class with class attributes only (no instances).
     Use it directly in your class MRO:
 
         class MyApp(defineAppSpec(title="Svc", db=...)):
             pass
 
-    or pass it to `deriveApp(...)` to get a concrete App subclass.
+    or pass it to ``deriveApp(...)`` to get a concrete :class:`App` subclass.
     """
     attrs = dict(
         TITLE=title,
@@ -53,11 +53,11 @@ def defineAppSpec(
         MIDDLEWARES=tuple(middlewares or ()),
         LIFESPAN=lifespan,
     )
-    return type("AppSpec", (AppSpecMixin,), attrs)
+    return type("AppSpec", (AppSpec,), attrs)
 
 
 def deriveApp(**kw: Any) -> Type[App]:
-    """Produce a concrete :class:`App` subclass that inherits the spec mixin."""
+    """Produce a concrete :class:`App` subclass that inherits the spec."""
     Spec = defineAppSpec(**kw)
     return type("AppWithSpec", (Spec, App), {})
 

--- a/pkgs/standards/autoapi/autoapi/v3/table/shortcuts.py
+++ b/pkgs/standards/autoapi/autoapi/v3/table/shortcuts.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any, Sequence, Type
 
-from .table_spec import TableSpecMixin
+from .table_spec import TableSpec
 from ._table import Table
 
 
@@ -19,15 +19,15 @@ def defineTableSpec(
     # dependency stacks
     security_deps: Sequence[Any] = (),
     deps: Sequence[Any] = (),
-) -> Type[TableSpecMixin]:
+) -> Type[TableSpec]:
     """
-    Build a Table-spec *mixin* class with class attributes only (no instances).
+    Build a Table spec class with class attributes only (no instances).
     Use directly in your ORM class MRO:
 
         class User(defineTableSpec(db=..., ops=(...)), Base, Table):
             __tablename__ = "users"
 
-    or pass it to `deriveTable(Model, ...)` to get a configured subclass.
+    or pass it to ``deriveTable(Model, ...)`` to get a configured subclass.
     """
     attrs = {
         # top-level mirrors read by collectors
@@ -44,11 +44,11 @@ def defineTableSpec(
     if db is not None:
         attrs["table_config"] = {"db": db}
 
-    return type("TableSpec", (TableSpecMixin,), attrs)
+    return type("TableSpec", (TableSpec,), attrs)
 
 
 def deriveTable(model: Type[Table], **kw: Any) -> Type[Table]:
-    """Produce a concrete ORM subclass that inherits the spec mixin."""
+    """Produce a concrete ORM subclass that inherits the spec."""
     Spec = defineTableSpec(**kw)
     name = f"{model.__name__}WithSpec"
     return type(name, (Spec, model), {})


### PR DESCRIPTION
## Summary
- update v3 app, api, and table shortcuts to derive from `AppSpec`, `APISpec`, and `TableSpec`
- adjust docstrings to reflect spec classes rather than mixins

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b5c9c94b1c83269a7122e18aed50f5