### PR TITLE
refactor: rename v3 mixins without Mixin suffix

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/orm/api_key.py
+++ b/pkgs/standards/auto_authn/auto_authn/orm/api_key.py
@@ -7,11 +7,11 @@ import secrets
 
 from autoapi.v3.orm.tables import ApiKey as ApiKeyBase
 from autoapi.v3.types import UniqueConstraint, relationship
-from autoapi.v3.orm.mixins import UserMixin
+from autoapi.v3.orm.mixins import UserColumn
 from autoapi.v3 import hook_ctx
 
 
-class ApiKey(ApiKeyBase, UserMixin):
+class ApiKey(ApiKeyBase, UserColumn):
     __table_args__ = (
         UniqueConstraint("digest"),
         {"extend_existing": True, "schema": "authn"},

--- a/pkgs/standards/auto_authn/auto_authn/orm/auth_code.py
+++ b/pkgs/standards/auto_authn/auto_authn/orm/auth_code.py
@@ -6,7 +6,7 @@ import datetime as dt
 import uuid
 
 from autoapi.v3.orm.tables import Base
-from autoapi.v3.orm.mixins import TenantMixin, Timestamped, UserMixin
+from autoapi.v3.orm.mixins import TenantColumn, Timestamped, UserColumn
 from autoapi.v3.specs import S, acol
 from autoapi.v3.specs.storage_spec import ForeignKeySpec
 from autoapi.v3.types import JSON, PgUUID, String, TZDateTime, Mapped
@@ -20,7 +20,7 @@ from ..routers.shared import _jwt, _require_tls
 from .user import User
 
 
-class AuthCode(Base, Timestamped, UserMixin, TenantMixin):
+class AuthCode(Base, Timestamped, UserColumn, TenantColumn):
     __tablename__ = "auth_codes"
     __table_args__ = ({"schema": "authn"},)
 

--- a/pkgs/standards/auto_authn/auto_authn/orm/auth_session.py
+++ b/pkgs/standards/auto_authn/auto_authn/orm/auth_session.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import datetime as dt
 
 from autoapi.v3.orm.tables import Base
-from autoapi.v3.orm.mixins import TenantMixin, Timestamped, UserMixin
+from autoapi.v3.orm.mixins import TenantColumn, Timestamped, UserColumn
 from autoapi.v3.specs import S, acol
 from autoapi.v3.types import Mapped, String, TZDateTime
 from autoapi.v3 import hook_ctx, op_ctx
@@ -13,7 +13,7 @@ from fastapi import HTTPException, status
 from fastapi.responses import JSONResponse, Response
 
 
-class AuthSession(Base, Timestamped, UserMixin, TenantMixin):
+class AuthSession(Base, Timestamped, UserColumn, TenantColumn):
     __tablename__ = "sessions"
     __table_args__ = ({"schema": "authn"},)
 

--- a/pkgs/standards/autoapi/autoapi/v3/orm/mixins/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/orm/mixins/__init__.py
@@ -84,7 +84,7 @@ class GUIDPk:
 
 
 @declarative_mixin
-class TenantMixin:
+class TenantColumn:
     """
     Adds tenant_id with a schema-qualified FK to <schema>.tenants.id.
     Schema is inferred from the mapped subclass's __table_args__ unless
@@ -108,10 +108,10 @@ class TenantMixin:
 
 
 # ──────────────────────────────────────────────────────────────────────────────
-# User FK mixin
+# User FK column
 # ──────────────────────────────────────────────────────────────────────────────
 @declarative_mixin
-class UserMixin:
+class UserColumn:
     """
     Adds user_id with a schema-qualified FK to <schema>.users.id.
     Schema is inferred from the mapped subclass's __table_args__ unless
@@ -135,7 +135,7 @@ class UserMixin:
 
 
 @declarative_mixin
-class OrgMixin:
+class OrgColumn:
     """
     Adds user_id with a schema-qualified FK to <schema>.users.id.
     Schema is inferred from the mapped subclass's __table_args__ unless
@@ -468,9 +468,9 @@ class Slugged:
 
 
 # ----------------------------------------------------------------------
-# StatusMixin ── finite workflow states
+# StatusColumn ── finite workflow states
 @declarative_mixin
-class StatusMixin:
+class StatusColumn:
     status: Mapped[str] = acol(
         spec=ColumnSpec(
             storage=S(

--- a/pkgs/standards/autoapi/tests/i9n/test_mixins.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_mixins.py
@@ -24,7 +24,7 @@ from autoapi.v3.orm.mixins import (
     Replaceable,
     Slugged,
     SoftDelete,
-    StatusMixin,
+    StatusColumn,
     Streamable,
     Timestamped,
     ValidityWindow,
@@ -105,10 +105,10 @@ class DummyModelSlugged(Base, GUIDPk, Slugged):
     name = Column(String)
 
 
-class DummyModelStatusMixin(Base, GUIDPk, StatusMixin):
-    """Test model for StatusMixin."""
+class DummyModelStatusColumn(Base, GUIDPk, StatusColumn):
+    """Test model for StatusColumn."""
 
-    __tablename__ = "dummy_status_mixin"
+    __tablename__ = "dummy_status_column"
     name = Column(String)
 
 
@@ -322,13 +322,13 @@ async def test_slugged_mixin(create_test_api):
 
 @pytest.mark.i9n
 @pytest.mark.asyncio
-async def test_status_mixin(create_test_api):
-    """Test that StatusMixin adds status field."""
-    create_test_api(DummyModelStatusMixin)
+async def test_status_column(create_test_api):
+    """Test that StatusColumn adds status field."""
+    create_test_api(DummyModelStatusColumn)
 
     # Get schemas
-    create_schema = _build_schema(DummyModelStatusMixin, verb="create")
-    read_schema = _build_schema(DummyModelStatusMixin, verb="read")
+    create_schema = _build_schema(DummyModelStatusColumn, verb="create")
+    read_schema = _build_schema(DummyModelStatusColumn, verb="read")
 
     # status should be in schemas
     assert "status" in create_schema.model_fields
@@ -489,7 +489,7 @@ async def test_multiple_mixins_combination(create_test_api):
     """Test that multiple mixins can be combined correctly."""
 
     class DummyMultipleMixins(
-        Base, GUIDPk, Timestamped, ActiveToggle, Slugged, StatusMixin
+        Base, GUIDPk, Timestamped, ActiveToggle, Slugged, StatusColumn
     ):
         __tablename__ = "dummy_multiple_mixins"
         name = Column(String)
@@ -509,7 +509,7 @@ async def test_multiple_mixins_combination(create_test_api):
     assert "slug" in create_schema.model_fields
     assert "slug" in read_schema.model_fields
 
-    # From StatusMixin
+    # From StatusColumn
     assert "status" in create_schema.model_fields
     assert "status" in read_schema.model_fields
 

--- a/pkgs/standards/peagen/peagen/orm/keys.py
+++ b/pkgs/standards/peagen/peagen/orm/keys.py
@@ -11,7 +11,7 @@ from autoapi.v3.types import (
     Mapped,
     relationship,
 )
-from autoapi.v3.orm.mixins import GUIDPk, Timestamped, UserMixin
+from autoapi.v3.orm.mixins import GUIDPk, Timestamped, UserColumn
 from autoapi.v3.specs import S, acol
 from autoapi.v3 import hook_ctx
 from typing import TYPE_CHECKING
@@ -21,7 +21,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from .repositories import Repository
 
 
-class PublicKey(Base, GUIDPk, UserMixin, Timestamped, HookProvider):
+class PublicKey(Base, GUIDPk, UserColumn, Timestamped, HookProvider):
     __tablename__ = "public_keys"
     __table_args__ = (
         UniqueConstraint("user_id", "public_key"),
@@ -58,7 +58,7 @@ class PublicKey(Base, GUIDPk, UserMixin, Timestamped, HookProvider):
         # hooks registered via @hook_ctx
 
 
-class GPGKey(Base, GUIDPk, UserMixin, Timestamped, HookProvider):
+class GPGKey(Base, GUIDPk, UserColumn, Timestamped, HookProvider):
     __tablename__ = "gpg_keys"
     __table_args__ = (
         UniqueConstraint("user_id", "gpg_key"),

--- a/pkgs/standards/peagen/peagen/orm/repositories.py
+++ b/pkgs/standards/peagen/peagen/orm/repositories.py
@@ -18,7 +18,7 @@ from autoapi.v3.orm.mixins import (
     TenantPolicy,
     Ownable,
     OwnerPolicy,
-    StatusMixin,
+    StatusColumn,
 )
 from autoapi.v3.runtime.errors import create_standardized_error
 from autoapi.v3.specs import F, IO, S, acol, vcol
@@ -30,7 +30,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from .tasks import Task
 
 
-class Repository(Base, GUIDPk, Timestamped, Ownable, TenantBound, StatusMixin):
+class Repository(Base, GUIDPk, Timestamped, Ownable, TenantBound, StatusColumn):
     __tablename__ = "repositories"
     __table_args__ = (
         UniqueConstraint("url"),

--- a/pkgs/standards/peagen/peagen/orm/secrets.py
+++ b/pkgs/standards/peagen/peagen/orm/secrets.py
@@ -9,7 +9,7 @@ from autoapi.v3.types import (
     relationship,
     Mapped,
 )
-from autoapi.v3.orm.mixins import GUIDPk, OrgMixin, Timestamped, UserMixin
+from autoapi.v3.orm.mixins import GUIDPk, OrgColumn, Timestamped, UserColumn
 from autoapi.v3.specs import S, acol
 from autoapi.v3 import hook_ctx
 from typing import TYPE_CHECKING
@@ -29,7 +29,7 @@ class _SecretCoreMixin:
     )
 
 
-class UserSecret(Base, GUIDPk, _SecretCoreMixin, UserMixin, Timestamped):
+class UserSecret(Base, GUIDPk, _SecretCoreMixin, UserColumn, Timestamped):
     __tablename__ = "user_secrets"
     __table_args__ = (
         UniqueConstraint("user_id", "name"),
@@ -37,7 +37,7 @@ class UserSecret(Base, GUIDPk, _SecretCoreMixin, UserMixin, Timestamped):
     )
 
 
-class OrgSecret(Base, GUIDPk, _SecretCoreMixin, OrgMixin, Timestamped):
+class OrgSecret(Base, GUIDPk, _SecretCoreMixin, OrgColumn, Timestamped):
     __tablename__ = "org_secrets"
     __table_args__ = (
         UniqueConstraint("org_id", "name"),

--- a/pkgs/standards/peagen/peagen/orm/tasks.py
+++ b/pkgs/standards/peagen/peagen/orm/tasks.py
@@ -19,7 +19,7 @@ from autoapi.v3.orm.mixins import (
     Timestamped,
     TenantBound,
     Ownable,
-    StatusMixin,
+    StatusColumn,
 )
 from autoapi.v3.specs import S, acol
 from autoapi.v3.specs.storage_spec import ForeignKeySpec
@@ -55,7 +55,7 @@ class Task(
     TenantBound,
     Ownable,
     RepositoryRefMixin,
-    StatusMixin,
+    StatusColumn,
     HookProvider,
 ):
     __tablename__ = "tasks"

--- a/pkgs/standards/peagen/peagen/orm/user_repositories.py
+++ b/pkgs/standards/peagen/peagen/orm/user_repositories.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 from autoapi.v3.orm.tables import Base
-from autoapi.v3.orm.mixins import GUIDPk, UserMixin
+from autoapi.v3.orm.mixins import GUIDPk, UserColumn
 
 from .mixins import RepositoryMixin
 
 
-class UserRepository(Base, GUIDPk, RepositoryMixin, UserMixin):
+class UserRepository(Base, GUIDPk, RepositoryMixin, UserColumn):
     """Edge capturing any per-repository permission or ownership the user may have."""
 
     __tablename__ = "user_repositories"

--- a/pkgs/standards/peagen/peagen/orm/works.py
+++ b/pkgs/standards/peagen/peagen/orm/works.py
@@ -9,7 +9,7 @@ from autoapi.v3.types import (
     HookProvider,
     Mapped,
 )
-from autoapi.v3.orm.mixins import GUIDPk, Timestamped, StatusMixin
+from autoapi.v3.orm.mixins import GUIDPk, Timestamped, StatusColumn
 from autoapi.v3.specs import S, acol
 from autoapi.v3.specs.storage_spec import ForeignKeySpec
 from autoapi.v3 import hook_ctx
@@ -21,7 +21,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from .eval_result import EvalResult
 
 
-class Work(Base, GUIDPk, Timestamped, StatusMixin, HookProvider):
+class Work(Base, GUIDPk, Timestamped, StatusColumn, HookProvider):
     __tablename__ = "works"
     __table_args__ = ({"schema": "peagen"},)
     task_id: Mapped[PgUUID] = acol(


### PR DESCRIPTION
## Summary
- rename TenantMixin, UserMixin, OrgMixin, and StatusMixin to *Column counterparts in AutoAPI v3
- update authentication, peagen modules, and tests to use the new mixin names

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check . --fix`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b5cd667c248326b2d63cdebb8d4866