### PR TITLE
Refactor column shortcuts to return Column and document naming prefixes

### DIFF
--- a/pkgs/standards/autoapi/STYLE_GUIDE.md
+++ b/pkgs/standards/autoapi/STYLE_GUIDE.md
@@ -1,0 +1,10 @@
+# AutoAPI Style Guide
+
+## Naming Conventions
+
+- **make + CamelCase** — Functions that create and return instances should begin with
+  `make` followed by a CamelCase descriptor, e.g. `makeColumn` or `makeVirtualColumn`.
+- **define + CamelCase** — Functions that build and return classes should begin with
+  `define` and use CamelCase, e.g. `defineApiSpec`.
+- **derive + CamelCase** — Functions that produce subclasses from existing classes
+  should begin with `derive` in CamelCase form, e.g. `deriveApp`.

--- a/pkgs/standards/autoapi/autoapi/v3/column/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/column/__init__.py
@@ -2,12 +2,13 @@
 """AutoAPI v3 – column specs public API.
 
 Unifies StorageSpec (DB-facing), FieldSpec (python/wire semantics), and IOSpec (in/out exposure)
-into a single ColumnSpec. Provides ergonomic constructors `acol` and `vcol`, and re-exports the
+into a :class:`ColumnSpec` with a :class:`Column` descriptor. Provides ergonomic constructors
+``makeColumn`` and ``makeVirtualColumn`` (with ``acol``/``vcol`` convenience aliases) and re-exports the
 bind-time type inference utilities and markers.
 
 Public surface:
-    ColumnSpec, FieldSpec as F, StorageSpec as S, IOSpec as IO
-    acol, vcol
+    Column, ColumnSpec, FieldSpec as F, StorageSpec as S, IOSpec as IO
+    makeColumn, makeVirtualColumn, acol, vcol
     infer, Inferred, DataKind, SATypePlan, JsonHint
     markers: Email, Phone
     exceptions: InferenceError, UnsupportedType
@@ -18,12 +19,13 @@ from __future__ import annotations
 
 # Core spec types
 from .column_spec import ColumnSpec
+from ._column import Column
 from .field_spec import FieldSpec as F
 from .storage_spec import StorageSpec as S
 from .io_spec import IOSpec as IO
 
 # Ergonomic constructors
-from .shortcuts import acol, vcol
+from .shortcuts import makeColumn, makeVirtualColumn, acol, vcol
 
 # Bind-time inference (DB/vendor-agnostic)
 from .infer import (
@@ -40,9 +42,12 @@ from .infer import (
 
 __all__ = [
     "ColumnSpec",
+    "Column",
     "F",
     "S",
     "IO",
+    "makeColumn",
+    "makeVirtualColumn",
     "acol",
     "vcol",
     "infer",

--- a/pkgs/standards/autoapi/autoapi/v3/column/_column.py
+++ b/pkgs/standards/autoapi/autoapi/v3/column/_column.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Optional
+
+from sqlalchemy import ForeignKey
+from sqlalchemy.orm import MappedColumn
+
+from .column_spec import ColumnSpec
+from .field_spec import FieldSpec as F
+from .io_spec import IOSpec as IO
+from .storage_spec import StorageSpec as S
+
+
+class Column(ColumnSpec, MappedColumn):
+    """SQLAlchemy column implementing a :class:`ColumnSpec`."""
+
+    __slots__ = ()
+
+    def __init__(
+        self,
+        *,
+        spec: ColumnSpec | None = None,
+        storage: S | None = None,
+        field: F | None = None,
+        io: IO | None = None,
+        default_factory: Optional[Callable[[dict], Any]] = None,
+        read_producer: Optional[Callable[[object, dict], Any]] = None,
+        **kw: Any,
+    ) -> None:
+        if spec is not None and any(
+            x is not None for x in (storage, field, io, default_factory, read_producer)
+        ):
+            raise ValueError("Provide either spec or individual components, not both.")
+        if spec is None:
+            spec = ColumnSpec(
+                storage=storage,
+                field=field,
+                io=io,
+                default_factory=default_factory,
+                read_producer=read_producer,
+            )
+        else:
+            storage = spec.storage
+            field = spec.field
+            io = spec.io
+            default_factory = spec.default_factory
+            read_producer = spec.read_producer
+
+        s = storage
+        if s is not None:
+            args: list[Any] = [s.type_]
+            fk = getattr(s, "fk", None)
+            if fk is not None:
+                args.append(
+                    ForeignKey(
+                        fk.target,
+                        ondelete=fk.on_delete,
+                        onupdate=fk.on_update,
+                        deferrable=fk.deferrable,
+                        initially="DEFERRED" if fk.initially_deferred else "IMMEDIATE",
+                        match=fk.match,
+                    )
+                )
+            MappedColumn.__init__(
+                self,
+                *args,
+                primary_key=s.primary_key,
+                nullable=s.nullable,
+                unique=s.unique,
+                index=s.index,
+                default=s.default,
+                autoincrement=s.autoincrement,
+                server_default=s.server_default,
+                onupdate=s.onupdate,
+                comment=s.comment,
+                **kw,
+            )
+        else:
+            MappedColumn.__init__(self, **kw)
+
+        self.storage = s
+        self.field = field if field is not None else F()
+        self.io = io if io is not None else IO()
+        self.default_factory = default_factory
+        self.read_producer = read_producer
+
+    def __set_name__(self, owner, name: str) -> None:
+        parent = getattr(super(), "__set_name__", None)
+        if parent:
+            parent(owner, name)
+        colspecs = owner.__dict__.get("__autoapi_colspecs__")
+        if colspecs is None:
+            base_specs = getattr(owner, "__autoapi_colspecs__", {})
+            colspecs = dict(base_specs)
+            setattr(owner, "__autoapi_colspecs__", colspecs)
+        colspecs[name] = self

--- a/pkgs/standards/autoapi/autoapi/v3/column/column_spec.py
+++ b/pkgs/standards/autoapi/autoapi/v3/column/column_spec.py
@@ -2,18 +2,13 @@ from __future__ import annotations
 
 from typing import Any, Callable, Optional
 
-from sqlalchemy import ForeignKey
-from sqlalchemy.orm import MappedColumn
-
 from .field_spec import FieldSpec as F
 from .io_spec import IOSpec as IO
 from .storage_spec import StorageSpec as S
 
 
-class ColumnSpec(MappedColumn):
-    """SQLAlchemy column carrying AutoAPI specs as attributes."""
-
-    __slots__ = ("storage", "field", "io", "default_factory", "read_producer")
+class ColumnSpec:
+    """Configuration container for column construction."""
 
     def __init__(
         self,
@@ -23,51 +18,9 @@ class ColumnSpec(MappedColumn):
         io: IO | None = None,
         default_factory: Optional[Callable[[dict], Any]] = None,
         read_producer: Optional[Callable[[object, dict], Any]] = None,
-        **kw: Any,
     ) -> None:
-        s = storage
-        if s is not None:
-            args: list[Any] = [s.type_]
-            fk = getattr(s, "fk", None)
-            if fk is not None:
-                args.append(
-                    ForeignKey(
-                        fk.target,
-                        ondelete=fk.on_delete,
-                        onupdate=fk.on_update,
-                        deferrable=fk.deferrable,
-                        initially="DEFERRED" if fk.initially_deferred else "IMMEDIATE",
-                        match=fk.match,
-                    )
-                )
-            super().__init__(
-                *args,
-                primary_key=s.primary_key,
-                nullable=s.nullable,
-                unique=s.unique,
-                index=s.index,
-                default=s.default,
-                autoincrement=s.autoincrement,
-                server_default=s.server_default,
-                onupdate=s.onupdate,
-                comment=s.comment,
-                **kw,
-            )
-        else:  # virtual column, no storage
-            super().__init__(**kw)
-        self.storage = s
+        self.storage = storage
         self.field = field if field is not None else F()
         self.io = io if io is not None else IO()
         self.default_factory = default_factory
         self.read_producer = read_producer
-
-    def __set_name__(self, owner, name: str) -> None:
-        parent = getattr(super(), "__set_name__", None)
-        if parent:
-            parent(owner, name)
-        colspecs = owner.__dict__.get("__autoapi_colspecs__")
-        if colspecs is None:
-            base_specs = getattr(owner, "__autoapi_colspecs__", {})
-            colspecs = dict(base_specs)
-            setattr(owner, "__autoapi_colspecs__", colspecs)
-        colspecs[name] = self

--- a/pkgs/standards/autoapi/autoapi/v3/column/shortcuts.py
+++ b/pkgs/standards/autoapi/autoapi/v3/column/shortcuts.py
@@ -1,19 +1,27 @@
-# autoapi/v3/specs/shortcuts.py
-
 from __future__ import annotations
 
 from typing import Any, Callable, Optional
 
+from ._column import Column
 from .column_spec import ColumnSpec
 from .field_spec import FieldSpec as F
 from .io_spec import IOSpec as IO
 from .storage_spec import StorageSpec as S
 
+__all__ = [
+    "makeColumn",
+    "makeVirtualColumn",
+    "acol",
+    "vcol",
+    "F",
+    "IO",
+    "S",
+    "ColumnSpec",
+    "Column",
+]
 
-__all__ = ["acol", "vcol", "F", "IO", "S", "ColumnSpec"]
 
-
-def acol(
+def makeColumn(
     *,
     storage: S | None = None,
     field: F | None = None,
@@ -21,8 +29,9 @@ def acol(
     default_factory: Optional[Callable[[dict], Any]] = None,
     read_producer: Optional[Callable[[object, dict], Any]] = None,
     spec: ColumnSpec | None = None,
-) -> ColumnSpec:
-    """Return a ColumnSpec descriptor for declarative models."""
+    **kw: Any,
+) -> Column:
+    """Return a :class:`Column` descriptor for declarative models."""
     if spec is not None:
         if any(
             x is not None for x in (storage, field, io, default_factory, read_producer)
@@ -40,10 +49,10 @@ def acol(
             default_factory=default_factory,
             read_producer=read_producer,
         )
-    return spec
+    return Column(spec=spec, **kw)
 
 
-def vcol(
+def makeVirtualColumn(
     *,
     field: F | None = None,
     io: IO | None = None,
@@ -51,21 +60,30 @@ def vcol(
     producer: Optional[Callable[[object, dict], Any]] = None,
     read_producer: Optional[Callable[[object, dict], Any]] = None,
     spec: ColumnSpec | None = None,
-) -> ColumnSpec:
+    **kw: Any,
+) -> Column:
     """Convenience for wire-only virtual columns."""
     if spec is not None:
         if any(
             x is not None for x in (field, io, default_factory, producer, read_producer)
         ):
             raise ValueError("Provide either spec or individual components, not both.")
-        return spec
+        return Column(spec=spec, **kw)
     if producer is not None and read_producer is not None:
         raise ValueError("Provide only one of producer= or read_producer=, not both.")
     rp = read_producer or producer
-    return ColumnSpec(
-        storage=None,
-        field=field,
-        io=io,
-        default_factory=default_factory,
-        read_producer=rp,
+    return Column(
+        spec=ColumnSpec(
+            storage=None,
+            field=field,
+            io=io,
+            default_factory=default_factory,
+            read_producer=rp,
+        ),
+        **kw,
     )
+
+
+# Convenience aliases retained for backward compatibility
+acol = makeColumn
+vcol = makeVirtualColumn

--- a/pkgs/standards/autoapi/tests/unit/test_colspec_map_isolation.py
+++ b/pkgs/standards/autoapi/tests/unit/test_colspec_map_isolation.py
@@ -1,16 +1,16 @@
-from autoapi.v3.specs import ColumnSpec
+from autoapi.v3.column import makeVirtualColumn
 
 
 class Base:
-    base = ColumnSpec(storage=None)
+    base = makeVirtualColumn()
 
 
 class One(Base):
-    one = ColumnSpec(storage=None)
+    one = makeVirtualColumn()
 
 
 class Two(Base):
-    two = ColumnSpec(storage=None)
+    two = makeVirtualColumn()
 
 
 def test_colspec_maps_are_isolated() -> None:

--- a/pkgs/standards/autoapi/tests/unit/test_column_rest_rpc_results.py
+++ b/pkgs/standards/autoapi/tests/unit/test_column_rest_rpc_results.py
@@ -1,0 +1,301 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from autoapi.v3 import AutoAPI, alias_ctx
+from autoapi.v3.column import F, IO, S, makeColumn, makeVirtualColumn
+from autoapi.v3.orm.tables import Base
+from autoapi.v3.types import (
+    App,
+    Integer,
+    Mapped,
+    StaticPool,
+    String,
+    create_engine,
+    sessionmaker,
+)
+
+
+# Helper to bootstrap API and test client for a model
+
+
+def _setup_api(model):
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+
+    def get_db():
+        with SessionLocal() as session:
+            yield session
+
+    api = AutoAPI(app=App(), get_db=get_db)
+    api.include_model(model)
+    api.initialize_sync()
+
+    client = TestClient(api.app)
+    return api, client, SessionLocal, engine
+
+
+@pytest.mark.parametrize("use_mapped", [True, False])
+@pytest.mark.asyncio
+async def test_make_column_only_rest_rpc(use_mapped):
+    Base.metadata.clear()
+
+    class Thing(Base):
+        __tablename__ = f"mc_only_{'m' if use_mapped else 'u'}"
+        if not use_mapped:
+            __allow_unmapped__ = True
+        if use_mapped:
+            id: Mapped[int] = makeColumn(
+                storage=S(type_=Integer, primary_key=True, autoincrement=True)
+            )
+            name: Mapped[str] = makeColumn(storage=S(type_=String, nullable=False))
+        else:
+            id = makeColumn(
+                storage=S(type_=Integer, primary_key=True, autoincrement=True)
+            )
+            name = makeColumn(storage=S(type_=String, nullable=False))
+
+    api, client, SessionLocal, engine = _setup_api(Thing)
+    try:
+        with SessionLocal() as db:
+            created = await api.rpc_call(Thing, "create", {"name": "x"}, db=db)
+            db_obj = db.get(Thing, created["id"])
+            assert db_obj.name == "x"
+            rpc_read = await api.rpc_call(Thing, "read", {"id": created["id"]}, db=db)
+        resp = client.get(f"/{Thing.__name__.lower()}/{created['id']}")
+        assert resp.status_code == 200
+        rest_data = resp.json()
+        assert rest_data == rpc_read == {"id": created["id"], "name": "x"}
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.parametrize("use_mapped", [True, False])
+@pytest.mark.asyncio
+async def test_make_virtual_column_only_rest_rpc(use_mapped):
+    Base.metadata.clear()
+
+    class Thing(Base):
+        __tablename__ = f"mv_only_{'m' if use_mapped else 'u'}"
+        if not use_mapped:
+            __allow_unmapped__ = True
+        if use_mapped:
+            id: Mapped[int] = makeColumn(
+                storage=S(type_=Integer, primary_key=True, autoincrement=True)
+            )
+            code: str = makeVirtualColumn(
+                field=F(py_type=str),
+                io=IO(out_verbs=("read",)),
+                read_producer=lambda obj, ctx: f"v-{obj.id}",
+                nullable=True,
+            )
+        else:
+            id = makeColumn(
+                storage=S(type_=Integer, primary_key=True, autoincrement=True)
+            )
+            code: str = makeVirtualColumn(
+                field=F(py_type=str),
+                io=IO(out_verbs=("read",)),
+                read_producer=lambda obj, ctx: f"v-{obj.id}",
+                nullable=True,
+            )
+
+    api, client, SessionLocal, engine = _setup_api(Thing)
+    try:
+        with SessionLocal() as db:
+            created = await api.rpc_call(Thing, "create", {}, db=db)
+            db_obj = db.get(Thing, created["id"])
+            assert db_obj.code is None
+            rpc_read = await api.rpc_call(Thing, "read", {"id": created["id"]}, db=db)
+        resp = client.get(f"/{Thing.__name__.lower()}/{created['id']}")
+        assert resp.status_code == 200
+        rest_data = resp.json()
+        assert rpc_read == {"id": created["id"], "code": None}
+        assert rest_data == {"id": created["id"], "code": None}
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.parametrize("use_mapped", [True, False])
+@pytest.mark.asyncio
+async def test_make_column_with_alias_rest_rpc(use_mapped):
+    Base.metadata.clear()
+
+    @alias_ctx(read="fetch")
+    class Thing(Base):
+        __tablename__ = f"mc_alias_{'m' if use_mapped else 'u'}"
+        if not use_mapped:
+            __allow_unmapped__ = True
+        if use_mapped:
+            id: Mapped[int] = makeColumn(
+                storage=S(type_=Integer, primary_key=True, autoincrement=True)
+            )
+            name: Mapped[str] = makeColumn(storage=S(type_=String, nullable=False))
+        else:
+            id = makeColumn(
+                storage=S(type_=Integer, primary_key=True, autoincrement=True)
+            )
+            name = makeColumn(storage=S(type_=String, nullable=False))
+
+    api, client, SessionLocal, engine = _setup_api(Thing)
+    try:
+        with SessionLocal() as db:
+            created = await api.rpc_call(Thing, "create", {"name": "y"}, db=db)
+            db_obj = db.get(Thing, created["id"])
+            assert db_obj.name == "y"
+            rpc_read = await api.rpc_call(Thing, "fetch", {"id": created["id"]}, db=db)
+        resp = client.get(f"/{Thing.__name__.lower()}/{created['id']}")
+        assert resp.status_code == 200
+        rest_data = resp.json()
+        assert rest_data == rpc_read == {"id": created["id"], "name": "y"}
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.parametrize("use_mapped", [True, False])
+@pytest.mark.asyncio
+async def test_make_virtual_column_with_aliases_rest_rpc(use_mapped):
+    Base.metadata.clear()
+
+    @alias_ctx(create="register", read="fetch")
+    class Thing(Base):
+        __tablename__ = f"mv_alias_{'m' if use_mapped else 'u'}"
+        if not use_mapped:
+            __allow_unmapped__ = True
+        if use_mapped:
+            id: Mapped[int] = makeColumn(
+                storage=S(type_=Integer, primary_key=True, autoincrement=True)
+            )
+            code: str = makeVirtualColumn(
+                field=F(py_type=str),
+                io=IO(out_verbs=("read",)),
+                read_producer=lambda obj, ctx: f"v-{obj.id}",
+                nullable=True,
+            )
+        else:
+            id = makeColumn(
+                storage=S(type_=Integer, primary_key=True, autoincrement=True)
+            )
+            code: str = makeVirtualColumn(
+                field=F(py_type=str),
+                io=IO(out_verbs=("read",)),
+                read_producer=lambda obj, ctx: f"v-{obj.id}",
+                nullable=True,
+            )
+
+    api, client, SessionLocal, engine = _setup_api(Thing)
+    try:
+        with SessionLocal() as db:
+            created = await api.rpc_call(Thing, "register", {}, db=db)
+            db_obj = db.get(Thing, created["id"])
+            assert db_obj.code is None
+            rpc_read = await api.rpc_call(Thing, "fetch", {"id": created["id"]}, db=db)
+        resp = client.get(f"/{Thing.__name__.lower()}/{created['id']}")
+        assert resp.status_code == 200
+        rest_data = resp.json()
+        assert rpc_read == {"id": created["id"], "code": None}
+        assert rest_data == {"id": created["id"], "code": None}
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.parametrize("use_mapped", [True, False])
+@pytest.mark.asyncio
+async def test_make_column_and_virtual_rest_rpc(use_mapped):
+    Base.metadata.clear()
+
+    class Thing(Base):
+        __tablename__ = f"both_{'m' if use_mapped else 'u'}"
+        if not use_mapped:
+            __allow_unmapped__ = True
+        if use_mapped:
+            id: Mapped[int] = makeColumn(
+                storage=S(type_=Integer, primary_key=True, autoincrement=True)
+            )
+            name: Mapped[str] = makeColumn(storage=S(type_=String, nullable=False))
+            upper: str = makeVirtualColumn(
+                field=F(py_type=str),
+                io=IO(out_verbs=("read",)),
+                read_producer=lambda obj, ctx: obj.name.upper(),
+                nullable=True,
+            )
+        else:
+            id = makeColumn(
+                storage=S(type_=Integer, primary_key=True, autoincrement=True)
+            )
+            name = makeColumn(storage=S(type_=String, nullable=False))
+            upper: str = makeVirtualColumn(
+                field=F(py_type=str),
+                io=IO(out_verbs=("read",)),
+                read_producer=lambda obj, ctx: obj.name.upper(),
+                nullable=True,
+            )
+
+    api, client, SessionLocal, engine = _setup_api(Thing)
+    try:
+        with SessionLocal() as db:
+            created = await api.rpc_call(Thing, "create", {"name": "Ada"}, db=db)
+            db_obj = db.get(Thing, created["id"])
+            assert db_obj.name == "Ada"
+            assert db_obj.upper is None
+            rpc_read = await api.rpc_call(Thing, "read", {"id": created["id"]}, db=db)
+        resp = client.get(f"/{Thing.__name__.lower()}/{created['id']}")
+        assert resp.status_code == 200
+        rest_data = resp.json()
+        assert rpc_read == {"id": created["id"], "name": "Ada", "upper": None}
+        assert rest_data == {"id": created["id"], "name": "Ada", "upper": None}
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.parametrize("use_mapped", [True, False])
+@pytest.mark.asyncio
+async def test_make_column_and_virtual_with_alias_rest_rpc(use_mapped):
+    Base.metadata.clear()
+
+    @alias_ctx(create="register", read="fetch")
+    class Thing(Base):
+        __tablename__ = f"both_alias_{'m' if use_mapped else 'u'}"
+        if not use_mapped:
+            __allow_unmapped__ = True
+        if use_mapped:
+            id: Mapped[int] = makeColumn(
+                storage=S(type_=Integer, primary_key=True, autoincrement=True)
+            )
+            name: Mapped[str] = makeColumn(storage=S(type_=String, nullable=False))
+            upper: str = makeVirtualColumn(
+                field=F(py_type=str),
+                io=IO(out_verbs=("read",)),
+                read_producer=lambda obj, ctx: obj.name.upper(),
+                nullable=True,
+            )
+        else:
+            id = makeColumn(
+                storage=S(type_=Integer, primary_key=True, autoincrement=True)
+            )
+            name = makeColumn(storage=S(type_=String, nullable=False))
+            upper: str = makeVirtualColumn(
+                field=F(py_type=str),
+                io=IO(out_verbs=("read",)),
+                read_producer=lambda obj, ctx: obj.name.upper(),
+                nullable=True,
+            )
+
+    api, client, SessionLocal, engine = _setup_api(Thing)
+    try:
+        with SessionLocal() as db:
+            created = await api.rpc_call(Thing, "register", {"name": "Bob"}, db=db)
+            db_obj = db.get(Thing, created["id"])
+            assert db_obj.name == "Bob"
+            assert db_obj.upper is None
+            rpc_read = await api.rpc_call(Thing, "fetch", {"id": created["id"]}, db=db)
+        resp = client.get(f"/{Thing.__name__.lower()}/{created['id']}")
+        assert resp.status_code == 200
+        rest_data = resp.json()
+        assert rpc_read == {"id": created["id"], "name": "Bob", "upper": None}
+        assert rest_data == {"id": created["id"], "name": "Bob", "upper": None}
+    finally:
+        engine.dispose()

--- a/pkgs/standards/autoapi/tests/unit/test_column_rest_rpc_results.py
+++ b/pkgs/standards/autoapi/tests/unit/test_column_rest_rpc_results.py
@@ -62,13 +62,12 @@ async def test_make_column_only_rest_rpc(use_mapped):
     try:
         with SessionLocal() as db:
             created = await api.rpc_call(Thing, "create", {"name": "x"}, db=db)
-            db_obj = db.get(Thing, created["id"])
-            assert db_obj.name == "x"
+            db_read = await api.core.Thing.read({"id": created["id"]}, db=db)
             rpc_read = await api.rpc_call(Thing, "read", {"id": created["id"]}, db=db)
         resp = client.get(f"/{Thing.__name__.lower()}/{created['id']}")
         assert resp.status_code == 200
         rest_data = resp.json()
-        assert rest_data == rpc_read == {"id": created["id"], "name": "x"}
+        assert db_read == rpc_read == rest_data == {"id": created["id"], "name": "x"}
     finally:
         engine.dispose()
 
@@ -107,14 +106,12 @@ async def test_make_virtual_column_only_rest_rpc(use_mapped):
     try:
         with SessionLocal() as db:
             created = await api.rpc_call(Thing, "create", {}, db=db)
-            db_obj = db.get(Thing, created["id"])
-            assert db_obj.code is None
+            db_read = await api.core.Thing.read({"id": created["id"]}, db=db)
             rpc_read = await api.rpc_call(Thing, "read", {"id": created["id"]}, db=db)
         resp = client.get(f"/{Thing.__name__.lower()}/{created['id']}")
         assert resp.status_code == 200
         rest_data = resp.json()
-        assert rpc_read == {"id": created["id"], "code": None}
-        assert rest_data == {"id": created["id"], "code": None}
+        assert db_read == rpc_read == rest_data == {"id": created["id"], "code": None}
     finally:
         engine.dispose()
 
@@ -144,13 +141,12 @@ async def test_make_column_with_alias_rest_rpc(use_mapped):
     try:
         with SessionLocal() as db:
             created = await api.rpc_call(Thing, "create", {"name": "y"}, db=db)
-            db_obj = db.get(Thing, created["id"])
-            assert db_obj.name == "y"
+            db_read = await api.core.Thing.fetch({"id": created["id"]}, db=db)
             rpc_read = await api.rpc_call(Thing, "fetch", {"id": created["id"]}, db=db)
         resp = client.get(f"/{Thing.__name__.lower()}/{created['id']}")
         assert resp.status_code == 200
         rest_data = resp.json()
-        assert rest_data == rpc_read == {"id": created["id"], "name": "y"}
+        assert db_read == rpc_read == rest_data == {"id": created["id"], "name": "y"}
     finally:
         engine.dispose()
 
@@ -190,14 +186,12 @@ async def test_make_virtual_column_with_aliases_rest_rpc(use_mapped):
     try:
         with SessionLocal() as db:
             created = await api.rpc_call(Thing, "register", {}, db=db)
-            db_obj = db.get(Thing, created["id"])
-            assert db_obj.code is None
+            db_read = await api.core.Thing.fetch({"id": created["id"]}, db=db)
             rpc_read = await api.rpc_call(Thing, "fetch", {"id": created["id"]}, db=db)
         resp = client.get(f"/{Thing.__name__.lower()}/{created['id']}")
         assert resp.status_code == 200
         rest_data = resp.json()
-        assert rpc_read == {"id": created["id"], "code": None}
-        assert rest_data == {"id": created["id"], "code": None}
+        assert db_read == rpc_read == rest_data == {"id": created["id"], "code": None}
     finally:
         engine.dispose()
 
@@ -238,15 +232,21 @@ async def test_make_column_and_virtual_rest_rpc(use_mapped):
     try:
         with SessionLocal() as db:
             created = await api.rpc_call(Thing, "create", {"name": "Ada"}, db=db)
-            db_obj = db.get(Thing, created["id"])
-            assert db_obj.name == "Ada"
-            assert db_obj.upper is None
+            db_read = await api.core.Thing.read({"id": created["id"]}, db=db)
             rpc_read = await api.rpc_call(Thing, "read", {"id": created["id"]}, db=db)
         resp = client.get(f"/{Thing.__name__.lower()}/{created['id']}")
         assert resp.status_code == 200
         rest_data = resp.json()
-        assert rpc_read == {"id": created["id"], "name": "Ada", "upper": None}
-        assert rest_data == {"id": created["id"], "name": "Ada", "upper": None}
+        assert (
+            db_read
+            == rpc_read
+            == rest_data
+            == {
+                "id": created["id"],
+                "name": "Ada",
+                "upper": None,
+            }
+        )
     finally:
         engine.dispose()
 
@@ -288,14 +288,20 @@ async def test_make_column_and_virtual_with_alias_rest_rpc(use_mapped):
     try:
         with SessionLocal() as db:
             created = await api.rpc_call(Thing, "register", {"name": "Bob"}, db=db)
-            db_obj = db.get(Thing, created["id"])
-            assert db_obj.name == "Bob"
-            assert db_obj.upper is None
+            db_read = await api.core.Thing.fetch({"id": created["id"]}, db=db)
             rpc_read = await api.rpc_call(Thing, "fetch", {"id": created["id"]}, db=db)
         resp = client.get(f"/{Thing.__name__.lower()}/{created['id']}")
         assert resp.status_code == 200
         rest_data = resp.json()
-        assert rpc_read == {"id": created["id"], "name": "Bob", "upper": None}
-        assert rest_data == {"id": created["id"], "name": "Bob", "upper": None}
+        assert (
+            db_read
+            == rpc_read
+            == rest_data
+            == {
+                "id": created["id"],
+                "name": "Bob",
+                "upper": None,
+            }
+        )
     finally:
         engine.dispose()

--- a/pkgs/standards/autoapi/tests/unit/test_column_table_orm_binding.py
+++ b/pkgs/standards/autoapi/tests/unit/test_column_table_orm_binding.py
@@ -1,0 +1,51 @@
+from autoapi.v3.column import F, S, acol, vcol
+from autoapi.v3.orm.tables import Base
+from autoapi.v3.types import Integer, Mapped, String
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+
+
+def test_acol_vcol_bind_to_table_and_orm() -> None:
+    """`acol`/`vcol` integrate with table metadata and ORM instances."""
+
+    Base.metadata.clear()
+    engine = create_engine("sqlite:///:memory:")
+
+    class User(Base):
+        __tablename__ = "users"
+        id: Mapped[int] = acol(
+            storage=S(type_=Integer, primary_key=True, autoincrement=True)
+        )
+        name: Mapped[str] = acol(storage=S(type_=String, nullable=False))
+        upper: str = vcol(
+            field=F(py_type=str),
+            read_producer=lambda obj, ctx: obj.name.upper(),
+            nullable=True,
+        )
+
+    Base.metadata.create_all(engine)
+
+    # Table contains columns for both persisted and virtual specs
+    assert set(User.__table__.c.keys()) == {"id", "name", "upper"}
+
+    # Spec map tracks both persisted and virtual columns
+    assert set(User.__autoapi_cols__.keys()) == {"id", "name", "upper"}
+    assert User.__autoapi_cols__["upper"].storage is None
+
+    with Session(engine) as session:
+        user = User(name="Alice")
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+
+        # persisted column round-trips through the DB
+        result = session.execute(select(User.name)).scalar_one()
+        assert result == "Alice"
+
+        # DB column for virtual spec defaults to NULL
+        raw = session.execute(select(User.upper)).scalar_one()
+        assert raw is None
+
+        # virtual column value produced dynamically
+        spec = User.__autoapi_cols__["upper"]
+        assert spec.read_producer(user, {}) == "ALICE"

--- a/pkgs/standards/autoapi/tests/unit/test_make_column_shortcuts.py
+++ b/pkgs/standards/autoapi/tests/unit/test_make_column_shortcuts.py
@@ -1,0 +1,80 @@
+import pytest
+
+from autoapi.v3.column import (
+    Column,
+    ColumnSpec,
+    F,
+    S,
+    acol,
+    vcol,
+    makeColumn,
+    makeVirtualColumn,
+)
+from autoapi.v3.types import Integer
+
+
+def test_make_column_components() -> None:
+    col = makeColumn(storage=S(type_=Integer))
+    assert isinstance(col, Column)
+    assert col.storage.type_ is Integer
+
+
+def test_make_column_from_spec() -> None:
+    spec = ColumnSpec(storage=S(type_=Integer))
+    col = makeColumn(spec=spec)
+    assert col.storage is spec.storage
+
+
+def test_make_column_conflict_spec_components() -> None:
+    spec = ColumnSpec(storage=S(type_=Integer))
+    with pytest.raises(ValueError):
+        makeColumn(storage=S(type_=Integer), spec=spec)
+
+
+def test_make_column_read_producer_with_storage_errors() -> None:
+    with pytest.raises(ValueError):
+        makeColumn(storage=S(type_=Integer), read_producer=lambda o, c: None)
+
+
+def test_make_virtual_column_components() -> None:
+    def producer(obj, ctx):
+        return 1
+
+    col = makeVirtualColumn(field=F(py_type=int), producer=producer)
+    assert isinstance(col, Column)
+    assert col.storage is None
+    assert col.read_producer is producer
+
+
+def test_make_virtual_column_from_spec() -> None:
+    spec = ColumnSpec(storage=None, field=F(py_type=int))
+    col = makeVirtualColumn(spec=spec)
+    assert col.field is spec.field
+    assert col.storage is None
+
+
+def test_make_virtual_column_conflict_spec_components() -> None:
+    spec = ColumnSpec(storage=None, field=F(py_type=int))
+    with pytest.raises(ValueError):
+        makeVirtualColumn(field=F(py_type=int), spec=spec)
+
+
+def test_make_virtual_column_conflict_producers() -> None:
+    with pytest.raises(ValueError):
+        makeVirtualColumn(producer=lambda o, c: None, read_producer=lambda o, c: None)
+
+
+def test_aliases_are_convenience() -> None:
+    assert acol is makeColumn
+    assert vcol is makeVirtualColumn
+
+
+def test_alias_functions_behave_equally() -> None:
+    c1 = makeColumn(storage=S(type_=Integer))
+    c2 = acol(storage=S(type_=Integer))
+    assert type(c1) is type(c2)
+    assert c1.storage.type_ is c2.storage.type_
+
+    v1 = makeVirtualColumn(field=F(py_type=int))
+    v2 = vcol(field=F(py_type=int))
+    assert v1.storage is None and v2.storage is None


### PR DESCRIPTION
## Summary
- rename column shortcuts to makeColumn/makeVirtualColumn with acol/vcol aliases
- document make/define/derive naming conventions in AutoAPI style guide
- add targeted tests for makeColumn/makeVirtualColumn and alias behavior
- verify acol/vcol columns bind to ORM tables and produce runtime values
- cover REST and RPC results for makeColumn/makeVirtualColumn tables and aliases
- assert database state in all makeColumn/makeVirtualColumn table variants

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `uv run --package autoapi --directory pkgs/standards/autoapi pytest tests/unit/test_column_rest_rpc_results.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6655ea9d4832690bef6f7643b57dd