### PR TITLE
feat(autoapi): expose starlette request

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/deps/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/deps/__init__.py
@@ -15,5 +15,5 @@ from .pydantic import *  # noqa: F403, F401
 # Re-export all FastAPI dependencies
 from .fastapi import *  # noqa: F403, F401
 
-# Note: starlette.py is reserved for future Starlette-specific imports
-# if we need to import directly from Starlette rather than through FastAPI
+# Re-export all Starlette dependencies
+from .starlette import *  # noqa: F403, F401

--- a/pkgs/standards/autoapi/autoapi/v3/deps/starlette.py
+++ b/pkgs/standards/autoapi/autoapi/v3/deps/starlette.py
@@ -1,0 +1,8 @@
+# ── Starlette Imports ──────────────────────────────────────────────────────
+from starlette.requests import Request as StarletteRequest
+
+
+# ── Public Exports ──────────────────────────────────────────────────────
+__all__ = [
+    "StarletteRequest",
+]


### PR DESCRIPTION
## Summary
- expose `StarletteRequest` through `autoapi.v3.deps`
- re-export `starlette` dependencies alongside FastAPI

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff format .`
- `uv run --directory standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b69d85471083269022de37942d26c3