### PR TITLE
fix: adapt AutoAPI to FastAPI APIRouter changes

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/autoapi.py
+++ b/pkgs/standards/autoapi/autoapi/v3/autoapi.py
@@ -74,8 +74,6 @@ class AutoAPI(_Api):
         **router_kwargs: Any,
     ) -> None:
         _Api.__init__(self, db=db, **router_kwargs)
-        # self acts as the aggregate router
-        self.router = self
         # DB dependencies for transports/diagnostics
         if get_db is not None:
             self.get_db = get_db
@@ -152,9 +150,7 @@ class AutoAPI(_Api):
         """
         # inject API-level hooks so the binder merges them
         self._merge_api_hooks_into_model(model, self._api_hooks_map)
-        return _include_model(
-            self, model, app=None, prefix=prefix, mount_router=mount_router
-        )
+        return _include_model(self, model, prefix=prefix, mount_router=mount_router)
 
     def include_models(
         self,
@@ -168,7 +164,6 @@ class AutoAPI(_Api):
         return _include_models(
             self,
             models,
-            app=None,
             base_prefix=base_prefix,
             mount_router=mount_router,
         )
@@ -190,7 +185,7 @@ class AutoAPI(_Api):
     # ------------------------- extras / mounting -------------------------
 
     def mount_jsonrpc(self, *, prefix: str | None = None) -> Any:
-        """Mount JSON-RPC router onto `.router` and the host app if present."""
+        """Mount JSON-RPC router onto this facade."""
         px = prefix if prefix is not None else self.jsonrpc_prefix
         router = _mount_jsonrpc(
             self,
@@ -202,7 +197,7 @@ class AutoAPI(_Api):
         return router
 
     def attach_diagnostics(self, *, prefix: str | None = None) -> Any:
-        """Mount diagnostics router onto `.router` and the host app if present."""
+        """Mount diagnostics router onto this facade."""
         px = prefix if prefix is not None else self.system_prefix
         router = _mount_diagnostics(
             self, get_db=self.get_db, get_async_db=self.get_async_db

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/api.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/api.py
@@ -312,12 +312,12 @@ def include_model(
         api: An arbitrary facade object; we’ll attach containers onto it if missing.
         model: The SQLAlchemy model (table class).
         app: Optional FastAPI app or Router (anything with `include_router`).
-             Routers are always mounted on `api.router`; if provided, we also
+             Routers are always mounted on `api` when possible; if provided, we also
              mount onto this `app` (or `api.app` when not given).
         prefix: Optional mount prefix. When None, defaults to `/{ModelClassName}` or
                 `/{__resource__}` if set on the model.
         mount_router: If False, we skip mounting onto the host app but still bind
-            the router under `api.router`/`api.rest`/`api.routers`.
+            the router under `api.rest`/`api.routers`.
 
     Returns:
         (model, router) – the model class and its Router (or None if not present).
@@ -333,8 +333,10 @@ def include_model(
     if prefix is None:
         prefix = _default_prefix(model)
 
-    # 3) Always bind model router to `api.router`
+    # 3) Always bind model router to `api` when possible
     root_router = getattr(api, "router", None)
+    if root_router is None and _has_include_router(api):
+        root_router = api
     if router is not None:
         _mount_router(root_router, router, prefix=prefix)
 


### PR DESCRIPTION
## Summary
- remove `app` attribute and `self.router` alias from `AutoAPI`
- mount included model routers directly on the API when it supports `include_router`

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b69bfc0a048326aba4a5e081db142a