### PR TITLE
fix: adapt AutoAPI to FastAPI APIRouter changes

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/autoapi.py
+++ b/pkgs/standards/autoapi/autoapi/v3/autoapi.py
@@ -74,8 +74,6 @@ class AutoAPI(_Api):
         **router_kwargs: Any,
     ) -> None:
         _Api.__init__(self, db=db, **router_kwargs)
-        # self acts as the aggregate router
-        self.router = self
         # DB dependencies for transports/diagnostics
         if get_db is not None:
             self.get_db = get_db
@@ -190,7 +188,7 @@ class AutoAPI(_Api):
     # ------------------------- extras / mounting -------------------------
 
     def mount_jsonrpc(self, *, prefix: str | None = None) -> Any:
-        """Mount JSON-RPC router onto `.router` and the host app if present."""
+        """Mount a JSON-RPC router onto this AutoAPI instance."""
         px = prefix if prefix is not None else self.jsonrpc_prefix
         router = _mount_jsonrpc(
             self,
@@ -202,7 +200,7 @@ class AutoAPI(_Api):
         return router
 
     def attach_diagnostics(self, *, prefix: str | None = None) -> Any:
-        """Mount diagnostics router onto `.router` and the host app if present."""
+        """Mount a diagnostics router onto this AutoAPI instance."""
         px = prefix if prefix is not None else self.system_prefix
         router = _mount_diagnostics(
             self, get_db=self.get_db, get_async_db=self.get_async_db

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/api.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/api.py
@@ -333,8 +333,8 @@ def include_model(
     if prefix is None:
         prefix = _default_prefix(model)
 
-    # 3) Always bind model router to `api.router`
-    root_router = getattr(api, "router", None)
+    # 3) Always bind model router to the API object when possible
+    root_router = api if _has_include_router(api) else getattr(api, "router", None)
     if router is not None:
         _mount_router(root_router, router, prefix=prefix)
 

--- a/pkgs/standards/autoapi/tests/unit/test_column_rest_rpc_results.py
+++ b/pkgs/standards/autoapi/tests/unit/test_column_rest_rpc_results.py
@@ -30,11 +30,13 @@ def _setup_api(model):
         with SessionLocal() as session:
             yield session
 
-    api = AutoAPI(app=App(), get_db=get_db)
+    api = AutoAPI(get_db=get_db)
     api.include_model(model)
     api.initialize_sync()
 
-    client = TestClient(api.app)
+    app = App()
+    app.include_router(api)
+    client = TestClient(app)
     return api, client, SessionLocal, engine
 
 


### PR DESCRIPTION
## Summary
- drop embedded `app` handling from `AutoAPI`
- mount model routers directly on the API instance
- adjust column REST/RPC tests to mount a separate FastAPI app

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b69bfc0a048326aba4a5e081db142a