### PR TITLE
Fix autoapi ops HookSpec import

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/ops/types.py
+++ b/pkgs/standards/autoapi/autoapi/v3/ops/types.py
@@ -7,7 +7,7 @@ from typing import Any, Literal, Mapping, Optional, Tuple, Union, cast
 
 from ..config.constants import CANON as CANONICAL_VERB_TUPLE
 from ..hook.types import PHASE, HookPhase, PHASES, Ctx, StepFn, HookPredicate
-from ..hook_spec import HookSpec as OpHook
+from ..hook import HookSpec as OpHook
 from ..response.types import ResponseSpec
 from typing import TYPE_CHECKING
 


### PR DESCRIPTION
## Summary
- fix incorrect HookSpec import in autoapi operation spec

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest -q --disable-warnings -p no:logging`

------
https://chatgpt.com/codex/tasks/task_e_68b6a9049c40832694d26e018445a769