### PR TITLE
Ensure unique FastAPI operation IDs

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
@@ -6,6 +6,7 @@ import logging
 import re
 import typing as _typing
 from types import SimpleNamespace
+from uuid import uuid4
 from typing import (
     Annotated,
     Any,
@@ -1396,11 +1397,13 @@ def _build_router(model: type, specs: Sequence[OpSpec]) -> Router:
         if auth_dep and sp.alias not in allow_anon and sp.target not in allow_anon:
             route_deps = _normalize_deps([auth_dep])
 
+        unique_id = f"{endpoint.__name__}_{uuid4().hex}"
         route_kwargs = dict(
             path=path,
             endpoint=endpoint,
             methods=methods,
             name=f"{model.__name__}.{sp.alias}",
+            operation_id=unique_id,
             summary=label,
             description=label,
             response_model=response_model,

--- a/pkgs/standards/autoapi/tests/unit/test_rest_operation_id_uniqueness.py
+++ b/pkgs/standards/autoapi/tests/unit/test_rest_operation_id_uniqueness.py
@@ -1,0 +1,36 @@
+from fastapi import FastAPI
+
+from autoapi.v3.bindings.rest import _build_router
+from autoapi.v3.ops import OpSpec
+from autoapi.v3.orm.mixins import GUIDPk
+from autoapi.v3.orm.tables import Base
+
+
+class Item(Base, GUIDPk):
+    __tablename__ = "items_operation_id"
+
+
+def _collect_operation_ids(schema: dict) -> list[str]:
+    ids: list[str] = []
+    for path in schema["paths"].values():
+        for method in path.values():
+            operation_id = method.get("operationId")
+            if operation_id:
+                ids.append(operation_id)
+    return ids
+
+
+def test_operation_ids_are_unique():
+    Base.metadata.clear()
+    router = _build_router(
+        Item,
+        [
+            OpSpec(alias="dup", target="custom", arity="collection"),
+            OpSpec(alias="dup", target="custom", arity="member"),
+        ],
+    )
+    app = FastAPI()
+    app.include_router(router)
+    schema = app.openapi()
+    operation_ids = _collect_operation_ids(schema)
+    assert len(operation_ids) == len(set(operation_ids))


### PR DESCRIPTION
## Summary
- avoid FastAPI duplicate operation id warnings by generating unique ids
- add regression test ensuring route operation ids are distinct

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi pytest tests/unit/test_rest_operation_id_uniqueness.py`

------
https://chatgpt.com/codex/tasks/task_e_68b6b39935988326b77852f2f2e543fb