### PR TITLE
Refactor AutoApp and AutoAPI to use engine bindings

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/app.py
+++ b/pkgs/standards/auto_authn/auto_authn/app.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from autoapi.v3 import AutoApp
 
 from .routers.surface import surface_api
+from .db import dsn
 from .runtime_cfg import settings
 from .rfc8414 import include_rfc8414
 from .oidc_discovery import include_oidc_discovery
@@ -35,6 +36,7 @@ app = AutoApp(
     version="0.1.0",
     openapi_url="/openapi.json",
     docs_url="/docs",
+    engine=dsn,
 )
 
 # Mount routers

--- a/pkgs/standards/auto_authn/auto_authn/routers/surface.py
+++ b/pkgs/standards/auto_authn/auto_authn/routers/surface.py
@@ -32,15 +32,13 @@ from auto_authn.orm import (
     ServiceKey,
     AuthSession,
 )
-from ..db import get_async_db  # same module as before
+from ..db import dsn
 from .auth_flows import router as flows_router
 
 # ----------------------------------------------------------------------
 # 3.  Build AutoAPI instance & router
 # ----------------------------------------------------------------------
-surface_api = AutoAPI(
-    get_async_db=get_async_db,
-)
+surface_api = AutoAPI(engine=dsn)
 
 surface_api.include_models(
     [Tenant, User, Client, ApiKey, Service, ServiceKey, AuthSession]

--- a/pkgs/standards/auto_authn/tests/conftest.py
+++ b/pkgs/standards/auto_authn/tests/conftest.py
@@ -20,6 +20,7 @@ from sqlalchemy.pool import StaticPool
 
 from auto_authn.app import app
 from auto_authn.db import get_async_db
+from auto_authn.routers.surface import surface_api
 from auto_authn.orm import Base, Tenant, User, Client, ApiKey
 from auto_authn.crypto import hash_pw
 
@@ -86,6 +87,7 @@ def override_get_db(db_session):
         yield db_session
 
     app.dependency_overrides[get_async_db] = _get_test_db
+    app.dependency_overrides[surface_api.get_async_db] = _get_test_db
     yield
     app.dependency_overrides.clear()
 

--- a/pkgs/standards/auto_kms/auto_kms/app.py
+++ b/pkgs/standards/auto_kms/auto_kms/app.py
@@ -10,7 +10,6 @@ import os
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
 
 DB_URL = os.getenv("KMS_DATABASE_URL", "sqlite+aiosqlite:///./kms.db")
-
 engine = create_async_engine(DB_URL, future=True, echo=False)
 AsyncSessionLocal = async_sessionmaker(
     engine, expire_on_commit=False, class_=AsyncSession
@@ -45,6 +44,7 @@ app = AutoApp(
     version="0.1.0",
     openapi_url="/openapi.json",
     docs_url="/docs",
+    engine=DB_URL,
     get_async_db=get_async_db,
     api_hooks={"*": {"PRE_TX_BEGIN": [_stash_ctx]}},
 )

--- a/pkgs/standards/autoapi/autoapi/v3/api/_api.py
+++ b/pkgs/standards/autoapi/autoapi/v3/api/_api.py
@@ -19,7 +19,9 @@ class Api(APISpec, ApiRouter):
     MODELS: tuple[Any, ...] = ()
     TABLES: tuple[Any, ...] = ()
 
-    def __init__(self, *, db: EngineCfg | None = None, **router_kwargs: Any) -> None:
+    def __init__(
+        self, *, engine: EngineCfg | None = None, **router_kwargs: Any
+    ) -> None:
         ApiRouter.__init__(
             self,
             prefix=self.PREFIX,
@@ -33,7 +35,7 @@ class Api(APISpec, ApiRouter):
         self.models: dict[str, type] = {}
         self.tables: dict[str, Any] = {}
 
-        ctx = db if db is not None else getattr(self, "DB", None)
+        ctx = engine if engine is not None else getattr(self, "ENGINE", None)
         if ctx is not None:
             _resolver.register_api(self, ctx)
 

--- a/pkgs/standards/autoapi/autoapi/v3/api/api_spec.py
+++ b/pkgs/standards/autoapi/autoapi/v3/api/api_spec.py
@@ -14,7 +14,7 @@ class APISpec:
 
     name: str = "api"
     prefix: str = ""
-    db: Optional[EngineCfg] = None
+    engine: Optional[EngineCfg] = None
     tags: Sequence[str] = field(default_factory=tuple)
 
     # NEW

--- a/pkgs/standards/autoapi/autoapi/v3/api/shortcuts.py
+++ b/pkgs/standards/autoapi/autoapi/v3/api/shortcuts.py
@@ -14,7 +14,7 @@ def defineApiSpec(
     prefix: str = "",
     tags: Sequence[str] = (),
     # engine
-    db: Any = None,
+    engine: Any = None,
     # composition
     ops: Sequence[Any] = (),
     schemas: Sequence[Any] = (),
@@ -27,7 +27,7 @@ def defineApiSpec(
     Build an API-spec class with class attributes only (no instances).
     Use it directly in your class MRO:
 
-        class TenantA(defineApiSpec(name="tenantA", db=...)):
+        class TenantA(defineApiSpec(name="tenantA", engine=...)):
             pass
 
     or pass it to `deriveApi(...)` to get a concrete API subclass.
@@ -36,7 +36,7 @@ def defineApiSpec(
         NAME=name,
         PREFIX=prefix,
         TAGS=tuple(tags or ()),
-        DB=db,
+        ENGINE=engine,
         OPS=tuple(ops or ()),
         SCHEMAS=tuple(schemas or ()),
         HOOKS=tuple(hooks or ()),

--- a/pkgs/standards/autoapi/autoapi/v3/app/_app.py
+++ b/pkgs/standards/autoapi/autoapi/v3/app/_app.py
@@ -14,7 +14,9 @@ from .app_spec import AppSpec
 
 
 class App(AppSpec, FastAPI):
-    def __init__(self, *, db: EngineCfg | None = None, **fastapi_kwargs: Any) -> None:
+    def __init__(
+        self, *, engine: EngineCfg | None = None, **fastapi_kwargs: Any
+    ) -> None:
         FastAPI.__init__(
             self,
             title=self.TITLE,
@@ -22,7 +24,7 @@ class App(AppSpec, FastAPI):
             lifespan=self.LIFESPAN,
             **fastapi_kwargs,
         )
-        ctx = db if db is not None else getattr(self, "DB", None)
+        ctx = engine if engine is not None else getattr(self, "ENGINE", None)
         if ctx is not None:
             _resolver.set_default(ctx)
         for mw in getattr(self, "MIDDLEWARES", []):

--- a/pkgs/standards/autoapi/autoapi/v3/app/app_spec.py
+++ b/pkgs/standards/autoapi/autoapi/v3/app/app_spec.py
@@ -15,7 +15,7 @@ class AppSpec:
 
     title: str = "AutoAPI"
     version: str = "0.1.0"
-    db: Optional[EngineCfg] = None
+    engine: Optional[EngineCfg] = None
 
     # NEW: multi-API composition (store API classes or instances)
     apis: Sequence[Any] = field(default_factory=tuple)

--- a/pkgs/standards/autoapi/autoapi/v3/app/shortcuts.py
+++ b/pkgs/standards/autoapi/autoapi/v3/app/shortcuts.py
@@ -11,7 +11,7 @@ def defineAppSpec(
     *,
     title: str = "AutoAPI",
     version: str = "0.1.0",
-    db: Any = None,
+    engine: Any = None,
     # composition
     apis: Sequence[Any] = (),
     ops: Sequence[Any] = (),
@@ -32,7 +32,7 @@ def defineAppSpec(
     Build an App-spec class with class attributes only (no instances).
     Use it directly in your class MRO:
 
-        class MyApp(defineAppSpec(title="Svc", db=...)):
+        class MyApp(defineAppSpec(title="Svc", engine=...)):
             pass
 
     or pass it to `deriveApp(...)` to get a concrete App subclass.
@@ -40,7 +40,7 @@ def defineAppSpec(
     attrs = dict(
         TITLE=title,
         VERSION=version,
-        DB=db,
+        ENGINE=engine,
         APIS=tuple(apis or ()),
         OPS=tuple(ops or ()),
         MODELS=tuple(models or ()),

--- a/pkgs/standards/autoapi/autoapi/v3/autoapi.py
+++ b/pkgs/standards/autoapi/autoapi/v3/autoapi.py
@@ -63,7 +63,7 @@ class AutoAPI(_Api):
     def __init__(
         self,
         *,
-        db: EngineCfg | None = None,
+        engine: EngineCfg | None = None,
         get_db: Optional[Callable[..., Any]] = None,
         get_async_db: Optional[Callable[..., Awaitable[Any]]] = None,
         jsonrpc_prefix: str = "/rpc",
@@ -73,15 +73,15 @@ class AutoAPI(_Api):
         | None = None,
         **router_kwargs: Any,
     ) -> None:
-        _Api.__init__(self, db=db, **router_kwargs)
+        _Api.__init__(self, engine=engine, **router_kwargs)
         # DB dependencies for transports/diagnostics
         if get_db is not None:
             self.get_db = get_db
-        elif db is None:
+        elif engine is None:
             self.get_db = None
         if get_async_db is not None:
             self.get_async_db = get_async_db
-        elif db is None:
+        elif engine is None:
             self.get_async_db = None
         self.jsonrpc_prefix = jsonrpc_prefix
         self.system_prefix = system_prefix

--- a/pkgs/standards/autoapi/autoapi/v3/autoapp.py
+++ b/pkgs/standards/autoapi/autoapi/v3/autoapp.py
@@ -72,7 +72,7 @@ class AutoApp(_App):
     def __init__(
         self,
         *,
-        db: EngineCfg | None = None,
+        engine: EngineCfg | None = None,
         get_db: Optional[Callable[..., Any]] = None,
         get_async_db: Optional[Callable[..., Awaitable[Any]]] = None,
         jsonrpc_prefix: str = "/rpc",
@@ -91,17 +91,17 @@ class AutoApp(_App):
         lifespan = fastapi_kwargs.pop("lifespan", None)
         if lifespan is not None:
             self.LIFESPAN = lifespan
-        super().__init__(db=db, **fastapi_kwargs)
+        super().__init__(engine=engine, **fastapi_kwargs)
         # capture initial routes so refreshes retain FastAPI defaults
         self._base_routes = list(self.router.routes)
         # DB dependencies for transports/diagnostics
         if get_db is not None:
             self.get_db = get_db
-        elif db is None:
+        elif engine is None:
             self.get_db = None
         if get_async_db is not None:
             self.get_async_db = get_async_db
-        elif db is None:
+        elif engine is None:
             self.get_async_db = None
         self.jsonrpc_prefix = jsonrpc_prefix
         self.system_prefix = system_prefix

--- a/pkgs/standards/autoapi/autoapi/v3/engine/collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/engine/collect.py
@@ -6,11 +6,17 @@ from types import SimpleNamespace
 from typing import Any, Dict, Iterable, Mapping, Tuple
 
 
-def _read_db_attr(obj: Any):
-    for k in ("db", "database", "db_provider"):
+def _read_engine_attr(obj: Any):
+    for k in ("engine", "db", "database", "engine_provider", "db_provider"):
         if hasattr(obj, k):
             return getattr(obj, k)
-    for k in ("autoapi_db", "get_db", "get_database"):
+    for k in (
+        "autoapi_engine",
+        "autoapi_db",
+        "get_engine",
+        "get_db",
+        "get_database",
+    ):
         fn = getattr(obj, k, None)
         if callable(fn):
             return fn()
@@ -27,49 +33,60 @@ def _iter_op_decorators(model: Any) -> Dict[Tuple[Any, str], Mapping[str, Any]]:
                 continue
             for slot in ("handler", "core"):
                 fn = getattr(h, slot, None)
-                if callable(fn) and hasattr(fn, "__autoapi_db__"):
-                    out[(model, alias)] = {"db": getattr(fn, "__autoapi_db__")}
+                if callable(fn) and (
+                    hasattr(fn, "__autoapi_engine_ctx__")
+                    or hasattr(fn, "__autoapi_db__")
+                ):
+                    spec = getattr(fn, "__autoapi_engine_ctx__", None)
+                    if spec is None:
+                        spec = getattr(fn, "__autoapi_db__")
+                    out[(model, alias)] = {"engine": spec}
                     break
     rpcns = getattr(model, "rpc", SimpleNamespace())
     for alias in dir(rpcns):
         if alias.startswith("_"):
             continue
         fn = getattr(rpcns, alias, None)
-        if callable(fn) and hasattr(fn, "__autoapi_db__"):
-            out[(model, alias)] = {"db": getattr(fn, "__autoapi_db__")}
+        if callable(fn) and (
+            hasattr(fn, "__autoapi_engine_ctx__") or hasattr(fn, "__autoapi_db__")
+        ):
+            spec = getattr(fn, "__autoapi_engine_ctx__", None)
+            if spec is None:
+                spec = getattr(fn, "__autoapi_db__")
+            out[(model, alias)] = {"engine": spec}
     return out
 
 
 def collect_from_objects(
     *, app: Any | None = None, api: Any | None = None, models: Iterable[Any] = ()
 ) -> Dict[str, Any]:
-    """Collect database configuration from objects without binding them."""
-    app_db = _read_db_attr(app) if app is not None else None
-    api_db = _read_db_attr(api) if api is not None else None
+    """Collect engine configuration from objects without binding them."""
+    app_engine = _read_engine_attr(app) if app is not None else None
+    api_engine = _read_engine_attr(api) if api is not None else None
 
     tables: Dict[Any, Any] = {}
     ops: Dict[Tuple[Any, str], Any] = {}
 
     for m in models:
         cfg = getattr(m, "table_config", None)
-        tdb = None
+        t_engine = None
         if isinstance(cfg, Mapping):
-            for k in ("db", "database", "db_provider"):
+            for k in ("engine", "db", "database", "engine_provider", "db_provider"):
                 if k in cfg:
-                    tdb = cfg[k]
+                    t_engine = cfg[k]
                     break
-        if tdb is None:
-            tdb = _read_db_attr(m)
-        if tdb is not None:
-            tables[m] = tdb
+        if t_engine is None:
+            t_engine = _read_engine_attr(m)
+        if t_engine is not None:
+            tables[m] = t_engine
 
         for (model, alias), ocfg in _iter_op_decorators(m).items():
-            ops[(model, alias)] = ocfg.get("db")
+            ops[(model, alias)] = ocfg.get("engine")
 
-    api_map = {api: api_db} if api_db is not None and api is not None else {}
+    api_map = {api: api_engine} if api_engine is not None and api is not None else {}
 
     return {
-        "default": app_db,
+        "default": app_engine,
         "api": api_map,
         "tables": tables,
         "ops": ops,

--- a/pkgs/standards/autoapi/autoapi/v3/engine/decorators.py
+++ b/pkgs/standards/autoapi/autoapi/v3/engine/decorators.py
@@ -63,8 +63,8 @@ def engine_ctx(ctx: Optional[EngineCfg] = None, **kw: Any):
 
     What it stores:
       • For ops (functions/methods): sets __autoapi_engine_ctx__ (and legacy __autoapi_db__).
-      • For ORM table classes: injects mapping under model.table_config["db"].
-      • For App/API classes or instances: sets attribute .db = EngineCfg.
+      • For ORM table classes: injects mapping under model.table_config["engine"] (and legacy "db").
+      • For App/API classes or instances: sets attribute .engine = EngineCfg (and legacy .db).
 
     Downstream:
       • engine.install_from_objects(...) discovers these and registers
@@ -84,12 +84,14 @@ def engine_ctx(ctx: Optional[EngineCfg] = None, **kw: Any):
         # ORM model class?
         if inspect.isclass(obj) and hasattr(obj, "__tablename__"):
             cfg = dict(getattr(obj, "table_config", {}) or {})
-            cfg["db"] = spec  # keep using "db" key to align with existing collectors
+            cfg["engine"] = spec
+            cfg["db"] = spec  # legacy key for backward compatibility
             setattr(obj, "table_config", cfg)
             return obj
 
         # API/App classes or instances: keep a simple attribute
-        setattr(obj, "db", spec)
+        setattr(obj, "engine", spec)
+        setattr(obj, "db", spec)  # legacy attribute
         return obj
 
     return _decorate

--- a/pkgs/standards/autoapi/autoapi/v3/ops/collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/ops/collect.py
@@ -192,7 +192,7 @@ def _apply_alias_ctx_to_canon(specs: List[OpSpec], model: type) -> List[OpSpec]:
           - persist           → OpSpec.persist
           - arity             → OpSpec.arity
           - rest (bool)       → OpSpec.expose_routes
-          - db                → OpSpec.db                  (NEW)
+          - engine            → OpSpec.engine             (NEW)
 
     We do NOT support any `returns` override. If no response schema is set,
     binders should treat the op as returning raw.
@@ -231,9 +231,9 @@ def _apply_alias_ctx_to_canon(specs: List[OpSpec], model: type) -> List[OpSpec]:
                 repl_kwargs["request_model"] = ov["request_schema"]
             if ov.get("response_schema") is not None:
                 repl_kwargs["response_model"] = ov["response_schema"]
-            # allow per-verb engine binding via overrides["db"]
-            if ov.get("db") is not None:
-                repl_kwargs["db"] = ov["db"]
+            # allow per-verb engine binding via overrides["engine"]
+            if ov.get("engine") is not None:
+                repl_kwargs["engine"] = ov["engine"]
             if ov.get("persist") is not None:
                 val = ov["persist"]
                 if val in ("default", "skip", "override"):

--- a/pkgs/standards/autoapi/autoapi/v3/ops/types.py
+++ b/pkgs/standards/autoapi/autoapi/v3/ops/types.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from typing import Any, Literal, Mapping, Optional, Tuple, Union, cast
+from typing import Any, Literal, Mapping, Optional, Tuple, cast
 
 from ..config.constants import CANON as CANONICAL_VERB_TUPLE
 from ..hook.types import PHASE, HookPhase, PHASES, Ctx, StepFn, HookPredicate
 from ..hook import HookSpec as OpHook
 from ..response.types import ResponseSpec
+from ..engine.engine_spec import EngineCfg
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -48,11 +49,6 @@ VerbAliasPolicy = Literal["both", "alias_only", "canonical_only"]  # legacy expo
 # Engine binding (optional, used by resolver precedence: op > table > api > app)
 # ───────────────────────────────────────────────────────────────────────────────
 
-# DSN string (e.g., "sqlite+memory://", "sqlite:///path.db",
-# "postgresql://user:pwd@host:5432/db", "postgresql+asyncpg://…")
-# or a structured mapping as used elsewhere in v3 ({"kind":"sqlite"/"postgres", ...}).
-DBSpec = Union[str, Mapping[str, Any]]
-
 
 @dataclass(frozen=True, slots=True)
 class OpSpec:
@@ -67,7 +63,7 @@ class OpSpec:
       - otherwise → raw pass-through
 
     Optional engine binding:
-      - `db` allows per-op DB routing (string DSN or structured mapping).
+      - `engine` allows per-op routing (DSN string or structured mapping).
         When present, it participates in resolver precedence (op > table > api > app).
     """
 
@@ -80,7 +76,7 @@ class OpSpec:
     expose_method: bool = True
 
     # Optional per-op engine binding (DSN string or mapping spec)
-    db: Optional[DBSpec] = None
+    engine: Optional[EngineCfg] = None
 
     # HTTP behavior
     arity: Arity = "collection"
@@ -127,7 +123,7 @@ __all__ = [
     "Ctx",
     "StepFn",
     "HookPredicate",
-    "DBSpec",
+    "EngineCfg",
     "OpHook",
     "OpSpec",
     "CANON",

--- a/pkgs/standards/autoapi/autoapi/v3/specs.py
+++ b/pkgs/standards/autoapi/autoapi/v3/specs.py
@@ -39,5 +39,6 @@ sys.modules[f"{__name__}.io_spec"] = _io_spec
 sys.modules[f"{__name__}.shortcuts"] = _shortcuts
 sys.modules[f"{__name__}.storage_spec"] = _storage_spec
 
+
 def __dir__() -> list[str]:
     return sorted(__all__)

--- a/pkgs/standards/autoapi/autoapi/v3/table/shortcuts.py
+++ b/pkgs/standards/autoapi/autoapi/v3/table/shortcuts.py
@@ -10,7 +10,7 @@ from ._table import Table
 def defineTableSpec(
     *,
     # engine binding
-    db: Any = None,
+    engine: Any = None,
     # composition
     ops: Sequence[Any] = (),
     columns: Sequence[Any] = (),
@@ -24,7 +24,7 @@ def defineTableSpec(
     Build a Table-spec class with class attributes only (no instances).
     Use directly in your ORM class MRO:
 
-        class User(defineTableSpec(db=..., ops=(...)), Base, Table):
+        class User(defineTableSpec(engine=..., ops=(...)), Base, Table):
             __tablename__ = "users"
 
     or pass it to `deriveTable(Model, ...)` to get a configured subclass.
@@ -39,10 +39,10 @@ def defineTableSpec(
         "DEPS": tuple(deps or ()),
     }
 
-    # Engine binding is conventionally stored under table_config["db"]
-    # so existing collectors/autowiring can find it consistently.
-    if db is not None:
-        attrs["table_config"] = {"db": db}
+    # Engine binding is conventionally stored under table_config["engine"]
+    # (and legacy "db" for backward compatibility) so collectors can find it.
+    if engine is not None:
+        attrs["table_config"] = {"engine": engine, "db": engine}
 
     return type("TableSpec", (TableSpec,), attrs)
 

--- a/pkgs/standards/autoapi/autoapi/v3/table/table_spec.py
+++ b/pkgs/standards/autoapi/autoapi/v3/table/table_spec.py
@@ -15,7 +15,7 @@ class TableSpec:
     """
 
     model: Any  # ORM class
-    db: Optional[EngineCfg] = None
+    engine: Optional[EngineCfg] = None
 
     # NEW
     ops: Sequence[Any] = field(default_factory=tuple)  # OpSpec or shorthands

--- a/pkgs/standards/autoapi/tests/unit/test_engine_usage_levels.py
+++ b/pkgs/standards/autoapi/tests/unit/test_engine_usage_levels.py
@@ -1,0 +1,33 @@
+from autoapi.v3 import AutoApp, AutoAPI
+from autoapi.v3.ops.types import OpSpec
+from autoapi.v3.engine import resolver
+from autoapi.v3.engine.engine_spec import EngineSpec
+from autoapi.v3.engine.shortcuts import mem, sqlitef
+
+
+def test_engine_usage_levels_and_precedence(tmp_path):
+    app_engine = sqlitef(str(tmp_path / "app.db"))
+    api_engine = mem(async_=False)
+    table_engine = mem(async_=False)
+    op_engine = mem(async_=True)
+
+    app = AutoApp(engine=app_engine)
+    api = AutoAPI(engine=api_engine)
+
+    class Model:
+        table_config = {"engine": table_engine}
+        __name__ = "Model"
+
+    op_spec = OpSpec(alias="do", target="custom", table=Model, engine=op_engine)
+    Model.__autoapi_ops__ = [op_spec]
+
+    app.install_engines(api=api, models=(Model,))
+
+    assert resolver.resolve_provider().spec == EngineSpec.from_any(app_engine)
+    assert resolver.resolve_provider(api=api).spec == EngineSpec.from_any(api_engine)
+    assert resolver.resolve_provider(model=Model).spec == EngineSpec.from_any(
+        table_engine
+    )
+    assert resolver.resolve_provider(
+        model=Model, op_alias="do"
+    ).spec == EngineSpec.from_any(op_engine)

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -57,7 +57,7 @@ from peagen.plugins.queues import QueueBase
 from swarmauri_standard.loggers.Logger import Logger
 
 from . import _publish, schedule_helpers
-from .db import engine, get_async_db  # same module as before
+from .db import dsn, engine
 from .ws_server import router as ws_router
 from sqlalchemy.exc import IntegrityError
 
@@ -158,7 +158,7 @@ logging.getLogger("uvicorn.error").setLevel("INFO")
 READY: bool = False
 app = AutoApp(
     title="Peagen Pool-Manager Gateway",
-    get_async_db=get_async_db,
+    engine=dsn,
     api_hooks={"PRE_TX_BEGIN": [_shadow_principal]},
 )
 api = app


### PR DESCRIPTION
## Summary
- replace `db` config with `engine` across AutoApp and AutoAPI
- expose engine settings in AppSpec/APISpec and related shortcuts
- extend engine support to tables and ops
- migrate AutoKMS, AutoAuthN, and Peagen to DSN-based engine configuration
- add test verifying engine resolution precedence

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi pytest`
- `uv run --directory pkgs/standards/auto_kms --package auto_kms pytest`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn pytest`
- `uv run --directory pkgs/standards/peagen --package peagen pytest` *(fails: subprocess.CalledProcessError & assertion failure)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ab3d6ecc8326ac794af63fb9b26a