### PR TITLE
test: expand response coverage for non-aliased tables

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_response_rest.py
+++ b/pkgs/standards/autoapi/tests/unit/test_response_rest.py
@@ -6,6 +6,7 @@ from fastapi.testclient import TestClient
 from .response_utils import (
     RESPONSE_KINDS,
     build_model_for_response,
+    build_model_for_response_non_alias,
     build_ping_model,
     build_model_for_jinja_response,
 )
@@ -24,6 +25,35 @@ def test_response_rest_call():
 @pytest.mark.parametrize("kind", RESPONSE_KINDS)
 def test_response_rest_alias_table(kind, tmp_path):
     Widget, file_path = build_model_for_response(kind, tmp_path)
+    app = App()
+    app.include_router(Widget.rest.router)
+    client = TestClient(app)
+    kwargs = {"json": {}}
+    if kind == "redirect":
+        kwargs["follow_redirects"] = False
+    r = client.post("/widget/download", **kwargs)
+    if kind == "auto":
+        assert r.json() == {"data": {"pong": True}, "ok": True}
+    elif kind == "json":
+        assert r.json() == {"pong": True}
+    elif kind == "html":
+        assert r.text == "<h1>pong</h1>"
+    elif kind == "text":
+        assert r.text == "pong"
+    elif kind == "file":
+        assert r.content == file_path.read_bytes()
+    elif kind == "stream":
+        assert r.content == b"pong"
+    elif kind == "redirect":
+        assert r.status_code == 307
+        assert r.headers["location"] == "/redirected"
+        return
+    assert r.status_code == 200
+
+
+@pytest.mark.parametrize("kind", RESPONSE_KINDS)
+def test_response_rest_non_alias_table(kind, tmp_path):
+    Widget, file_path = build_model_for_response_non_alias(kind, tmp_path)
     app = App()
     app.include_router(Widget.rest.router)
     client = TestClient(app)

--- a/pkgs/standards/autoapi/tests/unit/test_response_rpc.py
+++ b/pkgs/standards/autoapi/tests/unit/test_response_rpc.py
@@ -8,6 +8,7 @@ from autoapi.v3.bindings import rpc_call
 from .response_utils import (
     RESPONSE_KINDS,
     build_model_for_response,
+    build_model_for_response_non_alias,
     build_ping_model,
     build_model_for_jinja_response,
 )
@@ -25,6 +26,34 @@ async def test_response_rpc_call():
 @pytest.mark.parametrize("kind", RESPONSE_KINDS)
 async def test_response_rpc_alias_table(kind, tmp_path):
     Widget, file_path = build_model_for_response(kind, tmp_path)
+    api = SimpleNamespace(models={"Widget": Widget})
+    result = await rpc_call(api, Widget, "download", {}, db=SimpleNamespace())
+    if kind == "auto":
+        assert json.loads(result["body"]) == {"data": {"pong": True}, "ok": True}
+    elif kind == "json":
+        assert json.loads(result["body"]) == {"pong": True}
+    elif kind == "html":
+        assert result["body"] == b"<h1>pong</h1>"
+    elif kind == "text":
+        assert result["body"] == b"pong"
+    elif kind == "file":
+        assert result["path"] == str(file_path)
+    elif kind == "stream":
+        content = b"".join([chunk async for chunk in result["body_iterator"]])
+        assert content == b"pong"
+    elif kind == "redirect":
+        assert result["status_code"] == 307
+        headers = dict(result["raw_headers"])
+        assert headers[b"location"].decode() == "/redirected"
+        return
+    if kind not in {"auto", "json"}:
+        assert result["status_code"] == 200
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", RESPONSE_KINDS)
+async def test_response_rpc_non_alias_table(kind, tmp_path):
+    Widget, file_path = build_model_for_response_non_alias(kind, tmp_path)
     api = SimpleNamespace(models={"Widget": Widget})
     result = await rpc_call(api, Widget, "download", {}, db=SimpleNamespace())
     if kind == "auto":


### PR DESCRIPTION
## Summary
- add helper to build non-aliased models for response kinds
- extend REST and RPC tests to exercise all response types on non-aliased tables

## Testing
- `uv run --directory standards --package autoapi ruff check autoapi/tests/unit/response_utils.py autoapi/tests/unit/test_response_rest.py autoapi/tests/unit/test_response_rpc.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b6be4a58b88326b744b7ec14373873