### PR TITLE
feat(autoapi): expose relationship dependency

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/deps/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/deps/__init__.py
@@ -7,6 +7,7 @@ making it easier to manage versions and potential replacements.
 """
 
 # Re-export all SQLAlchemy dependencies
+from .sqlalchemy import relationship  # noqa: F401
 from .sqlalchemy import *  # noqa: F403, F401
 
 # Re-export all Pydantic dependencies

--- a/pkgs/standards/autoapi/tests/unit/test_relationship_alias_cols.py
+++ b/pkgs/standards/autoapi/tests/unit/test_relationship_alias_cols.py
@@ -1,0 +1,98 @@
+import pytest
+from autoapi.v3.specs import F, S, acol, vcol
+from autoapi.v3.decorators import alias_ctx
+from autoapi.v3.orm.tables import Base
+from autoapi.v3.deps import (
+    Column,
+    Integer,
+    String,
+    ForeignKey,
+    relationship,
+    Mapped,
+    create_engine,
+    Session,
+)
+
+
+@pytest.mark.parametrize("col_variant", ["acol", "vcol", "both"])
+@pytest.mark.parametrize("aliasing", [False, True])
+@pytest.mark.parametrize("use_mapped", [False, True])
+def test_relationship_acol_vcol_alias(col_variant, aliasing, use_mapped):
+    Base.metadata.clear()
+    Base.registry.dispose()
+    engine = create_engine("sqlite:///:memory:")
+
+    decorator = alias_ctx(read="fetch") if aliasing else (lambda cls: cls)
+
+    if use_mapped:
+
+        @decorator
+        class Parent(Base):
+            __tablename__ = f"p_{col_variant}_{aliasing}_{use_mapped}"
+            id: Mapped[int] = Column(Integer, primary_key=True)
+            if col_variant in ("acol", "both"):
+                name: Mapped[str] = acol(storage=S(type_=String, nullable=True))
+            if col_variant in ("vcol", "both"):
+                nickname: str = vcol(
+                    field=F(py_type=str),
+                    read_producer=lambda obj, ctx: "nick",
+                    nullable=True,
+                )
+            children: Mapped[list["Child"]] = relationship(back_populates="parent")
+
+        @decorator
+        class Child(Base):
+            __tablename__ = f"c_{col_variant}_{aliasing}_{use_mapped}"
+            id: Mapped[int] = Column(Integer, primary_key=True)
+            parent_id: Mapped[int] = Column(
+                Integer, ForeignKey(f"{Parent.__tablename__}.id")
+            )
+            if col_variant in ("acol", "both"):
+                name: Mapped[str] = acol(storage=S(type_=String, nullable=True))
+            if col_variant in ("vcol", "both"):
+                nickname: str = vcol(
+                    field=F(py_type=str),
+                    read_producer=lambda obj, ctx: "nick",
+                    nullable=True,
+                )
+            parent: Mapped["Parent"] = relationship(back_populates="children")
+    else:
+
+        @decorator
+        class Parent(Base):
+            __tablename__ = f"p_{col_variant}_{aliasing}_{use_mapped}"
+            id = Column(Integer, primary_key=True)
+            if col_variant in ("acol", "both"):
+                name: str = acol(storage=S(type_=String, nullable=True))
+            if col_variant in ("vcol", "both"):
+                nickname: str = vcol(
+                    field=F(py_type=str),
+                    read_producer=lambda obj, ctx: "nick",
+                    nullable=True,
+                )
+            children = relationship("Child", back_populates="parent")
+
+        @decorator
+        class Child(Base):
+            __tablename__ = f"c_{col_variant}_{aliasing}_{use_mapped}"
+            id = Column(Integer, primary_key=True)
+            parent_id = Column(Integer, ForeignKey(f"{Parent.__tablename__}.id"))
+            if col_variant in ("acol", "both"):
+                name: str = acol(storage=S(type_=String, nullable=True))
+            if col_variant in ("vcol", "both"):
+                nickname: str = vcol(
+                    field=F(py_type=str),
+                    read_producer=lambda obj, ctx: "nick",
+                    nullable=True,
+                )
+            parent = relationship("Parent", back_populates="children")
+
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        p = Parent()
+        c = Child(parent=p)
+        session.add_all([p, c])
+        session.commit()
+        session.refresh(p)
+        assert c.parent is p
+        assert p.children[0] is c


### PR DESCRIPTION
## Summary
- re-export `relationship` from SQLAlchemy in autoapi v3 deps
- add parameterized tests validating relationships across alias, Mapped, and column-spec scenarios

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff format .`
- `uv run --directory standards/autoapi --package autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_relationship_alias_cols.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b6cc7314988326b3887b74aa3e6979