### PR TITLE
feat(engine): expose provider-scoped get_db dependency

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/transport/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/transport/__init__.py
@@ -12,8 +12,8 @@ Quick usage:
 
     # JSON-RPC
     app.include_router(build_jsonrpc_router(api), prefix="/rpc")
-    # or:
-    mount_jsonrpc(api, app, prefix="/rpc", get_db=get_session_dep)
+    # or supply a DB dependency from an Engine or Provider:
+    mount_jsonrpc(api, app, prefix="/rpc", get_db=my_engine.get_db)
 
     # REST (aggregate all model routers under one prefix)
     # after you include models with mount_router=False


### PR DESCRIPTION
## Summary
- allow Provider and Engine classes to supply their own `get_db` dependency
- update transport docs to reference engine/provider `get_db`

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b6d68d385c8326b1a013a3652aed06