### PR TITLE
refactor: move db factory into provider

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/api/_api.py
+++ b/pkgs/standards/autoapi/autoapi/v3/api/_api.py
@@ -1,9 +1,6 @@
 # autoapi/autoapi/v3/api/_api.py
 from __future__ import annotations
-from typing import (
-    Any,
-    Generator,
-)
+from typing import Any
 
 from ..deps.fastapi import APIRouter as ApiRouter
 from ..engine.engine_spec import EngineCfg
@@ -37,13 +34,9 @@ class Api(APISpec, ApiRouter):
         ctx = engine if engine is not None else getattr(self, "ENGINE", None)
         if ctx is not None:
             _resolver.register_api(self, ctx)
-
-    def get_db(self) -> Generator[Any, None, None]:
-        db, release = _resolver.acquire()
-        try:
-            yield db
-        finally:
-            release()
+            prov = _resolver.resolve_provider(api=self)
+            if prov is not None:
+                self.get_db = prov.get_db  # type: ignore[attr-defined]
 
     def install_engines(
         self, *, api: Any = None, models: tuple[Any, ...] | None = None

--- a/pkgs/standards/autoapi/autoapi/v3/app/_app.py
+++ b/pkgs/standards/autoapi/autoapi/v3/app/_app.py
@@ -1,9 +1,6 @@
 # autoapi/autoapi/v3/app/_app.py
 from __future__ import annotations
-from typing import (
-    Any,
-    Generator,
-)
+from typing import Any
 
 from ..deps.fastapi import FastAPI
 from ..engine.engine_spec import EngineCfg
@@ -26,15 +23,11 @@ class App(AppSpec, FastAPI):
         ctx = engine if engine is not None else getattr(self, "ENGINE", None)
         if ctx is not None:
             _resolver.set_default(ctx)
+            prov = _resolver.resolve_provider()
+            if prov is not None:
+                self.get_db = prov.get_db  # type: ignore[attr-defined]
         for mw in getattr(self, "MIDDLEWARES", []):
             self.add_middleware(mw.__class__, **getattr(mw, "kwargs", {}))
-
-    def get_db(self) -> Generator[Any, None, None]:
-        db, release = _resolver.acquire()
-        try:
-            yield db
-        finally:
-            release()
 
     def install_engines(
         self, *, api: Any = None, models: tuple[Any, ...] | None = None

--- a/pkgs/standards/autoapi/autoapi/v3/autoapi.py
+++ b/pkgs/standards/autoapi/autoapi/v3/autoapi.py
@@ -64,7 +64,6 @@ class AutoAPI(_Api):
         self,
         *,
         engine: EngineCfg | None = None,
-        get_db: Optional[Callable[..., Any]] = None,
         jsonrpc_prefix: str = "/rpc",
         system_prefix: str = "/system",
         api_hooks: Mapping[str, Iterable[Callable]]
@@ -73,10 +72,7 @@ class AutoAPI(_Api):
         **router_kwargs: Any,
     ) -> None:
         _Api.__init__(self, engine=engine, **router_kwargs)
-        # DB dependency for transports/diagnostics
-        if get_db is not None:
-            self.get_db = get_db
-        elif engine is None:
+        if engine is None:
             self.get_db = None
         self.jsonrpc_prefix = jsonrpc_prefix
         self.system_prefix = system_prefix

--- a/pkgs/standards/autoapi/autoapi/v3/autoapp.py
+++ b/pkgs/standards/autoapi/autoapi/v3/autoapp.py
@@ -73,7 +73,6 @@ class AutoApp(_App):
         self,
         *,
         engine: EngineCfg | None = None,
-        get_db: Optional[Callable[..., Any]] = None,
         jsonrpc_prefix: str = "/rpc",
         system_prefix: str = "/system",
         api_hooks: Mapping[str, Iterable[Callable]]
@@ -93,10 +92,7 @@ class AutoApp(_App):
         super().__init__(engine=engine, **fastapi_kwargs)
         # capture initial routes so refreshes retain FastAPI defaults
         self._base_routes = list(self.router.routes)
-        # DB dependency for transports/diagnostics
-        if get_db is not None:
-            self.get_db = get_db
-        elif engine is None:
+        if engine is None:
             self.get_db = None
         self.jsonrpc_prefix = jsonrpc_prefix
         self.system_prefix = system_prefix

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/api.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/api.py
@@ -204,8 +204,9 @@ def _seed_security_and_deps(api: Any, model: type) -> None:
     - __autoapi_rpc_dependencies__   : list of extra dependencies for JSON-RPC router
     """
     # DB deps
-    if getattr(api, "get_db", None):
-        setattr(model, AUTOAPI_GET_DB_ATTR, api.get_db)
+    prov = _resolver.resolve_provider(api=api)
+    if prov is not None:
+        setattr(model, AUTOAPI_GET_DB_ATTR, prov.get_db)
 
     # Authn (prefer optional dep when available)
     auth_dep = None

--- a/pkgs/standards/autoapi/autoapi/v3/engine/collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/engine/collect.py
@@ -14,8 +14,6 @@ def _read_engine_attr(obj: Any):
         "autoapi_engine",
         "autoapi_db",
         "get_engine",
-        "get_db",
-        "get_database",
     ):
         fn = getattr(obj, k, None)
         if callable(fn):


### PR DESCRIPTION
## Summary
- embed database factory in engine/provider classes
- expose provider factories on Api and App
- drop legacy get_db discovery

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b6d9f9571483268c41bc1b1d187c03