### PR TITLE
feat(engine): expose provider-scoped get_db dependency

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/autoapi.py
+++ b/pkgs/standards/autoapi/autoapi/v3/autoapi.py
@@ -189,7 +189,6 @@ class AutoAPI(_Api):
             self,
             self,
             prefix=px,
-            get_db=self.get_db,
         )
         return router
 

--- a/pkgs/standards/autoapi/autoapi/v3/autoapp.py
+++ b/pkgs/standards/autoapi/autoapi/v3/autoapp.py
@@ -208,7 +208,6 @@ class AutoApp(_App):
             self,
             self,
             prefix=px,
-            get_db=self.get_db,
         )
         self._base_routes = list(self.router.routes)
         return router

--- a/pkgs/standards/autoapi/autoapi/v3/transport/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/transport/__init__.py
@@ -12,8 +12,8 @@ Quick usage:
 
     # JSON-RPC
     app.include_router(build_jsonrpc_router(api), prefix="/rpc")
-    # or:
-    mount_jsonrpc(api, app, prefix="/rpc", get_db=get_session_dep)
+    # or supply a DB dependency from an Engine or Provider:
+    mount_jsonrpc(api, app, prefix="/rpc", engine=my_engine)
 
     # REST (aggregate all model routers under one prefix)
     # after you include models with mount_router=False
@@ -24,7 +24,7 @@ Quick usage:
 
 from __future__ import annotations
 
-from typing import Any, Callable, Optional, Sequence
+from typing import Any, Sequence
 
 # JSON-RPC transport
 from .jsonrpc import build_jsonrpc_router
@@ -38,7 +38,7 @@ def mount_jsonrpc(
     app: Any,
     *,
     prefix: str = "/rpc",
-    get_db: Optional[Callable[..., Any]] = None,
+    engine: Any | None = None,
     tags: Sequence[str] | None = ("rpc",),
 ):
     """
@@ -49,13 +49,16 @@ def mount_jsonrpc(
 
     Parameters
     ----------
+    engine:
+        Optional engine or provider supplying a ``get_db`` dependency.
     tags:
         Optional tags applied to the mounted "/rpc" endpoint. Defaults to
         ``("rpc",)``.
     """
+    dep = engine.get_db if engine is not None else getattr(api, "get_db", None)
     router = build_jsonrpc_router(
         api,
-        get_db=get_db,
+        get_db=dep,
         tags=tags,
     )
     include_router = getattr(app, "include_router", None)


### PR DESCRIPTION
## Summary
- allow Provider and Engine classes to supply their own `get_db` dependency
- update transport docs to reference engine/provider `get_db`
- `mount_jsonrpc` now accepts an engine and derives its `get_db`

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b6d68d385c8326b1a013a3652aed06