### PR TITLE
Fix duplicate operation IDs from double router mount

### DIFF
--- a/pkgs/standards/auto_kms/tests/unit/test_openapi_unique_operation_ids.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_openapi_unique_operation_ids.py
@@ -1,0 +1,15 @@
+import importlib
+import warnings
+
+
+def test_openapi_operation_ids_unique():
+    app_module = importlib.reload(importlib.import_module("auto_kms.app"))
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        schema = app_module.app.openapi()
+    op_ids = [
+        op["operationId"]
+        for methods in schema["paths"].values()
+        for op in methods.values()
+    ]
+    assert len(op_ids) == len(set(op_ids))

--- a/pkgs/standards/autoapi/autoapi/v3/autoapp.py
+++ b/pkgs/standards/autoapi/autoapi/v3/autoapp.py
@@ -160,9 +160,7 @@ class AutoApp(_App):
         """
         # inject API-level hooks so the binder merges them
         self._merge_api_hooks_into_model(model, self._api_hooks_map)
-        return _include_model(
-            self, model, app=self, prefix=prefix, mount_router=mount_router
-        )
+        return _include_model(self, model, prefix=prefix, mount_router=mount_router)
 
     def include_models(
         self,
@@ -176,7 +174,6 @@ class AutoApp(_App):
         return _include_models(
             self,
             models,
-            app=self,
             base_prefix=base_prefix,
             mount_router=mount_router,
         )


### PR DESCRIPTION
## Summary
- prevent AutoApp from mounting REST routers twice, eliminating duplicate operation IDs
- add regression test to ensure AutoKMS OpenAPI schema has unique operation IDs

## Testing
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff format .`
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest` (fails: 73 failed, 588 passed, 13 skipped, 116 errors)
- `uv run --package auto_kms --directory pkgs/standards/auto_kms ruff format .`
- `uv run --package auto_kms --directory pkgs/standards/auto_kms ruff check . --fix`
- `uv run --package auto_kms --directory standards/auto_kms pytest` (fails: 31 failed, 54 passed, 151 warnings)

------
https://chatgpt.com/codex/tasks/task_e_68b6e09bf66083268f80d5eeed03d1d9