### PR TITLE
fix: preserve op_ctx declaration order

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/decorators.py
+++ b/pkgs/standards/autoapi/autoapi/v3/decorators.py
@@ -341,8 +341,7 @@ def collect_decorated_ops(table: type) -> list[OpSpec]:
     out: list[OpSpec] = []
 
     for base in reversed(table.__mro__):
-        for name in dir(base):
-            attr = getattr(base, name, None)
+        for name, attr in base.__dict__.items():
             func = _unwrap(attr)
             decl: _OpDecl | None = getattr(func, "__autoapi_op_decl__", None)
             if not decl:

--- a/pkgs/standards/autoapi/tests/unit/test_v3_op_ctx_attributes.py
+++ b/pkgs/standards/autoapi/tests/unit/test_v3_op_ctx_attributes.py
@@ -70,3 +70,30 @@ def test_op_ctx_persist_policy_override():
 
     spec = collect_decorated_ops(Model)[0]
     assert spec.persist == "skip"
+
+
+def test_op_ctx_core_crud_order():
+    class Model:
+        @op_ctx(target="create")
+        def create(cls, ctx):
+            return None
+
+        @op_ctx(target="read")
+        def read(cls, ctx, obj):
+            return obj
+
+        @op_ctx(target="update")
+        def update(cls, ctx, obj):
+            return None
+
+        @op_ctx(target="delete")
+        def delete(cls, ctx, obj):
+            return None
+
+    specs = collect_decorated_ops(Model)
+    assert [sp.target for sp in specs] == [
+        "create",
+        "read",
+        "update",
+        "delete",
+    ]


### PR DESCRIPTION
## Summary
- keep op_ctx-registered operations in declaration order when collecting
- add regression test for op_ctx CRUD ordering

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_v3_op_ctx_attributes.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6e2bf2db083268205ec55645bff74