### PR TITLE
refactor: rely on engine provider for db access

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/api/_api.py
+++ b/pkgs/standards/autoapi/autoapi/v3/api/_api.py
@@ -31,12 +31,10 @@ class Api(APISpec, ApiRouter):
         self.models: dict[str, type] = {}
         self.tables: dict[str, Any] = {}
 
-        ctx = engine if engine is not None else getattr(self, "ENGINE", None)
-        if ctx is not None:
-            _resolver.register_api(self, ctx)
-            prov = _resolver.resolve_provider(api=self)
-            if prov is not None:
-                self.get_db = prov.get_db  # type: ignore[attr-defined]
+        _engine_ctx = engine if engine is not None else getattr(self, "ENGINE", None)
+        if _engine_ctx is not None:
+            _resolver.register_api(self, _engine_ctx)
+            _resolver.resolve_provider(api=self)
 
     def install_engines(
         self, *, api: Any = None, models: tuple[Any, ...] | None = None

--- a/pkgs/standards/autoapi/autoapi/v3/app/_app.py
+++ b/pkgs/standards/autoapi/autoapi/v3/app/_app.py
@@ -20,12 +20,10 @@ class App(AppSpec, FastAPI):
             lifespan=self.LIFESPAN,
             **fastapi_kwargs,
         )
-        ctx = engine if engine is not None else getattr(self, "ENGINE", None)
-        if ctx is not None:
-            _resolver.set_default(ctx)
-            prov = _resolver.resolve_provider()
-            if prov is not None:
-                self.get_db = prov.get_db  # type: ignore[attr-defined]
+        _engine_ctx = engine if engine is not None else getattr(self, "ENGINE", None)
+        if _engine_ctx is not None:
+            _resolver.set_default(_engine_ctx)
+            _resolver.resolve_provider()
         for mw in getattr(self, "MIDDLEWARES", []):
             self.add_middleware(mw.__class__, **getattr(mw, "kwargs", {}))
 


### PR DESCRIPTION
## Summary
- rename `ctx` to `_engine_ctx` in v3 App and Api
- drop `get_db` hooks in AutoApp/AutoAPI and use engine provider for initialization and mounting
- fix op_ctx core crud order tests to build an Engine directly

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff format tests/i9n/test_op_ctx_core_crud_order.py autoapi/v3/api/_api.py autoapi/v3/app/_app.py autoapi/v3/autoapp.py autoapi/v3/autoapi.py`
- `uv run --directory standards/autoapi --package autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_op_ctx_core_crud_order.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6e4125a188326a3bff7807d42b20d