### PR TITLE
refactor engine initialization

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/autoapp.py
+++ b/pkgs/standards/autoapi/autoapi/v3/autoapp.py
@@ -13,7 +13,6 @@ from typing import (
     Sequence,
     Tuple,
 )
-import inspect
 
 from .app._app import App as _App
 from .engine.engine_spec import EngineCfg
@@ -346,14 +345,39 @@ class AutoApp(_App):
         prov = _resolver.resolve_provider()
         if prov is None:
             raise ValueError("Engine provider is not configured")
-        with next(prov.get_db()) as db:
-            bind = db.get_bind()  # Connection or Engine
-            self._create_all_on_bind(
-                bind,
-                schemas=schemas,
-                sqlite_attachments=sqlite_attachments,
-                tables=tables,
-            )
+        engine, _ = prov.ensure()
+        if prov.kind == "async":
+
+            async def _run() -> None:
+                async with engine.begin() as conn:  # type: ignore[attribute-defined-outside-init]
+                    await conn.run_sync(
+                        lambda sync_conn: self._create_all_on_bind(
+                            sync_conn,
+                            schemas=schemas,
+                            sqlite_attachments=sqlite_attachments,
+                            tables=tables,
+                        )
+                    )
+
+            import asyncio
+            import threading
+
+            try:
+                asyncio.get_running_loop()
+            except RuntimeError:
+                asyncio.run(_run())
+            else:
+                thread = threading.Thread(target=lambda: asyncio.run(_run()))
+                thread.start()
+                thread.join()
+        else:
+            with engine.begin() as conn:  # type: ignore[attribute-defined-outside-init]
+                self._create_all_on_bind(
+                    conn,
+                    schemas=schemas,
+                    sqlite_attachments=sqlite_attachments,
+                    tables=tables,
+                )
         self._ddl_executed = True
 
     async def initialize_async(
@@ -365,41 +389,30 @@ class AutoApp(_App):
         if prov is None:
             raise ValueError("Engine provider is not configured")
 
-        if inspect.isasyncgenfunction(prov.get_db):
-            async for adb in prov.get_db():  # AsyncSession
-
-                def _sync_bootstrap(arg):
-                    bind = arg.get_bind() if hasattr(arg, "get_bind") else arg
-                    self._create_all_on_bind(
-                        bind,
+        engine, _ = prov.ensure()
+        if prov.kind == "async":
+            async with engine.begin() as conn:  # type: ignore[attribute-defined-outside-init]
+                await conn.run_sync(
+                    lambda sync_conn: self._create_all_on_bind(
+                        sync_conn,
                         schemas=schemas,
                         sqlite_attachments=sqlite_attachments,
                         tables=tables,
                     )
-
-                await adb.run_sync(_sync_bootstrap)
-                break
+                )
         else:
-            gen = prov.get_db()
-            adb = next(gen)
+            import asyncio
 
-            try:
-
-                def _sync_bootstrap(arg):
-                    bind = arg.get_bind() if hasattr(arg, "get_bind") else arg
+            def _sync() -> None:
+                with engine.begin() as conn:  # type: ignore[attribute-defined-outside-init]
                     self._create_all_on_bind(
-                        bind,
+                        conn,
                         schemas=schemas,
                         sqlite_attachments=sqlite_attachments,
                         tables=tables,
                     )
 
-                await adb.run_sync(_sync_bootstrap)
-            finally:
-                try:
-                    next(gen)
-                except StopIteration:
-                    pass
+            await asyncio.to_thread(_sync)
         self._ddl_executed = True
 
     # ------------------------- repr -------------------------

--- a/pkgs/standards/autoapi/tests/conftest.py
+++ b/pkgs/standards/autoapi/tests/conftest.py
@@ -198,6 +198,36 @@ def sample_item_data():
     return _create_item_data
 
 
+@pytest.fixture
+def sync_db_session():
+    from autoapi.v3.engine.shortcuts import provider_sqlite_memory
+    from autoapi.v3.engine import resolver as _resolver
+
+    prev = _resolver.resolve_provider()
+    prov = provider_sqlite_memory(async_=False)
+    _resolver.set_default(prov)
+    engine, _ = prov.ensure()
+    try:
+        yield engine, prov.get_db
+    finally:
+        _resolver.set_default(prev)
+
+
+@pytest.fixture
+def async_db_session():
+    from autoapi.v3.engine.shortcuts import provider_sqlite_memory
+    from autoapi.v3.engine import resolver as _resolver
+
+    prev = _resolver.resolve_provider()
+    prov = provider_sqlite_memory(async_=True)
+    _resolver.set_default(prov)
+    engine, _ = prov.ensure()
+    try:
+        yield engine, prov.get_db
+    finally:
+        _resolver.set_default(prev)
+
+
 @pytest_asyncio.fixture()
 async def api_client_v3():
     Base.metadata.clear()

--- a/pkgs/standards/autoapi/tests/unit/test_sqlite_attachments.py
+++ b/pkgs/standards/autoapi/tests/unit/test_sqlite_attachments.py
@@ -1,5 +1,6 @@
 import pytest
 from autoapi.v3.autoapp import AutoApp
+from autoapi.v3.engine.shortcuts import engine as make_engine, mem
 
 
 def _db_names(conn):
@@ -7,43 +8,47 @@ def _db_names(conn):
     return {row[1] for row in result.fetchall()}
 
 
-def test_initialize_sync_without_sqlite_attachments(sync_db_session):
-    engine, get_db = sync_db_session
-    api = AutoApp(get_db=get_db)
+def test_initialize_sync_without_sqlite_attachments():
+    eng = make_engine(mem(async_=False))
+    api = AutoApp(engine=eng)
     api.initialize_sync()
-    with engine.connect() as conn:
+    sql_engine, _ = eng.raw()
+    with sql_engine.connect() as conn:
         assert _db_names(conn) == {"main"}
 
 
-def test_initialize_sync_with_sqlite_attachments(sync_db_session, tmp_path):
-    engine, get_db = sync_db_session
+def test_initialize_sync_with_sqlite_attachments(tmp_path):
+    eng = make_engine(mem(async_=False))
     attach_db = tmp_path / "logs.sqlite"
     attach_db.touch()
-    api = AutoApp(get_db=get_db)
+    api = AutoApp(engine=eng)
     api.initialize_sync(sqlite_attachments={"logs": str(attach_db)})
-    with engine.connect() as conn:
+    sql_engine, _ = eng.raw()
+    with sql_engine.connect() as conn:
         assert "logs" in _db_names(conn)
 
 
 @pytest.mark.asyncio
-async def test_initialize_async_without_sqlite_attachments(async_db_session):
-    engine, get_db = async_db_session
-    api = AutoApp(get_db=get_db)
+async def test_initialize_async_without_sqlite_attachments():
+    eng = make_engine(mem())
+    api = AutoApp(engine=eng)
     await api.initialize_async()
-    async with engine.connect() as conn:
+    sql_engine, _ = eng.raw()
+    async with sql_engine.connect() as conn:
         result = await conn.exec_driver_sql("PRAGMA database_list")
         names = {row[1] for row in result.fetchall()}
     assert names == {"main"}
 
 
 @pytest.mark.asyncio
-async def test_initialize_async_with_sqlite_attachments(async_db_session, tmp_path):
-    engine, get_db = async_db_session
+async def test_initialize_async_with_sqlite_attachments(tmp_path):
+    eng = make_engine(mem())
     attach_db = tmp_path / "logs.sqlite"
     attach_db.touch()
-    api = AutoApp(get_db=get_db)
+    api = AutoApp(engine=eng)
     await api.initialize_async(sqlite_attachments={"logs": str(attach_db)})
-    async with engine.connect() as conn:
+    sql_engine, _ = eng.raw()
+    async with sql_engine.connect() as conn:
         result = await conn.exec_driver_sql("PRAGMA database_list")
         names = {row[1] for row in result.fetchall()}
     assert "logs" in names


### PR DESCRIPTION
## Summary
- call DDL initialization directly on resolved engine
- attach sqlite fixtures to AutoApp tests via engine helpers
- provide session fixtures for sync and async sqlite engines

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_sqlite_attachments.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6ee8cc76883269c4da54ef286b4b5