### PR TITLE
Refactor AutoAPI engine initialization

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/autoapi.py
+++ b/pkgs/standards/autoapi/autoapi/v3/autoapi.py
@@ -13,7 +13,7 @@ from typing import (
     Sequence,
     Tuple,
 )
-import inspect
+import asyncio
 
 from .api._api import Api as _Api
 from .engine.engine_spec import EngineCfg
@@ -317,14 +317,31 @@ class AutoAPI(_Api):
         prov = _resolver.resolve_provider(api=self)
         if prov is None:
             raise ValueError("Engine provider is not configured")
-        with next(prov.get_db()) as db:
-            bind = db.get_bind()  # Connection or Engine
+
+        engine, _ = prov.ensure()
+
+        if prov.kind == "async":
+
+            async def _run() -> None:
+                async with engine.begin() as conn:
+                    await conn.run_sync(
+                        lambda sync_conn: self._create_all_on_bind(
+                            sync_conn,
+                            schemas=schemas,
+                            sqlite_attachments=sqlite_attachments,
+                            tables=tables,
+                        )
+                    )
+
+            asyncio.run(_run())
+        else:
             self._create_all_on_bind(
-                bind,
+                engine,
                 schemas=schemas,
                 sqlite_attachments=sqlite_attachments,
                 tables=tables,
             )
+
         self._ddl_executed = True
 
     async def initialize_async(
@@ -336,41 +353,25 @@ class AutoAPI(_Api):
         if prov is None:
             raise ValueError("Engine provider is not configured")
 
-        if inspect.isasyncgenfunction(prov.get_db):
-            async for adb in prov.get_db():  # AsyncSession
+        engine, _ = prov.ensure()
 
-                def _sync_bootstrap(arg):
-                    bind = arg.get_bind() if hasattr(arg, "get_bind") else arg
-                    self._create_all_on_bind(
-                        bind,
+        if prov.kind == "async":
+            async with engine.begin() as conn:
+                await conn.run_sync(
+                    lambda sync_conn: self._create_all_on_bind(
+                        sync_conn,
                         schemas=schemas,
                         sqlite_attachments=sqlite_attachments,
                         tables=tables,
                     )
-
-                await adb.run_sync(_sync_bootstrap)
-                break
+                )
         else:
-            gen = prov.get_db()
-            adb = next(gen)
-
-            try:
-
-                def _sync_bootstrap(arg):
-                    bind = arg.get_bind() if hasattr(arg, "get_bind") else arg
-                    self._create_all_on_bind(
-                        bind,
-                        schemas=schemas,
-                        sqlite_attachments=sqlite_attachments,
-                        tables=tables,
-                    )
-
-                await adb.run_sync(_sync_bootstrap)
-            finally:
-                try:
-                    next(gen)
-                except StopIteration:
-                    pass
+            self._create_all_on_bind(
+                engine,
+                schemas=schemas,
+                sqlite_attachments=sqlite_attachments,
+                tables=tables,
+            )
         self._ddl_executed = True
 
     # ------------------------- repr -------------------------

--- a/pkgs/standards/autoapi/tests/conftest.py
+++ b/pkgs/standards/autoapi/tests/conftest.py
@@ -1,7 +1,11 @@
-from typing import AsyncIterator, Iterator
-
+import asyncio
 import pytest
 import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import Column, ForeignKey, Integer, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped
+
 from autoapi.v3 import AutoApp, Base
 from autoapi.v3.types import App
 from autoapi.v3.orm.mixins import BulkCapable, GUIDPk
@@ -10,13 +14,7 @@ from autoapi.v3.column.storage_spec import StorageTransform
 from autoapi.v3.schema import builder as v3_builder
 from autoapi.v3.runtime import kernel as runtime_kernel
 from autoapi.v3.engine.shortcuts import mem
-from httpx import ASGITransport, AsyncClient
-from sqlalchemy import Column, ForeignKey, Integer, String, create_engine
-from sqlalchemy.pool import StaticPool
-from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-from sqlalchemy.orm import Mapped, Session, sessionmaker
-import asyncio
+from autoapi.v3.engine import resolver as engine_resolver
 
 
 @pytest.fixture(scope="session")
@@ -142,36 +140,12 @@ async def api_client(db_mode):
 
     fastapi_app = App()
 
+    engine_cfg = mem() if db_mode == "async" else mem(async_=False)
+    api = AutoApp(engine=engine_cfg)
+    api.include_models([Tenant, Item])
     if db_mode == "async":
-        engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=True)
-
-        AsyncSessionLocal = async_sessionmaker(
-            bind=engine, class_=AsyncSession, expire_on_commit=False
-        )
-
-        async def get_db() -> AsyncIterator[AsyncSession]:
-            async with AsyncSessionLocal() as session:
-                yield session
-
-        api = AutoApp(get_db=get_db)
-        api.include_models([Tenant, Item])
         await api.initialize_async()
-
     else:
-        engine = create_engine(
-            "sqlite:///:memory:",
-            connect_args={"check_same_thread": False},
-            poolclass=StaticPool,
-        )
-
-        SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
-
-        def get_sync_db() -> Iterator[Session]:
-            with SessionLocal() as session:
-                yield session
-
-        api = AutoApp(get_db=get_sync_db)
-        api.include_models([Tenant, Item])
         api.initialize_sync()
 
     api.mount_jsonrpc()
@@ -241,23 +215,15 @@ async def api_client_v3():
             "secret": secret,
         }
 
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    AsyncSessionLocal = async_sessionmaker(
-        bind=engine, class_=AsyncSession, expire_on_commit=False
-    )
-
-    async def get_db():
-        async with AsyncSessionLocal() as session:
-            yield session
-
     fastapi_app = App()
-    api = AutoApp(get_db=get_db)
+    api = AutoApp(engine=mem())
     api.include_model(Widget, prefix="")
+    await api.initialize_async()
     api.mount_jsonrpc()
     api.attach_diagnostics()
     fastapi_app.include_router(api.router)
     transport = ASGITransport(app=fastapi_app)
     client = AsyncClient(transport=transport, base_url="http://test")
-    return client, api, Widget, AsyncSessionLocal
+    prov = engine_resolver.resolve_provider(api=api)
+    _, session_factory = prov.ensure()
+    return client, api, Widget, session_factory

--- a/pkgs/standards/autoapi/tests/conftest.py
+++ b/pkgs/standards/autoapi/tests/conftest.py
@@ -60,6 +60,36 @@ def pytest_generate_tests(metafunc):
 
 
 @pytest.fixture
+def sync_db_session():
+    """Provide a provider and sync session factory."""
+    from autoapi.v3.engine.shortcuts import prov
+
+    provider = prov(mem(async_=False))
+    _, session_factory = provider.ensure()
+
+    def get_sync_db():
+        with session_factory() as session:
+            yield session
+
+    return provider, get_sync_db
+
+
+@pytest_asyncio.fixture
+async def async_db_session():
+    """Provide a provider and async session factory."""
+    from autoapi.v3.engine.shortcuts import prov
+
+    provider = prov(mem())
+    _, session_factory = provider.ensure()
+
+    async def get_db():
+        async with session_factory() as session:
+            yield session
+
+    return provider, get_db
+
+
+@pytest.fixture
 def create_test_api():
     """Factory fixture to create AutoAPI instances for testing individual models."""
 

--- a/pkgs/standards/autoapi/tests/unit/test_sqlite_attachments.py
+++ b/pkgs/standards/autoapi/tests/unit/test_sqlite_attachments.py
@@ -1,5 +1,8 @@
 import pytest
-from autoapi.v3.autoapp import AutoApp
+
+from autoapi.v3 import AutoApp
+from autoapi.v3.engine.shortcuts import mem
+from autoapi.v3.engine import resolver as engine_resolver
 
 
 def _db_names(conn):
@@ -7,29 +10,32 @@ def _db_names(conn):
     return {row[1] for row in result.fetchall()}
 
 
-def test_initialize_sync_without_sqlite_attachments(sync_db_session):
-    engine, get_db = sync_db_session
-    api = AutoApp(get_db=get_db)
+def test_initialize_sync_without_sqlite_attachments():
+    api = AutoApp(engine=mem(async_=False))
     api.initialize_sync()
+    prov = engine_resolver.resolve_provider(api=api)
+    engine, _ = prov.ensure()
     with engine.connect() as conn:
         assert _db_names(conn) == {"main"}
 
 
-def test_initialize_sync_with_sqlite_attachments(sync_db_session, tmp_path):
-    engine, get_db = sync_db_session
+def test_initialize_sync_with_sqlite_attachments(tmp_path):
+    api = AutoApp(engine=mem(async_=False))
     attach_db = tmp_path / "logs.sqlite"
     attach_db.touch()
-    api = AutoApp(get_db=get_db)
     api.initialize_sync(sqlite_attachments={"logs": str(attach_db)})
+    prov = engine_resolver.resolve_provider(api=api)
+    engine, _ = prov.ensure()
     with engine.connect() as conn:
         assert "logs" in _db_names(conn)
 
 
 @pytest.mark.asyncio
-async def test_initialize_async_without_sqlite_attachments(async_db_session):
-    engine, get_db = async_db_session
-    api = AutoApp(get_db=get_db)
+async def test_initialize_async_without_sqlite_attachments():
+    api = AutoApp(engine=mem())
     await api.initialize_async()
+    prov = engine_resolver.resolve_provider(api=api)
+    engine, _ = prov.ensure()
     async with engine.connect() as conn:
         result = await conn.exec_driver_sql("PRAGMA database_list")
         names = {row[1] for row in result.fetchall()}
@@ -37,12 +43,13 @@ async def test_initialize_async_without_sqlite_attachments(async_db_session):
 
 
 @pytest.mark.asyncio
-async def test_initialize_async_with_sqlite_attachments(async_db_session, tmp_path):
-    engine, get_db = async_db_session
+async def test_initialize_async_with_sqlite_attachments(tmp_path):
+    api = AutoApp(engine=mem())
     attach_db = tmp_path / "logs.sqlite"
     attach_db.touch()
-    api = AutoApp(get_db=get_db)
     await api.initialize_async(sqlite_attachments={"logs": str(attach_db)})
+    prov = engine_resolver.resolve_provider(api=api)
+    engine, _ = prov.ensure()
     async with engine.connect() as conn:
         result = await conn.exec_driver_sql("PRAGMA database_list")
         names = {row[1] for row in result.fetchall()}


### PR DESCRIPTION
## Summary
- switch AutoAPI and AutoApp to build DDL via engine instead of session generators
- update test fixtures to provide engine-based sessions
- align SQLite attachment tests with engine bootstrap

## Testing
- `uv run --package autoapi --directory . ruff format autoapi/v3/autoapi.py autoapi/v3/autoapp.py tests/conftest.py tests/unit/test_sqlite_attachments.py`
- `uv run --package autoapi --directory . ruff check autoapi/v3/autoapi.py autoapi/v3/autoapp.py tests/conftest.py tests/unit/test_sqlite_attachments.py --fix`
- `uv run --package autoapi --directory . pytest` *(fails: AttributeError, missing fixtures, and numerous test errors)*
- `uv run --package autoapi --directory . pytest tests/i9n/test_error_mappings.py tests/i9n/test_healthz_methodz_hookz.py` *(fails: error parity assertions and KeyErrors)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ef0657d0832681567872e1f67868