### PR TITLE
Handle sync engine DDL in async initializer

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/autoapi.py
+++ b/pkgs/standards/autoapi/autoapi/v3/autoapi.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import copy
+import asyncio
+import inspect
 from types import SimpleNamespace
 from typing import (
     Any,
@@ -13,7 +15,6 @@ from typing import (
     Sequence,
     Tuple,
 )
-import inspect
 
 from .api._api import Api as _Api
 from .engine.engine_spec import EngineCfg
@@ -352,20 +353,30 @@ class AutoAPI(_Api):
                 break
         else:
             gen = prov.get_db()
-            adb = next(gen)
+            db = next(gen)
 
             try:
+                if hasattr(db, "run_sync"):
 
-                def _sync_bootstrap(arg):
-                    bind = arg.get_bind() if hasattr(arg, "get_bind") else arg
-                    self._create_all_on_bind(
+                    def _sync_bootstrap(arg):
+                        bind = arg.get_bind() if hasattr(arg, "get_bind") else arg
+                        self._create_all_on_bind(
+                            bind,
+                            schemas=schemas,
+                            sqlite_attachments=sqlite_attachments,
+                            tables=tables,
+                        )
+
+                    await db.run_sync(_sync_bootstrap)
+                else:
+                    bind = db.get_bind()
+                    await asyncio.to_thread(
+                        self._create_all_on_bind,
                         bind,
                         schemas=schemas,
                         sqlite_attachments=sqlite_attachments,
                         tables=tables,
                     )
-
-                await adb.run_sync(_sync_bootstrap)
             finally:
                 try:
                     next(gen)

--- a/pkgs/standards/autoapi/tests/unit/test_initialize_cross_ddl.py
+++ b/pkgs/standards/autoapi/tests/unit/test_initialize_cross_ddl.py
@@ -1,0 +1,26 @@
+import pytest
+from autoapi.v3.autoapp import AutoApp
+from autoapi.v3 import Base
+from autoapi.v3.specs import S, acol
+from autoapi.v3.engine.shortcuts import mem
+from sqlalchemy import Integer
+from sqlalchemy.orm import Mapped
+
+
+def _model():
+    class Widget(Base):
+        __tablename__ = "widgets"
+        id: Mapped[int] = acol(storage=S(type_=Integer, primary_key=True))
+        __autoapi_cols__ = {"id": id}
+
+    return Widget
+
+
+@pytest.mark.asyncio
+async def test_initialize_async_with_sync_engine():
+    Base.metadata.clear()
+    Widget = _model()
+    api = AutoApp(engine=mem(async_=False))
+    api.include_model(Widget)
+    await api.initialize_async()
+    assert api.tables["Widget"].name == "widgets"


### PR DESCRIPTION
## Summary
- ensure `initialize_async` runs DDL when using sync engines
- add regression test for async initialization with sync engine

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format autoapi/v3/autoapi.py autoapi/v3/autoapp.py tests/unit/test_initialize_cross_ddl.py`
- `uv run --package autoapi --directory standards/autoapi ruff check autoapi/v3/autoapi.py autoapi/v3/autoapp.py tests/unit/test_initialize_cross_ddl.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest` *(fails: 39 failed, 139 passed, 2 skipped, 1508 warnings, 30 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f1bd8b748326927b8851f65598af