### PR TITLE
Add SQLite attachment integration tests for AutoAPI v3

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_sqlite_attachments.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_sqlite_attachments.py
@@ -1,0 +1,33 @@
+import pytest
+from autoapi.v3.autoapp import AutoApp
+from autoapi.v3.engine.shortcuts import engine as build_engine, mem
+
+
+def _db_names(conn):
+    result = conn.exec_driver_sql("PRAGMA database_list")
+    return {row[1] for row in result.fetchall()}
+
+
+def test_initialize_sync_with_sqlite_attachments(tmp_path):
+    eng = build_engine(mem(async_=False))
+    attach_db = tmp_path / "logs.sqlite"
+    attach_db.touch()
+    api = AutoApp(engine=eng)
+    api.initialize_sync(sqlite_attachments={"logs": str(attach_db)})
+    sql_eng, _ = eng.raw()
+    with sql_eng.connect() as conn:
+        assert "logs" in _db_names(conn)
+
+
+@pytest.mark.asyncio
+async def test_initialize_async_with_sqlite_attachments(tmp_path):
+    eng = build_engine(mem())
+    attach_db = tmp_path / "logs.sqlite"
+    attach_db.touch()
+    api = AutoApp(engine=eng)
+    await api.initialize_async(sqlite_attachments={"logs": str(attach_db)})
+    sql_eng, _ = eng.raw()
+    async with sql_eng.connect() as conn:
+        result = await conn.exec_driver_sql("PRAGMA database_list")
+        names = {row[1] for row in result.fetchall()}
+    assert "logs" in names


### PR DESCRIPTION
## Summary
- add integration tests ensuring AutoApp initializes SQLite attachments for sync and async engines

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_sqlite_attachments.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6f6cd1da88326bc5dc12601152606