### PR TITLE
test: add db session fixtures for autoapi tests

### DIFF
--- a/pkgs/standards/autoapi/tests/conftest.py
+++ b/pkgs/standards/autoapi/tests/conftest.py
@@ -9,7 +9,8 @@ from autoapi.v3.specs import F, IO, S, acol
 from autoapi.v3.column.storage_spec import StorageTransform
 from autoapi.v3.schema import builder as v3_builder
 from autoapi.v3.runtime import kernel as runtime_kernel
-from autoapi.v3.engine.shortcuts import mem
+from autoapi.v3.engine.shortcuts import mem, provider_sqlite_memory
+from autoapi.v3.engine import resolver as _resolver
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import Column, ForeignKey, Integer, String, create_engine
 from sqlalchemy.pool import StaticPool
@@ -59,6 +60,42 @@ def pytest_generate_tests(metafunc):
         else:
             # Run both modes by default
             metafunc.parametrize("db_mode", ["sync", "async"])
+
+
+@pytest.fixture
+def sync_db_session():
+    """Provide a synchronous in-memory SQLite engine and DB session factory."""
+    provider = provider_sqlite_memory(async_=False)
+    _resolver.set_default(provider)
+    engine, maker = provider.ensure()
+
+    def get_db() -> Iterator[Session]:
+        with maker() as session:
+            yield session
+
+    try:
+        yield engine, get_db
+    finally:
+        engine.dispose()
+        _resolver.set_default(None)
+
+
+@pytest_asyncio.fixture
+async def async_db_session():
+    """Provide an asynchronous in-memory SQLite engine and DB session factory."""
+    provider = provider_sqlite_memory(async_=True)
+    _resolver.set_default(provider)
+    engine, maker = provider.ensure()
+
+    async def get_db() -> AsyncIterator[AsyncSession]:
+        async with maker() as session:
+            yield session
+
+    try:
+        yield engine, get_db
+    finally:
+        await engine.dispose()
+        _resolver.set_default(None)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- provide sync and async database session fixtures for autoapi tests

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_sqlite_attachments.py`
- `uv run --package autoapi --directory standards/autoapi pytest` *(fails: 10 failed, 32 passed, 1 skipped, 7 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f7651b44832698d6d5556c89dd08