### PR TITLE
Use engine during schema initialization

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/autoapi.py
+++ b/pkgs/standards/autoapi/autoapi/v3/autoapi.py
@@ -1,6 +1,7 @@
 # autoapi/v3/autoapi.py
 from __future__ import annotations
 
+import asyncio
 import copy
 from types import SimpleNamespace
 from typing import (
@@ -13,7 +14,6 @@ from typing import (
     Sequence,
     Tuple,
 )
-import inspect
 
 from .api._api import Api as _Api
 from .engine.engine_spec import EngineCfg
@@ -190,7 +190,7 @@ class AutoAPI(_Api):
     def attach_diagnostics(self, *, prefix: str | None = None) -> Any:
         """Mount a diagnostics router onto this AutoAPI instance."""
         px = prefix if prefix is not None else self.system_prefix
-        router = _mount_diagnostics(self)
+        router = _mount_diagnostics(self, get_db=self.engine.get_db)
         if hasattr(self, "include_router"):
             self.include_router(router, prefix=px)
         return router
@@ -317,10 +317,11 @@ class AutoAPI(_Api):
         prov = _resolver.resolve_provider(api=self)
         if prov is None:
             raise ValueError("Engine provider is not configured")
-        with next(prov.get_db()) as db:
-            bind = db.get_bind()  # Connection or Engine
+
+        engine, _ = prov.ensure()
+        with engine.begin() as conn:
             self._create_all_on_bind(
-                bind,
+                conn,
                 schemas=schemas,
                 sqlite_attachments=sqlite_attachments,
                 tables=tables,
@@ -336,41 +337,29 @@ class AutoAPI(_Api):
         if prov is None:
             raise ValueError("Engine provider is not configured")
 
-        if inspect.isasyncgenfunction(prov.get_db):
-            async for adb in prov.get_db():  # AsyncSession
-
-                def _sync_bootstrap(arg):
-                    bind = arg.get_bind() if hasattr(arg, "get_bind") else arg
-                    self._create_all_on_bind(
-                        bind,
+        engine, _ = prov.ensure()
+        if prov.kind == "async":
+            async with engine.begin() as conn:
+                await conn.run_sync(
+                    lambda sync_conn: self._create_all_on_bind(
+                        sync_conn,
                         schemas=schemas,
                         sqlite_attachments=sqlite_attachments,
                         tables=tables,
                     )
-
-                await adb.run_sync(_sync_bootstrap)
-                break
+                )
         else:
-            gen = prov.get_db()
-            adb = next(gen)
 
-            try:
-
-                def _sync_bootstrap(arg):
-                    bind = arg.get_bind() if hasattr(arg, "get_bind") else arg
+            def _sync_run():
+                with engine.begin() as conn:
                     self._create_all_on_bind(
-                        bind,
+                        conn,
                         schemas=schemas,
                         sqlite_attachments=sqlite_attachments,
                         tables=tables,
                     )
 
-                await adb.run_sync(_sync_bootstrap)
-            finally:
-                try:
-                    next(gen)
-                except StopIteration:
-                    pass
+            await asyncio.to_thread(_sync_run)
         self._ddl_executed = True
 
     # ------------------------- repr -------------------------

--- a/pkgs/standards/autoapi/autoapi/v3/system/diagnostics.py
+++ b/pkgs/standards/autoapi/autoapi/v3/system/diagnostics.py
@@ -10,7 +10,9 @@ Exposes a small router with:
 
 Usage:
     from autoapi.v3.system.diagnostics import mount_diagnostics
-    app.include_router(mount_diagnostics(api, get_db=get_db), prefix="/system")
+    app.include_router(
+        mount_diagnostics(api, get_db=engine.get_db), prefix="/system"
+    )
 """
 
 from __future__ import annotations

--- a/pkgs/standards/autoapi/tests/i9n/test_apikey_generation.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_apikey_generation.py
@@ -4,6 +4,7 @@ from httpx import ASGITransport, AsyncClient
 
 from autoapi.v3 import AutoApp
 from autoapi.v3.orm.tables import ApiKey
+from autoapi.v3.engine.shortcuts import mem
 
 
 class ConcreteApiKey(ApiKey):
@@ -16,12 +17,11 @@ class ConcreteApiKey(ApiKey):
 
 @pytest.mark.i9n
 @pytest.mark.asyncio
-async def test_api_key_creation_requires_valid_payload(sync_db_session):
+async def test_api_key_creation_requires_valid_payload():
     """Posting without required fields yields an unprocessable entity response."""
-    _, get_sync_db = sync_db_session
 
     app = App()
-    api = AutoApp(get_db=get_sync_db)
+    api = AutoApp(engine=mem(async_=False))
     api.include_models([ConcreteApiKey])
     api.initialize_sync()
     app.include_router(api.router)

--- a/pkgs/standards/autoapi/tests/i9n/test_authn_provider_integration.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_authn_provider_integration.py
@@ -1,14 +1,12 @@
 from autoapi.v3.types import App, HTTPException, Request, Security
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy.pool import StaticPool
 from uuid import uuid4
 
 from autoapi.v3 import AutoApp, Base
 from autoapi.v3.orm.mixins import GUIDPk
 from autoapi.v3.types.authn_abc import AuthNProvider
+from autoapi.v3.engine.shortcuts import mem
 
 AUTH_CONTEXT_KEY = "auth_context"
 
@@ -48,20 +46,9 @@ def _build_client_with_auth():
     class Tenant(Base, GUIDPk):
         __tablename__ = "tenants"
 
-    engine = create_engine(
-        "sqlite:///:memory:",
-        connect_args={"check_same_thread": False},
-        poolclass=StaticPool,
-    )
-    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
-
-    def get_db():
-        with SessionLocal() as session:
-            yield session
-
     auth = HookedAuth()
     app = App()
-    api = AutoApp(get_db=get_db)
+    api = AutoApp(engine=mem(async_=False))
     api.set_auth(authn=auth.get_principal)
     auth.register_inject_hook(api)
     api.include_model(Tenant)

--- a/pkgs/standards/autoapi/tests/i9n/test_core_access.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_core_access.py
@@ -28,7 +28,7 @@ def sync_api():
     api = AutoApp(engine=mem(async_=False))
     api.include_model(CoreTestUser)
     api.initialize_sync()
-    return api, api.get_db
+    return api, api.engine.get_db
 
 
 @pytest_asyncio.fixture
@@ -38,7 +38,7 @@ async def async_api():
     api = AutoApp(engine=mem())
     api.include_model(CoreTestUser)
     await api.initialize_async()
-    return api, api.get_db
+    return api, api.engine.get_db
 
 
 def test_api_exposes_core_proxies(sync_api):

--- a/pkgs/standards/autoapi/tests/i9n/test_hook_lifecycle.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_hook_lifecycle.py
@@ -9,11 +9,9 @@ from autoapi.v3 import App, AutoApp, Base
 from autoapi.v3.decorators import hook_ctx
 from autoapi.v3.orm.mixins import GUIDPk
 from httpx import ASGITransport, AsyncClient
-from sqlalchemy import Column, ForeignKey, String, create_engine
+from sqlalchemy import Column, ForeignKey, String
 from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-from sqlalchemy.orm import Session, sessionmaker
-from sqlalchemy.pool import StaticPool
+from autoapi.v3.engine.shortcuts import mem
 
 
 async def setup_client(db_mode, Tenant, Item):
@@ -21,31 +19,11 @@ async def setup_client(db_mode, Tenant, Item):
     fastapi_app = App()
 
     if db_mode == "async":
-        engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
-        AsyncSessionLocal = async_sessionmaker(
-            bind=engine, class_=AsyncSession, expire_on_commit=False
-        )
-
-        async def get_db() -> AsyncSession:
-            async with AsyncSessionLocal() as session:
-                yield session
-
-        api = AutoApp(get_db=get_db)
+        api = AutoApp(engine=mem())
         api.include_models([Tenant, Item])
         await api.initialize_async()
     else:
-        engine = create_engine(
-            "sqlite:///:memory:",
-            connect_args={"check_same_thread": False},
-            poolclass=StaticPool,
-        )
-        SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
-
-        def get_sync_db() -> Session:
-            with SessionLocal() as session:
-                yield session
-
-        api = AutoApp(get_db=get_sync_db)
+        api = AutoApp(engine=mem(async_=False))
         api.include_models([Tenant, Item])
         api.initialize_sync()
 

--- a/pkgs/standards/autoapi/tests/i9n/test_mixins.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_mixins.py
@@ -360,7 +360,7 @@ async def test_validity_window_mixin(create_test_api):
 @pytest.mark.asyncio
 async def test_validity_window_default(create_test_api):
     api = create_test_api(DummyModelValidityWindow)
-    session = next(api.get_db())
+    session = api.engine.provider.session()
     try:
         vf_default = tzutcnow()
         vt_default = tzutcnow_plus_day()

--- a/pkgs/standards/autoapi/tests/i9n/test_nested_routing_depth.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_nested_routing_depth.py
@@ -5,10 +5,11 @@ from autoapi.v3.orm.mixins import GUIDPk
 from autoapi.v3.types import App
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import Column, ForeignKey, String
+from autoapi.v3.engine.shortcuts import mem
 
 
 @pytest_asyncio.fixture
-async def three_level_api_client(db_mode, sync_db_session, async_db_session):
+async def three_level_api_client(db_mode):
     Base.metadata.clear()
     Base.registry.dispose()
 
@@ -36,13 +37,11 @@ async def three_level_api_client(db_mode, sync_db_session, async_db_session):
             return "/company/{company_id}/department/{department_id}/employee"
 
     if db_mode == "async":
-        _, get_db = async_db_session
-        api = AutoApp(get_db=get_db)
+        api = AutoApp(engine=mem())
         api.include_models([Company, Department, Employee])
         await api.initialize_async()
     else:
-        _, get_sync_db = sync_db_session
-        api = AutoApp(get_db=get_sync_db)
+        api = AutoApp(engine=mem(async_=False))
         api.include_models([Company, Department, Employee])
         api.initialize_sync()
 

--- a/pkgs/standards/autoapi/tests/i9n/test_op_ctx_behavior.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_op_ctx_behavior.py
@@ -6,15 +6,16 @@ from autoapi.v3 import AutoApp, op_ctx, schema_ctx, hook_ctx
 from autoapi.v3.orm.tables import Base
 from autoapi.v3.orm.mixins import GUIDPk
 from autoapi.v3.runtime.kernel import build_phase_chains
+from autoapi.v3.engine.shortcuts import mem
 
 
-# helper to set up AutoAPI with sync DB from fixture
+# helper to set up AutoAPI with sync DB
 
 
-def setup_api(model_cls, get_db):
+def setup_api(model_cls, get_db=None):
     Base.metadata.clear()
     app = App()
-    api = AutoApp(get_db=get_db)
+    api = AutoApp(engine=mem(async_=False))
     api.include_model(model_cls, prefix="")
     api.initialize_sync()
     app.include_router(api.router)

--- a/pkgs/standards/autoapi/tests/i9n/test_owner_tenant_policy.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_owner_tenant_policy.py
@@ -3,15 +3,14 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from fastapi.testclient import TestClient
 import pytest
 import uuid
-from sqlalchemy import Column, String, create_engine
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy.pool import StaticPool
+from sqlalchemy import Column, String
 
 from autoapi.v3 import AutoApp, Base
 from autoapi.v3.orm.mixins import GUIDPk
 from autoapi.v3.orm.mixins.ownable import Ownable, OwnerPolicy
 from autoapi.v3.orm.mixins.tenant_bound import TenantBound, TenantPolicy
 from autoapi.v3.types.authn_abc import AuthNProvider
+from autoapi.v3.engine.shortcuts import mem
 
 
 class DummyAuth(AuthNProvider):
@@ -79,30 +78,18 @@ def _client_for_owner(
         name = Column(String, nullable=False)
         __autoapi_owner_policy__ = policy
 
-    engine = create_engine(
-        "sqlite:///:memory:",
-        connect_args={"check_same_thread": False},
-        poolclass=StaticPool,
-    )
-    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
-    Base.metadata.create_all(bind=engine)
-
-    with SessionLocal() as session:
-        session.execute(User.__table__.insert().values(id=user_id, name="owner"))
-        session.commit()
-
-    def get_db():
-        with SessionLocal() as session:
-            yield session
-
     authn = DummyAuth(user_id, tenant_id)
-    api = AutoApp(get_db=get_db)
+    api = AutoApp(engine=mem(async_=False))
     api.set_auth(authn=authn.get_principal)
     authn.register_inject_hook(api)
     api.include_models([User, Item])
+    api.initialize_sync()
+    engine, SessionLocal = api.engine.raw()
+    with SessionLocal() as session:
+        session.execute(User.__table__.insert().values(id=user_id, name="owner"))
+        session.commit()
     app = App()
     app.include_router(api.router)
-    api.initialize_sync()
     return TestClient(app)
 
 
@@ -147,30 +134,18 @@ def _client_for_tenant(
         name = Column(String, nullable=False)
         __autoapi_tenant_policy__ = policy
 
-    engine = create_engine(
-        "sqlite:///:memory:",
-        connect_args={"check_same_thread": False},
-        poolclass=StaticPool,
-    )
-    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
-    Base.metadata.create_all(bind=engine)
-
-    with SessionLocal() as session:
-        session.execute(Tenant.__table__.insert().values(id=tenant_id, name="acme"))
-        session.commit()
-
-    def get_db():
-        with SessionLocal() as session:
-            yield session
-
     authn = DummyAuth(user_id, tenant_id)
-    api = AutoApp(get_db=get_db)
+    api = AutoApp(engine=mem(async_=False))
     api.set_auth(authn=authn.get_principal)
     authn.register_inject_hook(api)
     api.include_models([Tenant, Item])
+    api.initialize_sync()
+    engine, SessionLocal = api.engine.raw()
+    with SessionLocal() as session:
+        session.execute(Tenant.__table__.insert().values(id=tenant_id, name="acme"))
+        session.commit()
     app = App()
     app.include_router(api.router)
-    api.initialize_sync()
     return TestClient(app)
 
 

--- a/pkgs/standards/autoapi/tests/i9n/test_schema_ctx_op_ctx_integration.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_schema_ctx_op_ctx_integration.py
@@ -4,10 +4,10 @@ from pydantic import BaseModel
 from autoapi.v3.types import App
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import Column, String
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from autoapi.v3 import AutoApp, Base, op_ctx, schema_ctx
 from autoapi.v3.orm.mixins import GUIDPk
+from autoapi.v3.engine.shortcuts import mem
 
 
 @pytest_asyncio.fixture
@@ -35,17 +35,8 @@ async def widget_client():
         async def echo(cls, ctx):
             return ctx["payload"]
 
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    sessionmaker = async_sessionmaker(
-        bind=engine, class_=AsyncSession, expire_on_commit=False
-    )
-
-    async def get_db():
-        async with sessionmaker() as session:
-            yield session
-
     app = App()
-    api = AutoApp(get_db=get_db)
+    api = AutoApp(engine=mem())
     api.include_model(Widget, prefix="")
     api.mount_jsonrpc()
     await api.initialize_async()

--- a/pkgs/standards/autoapi/tests/unit/test_file_response.py
+++ b/pkgs/standards/autoapi/tests/unit/test_file_response.py
@@ -101,7 +101,7 @@ def test_file_response_api(tmp_path):
     async def fake_db():
         yield None
 
-    api.get_db = fake_db  # type: ignore[assignment]
+    object.__setattr__(api.engine.provider, "get_db", fake_db)
     include_model(api, Widget)
 
     resp = asyncio.run(Widget.handlers.download.handler({}))
@@ -129,7 +129,7 @@ def test_file_response_app(tmp_path):
     async def fake_db():
         yield None
 
-    api.get_db = fake_db  # type: ignore[assignment]
+    object.__setattr__(api.engine.provider, "get_db", fake_db)
     include_model(api, Widget)
 
     class FilesApp(AutoApp):

--- a/pkgs/standards/autoapi/tests/unit/test_response_alias_table_rpc.py
+++ b/pkgs/standards/autoapi/tests/unit/test_response_alias_table_rpc.py
@@ -5,8 +5,9 @@ from autoapi.v3.response import response_ctx
 from autoapi.v3.orm.mixins import GUIDPk
 from autoapi.v3.orm.tables import Base
 from autoapi.v3.specs import IO, S, F, acol as spec_acol
-from autoapi.v3.types import Session, String, StaticPool, create_engine, sessionmaker
+from autoapi.v3.types import Session, String
 from autoapi.v3.autoapi import AutoAPI
+from autoapi.v3.engine.shortcuts import mem
 
 
 @pytest.mark.asyncio
@@ -23,21 +24,11 @@ async def test_response_ctx_alias_table_rpc():
             io=IO(in_verbs=("create",), out_verbs=("read",)),
         )
 
-    engine = create_engine(
-        "sqlite:///:memory:",
-        connect_args={"check_same_thread": False},
-        poolclass=StaticPool,
-    )
-    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
-
-    def get_db() -> Session:
-        with SessionLocal() as session:
-            yield session
-
-    api = AutoAPI(get_db=get_db)
+    api = AutoAPI(engine=mem(async_=False))
     api.include_model(Widget, mount_router=False)
     api.initialize_sync()
 
+    _, SessionLocal = api.engine.raw()
     session: Session = SessionLocal()
     try:
         created = await api.rpc_call(Widget, "create", {"name": "a"}, db=session)
@@ -45,4 +36,3 @@ async def test_response_ctx_alias_table_rpc():
         assert fetched["id"] == created["id"]
     finally:
         session.close()
-        engine.dispose()

--- a/pkgs/standards/autoapi/tests/unit/test_rpc_default_ops.py
+++ b/pkgs/standards/autoapi/tests/unit/test_rpc_default_ops.py
@@ -5,13 +5,8 @@ from autoapi.v3.autoapp import AutoApp
 from autoapi.v3.orm.mixins import BulkCapable, GUIDPk
 from autoapi.v3.specs import IO, S, F, acol as spec_acol
 from autoapi.v3.orm.tables import Base
-from autoapi.v3.types import (
-    Session,
-    String,
-    StaticPool,
-    create_engine,
-    sessionmaker,
-)
+from autoapi.v3.types import Session, String
+from autoapi.v3.engine.shortcuts import mem
 
 
 @pytest.fixture()
@@ -30,27 +25,16 @@ def api_and_session() -> Iterator[tuple[AutoApp, Session, type[Base]]]:
             ),
         )
 
-    engine = create_engine(
-        "sqlite:///:memory:",
-        connect_args={"check_same_thread": False},
-        poolclass=StaticPool,
-    )
-    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
-
-    def get_db() -> Iterator[Session]:
-        with SessionLocal() as session:
-            yield session
-
-    api = AutoApp(get_db=get_db)
+    api = AutoApp(engine=mem(async_=False))
     api.include_model(Widget, mount_router=False)
     api.initialize_sync()
 
+    _, SessionLocal = api.engine.raw()
     session: Session = SessionLocal()
     try:
         yield api, session, Widget
     finally:
         session.close()
-        engine.dispose()
 
 
 @pytest.mark.asyncio

--- a/pkgs/standards/autoapi/tests/unit/test_sqlite_attachments.py
+++ b/pkgs/standards/autoapi/tests/unit/test_sqlite_attachments.py
@@ -1,5 +1,8 @@
 import pytest
+
 from autoapi.v3.autoapp import AutoApp
+from autoapi.v3.engine import resolver as _resolver
+from autoapi.v3.engine.shortcuts import mem
 
 
 def _db_names(conn):
@@ -7,29 +10,32 @@ def _db_names(conn):
     return {row[1] for row in result.fetchall()}
 
 
-def test_initialize_sync_without_sqlite_attachments(sync_db_session):
-    engine, get_db = sync_db_session
-    api = AutoApp(get_db=get_db)
+def test_initialize_sync_without_sqlite_attachments():
+    api = AutoApp(engine=mem(async_=False))
     api.initialize_sync()
+    prov = _resolver.resolve_provider(api=api)
+    engine, _ = prov.ensure()
     with engine.connect() as conn:
         assert _db_names(conn) == {"main"}
 
 
-def test_initialize_sync_with_sqlite_attachments(sync_db_session, tmp_path):
-    engine, get_db = sync_db_session
+def test_initialize_sync_with_sqlite_attachments(tmp_path):
     attach_db = tmp_path / "logs.sqlite"
     attach_db.touch()
-    api = AutoApp(get_db=get_db)
+    api = AutoApp(engine=mem(async_=False))
     api.initialize_sync(sqlite_attachments={"logs": str(attach_db)})
+    prov = _resolver.resolve_provider(api=api)
+    engine, _ = prov.ensure()
     with engine.connect() as conn:
         assert "logs" in _db_names(conn)
 
 
 @pytest.mark.asyncio
-async def test_initialize_async_without_sqlite_attachments(async_db_session):
-    engine, get_db = async_db_session
-    api = AutoApp(get_db=get_db)
+async def test_initialize_async_without_sqlite_attachments():
+    api = AutoApp(engine=mem())
     await api.initialize_async()
+    prov = _resolver.resolve_provider(api=api)
+    engine, _ = prov.ensure()
     async with engine.connect() as conn:
         result = await conn.exec_driver_sql("PRAGMA database_list")
         names = {row[1] for row in result.fetchall()}
@@ -37,12 +43,13 @@ async def test_initialize_async_without_sqlite_attachments(async_db_session):
 
 
 @pytest.mark.asyncio
-async def test_initialize_async_with_sqlite_attachments(async_db_session, tmp_path):
-    engine, get_db = async_db_session
+async def test_initialize_async_with_sqlite_attachments(tmp_path):
     attach_db = tmp_path / "logs.sqlite"
     attach_db.touch()
-    api = AutoApp(get_db=get_db)
+    api = AutoApp(engine=mem())
     await api.initialize_async(sqlite_attachments={"logs": str(attach_db)})
+    prov = _resolver.resolve_provider(api=api)
+    engine, _ = prov.ensure()
     async with engine.connect() as conn:
         result = await conn.exec_driver_sql("PRAGMA database_list")
         names = {row[1] for row in result.fetchall()}


### PR DESCRIPTION
## Summary
- replace `get_db` properties with engine provider lookups
- refactor tests to configure `AutoApp` using engine specs

## Testing
- `uv run --package autoapi --directory . ruff format autoapi/v3/autoapi.py autoapi/v3/autoapp.py autoapi/v3/system/diagnostics.py tests/i9n/test_allow_anon.py tests/i9n/test_apikey_generation.py tests/i9n/test_authn_provider_integration.py tests/i9n/test_core_access.py tests/i9n/test_field_spec_effects.py tests/i9n/test_hook_ctx_v3_i9n.py tests/i9n/test_hook_lifecycle.py tests/i9n/test_iospec_integration.py tests/i9n/test_mixins.py tests/i9n/test_nested_routing_depth.py tests/i9n/test_op_ctx_behavior.py tests/i9n/test_owner_tenant_policy.py tests/i9n/test_request_extras.py tests/i9n/test_schema_ctx_attributes_integration.py tests/i9n/test_schema_ctx_op_ctx_integration.py tests/i9n/test_v3_bulk_rest_endpoints.py tests/unit/test_column_rest_rpc_results.py tests/unit/test_file_response.py tests/unit/test_response_alias_table_rpc.py tests/unit/test_rpc_all_default_op_verbs.py tests/unit/test_rpc_default_ops.py`
- `uv run --package autoapi --directory . ruff check autoapi/v3/autoapi.py autoapi/v3/autoapp.py autoapi/v3/system/diagnostics.py tests/i9n/test_allow_anon.py tests/i9n/test_apikey_generation.py tests/i9n/test_authn_provider_integration.py tests/i9n/test_core_access.py tests/i9n/test_field_spec_effects.py tests/i9n/test_hook_ctx_v3_i9n.py tests/i9n/test_hook_lifecycle.py tests/i9n/test_iospec_integration.py tests/i9n/test_mixins.py tests/i9n/test_nested_routing_depth.py tests/i9n/test_op_ctx_behavior.py tests/i9n/test_owner_tenant_policy.py tests/i9n/test_request_extras.py tests/i9n/test_schema_ctx_attributes_integration.py tests/i9n/test_schema_ctx_op_ctx_integration.py tests/i9n/test_v3_bulk_rest_endpoints.py tests/unit/test_column_rest_rpc_results.py tests/unit/test_file_response.py tests/unit/test_response_alias_table_rpc.py tests/unit/test_rpc_all_default_op_verbs.py tests/unit/test_rpc_default_ops.py --fix`

------
https://chatgpt.com/codex/tasks/task_e_68b6f120fae88326b6fc0485b7f7fc2c