### PR TITLE
fix: normalize sqlite attachment paths

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/autoapp.py
+++ b/pkgs/standards/autoapi/autoapi/v3/autoapp.py
@@ -315,6 +315,8 @@ class AutoApp(_App):
                 attachments = sqlite_default_attach_map(engine, schema_names)
 
         if attachments:
+            # accept PathLike values for attachment targets
+            attachments = {k: str(v) for k, v in attachments.items()}
             # also applies ensure_schemas; immediate listener warm-up
             bootstrap_dbschema(
                 engine,

--- a/pkgs/standards/autoapi/tests/i9n/test_sqlite_attachments.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_sqlite_attachments.py
@@ -13,7 +13,7 @@ def test_initialize_sync_with_sqlite_attachments(tmp_path):
     attach_db = tmp_path / "logs.sqlite"
     attach_db.touch()
     api = AutoApp(engine=eng)
-    api.initialize_sync(sqlite_attachments={"logs": str(attach_db)})
+    api.initialize_sync(sqlite_attachments={"logs": attach_db})
     sql_eng, _ = eng.raw()
     with sql_eng.connect() as conn:
         assert "logs" in _db_names(conn)
@@ -25,7 +25,7 @@ async def test_initialize_async_with_sqlite_attachments(tmp_path):
     attach_db = tmp_path / "logs.sqlite"
     attach_db.touch()
     api = AutoApp(engine=eng)
-    await api.initialize_async(sqlite_attachments={"logs": str(attach_db)})
+    await api.initialize_async(sqlite_attachments={"logs": attach_db})
     sql_eng, _ = eng.raw()
     async with sql_eng.connect() as conn:
         result = await conn.exec_driver_sql("PRAGMA database_list")


### PR DESCRIPTION
## Summary
- normalize sqlite attachment mapping values to strings to accept PathLike objects
- test sqlite attachments without casting paths to strings

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_sqlite_attachments.py`
- `uv run --package autoapi --directory standards/autoapi pytest` *(fails: tests/i9n/test_allow_anon.py::test_allow_anon_list_and_read)*

------
https://chatgpt.com/codex/tasks/task_e_68b6fa8556888326a7acad9eb80fc7f8