### PR TITLE
refactor autoapi to use engine for ddl and sqlite attachments

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/autoapp.py
+++ b/pkgs/standards/autoapi/autoapi/v3/autoapp.py
@@ -347,14 +347,41 @@ class AutoApp(_App):
         prov = _resolver.resolve_provider()
         if prov is None:
             raise ValueError("Engine provider is not configured")
-        with next(prov.get_db()) as db:
-            bind = db.get_bind()  # Connection or Engine
-            self._create_all_on_bind(
-                bind,
-                schemas=schemas,
-                sqlite_attachments=sqlite_attachments,
-                tables=tables,
-            )
+
+        if inspect.isasyncgenfunction(prov.get_db):
+
+            async def _run_async() -> None:
+                async for adb in prov.get_db():  # AsyncSession
+
+                    def _sync_bootstrap(arg):
+                        bind = arg.get_bind() if hasattr(arg, "get_bind") else arg
+                        self._create_all_on_bind(
+                            bind,
+                            schemas=schemas,
+                            sqlite_attachments=sqlite_attachments,
+                            tables=tables,
+                        )
+
+                    await adb.run_sync(_sync_bootstrap)
+                    break
+
+            asyncio.run(_run_async())
+        else:
+            gen = prov.get_db()
+            db = next(gen)
+            try:
+                bind = db.get_bind()  # Connection or Engine
+                self._create_all_on_bind(
+                    bind,
+                    schemas=schemas,
+                    sqlite_attachments=sqlite_attachments,
+                    tables=tables,
+                )
+            finally:
+                try:
+                    next(gen)
+                except StopIteration:
+                    pass
         self._ddl_executed = True
 
     async def initialize_async(

--- a/pkgs/standards/autoapi/tests/conftest.py
+++ b/pkgs/standards/autoapi/tests/conftest.py
@@ -61,17 +61,12 @@ def pytest_generate_tests(metafunc):
 
 @pytest.fixture
 def sync_db_session():
-    """Provide a synchronous in-memory SQLite engine and DB session factory."""
+    """Provide a synchronous in-memory SQLite engine and provider."""
     provider = provider_sqlite_memory(async_=False)
     _resolver.set_default(provider)
-    engine, maker = provider.ensure()
-
-    def get_db() -> Iterator[Session]:
-        with maker() as session:
-            yield session
-
+    engine, _ = provider.ensure()
     try:
-        yield engine, get_db
+        yield engine, provider
     finally:
         engine.dispose()
         _resolver.set_default(None)
@@ -79,17 +74,12 @@ def sync_db_session():
 
 @pytest_asyncio.fixture
 async def async_db_session():
-    """Provide an asynchronous in-memory SQLite engine and DB session factory."""
+    """Provide an asynchronous in-memory SQLite engine and provider."""
     provider = provider_sqlite_memory(async_=True)
     _resolver.set_default(provider)
-    engine, maker = provider.ensure()
-
-    async def get_db() -> AsyncIterator[AsyncSession]:
-        async with maker() as session:
-            yield session
-
+    engine, _ = provider.ensure()
     try:
-        yield engine, get_db
+        yield engine, provider
     finally:
         await engine.dispose()
         _resolver.set_default(None)

--- a/pkgs/standards/autoapi/tests/unit/test_sqlite_attachments.py
+++ b/pkgs/standards/autoapi/tests/unit/test_sqlite_attachments.py
@@ -8,18 +8,18 @@ def _db_names(conn):
 
 
 def test_initialize_sync_without_sqlite_attachments(sync_db_session):
-    engine, get_db = sync_db_session
-    api = AutoApp(get_db=get_db)
+    engine, _ = sync_db_session
+    api = AutoApp()
     api.initialize_sync()
     with engine.connect() as conn:
         assert _db_names(conn) == {"main"}
 
 
 def test_initialize_sync_with_sqlite_attachments(sync_db_session, tmp_path):
-    engine, get_db = sync_db_session
+    engine, _ = sync_db_session
     attach_db = tmp_path / "logs.sqlite"
     attach_db.touch()
-    api = AutoApp(get_db=get_db)
+    api = AutoApp()
     api.initialize_sync(sqlite_attachments={"logs": str(attach_db)})
     with engine.connect() as conn:
         assert "logs" in _db_names(conn)
@@ -27,8 +27,8 @@ def test_initialize_sync_with_sqlite_attachments(sync_db_session, tmp_path):
 
 @pytest.mark.asyncio
 async def test_initialize_async_without_sqlite_attachments(async_db_session):
-    engine, get_db = async_db_session
-    api = AutoApp(get_db=get_db)
+    engine, _ = async_db_session
+    api = AutoApp()
     await api.initialize_async()
     async with engine.connect() as conn:
         result = await conn.exec_driver_sql("PRAGMA database_list")
@@ -38,10 +38,10 @@ async def test_initialize_async_without_sqlite_attachments(async_db_session):
 
 @pytest.mark.asyncio
 async def test_initialize_async_with_sqlite_attachments(async_db_session, tmp_path):
-    engine, get_db = async_db_session
+    engine, _ = async_db_session
     attach_db = tmp_path / "logs.sqlite"
     attach_db.touch()
-    api = AutoApp(get_db=get_db)
+    api = AutoApp()
     await api.initialize_async(sqlite_attachments={"logs": str(attach_db)})
     async with engine.connect() as conn:
         result = await conn.exec_driver_sql("PRAGMA database_list")


### PR DESCRIPTION
## Summary
- support async providers during sync initialization in AutoApp/AutoAPI
- expose engine providers in test fixtures and drop `get_db` usage
- verify SQLite attachments for sync and async initialization

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_sqlite_attachments.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_68b6fbb58a448326a34f6e4ddc6b0c95