### PR TITLE
fix: add missing type imports in autoapi tests

### DIFF
--- a/pkgs/standards/autoapi/tests/conftest.py
+++ b/pkgs/standards/autoapi/tests/conftest.py
@@ -1,20 +1,23 @@
 import pytest
+import asyncio
+from typing import AsyncIterator, Iterator
+
 import pytest_asyncio
-from autoapi.v3 import AutoApp, Base
-from autoapi.v3.types import App
-from autoapi.v3.orm.mixins import BulkCapable, GUIDPk
-from autoapi.v3.specs import F, IO, S, acol
-from autoapi.v3.column.storage_spec import StorageTransform
-from autoapi.v3.schema import builder as v3_builder
-from autoapi.v3.runtime import kernel as runtime_kernel
-from autoapi.v3.engine.shortcuts import mem, provider_sqlite_memory
-from autoapi.v3.engine import resolver as _resolver
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import Column, ForeignKey, Integer, String
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-from sqlalchemy.orm import Mapped
-import asyncio
+from sqlalchemy.orm import Mapped, Session
+
+from autoapi.v3 import AutoApp, Base
+from autoapi.v3.column.storage_spec import StorageTransform
+from autoapi.v3.engine import resolver as _resolver
+from autoapi.v3.engine.shortcuts import mem, provider_sqlite_memory
+from autoapi.v3.orm.mixins import BulkCapable, GUIDPk
+from autoapi.v3.runtime import kernel as runtime_kernel
+from autoapi.v3.schema import builder as v3_builder
+from autoapi.v3.specs import F, IO, S, acol
+from autoapi.v3.types import App
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Summary
- add missing typing and SQLAlchemy session imports to autoapi test fixtures

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_acol_vcol_knobs.py -q`
- `uv run --package autoapi --directory standards/autoapi pytest -q` *(fails: 71 failed, 199 passed, 7 skipped, 4 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b6fdad27dc83268ed3f25fec219906