### PR TITLE
Fix autoapi DB provider detection and type hints

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/api.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/api.py
@@ -207,6 +207,8 @@ def _seed_security_and_deps(api: Any, model: type) -> None:
     prov = _resolver.resolve_provider(api=api)
     if prov is not None:
         setattr(model, AUTOAPI_GET_DB_ATTR, prov.get_db)
+    elif hasattr(api, "get_db"):
+        setattr(model, AUTOAPI_GET_DB_ATTR, api.get_db)
 
     # Authn (prefer optional dep when available)
     auth_dep = None

--- a/pkgs/standards/autoapi/tests/conftest.py
+++ b/pkgs/standards/autoapi/tests/conftest.py
@@ -13,7 +13,8 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy import Column, ForeignKey, Integer, String
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-from sqlalchemy.orm import Mapped
+from sqlalchemy.orm import Mapped, Session
+from collections.abc import AsyncIterator, Iterator
 import asyncio
 
 


### PR DESCRIPTION
## Summary
- ensure autoapi binds DB dependency when API exposes get_db
- add missing type imports in tests

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_bindings_integration.py::test_include_model_and_rpc_call -q`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_db_dependency.py tests/unit/test_acol_vcol_knobs.py tests/i9n/test_bindings_integration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6fdaa7da88326ae431755a490bddf