### PR TITLE
Fix iterator imports in autoapi test fixtures

### DIFF
--- a/pkgs/standards/autoapi/tests/conftest.py
+++ b/pkgs/standards/autoapi/tests/conftest.py
@@ -1,3 +1,6 @@
+import asyncio
+from typing import AsyncIterator, Iterator
+
 import pytest
 import pytest_asyncio
 from autoapi.v3 import AutoApp, Base
@@ -13,8 +16,7 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy import Column, ForeignKey, Integer, String
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-from sqlalchemy.orm import Mapped
-import asyncio
+from sqlalchemy.orm import Mapped, Session
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Summary
- fix missing typing and Session imports in autoapi tests' fixtures

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_apikey_generation.py`
- `uv run --package autoapi --directory standards/autoapi pytest` *(fails: 31 failed, 57 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b6fe23e9a4832681444b1ed9077261