### PR TITLE
refactor: use provider for v3 diagnostics and jsonrpc

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/system/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/system/__init__.py
@@ -2,7 +2,7 @@
 """
 AutoAPI v3 – System/Diagnostics helpers.
 
-- mount_diagnostics(api, *, get_db=None) -> Router
+- mount_diagnostics(api, *, engine=None, prov=None) -> Router
 """
 
 from __future__ import annotations

--- a/pkgs/standards/autoapi/autoapi/v3/system/diagnostics.py
+++ b/pkgs/standards/autoapi/autoapi/v3/system/diagnostics.py
@@ -10,7 +10,7 @@ Exposes a small router with:
 
 Usage:
     from autoapi.v3.system.diagnostics import mount_diagnostics
-    app.include_router(mount_diagnostics(api, get_db=get_db), prefix="/system")
+    app.include_router(mount_diagnostics(api, engine=my_engine), prefix="/system")
 """
 
 from __future__ import annotations
@@ -353,7 +353,8 @@ def _build_planz_endpoint(api: Any):
 def mount_diagnostics(
     api: Any,
     *,
-    get_db: Optional[Callable[..., Any]] = None,
+    engine: Any | None = None,
+    prov: Any | None = None,
 ) -> Router:
     """
     Create & return a Router that exposes:
@@ -364,7 +365,7 @@ def mount_diagnostics(
     """
     router = Router()
 
-    dep = get_db
+    dep = getattr(prov or engine, "get_db", None)
 
     router.add_api_route(
         "/healthz",

--- a/pkgs/standards/autoapi/autoapi/v3/transport/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/transport/__init__.py
@@ -12,8 +12,8 @@ Quick usage:
 
     # JSON-RPC
     app.include_router(build_jsonrpc_router(api), prefix="/rpc")
-    # or supply a DB dependency from an Engine or Provider:
-    mount_jsonrpc(api, app, prefix="/rpc", get_db=my_engine.get_db)
+    # or supply an Engine or Provider for DB access:
+    mount_jsonrpc(api, app, prefix="/rpc", engine=my_engine)
 
     # REST (aggregate all model routers under one prefix)
     # after you include models with mount_router=False
@@ -24,7 +24,7 @@ Quick usage:
 
 from __future__ import annotations
 
-from typing import Any, Callable, Optional, Sequence
+from typing import Any, Sequence
 
 # JSON-RPC transport
 from .jsonrpc import build_jsonrpc_router
@@ -38,7 +38,8 @@ def mount_jsonrpc(
     app: Any,
     *,
     prefix: str = "/rpc",
-    get_db: Optional[Callable[..., Any]] = None,
+    engine: Any | None = None,
+    prov: Any | None = None,
     tags: Sequence[str] | None = ("rpc",),
 ):
     """
@@ -55,7 +56,8 @@ def mount_jsonrpc(
     """
     router = build_jsonrpc_router(
         api,
-        get_db=get_db,
+        engine=engine,
+        prov=prov,
         tags=tags,
     )
     include_router = getattr(app, "include_router", None)

--- a/pkgs/standards/autoapi/autoapi/v3/transport/jsonrpc/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/transport/jsonrpc/__init__.py
@@ -4,7 +4,7 @@ AutoAPI v3 – JSON-RPC transport.
 
 Public helper:
   - build_jsonrpc_router(
-        api, *, get_db=None, tags=("rpc",)
+        api, *, engine=None, prov=None, tags=("rpc",)
     ) -> Router
 
 Usage:

--- a/pkgs/standards/autoapi/tests/unit/test_v3_healthz_endpoint.py
+++ b/pkgs/standards/autoapi/tests/unit/test_v3_healthz_endpoint.py
@@ -22,12 +22,11 @@ class DummyDB:
 async def test_healthz_endpoint_select_case_fallback():
     db = DummyDB()
 
-    def get_db():
-        return db
+    prov = SimpleNamespace(get_db=lambda: db)
 
     api = SimpleNamespace(models={})
     app = App()
-    app.include_router(mount_diagnostics(api, get_db=get_db), prefix="/system")
+    app.include_router(mount_diagnostics(api, prov=prov), prefix="/system")
 
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://test"


### PR DESCRIPTION
## Summary
- replace direct get_db references in v3 transports and diagnostics with engine/provider abstractions
- adjust healthz tests to use provider interface

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `uv run --package autoapi --directory pkgs/standards/autoapi pytest` *(fails: 43 failed, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ffd4ae4c8326920738dc27eb846b