### PR TITLE
fix: update autoapi tests for new table namespace

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_sqlite_attachments.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_sqlite_attachments.py
@@ -28,6 +28,5 @@ async def test_initialize_async_with_sqlite_attachments(tmp_path):
     await api.initialize_async(sqlite_attachments={"logs": str(attach_db)})
     sql_eng, _ = eng.raw()
     async with sql_eng.connect() as conn:
-        result = await conn.exec_driver_sql("PRAGMA database_list")
-        names = {row[1] for row in result.fetchall()}
+        names = await conn.run_sync(_db_names)
     assert "logs" in names

--- a/pkgs/standards/autoapi/tests/unit/test_initialize_cross_ddl.py
+++ b/pkgs/standards/autoapi/tests/unit/test_initialize_cross_ddl.py
@@ -23,4 +23,4 @@ async def test_initialize_async_with_sync_engine():
     api = AutoApp(engine=mem(async_=False))
     api.include_model(Widget)
     await api.initialize_async()
-    assert api.tables["Widget"].name == "widgets"
+    assert getattr(api.tables, "Widget").name == "widgets"


### PR DESCRIPTION
## Summary
- adjust SQLite attachment test to reuse helper via run_sync
- update cross-ddl initialization test for SimpleNamespace tables

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format tests/i9n/test_sqlite_attachments.py tests/unit/test_initialize_cross_ddl.py`
- `uv run --package autoapi --directory standards/autoapi ruff check tests/i9n/test_sqlite_attachments.py tests/unit/test_initialize_cross_ddl.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_sqlite_attachments.py tests/unit/test_initialize_cross_ddl.py`

------
https://chatgpt.com/codex/tasks/task_e_68b7014e77a883269336c58e3f194302