### PR TITLE
refactor: allow custom db in autoapi

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/api/_api.py
+++ b/pkgs/standards/autoapi/autoapi/v3/api/_api.py
@@ -18,6 +18,7 @@ class Api(APISpec, ApiRouter):
     def __init__(
         self, *, engine: EngineCfg | None = None, **router_kwargs: Any
     ) -> None:
+        get_db = router_kwargs.pop("get_db", None)
         ApiRouter.__init__(
             self,
             prefix=self.PREFIX,
@@ -34,7 +35,12 @@ class Api(APISpec, ApiRouter):
         _engine_ctx = engine if engine is not None else getattr(self, "ENGINE", None)
         if _engine_ctx is not None:
             _resolver.register_api(self, _engine_ctx)
-            _resolver.resolve_provider(api=self)
+            prov = _resolver.resolve_provider(api=self)
+            if prov is not None and get_db is None:
+                get_db = prov.get_db
+
+        if get_db is not None:
+            self.get_db = get_db
 
     def install_engines(
         self, *, api: Any = None, models: tuple[Any, ...] | None = None

--- a/pkgs/standards/autoapi/tests/i9n/test_allow_anon.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_allow_anon.py
@@ -66,6 +66,7 @@ def _build_client():
         poolclass=StaticPool,
     )
     SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+    Base.metadata.create_all(bind=engine)
 
     def get_db():
         with SessionLocal() as session:
@@ -104,6 +105,7 @@ def _build_client_attr():
         poolclass=StaticPool,
     )
     SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+    Base.metadata.create_all(bind=engine)
 
     def get_db():
         with SessionLocal() as session:
@@ -174,6 +176,7 @@ def _build_client_create_noauth():
         poolclass=StaticPool,
     )
     SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+    Base.metadata.create_all(bind=engine)
 
     def get_db():
         with SessionLocal() as session:
@@ -209,6 +212,7 @@ def _build_client_create_attr_noauth():
         poolclass=StaticPool,
     )
     SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+    Base.metadata.create_all(bind=engine)
 
     def get_db():
         with SessionLocal() as session:


### PR DESCRIPTION
## Summary
- handle optional get_db in Api and App initializers
- fall back to provided get_db when engine provider missing
- initialize test schemas for allow_anon cases

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7001479688326adce41dcae628f80