### PR TITLE
refactor: update API key generation test for AutoApp

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_apikey_generation.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_apikey_generation.py
@@ -1,5 +1,4 @@
 import pytest
-from autoapi.v3.types import App
 from httpx import ASGITransport, AsyncClient
 
 from autoapi.v3 import AutoApp
@@ -18,13 +17,11 @@ class ConcreteApiKey(ApiKey):
 @pytest.mark.asyncio
 async def test_api_key_creation_requires_valid_payload(sync_db_session):
     """Posting without required fields yields an unprocessable entity response."""
-    _, get_sync_db = sync_db_session
+    _, _ = sync_db_session
 
-    app = App()
-    api = AutoApp(get_db=get_sync_db)
-    api.include_models([ConcreteApiKey])
-    api.initialize_sync()
-    app.include_router(api.router)
+    app = AutoApp()
+    app.include_models([ConcreteApiKey])
+    app.initialize_sync()
     transport = ASGITransport(app=app)
 
     async with AsyncClient(transport=transport, base_url="http://test") as client:


### PR DESCRIPTION
## Summary
- instantiate `AutoApp` directly in API key generation test
- rely on fixture-configured engine provider without legacy `App` wrapper

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_apikey_generation.py`
- `uv run --package autoapi --directory standards/autoapi pytest` *(fails: OperationalError no such table: tenants; engine provider not configured; various assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b7003064f483268e9b162b5411d50e