### PR TITLE
Explicit async engine for async_api fixture

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_core_access.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_core_access.py
@@ -36,7 +36,7 @@ def sync_api():
 async def async_api():
     """Create an async AutoAPI instance with CoreTestUser."""
     Base.metadata.clear()
-    eng = build_engine(mem())
+    eng = build_engine(mem(async_=True))
     api = AutoApp(engine=eng)
     api.include_model(CoreTestUser)
     await api.initialize_async()


### PR DESCRIPTION
## Summary
- ensure async_api fixture builds an asynchronous engine by setting `async_=True`

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b7098801288326ae602d7cece041b0