### PR TITLE
Fix REST ops tests by using sync in-memory engine

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_v3_default_rest_ops.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_v3_default_rest_ops.py
@@ -40,7 +40,12 @@ async def client_and_model():
         __autoapi_cols__ = {"id": id, "name": name, "age": age}
 
     app = App()
-    api = AutoAPIv3(engine=mem())
+    # AutoApp/AutoAPI dropped the ``get_db`` attribute in favor of using the
+    # engine facade. Using an async SQLite engine in this test triggers a
+    # ``MissingGreenlet`` error when SQLAlchemy performs I/O. Configure a
+    # synchronous in-memory engine instead so the REST operations run without
+    # requiring greenlet magic.
+    api = AutoAPIv3(engine=mem(async_=False))
     api.include_model(Gadget, prefix="")
     await api.initialize_async()
     app.include_router(api.router)


### PR DESCRIPTION
## Summary
- use synchronous in-memory engine in REST ops tests to avoid greenlet errors

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_v3_default_rest_ops.py::test_rest_read -q`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_v3_default_rest_ops.py::test_rest_update -q`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_v3_default_rest_ops.py::test_rest_replace -q`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_v3_default_rest_ops.py::test_rest_delete -q`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_v3_default_rest_ops.py::test_rest_list -q`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_v3_default_rest_ops.py -q`
- `uv run --package autoapi --directory standards/autoapi pytest -q` *(fails: 39, passed: 160, skipped: 3)*

------
https://chatgpt.com/codex/tasks/task_e_68b70f135b8c8326aa9a45bb8965d998