### PR TITLE
Fix async session wrappers in AutoAPI

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/engine/builders.py
+++ b/pkgs/standards/autoapi/autoapi/v3/engine/builders.py
@@ -77,20 +77,20 @@ class HybridSession(AsyncSession):
     def add(self, *a, **k):
         return self.sync_session.add(*a, **k)
 
-    def get(self, *a, **k):
-        return self.sync_session.get(*a, **k)
+    async def get(self, *a, **k):
+        return await super().get(*a, **k)
 
-    def flush(self, *a, **k):
-        return self.sync_session.flush(*a, **k)
+    async def flush(self, *a, **k):
+        return await super().flush(*a, **k)
 
-    def commit(self, *a, **k):
-        return self.sync_session.commit(*a, **k)
+    async def commit(self, *a, **k):
+        return await super().commit(*a, **k)
 
-    def refresh(self, *a, **k):
-        return self.sync_session.refresh(*a, **k)
+    async def refresh(self, *a, **k):
+        return await super().refresh(*a, **k)
 
-    def delete(self, *a, **k):
-        return self.sync_session.delete(*a, **k)
+    async def delete(self, *a, **k):
+        return await super().delete(*a, **k)
 
     # ---- DDL helper used at AutoAPI bootstrap --------------------------
     async def run_sync(self, fn, *a, **kw):


### PR DESCRIPTION
## Summary
- use async definitions for HybridSession helpers to avoid MissingGreenlet errors
- restore REST fallback serialization test

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format autoapi/v3/engine/builders.py`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check autoapi/v3/engine/builders.py --fix`
- `uv run --directory pkgs/standards/autoapi --package autoapi pytest tests/i9n/test_rest_fallback_serialization.py::test_rest_read_and_list_without_out_schema -vv`
- `uv run --directory pkgs/standards/autoapi --package autoapi pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b70f35b2b48326b07884b546559ba7