### PR TITLE
fix: update autoapp db access

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/autoapp.py
+++ b/pkgs/standards/autoapi/autoapi/v3/autoapp.py
@@ -197,10 +197,13 @@ class AutoApp(_App):
     def mount_jsonrpc(self, *, prefix: str | None = None) -> Any:
         """Mount JSON-RPC router onto this app."""
         px = prefix if prefix is not None else self.jsonrpc_prefix
+        prov = _resolver.resolve_provider()
+        get_db = prov.get_db if prov is not None else None
         router = _mount_jsonrpc(
             self,
             self,
             prefix=px,
+            get_db=get_db,
         )
         self._base_routes = list(self.router.routes)
         return router

--- a/pkgs/standards/autoapi/tests/i9n/test_iospec_integration.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_iospec_integration.py
@@ -1,12 +1,12 @@
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
-from sqlalchemy import create_engine, select
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy.pool import StaticPool
+from sqlalchemy import select
 from types import SimpleNamespace
 
 from autoapi.v3.autoapp import AutoApp
+from autoapi.v3.engine import resolver as _resolver
+from autoapi.v3.engine.shortcuts import mem
 from autoapi.v3.orm.tables import Base
 from autoapi.v3.orm.mixins import GUIDPk
 from autoapi.v3.specs import IO, S, acol
@@ -35,28 +35,16 @@ class Widget(Base, GUIDPk):
 
 @pytest_asyncio.fixture
 async def widget_setup():
-    engine = create_engine(
-        "sqlite:///:memory:",
-        connect_args={"check_same_thread": False},
-        poolclass=StaticPool,
-    )
-    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
-
-    def get_db():
-        with SessionLocal() as session:
-            yield session
-
-    # Other tests may clear ``Base.metadata``, leaving it empty. Creating the
-    # tables directly from the model definitions ensures this fixture remains
-    # functional regardless of prior global state.
-    Widget.__table__.create(bind=engine)
-
     app = App()
-    api = AutoApp(get_db=get_db)
+    api = AutoApp(engine=mem(async_=False))
     api.include_model(Widget, prefix="/widget")
     api.mount_jsonrpc(prefix="/rpc")
     api.attach_diagnostics(prefix="/system")
+    api.initialize_sync()
     app.include_router(api.router)
+
+    prov = _resolver.resolve_provider()
+    SessionLocal = prov.session
 
     transport = ASGITransport(app=app)
     client = AsyncClient(transport=transport, base_url="http://test")


### PR DESCRIPTION
## Summary
- use engine provider when mounting AutoApp JSON-RPC
- adapt iospec integration tests to engine-based sessions

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format autoapi/v3/autoapp.py tests/i9n/test_iospec_integration.py`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_iospec_integration.py`
- `uv run --package autoapi --directory standards/autoapi pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b70f3b97c48326841ebab92640424b