### PR TITLE
feat: propagate DB dependency in AutoApp

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/autoapp.py
+++ b/pkgs/standards/autoapi/autoapi/v3/autoapp.py
@@ -37,6 +37,7 @@ from .bindings.rest import build_router_and_attach as _build_router_and_attach
 from .transport import mount_jsonrpc as _mount_jsonrpc
 from .system import mount_diagnostics as _mount_diagnostics
 from .ops import get_registry, OpSpec
+from .config.constants import AUTOAPI_GET_DB_ATTR
 
 
 # optional compat: legacy transactional decorator
@@ -75,6 +76,7 @@ class AutoApp(_App):
         self,
         *,
         engine: EngineCfg | None = None,
+        get_db: Callable[..., Any] | None = None,
         jsonrpc_prefix: str = "/rpc",
         system_prefix: str = "/system",
         api_hooks: Mapping[str, Iterable[Callable]]
@@ -92,6 +94,8 @@ class AutoApp(_App):
         if lifespan is not None:
             self.LIFESPAN = lifespan
         super().__init__(engine=engine, **fastapi_kwargs)
+        if get_db is not None:
+            setattr(self, AUTOAPI_GET_DB_ATTR, get_db)
         # capture initial routes so refreshes retain FastAPI defaults
         self._base_routes = list(self.router.routes)
         self.jsonrpc_prefix = jsonrpc_prefix

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/api.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/api.py
@@ -207,6 +207,8 @@ def _seed_security_and_deps(api: Any, model: type) -> None:
     prov = _resolver.resolve_provider(api=api)
     if prov is not None:
         setattr(model, AUTOAPI_GET_DB_ATTR, prov.get_db)
+    elif hasattr(api, AUTOAPI_GET_DB_ATTR):
+        setattr(model, AUTOAPI_GET_DB_ATTR, getattr(api, AUTOAPI_GET_DB_ATTR))
 
     # Authn (prefer optional dep when available)
     auth_dep = None


### PR DESCRIPTION
## Summary
- allow passing `get_db` to AutoApp and attach it when no engine provider is registered
- propagate database dependency from AutoApp to models during binding

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format autoapi/v3/autoapp.py autoapi/v3/bindings/api.py`
- `uv run --package autoapi --directory standards/autoapi ruff check autoapi/v3/autoapp.py autoapi/v3/bindings/api.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest 'tests/i9n/test_field_spec_effects.py::test_field_spec_allow_null_update' -q`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7122aec808326857e5b65bbbf0266