### PR TITLE
refactor bindings integration test for engine API

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_bindings_integration.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_bindings_integration.py
@@ -1,8 +1,10 @@
 import asyncio
 from types import SimpleNamespace
 
-from sqlalchemy import String, create_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy import String
+
+from autoapi.v3.engine import resolver as _resolver
+from autoapi.v3.engine.shortcuts import engine as engine_factory, mem
 
 from autoapi.v3.types import uuid4
 from autoapi.v3.orm.tables import Base
@@ -41,21 +43,23 @@ class Gizmo(Base, GUIDPk):
 
 
 def _make_db():
-    engine = create_engine("sqlite:///:memory:")
+    engine = engine_factory(mem(async_=False))
+    raw_engine, _ = engine.raw()
     # The shared Declarative ``Base`` is cleared in various tests to maintain
-    # isolation.  If another test clears the metadata before this helper runs,
+    # isolation. If another test clears the metadata before this helper runs,
     # ``Base.metadata.create_all`` would create no tables, leading to runtime
-    # failures.  Creating the tables directly from the model definitions keeps
+    # failures. Creating the tables directly from the model definitions keeps
     # this helper resilient regardless of prior test side effects.
-    Widget.__table__.create(bind=engine)
-    Gizmo.__table__.create(bind=engine)
-    Session = sessionmaker(bind=engine)
-    return engine, Session()
+    Widget.__table__.create(bind=raw_engine)
+    Gizmo.__table__.create(bind=raw_engine)
+    db = engine.provider.session()
+    return engine, db
 
 
 def test_include_model_and_rpc_call():
-    _, db = _make_db()
-    api = SimpleNamespace(get_db=lambda: db)
+    engine, db = _make_db()
+    api = SimpleNamespace(engine=engine)
+    _resolver.register_api(api, engine)
 
     include_model(api, Widget, mount_router=False)
 
@@ -85,8 +89,9 @@ def test_include_model_and_rpc_call():
 
 
 def test_include_models():
-    _, db = _make_db()
-    api = SimpleNamespace(get_db=lambda: db)
+    engine, db = _make_db()
+    api = SimpleNamespace(engine=engine)
+    _resolver.register_api(api, engine)
 
     include_models(api, [Widget, Gizmo], mount_router=False)
 


### PR DESCRIPTION
## Summary
- adjust bindings integration tests to use engine provider instead of get_db

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_bindings_integration.py::test_include_model_and_rpc_call`
- `uv run --package autoapi --directory standards/autoapi pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7146147c883268d0df05c396512fe