### PR TITLE
test: use engine in iospec tests

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_iospec_attributes.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_iospec_attributes.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Mapped, sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from autoapi.v3.autoapp import AutoApp
+from autoapi.v3.engine.shortcuts import engine as engine_factory, mem
 from autoapi.v3.bindings.model import bind
 from autoapi.v3.bindings.rest import _build_router
 from autoapi.v3.bindings.rpc import register_and_attach
@@ -184,16 +185,7 @@ def test_storage_and_sqlalchemy_integration():
 
 @pytest.mark.i9n
 def test_rest_call_respects_aliases():
-    engine = create_engine(
-        "sqlite:///:memory:",
-        connect_args={"check_same_thread": False},
-        poolclass=StaticPool,
-    )
-    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
-
-    def get_db():
-        with SessionLocal() as session:
-            yield session
+    eng = engine_factory(mem(async_=False))
 
     class Thing(Base):
         __tablename__ = "iospec_rest_i9n"
@@ -208,9 +200,9 @@ def test_rest_call_respects_aliases():
             io=IO(in_verbs=("create",), out_verbs=("read",)),
         )
 
-    api = AutoApp(get_db=get_db)
+    api = AutoApp(engine=eng)
     api.include_model(Thing)
-    Base.metadata.create_all(engine)
+    Base.metadata.create_all(eng.raw()[0])
     client = TestClient(api)
 
     resp = client.post("/thing", json={"name": "Ada"})
@@ -254,16 +246,7 @@ async def test_rpc_call_uses_schemas():
 @pytest.mark.i9n
 @pytest.mark.asyncio
 async def test_core_crud_helpers_operate():
-    engine = create_engine(
-        "sqlite:///:memory:",
-        connect_args={"check_same_thread": False},
-        poolclass=StaticPool,
-    )
-    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
-
-    def get_db():
-        with SessionLocal() as session:
-            yield session
+    eng = engine_factory(mem(async_=False))
 
     class Thing(Base):
         __tablename__ = "iospec_core_i9n"
@@ -278,11 +261,11 @@ async def test_core_crud_helpers_operate():
             io=IO(in_verbs=("create",), out_verbs=("read",)),
         )
 
-    api = AutoApp(get_db=get_db)
+    api = AutoApp(engine=eng)
     api.include_model(Thing)
-    Base.metadata.create_all(engine)
+    Base.metadata.create_all(eng.raw()[0])
 
-    with SessionLocal() as session:
+    with eng.session() as session:
         created = await api.core.Thing.create({"name": "Zed"}, db=session)
         obj = await api.core.Thing.read({"id": created["id"]}, db=session)
     assert obj["name"] == "Zed"


### PR DESCRIPTION
## Summary
- update iospec integration tests to use engine-based database handling

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_iospec_attributes.py`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_iospec_attributes.py::test_rest_call_respects_aliases`


------
https://chatgpt.com/codex/tasks/task_e_68b71473989483269db31aced14cb5c2