### PR TITLE
fix: update autoapi tests for engine sessions

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_authn_provider_integration.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_authn_provider_integration.py
@@ -1,12 +1,10 @@
-from autoapi.v3.types import App, HTTPException, Request, Security
+from autoapi.v3.types import HTTPException, Request, Security
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy.pool import StaticPool
 from uuid import uuid4
 
-from autoapi.v3 import AutoApp, Base
+from autoapi.v3 import App, AutoApp, Base
+from autoapi.v3.engine.shortcuts import mem
 from autoapi.v3.orm.mixins import GUIDPk
 from autoapi.v3.types.authn_abc import AuthNProvider
 
@@ -48,20 +46,9 @@ def _build_client_with_auth():
     class Tenant(Base, GUIDPk):
         __tablename__ = "tenants"
 
-    engine = create_engine(
-        "sqlite:///:memory:",
-        connect_args={"check_same_thread": False},
-        poolclass=StaticPool,
-    )
-    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
-
-    def get_db():
-        with SessionLocal() as session:
-            yield session
-
     auth = HookedAuth()
     app = App()
-    api = AutoApp(get_db=get_db)
+    api = AutoApp(engine=mem(async_=False))
     api.set_auth(authn=auth.get_principal)
     auth.register_inject_hook(api)
     api.include_model(Tenant)


### PR DESCRIPTION
## Summary
- update allow anon tests to use engine-backed sessions
- adjust auth provider integration tests for engine-aware AutoApp

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_allow_anon.py`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_authn_provider_integration.py`
- `uv run --package autoapi --directory standards/autoapi pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b71453dc608326a013cbb22a780709