### PR TITLE
refactor: use engine facade in tenant policy tests

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_owner_tenant_policy.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_owner_tenant_policy.py
@@ -3,9 +3,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from fastapi.testclient import TestClient
 import pytest
 import uuid
-from sqlalchemy import Column, String, create_engine
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy.pool import StaticPool
+from sqlalchemy import Column, String
 
 from autoapi.v3 import AutoApp, Base
 from autoapi.v3.orm.mixins import GUIDPk
@@ -79,24 +77,20 @@ def _client_for_owner(
         name = Column(String, nullable=False)
         __autoapi_owner_policy__ = policy
 
-    engine = create_engine(
-        "sqlite:///:memory:",
-        connect_args={"check_same_thread": False},
-        poolclass=StaticPool,
-    )
-    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
-    Base.metadata.create_all(bind=engine)
+    from autoapi.v3.engine.shortcuts import mem
+    from autoapi.v3.engine.engine_spec import EngineSpec
+    from autoapi.v3.engine._engine import Engine
 
-    with SessionLocal() as session:
+    engine = Engine(EngineSpec.from_any(mem(async_=False)))
+    db_engine, _ = engine.raw()
+    Base.metadata.create_all(bind=db_engine)
+
+    with engine.session() as session:
         session.execute(User.__table__.insert().values(id=user_id, name="owner"))
         session.commit()
 
-    def get_db():
-        with SessionLocal() as session:
-            yield session
-
     authn = DummyAuth(user_id, tenant_id)
-    api = AutoApp(get_db=get_db)
+    api = AutoApp(engine=engine)
     api.set_auth(authn=authn.get_principal)
     authn.register_inject_hook(api)
     api.include_models([User, Item])
@@ -147,24 +141,20 @@ def _client_for_tenant(
         name = Column(String, nullable=False)
         __autoapi_tenant_policy__ = policy
 
-    engine = create_engine(
-        "sqlite:///:memory:",
-        connect_args={"check_same_thread": False},
-        poolclass=StaticPool,
-    )
-    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
-    Base.metadata.create_all(bind=engine)
+    from autoapi.v3.engine.shortcuts import mem
+    from autoapi.v3.engine.engine_spec import EngineSpec
+    from autoapi.v3.engine._engine import Engine
 
-    with SessionLocal() as session:
+    engine = Engine(EngineSpec.from_any(mem(async_=False)))
+    db_engine, _ = engine.raw()
+    Base.metadata.create_all(bind=db_engine)
+
+    with engine.session() as session:
         session.execute(Tenant.__table__.insert().values(id=tenant_id, name="acme"))
         session.commit()
 
-    def get_db():
-        with SessionLocal() as session:
-            yield session
-
     authn = DummyAuth(user_id, tenant_id)
-    api = AutoApp(get_db=get_db)
+    api = AutoApp(engine=engine)
     api.set_auth(authn=authn.get_principal)
     authn.register_inject_hook(api)
     api.include_models([Tenant, Item])


### PR DESCRIPTION
## Summary
- update owner/tenant policy integration tests to use engine facade instead of get_db

## Testing
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory pkgs/standards/autoapi pytest tests/i9n/test_owner_tenant_policy.py::test_tenant_policy_runtime_switch -vv`
- `uv run --package autoapi --directory pkgs/standards/autoapi pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b717fa80ec8326ba067d93c508c18e