### PR TITLE
Use engine provider for AutoAuthn test DB overrides

### DIFF
--- a/pkgs/standards/auto_authn/tests/conftest.py
+++ b/pkgs/standards/auto_authn/tests/conftest.py
@@ -21,6 +21,7 @@ from sqlalchemy.pool import StaticPool
 from auto_authn.app import app
 from auto_authn.db import get_async_db
 from auto_authn.routers.surface import surface_api
+from autoapi.v3.engine import resolver as _resolver
 from auto_authn.orm import Base, Tenant, User, Client, ApiKey
 from auto_authn.crypto import hash_pw
 
@@ -87,7 +88,9 @@ def override_get_db(db_session):
         yield db_session
 
     app.dependency_overrides[get_async_db] = _get_test_db
-    app.dependency_overrides[surface_api.get_async_db] = _get_test_db
+    prov = _resolver.resolve_provider(api=surface_api)
+    if prov:
+        app.dependency_overrides[prov.get_db] = _get_test_db
     yield
     app.dependency_overrides.clear()
 


### PR DESCRIPTION
## Summary
- update AutoAuthn tests to override database dependency via engine provider instead of removed `get_async_db`

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest`
- `uv run --package auto_authn --directory standards/auto_authn ruff format .`
- `uv run --package auto_authn --directory standards/auto_authn ruff check . --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_authorize_id_token_hashes.py::test_authorize_includes_at_hash -q`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_authorize_id_token_hashes.py::test_authorize_includes_c_hash -q`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_authorize_response_modes.py -q`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_jwks_rotation.py -q`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_oidc_authorize_scope_nonce.py -q`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_openid_configuration.py -q`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_openid_userinfo_endpoint.py -q`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_rfc7009_token_revocation.py -q`
- `uv run --package auto_authn --directory standards/auto_authn pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b79ce5c15883269f82d2c2f3115af6