### PR TITLE
Use Engine for database integration

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/adapters/local_adapter.py
+++ b/pkgs/standards/auto_authn/auto_authn/adapters/local_adapter.py
@@ -9,7 +9,7 @@ Usage
 -----
 >>> from autoapi.v3 import AutoAPI
 >>> from auto_authn.adapters import LocalAuthNAdapter
->>> api = AutoAPI(get_async_db=get_db, authn=LocalAuthNAdapter())
+>>> api = AutoAPI(engine=ENGINE, authn=LocalAuthNAdapter())
 """
 
 from __future__ import annotations

--- a/pkgs/standards/auto_authn/auto_authn/app.py
+++ b/pkgs/standards/auto_authn/auto_authn/app.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 from autoapi.v3 import AutoApp
 
 from .routers.surface import surface_api
-from .db import dsn
+from .db import ENGINE
 from .runtime_cfg import settings
 from .rfc8414 import include_rfc8414
 from .oidc_discovery import include_oidc_discovery
@@ -36,7 +36,7 @@ app = AutoApp(
     version="0.1.0",
     openapi_url="/openapi.json",
     docs_url="/docs",
-    engine=dsn,
+    engine=ENGINE,
 )
 
 # Mount routers

--- a/pkgs/standards/auto_authn/auto_authn/backends.py
+++ b/pkgs/standards/auto_authn/auto_authn/backends.py
@@ -27,7 +27,7 @@ from typing import Iterable, Optional
 from typing import TYPE_CHECKING
 
 from sqlalchemy import Select, or_, select
-from sqlalchemy.ext.asyncio import AsyncSession
+from typing import Any
 
 from .crypto import verify_pw
 from .typing import Principal
@@ -88,9 +88,7 @@ class PasswordBackend:
             user.is_active.is_(True),
         )
 
-    async def authenticate(
-        self, db: AsyncSession, identifier: str, password: str
-    ) -> User:
+    async def authenticate(self, db: Any, identifier: str, password: str) -> User:
         row: Optional["User"] = await db.scalar(await self._get_user_stmt(identifier))
         if not row or not verify_pw(password, row.password_hash):
             raise AuthError("invalid username/email or password")
@@ -128,9 +126,7 @@ class ApiKeyBackend:
         client = _Client()
         return select(client).where(client.is_active.is_(True))
 
-    async def authenticate(
-        self, db: AsyncSession, api_key: str
-    ) -> tuple[Principal, str]:
+    async def authenticate(self, db: Any, api_key: str) -> tuple[Principal, str]:
         api_key_cls = _ApiKey()
         digest = api_key_cls.digest_of(api_key)
 

--- a/pkgs/standards/auto_authn/auto_authn/db.py
+++ b/pkgs/standards/auto_authn/auto_authn/db.py
@@ -1,8 +1,4 @@
-from sqlalchemy.ext.asyncio import (
-    AsyncSession,
-    async_sessionmaker,
-    create_async_engine,
-)
+from autoapi.v3.engine import engine as make_engine
 
 from .runtime_cfg import settings
 
@@ -13,15 +9,4 @@ else:
     # Fallback to a local SQLite database when Postgres settings are missing
     dsn = "sqlite+aiosqlite:///./authn.db"
 
-engine = create_async_engine(
-    dsn,
-    pool_size=10,
-    max_overflow=20,
-    echo=False,
-)
-Session = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
-
-
-async def get_async_db() -> AsyncSession:
-    async with Session() as db:
-        yield db
+ENGINE = make_engine(dsn)

--- a/pkgs/standards/auto_authn/auto_authn/rfc8628.py
+++ b/pkgs/standards/auto_authn/auto_authn/rfc8628.py
@@ -16,7 +16,7 @@ import string
 from typing import Final, Literal, TYPE_CHECKING
 
 from pydantic import BaseModel
-from sqlalchemy.ext.asyncio import AsyncSession
+from typing import Any
 
 from .runtime_cfg import settings
 
@@ -63,9 +63,7 @@ class DeviceGrantForm(BaseModel):
     client_id: str
 
 
-async def approve_device_code(
-    device_code: str, sub: str, tid: str, db: AsyncSession
-) -> None:
+async def approve_device_code(device_code: str, sub: str, tid: str, db: Any) -> None:
     """Mark a device code as authorized (testing helper)."""
 
     from .orm import DeviceCode

--- a/pkgs/standards/auto_authn/auto_authn/rfc9126.py
+++ b/pkgs/standards/auto_authn/auto_authn/rfc9126.py
@@ -16,9 +16,8 @@ from typing import TYPE_CHECKING, Any, Dict, Final
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy import delete
-from sqlalchemy.ext.asyncio import AsyncSession
 
-from .db import get_async_db
+from .db import ENGINE
 from .runtime_cfg import settings
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -35,7 +34,7 @@ router = APIRouter()
 @router.post("/par", status_code=status.HTTP_201_CREATED)
 async def pushed_authorization_request(
     request: Request,
-    db: AsyncSession = Depends(get_async_db),
+    db: Any = Depends(ENGINE.get_db),
 ) -> Dict[str, Any]:
     """Handle Pushed Authorization Requests.
 
@@ -56,7 +55,7 @@ async def pushed_authorization_request(
 
 async def store_par_request(
     params: Dict[str, Any],
-    db: AsyncSession,
+    db: Any,
     expires_in: int = DEFAULT_PAR_EXPIRY,
 ) -> str:
     """Store *params* and return a unique ``request_uri``."""
@@ -78,7 +77,7 @@ async def store_par_request(
     return request_uri
 
 
-async def get_par_request(request_uri: str, db: AsyncSession) -> Dict[str, Any] | None:
+async def get_par_request(request_uri: str, db: Any) -> Dict[str, Any] | None:
     """Retrieve parameters for *request_uri* if present and not expired."""
 
     from .orm import PushedAuthorizationRequest
@@ -92,7 +91,7 @@ async def get_par_request(request_uri: str, db: AsyncSession) -> Dict[str, Any] 
     return obj.params
 
 
-async def reset_par_store(db: AsyncSession) -> None:
+async def reset_par_store(db: Any) -> None:
     """Clear stored pushed authorization requests (test helper)."""
 
     from .orm import PushedAuthorizationRequest

--- a/pkgs/standards/auto_authn/auto_authn/routers/auth_flows.py
+++ b/pkgs/standards/auto_authn/auto_authn/routers/auth_flows.py
@@ -4,10 +4,10 @@ import secrets
 
 from fastapi import Depends, HTTPException, Request, status
 from fastapi.responses import JSONResponse
-from sqlalchemy.ext.asyncio import AsyncSession
+from typing import Any
 
 from ..backends import AuthError
-from ..fastapi_deps import get_async_db
+from ..db import ENGINE
 from ..oidc_id_token import mint_id_token
 from ..orm.auth_session import AuthSession
 from ..routers.schemas import CredsIn, TokenPair
@@ -20,7 +20,7 @@ from .shared import _jwt, _pwd_backend, AUTH_CODES, SESSIONS
 async def login(
     creds: CredsIn,
     request: Request,
-    db: AsyncSession = Depends(get_async_db),
+    db: Any = Depends(ENGINE.get_db),
 ):
     try:
         user = await _pwd_backend.authenticate(db, creds.identifier, creds.password)

--- a/pkgs/standards/auto_authn/auto_authn/routers/authz/oidc.py
+++ b/pkgs/standards/auto_authn/auto_authn/routers/authz/oidc.py
@@ -9,9 +9,8 @@ from urllib.parse import urlencode
 
 from fastapi import Depends, HTTPException, Request, status
 from fastapi.responses import HTMLResponse, RedirectResponse
-from sqlalchemy.ext.asyncio import AsyncSession
 
-from ...fastapi_deps import get_async_db
+from ...db import ENGINE
 from ...orm import AuthCode, Client, User
 from ...oidc_id_token import mint_id_token, oidc_hash
 from ...rfc8414_metadata import ISSUER
@@ -36,7 +35,7 @@ async def authorize(
     max_age: Optional[int] = None,
     login_hint: Optional[str] = None,
     claims: Optional[str] = None,
-    db: AsyncSession = Depends(get_async_db),
+    db: Any = Depends(ENGINE.get_db),
 ):
     _require_tls(request)
     rts = set(response_type.split())

--- a/pkgs/standards/auto_authn/auto_authn/routers/authz/rfc6749.py
+++ b/pkgs/standards/auto_authn/auto_authn/routers/authz/rfc6749.py
@@ -8,11 +8,10 @@ from typing import Any
 from fastapi import Depends, HTTPException, Request, status
 from fastapi.responses import JSONResponse
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
 from pydantic import ValidationError
 
 from ...backends import AuthError
-from ...fastapi_deps import get_async_db
+from ...db import ENGINE
 from ...orm import AuthCode, Client, DeviceCode, User
 from ...rfc8707 import extract_resource
 from ...runtime_cfg import settings
@@ -39,9 +38,7 @@ from . import router
 
 
 @router.post("/token", response_model=TokenPair)
-async def token(
-    request: Request, db: AsyncSession = Depends(get_async_db)
-) -> TokenPair:
+async def token(request: Request, db: Any = Depends(ENGINE.get_db)) -> TokenPair:
     _require_tls(request)
     form = await request.form()
     resources = form.getlist("resource")

--- a/pkgs/standards/auto_authn/tests/conftest.py
+++ b/pkgs/standards/auto_authn/tests/conftest.py
@@ -19,7 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from sqlalchemy.pool import StaticPool
 
 from auto_authn.app import app
-from auto_authn.db import get_async_db
+from auto_authn.db import ENGINE
 from auto_authn.routers.surface import surface_api
 from auto_authn.orm import Base, Tenant, User, Client, ApiKey
 from auto_authn.crypto import hash_pw
@@ -89,7 +89,7 @@ def override_get_db(db_session, test_db_engine):
     async def _get_test_db():
         yield db_session
 
-    app.dependency_overrides[get_async_db] = _get_test_db
+    app.dependency_overrides[ENGINE.get_db] = _get_test_db
 
     original_provider = engine_resolver.resolve_provider(api=surface_api)
     spec = EngineSpec.from_any(TEST_DATABASE_URL)

--- a/pkgs/standards/auto_authn/tests/unit/test_fastapi_deps.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_fastapi_deps.py
@@ -28,13 +28,11 @@ from auto_authn.backends import AuthError
 class TestDatabaseDependency:
     """Test database session dependency functionality."""
 
-    def test_database_dependency_import(self):
-        """Test that database dependency can be imported correctly."""
-        from auto_authn.fastapi_deps import get_async_db
-        from auto_authn.db import get_async_db as db_get_async_db
+    def test_engine_dependency_import(self):
+        """Test that the Engine dependency is accessible."""
+        from auto_authn.db import ENGINE
 
-        # Verify they're the same function
-        assert get_async_db is db_get_async_db
+        assert callable(ENGINE.get_db)
 
     def test_database_session_mock_behavior(self):
         """Test that we can mock database session behavior for testing."""

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc6749_token_endpoint.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc6749_token_endpoint.py
@@ -5,9 +5,9 @@ import pytest_asyncio
 from fastapi import FastAPI, status
 from httpx import ASGITransport, AsyncClient, BasicAuth
 
-from auto_authn.fastapi_deps import get_async_db
 from auto_authn.routers.auth_flows import router
 from auto_authn.runtime_cfg import settings
+from auto_authn.db import ENGINE
 
 
 AUTH = BasicAuth("abc", "secret")
@@ -33,7 +33,7 @@ async def _override_db():
 async def client():
     app = FastAPI()
     app.include_router(router)
-    app.dependency_overrides[get_async_db] = _override_db
+    app.dependency_overrides[ENGINE.get_db] = _override_db
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as c:
         yield c

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc6750_bearer_token.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc6750_bearer_token.py
@@ -11,8 +11,9 @@ import pytest
 from fastapi import Depends, FastAPI, status
 from httpx import ASGITransport, AsyncClient
 
-from auto_authn.fastapi_deps import get_current_principal, get_async_db
+from auto_authn.fastapi_deps import get_current_principal
 from auto_authn.runtime_cfg import settings
+from auto_authn.db import ENGINE
 
 
 @pytest.mark.unit
@@ -43,7 +44,7 @@ async def test_lowercase_bearer_scheme():
         return {"ok": True}
 
     mock_db = AsyncMock()
-    app.dependency_overrides[get_async_db] = lambda: mock_db
+    app.dependency_overrides[ENGINE.get_db] = lambda: mock_db
 
     mock_user = MagicMock()
     with patch(
@@ -68,7 +69,7 @@ async def test_rfc6750_disabled_rejects_header():
         return {"ok": True}
 
     mock_db = AsyncMock()
-    app.dependency_overrides[get_async_db] = lambda: mock_db
+    app.dependency_overrides[ENGINE.get_db] = lambda: mock_db
 
     with patch.object(settings, "enable_rfc6750", False):
         transport = ASGITransport(app=app)
@@ -90,7 +91,7 @@ async def test_access_token_query_parameter_enabled():
         return {"ok": True}
 
     mock_db = AsyncMock()
-    app.dependency_overrides[get_async_db] = lambda: mock_db
+    app.dependency_overrides[ENGINE.get_db] = lambda: mock_db
 
     mock_user = MagicMock()
     with patch.object(settings, "enable_rfc6750_query", True):
@@ -117,7 +118,7 @@ async def test_access_token_query_parameter_disabled():
         return {"ok": True}
 
     mock_db = AsyncMock()
-    app.dependency_overrides[get_async_db] = lambda: mock_db
+    app.dependency_overrides[ENGINE.get_db] = lambda: mock_db
 
     with patch.object(settings, "enable_rfc6750_query", False):
         transport = ASGITransport(app=app)
@@ -137,7 +138,7 @@ async def test_access_token_form_body_enabled():
         return {"ok": True}
 
     mock_db = AsyncMock()
-    app.dependency_overrides[get_async_db] = lambda: mock_db
+    app.dependency_overrides[ENGINE.get_db] = lambda: mock_db
 
     mock_user = MagicMock()
     with patch.object(settings, "enable_rfc6750_form", True):
@@ -168,7 +169,7 @@ async def test_access_token_form_body_disabled():
         return {"ok": True}
 
     mock_db = AsyncMock()
-    app.dependency_overrides[get_async_db] = lambda: mock_db
+    app.dependency_overrides[ENGINE.get_db] = lambda: mock_db
 
     with patch.object(settings, "enable_rfc6750_form", False):
         transport = ASGITransport(app=app)

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7662_token_introspection.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7662_token_introspection.py
@@ -5,8 +5,8 @@ from fastapi import FastAPI, status
 from httpx import ASGITransport, AsyncClient
 
 from auto_authn.routers.auth_flows import router
-from auto_authn.fastapi_deps import get_async_db
 from auto_authn.rfc7662 import register_token, reset_tokens
+from auto_authn.db import ENGINE
 
 
 # RFC 7662 specification excerpt for reference within tests
@@ -35,7 +35,7 @@ async def test_introspection_endpoint_returns_active_field(enable_rfc7662):
     async def override_db():
         yield None
 
-    app.dependency_overrides[get_async_db] = override_db
+    app.dependency_overrides[ENGINE.get_db] = override_db
 
     # Register a token in the introspection registry to mark it as active
     register_token("dummy")
@@ -61,7 +61,7 @@ async def test_introspection_requires_token_parameter(enable_rfc7662):
     async def override_db():
         yield None
 
-    app.dependency_overrides[get_async_db] = override_db
+    app.dependency_overrides[ENGINE.get_db] = override_db
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc8707_resource_indicators.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc8707_resource_indicators.py
@@ -13,7 +13,7 @@ from httpx import ASGITransport, AsyncClient
 
 from auto_authn.runtime_cfg import settings
 from auto_authn.routers.auth_flows import router, _jwt
-from auto_authn.fastapi_deps import get_async_db
+from auto_authn.db import ENGINE
 
 
 @pytest.mark.unit
@@ -28,7 +28,7 @@ async def test_token_includes_aud_when_resource_provided(monkeypatch):
         "auto_authn.routers.auth_flows._pwd_backend.authenticate",
         AsyncMock(return_value=mock_user),
     )
-    app.dependency_overrides[get_async_db] = lambda: AsyncMock()
+    app.dependency_overrides[ENGINE.get_db] = lambda: AsyncMock()
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.post(
@@ -54,7 +54,7 @@ async def test_invalid_resource_returns_error(monkeypatch):
     app = FastAPI()
     app.include_router(router)
     monkeypatch.setattr(settings, "rfc8707_enabled", True)
-    app.dependency_overrides[get_async_db] = lambda: AsyncMock()
+    app.dependency_overrides[ENGINE.get_db] = lambda: AsyncMock()
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.post(
@@ -84,7 +84,7 @@ async def test_multiple_resources_uses_first(monkeypatch):
         "auto_authn.routers.auth_flows._pwd_backend.authenticate",
         AsyncMock(return_value=mock_user),
     )
-    app.dependency_overrides[get_async_db] = lambda: AsyncMock()
+    app.dependency_overrides[ENGINE.get_db] = lambda: AsyncMock()
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.post(
@@ -110,7 +110,7 @@ async def test_multiple_resources_with_invalid_returns_error(monkeypatch):
     app = FastAPI()
     app.include_router(router)
     monkeypatch.setattr(settings, "rfc8707_enabled", True)
-    app.dependency_overrides[get_async_db] = lambda: AsyncMock()
+    app.dependency_overrides[ENGINE.get_db] = lambda: AsyncMock()
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.post(
@@ -140,7 +140,7 @@ async def test_feature_flag_disables_resource(monkeypatch):
         "auto_authn.routers.auth_flows._pwd_backend.authenticate",
         AsyncMock(return_value=mock_user),
     )
-    app.dependency_overrides[get_async_db] = lambda: AsyncMock()
+    app.dependency_overrides[ENGINE.get_db] = lambda: AsyncMock()
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.post(

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc9126_pushed_authorization_requests.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc9126_pushed_authorization_requests.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI, status
 from httpx import ASGITransport, AsyncClient
 
 from auto_authn.rfc9126 import DEFAULT_PAR_EXPIRY, router
-from auto_authn.fastapi_deps import get_async_db
+from auto_authn.db import ENGINE
 
 # RFC 9126 specification excerpt for reference within tests
 RFC9126_SPEC = """
@@ -27,7 +27,7 @@ async def test_par_returns_request_uri_and_expires(enable_rfc9126, monkeypatch):
     async def override_db():
         yield None
 
-    app.dependency_overrides[get_async_db] = override_db
+    app.dependency_overrides[ENGINE.get_db] = override_db
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -52,7 +52,7 @@ async def test_par_disabled_returns_404(monkeypatch):
     async def override_db():
         yield None
 
-    app.dependency_overrides[get_async_db] = override_db
+    app.dependency_overrides[ENGINE.get_db] = override_db
 
     original = settings.enable_rfc9126
     settings.enable_rfc9126 = False

--- a/pkgs/standards/auto_kms/auto_kms/app.py
+++ b/pkgs/standards/auto_kms/auto_kms/app.py
@@ -7,21 +7,17 @@ from swarmauri_crypto_paramiko import ParamikoCrypto
 from swarmauri_standard.key_providers import InMemoryKeyProvider
 
 import os
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
+import logging
+from sqlalchemy.exc import OperationalError
+from autoapi.v3.engine import resolver as _resolver
+from autoapi.v3.engine import engine as make_engine
+
+
+logger = logging.getLogger(__name__)
 
 DB_URL = os.getenv("KMS_DATABASE_URL", "sqlite+aiosqlite:///./kms.db")
-engine = create_async_engine(DB_URL, future=True, echo=False)
-AsyncSessionLocal = async_sessionmaker(
-    engine, expire_on_commit=False, class_=AsyncSession
-)
-
-
-async def get_async_db():
-    async with AsyncSessionLocal() as s:
-        try:
-            yield s
-        finally:
-            await s.close()
+ENGINE = make_engine(DB_URL)
+engine, AsyncSessionLocal = ENGINE.raw()
 
 
 # API-level hooks (v3): stash shared services into ctx before any handler runs
@@ -44,8 +40,7 @@ app = AutoApp(
     version="0.1.0",
     openapi_url="/openapi.json",
     docs_url="/docs",
-    engine=DB_URL,
-    get_async_db=get_async_db,
+    engine=ENGINE,
     api_hooks={"*": {"PRE_TX_BEGIN": [_stash_ctx]}},
 )
 
@@ -59,4 +54,16 @@ app.attach_diagnostics(prefix="/system")
 # Initialize database tables on startup
 @app.on_event("startup")
 async def startup_event():
-    await app.initialize_async()
+    try:
+        await app.initialize_async()
+    except (OSError, OperationalError):
+        fallback_url = "sqlite+aiosqlite:///./kms.db"
+        global ENGINE
+        ENGINE = make_engine(fallback_url)
+        global engine, AsyncSessionLocal
+        engine, AsyncSessionLocal = ENGINE.raw()
+        _resolver.set_default(ENGINE)
+        logger.warning(
+            "DB connection failed; falling back to SQLite at %s", fallback_url
+        )
+        await app.initialize_async()

--- a/pkgs/standards/auto_kms/tests/unit/test_db_fallback.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_db_fallback.py
@@ -1,0 +1,11 @@
+import asyncio
+import importlib
+from autoapi.v3.engine import resolver as _resolver
+
+
+def test_startup_falls_back_to_sqlite(monkeypatch):
+    monkeypatch.setenv("KMS_DATABASE_URL", "postgresql+asyncpg://localhost:1/testdb")
+    app_mod = importlib.reload(importlib.import_module("auto_kms.app"))
+    asyncio.run(app_mod.startup_event())
+    prov = _resolver.resolve_provider()
+    assert str(prov.ensure()[0].url).startswith("sqlite")

--- a/pkgs/standards/autoapi/README.md
+++ b/pkgs/standards/autoapi/README.md
@@ -80,6 +80,26 @@ async with eng.asession() as session:
 provider_pg = Provider(spec_pg)
 ```
 
+### Conformance rules
+
+Downstream services **must** create database connections using
+`autoapi.v3.engine.Engine` (or the helpers in
+`autoapi.v3.engine.shortcuts`). Direct imports from
+`sqlalchemy.ext.asyncio` like `create_async_engine`, `AsyncSession`, or
+`async_sessionmaker` and hand-rolled `get_async_db` dependencies are not
+allowed. Use the Engine's `get_db` generator for FastAPI dependencies:
+
+```python
+from fastapi import Depends
+from autoapi.v3.engine import engine
+
+DB_ENGINE = engine("sqlite+aiosqlite:///./app.db")
+
+@app.get("/items")
+async def handler(db=Depends(DB_ENGINE.get_db)):
+    ...
+```
+
 ### Attaching engine contexts
 
 `engine_ctx` binds database configuration to different layers. It accepts a

--- a/pkgs/standards/autoapi/autoapi/v3/engine/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/engine/__init__.py
@@ -9,6 +9,8 @@ from .builders import (
     blocking_sqlite_engine,
     HybridSession,
 )
+from ._engine import Engine, Provider
+from .shortcuts import engine as engine, prov, engine_spec
 
 __all__ = [
     "collect_from_objects",
@@ -19,4 +21,9 @@ __all__ = [
     "async_sqlite_engine",
     "async_postgres_engine",
     "HybridSession",
+    "Engine",
+    "Provider",
+    "engine_spec",
+    "prov",
+    "engine",
 ]

--- a/pkgs/standards/peagen/peagen/gateway/db.py
+++ b/pkgs/standards/peagen/peagen/gateway/db.py
@@ -1,8 +1,4 @@
-from sqlalchemy.ext.asyncio import (
-    AsyncSession,
-    async_sessionmaker,
-    create_async_engine,
-)
+from autoapi.v3.engine import engine as make_engine
 
 from .runtime_cfg import settings
 
@@ -12,15 +8,5 @@ else:
     # Fallback to a local SQLite database when Postgres settings are missing
     dsn = "sqlite+aiosqlite:///./gateway.db"
 
-engine = create_async_engine(
-    dsn,
-    pool_size=10,
-    max_overflow=20,
-    echo=False,
-)
-Session = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
-
-
-async def get_async_db() -> AsyncSession:
-    async with Session() as db:
-        yield db
+ENGINE = make_engine(dsn)
+engine = ENGINE.raw()[0]


### PR DESCRIPTION
## Summary
- document and export Engine helpers for downstream services
- refactor auto_kms, auto_authn, and peagen gateway to build database sessions via Engine
- ensure auto_kms falls back to SQLite on startup failure

## Testing
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff format .`
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory pkgs/standards/autoapi pytest` *(partial: interrupted after 90 tests)*
- `uv run --package auto_kms --directory pkgs/standards/auto_kms ruff format .`
- `uv run --package auto_kms --directory pkgs/standards/auto_kms ruff check . --fix`
- `uv run --package auto_kms --directory pkgs/standards/auto_kms pytest`
- `uv run --package auto_authn --directory pkgs/standards/auto_authn ruff format .`
- `uv run --package auto_authn --directory pkgs/standards/auto_authn ruff check . --fix`
- `uv run --package auto_authn --directory pkgs/standards/auto_authn pytest` *(partial: interrupted after 11 tests)*
- `uv run --package peagen --directory pkgs/standards/peagen ruff format .`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest` *(partial: interrupted after 1 test)*


------
https://chatgpt.com/codex/tasks/task_e_68b7a82b7e608326ae566c1633af717f