### PR TITLE
Use AutoAPI Engine in services

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/adapters/local_adapter.py
+++ b/pkgs/standards/auto_authn/auto_authn/adapters/local_adapter.py
@@ -9,7 +9,7 @@ Usage
 -----
 >>> from autoapi.v3 import AutoAPI
 >>> from auto_authn.adapters import LocalAuthNAdapter
->>> api = AutoAPI(get_async_db=get_db, authn=LocalAuthNAdapter())
+>>> api = AutoAPI(engine=ENGINE, authn=LocalAuthNAdapter())
 """
 
 from __future__ import annotations

--- a/pkgs/standards/auto_authn/auto_authn/backends.py
+++ b/pkgs/standards/auto_authn/auto_authn/backends.py
@@ -27,7 +27,7 @@ from typing import Iterable, Optional
 from typing import TYPE_CHECKING
 
 from sqlalchemy import Select, or_, select
-from sqlalchemy.ext.asyncio import AsyncSession
+from autoapi.v3.engine import HybridSession as AsyncSession
 
 from .crypto import verify_pw
 from .typing import Principal

--- a/pkgs/standards/auto_authn/auto_authn/db.py
+++ b/pkgs/standards/auto_authn/auto_authn/db.py
@@ -1,27 +1,12 @@
-from sqlalchemy.ext.asyncio import (
-    AsyncSession,
-    async_sessionmaker,
-    create_async_engine,
-)
-
+from autoapi.v3.engine import engine as build_engine
 from .runtime_cfg import settings
-
 
 if settings.pg_dsn_env or (settings.pg_host and settings.pg_db and settings.pg_user):
     dsn = settings.apg_dsn
 else:
-    # Fallback to a local SQLite database when Postgres settings are missing
     dsn = "sqlite+aiosqlite:///./authn.db"
 
-engine = create_async_engine(
-    dsn,
-    pool_size=10,
-    max_overflow=20,
-    echo=False,
-)
-Session = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+ENGINE = build_engine(dsn)
+get_db = ENGINE.get_db
 
-
-async def get_async_db() -> AsyncSession:
-    async with Session() as db:
-        yield db
+__all__ = ["ENGINE", "get_db", "dsn"]

--- a/pkgs/standards/auto_authn/auto_authn/fastapi_deps.py
+++ b/pkgs/standards/auto_authn/auto_authn/fastapi_deps.py
@@ -18,14 +18,14 @@ Both helpers are **framework-thin**: they translate `AuthError` raised by
 from __future__ import annotations
 
 from fastapi import Depends, Header, HTTPException, Request, status
-from sqlalchemy.ext.asyncio import AsyncSession
+from autoapi.v3.engine import HybridSession as AsyncSession
 
 from .backends import (
     ApiKeyBackend,
     AuthError,
     PasswordBackend,
 )  # PasswordBackend not used here, but re-exported for completeness
-from .db import get_async_db
+from .db import get_db
 from .jwtoken import JWTCoder, InvalidTokenError
 from .orm import User
 from .principal_ctx import principal_var
@@ -74,7 +74,7 @@ async def get_principal(  # <-- AutoAPI calls this
     authorization: str = Header("", alias="Authorization"),
     api_key: str | None = Header(None, alias="x-api-key"),
     dpop: str | None = Header(None, alias="DPoP"),
-    db: AsyncSession = Depends(get_async_db),
+    db: AsyncSession = Depends(get_db),
 ) -> dict:
     """
     Return a lightweight principal dict that AutoAPI understands:
@@ -101,7 +101,7 @@ async def get_current_principal(  # type: ignore[override]
     authorization: str = Header("", alias="Authorization"),
     api_key: str | None = Header(None, alias="x-api-key"),
     dpop: str | None = Header(None, alias="DPoP"),
-    db: AsyncSession = Depends(get_async_db),
+    db: AsyncSession = Depends(get_db),
 ) -> Principal:
     """
     Resolve the request principal via **exactly one** of:

--- a/pkgs/standards/auto_authn/auto_authn/rfc8628.py
+++ b/pkgs/standards/auto_authn/auto_authn/rfc8628.py
@@ -16,7 +16,7 @@ import string
 from typing import Final, Literal, TYPE_CHECKING
 
 from pydantic import BaseModel
-from sqlalchemy.ext.asyncio import AsyncSession
+from autoapi.v3.engine import HybridSession as AsyncSession
 
 from .runtime_cfg import settings
 

--- a/pkgs/standards/auto_authn/auto_authn/rfc9126.py
+++ b/pkgs/standards/auto_authn/auto_authn/rfc9126.py
@@ -16,9 +16,9 @@ from typing import TYPE_CHECKING, Any, Dict, Final
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy import delete
-from sqlalchemy.ext.asyncio import AsyncSession
+from autoapi.v3.engine import HybridSession as AsyncSession
 
-from .db import get_async_db
+from .db import get_db
 from .runtime_cfg import settings
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -35,7 +35,7 @@ router = APIRouter()
 @router.post("/par", status_code=status.HTTP_201_CREATED)
 async def pushed_authorization_request(
     request: Request,
-    db: AsyncSession = Depends(get_async_db),
+    db: AsyncSession = Depends(get_db),
 ) -> Dict[str, Any]:
     """Handle Pushed Authorization Requests.
 

--- a/pkgs/standards/auto_authn/auto_authn/routers/auth_flows.py
+++ b/pkgs/standards/auto_authn/auto_authn/routers/auth_flows.py
@@ -4,10 +4,10 @@ import secrets
 
 from fastapi import Depends, HTTPException, Request, status
 from fastapi.responses import JSONResponse
-from sqlalchemy.ext.asyncio import AsyncSession
+from autoapi.v3.engine import HybridSession as AsyncSession
 
 from ..backends import AuthError
-from ..fastapi_deps import get_async_db
+from ..fastapi_deps import get_db
 from ..oidc_id_token import mint_id_token
 from ..orm.auth_session import AuthSession
 from ..routers.schemas import CredsIn, TokenPair
@@ -20,7 +20,7 @@ from .shared import _jwt, _pwd_backend, AUTH_CODES, SESSIONS
 async def login(
     creds: CredsIn,
     request: Request,
-    db: AsyncSession = Depends(get_async_db),
+    db: AsyncSession = Depends(get_db),
 ):
     try:
         user = await _pwd_backend.authenticate(db, creds.identifier, creds.password)

--- a/pkgs/standards/auto_authn/auto_authn/routers/authz/oidc.py
+++ b/pkgs/standards/auto_authn/auto_authn/routers/authz/oidc.py
@@ -9,9 +9,9 @@ from urllib.parse import urlencode
 
 from fastapi import Depends, HTTPException, Request, status
 from fastapi.responses import HTMLResponse, RedirectResponse
-from sqlalchemy.ext.asyncio import AsyncSession
+from autoapi.v3.engine import HybridSession as AsyncSession
 
-from ...fastapi_deps import get_async_db
+from ...fastapi_deps import get_db
 from ...orm import AuthCode, Client, User
 from ...oidc_id_token import mint_id_token, oidc_hash
 from ...rfc8414_metadata import ISSUER
@@ -36,7 +36,7 @@ async def authorize(
     max_age: Optional[int] = None,
     login_hint: Optional[str] = None,
     claims: Optional[str] = None,
-    db: AsyncSession = Depends(get_async_db),
+    db: AsyncSession = Depends(get_db),
 ):
     _require_tls(request)
     rts = set(response_type.split())

--- a/pkgs/standards/auto_authn/auto_authn/routers/authz/rfc6749.py
+++ b/pkgs/standards/auto_authn/auto_authn/routers/authz/rfc6749.py
@@ -8,11 +8,11 @@ from typing import Any
 from fastapi import Depends, HTTPException, Request, status
 from fastapi.responses import JSONResponse
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
+from autoapi.v3.engine import HybridSession as AsyncSession
 from pydantic import ValidationError
 
 from ...backends import AuthError
-from ...fastapi_deps import get_async_db
+from ...fastapi_deps import get_db
 from ...orm import AuthCode, Client, DeviceCode, User
 from ...rfc8707 import extract_resource
 from ...runtime_cfg import settings
@@ -39,9 +39,7 @@ from . import router
 
 
 @router.post("/token", response_model=TokenPair)
-async def token(
-    request: Request, db: AsyncSession = Depends(get_async_db)
-) -> TokenPair:
+async def token(request: Request, db: AsyncSession = Depends(get_db)) -> TokenPair:
     _require_tls(request)
     form = await request.form()
     resources = form.getlist("resource")

--- a/pkgs/standards/auto_authn/tests/conftest.py
+++ b/pkgs/standards/auto_authn/tests/conftest.py
@@ -19,7 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from sqlalchemy.pool import StaticPool
 
 from auto_authn.app import app
-from auto_authn.db import get_async_db
+from auto_authn.db import get_db
 from auto_authn.routers.surface import surface_api
 from auto_authn.orm import Base, Tenant, User, Client, ApiKey
 from auto_authn.crypto import hash_pw
@@ -89,7 +89,7 @@ def override_get_db(db_session, test_db_engine):
     async def _get_test_db():
         yield db_session
 
-    app.dependency_overrides[get_async_db] = _get_test_db
+    app.dependency_overrides[get_db] = _get_test_db
 
     original_provider = engine_resolver.resolve_provider(api=surface_api)
     spec = EngineSpec.from_any(TEST_DATABASE_URL)

--- a/pkgs/standards/auto_authn/tests/unit/test_fastapi_deps.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_fastapi_deps.py
@@ -30,11 +30,11 @@ class TestDatabaseDependency:
 
     def test_database_dependency_import(self):
         """Test that database dependency can be imported correctly."""
-        from auto_authn.fastapi_deps import get_async_db
-        from auto_authn.db import get_async_db as db_get_async_db
+        from auto_authn.fastapi_deps import get_db
+        from auto_authn.db import get_db as db_get_db
 
         # Verify they're the same function
-        assert get_async_db is db_get_async_db
+        assert get_db is db_get_db
 
     def test_database_session_mock_behavior(self):
         """Test that we can mock database session behavior for testing."""

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc6749_token_endpoint.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc6749_token_endpoint.py
@@ -5,7 +5,7 @@ import pytest_asyncio
 from fastapi import FastAPI, status
 from httpx import ASGITransport, AsyncClient, BasicAuth
 
-from auto_authn.fastapi_deps import get_async_db
+from auto_authn.fastapi_deps import get_db
 from auto_authn.routers.auth_flows import router
 from auto_authn.runtime_cfg import settings
 
@@ -33,7 +33,7 @@ async def _override_db():
 async def client():
     app = FastAPI()
     app.include_router(router)
-    app.dependency_overrides[get_async_db] = _override_db
+    app.dependency_overrides[get_db] = _override_db
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as c:
         yield c

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc6750_bearer_token.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc6750_bearer_token.py
@@ -11,7 +11,7 @@ import pytest
 from fastapi import Depends, FastAPI, status
 from httpx import ASGITransport, AsyncClient
 
-from auto_authn.fastapi_deps import get_current_principal, get_async_db
+from auto_authn.fastapi_deps import get_current_principal, get_db
 from auto_authn.runtime_cfg import settings
 
 
@@ -43,7 +43,7 @@ async def test_lowercase_bearer_scheme():
         return {"ok": True}
 
     mock_db = AsyncMock()
-    app.dependency_overrides[get_async_db] = lambda: mock_db
+    app.dependency_overrides[get_db] = lambda: mock_db
 
     mock_user = MagicMock()
     with patch(
@@ -68,7 +68,7 @@ async def test_rfc6750_disabled_rejects_header():
         return {"ok": True}
 
     mock_db = AsyncMock()
-    app.dependency_overrides[get_async_db] = lambda: mock_db
+    app.dependency_overrides[get_db] = lambda: mock_db
 
     with patch.object(settings, "enable_rfc6750", False):
         transport = ASGITransport(app=app)
@@ -90,7 +90,7 @@ async def test_access_token_query_parameter_enabled():
         return {"ok": True}
 
     mock_db = AsyncMock()
-    app.dependency_overrides[get_async_db] = lambda: mock_db
+    app.dependency_overrides[get_db] = lambda: mock_db
 
     mock_user = MagicMock()
     with patch.object(settings, "enable_rfc6750_query", True):
@@ -117,7 +117,7 @@ async def test_access_token_query_parameter_disabled():
         return {"ok": True}
 
     mock_db = AsyncMock()
-    app.dependency_overrides[get_async_db] = lambda: mock_db
+    app.dependency_overrides[get_db] = lambda: mock_db
 
     with patch.object(settings, "enable_rfc6750_query", False):
         transport = ASGITransport(app=app)
@@ -137,7 +137,7 @@ async def test_access_token_form_body_enabled():
         return {"ok": True}
 
     mock_db = AsyncMock()
-    app.dependency_overrides[get_async_db] = lambda: mock_db
+    app.dependency_overrides[get_db] = lambda: mock_db
 
     mock_user = MagicMock()
     with patch.object(settings, "enable_rfc6750_form", True):
@@ -168,7 +168,7 @@ async def test_access_token_form_body_disabled():
         return {"ok": True}
 
     mock_db = AsyncMock()
-    app.dependency_overrides[get_async_db] = lambda: mock_db
+    app.dependency_overrides[get_db] = lambda: mock_db
 
     with patch.object(settings, "enable_rfc6750_form", False):
         transport = ASGITransport(app=app)

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc7662_token_introspection.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc7662_token_introspection.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI, status
 from httpx import ASGITransport, AsyncClient
 
 from auto_authn.routers.auth_flows import router
-from auto_authn.fastapi_deps import get_async_db
+from auto_authn.fastapi_deps import get_db
 from auto_authn.rfc7662 import register_token, reset_tokens
 
 
@@ -35,7 +35,7 @@ async def test_introspection_endpoint_returns_active_field(enable_rfc7662):
     async def override_db():
         yield None
 
-    app.dependency_overrides[get_async_db] = override_db
+    app.dependency_overrides[get_db] = override_db
 
     # Register a token in the introspection registry to mark it as active
     register_token("dummy")
@@ -61,7 +61,7 @@ async def test_introspection_requires_token_parameter(enable_rfc7662):
     async def override_db():
         yield None
 
-    app.dependency_overrides[get_async_db] = override_db
+    app.dependency_overrides[get_db] = override_db
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc8707_resource_indicators.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc8707_resource_indicators.py
@@ -13,7 +13,7 @@ from httpx import ASGITransport, AsyncClient
 
 from auto_authn.runtime_cfg import settings
 from auto_authn.routers.auth_flows import router, _jwt
-from auto_authn.fastapi_deps import get_async_db
+from auto_authn.fastapi_deps import get_db
 
 
 @pytest.mark.unit
@@ -28,7 +28,7 @@ async def test_token_includes_aud_when_resource_provided(monkeypatch):
         "auto_authn.routers.auth_flows._pwd_backend.authenticate",
         AsyncMock(return_value=mock_user),
     )
-    app.dependency_overrides[get_async_db] = lambda: AsyncMock()
+    app.dependency_overrides[get_db] = lambda: AsyncMock()
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.post(
@@ -54,7 +54,7 @@ async def test_invalid_resource_returns_error(monkeypatch):
     app = FastAPI()
     app.include_router(router)
     monkeypatch.setattr(settings, "rfc8707_enabled", True)
-    app.dependency_overrides[get_async_db] = lambda: AsyncMock()
+    app.dependency_overrides[get_db] = lambda: AsyncMock()
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.post(
@@ -84,7 +84,7 @@ async def test_multiple_resources_uses_first(monkeypatch):
         "auto_authn.routers.auth_flows._pwd_backend.authenticate",
         AsyncMock(return_value=mock_user),
     )
-    app.dependency_overrides[get_async_db] = lambda: AsyncMock()
+    app.dependency_overrides[get_db] = lambda: AsyncMock()
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.post(
@@ -110,7 +110,7 @@ async def test_multiple_resources_with_invalid_returns_error(monkeypatch):
     app = FastAPI()
     app.include_router(router)
     monkeypatch.setattr(settings, "rfc8707_enabled", True)
-    app.dependency_overrides[get_async_db] = lambda: AsyncMock()
+    app.dependency_overrides[get_db] = lambda: AsyncMock()
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.post(
@@ -140,7 +140,7 @@ async def test_feature_flag_disables_resource(monkeypatch):
         "auto_authn.routers.auth_flows._pwd_backend.authenticate",
         AsyncMock(return_value=mock_user),
     )
-    app.dependency_overrides[get_async_db] = lambda: AsyncMock()
+    app.dependency_overrides[get_db] = lambda: AsyncMock()
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.post(

--- a/pkgs/standards/auto_authn/tests/unit/test_rfc9126_pushed_authorization_requests.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_rfc9126_pushed_authorization_requests.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI, status
 from httpx import ASGITransport, AsyncClient
 
 from auto_authn.rfc9126 import DEFAULT_PAR_EXPIRY, router
-from auto_authn.fastapi_deps import get_async_db
+from auto_authn.fastapi_deps import get_db
 
 # RFC 9126 specification excerpt for reference within tests
 RFC9126_SPEC = """
@@ -27,7 +27,7 @@ async def test_par_returns_request_uri_and_expires(enable_rfc9126, monkeypatch):
     async def override_db():
         yield None
 
-    app.dependency_overrides[get_async_db] = override_db
+    app.dependency_overrides[get_db] = override_db
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -52,7 +52,7 @@ async def test_par_disabled_returns_404(monkeypatch):
     async def override_db():
         yield None
 
-    app.dependency_overrides[get_async_db] = override_db
+    app.dependency_overrides[get_db] = override_db
 
     original = settings.enable_rfc9126
     settings.enable_rfc9126 = False

--- a/pkgs/standards/auto_kms/auto_kms/app.py
+++ b/pkgs/standards/auto_kms/auto_kms/app.py
@@ -1,27 +1,16 @@
 from __future__ import annotations
 
 from autoapi.v3 import AutoApp
+from autoapi.v3.engine import engine as build_engine
 from .orm import Key, KeyVersion
 
 from swarmauri_crypto_paramiko import ParamikoCrypto
 from swarmauri_standard.key_providers import InMemoryKeyProvider
 
 import os
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
 
 DB_URL = os.getenv("KMS_DATABASE_URL", "sqlite+aiosqlite:///./kms.db")
-engine = create_async_engine(DB_URL, future=True, echo=False)
-AsyncSessionLocal = async_sessionmaker(
-    engine, expire_on_commit=False, class_=AsyncSession
-)
-
-
-async def get_async_db():
-    async with AsyncSessionLocal() as s:
-        try:
-            yield s
-        finally:
-            await s.close()
+ENGINE = build_engine(DB_URL)
 
 
 # API-level hooks (v3): stash shared services into ctx before any handler runs
@@ -44,8 +33,7 @@ app = AutoApp(
     version="0.1.0",
     openapi_url="/openapi.json",
     docs_url="/docs",
-    engine=DB_URL,
-    get_async_db=get_async_db,
+    engine=ENGINE,
     api_hooks={"*": {"PRE_TX_BEGIN": [_stash_ctx]}},
 )
 

--- a/pkgs/standards/auto_kms/tests/unit/test_encrypt_decrypt_roundtrip.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_encrypt_decrypt_roundtrip.py
@@ -21,7 +21,8 @@ def client(tmp_path, monkeypatch):
     app = importlib.reload(importlib.import_module("auto_kms.app"))
 
     async def init_db():
-        async with app.engine.begin() as conn:
+        eng, _ = app.ENGINE.raw()
+        async with eng.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
 
     asyncio.run(init_db())

--- a/pkgs/standards/auto_kms/tests/unit/test_encrypt_invalid_base64.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_encrypt_invalid_base64.py
@@ -21,7 +21,8 @@ def client(tmp_path, monkeypatch):
     app = importlib.reload(importlib.import_module("auto_kms.app"))
 
     async def init_db():
-        async with app.engine.begin() as conn:
+        eng, _ = app.ENGINE.raw()
+        async with eng.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
 
     asyncio.run(init_db())

--- a/pkgs/standards/auto_kms/tests/unit/test_key_bulk_create.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_key_bulk_create.py
@@ -13,7 +13,8 @@ def client(tmp_path, monkeypatch):
     app = importlib.reload(importlib.import_module("auto_kms.app"))
 
     async def init_db():
-        async with app.engine.begin() as conn:
+        eng, _ = app.ENGINE.raw()
+        async with eng.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
 
     asyncio.run(init_db())

--- a/pkgs/standards/auto_kms/tests/unit/test_key_creation_versions.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_key_creation_versions.py
@@ -25,7 +25,8 @@ def client_app(tmp_path, monkeypatch):
     app = importlib.reload(importlib.import_module("auto_kms.app"))
 
     async def init_db():
-        async with app.engine.begin() as conn:
+        eng, _ = app.ENGINE.raw()
+        async with eng.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
 
     asyncio.run(init_db())
@@ -49,7 +50,8 @@ def test_key_creation_seeded_version(client_app):
     assert data["primary_version"] == 1
 
     async def fetch_versions():
-        async with app.engine.begin() as conn:
+        eng, _ = app.ENGINE.raw()
+        async with eng.begin() as conn:
             res = await conn.execute(
                 select(KeyVersion.version).where(KeyVersion.key_id == UUID(key_id))
             )

--- a/pkgs/standards/auto_kms/tests/unit/test_key_lifecycle.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_key_lifecycle.py
@@ -16,7 +16,8 @@ def client_app(tmp_path, monkeypatch):
     app = importlib.reload(importlib.import_module("auto_kms.app"))
 
     async def init_db():
-        async with app.engine.begin() as conn:
+        eng, _ = app.ENGINE.raw()
+        async with eng.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
 
     asyncio.run(init_db())
@@ -30,7 +31,7 @@ def client_app(tmp_path, monkeypatch):
 
 def _fetch_versions(app, key_id):
     async def _inner():
-        async with app.AsyncSessionLocal() as session:
+        async with app.ENGINE.asession() as session:
             result = await session.execute(
                 select(KeyVersion.version).where(KeyVersion.key_id == UUID(str(key_id)))
             )

--- a/pkgs/standards/auto_kms/tests/unit/test_key_read_list.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_key_read_list.py
@@ -14,7 +14,8 @@ def client_app(tmp_path, monkeypatch):
     app = importlib.reload(importlib.import_module("auto_kms.app"))
 
     async def init_db():
-        async with app.engine.begin() as conn:
+        eng, _ = app.ENGINE.raw()
+        async with eng.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
 
     asyncio.run(init_db())

--- a/pkgs/standards/auto_kms/tests/unit/test_key_rotate.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_key_rotate.py
@@ -18,7 +18,8 @@ def client_app(tmp_path, monkeypatch):
     app = importlib.reload(importlib.import_module("auto_kms.app"))
 
     async def init_db():
-        async with app.engine.begin() as conn:
+        eng, _ = app.ENGINE.raw()
+        async with eng.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
 
     asyncio.run(init_db())
@@ -43,7 +44,7 @@ def test_key_rotate_creates_new_version(client_app):
     assert res.content == b""
 
     async def fetch_primary_version():
-        async with app.AsyncSessionLocal() as session:
+        async with app.ENGINE.asession() as session:
             result = await session.execute(
                 select(Key.primary_version).where(Key.id == UUID(str(key["id"])))
             )
@@ -52,7 +53,7 @@ def test_key_rotate_creates_new_version(client_app):
     assert asyncio.run(fetch_primary_version()) == 2
 
     async def fetch_versions():
-        async with app.AsyncSessionLocal() as session:
+        async with app.ENGINE.asession() as session:
             result = await session.execute(
                 select(KeyVersion.version).where(
                     KeyVersion.key_id == UUID(str(key["id"]))

--- a/pkgs/standards/auto_kms/tests/unit/test_paramiko_integration.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_paramiko_integration.py
@@ -22,7 +22,8 @@ def client_paramiko(tmp_path, monkeypatch):
     app = importlib.reload(importlib.import_module("auto_kms.app"))
 
     async def init_db():
-        async with app.engine.begin() as conn:
+        eng, _ = app.ENGINE.raw()
+        async with eng.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
 
     asyncio.run(init_db())

--- a/pkgs/standards/auto_kms/tests/unit/test_wrap_unwrap_errors.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_wrap_unwrap_errors.py
@@ -30,7 +30,8 @@ def client(tmp_path, monkeypatch):
     app = importlib.reload(importlib.import_module("auto_kms.app"))
 
     async def init_db():
-        async with app.engine.begin() as conn:
+        eng, _ = app.ENGINE.raw()
+        async with eng.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
 
     asyncio.run(init_db())

--- a/pkgs/standards/auto_kms/tests/unit/test_wrap_unwrap_roundtrip.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_wrap_unwrap_roundtrip.py
@@ -32,7 +32,8 @@ def client(tmp_path, monkeypatch):
     app = importlib.reload(importlib.import_module("auto_kms.app"))
 
     async def init_db():
-        async with app.engine.begin() as conn:
+        eng, _ = app.ENGINE.raw()
+        async with eng.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
 
     asyncio.run(init_db())

--- a/pkgs/standards/autoapi/autoapi/v3/README.md
+++ b/pkgs/standards/autoapi/autoapi/v3/README.md
@@ -1,0 +1,21 @@
+# AutoAPI v3 Engine Conformance
+
+Applications built on AutoAPI v3 **must** create database engines and sessions
+through the `autoapi.v3.engine` package. Direct imports from
+`sqlalchemy.ext.asyncio`—such as `AsyncSession`, `create_async_engine`, or
+`async_sessionmaker`—are **not permitted**.
+
+Instead, construct an engine via `Engine` or the helper `engine()` function:
+
+```python
+from autoapi.v3.engine import engine
+
+DB = engine("sqlite+aiosqlite:///./app.db")
+app = AutoApp(engine=DB)
+```
+
+Use `DB.get_db` as the FastAPI dependency for acquiring sessions and avoid
+exporting custom `get_async_db` helpers.
+
+These rules apply to all first-party applications, including
+`auto_kms`, `auto_authn`, and the `peagen` gateway.

--- a/pkgs/standards/autoapi/autoapi/v3/engine/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/engine/__init__.py
@@ -9,6 +9,8 @@ from .builders import (
     blocking_sqlite_engine,
     HybridSession,
 )
+from ._engine import Engine
+from .shortcuts import engine
 
 __all__ = [
     "collect_from_objects",
@@ -19,4 +21,6 @@ __all__ = [
     "async_sqlite_engine",
     "async_postgres_engine",
     "HybridSession",
+    "Engine",
+    "engine",
 ]

--- a/pkgs/standards/peagen/peagen/gateway/db.py
+++ b/pkgs/standards/peagen/peagen/gateway/db.py
@@ -1,26 +1,12 @@
-from sqlalchemy.ext.asyncio import (
-    AsyncSession,
-    async_sessionmaker,
-    create_async_engine,
-)
-
+from autoapi.v3.engine import engine as build_engine
 from .runtime_cfg import settings
 
 if settings.pg_dsn_env or (settings.pg_host and settings.pg_db and settings.pg_user):
     dsn = settings.apg_dsn
 else:
-    # Fallback to a local SQLite database when Postgres settings are missing
     dsn = "sqlite+aiosqlite:///./gateway.db"
 
-engine = create_async_engine(
-    dsn,
-    pool_size=10,
-    max_overflow=20,
-    echo=False,
-)
-Session = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+ENGINE = build_engine(dsn)
+get_db = ENGINE.get_db
 
-
-async def get_async_db() -> AsyncSession:
-    async with Session() as db:
-        yield db
+__all__ = ["ENGINE", "get_db", "dsn"]


### PR DESCRIPTION
## Summary
- document AutoAPI v3 engine conformance rules
- expose Engine helpers and enforce Engine usage in auto_kms, auto_authn, and peagen gateway
- replace direct SQLAlchemy session management with Engine.get_db dependencies

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff check . --fix`
- `uv run --directory standards/autoapi --package autoapi pytest`
- `uv run --directory standards/auto_kms --package auto_kms ruff check . --fix`
- `uv run --directory standards/auto_kms --package auto_kms pytest`
- `uv run --directory standards/auto_authn --package auto_authn ruff check . --fix`
- `uv run --directory standards/auto_authn --package auto_authn pytest`
- `uv run --directory standards/peagen --package peagen ruff check . --fix`
- `uv run --directory standards/peagen --package peagen pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7ab6767e88326abd3be4d9ddc1e1f