### PR TITLE
Use shared autoapi sessions and add uvicorn startup tests

### DIFF
--- a/pkgs/standards/auto_authn/tests/unit/test_uvicorn_startup.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_uvicorn_startup.py
@@ -1,0 +1,36 @@
+import importlib
+import socket
+import threading
+import time
+
+import requests
+import uvicorn
+
+
+def test_uvicorn_startup(tmp_path, monkeypatch):
+    db_path = tmp_path / "authn.db"
+    monkeypatch.setenv("PG_DSN", f"sqlite+aiosqlite:///{db_path}")
+    mod = importlib.reload(importlib.import_module("auto_authn.app"))
+
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+
+    config = uvicorn.Config(mod.app, host="127.0.0.1", port=port, log_level="error")
+    server = uvicorn.Server(config)
+
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    for _ in range(50):
+        if server.started:
+            break
+        time.sleep(0.1)
+
+    try:
+        assert server.started
+        resp = requests.get(f"http://127.0.0.1:{port}/docs")
+        assert resp.status_code == 200
+    finally:
+        server.should_exit = True
+        thread.join()

--- a/pkgs/standards/auto_kms/auto_kms/app.py
+++ b/pkgs/standards/auto_kms/auto_kms/app.py
@@ -11,7 +11,7 @@ from autoapi.v3.engine import engine as engine_factory
 
 DB_URL = os.getenv("KMS_DATABASE_URL", "sqlite+aiosqlite:///./kms.db")
 db_engine = engine_factory(DB_URL)
-engine, SessionLocal = db_engine.raw()
+engine, _ = db_engine.raw()
 
 
 # API-level hooks (v3): stash shared services into ctx before any handler runs
@@ -54,9 +54,9 @@ async def startup_event():
         # Fallback to a local SQLite database if the configured database is unreachable
         from autoapi.v3.engine import engine as engine_factory
 
-        global DB_URL, db_engine, engine, SessionLocal
+        global DB_URL, db_engine, engine
         DB_URL = "sqlite+aiosqlite:///./kms.db"
         db_engine = engine_factory(DB_URL)
-        engine, SessionLocal = db_engine.raw()
+        engine, _ = db_engine.raw()
         app.bind = DB_URL
         await app.initialize_async()

--- a/pkgs/standards/auto_kms/tests/unit/test_key_lifecycle.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_key_lifecycle.py
@@ -30,7 +30,7 @@ def client_app(tmp_path, monkeypatch):
 
 def _fetch_versions(app, key_id):
     async def _inner():
-        async with app.AsyncSessionLocal() as session:
+        async with app.db_engine.asession() as session:
             result = await session.execute(
                 select(KeyVersion.version).where(KeyVersion.key_id == UUID(str(key_id)))
             )

--- a/pkgs/standards/auto_kms/tests/unit/test_key_rotate.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_key_rotate.py
@@ -43,7 +43,7 @@ def test_key_rotate_creates_new_version(client_app):
     assert res.content == b""
 
     async def fetch_primary_version():
-        async with app.AsyncSessionLocal() as session:
+        async with app.db_engine.asession() as session:
             result = await session.execute(
                 select(Key.primary_version).where(Key.id == UUID(str(key["id"])))
             )
@@ -52,7 +52,7 @@ def test_key_rotate_creates_new_version(client_app):
     assert asyncio.run(fetch_primary_version()) == 2
 
     async def fetch_versions():
-        async with app.AsyncSessionLocal() as session:
+        async with app.db_engine.asession() as session:
             result = await session.execute(
                 select(KeyVersion.version).where(
                     KeyVersion.key_id == UUID(str(key["id"]))

--- a/pkgs/standards/auto_kms/tests/unit/test_uvicorn_startup.py
+++ b/pkgs/standards/auto_kms/tests/unit/test_uvicorn_startup.py
@@ -1,0 +1,36 @@
+import importlib
+import socket
+import threading
+import time
+
+import requests
+import uvicorn
+
+
+def test_uvicorn_startup(tmp_path, monkeypatch):
+    db_path = tmp_path / "kms.db"
+    monkeypatch.setenv("KMS_DATABASE_URL", f"sqlite+aiosqlite:///{db_path}")
+    mod = importlib.reload(importlib.import_module("auto_kms.app"))
+
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+
+    config = uvicorn.Config(mod.app, host="127.0.0.1", port=port, log_level="error")
+    server = uvicorn.Server(config)
+
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    for _ in range(50):
+        if server.started:
+            break
+        time.sleep(0.1)
+
+    try:
+        assert server.started
+        resp = requests.get(f"http://127.0.0.1:{port}/docs")
+        assert resp.status_code == 200
+    finally:
+        server.should_exit = True
+        thread.join()

--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -319,7 +319,7 @@ async def _startup() -> None:
         _db.engine = engine_factory(fallback)
         global engine, sql_engine
         engine = _db.engine
-        sql_engine, _db.Session = engine.raw()
+        sql_engine, _ = engine.raw()
         api.bind = fallback
         await api.initialize_async()
 

--- a/pkgs/standards/peagen/peagen/gateway/db.py
+++ b/pkgs/standards/peagen/peagen/gateway/db.py
@@ -8,4 +8,4 @@ else:
     dsn = "sqlite+aiosqlite:///./gateway.db"
 
 engine = engine_factory(dsn)
-sql_engine, Session = engine.raw()
+sql_engine, _ = engine.raw()

--- a/pkgs/standards/peagen/tests/unit/test_gateway_uvicorn.py
+++ b/pkgs/standards/peagen/tests/unit/test_gateway_uvicorn.py
@@ -1,0 +1,36 @@
+import importlib
+import socket
+import threading
+import time
+
+import requests
+import uvicorn
+
+
+def test_gateway_uvicorn(tmp_path, monkeypatch):
+    db_path = tmp_path / "gateway.db"
+    monkeypatch.setenv("PG_DSN", f"sqlite+aiosqlite:///{db_path}")
+    mod = importlib.reload(importlib.import_module("peagen.gateway"))
+
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+
+    config = uvicorn.Config(mod.app, host="127.0.0.1", port=port, log_level="error")
+    server = uvicorn.Server(config)
+
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    for _ in range(50):
+        if server.started:
+            break
+        time.sleep(0.1)
+
+    try:
+        assert server.started
+        resp = requests.get(f"http://127.0.0.1:{port}/docs")
+        assert resp.status_code == 200
+    finally:
+        server.should_exit = True
+        thread.join()


### PR DESCRIPTION
## Summary
- refactor auto_kms to rely on autoapi engine session factory
- adjust tests to use engine-provided sessions
- add uvicorn startup tests for auto_kms, auto_authn, and peagen gateway

## Testing
- `uv run --package auto_kms --directory pkgs/standards/auto_kms pytest`
- `uv run --package auto_authn --directory pkgs/standards/auto_authn pytest -q`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/unit/test_gateway_uvicorn.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7c33f0770832697a8d3a7696aadb5