### PR TITLE
Respect PG* environment variables in AutoAPI Postgres builders

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/engine/builders.py
+++ b/pkgs/standards/autoapi/autoapi/v3/engine/builders.py
@@ -40,13 +40,18 @@ def blocking_sqlite_engine(path: str | None = None):
 # ---------------------------------------------------------------------
 def blocking_postgres_engine(
     user: str = "app",
-    pwd: str = os.getenv("PGPASSWORD", "secret"),
+    pwd: str | None = None,
     host: str = "localhost",
     port: int = 5432,
     db: str = "app_db",
     pool_size: int = 10,
     max_overflow: int = 20,
 ):
+    user = os.getenv("PGUSER", user)
+    pwd = os.getenv("PGPASSWORD", pwd or "secret")
+    host = os.getenv("PGHOST", host)
+    port = int(os.getenv("PGPORT", port))
+    db = os.getenv("PGDATABASE", db)
     url = f"postgresql+psycopg2://{user}:{pwd}@{host}:{port}/{db}"
     eng = create_engine(
         url,
@@ -121,13 +126,18 @@ def async_sqlite_engine(path: str | None = None):
 # ----------------------------------------------------------------------
 def async_postgres_engine(
     user: str = "app",
-    pwd: str = os.getenv("PGPASSWORD", "secret"),
+    pwd: str | None = None,
     host: str = "localhost",
     port: int = 5432,
     db: str = "app_db",
     pool_size: int = 10,
     max_size: int = 20,
 ):
+    user = os.getenv("PGUSER", user)
+    pwd = os.getenv("PGPASSWORD", pwd or "secret")
+    host = os.getenv("PGHOST", host)
+    port = int(os.getenv("PGPORT", port))
+    db = os.getenv("PGDATABASE", db)
     url = f"postgresql+asyncpg://{user}:{pwd}@{host}:{port}/{db}"
     eng = create_async_engine(
         url,

--- a/pkgs/standards/autoapi/tests/unit/test_postgres_engine_errors.py
+++ b/pkgs/standards/autoapi/tests/unit/test_postgres_engine_errors.py
@@ -1,0 +1,16 @@
+import pytest
+
+from autoapi.v3.engine.builders import async_postgres_engine
+
+
+@pytest.mark.asyncio
+async def test_async_postgres_engine_connection_error(monkeypatch):
+    monkeypatch.setenv("PGHOST", "localhost")
+    monkeypatch.setenv("PGPORT", "65432")
+    eng, Session = async_postgres_engine()
+
+    with pytest.raises(RuntimeError, match="Failed to connect to database"):
+        async with Session() as session:
+            await session.run_sync(lambda conn: None)
+
+    await eng.dispose()

--- a/pkgs/standards/autoapi/tests/unit/test_postgres_env_vars.py
+++ b/pkgs/standards/autoapi/tests/unit/test_postgres_env_vars.py
@@ -1,0 +1,17 @@
+from autoapi.v3.engine.builders import async_postgres_engine
+
+
+def test_async_postgres_engine_uses_pg_env(monkeypatch):
+    monkeypatch.setenv("PGUSER", "bob")
+    monkeypatch.setenv("PGPASSWORD", "pw")
+    monkeypatch.setenv("PGHOST", "dbhost")
+    monkeypatch.setenv("PGPORT", "5433")
+    monkeypatch.setenv("PGDATABASE", "mydb")
+
+    eng, _ = async_postgres_engine()
+
+    assert eng.url.username == "bob"
+    assert eng.url.password == "pw"
+    assert eng.url.host == "dbhost"
+    assert eng.url.port == 5433
+    assert eng.url.database == "mydb"


### PR DESCRIPTION
## Summary
- allow AutoAPI Postgres engine builders to read standard `PG*` environment variables for connection configuration
- add regression test for `async_postgres_engine` using `PG*` environment variables

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff format .`
- `uv run --directory standards/autoapi --package autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_postgres_env_vars.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7cec468dc8326a935997e6bed3b9a