### PR TITLE
Add temporary Postgres fixtures for AutoAPI tests

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_postgres_fixtures.py
+++ b/pkgs/standards/autoapi/tests/unit/test_postgres_fixtures.py
@@ -1,0 +1,60 @@
+import pytest
+from sqlalchemy import Integer, String, select
+from sqlalchemy.orm import Mapped
+
+from autoapi.v3 import Base
+from autoapi.v3.specs import F, IO, S, acol
+
+
+def test_pg_sync_db_session(pg_db_session):
+    engine, get_db = pg_db_session
+
+    class Widget(Base):
+        __tablename__ = "widgets_sync"
+        id: Mapped[int] = acol(
+            storage=S(type_=Integer, primary_key=True, autoincrement=True)
+        )
+        name: Mapped[str] = acol(
+            storage=S(type_=String, nullable=False),
+            field=F(),
+            io=IO(in_verbs=("create",), out_verbs=("read", "list")),
+        )
+        __autoapi_cols__ = {"id": id, "name": name}
+
+    Base.metadata.create_all(bind=engine)
+
+    with get_db() as db:
+        db.add(Widget(name="alpha"))
+        db.commit()
+
+    with get_db() as db:
+        assert db.query(Widget).count() == 1
+
+
+@pytest.mark.asyncio
+async def test_pg_async_db_session(async_pg_db_session):
+    engine, get_db = async_pg_db_session
+
+    class Widget(Base):
+        __tablename__ = "widgets_async"
+        id: Mapped[int] = acol(
+            storage=S(type_=Integer, primary_key=True, autoincrement=True)
+        )
+        name: Mapped[str] = acol(
+            storage=S(type_=String, nullable=False),
+            field=F(),
+            io=IO(in_verbs=("create",), out_verbs=("read", "list")),
+        )
+        __autoapi_cols__ = {"id": id, "name": name}
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    async with get_db() as db:
+        db.add(Widget(name="beta"))
+        await db.commit()
+
+    async with get_db() as db:
+        result = await db.execute(select(Widget))
+        items = result.scalars().all()
+        assert len(items) == 1


### PR DESCRIPTION
## Summary
- spin up a throwaway PostgreSQL server for tests
- provide sync and async Postgres session fixtures
- add integration tests using the new fixtures

## Testing
- `uv run --package autoapi --directory standards pytest autoapi/tests/unit/test_postgres_fixtures.py`

------
https://chatgpt.com/codex/tasks/task_e_68b7d00741848326936e9259521f83f1