### PR TITLE
feat(autoapi): support DSN-based PostgreSQL engine configs

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/engine/builders.py
+++ b/pkgs/standards/autoapi/autoapi/v3/engine/builders.py
@@ -40,6 +40,7 @@ def blocking_sqlite_engine(path: str | None = None):
 # 3. BLOCKING  •  PostgreSQL  (psycopg2)
 # ---------------------------------------------------------------------
 def blocking_postgres_engine(
+    dsn: str | None = None,
     user: str = "app",
     pwd: str | None = None,
     host: str = "localhost",
@@ -48,12 +49,15 @@ def blocking_postgres_engine(
     pool_size: int = 10,
     max_overflow: int = 20,
 ):
-    user = os.getenv("PGUSER", user)
-    pwd = os.getenv("PGPASSWORD", pwd or "secret")
-    host = os.getenv("PGHOST", host)
-    port = int(os.getenv("PGPORT", port))
-    db = os.getenv("PGDATABASE", db)
-    url = f"postgresql+psycopg2://{user}:{pwd}@{host}:{port}/{db}"
+    if dsn:
+        url = dsn
+    else:
+        user = os.getenv("PGUSER", user)
+        pwd = os.getenv("PGPASSWORD", pwd or "secret")
+        host = os.getenv("PGHOST", host)
+        port = int(os.getenv("PGPORT", port))
+        db = os.getenv("PGDATABASE", db)
+        url = f"postgresql+psycopg2://{user}:{pwd}@{host}:{port}/{db}"
     eng = create_engine(
         url,
         pool_size=pool_size,
@@ -134,6 +138,7 @@ def async_sqlite_engine(path: str | None = None):
 # 4. ASYNC  •  PostgreSQL  (asyncpg)
 # ----------------------------------------------------------------------
 def async_postgres_engine(
+    dsn: str | None = None,
     user: str = "app",
     pwd: str | None = None,
     host: str = "localhost",
@@ -142,12 +147,15 @@ def async_postgres_engine(
     pool_size: int = 10,
     max_size: int = 20,
 ):
-    user = os.getenv("PGUSER", user)
-    pwd = os.getenv("PGPASSWORD", pwd or "secret")
-    host = os.getenv("PGHOST", host)
-    port = int(os.getenv("PGPORT", port))
-    db = os.getenv("PGDATABASE", db)
-    url = f"postgresql+asyncpg://{user}:{pwd}@{host}:{port}/{db}"
+    if dsn:
+        url = dsn
+    else:
+        user = os.getenv("PGUSER", user)
+        pwd = os.getenv("PGPASSWORD", pwd or "secret")
+        host = os.getenv("PGHOST", host)
+        port = int(os.getenv("PGPORT", port))
+        db = os.getenv("PGDATABASE", db)
+        url = f"postgresql+asyncpg://{user}:{pwd}@{host}:{port}/{db}"
     eng = create_async_engine(
         url,
         pool_size=pool_size,

--- a/pkgs/standards/autoapi/tests/unit/test_engine_spec_and_shortcuts.py
+++ b/pkgs/standards/autoapi/tests/unit/test_engine_spec_and_shortcuts.py
@@ -32,6 +32,22 @@ def test_engine_spec_builds_from_mapping_postgres_sync():
     )  # :contentReference[oaicite:5]{index=5}
 
 
+def test_engine_spec_builds_from_dsn_postgres():
+    dsn = "postgresql://user:pwd@localhost:5432/db"
+    spec = engine_spec(dsn)
+    assert spec.kind == "postgres" and spec.dsn == dsn
+    assert spec.host is None and spec.user is None
+
+
+def test_engine_builds_from_dsn_postgres():
+    dsn = "postgresql://user:pwd@localhost:5432/db"
+    spec = EngineSpec.from_any(dsn)
+    eng, _ = spec.build()
+    assert eng.url.database == "db"
+    assert eng.url.host == "localhost"
+    eng.dispose()
+
+
 def test_prov_lazily_constructs_and_sessions_are_fresh_sync(tmp_path):
     p = prov(
         sqlitef(str(tmp_path / "x.sqlite"))


### PR DESCRIPTION
## Summary
- allow EngineSpec to accept optional host, port, name, user and password
- support building PostgreSQL engines directly from DSNs
- add tests for DSN-based engine creation

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff format .`
- `uv run --directory standards/autoapi --package autoapi ruff check . --fix`
- `uv run --directory standards/autoapi --package autoapi pytest tests/unit/test_engine_spec_and_shortcuts.py::test_engine_spec_builds_from_dsn_postgres tests/unit/test_engine_spec_and_shortcuts.py::test_engine_builds_from_dsn_postgres tests/unit/test_postgres_env_vars.py tests/unit/test_postgres_engine_errors.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7df2f59188326936eece467587e4b