### PR TITLE
Redact password in EngineSpec repr

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_engine_spec_and_shortcuts.py
+++ b/pkgs/standards/autoapi/tests/unit/test_engine_spec_and_shortcuts.py
@@ -39,6 +39,16 @@ def test_engine_spec_builds_from_dsn_postgres():
     assert spec.host is None and spec.user is None
 
 
+def test_engine_spec_repr_redacts_password():
+    spec = engine_spec({"kind": "postgres", "pwd": "s3cret"})
+    assert "s3cret" not in repr(spec)
+
+    spec = engine_spec("postgresql://user:pwd@localhost:5432/db")
+    rep = repr(spec)
+    assert "pwd" not in rep
+    assert "***" in rep
+
+
 def test_engine_builds_from_dsn_postgres():
     dsn = "postgresql://user:pwd@localhost:5432/db"
     spec = EngineSpec.from_any(dsn)


### PR DESCRIPTION
## Summary
- Hide engine passwords from `EngineSpec` representation
- Redact credentials in DSN strings
- Test that representation never leaks password values

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b7e43175708326a7899fd94371a106