### PR TITLE
feat(autoapi): add Op descriptor with engine binding

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/__init__.py
@@ -78,12 +78,13 @@ from .autoapp import AutoApp
 from .autoapi import AutoAPI
 
 from .table import Base
+from .op import Op
 from .types import App
 
 
 __all__: list[str] = []
 
-__all__ += ["AutoApp", "AutoAPI", "Base", "App"]
+__all__ += ["AutoApp", "AutoAPI", "Base", "App", "Op"]
 
 __all__ += [
     # OpSpec core

--- a/pkgs/standards/autoapi/autoapi/v3/op/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/op/__init__.py
@@ -1,0 +1,8 @@
+"""Operation module exposing Op."""
+
+from __future__ import annotations
+
+from ._op import Op
+from ..ops.types import OpSpec
+
+__all__ = ["Op", "OpSpec"]

--- a/pkgs/standards/autoapi/autoapi/v3/op/_op.py
+++ b/pkgs/standards/autoapi/autoapi/v3/op/_op.py
@@ -1,0 +1,31 @@
+# autoapi/autoapi/v3/op/_op.py
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any
+
+from ..ops.types import OpSpec
+
+
+class Op(OpSpec):
+    """Declarative operation descriptor with optional engine binding."""
+
+    __slots__ = ()
+
+    def __set_name__(self, owner: type, name: str) -> None:  # noqa: D401
+        spec = self
+        alias = self.alias or name
+        if self.table is not owner or self.alias != alias:
+            spec = replace(self, table=owner, alias=alias)
+        ops = list(getattr(owner, "__autoapi_ops__", ()) or [])
+        ops.append(spec)
+        owner.__autoapi_ops__ = tuple(ops)
+
+    def install_engines(
+        self, *, api: Any | None = None, model: type | None = None
+    ) -> None:
+        from ..engine import install_from_objects
+
+        m = model if model is not None else self.table
+        if m is not None:
+            install_from_objects(api=api, models=[m])

--- a/pkgs/standards/autoapi/tests/unit/test_op_class_engine_binding.py
+++ b/pkgs/standards/autoapi/tests/unit/test_op_class_engine_binding.py
@@ -1,0 +1,38 @@
+from autoapi.v3.engine import install_from_objects, resolver
+from autoapi.v3.engine.shortcuts import mem, pga, pgs, sqlitef
+from autoapi.v3.op import Op
+
+
+class Model:
+    __tablename__ = "t"
+    table_config = {"engine": mem(async_=False)}
+    __autoapi_ops__ = (
+        Op(alias="create", target="create", engine=pga(host="db", name="op_db")),
+    )
+
+
+class App:
+    def __init__(self, engine):
+        self.engine = engine
+
+
+class API:
+    def __init__(self, engine):
+        self.engine = engine
+
+
+def test_op_table_api_app_engines(tmp_path):
+    app = App(sqlitef(str(tmp_path / "app.sqlite"), async_=False))
+    api = API(pgs(host="db", name="api_db"))
+
+    install_from_objects(app=app, api=api, models=[Model])
+
+    p_app = resolver.resolve_provider()
+    p_api = resolver.resolve_provider(api=api)
+    p_table = resolver.resolve_provider(model=Model)
+    p_op = resolver.resolve_provider(model=Model, op_alias="create")
+
+    assert p_app is not None and p_app.kind == "sync"
+    assert p_api is not None and p_api is not p_app and p_api.kind == "sync"
+    assert p_table is not None and p_table is not p_api and p_table.kind == "sync"
+    assert p_op is not None and p_op is not p_table and p_op.kind == "async"


### PR DESCRIPTION
## Summary
- add `Op` descriptor for declarative operation specs
- bind engines from declared Op specs during collection
- re-export `Op` and verify engine precedence across App/API/Table/Op

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff format .`
- `uv run --directory standards/autoapi --package autoapi ruff check . --fix`
- `uv run --directory standards/autoapi --package autoapi pytest tests/unit/test_op_class_engine_binding.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b7f17a54fc8326bea87834dcc088b8