### PR TITLE
Fix worker policy gate DB usage

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/engine/builders.py
+++ b/pkgs/standards/autoapi/autoapi/v3/engine/builders.py
@@ -105,8 +105,7 @@ class HybridSession(AsyncSession):
     # ---- DDL helper used at AutoAPI bootstrap --------------------------
     async def run_sync(self, fn, *a, **kw):
         try:
-            async with self.bind.begin() as conn:
-                return await conn.run_sync(fn, *a, **kw)
+            return await super().run_sync(fn, *a, **kw)
         except (OSError, SQLAlchemyError) as exc:
             url = getattr(self.bind, "url", "unknown")
             await self.bind.dispose()

--- a/pkgs/standards/peagen/tests/unit/test_worker_policy_gate.py
+++ b/pkgs/standards/peagen/tests/unit/test_worker_policy_gate.py
@@ -1,0 +1,52 @@
+import pytest
+from types import SimpleNamespace
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+
+from peagen.orm.workers import Worker
+from autoapi.v3.orm.tables import Base
+from peagen.defaults import DEFAULT_POOL_ID
+
+
+@pytest.mark.asyncio
+async def test_pre_create_policy_gate_allows_session():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        execution_options={"schema_translate_map": {"peagen": None}},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+    async with SessionLocal() as session:
+        ctx = {
+            "env": SimpleNamespace(params={"pool_id": str(DEFAULT_POOL_ID)}),
+            "request": SimpleNamespace(
+                headers={}, client=SimpleNamespace(host="127.0.0.1")
+            ),
+            "db": session,
+        }
+        await Worker._pre_create_policy_gate(ctx)
+
+
+@pytest.mark.asyncio
+async def test_pre_update_policy_gate_allows_session():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        execution_options={"schema_translate_map": {"peagen": None}},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+    async with SessionLocal() as session:
+        ctx = {
+            "env": SimpleNamespace(
+                params={
+                    "id": "00000000-0000-0000-0000-000000000000",
+                    "pool_id": str(DEFAULT_POOL_ID),
+                }
+            ),
+            "request": SimpleNamespace(
+                headers={}, client=SimpleNamespace(host="127.0.0.1")
+            ),
+            "db": session,
+        }
+        await Worker._pre_update_policy_gate(ctx)


### PR DESCRIPTION
## Summary
- ensure autoapi HybridSession.run_sync delegates to AsyncSession so hooks receive Session objects
- revert worker policy gate hooks to use session-based queries
- update unit tests to exercise worker policy gates with sessions

## Testing
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff format autoapi/v3/engine/builders.py`
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff check autoapi/v3/engine/builders.py --fix`
- `uv run --package peagen --directory pkgs/standards/peagen ruff format peagen/orm/workers.py tests/unit/test_worker_policy_gate.py`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check peagen/orm/workers.py tests/unit/test_worker_policy_gate.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b800e0216483269f4f5b7ee906f2be