### PR TITLE
fix: ensure HybridSession.run_sync yields Session

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/engine/builders.py
+++ b/pkgs/standards/autoapi/autoapi/v3/engine/builders.py
@@ -105,8 +105,7 @@ class HybridSession(AsyncSession):
     # ---- DDL helper used at AutoAPI bootstrap --------------------------
     async def run_sync(self, fn, *a, **kw):
         try:
-            async with self.bind.begin() as conn:
-                return await conn.run_sync(fn, *a, **kw)
+            return await super().run_sync(fn, *a, **kw)
         except (OSError, SQLAlchemyError) as exc:
             url = getattr(self.bind, "url", "unknown")
             await self.bind.dispose()

--- a/pkgs/standards/autoapi/tests/unit/test_hybrid_session_run_sync.py
+++ b/pkgs/standards/autoapi/tests/unit/test_hybrid_session_run_sync.py
@@ -1,0 +1,18 @@
+import pytest
+
+from autoapi.v3.engine.builders import async_sqlite_engine
+from sqlalchemy.orm import Session as SyncSession
+
+
+@pytest.mark.asyncio
+async def test_hybrid_session_run_sync_provides_session():
+    eng, Session = async_sqlite_engine()
+    async with Session() as db:
+
+        def _check(sess: SyncSession) -> None:
+            assert isinstance(sess, SyncSession)
+            # accessing Session.get should not raise
+            sess.get  # noqa: B018 - attribute access for test
+
+        await db.run_sync(_check)
+    await eng.dispose()

--- a/pkgs/standards/autoapi/tests/unit/test_postgres_engine_errors.py
+++ b/pkgs/standards/autoapi/tests/unit/test_postgres_engine_errors.py
@@ -1,4 +1,5 @@
 import pytest
+from sqlalchemy import text
 
 from autoapi.v3.engine.builders import async_postgres_engine
 
@@ -11,6 +12,6 @@ async def test_async_postgres_engine_connection_error(monkeypatch):
 
     with pytest.raises(RuntimeError, match="Failed to connect to database"):
         async with Session() as session:
-            await session.run_sync(lambda conn: None)
+            await session.run_sync(lambda s: s.execute(text("select 1")))
 
     await eng.dispose()


### PR DESCRIPTION
## Summary
- ensure HybridSession.run_sync delegates to AsyncSession to supply a real Session
- verify run_sync with new unit test

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `uv run --package autoapi --directory pkgs/standards/autoapi pytest`
- `uv run --package autoapi --directory pkgs/standards/autoapi pytest tests/unit/test_hybrid_session_run_sync.py tests/unit/test_postgres_engine_errors.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8039fd62083268e8a67d3dabce230