### PR TITLE
refactor: remove HookProvider from peagen ORM models

### DIFF
--- a/pkgs/standards/peagen/peagen/orm/keys.py
+++ b/pkgs/standards/peagen/peagen/orm/keys.py
@@ -7,7 +7,6 @@ from autoapi.v3.types import (
     Boolean,
     String,
     UniqueConstraint,
-    HookProvider,
     Mapped,
     relationship,
 )
@@ -21,7 +20,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from .repositories import Repository
 
 
-class PublicKey(Base, GUIDPk, UserColumn, Timestamped, HookProvider):
+class PublicKey(Base, GUIDPk, UserColumn, Timestamped):
     __tablename__ = "public_keys"
     __table_args__ = (
         UniqueConstraint("user_id", "public_key"),
@@ -58,7 +57,7 @@ class PublicKey(Base, GUIDPk, UserColumn, Timestamped, HookProvider):
         # hooks registered via @hook_ctx
 
 
-class GPGKey(Base, GUIDPk, UserColumn, Timestamped, HookProvider):
+class GPGKey(Base, GUIDPk, UserColumn, Timestamped):
     __tablename__ = "gpg_keys"
     __table_args__ = (
         UniqueConstraint("user_id", "gpg_key"),
@@ -93,7 +92,7 @@ class GPGKey(Base, GUIDPk, UserColumn, Timestamped, HookProvider):
         # hooks registered via @hook_ctx
 
 
-class DeployKey(Base, GUIDPk, RepositoryRefMixin, Timestamped, HookProvider):
+class DeployKey(Base, GUIDPk, RepositoryRefMixin, Timestamped):
     __tablename__ = "deploy_keys"
     __table_args__ = (
         UniqueConstraint("repository_id", "public_key"),

--- a/pkgs/standards/peagen/peagen/orm/pools.py
+++ b/pkgs/standards/peagen/peagen/orm/pools.py
@@ -6,7 +6,6 @@ from autoapi.v3.types import (
     String,
     UniqueConstraint,
     MutableDict,
-    HookProvider,
     Mapped,
 )
 from autoapi.v3.orm.mixins import GUIDPk, Bootstrappable, Timestamped, TenantBound
@@ -15,7 +14,7 @@ from autoapi.v3 import hook_ctx
 from peagen.defaults import DEFAULT_POOL_NAME, DEFAULT_POOL_ID, DEFAULT_TENANT_ID
 
 
-class Pool(Base, GUIDPk, Bootstrappable, Timestamped, TenantBound, HookProvider):
+class Pool(Base, GUIDPk, Bootstrappable, Timestamped, TenantBound):
     __tablename__ = "pools"
     __table_args__ = (
         UniqueConstraint("tenant_id", "name"),

--- a/pkgs/standards/peagen/peagen/orm/secrets.py
+++ b/pkgs/standards/peagen/peagen/orm/secrets.py
@@ -5,7 +5,6 @@ from autoapi.v3.types import (
     String,
     UniqueConstraint,
     CheckConstraint,
-    HookProvider,
     relationship,
     Mapped,
 )
@@ -45,9 +44,7 @@ class OrgSecret(Base, GUIDPk, _SecretCoreMixin, OrgColumn, Timestamped):
     )
 
 
-class RepoSecret(
-    Base, GUIDPk, _SecretCoreMixin, RepositoryMixin, Timestamped, HookProvider
-):
+class RepoSecret(Base, GUIDPk, _SecretCoreMixin, RepositoryMixin, Timestamped):
     __tablename__ = "repo_secrets"
     repository: Mapped["Repository"] = relationship(
         "Repository", back_populates="secrets"

--- a/pkgs/standards/peagen/peagen/orm/tasks.py
+++ b/pkgs/standards/peagen/peagen/orm/tasks.py
@@ -11,7 +11,6 @@ from autoapi.v3.types import (
     PgUUID,
     Integer,
     relationship,
-    HookProvider,
     Mapped,
 )
 from autoapi.v3.orm.mixins import (
@@ -56,7 +55,6 @@ class Task(
     Ownable,
     RepositoryRefMixin,
     StatusColumn,
-    HookProvider,
 ):
     __tablename__ = "tasks"
     __table_args__ = ({"schema": "peagen"},)

--- a/pkgs/standards/peagen/peagen/orm/workers.py
+++ b/pkgs/standards/peagen/peagen/orm/workers.py
@@ -8,7 +8,6 @@ from autoapi.v3.types import (
     String,
     MutableDict,
     relationship,
-    HookProvider,
     AllowAnonProvider,
     Mapped,
 )
@@ -21,7 +20,7 @@ from peagen.defaults import DEFAULT_POOL_ID, WORKER_KEY, WORKER_TTL
 from .pools import Pool
 
 
-class Worker(Base, GUIDPk, Timestamped, HookProvider, AllowAnonProvider):
+class Worker(Base, GUIDPk, Timestamped, AllowAnonProvider):
     __tablename__ = "workers"
     __table_args__ = ({"schema": "peagen"},)
 

--- a/pkgs/standards/peagen/peagen/orm/works.py
+++ b/pkgs/standards/peagen/peagen/orm/works.py
@@ -6,7 +6,6 @@ from autoapi.v3.types import (
     PgUUID,
     Integer,
     relationship,
-    HookProvider,
     Mapped,
 )
 from autoapi.v3.orm.mixins import GUIDPk, Timestamped, StatusColumn
@@ -21,7 +20,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from .eval_result import EvalResult
 
 
-class Work(Base, GUIDPk, Timestamped, StatusColumn, HookProvider):
+class Work(Base, GUIDPk, Timestamped, StatusColumn):
     __tablename__ = "works"
     __table_args__ = ({"schema": "peagen"},)
     task_id: Mapped[PgUUID] = acol(


### PR DESCRIPTION
## Summary
- drop HookProvider inheritance from peagen ORM models
- verify auto_kms and auto_authn no longer depend on HookProvider

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b8066d54a48326b938983353e93fa0