### PR TITLE
docs: add worker create example

### DIFF
--- a/pkgs/standards/peagen/tests/test_worker_create_example.py
+++ b/pkgs/standards/peagen/tests/test_worker_create_example.py
@@ -1,0 +1,16 @@
+from peagen.gateway import app
+from fastapi.testclient import TestClient
+
+
+def test_worker_create_has_example():
+    client = TestClient(app)
+    schema = client.get("/openapi.json").json()
+    worker_schema = schema["components"]["schemas"]["WorkerCreateRequest"]
+    assert "example" in worker_schema
+    assert worker_schema["properties"].keys() >= {
+        "pool_id",
+        "url",
+        "advertises",
+        "handler_map",
+    }
+    assert worker_schema["example"]["url"] == "http://127.0.0.1:8001/rpc"


### PR DESCRIPTION
## Summary
- expose worker create fields in OpenAPI and add request example
- test that worker create schema includes example in docs

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format peagen/orm/workers.py tests/test_worker_create_example.py`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check peagen/orm/workers.py tests/test_worker_create_example.py --fix`
- `uv run --package peagen --directory pkgs/standards/peagen pytest tests/test_worker_create_example.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b80e6d99c0832682ee576108d99265