### PR TITLE
fix: align mixins with SQLAlchemy 2 annotations

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/orm/mixins/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/orm/mixins/__init__.py
@@ -1,4 +1,6 @@
 # mixins_generic.py ───── all mix-ins live here
+from __future__ import annotations
+
 import datetime as dt
 from decimal import Decimal
 

--- a/pkgs/standards/autoapi/tests/unit/test_mixins_sqlalchemy.py
+++ b/pkgs/standards/autoapi/tests/unit/test_mixins_sqlalchemy.py
@@ -1,0 +1,13 @@
+from autoapi.v3.orm.mixins import GUIDPk, Timestamped
+from autoapi.v3.table import Base
+
+
+def test_mixins_define_model_without_error() -> None:
+    class MyModel(Base, GUIDPk, Timestamped):
+        __tablename__ = "my_models"
+
+    assert {
+        "id",
+        "created_at",
+        "updated_at",
+    } <= set(MyModel.__table__.c.keys())


### PR DESCRIPTION
## Summary
- ensure autoapi mixins use postponed annotations for SQLAlchemy 2
- add regression test verifying GUIDPk & Timestamped mixins work with models

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b813312a448326b25c57c8c81b0ef7