### PR TITLE
Fix Worker create schema in gateway docs

### DIFF
--- a/pkgs/standards/peagen/peagen/orm/workers.py
+++ b/pkgs/standards/peagen/peagen/orm/workers.py
@@ -20,6 +20,9 @@ from peagen.defaults import DEFAULT_POOL_ID, WORKER_KEY, WORKER_TTL
 from .pools import Pool
 
 
+_RW_IO = {"in_verbs": ("create", "replace", "update"), "out_verbs": ("read", "list")}
+
+
 class Worker(Base, GUIDPk, Timestamped, AllowAnonProvider):
     __tablename__ = "workers"
     __table_args__ = ({"schema": "peagen"},)
@@ -32,15 +35,20 @@ class Worker(Base, GUIDPk, Timestamped, AllowAnonProvider):
             fk=ForeignKeySpec("peagen.pools.id"),
             nullable=False,
             default=DEFAULT_POOL_ID,
-        )
+        ),
+        io=IO(**_RW_IO),
     )
-    url: Mapped[str] = acol(storage=S(String, nullable=False))
+    url: Mapped[str] = acol(
+        storage=S(String, nullable=False),
+        io=IO(**_RW_IO),
+    )
     advertises: Mapped[dict | None] = acol(
         storage=S(
             MutableDict.as_mutable(JSON),
             default=lambda: {},
             nullable=True,
-        )
+        ),
+        io=IO(**_RW_IO),
     )
     handler_map: Mapped[dict | None] = acol(
         storage=S(
@@ -48,7 +56,7 @@ class Worker(Base, GUIDPk, Timestamped, AllowAnonProvider):
             default=lambda: {},
             nullable=True,
         ),
-        io=IO(alias_in="handlers", alias_out="handlers"),
+        io=IO(alias_in="handlers", alias_out="handlers", **_RW_IO),
     )
 
     pool: Mapped[Pool] = relationship(Pool, backref="workers")

--- a/pkgs/standards/peagen/tests/unit/test_worker_openapi.py
+++ b/pkgs/standards/peagen/tests/unit/test_worker_openapi.py
@@ -1,0 +1,17 @@
+from autoapi.v3 import get_schema
+from peagen.orm import Worker
+
+
+def test_worker_create_schema_includes_fields():
+    schema = get_schema(Worker, op="create", kind="in")
+    assert "url" in schema.model_fields
+    assert "pool_id" in schema.model_fields
+
+
+def test_worker_openapi_includes_request_fields():
+    from peagen.gateway import app
+
+    spec = app.openapi()
+    props = spec["components"]["schemas"]["WorkerCreateRequest"]["properties"]
+    assert "url" in props
+    assert "pool_id" in props


### PR DESCRIPTION
## Summary
- expose Worker fields for create by binding IO spec
- test Worker create schema appears in OpenAPI

## Testing
- `uv run --package peagen --directory standards/peagen ruff format peagen/orm/workers.py tests/unit/test_worker_openapi.py`
- `uv run --package peagen --directory standards/peagen ruff check peagen/orm/workers.py tests/unit/test_worker_openapi.py --fix`
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_worker_openapi.py`


------
https://chatgpt.com/codex/tasks/task_e_68b813a33fa88326a4852ca3a2cf285a