### PR TITLE
fix: auto bind op_ctx

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_op_ctx_dynamic_attach.py
+++ b/pkgs/standards/autoapi/tests/unit/test_op_ctx_dynamic_attach.py
@@ -1,0 +1,19 @@
+from autoapi.v3 import AutoAPI, Base, op_ctx
+from sqlalchemy.orm import Mapped, mapped_column
+
+
+def test_op_ctx_dynamic_attach_auto_discovers_ops():
+    api = AutoAPI()
+
+    class Book(Base):
+        __tablename__ = "book"
+        id: Mapped[int] = mapped_column(primary_key=True)
+
+    api.include_model(Book, mount_router=False)
+    assert "publish" not in [sp.alias for sp in Book.ops.all]
+
+    @op_ctx(bind=Book)
+    def publish(cls, ctx):
+        return None
+
+    assert "publish" in [sp.alias for sp in Book.ops.all]


### PR DESCRIPTION
## Summary
- auto rebind models when @op_ctx methods are attached
- allow external @op_ctx decorators to bind to explicit targets
- add regression test for explicit op_ctx binding

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_op_ctx_dynamic_attach.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8131332f48326b5b97a75ef798d67