### PR TITLE
fix: register file storage adapter as peagen plugin

### DIFF
--- a/pkgs/standards/peagen/peagen/plugins/storage_adapters/file_storage_adapter.py
+++ b/pkgs/standards/peagen/peagen/plugins/storage_adapters/file_storage_adapter.py
@@ -1,0 +1,5 @@
+"""Wrapper to expose the FileStorageAdapter as a built-in plugin."""
+
+from swarmauri_storage_file.file_storage_adapter import FileStorageAdapter
+
+__all__ = ["FileStorageAdapter"]


### PR DESCRIPTION
## Summary
- add wrapper module to expose swarmauri_storage_file FileStorageAdapter as built-in plugin

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format .`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check peagen/plugins/storage_adapters/file_storage_adapter.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b81ecdb6f88326b70ee60c73726c0c