### PR TITLE
Expose gateway app for import

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -342,3 +342,5 @@ async def _shutdown() -> None:
 
 app.add_event_handler("startup", _startup)
 app.add_event_handler("shutdown", _shutdown)
+
+__all__ = ["app"]


### PR DESCRIPTION
## Summary
- export the gateway's FastAPI application via `__all__` so tests can import `peagen.gateway.app`

## Testing
- `uv run --package peagen --directory standards/peagen ruff check . --fix`
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_worker_openapi.py::test_worker_openapi_includes_request_fields -q`


------
https://chatgpt.com/codex/tasks/task_e_68b81b313ab8832695b9afefe35d544c