### PR TITLE
fix: load file storage adapter via plugin manager

### DIFF
--- a/pkgs/standards/swarmauri_storage_file/pyproject.toml
+++ b/pkgs/standards/swarmauri_storage_file/pyproject.toml
@@ -35,6 +35,7 @@ FileStorageAdapter = "swarmauri_storage_file.file_storage_adapter:FileStorageAda
 
 [project.entry-points."peagen.plugins.storage_adapters"]
 file = "swarmauri_storage_file.file_storage_adapter:FileStorageAdapter"
+file_storage_adapter = "swarmauri_storage_file.file_storage_adapter:FileStorageAdapter"
 
 [tool.pytest.ini_options]
 norecursedirs = ["combined", "scripts"]


### PR DESCRIPTION
## Summary
- remove built-in file storage adapter wrapper
- alias `file_storage_adapter` entry point to `swarmauri_storage_file` implementation

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format .`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`
- `uv run --package swarmauri_storage_file --directory pkgs/standards/swarmauri_storage_file ruff format .`
- `uv run --package swarmauri_storage_file --directory pkgs/standards/swarmauri_storage_file ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b81ecdb6f88326b70ee60c73726c0c