### PR TITLE
Fix gateway stub leakage in KMS tests

### DIFF
--- a/pkgs/standards/peagen/tests/unit/test_kms_unwrap_keys.py
+++ b/pkgs/standards/peagen/tests/unit/test_kms_unwrap_keys.py
@@ -73,10 +73,10 @@ async def test_public_key_unwrap(monkeypatch):
 
     gw_pkg = ModuleType("peagen.gateway")
     gw_pkg.__path__ = []
-    sys.modules["peagen.gateway"] = gw_pkg
+    monkeypatch.setitem(sys.modules, "peagen.gateway", gw_pkg)
     kms_mod = ModuleType("peagen.gateway.kms")
     kms_mod.unwrap_key_with_kms = fake_unwrap
-    sys.modules["peagen.gateway.kms"] = kms_mod
+    monkeypatch.setitem(sys.modules, "peagen.gateway.kms", kms_mod)
 
     ctx = {"result": {"public_key": "pub", "private_key": "wrapped"}}
     await PublicKey._post_read(ctx)
@@ -95,10 +95,10 @@ async def test_gpg_key_unwrap(monkeypatch):
 
     gw_pkg = ModuleType("peagen.gateway")
     gw_pkg.__path__ = []
-    sys.modules["peagen.gateway"] = gw_pkg
+    monkeypatch.setitem(sys.modules, "peagen.gateway", gw_pkg)
     kms_mod = ModuleType("peagen.gateway.kms")
     kms_mod.unwrap_key_with_kms = fake_unwrap
-    sys.modules["peagen.gateway.kms"] = kms_mod
+    monkeypatch.setitem(sys.modules, "peagen.gateway.kms", kms_mod)
 
     ctx = {"result": {"gpg_key": "gpg", "private_key": "wrapped"}}
     await GPGKey._post_read(ctx)
@@ -118,10 +118,10 @@ async def test_deploy_key_unwrap(monkeypatch):
     gw_pkg = ModuleType("peagen.gateway")
     gw_pkg.__path__ = []
     gw_pkg.log = SimpleNamespace(info=lambda *a, **k: None)
-    sys.modules["peagen.gateway"] = gw_pkg
+    monkeypatch.setitem(sys.modules, "peagen.gateway", gw_pkg)
     kms_mod = ModuleType("peagen.gateway.kms")
     kms_mod.unwrap_key_with_kms = fake_unwrap
-    sys.modules["peagen.gateway.kms"] = kms_mod
+    monkeypatch.setitem(sys.modules, "peagen.gateway.kms", kms_mod)
 
     ctx = {"result": {"public_key": "pub", "private_key": "wrapped"}}
     await DeployKey._post_read(ctx)

--- a/pkgs/standards/peagen/tests/unit/test_kms_wrap_keys.py
+++ b/pkgs/standards/peagen/tests/unit/test_kms_wrap_keys.py
@@ -16,10 +16,10 @@ async def test_public_key_wrap(monkeypatch):
 
     gw_pkg = ModuleType("peagen.gateway")
     gw_pkg.__path__ = []  # mark as package
-    sys.modules["peagen.gateway"] = gw_pkg
+    monkeypatch.setitem(sys.modules, "peagen.gateway", gw_pkg)
     kms_mod = ModuleType("peagen.gateway.kms")
     kms_mod.wrap_key_with_kms = fake_wrap
-    sys.modules["peagen.gateway.kms"] = kms_mod
+    monkeypatch.setitem(sys.modules, "peagen.gateway.kms", kms_mod)
 
     params = SimpleNamespace(public_key="pub", private_key="priv")
     ctx = {"env": SimpleNamespace(params=params)}
@@ -39,10 +39,10 @@ async def test_gpg_key_wrap(monkeypatch):
 
     gw_pkg = ModuleType("peagen.gateway")
     gw_pkg.__path__ = []
-    sys.modules["peagen.gateway"] = gw_pkg
+    monkeypatch.setitem(sys.modules, "peagen.gateway", gw_pkg)
     kms_mod = ModuleType("peagen.gateway.kms")
     kms_mod.wrap_key_with_kms = fake_wrap
-    sys.modules["peagen.gateway.kms"] = kms_mod
+    monkeypatch.setitem(sys.modules, "peagen.gateway.kms", kms_mod)
 
     params = SimpleNamespace(gpg_key="gpg", private_key="priv")
     ctx = {"env": SimpleNamespace(params=params)}
@@ -69,10 +69,10 @@ async def test_deploy_key_wrap(monkeypatch):
     gw_pkg = ModuleType("peagen.gateway")
     gw_pkg.__path__ = []
     gw_pkg.log = SimpleNamespace(info=lambda *args, **kwargs: None)
-    sys.modules["peagen.gateway"] = gw_pkg
+    monkeypatch.setitem(sys.modules, "peagen.gateway", gw_pkg)
     kms_mod = ModuleType("peagen.gateway.kms")
     kms_mod.wrap_key_with_kms = fake_wrap
-    sys.modules["peagen.gateway.kms"] = kms_mod
+    monkeypatch.setitem(sys.modules, "peagen.gateway.kms", kms_mod)
     monkeypatch.setattr("pgpy.PGPKey", DummyPGPKey)
 
     params = SimpleNamespace(public_key="pub", private_key="priv")


### PR DESCRIPTION
## Summary
- ensure KMS key wrap/unwrap tests use monkeypatch to isolate peagen.gateway stubs

## Testing
- `uv run --package peagen --directory standards/peagen pytest tests/unit/test_kms_wrap_keys.py tests/unit/test_kms_unwrap_keys.py tests/unit/test_worker_openapi.py -q --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_68b8223d5e0c83268bcad8248d4f89fe