### PR TITLE
Require service name for Peagen gateway

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/orm/service.py
+++ b/pkgs/standards/auto_authn/auto_authn/orm/service.py
@@ -11,7 +11,7 @@ from autoapi.v3.orm.mixins import (
     ActiveToggle,
 )
 from autoapi.v3.types import Mapped, String, relationship
-from autoapi.v3.specs import S, acol
+from autoapi.v3.specs import F, IO, S, acol, ColumnSpec
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -23,7 +23,18 @@ class Service(Base, GUIDPk, Timestamped, TenantBound, Principal, ActiveToggle):
 
     __tablename__ = "services"
     __table_args__ = ({"schema": "authn"},)
-    name: Mapped[str] = acol(storage=S(String(120), unique=True, nullable=False))
+    name: Mapped[str] = acol(
+        spec=ColumnSpec(
+            storage=S(String(120), unique=True, nullable=False),
+            field=F(constraints={"max_length": 120}, required_in=("create",)),
+            io=IO(
+                in_verbs=("create", "update", "replace"),
+                out_verbs=("read", "list"),
+                filter_ops=("eq", "ilike"),
+                sortable=True,
+            ),
+        )
+    )
     _service_keys = relationship(
         "ServiceKey",
         back_populates="_service",


### PR DESCRIPTION
## Summary
- Ensure authn Service model requires `name` so gateway clients must provide it

## Testing
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff format .`
- `uv run --directory pkgs/standards/auto_authn --package auto_authn ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68b8266efe148326a7d2beba5f776ea6