### PR TITLE
Include secdeps, deps, and hooks in plan output

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/runtime/ordering.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/ordering.py
@@ -102,9 +102,9 @@ def flatten(
                 raise ValueError(f"Label missing anchor: {lbl}")
             by_anchor[lbl.anchor].append(lbl)
 
-    # Deterministic order for secdep/dep blocks
-    secdeps.sort(key=lambda label: (label.subject,))
-    deps.sort(key=lambda label: (label.subject,))
+    # `secdeps` and `deps` are received in their runtime execution order.
+    # Preserve that order rather than sorting alphabetically so diagnostics
+    # reflect the actual pre-phase dependency sequence.
 
     # Anchor list honoring persist pruning + canonical order
     anchors_present = tuple(a for a in by_anchor.keys())

--- a/pkgs/standards/autoapi/tests/perf/test_planz_performance.py
+++ b/pkgs/standards/autoapi/tests/perf/test_planz_performance.py
@@ -55,7 +55,7 @@ async def test_planz_performance(monkeypatch, count):
             return self.anchor
 
     def fake_flattened_order(
-        plan, *, persist, include_system_steps, deps, secdeps=None
+        plan, *, persist, include_system_steps, deps, secdeps=None, hooks=None
     ):
         return [Label(events[i % len(events)]) for i in range(10)]
 
@@ -102,7 +102,7 @@ async def test_planz_cached_call_faster(monkeypatch) -> None:
     calls = {"flatten": 0}
 
     def fake_flattened_order(
-        plan, *, persist, include_system_steps, deps, secdeps=None
+        plan, *, persist, include_system_steps, deps, secdeps=None, hooks=None
     ):
         calls["flatten"] += 1
         sleep(0.01)


### PR DESCRIPTION
## Summary
- ensure runtime ordering preserves declared dependency sequence
- extend plan flattening with hook integration and diagnostics support
- add tests for hook inclusion and dependency order

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi pytest tests/unit -q`

------
https://chatgpt.com/codex/tasks/task_e_68b82d92b86c83268648f66dcfacebfb