### PR TITLE
feat: add request/response schemas for register operation

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/orm/user.py
+++ b/pkgs/standards/auto_authn/auto_authn/orm/user.py
@@ -6,6 +6,7 @@ import uuid
 
 from autoapi.v3.orm.tables import User as UserBase
 from autoapi.v3 import hook_ctx, op_ctx
+from ..routers.schemas import RegisterIn, TokenPair
 from autoapi.v3.types import LargeBinary, Mapped, String, relationship
 from autoapi.v3.specs import F, IO, S, acol, ColumnSpec
 from typing import TYPE_CHECKING
@@ -67,7 +68,13 @@ class User(UserBase):
 
             payload["password_hash"] = hash_pw(plain)
 
-    @op_ctx(alias="register", target="create", arity="collection")
+    @op_ctx(
+        alias="register",
+        target="create",
+        arity="collection",
+        request_schema=RegisterIn,
+        response_schema=TokenPair,
+    )
     async def register(cls, ctx):
         import secrets
         from ..rfc8414_metadata import ISSUER

--- a/pkgs/standards/auto_authn/tests/unit/test_user_register_schema.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_user_register_schema.py
@@ -1,0 +1,11 @@
+import pytest
+from autoapi.v3.bindings import bind
+from auto_authn.orm import User
+from auto_authn.routers.schemas import RegisterIn, TokenPair
+
+
+@pytest.mark.unit
+def test_register_op_has_request_and_response_schema():
+    bind(User)
+    assert issubclass(User.schemas.register.in_, RegisterIn)
+    assert issubclass(User.schemas.register.out, TokenPair)

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/schemas.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/schemas.py
@@ -116,6 +116,10 @@ def _resolve_schema_arg(model: type, arg: SchemaArg) -> Optional[Type[BaseModel]
     if isinstance(arg, str) and arg.strip().lower() == "raw":
         return None
 
+    # direct Pydantic model
+    if isinstance(arg, type) and issubclass(arg, BaseModel):
+        return arg
+
     # SchemaRef
     if isinstance(arg, SchemaRef):
         if arg.kind not in ("in", "out"):

--- a/pkgs/standards/autoapi/tests/unit/test_op_ctx_attributes.py
+++ b/pkgs/standards/autoapi/tests/unit/test_op_ctx_attributes.py
@@ -117,6 +117,25 @@ def test_op_ctx_response_schema_coercion():
     assert parsed.x == 5
 
 
+def test_op_ctx_direct_model_schemas():
+    class Gadget:
+        class Payload(BaseModel):
+            x: int
+
+        class Result(BaseModel):
+            x: int
+
+        @op_ctx(alias="check", request_schema=Payload, response_schema=Result)
+        def check(cls, ctx):
+            return {"x": ctx["payload"]["x"]}
+
+    _build_all(Gadget)
+    in_model = Gadget.schemas.check.in_
+    out_model = Gadget.schemas.check.out
+    assert in_model(x="5").x == 5
+    assert out_model(x="5").x == 5
+
+
 def test_op_ctx_persist_attribute():
     class Gadget:
         @op_ctx(persist="skip")


### PR DESCRIPTION
## Summary
- support passing Pydantic models directly to op_ctx request/response schema parameters
- expose request and response bodies for auto_authn's register route
- test direct model schema binding and user register schemas

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package auto_authn --directory standards/auto_authn ruff format .`
- `uv run --package auto_authn --directory standards/auto_authn ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_op_ctx_attributes.py::test_op_ctx_direct_model_schemas -q`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_user_register_schema.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b8382ac4e083269765c885d7fe4a64