### PR TITLE
fix: service key schema uses service id

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/orm/api_key.py
+++ b/pkgs/standards/auto_authn/auto_authn/orm/api_key.py
@@ -2,16 +2,30 @@
 
 from __future__ import annotations
 
-from autoapi.v3.orm.tables import ApiKey as ApiKeyBase
-from autoapi.v3.orm.mixins import UserColumn
-from autoapi.v3.types import relationship
+from autoapi.v3.orm.mixins import (
+    Created,
+    GUIDPk,
+    KeyDigest,
+    LastUsed,
+    UserColumn,
+    ValidityWindow,
+)
+from autoapi.v3.orm.tables._base import Base
+from autoapi.v3.specs import F, S, acol
+from autoapi.v3.types import Mapped, String, relationship
 
 
-class ApiKey(ApiKeyBase, UserColumn):
+class ApiKey(Base, GUIDPk, Created, LastUsed, ValidityWindow, UserColumn, KeyDigest):
+    __tablename__ = "api_keys"
     __table_args__ = {
         "extend_existing": True,
         "schema": "authn",
     }
+
+    label: Mapped[str] = acol(
+        storage=S(String, nullable=False),
+        field=F(constraints={"max_length": 120}),
+    )
 
     _user = relationship(
         "User",

--- a/pkgs/standards/auto_authn/auto_authn/orm/service_key.py
+++ b/pkgs/standards/auto_authn/auto_authn/orm/service_key.py
@@ -2,19 +2,42 @@
 
 from __future__ import annotations
 
-from autoapi.v3.orm.tables import ApiKey as ApiKeyBase
-from autoapi.v3.specs import F, IO, S, acol
-from autoapi.v3.types import Mapped, PgUUID, relationship
-from autoapi.v3.column.storage_spec import ForeignKeySpec
+from hashlib import sha256
+from secrets import token_urlsafe
 from uuid import UUID
 
+from autoapi.v3.column.io_spec import Pair
+from autoapi.v3.column.storage_spec import ForeignKeySpec
+from autoapi.v3.orm.mixins import Created, GUIDPk, LastUsed, ValidityWindow
+from autoapi.v3.orm.tables._base import Base
+from autoapi.v3.specs import F, IO, S, acol
+from autoapi.v3.types import Mapped, PgUUID, String, relationship
 
-class ServiceKey(ApiKeyBase):
+
+class ServiceKey(Base, GUIDPk, Created, LastUsed, ValidityWindow):
     __tablename__ = "service_keys"
     __table_args__ = {
         "extend_existing": True,
         "schema": "authn",
     }
+
+    label: Mapped[str] = acol(
+        storage=S(String, nullable=False),
+        field=F(constraints={"max_length": 120}),
+    )
+
+    def _pair_api_key(ctx):
+        raw = token_urlsafe(32)
+        return Pair(raw=raw, stored=sha256(raw.encode()).hexdigest())
+
+    digest: Mapped[str] = acol(
+        storage=S(String, nullable=False, unique=True),
+        field=F(constraints={"max_length": 64}),
+        io=IO(out_verbs=("read", "list"), allow_in=False).paired(
+            _pair_api_key, alias="api_key"
+        ),
+    )
+
     service_id: Mapped[UUID] = acol(
         storage=S(
             PgUUID(as_uuid=True),
@@ -31,6 +54,18 @@ class ServiceKey(ApiKeyBase):
         back_populates="_service_keys",
         lazy="joined",
     )
+
+    @staticmethod
+    def digest_of(value: str) -> str:
+        return sha256(value.encode()).hexdigest()
+
+    @property
+    def raw_key(self) -> str:  # pragma: no cover - write-only
+        raise AttributeError("raw_key is write-only")
+
+    @raw_key.setter
+    def raw_key(self, value: str) -> None:
+        self.digest = self.digest_of(value)
 
 
 __all__ = ["ServiceKey"]

--- a/pkgs/standards/auto_authn/auto_authn/orm/service_key.py
+++ b/pkgs/standards/auto_authn/auto_authn/orm/service_key.py
@@ -2,19 +2,22 @@
 
 from __future__ import annotations
 
-from hashlib import sha256
-from secrets import token_urlsafe
 from uuid import UUID
 
-from autoapi.v3.column.io_spec import Pair
 from autoapi.v3.column.storage_spec import ForeignKeySpec
-from autoapi.v3.orm.mixins import Created, GUIDPk, LastUsed, ValidityWindow
+from autoapi.v3.orm.mixins import (
+    Created,
+    GUIDPk,
+    KeyDigest,
+    LastUsed,
+    ValidityWindow,
+)
 from autoapi.v3.orm.tables._base import Base
 from autoapi.v3.specs import F, IO, S, acol
 from autoapi.v3.types import Mapped, PgUUID, String, relationship
 
 
-class ServiceKey(Base, GUIDPk, Created, LastUsed, ValidityWindow):
+class ServiceKey(Base, GUIDPk, Created, LastUsed, ValidityWindow, KeyDigest):
     __tablename__ = "service_keys"
     __table_args__ = {
         "extend_existing": True,
@@ -24,18 +27,6 @@ class ServiceKey(Base, GUIDPk, Created, LastUsed, ValidityWindow):
     label: Mapped[str] = acol(
         storage=S(String, nullable=False),
         field=F(constraints={"max_length": 120}),
-    )
-
-    def _pair_api_key(ctx):
-        raw = token_urlsafe(32)
-        return Pair(raw=raw, stored=sha256(raw.encode()).hexdigest())
-
-    digest: Mapped[str] = acol(
-        storage=S(String, nullable=False, unique=True),
-        field=F(constraints={"max_length": 64}),
-        io=IO(out_verbs=("read", "list"), allow_in=False).paired(
-            _pair_api_key, alias="api_key"
-        ),
     )
 
     service_id: Mapped[UUID] = acol(
@@ -54,18 +45,6 @@ class ServiceKey(Base, GUIDPk, Created, LastUsed, ValidityWindow):
         back_populates="_service_keys",
         lazy="joined",
     )
-
-    @staticmethod
-    def digest_of(value: str) -> str:
-        return sha256(value.encode()).hexdigest()
-
-    @property
-    def raw_key(self) -> str:  # pragma: no cover - write-only
-        raise AttributeError("raw_key is write-only")
-
-    @raw_key.setter
-    def raw_key(self, value: str) -> None:
-        self.digest = self.digest_of(value)
 
 
 __all__ = ["ServiceKey"]

--- a/pkgs/standards/auto_authn/tests/unit/test_models.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_models.py
@@ -175,6 +175,18 @@ class TestServiceKeyModel:
         expected_digest = ServiceKey.digest_of(raw_key)
         assert service_key.digest == expected_digest
 
+    def test_service_key_schema_uses_service_id(self):
+        """Ensure ServiceKey API schema uses service_id and not user_id."""
+        from auto_authn.routers.surface import surface_api
+
+        create_fields = surface_api.schemas.ServiceKey.create.in_.model_fields
+        read_fields = surface_api.schemas.ServiceKey.read.out.model_fields
+
+        assert "service_id" in create_fields
+        assert "user_id" not in create_fields
+        assert "service_id" in read_fields
+        assert "user_id" not in read_fields
+
 
 @pytest.mark.unit
 class TestModelIntegration:

--- a/pkgs/standards/autoapi/autoapi/v3/orm/mixins/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/orm/mixins/__init__.py
@@ -8,6 +8,7 @@ from .bootstrappable import Bootstrappable as Bootstrappable
 from .upsertable import Upsertable as Upsertable
 from .ownable import Ownable as Ownable, OwnerPolicy as OwnerPolicy
 from .tenant_bound import TenantBound as TenantBound, TenantPolicy as TenantPolicy
+from .key_digest import KeyDigest as KeyDigest
 from ...specs import ColumnSpec, F, IO, S, acol
 from ...specs.storage_spec import ForeignKeySpec
 from ...types import (

--- a/pkgs/standards/autoapi/autoapi/v3/orm/mixins/key_digest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/orm/mixins/key_digest.py
@@ -1,31 +1,16 @@
 from __future__ import annotations
 
-
 from hashlib import sha256
 from secrets import token_urlsafe
 
 from ...column.io_spec import Pair
-from ...specs import acol, F, IO, S
-from ...types import Mapped, String
-from ._base import Base
-from ..mixins import GUIDPk, Created, LastUsed, ValidityWindow
+from ...specs import F, IO, S, acol
+from ...types import Mapped, String, declarative_mixin
 
 
-# ------------------------------------------------------------------ model
-class ApiKey(
-    Base,
-    GUIDPk,
-    Created,
-    LastUsed,
-    ValidityWindow,
-):
-    __tablename__ = "api_keys"
-    __abstract__ = True
-
-    label: Mapped[str] = acol(
-        storage=S(String, nullable=False),
-        field=F(constraints={"max_length": 120}),
-    )
+@declarative_mixin
+class KeyDigest:
+    """Provides hashed API key storage with helpers."""
 
     def _pair_api_key(ctx):
         raw = token_urlsafe(32)
@@ -39,9 +24,6 @@ class ApiKey(
         ),
     )
 
-    # ------------------------------------------------------------------
-    # Digest helpers
-    # ------------------------------------------------------------------
     @staticmethod
     def digest_of(value: str) -> str:
         return sha256(value.encode()).hexdigest()

--- a/pkgs/standards/autoapi/autoapi/v3/orm/tables/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/orm/tables/__init__.py
@@ -18,7 +18,6 @@ __all__ = [
     "Tenant",
     "Client",
     "User",
-    "ApiKey",
     "Group",
     "Org",
     "Role",
@@ -37,7 +36,6 @@ _module_map = {
     "Tenant": f"{__name__}.tenant",
     "Client": f"{__name__}.client",
     "User": f"{__name__}.user",
-    "ApiKey": f"{__name__}.apikey",
     "Group": f"{__name__}.group",
     "Org": f"{__name__}.org",
     "Role": f"{__name__}.rbac",
@@ -67,7 +65,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from .tenant import Tenant
     from .client import Client
     from .user import User
-    from .apikey import ApiKey
     from .group import Group
     from .org import Org
     from .rbac import Role, RoleGrant, RolePerm

--- a/pkgs/standards/autoapi/tests/i9n/test_apikey_generation.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_apikey_generation.py
@@ -1,17 +1,30 @@
 import pytest
-from autoapi.v3.types import App
+from autoapi.v3.types import App, Mapped, String
 from httpx import ASGITransport, AsyncClient
 
 from autoapi.v3 import AutoApp
-from autoapi.v3.orm.tables import ApiKey
+from autoapi.v3.orm.mixins import (
+    Created,
+    GUIDPk,
+    KeyDigest,
+    LastUsed,
+    ValidityWindow,
+)
+from autoapi.v3.orm.tables._base import Base
+from autoapi.v3.specs import F, S, acol
 
 
-class ConcreteApiKey(ApiKey):
+class ConcreteApiKey(Base, GUIDPk, Created, LastUsed, ValidityWindow, KeyDigest):
     """Concrete table for testing API key generation."""
 
     __abstract__ = False
     __resource__ = "apikey"
     __tablename__ = "apikeys_generation"
+
+    label: Mapped[str] = acol(
+        storage=S(String, nullable=False),
+        field=F(constraints={"max_length": 120}),
+    )
 
 
 @pytest.mark.i9n


### PR DESCRIPTION
## Summary
- ensure ServiceKey ORM defines service_id and not user_id
- test ServiceKey schema to confirm service_id in API surfaces

## Testing
- `uv run --package auto_authn --directory standards/auto_authn pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b837d7bd7c83268705cd843b03946e