### PR TITLE
fix: add examples for op_ctx aliases

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
@@ -506,7 +506,7 @@ def _default_path_suffix(sp: OpSpec) -> str | None:
         # Bulk operations now share the same collection path as their
         # single-record counterparts.
         return None
-    if sp.target == "custom":
+    if sp.alias != sp.target:
         return f"/{sp.alias}"
     return None
 

--- a/pkgs/standards/autoapi/tests/i9n/test_op_ctx_alias_examples.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_op_ctx_alias_examples.py
@@ -1,0 +1,28 @@
+import pytest
+from autoapi.v3.types import Column, String
+from autoapi.v3 import op_ctx
+from autoapi.v3.orm.mixins import GUIDPk
+from autoapi.v3.orm.tables import Base
+from .test_op_ctx_behavior import setup_api
+
+
+@pytest.mark.i9n
+def test_op_ctx_alias_create_examples(sync_db_session):
+    _, get_db = sync_db_session
+
+    class Person(Base, GUIDPk):
+        __tablename__ = "people"
+        __resource__ = "person"
+        name = Column(String, info={"autoapi": {"examples": ["Alice"]}})
+
+        @op_ctx(alias="register", target="create", arity="collection")
+        def register(cls, ctx):  # pragma: no cover - logic irrelevant
+            pass
+
+    app, _ = setup_api(Person, get_db)
+    spec = app.openapi()
+    _ = spec["paths"]["/person/register"]["post"]
+    req_props = spec["components"]["schemas"]["PersonRegisterRequest"]["properties"]
+    resp_props = spec["components"]["schemas"]["PersonRegisterResponse"]["properties"]
+    assert req_props["name"]["examples"][0] == "Alice"
+    assert resp_props["name"]["examples"][0] == "Alice"


### PR DESCRIPTION
## Summary
- ensure op_ctx aliases get unique REST paths to surface request/response examples
- cover alias example behavior with integration test

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_op_ctx_alias_examples.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8382ac4e083269765c885d7fe4a64