### PR TITLE
feat: inherit target schemas for op_ctx aliases

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_op_ctx_alias_examples.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_op_ctx_alias_examples.py
@@ -1,6 +1,7 @@
 import pytest
+from pydantic import BaseModel
 from autoapi.v3.types import Column, String
-from autoapi.v3 import op_ctx
+from autoapi.v3 import op_alias, op_ctx
 from autoapi.v3.orm.mixins import GUIDPk
 from autoapi.v3.orm.tables import Base
 from .test_op_ctx_behavior import setup_api
@@ -26,3 +27,33 @@ def test_op_ctx_alias_create_examples(sync_db_session):
     resp_props = spec["components"]["schemas"]["PersonRegisterResponse"]["properties"]
     assert req_props["name"]["examples"][0] == "Alice"
     assert resp_props["name"]["examples"][0] == "Alice"
+
+
+@pytest.mark.i9n
+def test_op_ctx_alias_inherits_canonical_schemas(sync_db_session):
+    _, get_db = sync_db_session
+
+    class CreateReq(BaseModel):
+        info: str
+
+    class CreateResp(BaseModel):
+        info: str
+
+    @op_alias(
+        alias="create",
+        target="create",
+        request_model=CreateReq,
+        response_model=CreateResp,
+    )
+    class Person(Base, GUIDPk):
+        __tablename__ = "people2"
+        __resource__ = "person2"
+        name = Column(String)
+
+        @op_ctx(alias="register", target="create", arity="collection")
+        def register(cls, ctx):  # pragma: no cover - logic irrelevant
+            pass
+
+    setup_api(Person, get_db)
+    assert set(Person.schemas.register.in_.model_fields) == {"info"}
+    assert set(Person.schemas.register.out.model_fields) == {"info"}


### PR DESCRIPTION
## Summary
- inherit canonical request/response schemas for aliased `op_ctx` operations
- add integration test for schema inheritance

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff check autoapi tests --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_op_ctx_alias_examples.py::test_op_ctx_alias_inherits_canonical_schemas -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8452ca014832695c9b9c6ddf02879