### PR TITLE
fix autoapi rest alias routing

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest.py
@@ -21,6 +21,7 @@ from typing import (
 )
 
 from typing import get_origin as _get_origin, get_args as _get_args
+from ..ops.types import CANON
 
 try:
     from ..types import (
@@ -506,7 +507,9 @@ def _default_path_suffix(sp: OpSpec) -> str | None:
         # Bulk operations now share the same collection path as their
         # single-record counterparts.
         return None
-    if sp.alias != sp.target:
+    if sp.alias != sp.target and (
+        sp.target in {"create", "custom"} or sp.target not in CANON
+    ):
         return f"/{sp.alias}"
     return None
 
@@ -518,8 +521,11 @@ def _path_for_spec(
     Return (path, is_member). We use a generic {item_id} placeholder for all member ops
     and remap it to the model's real PK name inside ``ctx.path_params``.
     """
-    suffix = sp.path_suffix or _default_path_suffix(sp) or ""
-    if not suffix.startswith("/") and suffix:
+    if sp.path_suffix is None:
+        suffix = _default_path_suffix(sp) or ""
+    else:
+        suffix = sp.path_suffix or ""
+    if suffix and not suffix.startswith("/"):
         suffix = "/" + suffix
 
     if sp.arity == "member" or sp.target in {
@@ -1328,8 +1334,11 @@ def _build_router(model: type, specs: Sequence[OpSpec]) -> Router:
 
         # Determine path and membership
         if nested_pref:
-            suffix = sp.path_suffix or _default_path_suffix(sp) or ""
-            if not suffix.startswith("/") and suffix:
+            if sp.path_suffix is None:
+                suffix = _default_path_suffix(sp) or ""
+            else:
+                suffix = sp.path_suffix or ""
+            if suffix and not suffix.startswith("/"):
                 suffix = "/" + suffix
             base = nested_pref.rstrip("/")
             if not base.endswith(f"/{resource}"):
@@ -1438,6 +1447,13 @@ def _build_router(model: type, specs: Sequence[OpSpec]) -> Router:
         route_secdeps = _normalize_secdeps(secdeps)
         if route_secdeps:
             route_kwargs["dependencies"] = route_secdeps
+
+        if (
+            sp.alias != sp.target
+            and sp.target in CANON
+            and sp.alias != getattr(sp.handler, "__name__", sp.alias)
+        ):
+            route_kwargs["include_in_schema"] = False
 
         router.add_api_route(**route_kwargs)
 

--- a/pkgs/standards/autoapi/autoapi/v3/decorators.py
+++ b/pkgs/standards/autoapi/autoapi/v3/decorators.py
@@ -302,6 +302,7 @@ def _wrap_ctx_hook(
 # ──────────────────────────────────────────────────────────────────────
 
 _COLLECTION_VERBS = {
+    "create",
     "list",
     "bulk_create",
     "bulk_update",

--- a/pkgs/standards/autoapi/autoapi/v3/ops/collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/ops/collect.py
@@ -221,7 +221,7 @@ def _apply_alias_ctx_to_canon(specs: List[OpSpec], model: type) -> List[OpSpec]:
                     sp.alias,
                 )
             else:
-                mutated = replace(mutated, alias=new_alias)
+                mutated = replace(mutated, alias=new_alias, path_suffix="")
 
         # 2) apply per-verb overrides (no returns handling)
         ov = overrides.get(canon)  # type: ignore[index]


### PR DESCRIPTION
## Summary
- fix REST path resolution for aliased operations
- keep handler-named ops in OpenAPI while hiding anonymous aliases
- ensure create ops are treated as collection routes

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff check autoapi/v3/bindings/rest.py autoapi/v3/decorators.py autoapi/v3/ops/collect.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b84759fa10832687f96ed255798fc7