### PR TITLE
Fix OpenAPI exposure for create aliases

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/decorators.py
+++ b/pkgs/standards/autoapi/autoapi/v3/decorators.py
@@ -381,8 +381,6 @@ def collect_decorated_ops(table: type) -> list[OpSpec]:
                 "clear",
             }:
                 expose_kwargs["expose_routes"] = False
-            elif alias != target and target == "create":
-                extra["include_in_schema"] = False
 
             spec = OpSpec(
                 table=table,


### PR DESCRIPTION
## Summary
- ensure `@op_ctx` create aliases are included in OpenAPI by default

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_op_ctx_alias_examples.py`


------
https://chatgpt.com/codex/tasks/task_e_68b84c92aee883268812f7ad006a1cec