### PR TITLE
feat(autoapi): phase-aware runtime plan

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/runtime/events.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/events.py
@@ -6,13 +6,15 @@ from typing import Dict, Iterable, List, Literal, Tuple
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Phases
+#   - PRE_TX is a synthetic phase for security/dependency checks.
 #   - START_TX / END_TX are reserved for system steps (no atom anchors there).
 #   - Atoms bind only to the event anchors below.
 # ──────────────────────────────────────────────────────────────────────────────
 
 Phase = Literal[
-    "PRE_HANDLER",
+    "PRE_TX",
     "START_TX",
+    "PRE_HANDLER",
     "HANDLER",
     "POST_HANDLER",
     "END_TX",
@@ -20,8 +22,9 @@ Phase = Literal[
 ]
 
 PHASES: Tuple[Phase, ...] = (
-    "PRE_HANDLER",
+    "PRE_TX",
     "START_TX",  # system-only
+    "PRE_HANDLER",
     "HANDLER",
     "POST_HANDLER",
     "END_TX",  # system-only
@@ -88,10 +91,9 @@ _ANCHORS: Dict[str, AnchorInfo] = {
     # PRE_HANDLER (not persist-tied)
     SCHEMA_COLLECT_IN: AnchorInfo(SCHEMA_COLLECT_IN, "PRE_HANDLER", 0, False),
     IN_VALIDATE: AnchorInfo(IN_VALIDATE, "PRE_HANDLER", 1, False),
-    # HANDLER (persist-tied)
-    RESOLVE_VALUES: AnchorInfo(RESOLVE_VALUES, "HANDLER", 2, True),
-    PRE_FLUSH: AnchorInfo(PRE_FLUSH, "HANDLER", 3, True),
-    EMIT_ALIASES_PRE: AnchorInfo(EMIT_ALIASES_PRE, "HANDLER", 4, True),
+    RESOLVE_VALUES: AnchorInfo(RESOLVE_VALUES, "PRE_HANDLER", 2, True),
+    PRE_FLUSH: AnchorInfo(PRE_FLUSH, "PRE_HANDLER", 3, True),
+    EMIT_ALIASES_PRE: AnchorInfo(EMIT_ALIASES_PRE, "PRE_HANDLER", 4, True),
     # POST_HANDLER (mixed)
     POST_FLUSH: AnchorInfo(POST_FLUSH, "POST_HANDLER", 5, True),
     EMIT_ALIASES_POST: AnchorInfo(EMIT_ALIASES_POST, "POST_HANDLER", 6, True),

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/labels.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/labels.py
@@ -34,6 +34,7 @@ DOMAINS: Tuple[str, ...] = (
     "schema",
     "storage",
     "wire",
+    "sys",
 )
 
 # minimal token rules (tight but readable)
@@ -276,7 +277,7 @@ def _validate_subject(subj: Optional[str]) -> None:
 
 def _validate_anchor(anchor: Optional[str]) -> None:
     _require(
-        anchor is not None and _ev.is_valid_event(anchor),
+        anchor is not None and (_ev.is_valid_event(anchor) or anchor in _ev.PHASES),
         f"Invalid or unknown anchor {anchor!r}",
     )
 

--- a/pkgs/standards/autoapi/tests/i9n/test_hook_ctx_v3_i9n.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_hook_ctx_v3_i9n.py
@@ -378,5 +378,5 @@ async def test_hook_ctx_system_steps_i9n():
     res = await client.get("/system/planz")
     data = res.json()
     steps = data["Item"]["create"]
-    assert "sys:handler:crud@HANDLER" in steps
+    assert "HANDLER:hook:sys:handler:crud@HANDLER" in steps
     await client.aclose()

--- a/pkgs/standards/autoapi/tests/i9n/test_iospec_integration.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_iospec_integration.py
@@ -177,5 +177,5 @@ async def test_planz_lists_atoms_and_steps(widget_setup):
     client, _, _ = widget_setup
     data = (await client.get("/system/planz")).json()
     steps = data["Widget"]["create"]
-    assert "sys:handler:crud@HANDLER" in steps
-    assert any("sys:txn:begin@START_TX" in s for s in steps)
+    assert "HANDLER:hook:sys:handler:crud@HANDLER" in steps
+    assert any("hook:sys:txn:begin@START_TX" in s for s in steps)

--- a/pkgs/standards/autoapi/tests/i9n/test_schema_ctx_attributes_integration.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_schema_ctx_attributes_integration.py
@@ -166,7 +166,7 @@ async def test_schema_ctx_atomz(schema_ctx_client):
     client, _, _, _ = schema_ctx_client
     planz = (await client.get("/system/planz")).json()
     steps = planz["Widget"]["create"]
-    assert "sys:handler:crud@HANDLER" in steps
+    assert "HANDLER:hook:sys:handler:crud@HANDLER" in steps
 
 
 @pytest.mark.i9n

--- a/pkgs/standards/autoapi/tests/i9n/test_schema_ctx_spec_integration.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_schema_ctx_spec_integration.py
@@ -197,7 +197,7 @@ async def test_schema_ctx_atomz(schema_ctx_client):
     client, _, _, _ = schema_ctx_client
     planz = (await client.get("/system/planz")).json()
     steps = planz["Widget"]["create"]
-    assert "sys:handler:crud@HANDLER" in steps
+    assert "HANDLER:hook:sys:handler:crud@HANDLER" in steps
 
 
 @pytest.mark.i9n

--- a/pkgs/standards/autoapi/tests/i9n/test_storage_spec_integration.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_storage_spec_integration.py
@@ -114,7 +114,7 @@ async def test_storage_spec_atomz(api_client_v3):
     client, _, _, _ = api_client_v3
     planz = (await client.get("/system/planz")).json()
     steps = planz["Widget"]["create"]
-    assert "sys:handler:crud@HANDLER" in steps
+    assert "HANDLER:hook:sys:handler:crud@HANDLER" in steps
 
 
 @pytest.mark.i9n

--- a/pkgs/standards/autoapi/tests/perf/test_planz_performance.py
+++ b/pkgs/standards/autoapi/tests/perf/test_planz_performance.py
@@ -57,7 +57,7 @@ async def test_planz_performance(monkeypatch, count):
     def fake_flattened_order(
         plan, *, persist, include_system_steps, deps, secdeps=None, hooks=None
     ):
-        return [Label(events[i % len(events)]) for i in range(10)]
+        return [f"PRE_HANDLER:{events[i % len(events)]}" for i in range(10)]
 
     monkeypatch.setattr(_plan, "flattened_order", fake_flattened_order)
 

--- a/pkgs/standards/autoapi/tests/unit/runtime/test_events_phases.py
+++ b/pkgs/standards/autoapi/tests/unit/runtime/test_events_phases.py
@@ -1,0 +1,14 @@
+from autoapi.v3.runtime import events as _ev
+
+
+def test_phases_constant_lists_all_phases_in_order() -> None:
+    """Ensure PHASES exports the complete ordered phase sequence."""
+    assert _ev.PHASES == (
+        "PRE_TX",
+        "START_TX",
+        "PRE_HANDLER",
+        "HANDLER",
+        "POST_HANDLER",
+        "END_TX",
+        "POST_RESPONSE",
+    )

--- a/pkgs/standards/autoapi/tests/unit/test_response_diagnostics_planz.py
+++ b/pkgs/standards/autoapi/tests/unit/test_response_diagnostics_planz.py
@@ -42,9 +42,9 @@ async def test_response_atom_in_diagnostics_planz(kind) -> None:
 
     planz = _build_planz_endpoint(api)
     data = await planz()
-    assert "atom:response:template@out:dump" in data["Model"]["read"]
-    assert "atom:response:negotiate@out:dump" in data["Model"]["read"]
-    assert "atom:response:render@out:dump" in data["Model"]["read"]
+    assert "POST_RESPONSE:atom:response:template@out:dump" in data["Model"]["read"]
+    assert "POST_RESPONSE:atom:response:negotiate@out:dump" in data["Model"]["read"]
+    assert "POST_RESPONSE:atom:response:render@out:dump" in data["Model"]["read"]
 
 
 @pytest.mark.asyncio
@@ -79,6 +79,6 @@ async def test_response_atom_in_diagnostics_planz_template(tmp_path) -> None:
 
     planz = _build_planz_endpoint(api)
     data = await planz()
-    assert "atom:response:template@out:dump" in data["Model"]["read"]
-    assert "atom:response:negotiate@out:dump" in data["Model"]["read"]
-    assert "atom:response:render@out:dump" in data["Model"]["read"]
+    assert "POST_RESPONSE:atom:response:template@out:dump" in data["Model"]["read"]
+    assert "POST_RESPONSE:atom:response:negotiate@out:dump" in data["Model"]["read"]
+    assert "POST_RESPONSE:atom:response:render@out:dump" in data["Model"]["read"]


### PR DESCRIPTION
## Summary
- add PRE_TX phase and migrate handler anchors to pre-handler
- convert system steps to hooks and prefix phase on runtime plans
- update diagnostics and tests for phase-aware ordering
- verify full phase list via dedicated unit test

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba88cfa3c483268661b7529299e225