### PR TITLE
Deduplicate ServiceKey CRUD handler and auto-generate key digest

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/orm/mixins/key_digest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/orm/mixins/key_digest.py
@@ -19,7 +19,7 @@ class KeyDigest:
     digest: Mapped[str] = acol(
         storage=S(String, nullable=False, unique=True),
         field=F(constraints={"max_length": 64}),
-        io=IO(out_verbs=("read", "list"), allow_in=False).paired(
+        io=IO(out_verbs=("read", "list", "create"), allow_in=True).paired(
             _pair_api_key, alias="api_key"
         ),
     )

--- a/pkgs/standards/autoapi/autoapi/v3/system/diagnostics.py
+++ b/pkgs/standards/autoapi/autoapi/v3/system/diagnostics.py
@@ -273,6 +273,14 @@ def _build_planz_endpoint(api: Any):
                         secdeps=secdeps,
                         hooks=hook_map,
                     )
+                    labels = [
+                        lbl
+                        for lbl in labels
+                        if not (
+                            lbl.startswith("HANDLER:hook:")
+                            and "hook:sys:handler:crud@HANDLER" not in lbl
+                        )
+                    ]
                     if sp.target == "custom" or getattr(sp, "persist", "default") in {
                         "override"
                     }:


### PR DESCRIPTION
## Summary
- avoid duplicate handler diagnostics by filtering non-system handler hooks
- generate ServiceKey digest and API key automatically and expose in create responses

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68ba9a98b06883268662e982d2e05e42