### PR TITLE
Fix ServiceKey digest generation on create

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/orm/mixins/key_digest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/orm/mixins/key_digest.py
@@ -19,9 +19,10 @@ class KeyDigest:
     digest: Mapped[str] = acol(
         storage=S(String, nullable=False, unique=True),
         field=F(constraints={"max_length": 64}),
-        io=IO(out_verbs=("read", "list", "create"), allow_in=True).paired(
-            _pair_api_key, alias="api_key"
-        ),
+        io=IO(
+            in_verbs=("create",),
+            out_verbs=("read", "list", "create"),
+        ).paired(_pair_api_key, alias="api_key"),
     )
 
     @staticmethod


### PR DESCRIPTION
## Summary
- ensure KeyDigest columns generate a digest during create operations

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff check . --fix`
- `uv run --directory standards/autoapi --package autoapi pytest tests/i9n/test_apikey_generation.py`


------
https://chatgpt.com/codex/tasks/task_e_68baa40602608326b6b4059a6d100f61