### PR TITLE
feat: auto-authn service key digest generation

### DIFF
--- a/pkgs/standards/auto_authn/tests/i9n/test_service_key_creation.py
+++ b/pkgs/standards/auto_authn/tests/i9n/test_service_key_creation.py
@@ -1,0 +1,117 @@
+import asyncio
+from uuid import UUID
+
+import httpx
+import pytest
+import uvicorn
+
+from auto_authn.orm.service_key import ServiceKey
+
+TENANT_ID = UUID("ffffffff-0000-0000-0000-000000000000")
+
+
+async def _wait_for_app(base_url: str) -> None:
+    async with httpx.AsyncClient() as client:
+        for _ in range(50):
+            try:
+                resp = await client.get(f"{base_url}/system/healthz")
+                if resp.status_code == 200:
+                    return
+            except Exception:
+                pass
+            await asyncio.sleep(0.1)
+    raise RuntimeError("server not ready")
+
+
+@pytest.fixture()
+async def running_app(override_get_db):
+    cfg = uvicorn.Config(
+        "auto_authn.app:app", host="127.0.0.1", port=8000, log_level="warning"
+    )
+    server = uvicorn.Server(cfg)
+    task = asyncio.create_task(server.serve())
+    await _wait_for_app("http://127.0.0.1:8000")
+    try:
+        yield "http://127.0.0.1:8000"
+    finally:
+        server.should_exit = True
+        await task
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_service_key_workflow(running_app):
+    base = running_app
+    async with httpx.AsyncClient() as client:
+        # create service
+        svc_resp = await client.post(
+            f"{base}/service",
+            json={"tenant_id": str(TENANT_ID), "name": "svc"},
+        )
+        assert svc_resp.status_code == 201
+        service_id = svc_resp.json()["id"]
+
+        # create service key without validity window
+        create_payload = {"label": "test", "service_id": service_id}
+        key_resp = await client.post(f"{base}/servicekey", json=create_payload)
+        assert key_resp.status_code == 201
+        body = key_resp.json()
+
+        expected_keys = {
+            "id",
+            "label",
+            "service_id",
+            "digest",
+            "valid_from",
+            "valid_to",
+            "last_used_at",
+            "created_at",
+            "api_key",
+        }
+        assert set(body) == expected_keys
+        assert body["valid_from"] and body["valid_to"]
+        assert body["digest"] == ServiceKey.digest_of(body["api_key"])
+
+        # verify persistence and exclusion of api_key
+        key_id = body["id"]
+        read_resp = await client.get(f"{base}/servicekey/{key_id}")
+        assert read_resp.status_code == 200
+        read_body = read_resp.json()
+        assert "api_key" not in read_body
+        assert read_body["digest"] == body["digest"]
+        assert read_body["valid_from"] == body["valid_from"]
+        assert read_body["valid_to"] == body["valid_to"]
+
+        # valid_from and valid_to are optional but persisted when provided
+        custom_from = "2024-01-01T00:00:00+00:00"
+        custom_to = "2024-12-31T00:00:00+00:00"
+        payload2 = {
+            "label": "custom",
+            "service_id": service_id,
+            "valid_from": custom_from,
+            "valid_to": custom_to,
+        }
+        key_resp2 = await client.post(f"{base}/servicekey", json=payload2)
+        assert key_resp2.status_code == 201
+        body2 = key_resp2.json()
+        assert body2["valid_from"] == custom_from
+        assert body2["valid_to"] == custom_to
+        read_body2 = (await client.get(f"{base}/servicekey/{body2['id']}")).json()
+        assert read_body2["valid_from"] == custom_from
+        assert read_body2["valid_to"] == custom_to
+
+        # digest or api_key are not accepted in the request body
+        bad_payload = {"label": "bad", "service_id": service_id, "digest": "x"}
+        bad_resp = await client.post(f"{base}/servicekey", json=bad_payload)
+        assert bad_resp.status_code == 422
+        bad_payload2 = {"label": "bad", "service_id": service_id, "api_key": "raw"}
+        bad_resp2 = await client.post(f"{base}/servicekey", json=bad_payload2)
+        assert bad_resp2.status_code == 422
+
+        # check openapi response example includes validity window
+        openapi = (await client.get(f"{base}/openapi.json")).json()
+        schema = openapi["components"]["schemas"]["ServiceKeyCreateResponse"]
+        assert "valid_from" in schema["properties"]
+        assert "valid_to" in schema["properties"]
+        example = schema.get("example") or (schema.get("examples") or [{}])[0]
+        assert "valid_from" in example and "valid_to" in example

--- a/pkgs/standards/auto_authn/tests/unit/test_models.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_models.py
@@ -176,16 +176,32 @@ class TestServiceKeyModel:
         assert service_key.digest == expected_digest
 
     def test_service_key_schema_uses_service_id(self):
-        """Ensure ServiceKey API schema uses service_id and not user_id."""
+        """Ensure ServiceKey API schema exposes correct fields."""
         from auto_authn.routers.surface import surface_api
 
+        create_schema = surface_api.schemas.ServiceKey.create.in_.model_json_schema()
         create_fields = surface_api.schemas.ServiceKey.create.in_.model_fields
-        read_fields = surface_api.schemas.ServiceKey.read.out.model_fields
+        read_schema = surface_api.schemas.ServiceKey.read.out.model_json_schema()
 
+        # Only expected fields are exposed on create
+        assert set(create_fields.keys()) == {
+            "label",
+            "service_id",
+            "valid_from",
+            "valid_to",
+        }
+        # Only label and service_id are required
+        assert set(create_schema.get("required", [])) == {"label", "service_id"}
+        # Digest should not be part of the create payload
+        assert "digest" not in create_fields
+        # Validity window fields are included in responses
+        assert "valid_from" in read_schema.get("properties", {})
+        assert "valid_to" in read_schema.get("properties", {})
+        # Schemas still reference service_id and exclude user_id
         assert "service_id" in create_fields
         assert "user_id" not in create_fields
-        assert "service_id" in read_fields
-        assert "user_id" not in read_fields
+        assert "service_id" in surface_api.schemas.ServiceKey.read.out.model_fields
+        assert "user_id" not in surface_api.schemas.ServiceKey.read.out.model_fields
 
 
 @pytest.mark.unit

--- a/pkgs/standards/autoapi/autoapi/v3/orm/mixins/key_digest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/orm/mixins/key_digest.py
@@ -20,7 +20,6 @@ class KeyDigest:
         storage=S(String, nullable=False, unique=True),
         field=F(constraints={"max_length": 64}),
         io=IO(
-            in_verbs=("create",),
             out_verbs=("read", "list", "create"),
         ).paired(_pair_api_key, alias="api_key"),
     )


### PR DESCRIPTION
## Summary
- allow KeyDigest to generate API key digests without request input
- verify ServiceKey schema exposes only expected fields
- add end-to-end tests for creating service keys via auto_authn server

## Testing
- `uv run --package autoapi --directory pkgs/standards/autoapi pytest`
- `uv run --package auto_authn --directory pkgs/standards/auto_authn pytest`


------
https://chatgpt.com/codex/tasks/task_e_68baadcbabf48326b3d9b0c46834361f