### PR TITLE
feat: generate service key digest automatically

### DIFF
--- a/pkgs/standards/auto_authn/tests/i9n/test_service_key_uvicorn.py
+++ b/pkgs/standards/auto_authn/tests/i9n/test_service_key_uvicorn.py
@@ -1,0 +1,73 @@
+import asyncio
+from datetime import datetime, timedelta, timezone
+from hashlib import sha256
+
+import pytest
+from httpx import AsyncClient
+import uvicorn
+
+from auto_authn.app import app
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_create_service_and_service_key_via_uvicorn_server(override_get_db):
+    """Create service and service key through a running Uvicorn server."""
+    config = uvicorn.Config(
+        app, host="127.0.0.1", port=8001, log_level="warning", loop="asyncio"
+    )
+    server = uvicorn.Server(config)
+    server_task = asyncio.create_task(server.serve())
+    while not server.started:
+        await asyncio.sleep(0.1)
+
+    try:
+        async with AsyncClient(base_url="http://127.0.0.1:8001") as client:
+            tenant_payload = {
+                "name": "Acme",
+                "email": "acme@example.com",
+                "slug": "acme",
+            }
+            res_tenant = await client.post("/tenants", json=tenant_payload)
+            assert res_tenant.status_code == 201
+            tenant_id = res_tenant.json()["id"]
+
+            service_payload = {"name": "svc", "tenant_id": tenant_id}
+            res_service = await client.post("/services", json=service_payload)
+            assert res_service.status_code == 201
+            service_id = res_service.json()["id"]
+
+            bad = {"label": "bad", "service_id": service_id, "digest": "x"}
+            res_bad = await client.post("/service_keys", json=bad)
+            assert res_bad.status_code == 422
+
+            now = datetime.now(timezone.utc)
+            later = now + timedelta(days=7)
+            key_payload = {
+                "label": "key1",
+                "service_id": service_id,
+                "valid_from": now.isoformat(),
+                "valid_to": later.isoformat(),
+            }
+            res_key = await client.post("/service_keys", json=key_payload)
+            assert res_key.status_code == 201
+            body = res_key.json()
+            assert body["label"] == "key1"
+            assert body["service_id"] == service_id
+            assert body["valid_from"] == key_payload["valid_from"]
+            assert body["valid_to"] == key_payload["valid_to"]
+            api_key = body["api_key"]
+            digest = body["digest"]
+            assert digest == sha256(api_key.encode()).hexdigest()
+
+            key_id = body["id"]
+            res_get = await client.get(f"/service_keys/{key_id}")
+            assert res_get.status_code == 200
+            fetched = res_get.json()
+            assert fetched["digest"] == digest
+            assert "api_key" not in fetched
+            assert fetched["valid_from"] == key_payload["valid_from"]
+            assert fetched["valid_to"] == key_payload["valid_to"]
+    finally:
+        server.should_exit = True
+        await server_task

--- a/pkgs/standards/auto_authn/tests/unit/test_models.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_models.py
@@ -187,6 +187,22 @@ class TestServiceKeyModel:
         assert "service_id" in read_fields
         assert "user_id" not in read_fields
 
+    def test_service_key_create_schema_fields(self):
+        """ServiceKey create schema exposes only expected fields."""
+        from auto_authn.routers.surface import surface_api
+
+        create_fields = surface_api.schemas.ServiceKey.create.in_.model_fields
+        assert set(create_fields.keys()) == {
+            "label",
+            "service_id",
+            "valid_from",
+            "valid_to",
+        }
+        assert create_fields["label"].is_required() is True
+        assert create_fields["service_id"].is_required() is True
+        assert create_fields["valid_from"].is_required() is False
+        assert create_fields["valid_to"].is_required() is False
+
 
 @pytest.mark.unit
 class TestModelIntegration:

--- a/pkgs/standards/auto_authn/tests/unit/test_openapi_examples.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_openapi_examples.py
@@ -61,3 +61,37 @@ def test_all_models_registered_on_api_and_tables() -> None:
     expected = set(ORM_MODELS)
     assert expected == set(surface_api.tables.keys())
     assert expected.issubset(vars(surface_api.schemas).keys())
+
+
+def test_service_key_request_schema(openapi_spec: dict) -> None:
+    """ServiceKey request body exposes only allowed fields."""
+    schema = openapi_spec["components"]["schemas"]["ServiceKeyCreateRequest"]
+    assert set(schema["properties"].keys()) == {
+        "label",
+        "service_id",
+        "valid_from",
+        "valid_to",
+    }
+    assert set(schema["required"]) == {"label", "service_id"}
+    assert "digest" not in schema["properties"]
+    assert "api_key" not in schema["properties"]
+
+
+def test_service_key_response_examples_include_validity(openapi_spec: dict) -> None:
+    """Response examples include digest and validity window."""
+    schema = openapi_spec["components"]["schemas"]["ServiceKeyCreateResponse"]
+    props = schema["properties"]
+    assert {
+        "id",
+        "label",
+        "service_id",
+        "digest",
+        "valid_from",
+        "valid_to",
+        "last_used_at",
+        "created_at",
+    }.issubset(props.keys())
+    examples = schema.get("examples")
+    if examples:
+        example = examples[0]["value"]
+        assert "valid_from" in example and "valid_to" in example

--- a/pkgs/standards/autoapi/autoapi/v3/orm/mixins/key_digest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/orm/mixins/key_digest.py
@@ -18,11 +18,10 @@ class KeyDigest:
 
     digest: Mapped[str] = acol(
         storage=S(String, nullable=False, unique=True),
-        field=F(constraints={"max_length": 64}),
+        field=F(constraints={"max_length": 64}, required_in=()),
         io=IO(
-            in_verbs=("create",),
             out_verbs=("read", "list", "create"),
-        ).paired(_pair_api_key, alias="api_key"),
+        ).paired(_pair_api_key, alias="api_key", emit="pre_response"),
     )
 
     @staticmethod

--- a/pkgs/standards/autoapi/tests/i9n/test_apikey_generation.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_apikey_generation.py
@@ -44,3 +44,22 @@ async def test_api_key_creation_requires_valid_payload(sync_db_session):
         res = await client.post("/apikey", json={})
 
     assert res.status_code == 422
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_api_key_creation_disallows_api_key_input(sync_db_session):
+    """Client cannot supply api_key when creating a key."""
+    _, get_sync_db = sync_db_session
+
+    app = App()
+    api = AutoApp(get_db=get_sync_db)
+    api.include_models([ConcreteApiKey])
+    api.initialize()
+    app.include_router(api.router)
+    transport = ASGITransport(app=app)
+
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        res = await client.post("/apikey", json={"label": "Key", "api_key": "raw"})
+
+    assert res.status_code == 422


### PR DESCRIPTION
## Summary
- ensure API key digests are generated server-side and not required in requests
- tighten ServiceKey schemas and document validity fields in OpenAPI
- add integration test scaffolding for service and service key creation

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_apikey_generation.py`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_models.py::TestServiceKeyModel::test_service_key_create_schema_fields tests/unit/test_openapi_examples.py::test_service_key_request_schema tests/unit/test_openapi_examples.py::test_service_key_response_examples_include_validity`


------
https://chatgpt.com/codex/tasks/task_e_68baae90f1bc8326893a3a56a672487b