### PR TITLE
refactor: split model binding helpers

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/model_helpers.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/model_helpers.py
@@ -1,0 +1,135 @@
+# autoapi/v3/bindings/model_helpers.py
+"""Internal helpers for the model bindings."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Dict, List, Optional, Sequence, Set, Tuple
+
+from ..ops import OpSpec
+
+
+_Key = Tuple[str, str]  # (alias, target)
+
+
+def _key(sp: OpSpec) -> _Key:
+    return (sp.alias, sp.target)
+
+
+def _ensure_model_namespaces(model: type) -> None:
+    """Create top-level namespaces on the model class if missing."""
+
+    # op indexes & metadata
+    if not hasattr(model, "ops"):
+        if hasattr(model, "opspecs"):
+            model.ops = model.opspecs
+        else:
+            model.ops = SimpleNamespace(all=(), by_key={}, by_alias={})
+    # Backwards compatibility: older code may still expect `model.opspecs`
+    model.opspecs = model.ops
+    # pydantic schemas: .<alias>.in_ / .<alias>.out
+    if not hasattr(model, "schemas"):
+        model.schemas = SimpleNamespace()
+    # hooks: phase chains & raw hook descriptors if you want to expose them
+    if not hasattr(model, "hooks"):
+        model.hooks = SimpleNamespace()
+    # handlers: .<alias>.raw (core/custom), .<alias>.handler (HANDLER chain entry point)
+    if not hasattr(model, "handlers"):
+        model.handlers = SimpleNamespace()
+    # rpc: callables to be registered/mounted elsewhere as JSON-RPC methods
+    if not hasattr(model, "rpc"):
+        model.rpc = SimpleNamespace()
+    # rest: .router (FastAPI Router or compatible) – built in rest binding
+    if not hasattr(model, "rest"):
+        model.rest = SimpleNamespace(router=None)
+    # basic table metadata for convenience (introspective only; NEVER used for HTTP paths)
+    if not hasattr(model, "columns"):
+        table = getattr(model, "__table__", None)
+        cols = tuple(getattr(table, "columns", ()) or ())
+        model.columns = tuple(
+            getattr(c, "name", None) for c in cols if getattr(c, "name", None)
+        )
+    if not hasattr(model, "table_config"):
+        table = getattr(model, "__table__", None)
+        model.table_config = dict(getattr(table, "kwargs", {}) or {})
+    # ensure raw hook store exists for decorator merges
+    if not hasattr(model, "__autoapi_hooks__"):
+        setattr(model, "__autoapi_hooks__", {})
+
+
+def _index_specs(
+    specs: Sequence[OpSpec],
+) -> Tuple[Tuple[OpSpec, ...], Dict[_Key, OpSpec], Dict[str, List[OpSpec]]]:
+    all_specs: Tuple[OpSpec, ...] = tuple(specs)
+    by_key: Dict[_Key, OpSpec] = {}
+    by_alias: Dict[str, List[OpSpec]] = {}
+    for sp in specs:
+        k = _key(sp)
+        by_key[k] = sp
+        by_alias.setdefault(sp.alias, []).append(sp)
+    return all_specs, by_key, by_alias
+
+
+def _drop_old_entries(model: type, *, keys: Set[_Key] | None) -> None:
+    """
+    Remove per-op artifacts for the provided keys before a targeted rebuild.
+    Safe no-ops if keys are None (full rebuild happens cleanly by overwrite).
+    """
+
+    if not keys:
+        return
+    # schemas
+    for alias, _target in keys:
+        ns = getattr(model.schemas, alias, None)
+        if ns:
+            for attr in ("in_", "out", "list"):
+                try:
+                    delattr(ns, attr)
+                except Exception:
+                    pass
+            if not ns.__dict__:
+                try:
+                    delattr(model.schemas, alias)
+                except Exception:
+                    pass
+    # handlers
+    for alias, _target in keys:
+        if hasattr(model.handlers, alias):
+            try:
+                delattr(model.handlers, alias)
+            except Exception:
+                pass
+    # hooks
+    for alias, _target in keys:
+        if hasattr(model.hooks, alias):
+            try:
+                delattr(model.hooks, alias)
+            except Exception:
+                pass
+    # rpc
+    for alias, _target in keys:
+        if hasattr(model.rpc, alias):
+            try:
+                delattr(model.rpc, alias)
+            except Exception:
+                pass
+    # REST endpoints are refreshed wholesale by rest binding as needed
+
+
+def _filter_specs(
+    specs: Sequence[OpSpec], only_keys: Optional[Set[_Key]]
+) -> List[OpSpec]:
+    if not only_keys:
+        return list(specs)
+    ok = only_keys
+    return [sp for sp in specs if _key(sp) in ok]
+
+
+__all__ = [
+    "_Key",
+    "_key",
+    "_ensure_model_namespaces",
+    "_index_specs",
+    "_drop_old_entries",
+    "_filter_specs",
+]

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/model_registry.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/model_registry.py
@@ -1,0 +1,74 @@
+# autoapi/v3/bindings/model_registry.py
+"""Registry helpers for model bindings."""
+
+from __future__ import annotations
+
+import logging
+from typing import Set
+
+from ..config.constants import AUTOAPI_REGISTRY_LISTENER_ATTR
+from ..ops import OpspecRegistry, get_registry
+
+from .model_helpers import _Key
+
+logger = logging.getLogger(__name__)
+
+
+def _ensure_registry_listener(model: type) -> None:
+    """
+    Subscribe (once) to the per-model OpspecRegistry so future register_ops/add/remove/set
+    calls automatically refresh the model namespaces.
+    """
+
+    reg: OpspecRegistry = get_registry(model)
+
+    # If we already subscribed, skip
+    if getattr(model, AUTOAPI_REGISTRY_LISTENER_ATTR, None):
+        return
+
+    def _on_registry_change(registry: OpspecRegistry, changed: Set[_Key]) -> None:
+        from .model import rebind
+
+        try:
+            rebind(model, changed_keys=changed)  # targeted rebind
+        except Exception as e:  # pragma: no cover
+            logger.exception(
+                "autoapi: rebind failed for %s on ops %s: %s",
+                model.__name__,
+                changed,
+                e,
+            )
+
+    reg.subscribe(_on_registry_change)
+    # Keep a reference to avoid GC of the closure and to prevent double-subscribe
+    setattr(model, AUTOAPI_REGISTRY_LISTENER_ATTR, _on_registry_change)
+
+
+def _ensure_op_ctx_attach_hook(model: type) -> None:
+    """Patch the model's metaclass to auto-rebind on ctx-only op attachment."""
+
+    meta = type(model)
+    if getattr(meta, "__autoapi_op_ctx_meta_patch__", False):
+        return
+
+    orig_meta_setattr = meta.__setattr__
+
+    def _meta_setattr(cls, name, value):
+        from .model import rebind
+
+        orig_meta_setattr(cls, name, value)
+        fn = getattr(value, "__func__", value)
+        decl = getattr(fn, "__autoapi_op_decl__", None)
+        if decl and getattr(cls, "__autoapi_op_ctx_watch__", False):
+            alias = decl.alias or name
+            target = decl.target or "custom"
+            rebind(cls, changed_keys={(alias, target)})
+
+    meta.__setattr__ = _meta_setattr  # type: ignore[attr-defined]
+    setattr(meta, "__autoapi_op_ctx_meta_patch__", True)
+
+
+__all__ = [
+    "_ensure_registry_listener",
+    "_ensure_op_ctx_attach_hook",
+]


### PR DESCRIPTION
## Summary
- extract helper routines into `model_helpers.py`
- move registry-related logic into `model_registry.py`
- simplify `model.py` to use extracted helpers

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bb56b2ff108326ab69c112e7577247