### PR TITLE
chore(autoapi): stop exporting collect helpers

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/decorators.py
+++ b/pkgs/standards/autoapi/autoapi/v3/decorators.py
@@ -6,8 +6,6 @@ from .op.decorators import *  # noqa: F401,F403
 from .hook.decorators import *  # noqa: F401,F403
 from .schema.decorators import schema_ctx
 from .engine.decorators import engine_ctx
-from .op.collect import collect_decorated_ops, alias_map_for, apply_alias
-from .hook.collect import collect_decorated_hooks
 from .op.decorators import __all__ as _op_all
 from .hook.decorators import __all__ as _hook_all
 
@@ -16,8 +14,4 @@ __all__ = [
     *_hook_all,
     "schema_ctx",
     "engine_ctx",
-    "collect_decorated_ops",
-    "collect_decorated_hooks",
-    "alias_map_for",
-    "apply_alias",
 ]


### PR DESCRIPTION
## Summary
- limit autoapi v3 decorators module exports to decorator utilities

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68bb634233088326a16499a30e189f9f