### PR TITLE
feat(autoapi): collect mixin column specs

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/column/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/column/__init__.py
@@ -23,6 +23,7 @@ from ._column import Column
 from .field_spec import FieldSpec as F
 from .storage_spec import StorageSpec as S
 from .io_spec import IOSpec as IO
+from .collect import collect_columns
 
 # Ergonomic constructors
 from .shortcuts import makeColumn, makeVirtualColumn, acol, vcol
@@ -60,6 +61,7 @@ __all__ = [
     "InferenceError",
     "UnsupportedType",
     "is_virtual",
+    "collect_columns",
 ]
 
 

--- a/pkgs/standards/autoapi/autoapi/v3/column/collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/column/collect.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from .column_spec import ColumnSpec
+
+
+def collect_columns(model: type) -> Dict[str, ColumnSpec]:
+    """Gather ColumnSpecs declared on *model* and all mixins.
+
+    Iterates across the model's MRO so that mixin-defined columns are included
+    in the resulting mapping. Later definitions take precedence over earlier
+    ones in the MRO.
+    """
+    out: Dict[str, ColumnSpec] = {}
+    for base in reversed(model.__mro__):
+        mapping = getattr(base, "__autoapi_colspecs__", None)
+        if isinstance(mapping, dict):
+            out.update(mapping)
+        mapping = getattr(base, "__autoapi_cols__", None)
+        if isinstance(mapping, dict):
+            out.update(mapping)
+    return out
+
+
+__all__ = ["collect_columns"]

--- a/pkgs/standards/autoapi/autoapi/v3/core/crud/helpers/model.py
+++ b/pkgs/standards/autoapi/autoapi/v3/core/crud/helpers/model.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any, Dict, Mapping, Tuple
 
+from ....column.collect import collect_columns
+
 
 def _pk_columns(model: type) -> Tuple[Any, ...]:
     table = getattr(model, "__table__", None)
@@ -46,13 +48,7 @@ def _model_columns(model: type) -> Tuple[str, ...]:
 
 
 def _colspecs(model: type) -> Mapping[str, Any]:
-    specs = getattr(model, "__autoapi_colspecs__", None)
-    if isinstance(specs, Mapping):
-        return specs
-    specs = getattr(model, "__autoapi_cols__", None)
-    if isinstance(specs, Mapping):
-        return specs
-    return {}
+    return collect_columns(model)
 
 
 def _filter_in_values(

--- a/pkgs/standards/autoapi/autoapi/v3/schema/builder/build_schema.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/builder/build_schema.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, Iterable, Mapping, Set, Tuple, Type, Union
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, create_model
 
 from ..utils import namely_model
+from ...column.collect import collect_columns
 from .cache import _SchemaCache
 from .compat import _info_check, hybrid_property
 from .extras import _merge_request_extras, _merge_response_extras
@@ -50,9 +51,7 @@ def _build_schema(
     # ── PASS 1: table-backed columns only (avoid mapper relationships)
     table = getattr(orm_cls, "__table__", None)
     table_cols: Iterable[Any] = tuple(table.columns) if table is not None else ()
-    specs: Dict[str, Any] = {}
-    specs.update(getattr(orm_cls, "__autoapi_colspecs__", {}))
-    specs.update(getattr(orm_cls, "__autoapi_cols__", {}))
+    specs: Dict[str, Any] = collect_columns(orm_cls)
 
     for col in table_cols:
         attr_name = col.key or col.name

--- a/pkgs/standards/autoapi/autoapi/v3/schema/builder/list_params.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/builder/list_params.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import logging
 import uuid
-from typing import Any, Mapping, Type
+from typing import Any, Type
 
 from pydantic import BaseModel, ConfigDict, Field, create_model
 
 from ..utils import namely_model
+from ...column.collect import collect_columns
 
 logger = logging.getLogger(__name__)
 
@@ -78,10 +79,8 @@ def _build_list_params(model: type) -> Type[BaseModel]:
             continue
         py_t = getattr(c.type, "python_type", Any)
         if py_t in _scalars:
-            spec_map = getattr(model, "__autoapi_colspecs__", None) or getattr(
-                model, "__autoapi_cols__", {}
-            )
-            spec = spec_map.get(c.name) if isinstance(spec_map, Mapping) else None
+            spec_map = collect_columns(model)
+            spec = spec_map.get(c.name)
             io = getattr(spec, "io", None)
             ops_raw = set(getattr(io, "filter_ops", ()) or [])
             if not ops_raw:

--- a/pkgs/standards/autoapi/autoapi/v3/system/diagnostics/planz.py
+++ b/pkgs/standards/autoapi/autoapi/v3/system/diagnostics/planz.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 
 from ...op.types import PHASES
 from ...runtime import plan as _plan
+from ...column.collect import collect_columns
 
 
 def build_planz_endpoint(api: Any):
@@ -31,10 +32,8 @@ def build_planz_endpoint(api: Any):
                 getattr(model, "runtime", SimpleNamespace()), "plan", None
             )
             if compiled_plan is None:
-                specs = getattr(model, "__autoapi_colspecs__", None) or getattr(
-                    model, "__autoapi_cols__", None
-                )
-                if specs is not None:
+                specs = collect_columns(model)
+                if specs:
                     try:
                         compiled_plan = _plan.attach_atoms_for_model(model, specs)
                     except Exception:

--- a/pkgs/standards/autoapi/tests/unit/test_column_collect_mixins.py
+++ b/pkgs/standards/autoapi/tests/unit/test_column_collect_mixins.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from autoapi.v3.column.collect import collect_columns
+from autoapi.v3.orm.mixins import GUIDPk
+from autoapi.v3.orm.tables._base import Base
+from autoapi.v3.specs import S, acol
+from autoapi.v3.types import Mapped, String
+
+
+class NameMixin:
+    name: Mapped[str] = acol(storage=S(String, nullable=False))
+
+
+class Thing(Base, GUIDPk, NameMixin):
+    __tablename__ = "thing_collect_mixins"
+
+
+def test_collect_columns_includes_mixin_fields():
+    specs = collect_columns(Thing)
+    assert "id" in specs
+    assert "name" in specs


### PR DESCRIPTION
## Summary
- add `collect_columns` helper to gather column specs across a model's mixins
- use the collector in schema builders, CRUD helpers, and diagnostics
- expose collector in column API and cover mixin behavior with tests

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff format .`
- `uv run --directory standards/autoapi --package autoapi ruff check . --fix`
- `uv run --directory standards/autoapi --package autoapi pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb69d7fa788326b0338b5d1450fc83