### PR TITLE
fix(autoapi): detect io paired columns

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/resolve/paired_gen.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/resolve/paired_gen.py
@@ -140,18 +140,22 @@ def _ctx_view(ctx: Any) -> Dict[str, Any]:
 
 
 def _is_paired(colspec: Any) -> bool:
-    """
-    Heuristic: recognize secret-once/paired columns without hard-coding spec structure.
-    """
-    for obj in (colspec, getattr(colspec, "field", None)):
+    """Best-effort detection of secret-once/paired columns."""
+
+    field = getattr(colspec, "field", None)
+    io = getattr(colspec, "io", None)
+    field_io = getattr(field, "io", None)
+
+    for obj in (colspec, field, io, field_io):
         if obj is None:
             continue
+        if getattr(obj, "_paired", None) is not None:
+            return True
         if any(
             bool(getattr(obj, name, False))
             for name in ("secret_once", "paired", "paired_input", "generate_on_absent")
         ):
             return True
-        # Presence of a generator implies paired
         if any(
             callable(getattr(obj, name, None))
             for name in ("generator", "paired_generator", "secret_generator")
@@ -162,9 +166,16 @@ def _is_paired(colspec: Any) -> bool:
 
 def _get_generator(colspec: Any):
     """Return the first available generator callable, if any."""
-    for obj in (colspec, getattr(colspec, "field", None)):
+    field = getattr(colspec, "field", None)
+    io = getattr(colspec, "io", None)
+    field_io = getattr(field, "io", None)
+
+    for obj in (colspec, field, io, field_io):
         if obj is None:
             continue
+        paired_cfg = getattr(obj, "_paired", None)
+        if paired_cfg is not None and callable(getattr(paired_cfg, "gen", None)):
+            return paired_cfg.gen
         for name in ("generator", "paired_generator", "secret_generator"):
             fn = getattr(obj, name, None)
             if callable(fn):

--- a/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_resolve_paired_gen.py
+++ b/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_resolve_paired_gen.py
@@ -1,6 +1,8 @@
 from types import SimpleNamespace
 
+from autoapi.v3.column.io_spec import Pair
 from autoapi.v3.runtime.atoms.resolve import paired_gen
+from autoapi.v3.specs import IO
 
 
 class Col:
@@ -15,3 +17,14 @@ def test_generate_paired_value() -> None:
     pf = ctx.temp["persist_from_paired"]
     assert "secret" in pv and "raw" in pv["secret"]
     assert pf["secret"]["source"] == ("paired_values", "secret", "raw")
+
+
+class ColIO:
+    io = IO().paired(lambda ctx: Pair(raw="r", stored="s"), alias="extra")
+
+
+def test_generate_paired_value_from_io() -> None:
+    ctx = SimpleNamespace(persist=True, specs={"secret": ColIO()}, temp={})
+    paired_gen.run(None, ctx)
+    pv = ctx.temp["paired_values"]
+    assert pv["secret"]["raw"] == "r"


### PR DESCRIPTION
## Summary
- treat IOSpec.paired columns as paired for runtime generation
- detect generators on IO-paired columns
- cover IO.paired detection with unit test

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff format .`
- `uv run --directory standards/autoapi --package autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest`
- `uv run --package auto_authn --directory standards/auto_authn pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb7cd5565883268c2a37bf89ab359a