### PR TITLE
fix: honor paired io spec for key digests

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/emit/paired_pre.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/emit/paired_pre.py
@@ -121,6 +121,10 @@ def _infer_alias_from_spec(field: str, colspec: Any) -> Optional[str]:
     # IO-level hints
     io = getattr(colspec, "io", None)
     if io is not None:
+        paired = getattr(io, "_paired", None)
+        if paired is not None and isinstance(getattr(paired, "alias", None), str):
+            if paired.alias:
+                return paired.alias
         for name in ("emit_alias", "response_alias", "alias_out", "out_alias"):
             val = getattr(io, name, None)
             if isinstance(val, str) and val:

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/emit/readtime_alias.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/emit/readtime_alias.py
@@ -122,6 +122,10 @@ def _infer_alias_from_spec(field: str, colspec: Any) -> Optional[str]:
     # IO-level hints
     io = getattr(colspec, "io", None)
     if io is not None:
+        paired = getattr(io, "_paired", None)
+        if paired is not None and isinstance(getattr(paired, "alias", None), str):
+            if paired.alias:
+                return paired.alias
         for name in ("emit_alias", "response_alias", "alias_out", "out_alias", "alias"):
             val = getattr(io, name, None)
             if isinstance(val, str) and val:

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/resolve/paired_gen.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/resolve/paired_gen.py
@@ -157,11 +157,22 @@ def _is_paired(colspec: Any) -> bool:
             for name in ("generator", "paired_generator", "secret_generator")
         ):
             return True
+        io = getattr(obj, "io", None)
+        if getattr(getattr(io, "_paired", None), "gen", None) is not None:
+            return True
+    io = getattr(colspec, "io", None)
+    if getattr(getattr(io, "_paired", None), "gen", None) is not None:
+        return True
     return False
 
 
 def _get_generator(colspec: Any):
     """Return the first available generator callable, if any."""
+    io = getattr(colspec, "io", None)
+    if getattr(getattr(io, "_paired", None), "gen", None):
+        fn = io._paired.gen
+        if callable(fn):
+            return fn
     for obj in (colspec, getattr(colspec, "field", None)):
         if obj is None:
             continue
@@ -188,6 +199,10 @@ def _infer_alias_from_spec(field: str, colspec: Any) -> Optional[str]:
     # IO-level hints
     io = getattr(colspec, "io", None)
     if io is not None:
+        paired = getattr(io, "_paired", None)
+        if paired is not None and isinstance(getattr(paired, "alias", None), str):
+            if paired.alias:
+                return paired.alias
         for name in ("emit_alias", "response_alias", "alias_out", "out_alias", "alias"):
             val = getattr(io, name, None)
             if isinstance(val, str) and val:

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/storage/to_stored.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/storage/to_stored.py
@@ -173,6 +173,10 @@ def _get_deriver(colspec: Any) -> Callable[[Any, Any], Any]:
     Return a callable(raw, ctx) that derives stored from paired raw.
     If none provided, fall back to a SHA-256 hex digester with optional pepper/salt.
     """
+    io = getattr(colspec, "io", None)
+    paired = getattr(io, "_paired", None)
+    if paired is not None and callable(getattr(paired, "store", None)):
+        return paired.store
     for obj in (colspec, getattr(colspec, "field", None)):
         if obj is None:
             continue


### PR DESCRIPTION
## Summary
- ensure IOSpec paired configuration is recognized by runtime
- derive stored values using paired store function
- surface paired aliases for emission and read-time views

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest`
- `uv run --package auto_authn --directory standards/auto_authn pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb7cf16c288326af7f78fbdffe727d