### PR TITLE
fix: ensure paired values persist correctly

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/column/io_spec.py
+++ b/pkgs/standards/autoapi/autoapi/v3/column/io_spec.py
@@ -74,9 +74,20 @@ class IOSpec:
         """Return a new spec with a paired field configuration."""
 
         def gen(ctx):
-            return make(ctx).raw
+            pair = make(ctx)
+            temp = (
+                ctx.get("temp") if isinstance(ctx, dict) else getattr(ctx, "temp", None)
+            )
+            if isinstance(temp, dict):
+                temp.setdefault("_paired_cache", {})[alias] = pair.stored
+            return pair.raw
 
         def store(raw, ctx):
+            temp = getattr(ctx, "temp", None)
+            if isinstance(temp, dict):
+                cached = temp.get("_paired_cache", {}).pop(alias, None)
+                if cached is not None:
+                    return cached
             return make(ctx).stored
 
         cfg = _PairedCfg(


### PR DESCRIPTION
## Summary
- cache paired field data during generation to reuse when deriving stored values

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `uv run --package autoapi --directory pkgs/standards/autoapi pytest -q`
- `uv run --package auto_authn --directory pkgs/standards/auto_authn pytest -m integration tests/i9n/test_service_key_creation.py -q` *(fails: 503 Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb826faac48326a414672a83c40cd1