### PR TITLE
fix: ensure paired values persist correctly

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/column/io_spec.py
+++ b/pkgs/standards/autoapi/autoapi/v3/column/io_spec.py
@@ -74,9 +74,20 @@ class IOSpec:
         """Return a new spec with a paired field configuration."""
 
         def gen(ctx):
-            return make(ctx).raw
+            pair = make(ctx)
+            temp = (
+                ctx.get("temp") if isinstance(ctx, dict) else getattr(ctx, "temp", None)
+            )
+            if isinstance(temp, dict):
+                temp.setdefault("_paired_cache", {})[alias] = pair.stored
+            return pair.raw
 
         def store(raw, ctx):
+            temp = getattr(ctx, "temp", None)
+            if isinstance(temp, dict):
+                cached = temp.get("_paired_cache", {}).pop(alias, None)
+                if cached is not None:
+                    return cached
             return make(ctx).stored
 
         cfg = _PairedCfg(

--- a/pkgs/standards/autoapi/autoapi/v3/engine/resolver.py
+++ b/pkgs/standards/autoapi/autoapi/v3/engine/resolver.py
@@ -63,7 +63,13 @@ def register_api(api: Any, ctx: EngineCfg | None) -> None:
     if prov is None:
         return
     with _LOCK:
+        global _DEFAULT
         _API[id(api)] = prov
+        models = getattr(api, "models", None)
+        if isinstance(models, dict):
+            for m in models.values():
+                _TAB[m] = prov
+        _DEFAULT = prov
 
 
 def register_table(model: Any, ctx: EngineCfg | None) -> None:


### PR DESCRIPTION
## Summary
- cache paired field data during generation to reuse when deriving stored values
- propagate AutoAPI engine registration to tables and default provider

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff format .`
- `uv run --directory standards/autoapi --package autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/runtime/atoms/test_resolve_paired_gen.py::test_generate_paired_value tests/unit/runtime/atoms/test_storage_to_stored.py::test_to_stored_derives_from_paired_raw -q`
- `uv run --package auto_authn --directory standards/auto_authn pytest -m integration tests/i9n/test_service_key_creation.py -q` *(fails: 503 Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb826faac48326a414672a83c40cd1