### PR TITLE
Add KeyDigest uvicorn integration test and generation fix

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/orm/mixins/key_digest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/orm/mixins/key_digest.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from hashlib import sha256
 from secrets import token_urlsafe
 
+from sqlalchemy import event
+
 from ...column.io_spec import Pair
 from ...specs import F, IO, S, acol
 from ...types import Mapped, String, declarative_mixin
@@ -12,17 +14,29 @@ from ...types import Mapped, String, declarative_mixin
 class KeyDigest:
     """Provides hashed API key storage with helpers."""
 
-    def _pair_api_key(ctx):
+    @staticmethod
+    def _generate_pair() -> Pair:
         raw = token_urlsafe(32)
         return Pair(raw=raw, stored=sha256(raw.encode()).hexdigest())
 
     digest: Mapped[str] = acol(
         storage=S(String, nullable=False, unique=True),
         field=F(constraints={"max_length": 64}),
-        io=IO(
-            out_verbs=("read", "list", "create"),
-        ).paired(_pair_api_key, alias="api_key", verbs=("create")),
+        io=IO(out_verbs=("read", "list", "create")).alias_readtime(
+            "api_key",
+            lambda obj, ctx: getattr(obj, "_api_key", None),
+            verbs=("create",),
+        ),
     )
+
+    @classmethod
+    def __declare_last__(cls) -> None:  # pragma: no cover - SQLAlchemy hook
+        @event.listens_for(cls, "before_insert", propagate=True)
+        def _set_digest(_mapper, _conn, target) -> None:
+            if not getattr(target, "digest", None):
+                pair = cls._generate_pair()
+                target.digest = pair.stored
+                setattr(target, "_api_key", pair.raw)
 
     @staticmethod
     def digest_of(value: str) -> str:

--- a/pkgs/standards/autoapi/tests/i9n/test_key_digest_uvicorn.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_key_digest_uvicorn.py
@@ -1,0 +1,134 @@
+from uuid import uuid4
+
+import asyncio
+import httpx
+import pytest
+import uvicorn
+import pytest_asyncio
+
+from autoapi.v3 import AutoApp
+from autoapi.v3.orm.mixins import GUIDPk, Created, LastUsed, ValidityWindow, KeyDigest
+from autoapi.v3.orm.mixins.utils import CRUD_IO
+from autoapi.v3.orm.tables._base import Base
+from autoapi.v3.specs import F, S, acol
+from autoapi.v3.types import App, Mapped, String
+from sqlalchemy import inspect
+
+
+class ApiKey(Base, GUIDPk, Created, LastUsed, ValidityWindow, KeyDigest):
+    __abstract__ = False
+    __tablename__ = "apikeys_uvicorn"
+    __resource__ = "apikey"
+
+    label: Mapped[str] = acol(
+        storage=S(String, nullable=False),
+        field=F(constraints={"max_length": 120}),
+        io=CRUD_IO,
+    )
+    service_id: Mapped[str] = acol(
+        storage=S(String, nullable=False),
+        field=F(constraints={"max_length": 120}),
+        io=CRUD_IO,
+    )
+
+
+@pytest_asyncio.fixture()
+async def running_app(sync_db_session):
+    engine, get_sync_db = sync_db_session
+
+    app = App()
+    api = AutoApp(get_db=get_sync_db)
+    api.include_models([ApiKey])
+    api.initialize()
+    app.include_router(api.router)
+
+    cfg = uvicorn.Config(app, host="127.0.0.1", port=8000, log_level="warning")
+    server = uvicorn.Server(cfg)
+    task = asyncio.create_task(server.serve())
+    while not server.started:
+        await asyncio.sleep(0.1)
+    try:
+        yield ("http://127.0.0.1:8000", engine)
+    finally:
+        server.should_exit = True
+        await task
+
+
+def _payload() -> dict:
+    return {
+        "label": "test",
+        "service_id": str(uuid4()),
+        "valid_from": "2024-01-01T00:00:00+00:00",
+        "valid_to": "2024-12-31T00:00:00+00:00",
+    }
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_create_apikey_success(running_app):
+    base_url, _ = running_app
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(f"{base_url}/apikey", json=_payload())
+    assert resp.status_code == 201
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_create_response_fields(running_app):
+    base_url, _ = running_app
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(f"{base_url}/apikey", json=_payload())
+    body = resp.json()
+    expected = {
+        "api_key",
+        "label",
+        "service_id",
+        "valid_from",
+        "valid_to",
+        "digest",
+        "last_used_at",
+        "created_at",
+        "id",
+    }
+    assert set(body) == expected
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_persisted_columns(running_app):
+    base_url, engine = running_app
+    async with httpx.AsyncClient() as client:
+        await client.post(f"{base_url}/apikey", json=_payload())
+    inspector = inspect(engine)
+    cols = {col["name"] for col in inspector.get_columns("apikeys_uvicorn")}
+    expected = {
+        "label",
+        "service_id",
+        "valid_from",
+        "valid_to",
+        "digest",
+        "last_used_at",
+        "created_at",
+        "id",
+    }
+    assert cols == expected
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_rejects_digest_in_request(running_app):
+    base_url, _ = running_app
+    bad = _payload() | {"digest": "x"}
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(f"{base_url}/apikey", json=bad)
+    assert resp.status_code == 422
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+async def test_rejects_api_key_in_request(running_app):
+    base_url, _ = running_app
+    bad = _payload() | {"api_key": "raw"}
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(f"{base_url}/apikey", json=bad)
+    assert resp.status_code == 422


### PR DESCRIPTION
## Summary
- add uvicorn-based tests verifying KeyDigest integration
- generate API key digest with SQLAlchemy `before_insert` hook and expose raw key via read-time alias

## Testing
- `uv run --package autoapi --directory standards/autoapi --with uvicorn pytest tests/i9n/test_key_digest_uvicorn.py -q` *(fails: expected fields missing and improper 422 handling)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8d8246b0832681ce3c26bc7c81dd