### PR TITLE
feat(autoapi): expose per-field assemble and paired info

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/runtime/plan.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/plan.py
@@ -128,6 +128,12 @@ def build_plan(
         ("wire", "validate_in"),  # accept old name if registrar exports it
         ("wire", "build_out"),
         ("wire", "dump"),
+        # resolve (value preparation)
+        ("resolve", "assemble"),
+        ("resolve", "paired_gen"),
+        # emit (alias handling for paired values)
+        ("emit", "paired_pre"),
+        ("emit", "paired_post"),
         # storage / out
         ("storage", "to_stored"),
         ("out", "masking"),


### PR DESCRIPTION
## Summary
- list assemble, paired_gen, and paired alias fields separately in /planz by instantiating per-field atoms
- adjust runtime plan tests for per-field resolve and emit atoms

## Testing
- `uv run --package autoapi --directory standards ruff format autoapi`
- `uv run --package autoapi --directory standards ruff check autoapi --fix`


------
https://chatgpt.com/codex/tasks/task_e_68bb98049d44832696e7d2771517e506