### PR TITLE
chore(autoapi): update op ctx behavior tests

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_op_ctx_behavior.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_op_ctx_behavior.py
@@ -1,6 +1,6 @@
 import pytest
 from httpx import ASGITransport, AsyncClient
-from autoapi.v3.types import App, BaseModel, Column, String, UUID, uuid4
+from autoapi.v3.types import App, BaseModel, Column, String, UUID
 
 from autoapi.v3 import AutoApp, op_ctx, schema_ctx, hook_ctx
 from autoapi.v3.orm.tables import Base
@@ -98,7 +98,7 @@ async def test_op_ctx_defaults_value_resolution(sync_db_session):
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://test"
     ) as client:
-        res = await client.post("/thing", json={"id": str(uuid4()), "name": "a"})
+        res = await client.post("/thing", json={"name": "a"})
     assert res.status_code == 201
     item_id = UUID(res.json()["id"])
     assert res.json()["status"] == "new"
@@ -132,7 +132,7 @@ async def test_op_ctx_internal_orm_models(sync_db_session):
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://test"
     ) as client:
-        res = await client.post("/item", json={"id": str(uuid4()), "name": "a"})
+        res = await client.post("/item", json={"name": "a"})
     assert res.status_code == 201
     item_id = UUID(res.json()["id"])
 
@@ -219,7 +219,7 @@ async def test_op_ctx_storage_sqlalchemy(sync_db_session):
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://test"
     ) as client:
-        res = await client.post("/widget", json={"id": str(uuid4()), "name": "w"})
+        res = await client.post("/widget", json={"name": "w"})
     assert res.status_code == 201
     item_id = UUID(res.json()["id"])
 


### PR DESCRIPTION
## Summary
- drop explicit id fields in op_ctx create tests
- remove unused uuid4 import

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_op_ctx_behavior.py`
- `uv run --package autoapi --directory standards/autoapi pytest` *(fails: tests/i9n/test_allow_anon.py::test_allow_anon_create_method - AssertionError: assert 422 == 201)*

------
https://chatgpt.com/codex/tasks/task_e_68bba2d1fc048326bdf0171b91e63da5