### PR TITLE
fix missing IO import

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/orm/mixins/lifecycle.py
+++ b/pkgs/standards/autoapi/autoapi/v3/orm/mixins/lifecycle.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime as dt
 
-from ...specs import ColumnSpec, F, S, acol
+from ...specs import ColumnSpec, F, S, acol, IO
 from ...types import (
     TZDateTime,
     Boolean,


### PR DESCRIPTION
## Summary
- fix missing IO import in lifecycle mixin

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_key_digest_uvicorn.py -q` *(fails: test_create_response_fields)*

------
https://chatgpt.com/codex/tasks/task_e_68bbbe1cd42c8326a399988ab3930fa7