### PR TITLE
feat(autoapi): add paired io for key digest

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/orm/mixins/lifecycle.py
+++ b/pkgs/standards/autoapi/autoapi/v3/orm/mixins/lifecycle.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime as dt
 
-from ...specs import ColumnSpec, F, S, acol
+from ...specs import ColumnSpec, F, IO, S, acol
 from ...types import (
     TZDateTime,
     Boolean,


### PR DESCRIPTION
## Summary
- switch key digest mixin to paired IO config
- add missing IO import in lifecycle mixins

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_key_digest_uvicorn.py -q` *(fails: 2 failed)*


------
https://chatgpt.com/codex/tasks/task_e_68bbc19f1d98832686494cc20f4ee7c2