### PR TITLE
fix: generate paired key digests via column specs

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/wire/validate_in.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/wire/validate_in.py
@@ -173,6 +173,8 @@ def _target_type(colspec: Any) -> Optional[type]:
         return None
     for name in ("py_type", "python_type"):
         t = getattr(field, name, None)
+        if t is Any:
+            return None
         if isinstance(t, type):
             return t
     return None


### PR DESCRIPTION
## Summary
- ensure REST and RPC contexts include ColumnSpecs and emit paired secrets
- skip `typing.Any` in inbound type validation

## Testing
- `uv run --directory standards --package autoapi ruff check . --fix`
- `uv run --directory standards --package autoapi pytest autoapi/tests/i9n/test_key_digest_uvicorn.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bbca41258883269919ba12010fd9f6