### PR TITLE
fix: ignore None dataclass config values

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/config/resolver.py
+++ b/pkgs/standards/autoapi/autoapi/v3/config/resolver.py
@@ -144,7 +144,8 @@ def _coerce_map(obj: Any) -> Mapping[str, Any]:
     # dataclass?
     if is_dataclass(obj):
         try:
-            return asdict(obj)
+            # Drop keys with ``None`` values so they don't override defaults.
+            return {k: v for k, v in asdict(obj).items() if v is not None}
         except Exception:
             pass
     # namespace-like with __dict__

--- a/pkgs/standards/autoapi/tests/unit/test_config_dataclass_none.py
+++ b/pkgs/standards/autoapi/tests/unit/test_config_dataclass_none.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+from autoapi.v3.config import resolve_cfg
+
+
+def test_dataclass_none_fields_do_not_override_defaults() -> None:
+    @dataclass
+    class AppSpec:
+        trace: dict | None = None
+
+    cfg = resolve_cfg(appspec=AppSpec())
+    assert cfg.trace == {"enabled": True}


### PR DESCRIPTION
## Summary
- drop None-valued entries when coercing dataclass configs so defaults aren't overridden
- add regression test to ensure defaults persist

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_config_dataclass_none.py`


------
https://chatgpt.com/codex/tasks/task_e_68bbd3ac7e288326b9073a7bbe4b7c1e