### PR TITLE
Handle slot objects in autoapi JSON serialization

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_rpc_slots_serialization.py
+++ b/pkgs/standards/autoapi/tests/unit/test_rpc_slots_serialization.py
@@ -1,0 +1,36 @@
+from fastapi.testclient import TestClient
+from sqlalchemy import Column, String
+from autoapi.v3 import AutoApp, op_ctx
+from autoapi.v3.orm.tables import Base
+from autoapi.v3.orm.mixins import GUIDPk
+
+
+class SlotsObj:
+    __slots__ = ("x",)
+
+    def __init__(self, x: int) -> None:
+        self.x = x
+
+
+Base.metadata.clear()
+
+
+class Widget(Base, GUIDPk):
+    __tablename__ = "widgets"
+    name = Column(String, nullable=False)
+
+    @op_ctx(alias="slot", target="custom")
+    def slot(cls, ctx):
+        return SlotsObj(5)
+
+
+def test_rpc_serializes_slots_objects():
+    app = AutoApp()
+    app.include_model(Widget)
+    app.mount_jsonrpc()
+    client = TestClient(app)
+    resp = client.post(
+        "/rpc", json={"jsonrpc": "2.0", "method": "Widget.slot", "id": 1}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["result"] == {"x": 5}


### PR DESCRIPTION
## Summary
- ensure `_ensure_jsonable` serializes dataclasses and `__slots__` objects
- add regression test for slot-based RPC return values

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest -q` *(fails: KeyError, AssertionError, TypeError)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe772dd7c8326a3a82b68a7305ab5