### PR TITLE
fix: pass ctx results to atoms

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/response/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/response/__init__.py
@@ -65,7 +65,7 @@ def _render_run(
         return
     hints = getattr(resp_ns, "hints", None)
     default_media = getattr(resp_ns, "default_media", "application/json")
-    envelope_default = getattr(resp_ns, "envelope_default", True)
+    envelope_default = getattr(resp_ns, "envelope_default", False)
     resp_ns.result = _render.render(
         req,
         result,

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/response/render.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/response/render.py
@@ -56,7 +56,7 @@ def render(
     *,
     hints: Optional[ResponseHints] = None,
     default_media: str = "application/json",
-    envelope_default: bool = True,
+    envelope_default: bool = False,
 ) -> Response:
     if isinstance(payload, Response):
         return payload

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/schema/collect_out.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/schema/collect_out.py
@@ -58,6 +58,7 @@ def run(obj: Optional[object], ctx: Any) -> None:
     if "schema_out" in temp:
         return
 
+    op = (getattr(ctx, "op", None) or getattr(ctx, "method", None) or "").lower() or None
     fields_sorted = sorted(specs.keys())
     entries: list[Dict[str, Any]] = []
     by_field: Dict[str, Dict[str, Any]] = {}
@@ -71,6 +72,9 @@ def run(obj: Optional[object], ctx: Any) -> None:
         f = getattr(col, "field", None)
 
         out_enabled = _bool_attr(io, "out", "allow_out", "expose_out", default=True)
+        if out_enabled and op and getattr(io, "out_verbs", ()):  # type: ignore[arg-type]
+            if op not in getattr(io, "out_verbs", ()):  # type: ignore[arg-type]
+                out_enabled = False
         if not out_enabled:
             # Not exposed on output — skip entirely for outbound schema
             continue

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/kernel.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/kernel.py
@@ -52,7 +52,8 @@ def _discover_atoms() -> list[_DiscoveredAtom]:
 
 def _wrap_atom(run: _AtomRun) -> StepFn:
     async def _step(ctx: Any) -> Any:
-        rv = run(None, ctx)
+        obj = getattr(ctx, "result", None)
+        rv = run(obj, ctx)
         if hasattr(rv, "__await__"):
             return await rv  # type: ignore[misc]
         return rv


### PR DESCRIPTION
## Summary
- ensure runtime atoms receive the latest context result
- default response rendering to no envelope
- respect op-specific out_verbs when collecting outbound schema

## Testing
- `uv run --package autoapi --directory . ruff format autoapi/v3/runtime/kernel.py`
- `uv run --package autoapi --directory . ruff check autoapi/v3/runtime/kernel.py --fix`
- `uv run --package autoapi --directory . ruff format autoapi/v3/runtime/atoms/response/__init__.py autoapi/v3/runtime/atoms/response/render.py`
- `uv run --package autoapi --directory . ruff check autoapi/v3/runtime/atoms/response/__init__.py autoapi/v3/runtime/atoms/response/render.py --fix`
- `uv run --package autoapi --directory . ruff format autoapi/v3/runtime/atoms/schema/collect_out.py`
- `uv run --package autoapi --directory . ruff check autoapi/v3/runtime/atoms/schema/collect_out.py --fix`
- `uv run --package autoapi --directory . pytest`
- `uv run --package autoapi --directory . pytest tests/i9n/test_v3_default_rest_ops.py::test_rest_create tests/i9n/test_v3_default_rest_ops.py::test_rest_read tests/i9n/test_v3_default_rest_ops.py::test_rest_update -q`

------
https://chatgpt.com/codex/tasks/task_e_68bbe776503083269da7dba67708e668