### PR TITLE
fix autoapi runtime object propagation

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/wire/build_out.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/wire/build_out.py
@@ -28,6 +28,8 @@ def run(obj: Optional[object], ctx: Any) -> None:
     - We intentionally keep keys as canonical field names so out:masking can
       evaluate sensitivity on real fields, while alias extras remain separate.
     """
+    if obj is None:
+        return
     schema_out = _schema_out(ctx)
     if not schema_out:
         return

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/kernel.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/kernel.py
@@ -52,7 +52,19 @@ def _discover_atoms() -> list[_DiscoveredAtom]:
 
 def _wrap_atom(run: _AtomRun) -> StepFn:
     async def _step(ctx: Any) -> Any:
-        rv = run(None, ctx)
+        candidate = getattr(ctx, "result", None)
+        if candidate is None or isinstance(candidate, (list, tuple, set, Mapping)):
+            obj = getattr(ctx, "obj", None)
+        else:
+            obj = candidate
+        if isinstance(obj, (list, tuple, set, Mapping)):
+            obj = None
+        if obj is not None:
+            try:
+                setattr(ctx, "obj", obj)
+            except Exception:
+                pass
+        rv = run(obj, ctx)
         if hasattr(rv, "__await__"):
             return await rv  # type: ignore[misc]
         return rv


### PR DESCRIPTION
## Summary
- ensure kernel passes hydrated objects to runtime atoms
- skip building outbound payload when object is missing to avoid null responses

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbe8ba5ccc8326ae226ba2c7db5dfd