### PR TITLE
Fix POST_RESPONSE result override in autoapi executor

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/runtime/executor/invoke.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/executor/invoke.py
@@ -142,8 +142,7 @@ async def _invoke(
         in_tx=False,
         nonfatal=True,
     )
-    if ctx.get("result") is not None:
-        ctx.response.result = ctx.get("result")
+    ctx["result"] = ctx.response.result
     if db is not None and _in_tx(db):
         try:
             if _is_async_db(db):


### PR DESCRIPTION
## Summary
- preserve POST_RESPONSE hook mutations by syncing response.result back to context result

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_hook_ctx_v3_i9n.py tests/i9n/test_hook_lifecycle.py::test_hook_context_modification -q`

------
https://chatgpt.com/codex/tasks/task_e_68bbef2a5b1c8326bed4f2f3e9d86554