### PR TITLE
feat(autoapi): integrate uvicorn logging into bindings

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/__init__.py
@@ -35,6 +35,7 @@ API integration:
 """
 
 from __future__ import annotations
+import logging
 
 # Core model orchestrator
 from .model import bind, rebind
@@ -49,6 +50,9 @@ from ..response.bind import bind as bind_response
 
 # API facade integration
 from .api import include_model, include_models, rpc_call
+
+logger = logging.getLogger("uvicorn")
+logger.debug("Loaded module v3/bindings/__init__")
 
 
 __all__ = [

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/api/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/api/__init__.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
+import logging
 
 from .common import AttrDict, _default_prefix, _mount_router  # noqa: F401
 from .include import include_model, include_models, _seed_security_and_deps  # noqa: F401
 from .rpc import rpc_call
+
+logger = logging.getLogger("uvicorn")
+logger.debug("Loaded module v3/bindings/api/__init__")
 
 __all__ = ["include_model", "include_models", "rpc_call"]

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/api/common.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/api/common.py
@@ -4,7 +4,8 @@ import logging
 from types import SimpleNamespace
 from typing import Any
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("uvicorn")
+logger.debug("Loaded module v3/bindings/api/common")
 
 
 class AttrDict(dict):

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/api/include.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/api/include.py
@@ -24,7 +24,8 @@ from ...config.constants import (
 )
 from ...engine import resolver as _resolver
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("uvicorn")
+logger.debug("Loaded module v3/bindings/api/include")
 
 
 # --- keep as helper, no behavior change to transports/kernel ---

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/api/resource_proxy.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/api/resource_proxy.py
@@ -8,7 +8,8 @@ from ..rpc import _coerce_payload, _get_phase_chains, _validate_input, _serializ
 from ...runtime import executor as _executor
 from ...engine import resolver as _resolver
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("uvicorn")
+logger.debug("Loaded module v3/bindings/api/resource_proxy")
 
 
 class _ResourceProxy:

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/api/rpc.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/api/rpc.py
@@ -7,7 +7,8 @@ from typing import Any, Dict, Optional, Union
 from .common import ApiLike, _ensure_api_ns
 from ...engine import resolver as _resolver
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("uvicorn")
+logger.debug("Loaded module v3/bindings/api/rpc")
 
 
 async def rpc_call(

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/col_info.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/col_info.py
@@ -7,6 +7,7 @@ This will be fully deprecated in place of ColumnSpecs.
 """
 
 from __future__ import annotations
+import logging
 
 import warnings
 
@@ -19,6 +20,9 @@ from ..schema.col_info import (
     should_include_in_input,
     should_include_in_output,
 )
+
+logger = logging.getLogger("uvicorn")
+logger.debug("Loaded module v3/bindings/col_info")
 
 warnings.warn(
     "autoapi.v3.bindings.col_info is deprecated; Column.info['autoapi'] will be removed. "

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/columns.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/columns.py
@@ -1,6 +1,11 @@
+import logging
+
 # autoapi/v3/bindings/columns.py
 from sqlalchemy import Column
 from ..specs import ColumnSpec, is_virtual
+
+logger = logging.getLogger("uvicorn")
+logger.debug("Loaded module v3/bindings/columns")
 
 
 def build_and_attach(model: type, specs=None, only_keys=None):

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/handlers/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/handlers/__init__.py
@@ -1,6 +1,10 @@
 # autoapi/v3/bindings/handlers/__init__.py
 from __future__ import annotations
+import logging
 
 from .builder import build_and_attach
+
+logger = logging.getLogger("uvicorn")
+logger.debug("Loaded module v3/bindings/handlers/__init__")
 
 __all__ = ["build_and_attach"]

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/handlers/builder.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/handlers/builder.py
@@ -9,7 +9,8 @@ from ...op.types import StepFn
 from .namespaces import _ensure_alias_handlers_ns, _ensure_alias_hooks_ns
 from .steps import _wrap_core, _wrap_custom
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("uvicorn")
+logger.debug("Loaded module v3/bindings/handlers/builder")
 
 _Key = Tuple[str, str]
 

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/handlers/ctx.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/handlers/ctx.py
@@ -1,7 +1,11 @@
 # autoapi/v3/bindings/handlers/ctx.py
 from __future__ import annotations
+import logging
 
 from typing import Any, Mapping, Sequence
+
+logger = logging.getLogger("uvicorn")
+logger.debug("Loaded module v3/bindings/handlers/ctx")
 
 
 def _ctx_get(ctx: Mapping[str, Any], key: str, default: Any = None) -> Any:

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/handlers/identifiers.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/handlers/identifiers.py
@@ -1,10 +1,14 @@
 # autoapi/v3/bindings/handlers/identifiers.py
 from __future__ import annotations
+import logging
 
 import uuid
 from typing import Any, Mapping, Optional
 
 from .ctx import _ctx_payload, _ctx_path_params
+
+logger = logging.getLogger("uvicorn")
+logger.debug("Loaded module v3/bindings/handlers/identifiers")
 
 try:  # pragma: no cover
     from sqlalchemy.inspection import inspect as _sa_inspect  # type: ignore

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/handlers/namespaces.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/handlers/namespaces.py
@@ -1,7 +1,11 @@
 # autoapi/v3/bindings/handlers/namespaces.py
 from __future__ import annotations
+import logging
 
 from types import SimpleNamespace
+
+logger = logging.getLogger("uvicorn")
+logger.debug("Loaded module v3/bindings/handlers/namespaces")
 
 
 def _ensure_alias_hooks_ns(model: type, alias: str) -> SimpleNamespace:

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/handlers/steps.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/handlers/steps.py
@@ -1,5 +1,6 @@
 # autoapi/v3/bindings/handlers/steps.py
 from __future__ import annotations
+import logging
 
 import inspect
 from typing import Any, Callable, Mapping, Optional
@@ -10,6 +11,9 @@ from ...op.types import StepFn
 from ...runtime.executor import _Ctx
 from .ctx import _ctx_db, _ctx_payload, _ctx_request
 from .identifiers import _resolve_ident
+
+logger = logging.getLogger("uvicorn")
+logger.debug("Loaded module v3/bindings/handlers/steps")
 
 
 async def _call_list_core(

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/hooks.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/hooks.py
@@ -25,7 +25,8 @@ from ..config.constants import (
     CTX_SKIP_PERSIST_FLAG,
 )
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("uvicorn")
+logger.debug("Loaded module v3/bindings/hooks")
 
 _Key = Tuple[str, str]  # (alias, target)
 

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/model.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/model.py
@@ -40,7 +40,8 @@ from .model_helpers import (
 )
 from .model_registry import _ensure_op_ctx_attach_hook, _ensure_registry_listener
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("uvicorn")
+logger.debug("Loaded module v3/bindings/model")
 
 
 # ───────────────────────────────────────────────────────────────────────────────

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/model_helpers.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/model_helpers.py
@@ -2,11 +2,15 @@
 """Internal helpers for the model bindings."""
 
 from __future__ import annotations
+import logging
 
 from types import SimpleNamespace
 from typing import Dict, List, Optional, Sequence, Set, Tuple
 
 from ..op import OpSpec
+
+logger = logging.getLogger("uvicorn")
+logger.debug("Loaded module v3/bindings/model_helpers")
 
 
 _Key = Tuple[str, str]  # (alias, target)

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/model_registry.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/model_registry.py
@@ -11,7 +11,8 @@ from ..op import OpspecRegistry, get_registry
 
 from .model_helpers import _Key
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("uvicorn")
+logger.debug("Loaded module v3/bindings/model_registry")
 
 
 def _ensure_registry_listener(model: type) -> None:

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest/__init__.py
@@ -1,3 +1,7 @@
+import logging
 from .attach import build_router_and_attach
+
+logger = logging.getLogger("uvicorn")
+logger.debug("Loaded module v3/bindings/rest/__init__")
 
 __all__ = ["build_router_and_attach"]

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest/attach.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest/attach.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
+import logging
 
 from types import SimpleNamespace
 from typing import Optional, Sequence
 
-from .common import OpSpec, _Key, logger
+from .common import OpSpec, _Key
 from .router import _build_router
+
+logger = logging.getLogger("uvicorn")
+logger.debug("Loaded module v3/bindings/rest/attach")
 
 
 def build_router_and_attach(

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest/collection.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest/collection.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import logging
 
 import inspect
 from types import SimpleNamespace
@@ -21,6 +22,10 @@ from .common import (
     _validate_query,
     _executor,
 )
+
+
+logger = logging.getLogger("uvicorn")
+logger.debug("Loaded module v3/bindings/rest/collection")
 
 
 def _make_collection_endpoint(

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest/common.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest/common.py
@@ -5,6 +5,7 @@ import surface stable while easing maintenance.
 """
 
 from __future__ import annotations
+import logging
 
 from pydantic import BaseModel
 
@@ -29,7 +30,6 @@ from .helpers import (
     _pk_names,
     _req_state_db,
     _resource_name,
-    logger,
 )
 from .io import (
     _make_list_query_dep,
@@ -62,6 +62,9 @@ from ...op.types import CANON, PHASES
 from ...rest import _nested_prefix
 from ...runtime import executor as _executor
 from ...schema.builder import _strip_parent_fields
+
+logger = logging.getLogger("uvicorn")
+logger.debug("Loaded module v3/bindings/rest/common")
 
 __all__ = [
     "Body",

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest/fastapi.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest/fastapi.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
+import logging
 
 from types import SimpleNamespace
 from typing import Callable, Sequence
+
+logger = logging.getLogger("uvicorn")
+logger.debug("Loaded module v3/bindings/rest/fastapi")
 
 try:
     from ...types import (

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest/helpers.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest/helpers.py
@@ -12,7 +12,8 @@ try:
 except Exception:  # pragma: no cover
     _kernel_build_phase_chains = None  # type: ignore
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("uvicorn")
+logger.debug("Loaded module v3/bindings/rest/helpers")
 
 _Key = Tuple[str, str]  # (alias, target)
 

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest/io.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest/io.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import logging
 
 import inspect
 from types import SimpleNamespace
@@ -9,8 +10,11 @@ import typing as _typing
 from pydantic import BaseModel, Field, create_model
 
 from .fastapi import HTTPException, Query, Request, _status
-from .helpers import _ensure_jsonable, logger
+from .helpers import _ensure_jsonable
 from ...op import OpSpec
+
+logger = logging.getLogger("uvicorn")
+logger.debug("Loaded module v3/bindings/rest/io")
 
 
 def _serialize_output(

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest/member.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest/member.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import logging
 
 import inspect
 from types import SimpleNamespace
@@ -31,6 +32,10 @@ from .common import (
     _executor,
     _status,
 )
+
+
+logger = logging.getLogger("uvicorn")
+logger.debug("Loaded module v3/bindings/rest/member")
 
 
 def _make_member_endpoint(

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest/router.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest/router.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import logging
 
 import inspect
 import re
@@ -30,10 +31,12 @@ from .common import (
     _status_for,
     _strip_parent_fields,
     _RESPONSES_META,
-    logger,
 )
 import typing as _typing
 from typing import get_args as _get_args, get_origin as _get_origin
+
+logger = logging.getLogger("uvicorn")
+logger.debug("Loaded module v3/bindings/rest/router")
 
 
 def _build_router(model: type, specs: Sequence[OpSpec]) -> Router:

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest/routing.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest/routing.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import logging
 
 from types import SimpleNamespace
 from typing import Any, Dict, Optional, Sequence, Tuple
@@ -7,6 +8,9 @@ from typing import Any, Dict, Optional, Sequence, Tuple
 from .fastapi import Depends, Security, _status
 from ...op import OpSpec
 from ...op.types import CANON
+
+logger = logging.getLogger("uvicorn")
+logger.debug("Loaded module v3/bindings/rest/routing")
 
 
 def _normalize_deps(deps: Optional[Sequence[Any]]) -> list[Any]:

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rpc.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rpc.py
@@ -27,7 +27,8 @@ try:
 except Exception:  # pragma: no cover
     _kernel_build_phase_chains = None  # type: ignore
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("uvicorn")
+logger.debug("Loaded module v3/bindings/rpc")
 
 _Key = Tuple[str, str]  # (alias, target)
 

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/schemas/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/schemas/__init__.py
@@ -1,6 +1,10 @@
 # autoapi/v3/bindings/schemas/__init__.py
 from __future__ import annotations
+import logging
 
 from .builder import build_and_attach
+
+logger = logging.getLogger("uvicorn")
+logger.debug("Loaded module v3/bindings/schemas/__init__")
 
 __all__ = ["build_and_attach"]

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/schemas/builder.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/schemas/builder.py
@@ -13,7 +13,8 @@ from ...schema import collect_decorated_schemas
 from .defaults import _default_schemas_for_spec
 from .utils import _alias_schema, _ensure_alias_namespace, _resolve_schema_arg, _Key
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("uvicorn")
+logger.debug("Loaded module v3/bindings/schemas/builder")
 
 
 def build_and_attach(

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/schemas/defaults.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/schemas/defaults.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import logging
 
 # autoapi/v3/bindings/schemas/defaults.py
 
@@ -17,6 +18,9 @@ from ...schema import (
     _make_pk_model,
 )
 from .utils import _pk_info
+
+logger = logging.getLogger("uvicorn")
+logger.debug("Loaded module v3/bindings/schemas/defaults")
 
 
 def _default_schemas_for_spec(

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/schemas/utils.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/schemas/utils.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import logging
 
 # autoapi/v3/bindings/schemas/utils.py
 
@@ -9,6 +10,9 @@ from pydantic import BaseModel, create_model
 
 from ...schema.types import SchemaArg, SchemaRef
 from ...schema import namely_model
+
+logger = logging.getLogger("uvicorn")
+logger.debug("Loaded module v3/bindings/schemas/utils")
 
 
 _Key = Tuple[str, str]  # (alias, target)


### PR DESCRIPTION
## Summary
- use uvicorn logger across autoapi v3 bindings
- emit module load debug logs for easier tracing

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68bc0d9dca948326a770ab1ac12f6c8f