### PR TITLE
Add uvicorn logging to autoapi v3 collect files

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/column/collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/column/collect.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import logging
 from typing import Dict
 
 from .column_spec import ColumnSpec
+
+logger = logging.getLogger("uvicorn")
 
 
 def collect_columns(model: type) -> Dict[str, ColumnSpec]:
@@ -12,6 +15,7 @@ def collect_columns(model: type) -> Dict[str, ColumnSpec]:
     in the resulting mapping. Later definitions take precedence over earlier
     ones in the MRO.
     """
+    logger.info("Collecting columns for %s", model.__name__)
     out: Dict[str, ColumnSpec] = {}
     for base in reversed(model.__mro__):
         mapping = getattr(base, "__autoapi_colspecs__", None)
@@ -20,6 +24,7 @@ def collect_columns(model: type) -> Dict[str, ColumnSpec]:
         mapping = getattr(base, "__autoapi_cols__", None)
         if isinstance(mapping, dict):
             out.update(mapping)
+    logger.debug("Collected %d columns for %s", len(out), model.__name__)
     return out
 
 

--- a/pkgs/standards/autoapi/autoapi/v3/engine/collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/engine/collect.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import logging
 from types import SimpleNamespace
 from typing import Any, Dict, Iterable, Mapping, Tuple
+
+
+logger = logging.getLogger("uvicorn")
 
 
 def _read_engine_attr(obj: Any):
@@ -69,6 +73,7 @@ def collect_from_objects(
     *, app: Any | None = None, api: Any | None = None, models: Iterable[Any] = ()
 ) -> Dict[str, Any]:
     """Collect engine configuration from objects without binding them."""
+    logger.info("Collecting engine configuration")
     app_engine = _read_engine_attr(app) if app is not None else None
     api_engine = _read_engine_attr(api) if api is not None else None
 
@@ -95,6 +100,7 @@ def collect_from_objects(
 
     api_map = {api: api_engine} if api_engine is not None and api is not None else {}
 
+    logger.debug("Collected engine config for %d models", len(models))
     return {
         "default": app_engine,
         "api": api_map,

--- a/pkgs/standards/autoapi/autoapi/v3/hook/collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/hook/collect.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Callable, Dict, Iterable, Union
 
 from ..runtime.executor import _Ctx
 from ..op.collect import alias_map_for, apply_alias
 from ..op.decorators import _maybe_await, _unwrap
 from .decorators import HOOK_DECLS_ATTR, Hook
+
+logger = logging.getLogger("uvicorn")
 
 
 def _phase_io_key(phase: str) -> str | None:
@@ -48,6 +51,7 @@ def collect_decorated_hooks(
 ) -> Dict[str, Dict[str, list[Callable[..., Any]]]]:
     """Build alias→phase→[hook] map from ctx-only hook declarations."""
 
+    logger.info("Collecting hooks for %s", table.__name__)
     mapping: Dict[str, Dict[str, list[Callable[..., Any]]]] = {}
     aliases = alias_map_for(table)
 
@@ -76,6 +80,7 @@ def collect_decorated_hooks(
                     mapping.setdefault(op, {}).setdefault(ph, []).append(
                         _wrap_ctx_hook(table, d.fn, ph)
                     )
+    logger.debug("Collected hooks for aliases: %s", list(mapping.keys()))
     return mapping
 
 

--- a/pkgs/standards/autoapi/autoapi/v3/op/collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/op/collect.py
@@ -31,7 +31,7 @@ except Exception:  # pragma: no cover
         return ()
 
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("uvicorn")
 
 _ALIAS_RE = re.compile(r"^[a-z][a-z0-9_]*$")
 
@@ -72,6 +72,7 @@ def _wrap_ctx_core(table: type, func: Callable[..., Any]) -> Callable[..., Any]:
 def collect_decorated_ops(table: type) -> list[OpSpec]:
     """Scan MRO for ctx-only op declarations (@op_ctx) and build OpSpecs."""
 
+    logger.info("Collecting decorated ops for %s", table.__name__)
     out: list[OpSpec] = []
 
     for base in reversed(table.__mro__):
@@ -120,6 +121,7 @@ def collect_decorated_ops(table: type) -> list[OpSpec]:
             )
             out.append(spec)
 
+    logger.debug("Collected %d ops for %s", len(out), table.__name__)
     return out
 
 

--- a/pkgs/standards/autoapi/autoapi/v3/schema/collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/collect.py
@@ -2,15 +2,19 @@
 from __future__ import annotations
 
 import inspect
+import logging
 from typing import Dict
 
 from ..config.constants import AUTOAPI_SCHEMA_DECLS_ATTR
 
 from .decorators import _SchemaDecl
 
+logger = logging.getLogger("uvicorn")
+
 
 def collect_decorated_schemas(model: type) -> Dict[str, Dict[str, type]]:
     """Gather schema declarations for ``model`` across its MRO."""
+    logger.info("Collecting decorated schemas for %s", model.__name__)
     out: Dict[str, Dict[str, type]] = {}
 
     # Explicit registrations (MRO-merged)
@@ -34,6 +38,7 @@ def collect_decorated_schemas(model: type) -> Dict[str, Dict[str, type]]:
             bucket = out.setdefault(decl.alias, {})
             bucket[decl.kind] = obj
 
+    logger.debug("Collected schema aliases: %s", list(out.keys()))
     return out
 
 


### PR DESCRIPTION
## Summary
- add uvicorn-based logging to autoapi v3 collect modules
- report collect operations via uvicorn's logger
- tidy engine collect module imports

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- no tests run (per user instruction)


------
https://chatgpt.com/codex/tasks/task_e_68bc0db7bd1c8326aca020aced6209b9