### PR TITLE
Use uvicorn logger across autoapi v3 atom modules

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/__init__.py
@@ -23,7 +23,7 @@ RunFn = Callable[[Optional[object], Any], None]
 #:   { (domain, subject): (anchor, runner) }
 REGISTRY: Dict[Tuple[str, str], Tuple[str, RunFn]] = {}
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("uvicorn")
 
 
 def _add_bulk(source: Dict[Tuple[str, str], Tuple[str, RunFn]]) -> None:

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/emit/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/emit/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import Any, Callable, Dict, Optional, Tuple
+import logging
 
 # Atom implementations (model-scoped)
 from . import paired_pre as _paired_pre
@@ -19,10 +20,14 @@ REGISTRY: Dict[Tuple[str, str], Tuple[str, RunFn]] = {
     ("emit", "readtime_alias"): (_readtime_alias.ANCHOR, _readtime_alias.run),
 }
 
+logger = logging.getLogger("uvicorn")
+
 
 def subjects() -> Tuple[str, ...]:
     """Return the subject names exported by this domain."""
-    return tuple(s for (_, s) in REGISTRY.keys())
+    subjects = tuple(s for (_, s) in REGISTRY.keys())
+    logger.debug("Listing 'emit' subjects: %s", subjects)
+    return subjects
 
 
 def get(subject: str) -> Tuple[str, RunFn]:
@@ -30,6 +35,7 @@ def get(subject: str) -> Tuple[str, RunFn]:
     key = ("emit", subject)
     if key not in REGISTRY:
         raise KeyError(f"Unknown emit atom subject: {subject!r}")
+    logger.debug("Retrieving 'emit' subject %s", subject)
     return REGISTRY[key]
 
 

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/emit/paired_post.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/emit/paired_post.py
@@ -2,11 +2,14 @@
 from __future__ import annotations
 
 from typing import Any, Dict, Mapping, MutableMapping, Optional
+import logging
 
 from ... import events as _ev
 
 # Runs after DB flush + refresh, before out model construction.
 ANCHOR = _ev.EMIT_ALIASES_POST  # "emit:aliases:post_refresh"
+
+logger = logging.getLogger("uvicorn")
 
 
 def run(obj: Optional[object], ctx: Any) -> None:
@@ -37,6 +40,7 @@ def run(obj: Optional[object], ctx: Any) -> None:
     """
     # Non-persisting ops should have pruned this anchor via the planner,
     # but guard anyway for robustness.
+    logger.debug("Running emit:paired_post")
     if getattr(ctx, "persist", True) is False:
         return
 

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/emit/paired_pre.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/emit/paired_pre.py
@@ -2,11 +2,14 @@
 from __future__ import annotations
 
 from typing import Any, Dict, Mapping, MutableMapping, Optional
+import logging
 
 from ... import events as _ev
 
 # This atom runs before the flush, after values have been assembled/generated.
 ANCHOR = _ev.EMIT_ALIASES_PRE  # "emit:aliases:pre_flush"
+
+logger = logging.getLogger("uvicorn")
 
 
 def run(obj: Optional[object], ctx: Any) -> None:
@@ -37,6 +40,7 @@ def run(obj: Optional[object], ctx: Any) -> None:
     """
     # Non-persisting ops should have pruned this anchor via the planner,
     # but guard anyway for robustness.
+    logger.debug("Running emit:paired_pre")
     if getattr(ctx, "persist", True) is False:
         return
 

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/emit/readtime_alias.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/emit/readtime_alias.py
@@ -2,11 +2,14 @@
 from __future__ import annotations
 
 from typing import Any, Dict, Mapping, MutableMapping, Optional
+import logging
 
 from ... import events as _ev
 
 # Runs near the end of the lifecycle, before wire:dump/out:masking.
 ANCHOR = _ev.EMIT_ALIASES_READ  # "emit:aliases:readtime"
+
+logger = logging.getLogger("uvicorn")
 
 
 def run(obj: Optional[object], ctx: Any) -> None:
@@ -37,6 +40,7 @@ def run(obj: Optional[object], ctx: Any) -> None:
     - Records a minimal descriptor in emit_aliases["read"] (no raw).
     - Never reads or emits any "raw" secret (paired_post already scrubbed).
     """
+    logger.debug("Running emit:readtime_alias")
     temp = _ensure_temp(ctx)
     emit_buf = _ensure_emit_buf(temp)
     extras = _ensure_response_extras(temp)

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/out/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/out/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import Any, Callable, Dict, Optional, Tuple
+import logging
 
 # Atom implementations (model-scoped)
 from . import masking as _masking
@@ -15,10 +16,14 @@ REGISTRY: Dict[Tuple[str, str], Tuple[str, RunFn]] = {
     ("out", "masking"): (_masking.ANCHOR, _masking.run),
 }
 
+logger = logging.getLogger("uvicorn")
+
 
 def subjects() -> Tuple[str, ...]:
     """Return the subject names exported by this domain."""
-    return tuple(s for (_, s) in REGISTRY.keys())
+    subjects = tuple(s for (_, s) in REGISTRY.keys())
+    logger.debug("Listing 'out' subjects: %s", subjects)
+    return subjects
 
 
 def get(subject: str) -> Tuple[str, RunFn]:
@@ -26,6 +31,7 @@ def get(subject: str) -> Tuple[str, RunFn]:
     key = ("out", subject)
     if key not in REGISTRY:
         raise KeyError(f"Unknown out atom subject: {subject!r}")
+    logger.debug("Retrieving 'out' subject %s", subject)
     return REGISTRY[key]
 
 

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/out/masking.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/out/masking.py
@@ -2,11 +2,14 @@
 from __future__ import annotations
 
 from typing import Any, Dict, Mapping, MutableMapping, Optional, Sequence
+import logging
 
 from ... import events as _ev
 
 # Runs at the very end of the lifecycle (after wire:dump).
 ANCHOR = _ev.OUT_DUMP  # "out:dump"
+
+logger = logging.getLogger("uvicorn")
 
 
 def run(obj: Optional[object], ctx: Any) -> None:
@@ -35,6 +38,7 @@ def run(obj: Optional[object], ctx: Any) -> None:
     - Leaves alias extras untouched (based on the alias sets captured from
       emit_aliases.post/read).
     """
+    logger.debug("Running out:masking")
     specs: Mapping[str, Any] = getattr(ctx, "specs", {}) or {}
     if not specs:
         return

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/refresh/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/refresh/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import Any, Callable, Dict, Optional, Tuple
+import logging
 
 # Atom implementations (model-scoped)
 from . import demand as _demand
@@ -15,10 +16,14 @@ REGISTRY: Dict[Tuple[str, str], Tuple[str, RunFn]] = {
     ("refresh", "demand"): (_demand.ANCHOR, _demand.run),
 }
 
+logger = logging.getLogger("uvicorn")
+
 
 def subjects() -> Tuple[str, ...]:
     """Return the subject names exported by this domain."""
-    return tuple(s for (_, s) in REGISTRY.keys())
+    subjects = tuple(s for (_, s) in REGISTRY.keys())
+    logger.debug("Listing 'refresh' subjects: %s", subjects)
+    return subjects
 
 
 def get(subject: str) -> Tuple[str, RunFn]:
@@ -26,6 +31,7 @@ def get(subject: str) -> Tuple[str, RunFn]:
     key = ("refresh", subject)
     if key not in REGISTRY:
         raise KeyError(f"Unknown refresh atom subject: {subject!r}")
+    logger.debug("Retrieving 'refresh' subject %s", subject)
     return REGISTRY[key]
 
 

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/refresh/demand.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/refresh/demand.py
@@ -2,11 +2,14 @@
 from __future__ import annotations
 
 from typing import Any, Iterable, Mapping, MutableMapping, Optional, Tuple
+import logging
 
 from ... import events as _ev
 
 # After the handler flushes changes; decide whether to hydrate DB-generated values.
 ANCHOR = _ev.POST_FLUSH  # "post:flush"
+
+logger = logging.getLogger("uvicorn")
 
 
 def run(obj: Optional[object], ctx: Any) -> None:
@@ -35,6 +38,7 @@ def run(obj: Optional[object], ctx: Any) -> None:
     - ctx.temp["refresh_fields"] : tuple[str, ...] (hint: which fields likely changed in DB)
     - ctx.temp["refresh_reason"] : str (diagnostic only)
     """
+    logger.debug("Running refresh:demand")
     if getattr(ctx, "persist", True) is False:
         return
 

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/resolve/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/resolve/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import Any, Callable, Dict, Optional, Tuple
+import logging
 
 # Atom implementations (model-scoped)
 from . import assemble as _assemble
@@ -17,10 +18,14 @@ REGISTRY: Dict[Tuple[str, str], Tuple[str, RunFn]] = {
     ("resolve", "paired_gen"): (_paired_gen.ANCHOR, _paired_gen.run),
 }
 
+logger = logging.getLogger("uvicorn")
+
 
 def subjects() -> Tuple[str, ...]:
     """Return the subject names exported by this domain."""
-    return tuple(s for (_, s) in REGISTRY.keys())
+    subjects = tuple(s for (_, s) in REGISTRY.keys())
+    logger.debug("Listing 'resolve' subjects: %s", subjects)
+    return subjects
 
 
 def get(subject: str) -> Tuple[str, RunFn]:
@@ -28,6 +33,7 @@ def get(subject: str) -> Tuple[str, RunFn]:
     key = ("resolve", subject)
     if key not in REGISTRY:
         raise KeyError(f"Unknown resolve atom subject: {subject!r}")
+    logger.debug("Retrieving 'resolve' subject %s", subject)
     return REGISTRY[key]
 
 

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/resolve/assemble.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/resolve/assemble.py
@@ -2,11 +2,14 @@
 from __future__ import annotations
 
 from typing import Any, Mapping, MutableMapping, Optional, Dict, Tuple
+import logging
 
 from ... import events as _ev
 
 # Runs in HANDLER phase, before pre:flush and any storage transforms.
 ANCHOR = _ev.RESOLVE_VALUES  # "resolve:values"
+
+logger = logging.getLogger("uvicorn")
 
 
 def run(obj: Optional[object], ctx: Any) -> None:
@@ -41,6 +44,7 @@ def run(obj: Optional[object], ctx: Any) -> None:
     if getattr(ctx, "persist", True) is False:
         return
 
+    logger.debug("Running resolve:assemble")
     specs: Mapping[str, Any] = getattr(ctx, "specs", {}) or {}
     if not specs:
         return

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/resolve/paired_gen.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/resolve/paired_gen.py
@@ -2,12 +2,15 @@
 from __future__ import annotations
 
 import secrets
+import logging
 from typing import Any, Dict, Mapping, MutableMapping, Optional
 
 from ... import events as _ev
 
 # Runs in HANDLER phase, before pre:flush (and before storage transforms).
 ANCHOR = _ev.RESOLVE_VALUES  # "resolve:values"
+
+logger = logging.getLogger("uvicorn")
 
 
 def run(obj: Optional[object], ctx: Any) -> None:
@@ -46,6 +49,7 @@ def run(obj: Optional[object], ctx: Any) -> None:
     if getattr(ctx, "persist", True) is False:
         return
 
+    logger.debug("Running resolve:paired_gen")
     specs: Mapping[str, Any] = getattr(ctx, "specs", {}) or {}
     if not specs:
         return

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/response/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/response/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from typing import Any, Callable, Dict, Optional, Tuple
+import logging
 
 from ... import events as _ev
 from . import render as _render
@@ -8,8 +9,11 @@ from . import templates as _tmpl
 
 RunFn = Callable[[Optional[object], Any], None]
 
+logger = logging.getLogger("uvicorn")
+
 
 async def _template(obj: Optional[object], ctx: Any) -> None:
+    logger.debug("Running response:template")
     resp_ns = getattr(ctx, "response", None)
     req = getattr(ctx, "request", None)
     if resp_ns is None or req is None:
@@ -39,6 +43,7 @@ async def _template(obj: Optional[object], ctx: Any) -> None:
 
 
 def _negotiate(obj: Optional[object], ctx: Any) -> None:
+    logger.debug("Running response:negotiate")
     resp_ns = getattr(ctx, "response", None)
     req = getattr(ctx, "request", None)
     if resp_ns is None or req is None:
@@ -56,6 +61,7 @@ def _negotiate(obj: Optional[object], ctx: Any) -> None:
 def _render_run(
     obj: Optional[object], ctx: Any
 ) -> None:  # pragma: no cover - glue code
+    logger.debug("Running response:render")
     resp_ns = getattr(ctx, "response", None)
     req = getattr(ctx, "request", None)
     if resp_ns is None or req is None:

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/response/negotiation.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/response/negotiation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from typing import List
+import logging
 
 
 def _parse(accept: str) -> List[str]:
@@ -18,7 +19,11 @@ def _parse(accept: str) -> List[str]:
     return sorted(parts, key=q, reverse=True)
 
 
+logger = logging.getLogger("uvicorn")
+
+
 def negotiate_media_type(accept: str, default_media: str) -> str:
+    logger.debug("Negotiating media type from Accept header %s", accept)
     if not accept or accept == "*/*":
         return default_media
     for cand in _parse(accept):

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/response/render.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/response/render.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, AsyncIterable, Iterable, Mapping, Optional, Union, cast
+import logging
 
 from ....deps.starlette import BackgroundTask, Response
 
@@ -14,6 +15,8 @@ from ....response.shortcuts import (
 )
 
 JSON = Mapping[str, Any]
+
+logger = logging.getLogger("uvicorn")
 
 
 @dataclass
@@ -58,6 +61,7 @@ def render(
     default_media: str = "application/json",
     envelope_default: bool = True,
 ) -> Response:
+    logger.debug("Rendering response with payload type %s", type(payload))
     if isinstance(payload, Response):
         return payload
 

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/response/templates.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/response/templates.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from functools import lru_cache
+import logging
 from typing import Any, Dict, Iterable, Optional, Tuple
 
 from ....deps.starlette import Request
@@ -12,6 +13,7 @@ from ....deps.jinja import (
     TemplateNotFound,
 )
 
+logger = logging.getLogger("uvicorn")
 if Environment is None:  # pragma: no cover - jinja2 not installed
 
     async def render_template(
@@ -25,6 +27,7 @@ if Environment is None:  # pragma: no cover - jinja2 not installed
         globals_: Optional[Dict[str, Any]] = None,
         request: Optional[Request] = None,
     ) -> str:
+        logger.debug("Rendering template %s", name)
         raise RuntimeError("jinja2 is required for template rendering")
 
 else:
@@ -64,6 +67,7 @@ else:
         globals_: Optional[Dict[str, Any]] = None,
         request: Optional[Request] = None,
     ) -> str:
+        logger.debug("Rendering template %s", name)
         env = _get_env(tuple(search_paths), package, auto_reload)
         if filters:
             env.filters.update(filters)

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/schema/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/schema/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import Any, Callable, Dict, Optional, Tuple
+import logging
 
 # Atom implementations (model-scoped)
 from . import collect_in as _collect_in
@@ -17,10 +18,14 @@ REGISTRY: Dict[Tuple[str, str], Tuple[str, RunFn]] = {
     ("schema", "collect_out"): (_collect_out.ANCHOR, _collect_out.run),
 }
 
+logger = logging.getLogger("uvicorn")
+
 
 def subjects() -> Tuple[str, ...]:
     """Return the subject names exported by this domain."""
-    return tuple(s for (_, s) in REGISTRY.keys())
+    subjects = tuple(s for (_, s) in REGISTRY.keys())
+    logger.debug("Listing 'schema' subjects: %s", subjects)
+    return subjects
 
 
 def get(subject: str) -> Tuple[str, RunFn]:
@@ -28,6 +33,7 @@ def get(subject: str) -> Tuple[str, RunFn]:
     key = ("schema", subject)
     if key not in REGISTRY:
         raise KeyError(f"Unknown schema atom subject: {subject!r}")
+    logger.debug("Retrieving 'schema' subject %s", subject)
     return REGISTRY[key]
 
 

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/schema/collect_in.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/schema/collect_in.py
@@ -2,11 +2,14 @@
 from __future__ import annotations
 
 from typing import Any, Dict, Mapping, MutableMapping, Optional
+import logging
 
 from ... import events as _ev
 
 # Runs at the very beginning of the lifecycle, before in-model build/validation.
 ANCHOR = _ev.SCHEMA_COLLECT_IN  # "schema:collect_in"
+
+logger = logging.getLogger("uvicorn")
 
 
 def run(obj: Optional[object], ctx: Any) -> None:
@@ -49,6 +52,7 @@ def run(obj: Optional[object], ctx: Any) -> None:
         "order": tuple[str, ...],           # stable field order for wire builder
       }
     """
+    logger.debug("Running schema:collect_in")
     specs: Mapping[str, Any] = getattr(ctx, "specs", {}) or {}
     if not specs:
         return

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/schema/collect_out.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/schema/collect_out.py
@@ -2,11 +2,14 @@
 from __future__ import annotations
 
 from typing import Any, Dict, Mapping, MutableMapping, Optional
+import logging
 
 from ... import events as _ev
 
 # Runs late in POST_HANDLER, before out model build and dumping.
 ANCHOR = _ev.SCHEMA_COLLECT_OUT  # "schema:collect_out"
+
+logger = logging.getLogger("uvicorn")
 
 
 def run(obj: Optional[object], ctx: Any) -> None:
@@ -50,6 +53,7 @@ def run(obj: Optional[object], ctx: Any) -> None:
         "order": tuple[str, ...],          # stable field order for model build
       }
     """
+    logger.debug("Running schema:collect_out")
     specs: Mapping[str, Any] = getattr(ctx, "specs", {}) or {}
     if not specs:
         return

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/storage/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/storage/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import Any, Callable, Dict, Optional, Tuple
+import logging
 
 # Atom implementations (model-scoped)
 from . import to_stored as _to_stored
@@ -15,10 +16,14 @@ REGISTRY: Dict[Tuple[str, str], Tuple[str, RunFn]] = {
     ("storage", "to_stored"): (_to_stored.ANCHOR, _to_stored.run),
 }
 
+logger = logging.getLogger("uvicorn")
+
 
 def subjects() -> Tuple[str, ...]:
     """Return the subject names exported by this domain."""
-    return tuple(s for (_, s) in REGISTRY.keys())
+    subjects = tuple(s for (_, s) in REGISTRY.keys())
+    logger.debug("Listing 'storage' subjects: %s", subjects)
+    return subjects
 
 
 def get(subject: str) -> Tuple[str, RunFn]:
@@ -26,6 +31,7 @@ def get(subject: str) -> Tuple[str, RunFn]:
     key = ("storage", subject)
     if key not in REGISTRY:
         raise KeyError(f"Unknown storage atom subject: {subject!r}")
+    logger.debug("Retrieving 'storage' subject %s", subject)
     return REGISTRY[key]
 
 

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/storage/to_stored.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/storage/to_stored.py
@@ -2,12 +2,15 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 from typing import Any, Callable, Dict, Mapping, MutableMapping, Optional
 
 from ... import events as _ev
 
 # Runs right before the handler flushes to the DB.
 ANCHOR = _ev.PRE_FLUSH  # "pre:flush"
+
+logger = logging.getLogger("uvicorn")
 
 
 def run(obj: Optional[object], ctx: Any) -> None:
@@ -44,6 +47,7 @@ def run(obj: Optional[object], ctx: Any) -> None:
     - Appends diagnostic entries to ctx.temp["storage_log"].
     - On failure to derive for paired columns, raises ValueError (mapped by higher layers).
     """
+    logger.debug("Running storage:to_stored")
     if getattr(ctx, "persist", True) is False:
         return
 

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/wire/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/wire/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import Any, Callable, Dict, Optional, Tuple
+import logging
 
 # Atom implementations (per-field)
 from . import build_in as _build_in
@@ -22,10 +23,14 @@ REGISTRY: Dict[Tuple[str, str], Tuple[str, RunFn]] = {
     ("wire", "dump"): (_dump.ANCHOR, _dump.run),
 }
 
+logger = logging.getLogger("uvicorn")
+
 
 def subjects() -> Tuple[str, ...]:
     """Return the subject names exported by this domain."""
-    return tuple(s for (_, s) in REGISTRY.keys())
+    subjects = tuple(s for (_, s) in REGISTRY.keys())
+    logger.debug("Listing 'wire' subjects: %s", subjects)
+    return subjects
 
 
 def get(subject: str) -> Tuple[str, RunFn]:
@@ -33,6 +38,7 @@ def get(subject: str) -> Tuple[str, RunFn]:
     key = ("wire", subject)
     if key not in REGISTRY:
         raise KeyError(f"Unknown wire atom subject: {subject!r}")
+    logger.debug("Retrieving 'wire' subject %s", subject)
     return REGISTRY[key]
 
 

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/wire/build_in.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/wire/build_in.py
@@ -2,11 +2,14 @@
 from __future__ import annotations
 
 from typing import Any, Dict, Mapping, MutableMapping, Optional
+import logging
 
 from ... import events as _ev
 
 # Runs in PRE_HANDLER just before validation.
 ANCHOR = _ev.IN_VALIDATE  # "in:validate"
+
+logger = logging.getLogger("uvicorn")
 
 
 def run(obj: Optional[object], ctx: Any) -> None:
@@ -37,6 +40,7 @@ def run(obj: Optional[object], ctx: Any) -> None:
     if not schema_in:
         return  # nothing to do
 
+    logger.debug("Running wire:build_in")
     temp = _ensure_temp(ctx)
 
     payload = _coerce_payload(ctx)

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/wire/build_out.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/wire/build_out.py
@@ -2,11 +2,14 @@
 from __future__ import annotations
 
 from typing import Any, Dict, Mapping, MutableMapping, Optional
+import logging
 
 from ... import events as _ev
 
 # POST_HANDLER, runs before readtime aliases and dump.
 ANCHOR = _ev.OUT_BUILD  # "out:build"
+
+logger = logging.getLogger("uvicorn")
 
 
 def run(obj: Optional[object], ctx: Any) -> None:
@@ -32,6 +35,7 @@ def run(obj: Optional[object], ctx: Any) -> None:
     if not schema_out:
         return
 
+    logger.debug("Running wire:build_out")
     temp = _ensure_temp(ctx)
     specs: Mapping[str, Any] = getattr(ctx, "specs", {}) or {}
     _by_field: Mapping[str, Mapping[str, Any]] = schema_out.get("by_field", {})  # type: ignore[assignment]

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/wire/dump.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/wire/dump.py
@@ -5,12 +5,15 @@ import base64
 import datetime as _dt
 import decimal as _dc
 import uuid as _uuid
+import logging
 from typing import Any, Dict, Mapping, MutableMapping, Optional
 
 from ... import events as _ev
 
 # Runs at the very end of model shaping; out:masking follows at the same anchor.
 ANCHOR = _ev.OUT_DUMP  # "out:dump"
+
+logger = logging.getLogger("uvicorn")
 
 
 def run(obj: Optional[object], ctx: Any) -> None:
@@ -37,6 +40,7 @@ def run(obj: Optional[object], ctx: Any) -> None:
     - This step does NOT perform masking/redaction; that is handled by out:masking.
     - For collection/list responses, extras are not merged (they are usually per-item).
     """
+    logger.debug("Running wire:dump")
     temp = _ensure_temp(ctx)
     out_values = temp.get("out_values")
 

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/wire/validate_in.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/wire/validate_in.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import datetime as _dt
 import decimal as _dc
 import uuid as _uuid
+import logging
 from typing import Any, Callable, Dict, Mapping, MutableMapping, Optional, Tuple
 
 from fastapi import HTTPException, status as _status
@@ -12,6 +13,8 @@ from ... import events as _ev
 
 # PRE_HANDLER, runs after wire:build_in
 ANCHOR = _ev.IN_VALIDATE  # "in:validate"
+
+logger = logging.getLogger("uvicorn")
 
 
 def run(obj: Optional[object], ctx: Any) -> None:
@@ -38,6 +41,7 @@ def run(obj: Optional[object], ctx: Any) -> None:
         ctx.temp["in_coerced"] : tuple of coerced field names (if any)
     - Raises HTTPException(422) if any validation errors are found
     """
+    logger.debug("Running wire:validate_in")
     temp = _ensure_temp(ctx)
     schema_in = _schema_in(ctx)
     specs: Mapping[str, Any] = getattr(ctx, "specs", {}) or {}


### PR DESCRIPTION
## Summary
- route all atom logs through uvicorn's logger for unified output
- add debug traces to each atom's run function

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `uv run --directory pkgs/standards/autoapi --package autoapi pytest` *(fails: tests/i9n/test_key_digest_uvicorn.py::test_create_apikey_success, tests/i9n/test_key_digest_uvicorn.py::test_create_response_fields)*


------
https://chatgpt.com/codex/tasks/task_e_68bc0f935a9c8326a2e608677d23c49a