### PR TITLE
feat: cache autoapi collect modules

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/column/collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/column/collect.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from functools import lru_cache
 from typing import Dict
 
 from .column_spec import ColumnSpec
@@ -8,6 +9,7 @@ from .column_spec import ColumnSpec
 logger = logging.getLogger("uvicorn")
 
 
+@lru_cache(maxsize=None)
 def collect_columns(model: type) -> Dict[str, ColumnSpec]:
     """Gather ColumnSpecs declared on *model* and all mixins.
 

--- a/pkgs/standards/autoapi/autoapi/v3/engine/collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/engine/collect.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from functools import lru_cache
 from types import SimpleNamespace
 from typing import Any, Dict, Iterable, Mapping, Tuple
 
@@ -73,6 +74,13 @@ def collect_from_objects(
     *, app: Any | None = None, api: Any | None = None, models: Iterable[Any] = ()
 ) -> Dict[str, Any]:
     """Collect engine configuration from objects without binding them."""
+    return _collect_from_objects_cached(app, api, tuple(models))
+
+
+@lru_cache(maxsize=None)
+def _collect_from_objects_cached(
+    app: Any | None, api: Any | None, models: Tuple[Any, ...]
+) -> Dict[str, Any]:
     logger.info("Collecting engine configuration")
     app_engine = _read_engine_attr(app) if app is not None else None
     api_engine = _read_engine_attr(api) if api is not None else None
@@ -107,3 +115,11 @@ def collect_from_objects(
         "tables": tables,
         "ops": ops,
     }
+
+
+collect_from_objects.cache_clear = (  # type: ignore[attr-defined]
+    _collect_from_objects_cached.cache_clear
+)
+collect_from_objects.cache_info = (  # type: ignore[attr-defined]
+    _collect_from_objects_cached.cache_info
+)

--- a/pkgs/standards/autoapi/autoapi/v3/op/collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/op/collect.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from dataclasses import replace
 import logging
 import re
+from functools import lru_cache
 from typing import (
     Any,
     Callable,
@@ -69,6 +70,7 @@ def _wrap_ctx_core(table: type, func: Callable[..., Any]) -> Callable[..., Any]:
     return core
 
 
+@lru_cache(maxsize=None)
 def collect_decorated_ops(table: type) -> list[OpSpec]:
     """Scan MRO for ctx-only op declarations (@op_ctx) and build OpSpecs."""
 

--- a/pkgs/standards/autoapi/autoapi/v3/schema/collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/collect.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import inspect
 import logging
+from functools import lru_cache
 from typing import Dict
 
 from ..config.constants import AUTOAPI_SCHEMA_DECLS_ATTR
@@ -12,6 +13,7 @@ from .decorators import _SchemaDecl
 logger = logging.getLogger("uvicorn")
 
 
+@lru_cache(maxsize=None)
 def collect_decorated_schemas(model: type) -> Dict[str, Dict[str, type]]:
     """Gather schema declarations for ``model`` across its MRO."""
     logger.info("Collecting decorated schemas for %s", model.__name__)

--- a/pkgs/standards/autoapi/tests/i9n/test_collect_caching.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_collect_caching.py
@@ -1,0 +1,42 @@
+from autoapi.v3.column.collect import collect_columns
+from autoapi.v3.column.column_spec import ColumnSpec
+from autoapi.v3.engine.collect import collect_from_objects
+from autoapi.v3.hook.collect import collect_decorated_hooks
+from autoapi.v3.op.collect import collect_decorated_ops
+from autoapi.v3.schema.collect import collect_decorated_schemas
+
+
+class Model:
+    __autoapi_cols__ = {"a": ColumnSpec(storage=None)}
+
+
+def test_collect_caching_behaves_consistently():
+    collect_columns.cache_clear()
+    first = collect_columns(Model)
+    second = collect_columns(Model)
+    assert first is second
+    assert collect_columns.cache_info().hits >= 1
+
+    collect_decorated_ops.cache_clear()
+    first_ops = collect_decorated_ops(Model)
+    second_ops = collect_decorated_ops(Model)
+    assert first_ops is second_ops
+    assert collect_decorated_ops.cache_info().hits >= 1
+
+    collect_decorated_hooks.cache_clear()
+    first_hooks = collect_decorated_hooks(Model, visible_aliases=set())
+    second_hooks = collect_decorated_hooks(Model, visible_aliases=set())
+    assert first_hooks is second_hooks
+    assert collect_decorated_hooks.cache_info().hits >= 1
+
+    collect_decorated_schemas.cache_clear()
+    first_schema = collect_decorated_schemas(Model)
+    second_schema = collect_decorated_schemas(Model)
+    assert first_schema is second_schema
+    assert collect_decorated_schemas.cache_info().hits >= 1
+
+    collect_from_objects.cache_clear()
+    first_eng = collect_from_objects(models=(Model,))
+    second_eng = collect_from_objects(models=(Model,))
+    assert first_eng is second_eng
+    assert collect_from_objects.cache_info().hits >= 1

--- a/pkgs/standards/autoapi/tests/perf/test_collect_caching.py
+++ b/pkgs/standards/autoapi/tests/perf/test_collect_caching.py
@@ -1,0 +1,26 @@
+from autoapi.v3.column.collect import collect_columns
+from autoapi.v3.column.column_spec import ColumnSpec
+from autoapi.v3.engine.collect import collect_from_objects
+from autoapi.v3.hook.collect import collect_decorated_hooks
+from autoapi.v3.op.collect import collect_decorated_ops
+from autoapi.v3.schema.collect import collect_decorated_schemas
+
+
+class Model:
+    __autoapi_cols__ = {"a": ColumnSpec(storage=None)}
+
+
+def _run_collect(func, *args, **kwargs):
+    func.cache_clear()
+    for _ in range(5):
+        func(*args, **kwargs)
+    info = func.cache_info()
+    return info.misses, info.hits
+
+
+def test_collect_caching_performance():
+    assert _run_collect(collect_columns, Model) == (1, 4)
+    assert _run_collect(collect_decorated_ops, Model) == (1, 4)
+    assert _run_collect(collect_decorated_hooks, Model, visible_aliases=set()) == (1, 4)
+    assert _run_collect(collect_decorated_schemas, Model) == (1, 4)
+    assert _run_collect(collect_from_objects, models=(Model,)) == (1, 4)


### PR DESCRIPTION
## Summary
- cache collect utilities across AutoAPI modules with lru_cache
- expose cache controls for hook and engine collectors
- add functional and performance tests covering cache behavior

## Testing
- `uv run --package autoapi --directory . ruff format autoapi/v3/hook/collect.py autoapi/v3/engine/collect.py`
- `uv run --package autoapi --directory . ruff check . --fix`
- `uv run --package autoapi --directory . pytest tests/i9n/test_collect_caching.py`
- `uv run --package autoapi --directory . pytest tests/perf/test_collect_caching.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc16aa4e9c8326a29071a2a206684a