### PR TITLE
chore(auto_kms): enable default debug logging

### DIFF
--- a/pkgs/standards/auto_kms/auto_kms/app.py
+++ b/pkgs/standards/auto_kms/auto_kms/app.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
+import logging
+import os
+
 from autoapi.v3 import AutoApp
 from autoapi.v3.engine import engine as build_engine
-from .orm import Key, KeyVersion
-
 from swarmauri_crypto_paramiko import ParamikoCrypto
 from swarmauri_standard.key_providers import InMemoryKeyProvider
+from .orm import Key, KeyVersion
 
-import os
+logging.getLogger("uvicorn").setLevel(logging.DEBUG)
 
 DB_URL = os.getenv("KMS_DATABASE_URL", "sqlite+aiosqlite:///./kms.db")
 ENGINE = build_engine(DB_URL)


### PR DESCRIPTION
## Summary
- set uvicorn logger to debug level so atom diagnostics are visible by default

## Testing
- `uv run --directory pkgs/standards/auto_kms --package auto_kms ruff format .`
- `uv run --directory pkgs/standards/auto_kms --package auto_kms ruff check . --fix`
- `uv run --directory pkgs/standards/auto_kms --package auto_kms python - <<'PY' 2>&1 | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68bc1765e078832695ede5fa3db851a3