### PR TITLE
Add debug logging to AutoAPI CRUD methods

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/core/crud/helpers/db.py
+++ b/pkgs/standards/autoapi/autoapi/v3/core/crud/helpers/db.py
@@ -2,40 +2,61 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Sequence, Union
 
+import logging
+
 from . import AsyncSession, Session
 from .model import _model_columns, _single_pk_name
 
+logging.getLogger("uvicorn").setLevel(logging.DEBUG)
+logger = logging.getLogger("uvicorn")
+
 
 def _is_async_db(db: Any) -> bool:
-    return isinstance(db, AsyncSession) or hasattr(db, "run_sync")
+    logger.debug("_is_async_db called with db=%s", db)
+    result = isinstance(db, AsyncSession) or hasattr(db, "run_sync")
+    logger.debug("_is_async_db returning %s", result)
+    return result
 
 
 async def _maybe_get(db: Union[Session, AsyncSession], model: type, pk_value: Any):
+    logger.debug("_maybe_get model=%s pk_value=%s", model, pk_value)
     if _is_async_db(db):
-        return await db.get(model, pk_value)  # type: ignore[attr-defined]
-    return db.get(model, pk_value)  # type: ignore[attr-defined]
+        result = await db.get(model, pk_value)  # type: ignore[attr-defined]
+    else:
+        result = db.get(model, pk_value)  # type: ignore[attr-defined]
+    logger.debug("_maybe_get returning %s", result)
+    return result
 
 
 async def _maybe_execute(db: Union[Session, AsyncSession], stmt: Any):
+    logger.debug("_maybe_execute stmt=%s", stmt)
     if _is_async_db(db):
-        return await db.execute(stmt)  # type: ignore[attr-defined]
-    return db.execute(stmt)  # type: ignore[attr-defined]
+        result = await db.execute(stmt)  # type: ignore[attr-defined]
+    else:
+        result = db.execute(stmt)  # type: ignore[attr-defined]
+    logger.debug("_maybe_execute returning %s", result)
+    return result
 
 
 async def _maybe_flush(db: Union[Session, AsyncSession]) -> None:
+    logger.debug("_maybe_flush called")
     if _is_async_db(db):
         await db.flush()  # type: ignore[attr-defined]
     else:
         db.flush()  # type: ignore[attr-defined]
+    logger.debug("_maybe_flush completed")
 
 
 async def _maybe_delete(db: Union[Session, AsyncSession], obj: Any) -> None:
+    logger.debug("_maybe_delete called with obj=%s", obj)
     if not hasattr(db, "delete"):
+        logger.debug("_maybe_delete skipping delete; no attribute")
         return
     if _is_async_db(db):
         await db.delete(obj)  # type: ignore[attr-defined]
     else:
         db.delete(obj)  # type: ignore[attr-defined]
+    logger.debug("_maybe_delete completed for obj=%s", obj)
 
 
 def _set_attrs(
@@ -45,6 +66,13 @@ def _set_attrs(
     allow_missing: bool = True,
     skip: Sequence[str] = (),
 ) -> None:
+    logger.debug(
+        "_set_attrs called on obj=%s values=%s allow_missing=%s skip=%s",
+        obj,
+        values,
+        allow_missing,
+        skip,
+    )
     cols = set(_model_columns(type(obj)))
     pk = _single_pk_name(type(obj))
     skip_set = set(skip) | {pk}
@@ -61,3 +89,4 @@ def _set_attrs(
                 setattr(obj, c, values[c])
             else:
                 setattr(obj, c, None)
+    logger.debug("_set_attrs completed for obj=%s", obj)

--- a/pkgs/standards/autoapi/autoapi/v3/core/crud/helpers/model.py
+++ b/pkgs/standards/autoapi/autoapi/v3/core/crud/helpers/model.py
@@ -2,61 +2,85 @@ from __future__ import annotations
 
 from typing import Any, Dict, Mapping, Tuple
 
+import logging
+
 from ....column.collect import collect_columns
+
+logging.getLogger("uvicorn").setLevel(logging.DEBUG)
+logger = logging.getLogger("uvicorn")
 
 
 def _pk_columns(model: type) -> Tuple[Any, ...]:
+    logger.debug("_pk_columns called with model=%s", model)
     table = getattr(model, "__table__", None)
     if table is None:
         raise ValueError(f"{model.__name__} has no __table__")
     pks = tuple(table.primary_key.columns)  # type: ignore[attr-defined]
     if not pks:
         raise ValueError(f"{model.__name__} has no primary key")
+    logger.debug("_pk_columns returning %s", pks)
     return pks
 
 
 def _single_pk_name(model: type) -> str:
+    logger.debug("_single_pk_name called with model=%s", model)
     pks = _pk_columns(model)
     if len(pks) != 1:
         raise NotImplementedError(
             f"{model.__name__} has composite PK; not supported by default core"
         )
-    return pks[0].name
+    name = pks[0].name
+    logger.debug("_single_pk_name returning %s", name)
+    return name
 
 
 def _coerce_pk_value(model: type, value: Any) -> Any:
+    logger.debug("_coerce_pk_value called with model=%s value=%s", model, value)
     if value is None:
         return None
     try:
         col = _pk_columns(model)[0]
         py_type = col.type.python_type  # type: ignore[attr-defined]
     except Exception:  # pragma: no cover - best effort
+        logger.debug("_coerce_pk_value returning original value %s", value)
         return value
     if isinstance(value, py_type):
         return value
     try:
-        return py_type(value)
+        coerced = py_type(value)
+        logger.debug("_coerce_pk_value coerced %s to %s", value, coerced)
+        return coerced
     except Exception:  # pragma: no cover - fallback to original
+        logger.debug("_coerce_pk_value failed to coerce %s", value)
         return value
 
 
 def _model_columns(model: type) -> Tuple[str, ...]:
+    logger.debug("_model_columns called with model=%s", model)
     table = getattr(model, "__table__", None)
     if table is None:
         return ()
-    return tuple(c.name for c in table.columns)
+    cols = tuple(c.name for c in table.columns)
+    logger.debug("_model_columns returning %s", cols)
+    return cols
 
 
 def _colspecs(model: type) -> Mapping[str, Any]:
-    return collect_columns(model)
+    logger.debug("_colspecs called with model=%s", model)
+    specs = collect_columns(model)
+    logger.debug("_colspecs returning %s", specs)
+    return specs
 
 
 def _filter_in_values(
     model: type, data: Mapping[str, Any], verb: str
 ) -> Dict[str, Any]:
+    logger.debug("_filter_in_values called with data=%s verb=%s", data, verb)
     specs = _colspecs(model)
     if not specs:
-        return dict(data)
+        result = dict(data)
+        logger.debug("_filter_in_values returning %s", result)
+        return result
     out: Dict[str, Any] = {}
     for k, v in data.items():
         sp = specs.get(k)
@@ -74,10 +98,12 @@ def _filter_in_values(
                 allowed = False
         if allowed:
             out[k] = v
+    logger.debug("_filter_in_values returning %s", out)
     return out
 
 
 def _immutable_columns(model: type, verb: str) -> set[str]:
+    logger.debug("_immutable_columns called with model=%s verb=%s", model, verb)
     specs = _colspecs(model)
     if not specs:
         return set()
@@ -87,4 +113,5 @@ def _immutable_columns(model: type, verb: str) -> set[str]:
         mutable = getattr(io, "mutable_verbs", ()) if io else ()
         if mutable and verb not in mutable:
             imm.add(name)
+    logger.debug("_immutable_columns returning %s", imm)
     return imm

--- a/pkgs/standards/autoapi/autoapi/v3/core/crud/helpers/normalize.py
+++ b/pkgs/standards/autoapi/autoapi/v3/core/crud/helpers/normalize.py
@@ -2,41 +2,56 @@ from __future__ import annotations
 
 from typing import Any, Dict, Mapping, Optional, Union
 import builtins as _builtins
+import logging
 
 from . import AsyncSession, Session
 
+logging.getLogger("uvicorn").setLevel(logging.DEBUG)
+logger = logging.getLogger("uvicorn")
+
 
 def _pop_bound_self(args: list[Any]) -> None:
+    logger.debug("_pop_bound_self called with args=%s", args)
     if args and not isinstance(args[0], type):
         args.pop(0)
+    logger.debug("_pop_bound_self result args=%s", args)
 
 
 def _extract_db(
     args: list[Any], kwargs: dict[str, Any]
 ) -> Union[Session, AsyncSession]:
+    logger.debug("_extract_db called with args=%s kwargs=%s", args, kwargs)
     db = kwargs.pop("db", None)
     if db is not None:
+        logger.debug("_extract_db found db in kwargs=%s", db)
         return db
     for i, a in enumerate(args):
         if isinstance(a, (Session, AsyncSession)) or hasattr(a, "execute"):
             args.pop(i)
+            logger.debug("_extract_db using positional db=%s", a)
             return a  # type: ignore[return-value]
+    logger.debug("_extract_db failed to find db")
     raise TypeError("db session is required")
 
 
 def _as_pos_int(x: Any) -> Optional[int]:
+    logger.debug("_as_pos_int called with x=%s", x)
     if x is None:
         return None
     try:
         v = int(x)
-        return v if v >= 0 else 0
+        result = v if v >= 0 else 0
+        logger.debug("_as_pos_int returning %s", result)
+        return result
     except Exception:
+        logger.debug("_as_pos_int returning None for x=%s", x)
         return None
 
 
 def _normalize_list_call(
     _args: tuple[Any, ...], _kwargs: dict[str, Any]
 ) -> tuple[type, Dict[str, Any]]:
+    logger.debug("_normalize_list_call called with _args=%s _kwargs=%s", _args, _kwargs)
     args = _builtins.list(_args)
     kwargs = dict(_kwargs)
 
@@ -73,10 +88,12 @@ def _normalize_list_call(
     if filters is None:
         filters = {}
 
-    return model, {
+    result = {
         "filters": filters,
         "skip": skip,
         "limit": limit,
         "db": db,
         "sort": sort,
     }
+    logger.debug("_normalize_list_call returning model=%s params=%s", model, result)
+    return model, result

--- a/pkgs/standards/autoapi/autoapi/v3/core/crud/ops.py
+++ b/pkgs/standards/autoapi/autoapi/v3/core/crud/ops.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Mapping, Optional, Union
 
 import builtins as _builtins
+import logging
 
 from .helpers import (
     AsyncSession,
@@ -26,6 +27,9 @@ from .helpers import (
     _validate_enum_values,
 )
 
+logging.getLogger("uvicorn").setLevel(logging.DEBUG)
+logger = logging.getLogger("uvicorn")
+
 
 async def create(
     model: type, data: Mapping[str, Any], db: Union[Session, AsyncSession]
@@ -34,12 +38,14 @@ async def create(
     Insert a single row. Returns the persisted model instance.
     Flush-only (commit happens later in END_TX).
     """
+    logger.debug("create called with model=%s data=%s", model, data)
     data = _filter_in_values(model, data or {}, "create")
     _validate_enum_values(model, data)
     obj = model(**data)
     if hasattr(db, "add"):
         db.add(obj)
     await _maybe_flush(db)
+    logger.debug("create persisted obj=%s", obj)
     return obj
 
 
@@ -47,9 +53,12 @@ async def read(model: type, ident: Any, db: Union[Session, AsyncSession]) -> Any
     """
     Load a single row by primary key. Raises NoResultFound if not found.
     """
+    logger.debug("read called with model=%s ident=%s", model, ident)
     obj = await _maybe_get(db, model, ident)
     if obj is None:
+        logger.debug("read did not find model=%s ident=%s", model, ident)
         raise NoResultFound(f"{model.__name__}({ident!r}) not found")
+    logger.debug("read returning obj=%s", obj)
     return obj
 
 
@@ -60,12 +69,14 @@ async def update(
     Partial update by primary key. Missing keys are left unchanged.
     Returns the updated model instance. Flush-only.
     """
+    logger.debug("update called with model=%s ident=%s data=%s", model, ident, data)
     data = _filter_in_values(model, data or {}, "update")
     _validate_enum_values(model, data)
     obj = await read(model, ident, db)
     skip = _immutable_columns(model, "update")
     _set_attrs(obj, data, allow_missing=True, skip=skip)
     await _maybe_flush(db)
+    logger.debug("update returning obj=%s", obj)
     return obj
 
 
@@ -79,16 +90,20 @@ async def replace(
     If the row does not exist it is created with the provided identifier.
     Flush-only.
     """
+    logger.debug("replace called with model=%s ident=%s data=%s", model, ident, data)
     data = _filter_in_values(model, data or {}, "replace")
     _validate_enum_values(model, data)
     pk = _single_pk_name(model)
     obj = await _maybe_get(db, model, ident)
     if obj is None:
         payload = {pk: ident, **data}
-        return await create(model, payload, db=db)
+        result = await create(model, payload, db=db)
+        logger.debug("replace created obj=%s", result)
+        return result
     skip = _immutable_columns(model, "replace")
     _set_attrs(obj, data, allow_missing=False, skip=skip)
     await _maybe_flush(db)
+    logger.debug("replace updated obj=%s", obj)
     return obj
 
 
@@ -96,21 +111,24 @@ async def merge(
     model: type, ident: Any, data: Mapping[str, Any], db: Union[Session, AsyncSession]
 ) -> Any:
     """PATCH semantics with upsert behaviour."""
+    logger.debug("merge called with model=%s ident=%s data=%s", model, ident, data)
     pk = _single_pk_name(model)
     ident = _coerce_pk_value(model, ident)
     obj = await _maybe_get(db, model, ident)
 
-    # Respect create-only fields when upserting a new row
     verb = "update" if obj is not None else "create"
     data = _filter_in_values(model, data or {}, verb)
     _validate_enum_values(model, data)
     data_no_pk = {k: v for k, v in data.items() if k != pk}
     if obj is None:
         payload = {pk: ident, **data_no_pk}
-        return await create(model, payload, db=db)
+        result = await create(model, payload, db=db)
+        logger.debug("merge created obj=%s", result)
+        return result
     skip = _immutable_columns(model, "update")
     _set_attrs(obj, data_no_pk, allow_missing=True, skip=skip)
     await _maybe_flush(db)
+    logger.debug("merge updated obj=%s", obj)
     return obj
 
 
@@ -121,9 +139,11 @@ async def delete(
     Delete by primary key. Returns {"deleted": 1} if removed, else raises NoResultFound.
     Flush-only.
     """
+    logger.debug("delete called with model=%s ident=%s", model, ident)
     obj = await read(model, ident, db)
     await _maybe_delete(db, obj)
     await _maybe_flush(db)
+    logger.debug("delete removed obj=%s", obj)
     return {"deleted": 1}
 
 
@@ -137,6 +157,7 @@ async def list(*_args: Any, **_kwargs: Any) -> List[Any]:  # noqa: A001  (shadow
       - positional or keyword args
       - stray extras (e.g., request) which are ignored
     """
+    logger.debug("list called with args=%s kwargs=%s", _args, _kwargs)
     model, params = _normalize_list_call(_args, _kwargs)
 
     filters: Mapping[str, Any] = _coerce_filters(model, params["filters"])
@@ -172,7 +193,9 @@ async def list(*_args: Any, **_kwargs: Any) -> List[Any]:  # noqa: A001  (shadow
         stmt = stmt.limit(max(limit, 0))
 
     result = await _maybe_execute(db, stmt)
-    return _builtins.list(result.scalars().all())  # type: ignore[attr-defined]
+    items = _builtins.list(result.scalars().all())  # type: ignore[attr-defined]
+    logger.debug("list returning %d items", len(items))
+    return items
 
 
 async def clear(
@@ -184,6 +207,7 @@ async def clear(
     Flush-only. Tolerant to the same calling variations as `list`.
     """
     # Reuse normalizer to accept the same shapes
+    logger.debug("clear called with args=%s kwargs=%s", args, kwargs)
     model, params = _normalize_list_call(args, kwargs)
     raw_filters: Mapping[str, Any] = params["filters"]
     db: Union[Session, AsyncSession] = params["db"]
@@ -204,8 +228,8 @@ async def clear(
     if where is not None:
         stmt = stmt.where(where)
 
-    res = await _maybe_execute(db, stmt)
-    await _maybe_flush(db)
-    # Some dialects don't populate rowcount; best-effort
-    n = int(getattr(res, "rowcount", 0) or 0)
-    return {"deleted": n}
+        res = await _maybe_execute(db, stmt)
+        await _maybe_flush(db)
+        n = int(getattr(res, "rowcount", 0) or 0)
+        logger.debug("clear removed %d rows", n)
+        return {"deleted": n}


### PR DESCRIPTION
## Summary
- add uvicorn-based debug logging to CRUD operations in autoapi
- instrument helper utilities with detailed debug statements

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68bcd3215cf08326bc95078d5378b1a0