### PR TITLE
feat(autoapi): add debug logging for schema operations

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/schemas/builder.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/schemas/builder.py
@@ -13,6 +13,7 @@ from ...schema import collect_decorated_schemas
 from .defaults import _default_schemas_for_spec
 from .utils import _alias_schema, _ensure_alias_namespace, _resolve_schema_arg, _Key
 
+logging.getLogger("uvicorn").setLevel(logging.DEBUG)
 logger = logging.getLogger("uvicorn")
 logger.debug("Loaded module v3/bindings/schemas/builder")
 
@@ -34,23 +35,38 @@ def build_and_attach(
     Defaults are still ensured for all specs so cross-op SchemaRefs resolve reliably
     for canonical ops.
     """
+    logger.debug(
+        "Building schemas for %s with %d specs (only_keys=%s)",
+        model.__name__,
+        len(specs),
+        only_keys,
+    )
     if not hasattr(model, "schemas"):
         model.schemas = SimpleNamespace()
+        logger.debug("Created new schemas namespace on %s", model.__name__)
+    else:
+        logger.debug("Using existing schemas namespace on %s", model.__name__)
 
     wanted = set(only_keys or ())
+    if wanted:
+        logger.debug("Filtering overrides to keys: %s", wanted)
 
     # Pass 0: attach schemas declared via @schema_ctx
     declared = collect_decorated_schemas(model)  # {alias: {"in": cls, "out": cls}}
     for alias, kinds in (declared or {}).items():
+        logger.debug("Applying declared schemas for alias '%s'", alias)
         ns = _ensure_alias_namespace(model, alias)
         if "in" in kinds:
             setattr(ns, "in_", kinds["in"])
+            logger.debug("Declared request schema for %s.%s", model.__name__, alias)
         if "out" in kinds:
             setattr(ns, "out", kinds["out"])
+            logger.debug("Declared response schema for %s.%s", model.__name__, alias)
 
     # Ensure a namespace per op alias (even if empty)
     for sp in specs:
         _ = _ensure_alias_namespace(model, sp.alias)
+        logger.debug("Ensured namespace for alias '%s'", sp.alias)
 
     # Pass 1: attach defaults for all specs and capture them so canonical
     # defaults can be restored later if needed.
@@ -67,6 +83,21 @@ def build_and_attach(
             existing_in = getattr(ns, "in_", None)
             if existing_in is None or not getattr(existing_in, "model_fields", None):
                 setattr(ns, "in_", shapes["in_"])
+                logger.debug(
+                    "Attached default request schema for %s.%s",
+                    model.__name__,
+                    sp.alias,
+                )
+            else:
+                logger.debug(
+                    "Keeping existing request schema for %s.%s",
+                    model.__name__,
+                    sp.alias,
+                )
+        else:
+            logger.debug(
+                "No default request schema for %s.%s", model.__name__, sp.alias
+            )
 
         if shapes.get("in_item") is not None:
             existing_in_item = getattr(ns, "in_item", None)
@@ -74,11 +105,41 @@ def build_and_attach(
                 existing_in_item, "model_fields", None
             ):
                 setattr(ns, "in_item", shapes["in_item"])
+                logger.debug(
+                    "Attached default request item schema for %s.%s",
+                    model.__name__,
+                    sp.alias,
+                )
+            else:
+                logger.debug(
+                    "Keeping existing request item schema for %s.%s",
+                    model.__name__,
+                    sp.alias,
+                )
+        else:
+            logger.debug(
+                "No default request item schema for %s.%s", model.__name__, sp.alias
+            )
 
         if shapes.get("out") is not None:
             existing_out = getattr(ns, "out", None)
             if existing_out is None or not getattr(existing_out, "model_fields", None):
                 setattr(ns, "out", shapes["out"])
+                logger.debug(
+                    "Attached default response schema for %s.%s",
+                    model.__name__,
+                    sp.alias,
+                )
+            else:
+                logger.debug(
+                    "Keeping existing response schema for %s.%s",
+                    model.__name__,
+                    sp.alias,
+                )
+        else:
+            logger.debug(
+                "No default response schema for %s.%s", model.__name__, sp.alias
+            )
 
         if shapes.get("out_item") is not None:
             existing_out_item = getattr(ns, "out_item", None)
@@ -86,6 +147,21 @@ def build_and_attach(
                 existing_out_item, "model_fields", None
             ):
                 setattr(ns, "out_item", shapes["out_item"])
+                logger.debug(
+                    "Attached default response item schema for %s.%s",
+                    model.__name__,
+                    sp.alias,
+                )
+            else:
+                logger.debug(
+                    "Keeping existing response item schema for %s.%s",
+                    model.__name__,
+                    sp.alias,
+                )
+        else:
+            logger.debug(
+                "No default response item schema for %s.%s", model.__name__, sp.alias
+            )
 
         logger.debug(
             "schemas(default): %s.%s -> in=%s out=%s",
@@ -99,11 +175,19 @@ def build_and_attach(
     for sp in specs:
         key = (sp.alias, sp.target)
         if wanted and key not in wanted:
+            logger.debug(
+                "Skipping overrides for %s.%s not in only_keys",
+                model.__name__,
+                sp.alias,
+            )
             continue
 
         ns = _ensure_alias_namespace(model, sp.alias)
 
         if sp.request_model is not None:
+            logger.debug(
+                "Resolving request override for %s.%s", model.__name__, sp.alias
+            )
             try:
                 resolved_in = _resolve_schema_arg(
                     model, sp.request_model
@@ -116,10 +200,14 @@ def build_and_attach(
                     e,
                 )
                 raise
-            # Set to model or None (raw)
             setattr(ns, "in_", resolved_in)
+        else:
+            logger.debug("No request override for %s.%s", model.__name__, sp.alias)
 
         if sp.response_model is not None:
+            logger.debug(
+                "Resolving response override for %s.%s", model.__name__, sp.alias
+            )
             try:
                 resolved_out = _resolve_schema_arg(
                     model, sp.response_model
@@ -132,8 +220,9 @@ def build_and_attach(
                     e,
                 )
                 raise
-            # Set to model or None (raw)
             setattr(ns, "out", resolved_out)
+        else:
+            logger.debug("No response override for %s.%s", model.__name__, sp.alias)
 
         logger.debug(
             "schemas(override): %s.%s -> in=%s out=%s",
@@ -146,17 +235,38 @@ def build_and_attach(
     # Pass 2b: restore canonical defaults if overrides cleared them
     for sp in specs:
         if sp.target == "custom":
+            logger.debug(
+                "Skipping default restoration for custom target %s.%s",
+                model.__name__,
+                sp.alias,
+            )
             continue
         ns = _ensure_alias_namespace(model, sp.alias)
         shapes = defaults.get((sp.alias, sp.target)) or {}
         if getattr(ns, "in_", None) is None and shapes.get("in_") is not None:
             setattr(ns, "in_", shapes["in_"])
+            logger.debug(
+                "Restored default request schema for %s.%s", model.__name__, sp.alias
+            )
         if getattr(ns, "in_item", None) is None and shapes.get("in_item") is not None:
             setattr(ns, "in_item", shapes["in_item"])
+            logger.debug(
+                "Restored default request item schema for %s.%s",
+                model.__name__,
+                sp.alias,
+            )
         if getattr(ns, "out", None) is None and shapes.get("out") is not None:
             setattr(ns, "out", shapes["out"])
+            logger.debug(
+                "Restored default response schema for %s.%s", model.__name__, sp.alias
+            )
         if getattr(ns, "out_item", None) is None and shapes.get("out_item") is not None:
             setattr(ns, "out_item", shapes["out_item"])
+            logger.debug(
+                "Restored default response item schema for %s.%s",
+                model.__name__,
+                sp.alias,
+            )
 
     # Pass 3: ensure alias-specific request/response schema names
     for sp in specs:
@@ -167,10 +277,17 @@ def build_and_attach(
             and issubclass(in_model, BaseModel)
             and getattr(in_model, "__autoapi_schema_decl__", None) is None
         ):
+            logger.debug("Aliasing request schema for %s.%s", model.__name__, sp.alias)
             setattr(
                 ns,
                 "in_",
                 _alias_schema(in_model, model=model, alias=sp.alias, kind="Request"),
+            )
+        else:
+            logger.debug(
+                "Request schema for %s.%s already aliased or missing",
+                model.__name__,
+                sp.alias,
             )
         out_model = getattr(ns, "out", None)
         if (
@@ -178,10 +295,17 @@ def build_and_attach(
             and issubclass(out_model, BaseModel)
             and getattr(out_model, "__autoapi_schema_decl__", None) is None
         ):
+            logger.debug("Aliasing response schema for %s.%s", model.__name__, sp.alias)
             setattr(
                 ns,
                 "out",
                 _alias_schema(out_model, model=model, alias=sp.alias, kind="Response"),
+            )
+        else:
+            logger.debug(
+                "Response schema for %s.%s already aliased or missing",
+                model.__name__,
+                sp.alias,
             )
 
 

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/schemas/utils.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/schemas/utils.py
@@ -11,9 +11,9 @@ from pydantic import BaseModel, create_model
 from ...schema.types import SchemaArg, SchemaRef
 from ...schema import namely_model
 
+logging.getLogger("uvicorn").setLevel(logging.DEBUG)
 logger = logging.getLogger("uvicorn")
 logger.debug("Loaded module v3/bindings/schemas/utils")
-
 
 _Key = Tuple[str, str]  # (alias, target)
 
@@ -25,13 +25,23 @@ def _camel(s: str) -> str:
 def _alias_schema(
     schema: Type[BaseModel], *, model: type, alias: str, kind: str
 ) -> Type[BaseModel]:
+    logger.debug(
+        "Aliasing schema %s for %s as %s %s",
+        schema.__name__,
+        model.__name__,
+        alias,
+        kind,
+    )
     name = f"{model.__name__}{_camel(alias)}{kind}"
     if getattr(schema, "__name__", None) == name:
+        logger.debug("Schema already aliased as %s", name)
         return schema
     try:
         clone = create_model(name, __base__=schema)  # type: ignore[arg-type]
-    except Exception:  # pragma: no cover - best effort
+    except Exception as e:  # pragma: no cover - best effort
+        logger.debug("Failed to clone schema %s: %s", schema.__name__, e)
         return schema
+    logger.debug("Created alias schema %s", name)
     return namely_model(
         clone,
         name=name,
@@ -44,6 +54,9 @@ def _ensure_alias_namespace(model: type, alias: str) -> SimpleNamespace:
     if ns is None:
         ns = SimpleNamespace()
         setattr(model.schemas, alias, ns)
+        logger.debug("Created namespace for %s.%s", model.__name__, alias)
+    else:
+        logger.debug("Using existing namespace for %s.%s", model.__name__, alias)
     return ns
 
 
@@ -53,16 +66,25 @@ def _pk_info(model: type) -> Tuple[str, type | Any]:
     """
     table = getattr(model, "__table__", None)
     if table is None or not getattr(table, "primary_key", None):
+        logger.debug("Model %s has no table or primary key", model.__name__)
         return ("id", Any)
     cols = list(table.primary_key.columns)  # type: ignore[attr-defined]
     if not cols:
+        logger.debug("Model %s primary key columns empty", model.__name__)
         return ("id", Any)
     if len(cols) > 1:
+        logger.debug("Model %s has composite primary key", model.__name__)
         # Composite keys: schema builder uses verb='delete' to require what's needed.
         # For bulk_delete we fall back to Any.
         return ("id", Any)
     col = cols[0]
     py_t = getattr(getattr(col, "type", None), "python_type", Any)
+    logger.debug(
+        "Model %s primary key %s of type %s",
+        model.__name__,
+        getattr(col, "name", "id"),
+        py_t,
+    )
     return (getattr(col, "name", "id"), py_t or Any)
 
 
@@ -71,14 +93,18 @@ def _parse_str_ref(s: str) -> Tuple[str, str]:
     Parse dotted schema ref "alias.in" | "alias.out".
     """
     s = s.strip()
+    logger.debug("Parsing schema ref '%s'", s)
     if "." not in s:
+        logger.debug("Schema ref '%s' missing '.'", s)
         raise ValueError(
             f"Invalid schema path '{s}', expected 'alias.in' or 'alias.out'"
         )
     alias, kind = s.split(".", 1)
     kind = kind.strip()
     if kind not in {"in", "out"}:
+        logger.debug("Schema ref '%s' has invalid kind '%s'", s, kind)
         raise ValueError(f"Invalid schema kind '{kind}', expected 'in' or 'out'")
+    logger.debug("Parsed schema ref alias=%s kind=%s", alias, kind)
     return alias.strip(), kind
 
 
@@ -95,30 +121,40 @@ def _resolve_schema_arg(model: type, arg: SchemaArg) -> Optional[Type[BaseModel]
       • callables/thunks
       • any other strings
     """
+    logger.debug("Resolving schema arg %s for %s", arg, model.__name__)
     if arg is None:
+        logger.debug("Schema arg is None; returning None")
         return None
 
     # explicit raw
     if isinstance(arg, str) and arg.strip().lower() == "raw":
+        logger.debug("Schema arg is explicit raw")
         return None
 
     # direct Pydantic model
     if isinstance(arg, type) and issubclass(arg, BaseModel):
+        logger.debug("Schema arg is direct model %s", arg.__name__)
         return arg
 
     # SchemaRef
     if isinstance(arg, SchemaRef):
+        logger.debug("Schema arg is SchemaRef(alias=%s, kind=%s)", arg.alias, arg.kind)
         if arg.kind not in ("in", "out"):
+            logger.debug("Unsupported SchemaRef kind '%s'", arg.kind)
             raise ValueError(
-                f"Unsupported SchemaRef kind '{arg.kind}'. Use 'in' or 'out'."
+                f"Unsupported SchemaRef kind '{arg.kind}'. Use 'in' or 'out'.",
             )
         ns = getattr(model, "schemas", None)
         if ns is None or getattr(ns, arg.alias, None) is None:
+            logger.debug("Unknown schema alias '%s' on %s", arg.alias, model.__name__)
             raise KeyError(f"Unknown schema alias '{arg.alias}' on {model.__name__}")
         alias_ns = getattr(ns, arg.alias)
         attr = "in_" if arg.kind == "in" else "out"
         res = getattr(alias_ns, attr, None)
         if res is None:
+            logger.debug(
+                "Schema '%s.%s' not found on %s", arg.alias, attr, model.__name__
+            )
             raise KeyError(f"Schema '{arg.alias}.{attr}' not found on {model.__name__}")
         return res  # type: ignore[return-value]
 
@@ -127,16 +163,19 @@ def _resolve_schema_arg(model: type, arg: SchemaArg) -> Optional[Type[BaseModel]
         alias, kind = _parse_str_ref(arg)
         ns = getattr(model, "schemas", None)
         if ns is None or getattr(ns, alias, None) is None:
+            logger.debug("Unknown schema alias '%s' on %s", alias, model.__name__)
             raise KeyError(f"Unknown schema alias '{alias}' on {model.__name__}")
         alias_ns = getattr(ns, alias)
         attr = "in_" if kind == "in" else "out"
         res = getattr(alias_ns, attr, None)
         if res is None:
+            logger.debug("Schema '%s.%s' not found on %s", alias, attr, model.__name__)
             raise KeyError(f"Schema '{alias}.{attr}' not found on {model.__name__}")
         return res  # type: ignore[return-value]
 
+    logger.debug("Unsupported SchemaArg type: %s", type(arg))
     # Everything else is unsupported now
     raise TypeError(
         f"Unsupported SchemaArg type: {type(arg)}. "
-        "Use SchemaRef(...,'in'|'out'), 'alias.in'/'alias.out', 'raw', or None."
+        "Use SchemaRef(...,'in'|'out'), 'alias.in'/'alias.out', 'raw', or None.",
     )


### PR DESCRIPTION
## Summary
- add uvicorn-based debug logger to autoapi schema modules
- trace schema building and resolution branches

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format autoapi/v3/bindings/schemas/builder.py autoapi/v3/bindings/schemas/defaults.py autoapi/v3/bindings/schemas/utils.py`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check autoapi/v3/bindings/schemas/builder.py autoapi/v3/bindings/schemas/defaults.py autoapi/v3/bindings/schemas/utils.py --fix`
- `uv run --package autoapi --directory pkgs/standards/autoapi pytest` *(fails: tests/i9n/test_key_digest_uvicorn.py::test_create_apikey_success, tests/i9n/test_key_digest_uvicorn.py::test_create_response_fields)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd39acf908326b46c491d30341c53