### PR TITLE
Improve debug logging in runtime atoms

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/emit/paired_pre.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/emit/paired_pre.py
@@ -42,6 +42,7 @@ def run(obj: Optional[object], ctx: Any) -> None:
     # but guard anyway for robustness.
     logger.debug("Running emit:paired_pre")
     if getattr(ctx, "persist", True) is False:
+        logger.debug("Skipping emit:paired_pre; ctx.persist is False")
         return
 
     temp = _ensure_temp(ctx)
@@ -49,14 +50,19 @@ def run(obj: Optional[object], ctx: Any) -> None:
     paired = _get_paired_values(temp)
 
     if not paired:
+        logger.debug("No paired values found; nothing to schedule")
         return
 
     specs: Mapping[str, Any] = getattr(ctx, "specs", {}) or {}
 
     for field, entry in paired.items():
         if not isinstance(entry, dict):
+            logger.debug(
+                "Skipping non-dict paired entry for field %s: %s", field, entry
+            )
             continue
         if "raw" not in entry:
+            logger.debug("Paired entry for field %s lacks raw value", field)
             # nothing to emit
             continue
 
@@ -75,6 +81,7 @@ def run(obj: Optional[object], ctx: Any) -> None:
                 "meta": entry.get("meta") or {},
             }
         )
+        logger.debug("Queued deferred alias '%s' for field '%s'", alias, field)
 
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/schema/collect_in.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/schema/collect_in.py
@@ -55,10 +55,12 @@ def run(obj: Optional[object], ctx: Any) -> None:
     logger.debug("Running schema:collect_in")
     specs: Mapping[str, Any] = getattr(ctx, "specs", {}) or {}
     if not specs:
+        logger.debug("No specs provided; skipping schema collection")
         return
 
     temp = _ensure_temp(ctx)
     if "schema_in" in temp:
+        logger.debug("schema_in already populated; skipping")
         return
     op = (getattr(ctx, "op", None) or "").lower() or None
 
@@ -83,6 +85,7 @@ def run(obj: Optional[object], ctx: Any) -> None:
             if not getattr(io, "in_verbs", ()):  # implicit: no inbound verbs specified
                 in_enabled = False
         if not in_enabled:
+            logger.debug("Field %s excluded from inbound schema", field)
             # Not accepted on input — skip entirely for inbound schema
             continue
 
@@ -117,6 +120,13 @@ def run(obj: Optional[object], ctx: Any) -> None:
         entries.append(entry)
         by_field[field] = entry
         (req if entry["required"] else opt).append(field)
+        logger.debug(
+            "Collected field %s (required=%s, virtual=%s, alias=%s)",
+            field,
+            entry["required"],
+            entry["virtual"],
+            alias_in,
+        )
 
     schema_in = {
         "fields": entries,
@@ -126,6 +136,7 @@ def run(obj: Optional[object], ctx: Any) -> None:
         "order": tuple(e["name"] for e in entries),
     }
     temp["schema_in"] = schema_in
+    logger.debug("schema_in populated with %d fields", len(entries))
 
 
 # ──────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add detailed branch logging in emit aliases
- expand debug coverage for resolve and storage atoms
- log payload handling across wire layer

## Testing
- `uv run --package autoapi --directory . ruff format autoapi/v3/runtime/atoms`
- `uv run --package autoapi --directory . ruff check autoapi/v3/runtime/atoms --fix`


------
https://chatgpt.com/codex/tasks/task_e_68bcd34d20e48326a99bc385908b0434