### PR TITLE
feat: add debug logging for autoapi schema and handlers

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/handlers/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/handlers/__init__.py
@@ -4,6 +4,7 @@ import logging
 
 from .builder import build_and_attach
 
+logging.getLogger("uvicorn").setLevel(logging.DEBUG)
 logger = logging.getLogger("uvicorn")
 logger.debug("Loaded module v3/bindings/handlers/__init__")
 

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/handlers/ctx.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/handlers/ctx.py
@@ -4,37 +4,51 @@ import logging
 
 from typing import Any, Mapping, Sequence
 
+logging.getLogger("uvicorn").setLevel(logging.DEBUG)
 logger = logging.getLogger("uvicorn")
 logger.debug("Loaded module v3/bindings/handlers/ctx")
 
 
 def _ctx_get(ctx: Mapping[str, Any], key: str, default: Any = None) -> Any:
+    logger.debug("_ctx_get retrieving key '%s'", key)
     try:
-        return ctx[key]
+        value = ctx[key]
+        logger.debug("Key '%s' found via mapping access", key)
+        return value
     except Exception:
+        logger.debug("Key '%s' not found; using getattr fallback", key)
         return getattr(ctx, key, default)
 
 
 def _ctx_payload(ctx: Mapping[str, Any]) -> Any:
     v = _ctx_get(ctx, "payload", None)
     if isinstance(v, Mapping):
+        logger.debug("Payload is a mapping")
         return v
     if isinstance(v, Sequence) and not isinstance(v, (str, bytes)):
+        logger.debug("Payload is a non-string sequence")
         return v
+    logger.debug("Payload absent or unsupported; defaulting to empty dict")
     return {}
 
 
 def _ctx_db(ctx: Mapping[str, Any]) -> Any:
+    logger.debug("Retrieving 'db' from context")
     return _ctx_get(ctx, "db")
 
 
 def _ctx_request(ctx: Mapping[str, Any]) -> Any:
+    logger.debug("Retrieving 'request' from context")
     return _ctx_get(ctx, "request")
 
 
 def _ctx_path_params(ctx: Mapping[str, Any]) -> Mapping[str, Any]:
     v = _ctx_get(ctx, "path_params", None)
-    return v if isinstance(v, Mapping) else {}
+    if isinstance(v, Mapping):
+        logger.debug("Path params found: %s", list(v.keys()))
+        return v
+    logger.debug("No path params found; returning empty mapping")
+    return {}
 
 
 __all__ = [

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/handlers/identifiers.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/handlers/identifiers.py
@@ -7,6 +7,7 @@ from typing import Any, Mapping, Optional
 
 from .ctx import _ctx_payload, _ctx_path_params
 
+logging.getLogger("uvicorn").setLevel(logging.DEBUG)
 logger = logging.getLogger("uvicorn")
 logger.debug("Loaded module v3/bindings/handlers/identifiers")
 
@@ -22,17 +23,20 @@ except Exception:  # pragma: no cover
 
 def _pk_name(model: type) -> str:
     """Best-effort primary-key column name."""
+    logger.debug("Resolving PK name for %s", model.__name__)
     if _sa_inspect is not None:
         try:
             mapper = _sa_inspect(model)
             pk_cols = list(getattr(mapper, "primary_key", []) or [])
+            logger.debug("SQLAlchemy mapper found %d PK cols", len(pk_cols))
             if len(pk_cols) == 1:
                 col = pk_cols[0]
                 name = getattr(col, "key", None) or getattr(col, "name", None)
+                logger.debug("PK name via mapper: %s", name)
                 if isinstance(name, str) and name:
                     return name
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug("SQLAlchemy inspection failed: %s", exc)
 
     table = getattr(model, "__table__", None)
     if table is not None:
@@ -40,27 +44,33 @@ def _pk_name(model: type) -> str:
             pk = getattr(table, "primary_key", None)
             cols_iter = getattr(pk, "columns", None)
             cols = [c for c in cols_iter] if cols_iter is not None else []
+            logger.debug("Table inspection found %d PK cols", len(cols))
             if len(cols) == 1:
                 col = cols[0]
                 name = getattr(col, "key", None) or getattr(col, "name", None)
+                logger.debug("PK name via table: %s", name)
                 if isinstance(name, str) and name:
                     return name
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug("Table inspection failed: %s", exc)
 
+    logger.debug("Falling back to default PK name 'id'")
     return "id"
 
 
 def _pk_type_info(model: type) -> tuple[Optional[type], Optional[Any]]:
     """Return (python_type, sqlatype_instance) for the PK column if discoverable."""
+    logger.debug("Resolving PK type info for %s", model.__name__)
     col = None
     if _sa_inspect is not None:
         try:
             mapper = _sa_inspect(model)
             pk_cols = list(getattr(mapper, "primary_key", []) or [])
+            logger.debug("Mapper returned %d PK cols", len(pk_cols))
             if len(pk_cols) == 1:
                 col = pk_cols[0]
-        except Exception:
+        except Exception as exc:
+            logger.debug("Mapper inspection failed: %s", exc)
             col = None
 
     if col is None:
@@ -70,49 +80,61 @@ def _pk_type_info(model: type) -> tuple[Optional[type], Optional[Any]]:
                 pk = getattr(table, "primary_key", None)
                 cols_iter = getattr(pk, "columns", None)
                 cols = [c for c in cols_iter] if cols_iter is not None else []
+                logger.debug("Table inspection yielded %d PK cols", len(cols))
                 if len(cols) == 1:
                     col = cols[0]
-            except Exception:
+            except Exception as exc:
+                logger.debug("Table inspection failed: %s", exc)
                 col = None
 
     if col is None:
+        logger.debug("PK column not found; returning (None, None)")
         return (None, None)
 
     try:
         coltype = getattr(col, "type", None)
-    except Exception:
+    except Exception as exc:
+        logger.debug("Failed to get column type: %s", exc)
         coltype = None
 
     py_t = None
     try:
         py_t = getattr(coltype, "python_type", None)
-    except Exception:
+    except Exception as exc:
+        logger.debug("Failed to get python_type: %s", exc)
         py_t = None
 
+    logger.debug("Resolved PK type info py_t=%s sa_type=%s", py_t, coltype)
     return (py_t, coltype)
 
 
 def _looks_like_uuid_string(s: str) -> bool:
     if not isinstance(s, str):
+        logger.debug("Value %r is not a string; cannot be UUID", s)
         return False
     try:
         uuid.UUID(s)
+        logger.debug("Value %s looks like a UUID string", s)
         return True
     except Exception:
+        logger.debug("Value %s is not a valid UUID string", s)
         return False
 
 
 def _is_uuid_type(py_t: Optional[type], sa_type: Optional[Any]) -> bool:
     if py_t is uuid.UUID:
+        logger.debug("PK python type is UUID")
         return True
     try:
         if getattr(sa_type, "as_uuid", False):
+            logger.debug("SQLAlchemy type %r uses as_uuid", sa_type)
             return True
     except Exception:
         pass
     try:
         tname = type(sa_type).__name__.lower() if sa_type is not None else ""
         if "uuid" in tname:
+            logger.debug("SQLAlchemy type name contains 'uuid': %s", tname)
             return True
     except Exception:
         pass
@@ -121,9 +143,12 @@ def _is_uuid_type(py_t: Optional[type], sa_type: Optional[Any]) -> bool:
 
 def _coerce_ident_to_pk_type(model: type, value: Any) -> Any:
     py_t, sa_t = _pk_type_info(model)
+    logger.debug("Coercing identifier %r to PK type %s", value, py_t)
     if SAClause is not None and isinstance(value, SAClause):  # pragma: no cover
+        logger.debug("Value is SAClause; returning as-is")
         return value
     if _is_uuid_type(py_t, sa_t):
+        logger.debug("PK type identified as UUID")
         if isinstance(value, uuid.UUID):
             return value
         if isinstance(value, str):
@@ -134,13 +159,15 @@ def _coerce_ident_to_pk_type(model: type, value: Any) -> Any:
             return uuid.UUID(str(value))
         return value
     if py_t is int:
+        logger.debug("PK type identified as int")
         if isinstance(value, int):
             return value
         if isinstance(value, str):
             return int(value)
         try:
             return int(value)  # type: ignore[arg-type]
-        except Exception:
+        except Exception as exc:
+            logger.debug("Failed int coercion: %s", exc)
             return value
     return value
 
@@ -153,6 +180,7 @@ def _resolve_ident(model: type, ctx: Mapping[str, Any]) -> Any:
     payload = _ctx_payload(ctx)
     path = _ctx_path_params(ctx)
     pk = _pk_name(model)
+    logger.debug("Resolving identifier for %s using pk %s", model.__name__, pk)
 
     candidates_keys = [
         (path, pk),
@@ -176,15 +204,19 @@ def _resolve_ident(model: type, ctx: Mapping[str, Any]) -> Any:
             v = source.get(key)  # type: ignore[call-arg]
         except Exception:
             v = None
+        logger.debug("Checking candidate key '%s' → %r", key, v)
         if v is None:
             continue
         if _is_clause(v):
+            logger.debug("Value for key '%s' is a clause; skipping", key)
             continue
         try:
             return _coerce_ident_to_pk_type(model, v)
         except Exception:
+            logger.debug("Invalid identifier %r for pk %s", v, pk)
             raise TypeError(f"Invalid identifier for '{pk}': {v!r}")
 
+    logger.debug("Identifier for pk %s not found", pk)
     raise TypeError(f"Missing identifier '{pk}' in path or payload")
 
 

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/handlers/namespaces.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/handlers/namespaces.py
@@ -4,6 +4,7 @@ import logging
 
 from types import SimpleNamespace
 
+logging.getLogger("uvicorn").setLevel(logging.DEBUG)
 logger = logging.getLogger("uvicorn")
 logger.debug("Loaded module v3/bindings/handlers/namespaces")
 
@@ -11,15 +12,18 @@ logger.debug("Loaded module v3/bindings/handlers/namespaces")
 def _ensure_alias_hooks_ns(model: type, alias: str) -> SimpleNamespace:
     hooks_root = getattr(model, "hooks", None)
     if hooks_root is None:
+        logger.debug("Creating hooks namespace for %s", model.__name__)
         hooks_root = SimpleNamespace()
         setattr(model, "hooks", hooks_root)
 
     ns = getattr(hooks_root, alias, None)
     if ns is None:
+        logger.debug("Creating hooks alias namespace '%s'", alias)
         ns = SimpleNamespace()
         setattr(hooks_root, alias, ns)
 
     if not hasattr(ns, "HANDLER"):
+        logger.debug("Initializing HANDLER list for hooks '%s'", alias)
         setattr(ns, "HANDLER", [])
     return ns
 
@@ -27,16 +31,19 @@ def _ensure_alias_hooks_ns(model: type, alias: str) -> SimpleNamespace:
 def _ensure_alias_handlers_ns(model: type, alias: str) -> SimpleNamespace:
     handlers_root = getattr(model, "handlers", None)
     if handlers_root is None:
+        logger.debug("Creating handlers namespace for %s", model.__name__)
         handlers_root = SimpleNamespace()
         setattr(model, "handlers", handlers_root)
 
     ns = getattr(handlers_root, alias, None)
     if ns is None:
+        logger.debug("Creating handlers alias namespace '%s'", alias)
         ns = SimpleNamespace()
         setattr(handlers_root, alias, ns)
 
     hooks_ns = _ensure_alias_hooks_ns(model, alias)
     if not hasattr(ns, "HANDLER"):
+        logger.debug("Linking HANDLER list from hooks namespace for '%s'", alias)
         setattr(ns, "HANDLER", getattr(hooks_ns, "HANDLER"))
     return ns
 

--- a/pkgs/standards/autoapi/autoapi/v3/schema/decorators.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/decorators.py
@@ -1,10 +1,14 @@
 # autoapi/v3/schema/decorators.py
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import Dict, Optional
 
 from ..config.constants import AUTOAPI_SCHEMA_DECLS_ATTR
+
+logging.getLogger("uvicorn").setLevel(logging.DEBUG)
+logger = logging.getLogger("uvicorn")
 
 
 @dataclass(frozen=True)
@@ -17,7 +21,14 @@ def _register_schema_decl(
     target_model: type, alias: str, kind: str, schema_cls: type
 ) -> None:
     """Store schema declarations on the model for later binding."""
+    logger.debug(
+        "Registering schema decl for %s alias=%s kind=%s",
+        target_model.__name__,
+        alias,
+        kind,
+    )
     if kind not in ("in", "out"):
+        logger.debug("Invalid kind '%s' for schema decl", kind)
         raise ValueError("schema_ctx(kind=...) must be 'in' or 'out'")
     mapping: Dict[str, Dict[str, type]] = (
         getattr(target_model, AUTOAPI_SCHEMA_DECLS_ATTR, None) or {}
@@ -26,6 +37,7 @@ def _register_schema_decl(
     bucket[kind] = schema_cls
     mapping[alias] = bucket
     setattr(target_model, AUTOAPI_SCHEMA_DECLS_ATTR, mapping)
+    logger.debug("Registered schema %s for alias '%s'", schema_cls, alias)
 
 
 def schema_ctx(*, alias: str, kind: str = "out", for_: Optional[type] = None):
@@ -33,11 +45,20 @@ def schema_ctx(*, alias: str, kind: str = "out", for_: Optional[type] = None):
 
     def deco(schema_cls: type):
         if not isinstance(schema_cls, type):
+            logger.debug("schema_ctx applied to non-class %r", schema_cls)
             raise TypeError("@schema_ctx must decorate a class")
         if for_ is not None:
+            logger.debug(
+                "Registering schema %s for model %s via decorator",
+                schema_cls,
+                for_.__name__,
+            )
             _register_schema_decl(for_, alias, kind, schema_cls)
         setattr(
             schema_cls, "__autoapi_schema_decl__", _SchemaDecl(alias=alias, kind=kind)
+        )
+        logger.debug(
+            "Attached schema decl to %s: alias=%s kind=%s", schema_cls, alias, kind
         )
         return schema_cls
 

--- a/pkgs/standards/autoapi/autoapi/v3/schema/get_schema.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/get_schema.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import logging
 from typing import Literal, Optional, Type
 
 from pydantic import BaseModel
+
+logging.getLogger("uvicorn").setLevel(logging.DEBUG)
+logger = logging.getLogger("uvicorn")
 
 
 def get_schema(
@@ -35,24 +39,38 @@ def get_schema(
     """
     ns = getattr(orm_cls, "schemas", None)
     if ns is None:
+        logger.debug("Model %s has no schemas namespace", orm_cls.__name__)
         raise KeyError(
             f"{orm_cls.__name__} has no bound schemas; did you include the model?",
         )
 
     alias_ns = getattr(ns, op, None)
     if alias_ns is None:
+        logger.debug("Unknown operation '%s' for model %s", op, orm_cls.__name__)
         raise KeyError(f"Unknown op '{op}' for {orm_cls.__name__}")
 
     kind = kind.lower()
     if kind not in {"in", "out"}:
+        logger.debug("Invalid schema kind '%s' requested", kind)
         raise ValueError("kind must be 'in' or 'out'")
 
     attr = "in_" if kind == "in" else "out"
     if not hasattr(alias_ns, attr):
+        logger.debug(
+            "Schema kind '%s' not found for op '%s' on %s", kind, op, orm_cls.__name__
+        )
         raise KeyError(
             f"Schema kind '{kind}' not found for op '{op}' on {orm_cls.__name__}",
         )
-    return getattr(alias_ns, attr)
+    schema = getattr(alias_ns, attr)
+    logger.debug(
+        "Resolved schema %s for model %s op=%s kind=%s",
+        schema,
+        orm_cls.__name__,
+        op,
+        kind,
+    )
+    return schema
 
 
 __all__ = ["get_schema"]


### PR DESCRIPTION
## Summary
- add uvicorn debug logger initialization across autoapi schema and handler modules
- trace branch decisions in handler attachment, context utilities, identifier resolution, and schema factories

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff format .`
- `uv run --directory standards/autoapi --package autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest` *(failed: KeyboardInterrupt after partial run)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd3cc5a348326adb02c4ba6b15ced