### PR TITLE
Add debug logging across autoapi v3 bindings

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest/attach.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest/attach.py
@@ -7,6 +7,7 @@ from typing import Optional, Sequence
 from .common import OpSpec, _Key
 from .router import _build_router
 
+logging.getLogger("uvicorn").setLevel(logging.DEBUG)
 logger = logging.getLogger("uvicorn")
 logger.debug("Loaded module v3/bindings/rest/attach")
 
@@ -19,6 +20,12 @@ def build_router_and_attach(
     For simplicity and correctness with FastAPI, we **rebuild the entire router**
     on each call (FastAPI does not support removing individual routes cleanly).
     """
+    logger.debug(
+        "build_router_and_attach model=%s specs=%d only_keys=%s",
+        model.__name__,
+        len(specs),
+        only_keys,
+    )
     router = _build_router(model, specs)
     rest_ns = getattr(model, "rest", None) or SimpleNamespace()
     rest_ns.router = router

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest/collection.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest/collection.py
@@ -24,6 +24,7 @@ from .common import (
 )
 
 
+logging.getLogger("uvicorn").setLevel(logging.DEBUG)
 logger = logging.getLogger("uvicorn")
 logger.debug("Loaded module v3/bindings/rest/collection")
 
@@ -39,9 +40,16 @@ def _make_collection_endpoint(
     alias = sp.alias
     target = sp.target
     nested_vars = list(nested_vars or [])
+    logger.debug(
+        "_make_collection_endpoint alias=%s target=%s nested=%s",
+        alias,
+        target,
+        nested_vars,
+    )
 
     # --- No body on GET list / DELETE clear ---
     if target in {"list", "clear"}:
+        logger.debug("building %s endpoint without body", target)
         if target == "list":
             list_dep = _make_list_query_dep(model, alias)
 
@@ -106,6 +114,7 @@ def _make_collection_endpoint(
             )
             _endpoint.__signature__ = inspect.Signature(params)
         else:
+            logger.debug("building clear endpoint")
 
             async def _endpoint(
                 request: Request,
@@ -170,6 +179,7 @@ def _make_collection_endpoint(
 
     # --- Body-based collection endpoints: create / bulk_* ---
 
+    logger.debug("building body-based endpoint for target %s", target)
     body_model = _request_model_for(sp, model)
     base_annotation = body_model if body_model is not None else Mapping[str, Any]
 

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest/common.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest/common.py
@@ -63,6 +63,7 @@ from ...rest import _nested_prefix
 from ...runtime import executor as _executor
 from ...schema.builder import _strip_parent_fields
 
+logging.getLogger("uvicorn").setLevel(logging.DEBUG)
 logger = logging.getLogger("uvicorn")
 logger.debug("Loaded module v3/bindings/rest/common")
 

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest/fastapi.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest/fastapi.py
@@ -4,6 +4,7 @@ import logging
 from types import SimpleNamespace
 from typing import Callable, Sequence
 
+logging.getLogger("uvicorn").setLevel(logging.DEBUG)
 logger = logging.getLogger("uvicorn")
 logger.debug("Loaded module v3/bindings/rest/fastapi")
 

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest/helpers.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest/helpers.py
@@ -12,6 +12,7 @@ try:
 except Exception:  # pragma: no cover
     _kernel_build_phase_chains = None  # type: ignore
 
+logging.getLogger("uvicorn").setLevel(logging.DEBUG)
 logger = logging.getLogger("uvicorn")
 logger.debug("Loaded module v3/bindings/rest/helpers")
 
@@ -20,25 +21,32 @@ _Key = Tuple[str, str]  # (alias, target)
 
 def _ensure_jsonable(obj: Any) -> Any:
     """Best-effort conversion of DB rows, row-mappings, or ORM objects to dicts."""
+    logger.debug("_ensure_jsonable type=%s", type(obj))
     if isinstance(obj, (list, tuple)):
+        logger.debug("converting sequence of length %d", len(obj))
         return [_ensure_jsonable(x) for x in obj]
 
     if isinstance(obj, Mapping):
         try:
+            logger.debug("converting mapping with %d keys", len(obj))
             return {k: _ensure_jsonable(v) for k, v in dict(obj).items()}
-        except Exception:  # pragma: no cover - fall back to original object
+        except Exception:
+            logger.debug("mapping conversion failed", exc_info=True)
             pass
 
     try:
         data = vars(obj)
     except TypeError:
+        logger.debug("object not introspectable; returning as-is")
         return obj
 
     return {k: _ensure_jsonable(v) for k, v in data.items() if not k.startswith("_")}
 
 
 def _req_state_db(request: Request) -> Any:
-    return getattr(request.state, "db", None)
+    db = getattr(request.state, "db", None)
+    logger.debug("_req_state_db -> %s", db)
+    return db
 
 
 def _resource_name(model: type) -> str:
@@ -49,7 +57,9 @@ def _resource_name(model: type) -> str:
     override or fall back to the model class name in lowercase.
     """
     override = getattr(model, "__resource__", None)
-    return override or model.__name__.lower()
+    result = override or model.__name__.lower()
+    logger.debug("_resource_name %s -> %s", model, result)
+    return result
 
 
 def _pk_name(model: type) -> str:
@@ -59,17 +69,23 @@ def _pk_name(model: type) -> str:
     """
     table = getattr(model, "__table__", None)
     if table is None:
+        logger.debug("_pk_name no table for %s", model)
         return "id"
     pk = getattr(table, "primary_key", None)
     if pk is None:
+        logger.debug("_pk_name no pk for %s", model)
         return "id"
     try:
         cols = list(pk.columns)
     except Exception:
+        logger.debug("_pk_name pk introspection failed for %s", model)
         return "id"
     if len(cols) != 1:
+        logger.debug("_pk_name composite pk for %s", model)
         return "id"
-    return getattr(cols[0], "name", "id")
+    name = getattr(cols[0], "name", "id")
+    logger.debug("_pk_name %s -> %s", model, name)
+    return name
 
 
 def _pk_names(model: type) -> set[str]:
@@ -78,11 +94,15 @@ def _pk_names(model: type) -> set[str]:
     try:
         cols = getattr(getattr(table, "primary_key", None), "columns", None)
         if cols is None:
+            logger.debug("_pk_names no cols for %s", model)
             return {"id"}
         out = {getattr(c, "name", None) for c in cols}
         out.discard(None)
-        return out or {"id"}
+        result = out or {"id"}
+        logger.debug("_pk_names %s -> %s", model, result)
+        return result
     except Exception:
+        logger.debug("_pk_names failed for %s", model, exc_info=True)
         return {"id"}
 
 
@@ -95,6 +115,7 @@ def _get_phase_chains(
     """
     if _kernel_build_phase_chains is not None:
         try:
+            logger.debug("building phase chains via kernel for %s.%s", model, alias)
             return _kernel_build_phase_chains(model, alias)
         except Exception:
             logger.exception(
@@ -107,6 +128,7 @@ def _get_phase_chains(
     out: Dict[str, Sequence[Callable[..., Awaitable[Any]]]] = {}
     for ph in PHASES:
         out[ph] = list(getattr(alias_ns, ph, []) or [])
+    logger.debug("phase chains for %s.%s -> %s", model, alias, out)
     return out
 
 
@@ -115,5 +137,6 @@ def _coerce_parent_kw(model: type, parent_kw: Dict[str, Any]) -> None:
         col = getattr(model, name, None)
         try:
             parent_kw[name] = col.type.python_type(val)  # type: ignore[attr-defined]
+            logger.debug("coerced parent kw %s=%s", name, parent_kw[name])
         except Exception:
-            pass
+            logger.debug("failed coercing parent kw %s", name, exc_info=True)

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest/io.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest/io.py
@@ -13,6 +13,7 @@ from .fastapi import HTTPException, Query, Request, _status
 from .helpers import _ensure_jsonable
 from ...op import OpSpec
 
+logging.getLogger("uvicorn").setLevel(logging.DEBUG)
 logger = logging.getLogger("uvicorn")
 logger.debug("Loaded module v3/bindings/rest/io")
 
@@ -26,9 +27,13 @@ def _serialize_output(
     can JSON-encode the response.
     """
 
+    logger.debug(
+        "_serialize_output model=%s alias=%s target=%s", model.__name__, alias, target
+    )
     from ...types import Response as _Response  # local import to avoid cycles
 
     if isinstance(result, _Response):
+        logger.debug("result is already a Response")
         return result
 
     def _final(val: Any) -> Any:
@@ -38,9 +43,11 @@ def _serialize_output(
 
     schemas_root = getattr(model, "schemas", None)
     if not schemas_root:
+        logger.debug("no schemas root for %s", model.__name__)
         return _final(result)
     alias_ns = getattr(schemas_root, alias, None)
     if not alias_ns:
+        logger.debug("no alias namespace %s", alias)
         return _final(result)
     out_model = getattr(alias_ns, "out", None)
     if (
@@ -48,13 +55,16 @@ def _serialize_output(
         or not inspect.isclass(out_model)
         or not issubclass(out_model, BaseModel)
     ):
+        logger.debug("no valid out_model for %s.%s", model.__name__, alias)
         return _final(result)
     try:
         if target == "list" and isinstance(result, (list, tuple)):
+            logger.debug("serializing list output of length %d", len(result))
             return [
                 out_model.model_validate(x).model_dump(exclude_none=True, by_alias=True)
                 for x in result
             ]
+        logger.debug("serializing single output")
         return out_model.model_validate(result).model_dump(
             exclude_none=True, by_alias=True
         )
@@ -72,12 +82,20 @@ def _validate_body(
     model: type, alias: str, target: str, body: Any | None
 ) -> Mapping[str, Any] | Sequence[Mapping[str, Any]]:
     """Normalize and validate the incoming request body."""
+    logger.debug(
+        "_validate_body alias=%s target=%s body_type=%s",
+        alias,
+        target,
+        type(body),
+    )
     if isinstance(body, BaseModel):
+        logger.debug("body is BaseModel")
         return body.model_dump(exclude_none=True)
 
     if target in {"bulk_create", "bulk_update", "bulk_replace", "bulk_merge"}:
         items: Sequence[Any] = body or []
         if not isinstance(items, Sequence) or isinstance(items, (str, bytes)):
+            logger.debug("bulk body not sequence; defaulting to empty list")
             items = []
 
         schemas_root = getattr(model, "schemas", None)
@@ -88,6 +106,7 @@ def _validate_body(
         for item in items:
             if isinstance(item, BaseModel):
                 out.append(item.model_dump(exclude_none=True))
+                logger.debug("validated bulk item via model")
                 continue
             data: Mapping[str, Any] | None = None
             if in_item and inspect.isclass(in_item) and issubclass(in_item, BaseModel):
@@ -103,6 +122,7 @@ def _validate_body(
                     )
             if data is None:
                 data = dict(item) if isinstance(item, Mapping) else {}
+                logger.debug("bulk item fell back to mapping: %s", data)
             out.append(data)
         return out
 
@@ -111,6 +131,7 @@ def _validate_body(
         and isinstance(body, Sequence)
         and not isinstance(body, (str, bytes, Mapping))
     ):
+        logger.debug("treating sequence body as %s", f"bulk_{target}")
         bulk_target = f"bulk_{target}"
         items: Sequence[Any] = body
         schemas_root = getattr(model, "schemas", None)
@@ -121,6 +142,7 @@ def _validate_body(
         for item in items:
             if isinstance(item, BaseModel):
                 out.append(item.model_dump(exclude_none=True))
+                logger.debug("validated %s item via model", bulk_target)
                 continue
             data: Mapping[str, Any] | None = None
             if in_item and inspect.isclass(in_item) and issubclass(in_item, BaseModel):
@@ -136,24 +158,29 @@ def _validate_body(
                     )
             if data is None:
                 data = dict(item) if isinstance(item, Mapping) else {}
+                logger.debug("%s item fell back to mapping", bulk_target)
             out.append(data)
         return out
 
     body = body or {}
     if not isinstance(body, Mapping):
+        logger.debug("body not mapping; defaulting to empty dict")
         body = {}
 
     schemas_root = getattr(model, "schemas", None)
     if not schemas_root:
+        logger.debug("no schemas root for %s", model.__name__)
         return dict(body)
     alias_ns = getattr(schemas_root, alias, None)
     if not alias_ns:
+        logger.debug("no alias namespace %s", alias)
         return dict(body)
     in_model = getattr(alias_ns, "in_", None)
 
     if in_model and inspect.isclass(in_model) and issubclass(in_model, BaseModel):
         try:
             inst = in_model.model_validate(body)  # type: ignore[arg-type]
+            logger.debug("validated body with in_model")
             return inst.model_dump(exclude_none=True)
         except Exception as e:
             logger.debug(
@@ -173,14 +200,20 @@ def _validate_query(
     model: type, alias: str, target: str, query: Mapping[str, Any]
 ) -> Mapping[str, Any]:
     """Validate list/clear inputs coming from the query string."""
+    logger.debug(
+        "_validate_query alias=%s target=%s keys=%s", alias, target, list(query.keys())
+    )
     if not query or (isinstance(query, Mapping) and len(query) == 0):
+        logger.debug("empty query")
         return {}
 
     schemas_root = getattr(model, "schemas", None)
     if not schemas_root:
+        logger.debug("no schemas root for %s", model.__name__)
         return dict(query)
     alias_ns = getattr(schemas_root, alias, None)
     if not alias_ns:
+        logger.debug("no alias namespace %s", alias)
         return dict(query)
     in_model = getattr(alias_ns, "in_", None)
 
@@ -205,11 +238,14 @@ def _validate_query(
                 data[name] = val
 
             if not data:
+                logger.debug("no matching query params")
                 return {}
 
             inst = in_model.model_validate(data)  # type: ignore[arg-type]
+            logger.debug("validated query via in_model")
             return inst.model_dump(exclude_none=True)
         except Exception as e:
+            logger.debug("query validation failed", exc_info=True)
             raise HTTPException(
                 status_code=_status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)
             )
@@ -221,6 +257,7 @@ def _strip_optional(t: Any) -> Any:
     origin = _get_origin(t)
     if origin is _typing.Union:
         args = tuple(a for a in _get_args(t) if a is not type(None))
+        logger.debug("_strip_optional %s -> %s", t, args)
         return args[0] if len(args) == 1 else Any
     return t
 
@@ -233,6 +270,7 @@ def _make_list_query_dep(model: type, alias: str):
     in_model = getattr(alias_ns, "in_", None)
 
     if not (in_model and inspect.isclass(in_model) and issubclass(in_model, BaseModel)):
+        logger.debug("building simple list query dep for %s.%s", model.__name__, alias)
 
         def _dep(request: Request) -> Dict[str, Any]:
             return dict(request.query_params)
@@ -244,6 +282,7 @@ def _make_list_query_dep(model: type, alias: str):
 
     def _dep(**raw: Any) -> Dict[str, Any]:
         """Collect only user-supplied values; never apply schema defaults here."""
+        logger.debug("list query dep raw keys=%s", list(raw.keys()))
         data: Dict[str, Any] = {}
         for name, f in fields.items():
             key = getattr(f, "alias", None) or name
@@ -257,6 +296,7 @@ def _make_list_query_dep(model: type, alias: str):
             if isinstance(val, (list, tuple, set)) and len(val) == 0:
                 continue
             data[key] = val
+        logger.debug("list query dep result=%s", data)
         return data
 
     params: list[inspect.Parameter] = []
@@ -292,6 +332,9 @@ def _optionalize_list_in_model(in_model: type[BaseModel]) -> type[BaseModel]:
     try:
         fields = getattr(in_model, "model_fields", {})
     except Exception:
+        logger.debug(
+            "_optionalize_list_in_model failed to inspect fields", exc_info=True
+        )
         return in_model
 
     defs: Dict[str, tuple[Any, Any]] = {}
@@ -312,4 +355,5 @@ def _optionalize_list_in_model(in_model: type[BaseModel]) -> type[BaseModel]:
         **defs,
     )
     setattr(New, "__autoapi_optionalized__", True)
+    logger.debug("_optionalize_list_in_model created %s", New)
     return New

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest/member.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest/member.py
@@ -34,6 +34,7 @@ from .common import (
 )
 
 
+logging.getLogger("uvicorn").setLevel(logging.DEBUG)
 logger = logging.getLogger("uvicorn")
 logger.debug("Loaded module v3/bindings/rest/member")
 
@@ -52,6 +53,9 @@ def _make_member_endpoint(
     real_pk = _pk_name(model)
     pk_names = _pk_names(model)
     nested_vars = list(nested_vars or [])
+    logger.debug(
+        "_make_member_endpoint alias=%s target=%s nested=%s", alias, target, nested_vars
+    )
 
     # --- No body on GET read / DELETE delete ---
     if target in {"read", "delete"}:
@@ -129,6 +133,7 @@ def _make_member_endpoint(
 
     body_model = _request_model_for(sp, model)
     if body_model is None and sp.request_model is None and target == "custom":
+        logger.debug("building custom member endpoint without body")
 
         async def _endpoint(
             item_id: Any,

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/schemas/defaults.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/schemas/defaults.py
@@ -19,6 +19,7 @@ from ...schema import (
 )
 from .utils import _pk_info
 
+logging.getLogger("uvicorn").setLevel(logging.DEBUG)
 logger = logging.getLogger("uvicorn")
 logger.debug("Loaded module v3/bindings/schemas/defaults")
 
@@ -34,6 +35,9 @@ def _default_schemas_for_spec(
       • Custom target     → no defaults (raw) unless explicitly overridden.
     """
     target = sp.target
+    logger.debug(
+        "computing default schemas: model=%s target=%s", model.__name__, target
+    )
     result: Dict[str, Optional[Type[BaseModel]]] = {
         "in_": None,
         "out": None,
@@ -46,46 +50,55 @@ def _default_schemas_for_spec(
 
     # Canonical targets
     if target == "create":
+        logger.debug("target create")
         item_in = _build_schema(model, verb="create")
         result["in_"] = item_in
         result["out"] = read_schema
 
     elif target == "read":
+        logger.debug("target read")
         pk_name, pk_type = _pk_info(model)
         result["in_"] = _make_pk_model(model, "read", pk_name, pk_type)
         result["out"] = read_schema
 
     elif target == "update":
+        logger.debug("target update")
         pk_name, _ = _pk_info(model)
         result["in_"] = _build_schema(model, verb="update", exclude={pk_name})
         result["out"] = read_schema
 
     elif target == "replace":
+        logger.debug("target replace")
         pk_name, _ = _pk_info(model)
         result["in_"] = _build_schema(model, verb="replace", exclude={pk_name})
         result["out"] = read_schema
 
     elif target == "merge":
+        logger.debug("target merge")
         pk_name, _ = _pk_info(model)
         result["in_"] = _build_schema(model, verb="update", exclude={pk_name})
         result["out"] = read_schema
 
     elif target == "delete":
+        logger.debug("target delete")
         # For RPC delete, a body with PK is allowed; REST delete ignores body.
         result["in_"] = _build_schema(model, verb="delete")
         result["out"] = read_schema
 
     elif target == "list":
+        logger.debug("target list")
         params = _build_list_params(model)
         result["in_"] = params
         result["out"] = read_schema
 
     elif target == "clear":
+        logger.debug("target clear")
         params = _build_list_params(model)
         result["in_"] = params
         result["out"] = _make_deleted_response_model(model, "clear")
 
     elif target == "bulk_create":
+        logger.debug("target bulk_create")
         item_in = _build_schema(
             model,
             verb="create",
@@ -101,6 +114,7 @@ def _default_schemas_for_spec(
         result["out_item"] = read_schema
 
     elif target == "bulk_update":
+        logger.debug("target bulk_update")
         item_in = _build_schema(
             model,
             verb="update",
@@ -116,6 +130,7 @@ def _default_schemas_for_spec(
         result["out_item"] = read_schema
 
     elif target == "bulk_replace":
+        logger.debug("target bulk_replace")
         item_in = _build_schema(
             model,
             verb="replace",
@@ -131,6 +146,7 @@ def _default_schemas_for_spec(
         result["out_item"] = read_schema
 
     elif target == "bulk_merge":
+        logger.debug("target bulk_merge")
         item_in = _build_schema(
             model,
             verb="update",
@@ -146,11 +162,13 @@ def _default_schemas_for_spec(
         result["out_item"] = read_schema
 
     elif target == "bulk_delete":
+        logger.debug("target bulk_delete")
         pk_name, pk_type = _pk_info(model)
         result["in_"] = _make_bulk_ids_model(model, "bulk_delete", pk_type)
         result["out"] = _make_deleted_response_model(model, "bulk_delete")
 
     elif target == "custom":
+        logger.debug("target custom")
         # Build schemas for custom operations based on verb-specific IO specs
         alias = sp.alias
         specs = getattr(model, "__autoapi_cols__", {})
@@ -172,8 +190,10 @@ def _default_schemas_for_spec(
         )
 
     else:
+        logger.debug("target %s not recognized; using raw", target)
         # Defensive default: treat unknown like custom (raw)
         result["in_"] = None
         result["out"] = None
 
+    logger.debug("default schemas result for %s.%s: %s", model.__name__, target, result)
     return result

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/schemas/utils.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/schemas/utils.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, create_model
 from ...schema.types import SchemaArg, SchemaRef
 from ...schema import namely_model
 
+logging.getLogger("uvicorn").setLevel(logging.DEBUG)
 logger = logging.getLogger("uvicorn")
 logger.debug("Loaded module v3/bindings/schemas/utils")
 
@@ -26,11 +27,14 @@ def _alias_schema(
     schema: Type[BaseModel], *, model: type, alias: str, kind: str
 ) -> Type[BaseModel]:
     name = f"{model.__name__}{_camel(alias)}{kind}"
+    logger.debug("aliasing schema %s -> %s", getattr(schema, "__name__", None), name)
     if getattr(schema, "__name__", None) == name:
+        logger.debug("schema already aliased: %s", name)
         return schema
     try:
         clone = create_model(name, __base__=schema)  # type: ignore[arg-type]
-    except Exception:  # pragma: no cover - best effort
+    except Exception:
+        logger.debug("failed cloning schema %s", name, exc_info=True)
         return schema
     return namely_model(
         clone,
@@ -42,8 +46,11 @@ def _alias_schema(
 def _ensure_alias_namespace(model: type, alias: str) -> SimpleNamespace:
     ns = getattr(model.schemas, alias, None)
     if ns is None:
+        logger.debug("creating namespace for %s.%s", model.__name__, alias)
         ns = SimpleNamespace()
         setattr(model.schemas, alias, ns)
+    else:
+        logger.debug("reusing namespace for %s.%s", model.__name__, alias)
     return ns
 
 
@@ -53,17 +60,22 @@ def _pk_info(model: type) -> Tuple[str, type | Any]:
     """
     table = getattr(model, "__table__", None)
     if table is None or not getattr(table, "primary_key", None):
+        logger.debug("no table or pk for %s", model)
         return ("id", Any)
     cols = list(table.primary_key.columns)  # type: ignore[attr-defined]
     if not cols:
+        logger.debug("no pk columns for %s", model)
         return ("id", Any)
     if len(cols) > 1:
+        logger.debug("composite pk for %s", model)
         # Composite keys: schema builder uses verb='delete' to require what's needed.
         # For bulk_delete we fall back to Any.
         return ("id", Any)
     col = cols[0]
     py_t = getattr(getattr(col, "type", None), "python_type", Any)
-    return (getattr(col, "name", "id"), py_t or Any)
+    name = getattr(col, "name", "id")
+    logger.debug("pk info for %s -> %s", model, name)
+    return (name, py_t or Any)
 
 
 def _parse_str_ref(s: str) -> Tuple[str, str]:
@@ -72,13 +84,16 @@ def _parse_str_ref(s: str) -> Tuple[str, str]:
     """
     s = s.strip()
     if "." not in s:
+        logger.debug("invalid schema ref: %s", s)
         raise ValueError(
             f"Invalid schema path '{s}', expected 'alias.in' or 'alias.out'"
         )
     alias, kind = s.split(".", 1)
     kind = kind.strip()
     if kind not in {"in", "out"}:
+        logger.debug("invalid schema kind in ref: %s", kind)
         raise ValueError(f"Invalid schema kind '{kind}', expected 'in' or 'out'")
+    logger.debug("parsed schema ref: alias=%s kind=%s", alias.strip(), kind)
     return alias.strip(), kind
 
 
@@ -95,47 +110,61 @@ def _resolve_schema_arg(model: type, arg: SchemaArg) -> Optional[Type[BaseModel]
       • callables/thunks
       • any other strings
     """
+    logger.debug("resolving schema arg %s on %s", arg, model)
     if arg is None:
+        logger.debug("arg is None -> keep default")
         return None
 
     # explicit raw
     if isinstance(arg, str) and arg.strip().lower() == "raw":
+        logger.debug("arg explicitly raw")
         return None
 
     # direct Pydantic model
     if isinstance(arg, type) and issubclass(arg, BaseModel):
+        logger.debug("arg is direct model %s", arg)
         return arg
 
     # SchemaRef
     if isinstance(arg, SchemaRef):
+        logger.debug("arg is SchemaRef %s", arg)
         if arg.kind not in ("in", "out"):
+            logger.debug("unsupported SchemaRef kind %s", arg.kind)
             raise ValueError(
                 f"Unsupported SchemaRef kind '{arg.kind}'. Use 'in' or 'out'."
             )
         ns = getattr(model, "schemas", None)
         if ns is None or getattr(ns, arg.alias, None) is None:
+            logger.debug("unknown schema alias %s on %s", arg.alias, model)
             raise KeyError(f"Unknown schema alias '{arg.alias}' on {model.__name__}")
         alias_ns = getattr(ns, arg.alias)
         attr = "in_" if arg.kind == "in" else "out"
         res = getattr(alias_ns, attr, None)
         if res is None:
+            logger.debug("schema %s.%s missing on %s", arg.alias, attr, model)
             raise KeyError(f"Schema '{arg.alias}.{attr}' not found on {model.__name__}")
+        logger.debug("resolved SchemaRef to %s", res)
         return res  # type: ignore[return-value]
 
     # dotted string
     if isinstance(arg, str):
+        logger.debug("arg is dotted string %s", arg)
         alias, kind = _parse_str_ref(arg)
         ns = getattr(model, "schemas", None)
         if ns is None or getattr(ns, alias, None) is None:
+            logger.debug("unknown schema alias %s on %s", alias, model)
             raise KeyError(f"Unknown schema alias '{alias}' on {model.__name__}")
         alias_ns = getattr(ns, alias)
         attr = "in_" if kind == "in" else "out"
         res = getattr(alias_ns, attr, None)
         if res is None:
+            logger.debug("schema %s.%s missing on %s", alias, attr, model)
             raise KeyError(f"Schema '{alias}.{attr}' not found on {model.__name__}")
+        logger.debug("resolved dotted ref to %s", res)
         return res  # type: ignore[return-value]
 
     # Everything else is unsupported now
+    logger.debug("unsupported schema arg type %s", type(arg))
     raise TypeError(
         f"Unsupported SchemaArg type: {type(arg)}. "
         "Use SchemaRef(...,'in'|'out'), 'alias.in'/'alias.out', 'raw', or None."


### PR DESCRIPTION
## Summary
- enable detailed branch-level debug logs for schema and REST bindings in autoapi v3
- configure modules to use uvicorn logger at DEBUG level

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68bcd42244c88326b2c1edb6cd7179e6