### PR TITLE
Add debug logging for AutoAPI engine components

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/engine/builders.py
+++ b/pkgs/standards/autoapi/autoapi/v3/engine/builders.py
@@ -1,5 +1,6 @@
 """SQLAlchemy engine and sessionmaker builders."""
 
+import logging
 import os
 from sqlalchemy import create_engine
 from sqlalchemy.exc import SQLAlchemyError
@@ -7,6 +8,9 @@ from sqlalchemy.pool import StaticPool  # only for SQLite
 from sqlalchemy.orm import sessionmaker
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+logging.getLogger("uvicorn").setLevel(logging.DEBUG)
+logger = logging.getLogger("uvicorn")
 
 
 # ---------------------------------------------------------------------
@@ -20,7 +24,9 @@ def blocking_sqlite_engine(path: str | None = None):
         • None  → single shared in-memory DB (thread-safe).
         • "./db.sqlite3" etc. → file-backed database.
     """
+    logger.debug("blocking_sqlite_engine called with path=%r", path)
     if path is None:
+        logger.debug("blocking_sqlite_engine: creating shared in-memory SQLite engine")
         url = "sqlite+pysqlite://"
         kwargs = dict(
             connect_args={"check_same_thread": False},
@@ -29,10 +35,15 @@ def blocking_sqlite_engine(path: str | None = None):
             future=True,
         )
     else:
+        logger.debug(
+            "blocking_sqlite_engine: creating file-backed SQLite engine at %s",
+            path,
+        )
         url = f"sqlite+pysqlite:///{path}"
         kwargs = dict(echo=False, future=True)
 
     eng = create_engine(url, **kwargs)
+    logger.debug("blocking_sqlite_engine: created engine %r", eng)
     return eng, sessionmaker(bind=eng, expire_on_commit=False)
 
 
@@ -49,9 +60,19 @@ def blocking_postgres_engine(
     pool_size: int = 10,
     max_overflow: int = 20,
 ):
+    logger.debug(
+        "blocking_postgres_engine called with dsn=%r user=%r host=%r port=%r db=%r",
+        dsn,
+        user,
+        host,
+        port,
+        db,
+    )
     if dsn:
+        logger.debug("blocking_postgres_engine: using provided DSN")
         url = dsn
     else:
+        logger.debug("blocking_postgres_engine: constructing DSN from parameters")
         user = os.getenv("PGUSER", user)
         pwd = os.getenv("PGPASSWORD", pwd or "secret")
         host = os.getenv("PGHOST", host)
@@ -66,6 +87,7 @@ def blocking_postgres_engine(
         echo=False,
         future=True,
     )
+    logger.debug("blocking_postgres_engine: created engine %r", eng)
     return eng, sessionmaker(bind=eng, expire_on_commit=False)
 
 
@@ -82,32 +104,47 @@ class HybridSession(AsyncSession):
     # ---- synchronous wrappers (delegate to the sync mirror) ------------
     # NOTE: self.sync_session is provided by SQLAlchemy ≥1.4
     def query(self, *e, **k):
+        logger.debug("HybridSession.query called with args=%r kwargs=%r", e, k)
         return self.sync_session.query(*e, **k)
 
     def add(self, *a, **k):
+        logger.debug("HybridSession.add called with args=%r kwargs=%r", a, k)
         return self.sync_session.add(*a, **k)
 
     async def get(self, *a, **k):
+        logger.debug("HybridSession.get called with args=%r kwargs=%r", a, k)
         return await super().get(*a, **k)
 
     async def flush(self, *a, **k):
+        logger.debug("HybridSession.flush called with args=%r kwargs=%r", a, k)
         return await super().flush(*a, **k)
 
     async def commit(self, *a, **k):
+        logger.debug("HybridSession.commit called with args=%r kwargs=%r", a, k)
         return await super().commit(*a, **k)
 
     async def refresh(self, *a, **k):
+        logger.debug("HybridSession.refresh called with args=%r kwargs=%r", a, k)
         return await super().refresh(*a, **k)
 
     async def delete(self, *a, **k):
+        logger.debug("HybridSession.delete called with args=%r kwargs=%r", a, k)
         return await super().delete(*a, **k)
 
     # ---- DDL helper used at AutoAPI bootstrap --------------------------
     async def run_sync(self, fn, *a, **kw):
+        logger.debug(
+            "HybridSession.run_sync called with fn=%r args=%r kwargs=%r", fn, a, kw
+        )
         try:
-            return await super().run_sync(fn, *a, **kw)
+            rv = await super().run_sync(fn, *a, **kw)
+            logger.debug("HybridSession.run_sync succeeded with result=%r", rv)
+            return rv
         except (OSError, SQLAlchemyError) as exc:
             url = getattr(self.bind, "url", "unknown")
+            logger.debug(
+                "HybridSession.run_sync failed for url %s with exc=%r", url, exc
+            )
             await self.bind.dispose()
             raise RuntimeError(
                 f"Failed to connect to database at '{url}'. "
@@ -119,13 +156,16 @@ class HybridSession(AsyncSession):
 # 2. ASYNC  •  SQLite  (aiosqlite driver)
 # ----------------------------------------------------------------------
 def async_sqlite_engine(path: str | None = None):
+    logger.debug("async_sqlite_engine called with path=%r", path)
     url = "sqlite+aiosqlite://" + (f"/{path}" if path else "")
+    logger.debug("async_sqlite_engine: using url=%s", url)
     eng = create_async_engine(
         url,
         connect_args={"check_same_thread": False},
         poolclass=StaticPool,
         echo=False,
     )
+    logger.debug("async_sqlite_engine: created engine %r", eng)
     return eng, async_sessionmaker(
         eng,
         expire_on_commit=False,
@@ -146,9 +186,19 @@ def async_postgres_engine(
     pool_size: int = 10,
     max_size: int = 20,
 ):
+    logger.debug(
+        "async_postgres_engine called with dsn=%r user=%r host=%r port=%r db=%r",
+        dsn,
+        user,
+        host,
+        port,
+        db,
+    )
     if dsn:
+        logger.debug("async_postgres_engine: using provided DSN")
         url = dsn
     else:
+        logger.debug("async_postgres_engine: constructing DSN from parameters")
         user = os.getenv("PGUSER", user)
         pwd = os.getenv("PGPASSWORD", pwd or "secret")
         host = os.getenv("PGHOST", host)
@@ -162,6 +212,7 @@ def async_postgres_engine(
         pool_pre_ping=True,
         echo=False,
     )
+    logger.debug("async_postgres_engine: created engine %r", eng)
     return eng, async_sessionmaker(
         eng,
         expire_on_commit=False,

--- a/pkgs/standards/autoapi/autoapi/v3/engine/resolver.py
+++ b/pkgs/standards/autoapi/autoapi/v3/engine/resolver.py
@@ -3,11 +3,15 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import logging
 import threading
 from typing import Any, Callable, Optional
 
 from ._engine import AsyncSession, Engine, Provider, Session
 from .engine_spec import EngineSpec, EngineCfg
+
+logging.getLogger("uvicorn").setLevel(logging.DEBUG)
+logger = logging.getLogger("uvicorn")
 
 # Registry with strict precedence: op > model > api > app
 _LOCK = threading.RLock()
@@ -30,15 +34,21 @@ def _coerce(ctx: Optional[EngineCfg]) -> Optional[Provider]:
     """
     Promote an @engine_ctx value to a lazy Provider.
     """
+    logger.debug("_coerce called with ctx=%r", ctx)
     if ctx is None:
+        logger.debug("_coerce: ctx is None")
         return None
     if isinstance(ctx, Provider):
+        logger.debug("_coerce: ctx is already a Provider")
         return ctx
     if isinstance(ctx, Engine):
+        logger.debug("_coerce: ctx is an Engine; returning provider")
         return ctx.provider
     if isinstance(ctx, EngineSpec):
+        logger.debug("_coerce: ctx is an EngineSpec; converting to provider")
         return ctx.to_provider()
     spec = EngineSpec.from_any(ctx)
+    logger.debug("_coerce: EngineSpec.from_any returned %r", spec)
     return spec.to_provider() if spec else None
 
 
@@ -51,6 +61,7 @@ def set_default(ctx: EngineCfg | None) -> None:
     """
     global _DEFAULT
     prov = _coerce(ctx)
+    logger.debug("set_default: setting default provider to %r", prov)
     with _LOCK:
         _DEFAULT = prov
 
@@ -60,10 +71,13 @@ def register_api(api: Any, ctx: EngineCfg | None) -> None:
     Register an API-level Provider.
     """
     prov = _coerce(ctx)
+    logger.debug("register_api: api=%r coerced provider=%r", api, prov)
     if prov is None:
+        logger.debug("register_api: no provider; skipping registration")
         return
     with _LOCK:
         _API[id(api)] = prov
+        logger.debug("register_api: registered provider for api id %s", id(api))
 
 
 def register_table(model: Any, ctx: EngineCfg | None) -> None:
@@ -71,10 +85,13 @@ def register_table(model: Any, ctx: EngineCfg | None) -> None:
     Register a table/model-level Provider.
     """
     prov = _coerce(ctx)
+    logger.debug("register_table: model=%r coerced provider=%r", model, prov)
     if prov is None:
+        logger.debug("register_table: no provider; skipping registration")
         return
     with _LOCK:
         _TAB[model] = prov
+        logger.debug("register_table: registered provider for model %r", model)
 
 
 def register_op(model: Any, alias: str, ctx: EngineCfg | None) -> None:
@@ -82,10 +99,17 @@ def register_op(model: Any, alias: str, ctx: EngineCfg | None) -> None:
     Register an op-level Provider for (model, alias).
     """
     prov = _coerce(ctx)
+    logger.debug(
+        "register_op: model=%r alias=%r coerced provider=%r", model, alias, prov
+    )
     if prov is None:
+        logger.debug("register_op: no provider; skipping registration")
         return
     with _LOCK:
         _OP[(model, alias)] = prov
+        logger.debug(
+            "register_op: registered provider for model %r alias %s", model, alias
+        )
 
 
 # ---- resolution -------------------------------------------------------------
@@ -101,23 +125,43 @@ def resolve_provider(
     Resolve the effective Provider using precedence:
         op > model > api > app(default)
     """
+    logger.debug(
+        "resolve_provider called with api=%r model=%r op_alias=%r",
+        api,
+        model,
+        op_alias,
+    )
     with _LOCK:
         if model is not None and op_alias is not None:
+            logger.debug("resolve_provider: checking op-level provider")
             for m in _with_class(model):
+                logger.debug(
+                    "resolve_provider: looking for op provider for %r alias %s",
+                    m,
+                    op_alias,
+                )
                 p = _OP.get((m, op_alias))
                 if p:
+                    logger.debug("resolve_provider: found op-level provider %r", p)
                     return p
         if model is not None:
+            logger.debug("resolve_provider: checking model-level provider")
             for m in _with_class(model):
+                logger.debug("resolve_provider: looking for model provider %r", m)
                 p = _TAB.get(m)
                 if p:
+                    logger.debug("resolve_provider: found model-level provider %r", p)
                     return p
         if api is not None:
+            logger.debug("resolve_provider: checking api-level provider")
             for a in _with_class(api):
+                logger.debug("resolve_provider: looking for api provider %r", a)
                 # APIs are keyed by ``id`` to avoid relying on ``__hash__``
                 p = _API.get(id(a))
                 if p:
+                    logger.debug("resolve_provider: found api-level provider %r", p)
                     return p
+        logger.debug("resolve_provider: returning default provider %r", _DEFAULT)
         return _DEFAULT
 
 
@@ -139,30 +183,42 @@ def acquire(
     Raises:
         RuntimeError: if no Provider can be resolved and no default is set.
     """
+    logger.debug(
+        "acquire called with api=%r model=%r op_alias=%r", api, model, op_alias
+    )
     p = resolve_provider(api=api, model=model, op_alias=op_alias)
     if p is None:
+        logger.debug("acquire: no provider resolved; raising error")
         raise RuntimeError(
             f"No database provider configured for op={op_alias} "
             f"model={getattr(model, '__name__', model)} "
             f"api={type(api).__name__ if api else None} and no default"
         )
     db: SessionT = p.session()
+    logger.debug("acquire: session %r acquired from provider %r", db, p)
 
     def _release() -> None:
+        logger.debug("_release: attempting to release session %r", db)
         close = getattr(db, "close", None)
         if callable(close):
             try:
                 rv = close()
+                logger.debug("_release: close returned %r", rv)
                 if inspect.isawaitable(rv):
+                    logger.debug("_release: awaiting asynchronous close")
                     try:
                         loop = asyncio.get_running_loop()
                     except RuntimeError:
+                        logger.debug("_release: no running loop; using asyncio.run")
                         asyncio.run(rv)
                     else:
+                        logger.debug("_release: scheduling close on running loop")
                         loop.create_task(rv)
                 # If close is sync, it has already executed
             except Exception:
+                logger.debug("_release: error during close", exc_info=True)
                 # best-effort close; swallow to avoid masking handler errors
                 pass
+        logger.debug("_release: release complete for session %r", db)
 
     return db, _release


### PR DESCRIPTION
## Summary
- add uvicorn debug logging to engine resolver with branch coverage
- add uvicorn debug logging to engine builders and HybridSession helpers

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff format .`
- `uv run --directory standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68bcd6c562d483268fbf8f6682d19258