### PR TITLE
Add debug logging to schema resolution

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/schema/get_schema.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/get_schema.py
@@ -37,22 +37,29 @@ def get_schema(
     KeyError
         If the model has not been bound or the operation/kind is unknown.
     """
+    logger.debug(
+        "Resolving schema for model=%s op=%s kind=%s", orm_cls.__name__, op, kind
+    )
+
     ns = getattr(orm_cls, "schemas", None)
     if ns is None:
         logger.debug("Model %s has no schemas namespace", orm_cls.__name__)
         raise KeyError(
             f"{orm_cls.__name__} has no bound schemas; did you include the model?",
         )
+    logger.debug("Found schemas namespace for model %s", orm_cls.__name__)
 
     alias_ns = getattr(ns, op, None)
     if alias_ns is None:
         logger.debug("Unknown operation '%s' for model %s", op, orm_cls.__name__)
         raise KeyError(f"Unknown op '{op}' for {orm_cls.__name__}")
+    logger.debug("Found operation '%s' for model %s", op, orm_cls.__name__)
 
     kind = kind.lower()
     if kind not in {"in", "out"}:
         logger.debug("Invalid schema kind '%s' requested", kind)
         raise ValueError("kind must be 'in' or 'out'")
+    logger.debug("Using schema kind '%s'", kind)
 
     attr = "in_" if kind == "in" else "out"
     if not hasattr(alias_ns, attr):
@@ -62,6 +69,9 @@ def get_schema(
         raise KeyError(
             f"Schema kind '{kind}' not found for op '{op}' on {orm_cls.__name__}",
         )
+    logger.debug(
+        "Found schema attribute '%s' for op '%s' on %s", attr, op, orm_cls.__name__
+    )
     schema = getattr(alias_ns, attr)
     logger.debug(
         "Resolved schema %s for model %s op=%s kind=%s",


### PR DESCRIPTION
## Summary
- add debug logging for schema resolution branches

## Testing
- `uv run --package autoapi --directory pkgs/standards/autoapi pytest tests/i9n/test_core_access.py::test_core_and_core_raw_sync_operations -q` *(fails: AssertionError: assert not [{'email': 'jane_5c...'}])*

------
https://chatgpt.com/codex/tasks/task_e_68bcd6cea4d483268044164cfec75cd7