### PR TITLE
Add extensive debug logging to schema bindings

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/schemas/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/schemas/__init__.py
@@ -4,6 +4,7 @@ import logging
 
 from .builder import build_and_attach
 
+logging.getLogger("uvicorn").setLevel(logging.DEBUG)
 logger = logging.getLogger("uvicorn")
 logger.debug("Loaded module v3/bindings/schemas/__init__")
 

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/schemas/builder.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/schemas/builder.py
@@ -201,6 +201,12 @@ def build_and_attach(
                 )
                 raise
             setattr(ns, "in_", resolved_in)
+            logger.debug(
+                "Request override for %s.%s resolved to %s",
+                model.__name__,
+                sp.alias,
+                getattr(resolved_in, "__name__", None),
+            )
         else:
             logger.debug("No request override for %s.%s", model.__name__, sp.alias)
 
@@ -221,6 +227,12 @@ def build_and_attach(
                 )
                 raise
             setattr(ns, "out", resolved_out)
+            logger.debug(
+                "Response override for %s.%s resolved to %s",
+                model.__name__,
+                sp.alias,
+                getattr(resolved_out, "__name__", None),
+            )
         else:
             logger.debug("No response override for %s.%s", model.__name__, sp.alias)
 
@@ -248,10 +260,22 @@ def build_and_attach(
             logger.debug(
                 "Restored default request schema for %s.%s", model.__name__, sp.alias
             )
+        else:
+            logger.debug(
+                "No request schema restoration needed for %s.%s",
+                model.__name__,
+                sp.alias,
+            )
         if getattr(ns, "in_item", None) is None and shapes.get("in_item") is not None:
             setattr(ns, "in_item", shapes["in_item"])
             logger.debug(
                 "Restored default request item schema for %s.%s",
+                model.__name__,
+                sp.alias,
+            )
+        else:
+            logger.debug(
+                "No request item schema restoration needed for %s.%s",
                 model.__name__,
                 sp.alias,
             )
@@ -260,10 +284,22 @@ def build_and_attach(
             logger.debug(
                 "Restored default response schema for %s.%s", model.__name__, sp.alias
             )
+        else:
+            logger.debug(
+                "No response schema restoration needed for %s.%s",
+                model.__name__,
+                sp.alias,
+            )
         if getattr(ns, "out_item", None) is None and shapes.get("out_item") is not None:
             setattr(ns, "out_item", shapes["out_item"])
             logger.debug(
                 "Restored default response item schema for %s.%s",
+                model.__name__,
+                sp.alias,
+            )
+        else:
+            logger.debug(
+                "No response item schema restoration needed for %s.%s",
                 model.__name__,
                 sp.alias,
             )

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/schemas/defaults.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/schemas/defaults.py
@@ -44,6 +44,11 @@ def _default_schemas_for_spec(
 
     # Element schema for many OUT shapes
     read_schema: Optional[Type[BaseModel]] = _build_schema(model, verb="read")
+    logger.debug(
+        "Resolved base read schema for %s as %s",
+        model.__name__,
+        read_schema.__name__ if read_schema else None,
+    )
 
     # Canonical targets
     logger.debug(
@@ -109,12 +114,22 @@ def _default_schemas_for_spec(
         )
         result["in_"] = _make_bulk_rows_model(model, "bulk_create", item_in)
         result["in_item"] = item_in
-        result["out"] = (
-            _make_bulk_rows_response_model(model, "bulk_create", read_schema)
-            if read_schema
-            else None
-        )
-        result["out_item"] = read_schema
+        if read_schema:
+            result["out"] = _make_bulk_rows_response_model(
+                model, "bulk_create", read_schema
+            )
+            result["out_item"] = read_schema
+            logger.debug(
+                "Built bulk_create response schemas for %s.%s", model.__name__, sp.alias
+            )
+        else:
+            result["out"] = None
+            result["out_item"] = None
+            logger.debug(
+                "No read schema available for bulk_create %s.%s",
+                model.__name__,
+                sp.alias,
+            )
 
     elif target == "bulk_update":
         logger.debug("Using bulk_update defaults for %s.%s", model.__name__, sp.alias)
@@ -125,12 +140,22 @@ def _default_schemas_for_spec(
         )
         result["in_"] = _make_bulk_rows_model(model, "bulk_update", item_in)
         result["in_item"] = item_in
-        result["out"] = (
-            _make_bulk_rows_response_model(model, "bulk_update", read_schema)
-            if read_schema
-            else None
-        )
-        result["out_item"] = read_schema
+        if read_schema:
+            result["out"] = _make_bulk_rows_response_model(
+                model, "bulk_update", read_schema
+            )
+            result["out_item"] = read_schema
+            logger.debug(
+                "Built bulk_update response schemas for %s.%s", model.__name__, sp.alias
+            )
+        else:
+            result["out"] = None
+            result["out_item"] = None
+            logger.debug(
+                "No read schema available for bulk_update %s.%s",
+                model.__name__,
+                sp.alias,
+            )
 
     elif target == "bulk_replace":
         logger.debug("Using bulk_replace defaults for %s.%s", model.__name__, sp.alias)
@@ -141,12 +166,24 @@ def _default_schemas_for_spec(
         )
         result["in_"] = _make_bulk_rows_model(model, "bulk_replace", item_in)
         result["in_item"] = item_in
-        result["out"] = (
-            _make_bulk_rows_response_model(model, "bulk_replace", read_schema)
-            if read_schema
-            else None
-        )
-        result["out_item"] = read_schema
+        if read_schema:
+            result["out"] = _make_bulk_rows_response_model(
+                model, "bulk_replace", read_schema
+            )
+            result["out_item"] = read_schema
+            logger.debug(
+                "Built bulk_replace response schemas for %s.%s",
+                model.__name__,
+                sp.alias,
+            )
+        else:
+            result["out"] = None
+            result["out_item"] = None
+            logger.debug(
+                "No read schema available for bulk_replace %s.%s",
+                model.__name__,
+                sp.alias,
+            )
 
     elif target == "bulk_merge":
         logger.debug("Using bulk_merge defaults for %s.%s", model.__name__, sp.alias)
@@ -157,12 +194,22 @@ def _default_schemas_for_spec(
         )
         result["in_"] = _make_bulk_rows_model(model, "bulk_merge", item_in)
         result["in_item"] = item_in
-        result["out"] = (
-            _make_bulk_rows_response_model(model, "bulk_merge", read_schema)
-            if read_schema
-            else None
-        )
-        result["out_item"] = read_schema
+        if read_schema:
+            result["out"] = _make_bulk_rows_response_model(
+                model, "bulk_merge", read_schema
+            )
+            result["out_item"] = read_schema
+            logger.debug(
+                "Built bulk_merge response schemas for %s.%s", model.__name__, sp.alias
+            )
+        else:
+            result["out"] = None
+            result["out_item"] = None
+            logger.debug(
+                "No read schema available for bulk_merge %s.%s",
+                model.__name__,
+                sp.alias,
+            )
 
     elif target == "bulk_delete":
         logger.debug("Using bulk_delete defaults for %s.%s", model.__name__, sp.alias)

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/schemas/utils.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/schemas/utils.py
@@ -156,6 +156,12 @@ def _resolve_schema_arg(model: type, arg: SchemaArg) -> Optional[Type[BaseModel]
                 "Schema '%s.%s' not found on %s", arg.alias, attr, model.__name__
             )
             raise KeyError(f"Schema '{arg.alias}.{attr}' not found on {model.__name__}")
+        logger.debug(
+            "Resolved SchemaRef %s.%s to %s",
+            arg.alias,
+            attr,
+            getattr(res, "__name__", None),
+        )
         return res  # type: ignore[return-value]
 
     # dotted string
@@ -171,6 +177,12 @@ def _resolve_schema_arg(model: type, arg: SchemaArg) -> Optional[Type[BaseModel]
         if res is None:
             logger.debug("Schema '%s.%s' not found on %s", alias, attr, model.__name__)
             raise KeyError(f"Schema '{alias}.{attr}' not found on {model.__name__}")
+        logger.debug(
+            "Resolved schema path %s.%s to %s",
+            alias,
+            attr,
+            getattr(res, "__name__", None),
+        )
         return res  # type: ignore[return-value]
 
     logger.debug("Unsupported SchemaArg type: %s", type(arg))


### PR DESCRIPTION
## Summary
- add uvicorn debug logger setup for schema bindings
- log branch decisions during schema override resolution and default restoration
- track read schema presence and schema path resolutions

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format autoapi/v3/bindings/schemas/__init__.py autoapi/v3/bindings/schemas/builder.py autoapi/v3/bindings/schemas/defaults.py autoapi/v3/bindings/schemas/utils.py`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check autoapi/v3/bindings/schemas/__init__.py autoapi/v3/bindings/schemas/builder.py autoapi/v3/bindings/schemas/defaults.py autoapi/v3/bindings/schemas/utils.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_68bcd710662c83269cfc7abe186434ed