### PR TITLE
feat(autoapi): memoize core op wrappers

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/core/crud/ops.py
+++ b/pkgs/standards/autoapi/autoapi/v3/core/crud/ops.py
@@ -228,8 +228,8 @@ async def clear(
     if where is not None:
         stmt = stmt.where(where)
 
-        res = await _maybe_execute(db, stmt)
-        await _maybe_flush(db)
-        n = int(getattr(res, "rowcount", 0) or 0)
-        logger.debug("clear removed %d rows", n)
-        return {"deleted": n}
+    res = await _maybe_execute(db, stmt)
+    await _maybe_flush(db)
+    n = int(getattr(res, "rowcount", 0) or 0)
+    logger.debug("clear removed %d rows", n)
+    return {"deleted": n}

--- a/pkgs/standards/autoapi/tests/unit/test_core_wrap_memoization.py
+++ b/pkgs/standards/autoapi/tests/unit/test_core_wrap_memoization.py
@@ -1,0 +1,67 @@
+import time
+import pytest
+
+from autoapi.v3 import core as _core
+from autoapi.v3.bindings.handlers.steps import _wrap_core
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_wrap_core_create_dispatch(monkeypatch):
+    class Model:
+        pass
+
+    called = {}
+
+    async def fake_create(model, payload, db=None):
+        called["model"] = model
+        called["payload"] = payload
+        called["db"] = db
+        return {"ok": True}
+
+    monkeypatch.setattr(_core, "create", fake_create)
+    step = _wrap_core(Model, "create")
+    ctx = {"db": 123, "payload": {"a": 1}}
+    result = await step(ctx)
+    assert result == {"ok": True}
+    assert called == {"model": Model, "payload": {"a": 1}, "db": 123}
+
+
+@pytest.mark.perf
+def test_wrap_core_cache_hits():
+    class Model:
+        pass
+
+    _wrap_core.cache_clear()
+    _wrap_core(Model, "create")
+    info = _wrap_core.cache_info()
+    assert info.misses == 1
+    assert info.hits == 0
+    _wrap_core(Model, "create")
+    info = _wrap_core.cache_info()
+    assert info.hits == 1
+    assert info.misses == 1
+
+
+@pytest.mark.perf
+def test_wrap_core_cached_speed():
+    class Model:
+        pass
+
+    iterations = 1000
+
+    _wrap_core.cache_clear()
+    start = time.perf_counter()
+    for i in range(iterations):
+        _wrap_core(type(f"M{i}", (), {}), "create")
+    uncached = time.perf_counter() - start
+
+    _wrap_core.cache_clear()
+    _wrap_core(Model, "create")
+    start = time.perf_counter()
+    for _ in range(iterations):
+        _wrap_core(Model, "create")
+    cached = time.perf_counter() - start
+
+    print(f"uncached={uncached:.6f}s cached={cached:.6f}s")
+    assert cached < uncached / 5


### PR DESCRIPTION
## Summary
- memoize autoapi v3 core operation wrappers and reduce per-request conditionals
- add tests covering core wrapper dispatch, caching behavior, and memoization performance
- ensure `clear` core op always reports number of deleted rows

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_core_access.py::test_core_and_core_raw_sync_operations -q`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_core_wrap_memoization.py::test_wrap_core_cached_speed -vv -s`
- `uv run --package autoapi --directory standards/autoapi pytest -q` *(fails: tests/i9n/test_key_digest_uvicorn.py::test_create_apikey_success, tests/i9n/test_key_digest_uvicorn.py::test_create_response_fields)*

------
https://chatgpt.com/codex/tasks/task_e_68bd02fb9ed08326980fd25b8e7d03c8