### PR TITLE
fix: avoid duplicate sqlite db initialization

### DIFF
--- a/pkgs/standards/auto_authn/auto_authn/db.py
+++ b/pkgs/standards/auto_authn/auto_authn/db.py
@@ -4,7 +4,7 @@ from .runtime_cfg import settings
 if settings.pg_dsn_env or (settings.pg_host and settings.pg_db and settings.pg_user):
     dsn = settings.apg_dsn
 else:
-    dsn = "sqlite+aiosqlite:///./authn.db"
+    dsn = "sqlite+aiosqlite:///./authn__authn.db"
 
 ENGINE = build_engine(dsn)
 get_db = ENGINE.get_db

--- a/pkgs/standards/auto_authn/tests/unit/test_sqlite_db_initialization.py
+++ b/pkgs/standards/auto_authn/tests/unit/test_sqlite_db_initialization.py
@@ -1,0 +1,24 @@
+"""Ensure only a single SQLite database file is created on startup."""
+
+from importlib import reload
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_sqlite_single_database(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    from auto_authn import db as db_module
+    from auto_authn import app as app_module
+
+    reload(db_module)
+    reload(app_module)
+
+    await app_module._startup()
+
+    files = {p.name for p in Path(tmp_path).iterdir()}
+    assert "authn__authn.db" in files
+    assert "authn.db" not in files


### PR DESCRIPTION
## Summary
- ensure authn server uses <schema>__<db>.db for sqlite
- auto-collect SQLite attachments from schema list
- test that only one SQLite file is created

## Testing
- `uv run --package auto_authn --directory standards/auto_authn ruff check . --fix`
- `uv run --package auto_authn --directory standards/auto_authn pytest tests/unit/test_sqlite_db_initialization.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd0d3f2554832687f1b54958df214b