### PR TITLE
feat(plan): mark skipped atoms in diagnostics

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/runtime/test_plan.py
+++ b/pkgs/standards/autoapi/tests/unit/runtime/test_plan.py
@@ -183,6 +183,13 @@ def test_flattened_order_skips_system_steps(
     assert not any("hook:sys" in s for s in out)
 
 
+def test_flattened_order_reports_skipped_atoms() -> None:
+    node = _make_node("resolve", "assemble", _ev.RESOLVE_VALUES)
+    plan = plan_mod.Plan("M", {_ev.RESOLVE_VALUES: (node,)})
+    out = plan_mod.flattened_order(plan, persist=False, include_skipped=True)
+    assert out == ["PRE_HANDLER:atom:resolve:assemble@resolve:values [SKIPPED]"]
+
+
 def test_flattened_order_preserves_prelabel_order() -> None:
     """secdeps and deps appear in the order they are declared."""
     plan = plan_mod.Plan("M", {})


### PR DESCRIPTION
## Summary
- include optional placeholders for persist-pruned atoms in `flattened_order`
- test skipped atom reporting in plan diagnostics

## Testing
- `uv run --directory . --package autoapi ruff format .`
- `uv run --directory . --package autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest` *(partial run: 83 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68bd13c5a18c832691f853932d3154cc