### PR TITLE
feat(autoapi): add kernel plan diagnostic

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/system/diagnostics/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/system/diagnostics/__init__.py
@@ -3,6 +3,7 @@ from .router import mount_diagnostics
 from .methodz import build_methodz_endpoint as _build_methodz_endpoint
 from .hookz import build_hookz_endpoint as _build_hookz_endpoint
 from .planz import build_planz_endpoint as _build_planz_endpoint
+from .kernelz import build_kernelz_endpoint as _build_kernelz_endpoint
 from .utils import (
     model_iter as _model_iter,
     opspecs as _opspecs,
@@ -15,6 +16,7 @@ __all__ = [
     "_build_methodz_endpoint",
     "_build_hookz_endpoint",
     "_build_planz_endpoint",
+    "_build_kernelz_endpoint",
     "_model_iter",
     "_opspecs",
     "_label_callable",

--- a/pkgs/standards/autoapi/autoapi/v3/system/diagnostics/kernelz.py
+++ b/pkgs/standards/autoapi/autoapi/v3/system/diagnostics/kernelz.py
@@ -1,0 +1,39 @@
+"""Diagnostic endpoint exposing kernel phase plans."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from ...op.types import PHASES
+
+
+def build_kernelz_endpoint(api: Any):
+    cache: Optional[Dict[str, Dict[str, Dict[str, List[str]]]]] = None
+
+    async def _kernelz():
+        nonlocal cache
+        if cache is not None:
+            return cache
+        from . import _model_iter, _opspecs, _label_hook, build_phase_chains
+
+        out: Dict[str, Dict[str, Dict[str, List[str]]]] = {}
+        for model in _model_iter(api):
+            mname = getattr(model, "__name__", "Model")
+            model_map: Dict[str, Dict[str, List[str]]] = {}
+            for sp in _opspecs(model):
+                chains = build_phase_chains(model, sp.alias)
+                phase_map: Dict[str, List[str]] = {}
+                for ph in PHASES:
+                    steps = chains.get(ph, []) or []
+                    if steps:
+                        phase_map[ph] = [_label_hook(fn, ph) for fn in steps]
+                model_map[sp.alias] = phase_map
+            if model_map:
+                out[mname] = model_map
+        cache = out
+        return out
+
+    return _kernelz
+
+
+__all__ = ["build_kernelz_endpoint"]

--- a/pkgs/standards/autoapi/autoapi/v3/system/diagnostics/router.py
+++ b/pkgs/standards/autoapi/autoapi/v3/system/diagnostics/router.py
@@ -7,6 +7,7 @@ from .healthz import build_healthz_endpoint
 from .methodz import build_methodz_endpoint
 from .hookz import build_hookz_endpoint
 from .planz import build_planz_endpoint
+from .kernelz import build_kernelz_endpoint
 
 
 def mount_diagnostics(
@@ -20,6 +21,7 @@ def mount_diagnostics(
       GET /methodz
       GET /hookz
       GET /planz
+      GET /kernelz
     """
     router = Router()
 
@@ -65,6 +67,15 @@ def mount_diagnostics(
         tags=["system"],
         summary="Plan",
         description="Flattened runtime execution plan per operation.",
+    )
+    router.add_api_route(
+        "/kernelz",
+        build_kernelz_endpoint(api),
+        methods=["GET"],
+        name="kernelz",
+        tags=["system"],
+        summary="Kernel Plan",
+        description="Phase-chain plan as built by the kernel per operation.",
     )
 
     return router

--- a/pkgs/standards/autoapi/tests/unit/test_kernelz_endpoint.py
+++ b/pkgs/standards/autoapi/tests/unit/test_kernelz_endpoint.py
@@ -1,0 +1,53 @@
+import pytest
+from types import SimpleNamespace
+
+from autoapi.v3.op import OpSpec
+from autoapi.v3.system import diagnostics as _diag
+from autoapi.v3.system.diagnostics import _build_kernelz_endpoint
+
+
+def sample_hook(ctx):
+    return None
+
+
+def handler(ctx):
+    return None
+
+
+@pytest.mark.asyncio
+async def test_kernelz_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    class API:
+        pass
+
+    class Model:
+        __name__ = "Model"
+
+    Model.opspecs = SimpleNamespace(
+        all=(
+            OpSpec(
+                alias="create",
+                target="create",
+                table=Model,
+                persist="default",
+                handler=handler,
+            ),
+        )
+    )
+
+    api = API()
+    api.models = {"Model": Model}
+
+    def fake_build_phase_chains(model, alias):
+        assert model is Model and alias == "create"
+        return {"PRE_HANDLER": [sample_hook], "HANDLER": [handler]}
+
+    monkeypatch.setattr(_diag, "build_phase_chains", fake_build_phase_chains)
+
+    kernelz = _build_kernelz_endpoint(api)
+    data = await kernelz()
+
+    assert "Model" in data
+    assert "create" in data["Model"]
+    phases = data["Model"]["create"]
+    assert phases["PRE_HANDLER"] == [_diag._label_hook(sample_hook, "PRE_HANDLER")]
+    assert phases["HANDLER"] == [_diag._label_hook(handler, "HANDLER")]


### PR DESCRIPTION
## Summary
- add /kernelz diagnostic to inspect phase chain plan from kernel
- expose new endpoint through diagnostics router and exports
- cover kernelz endpoint with unit test

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest` *(fails: tests/i9n/test_key_digest_uvicorn.py::test_create_apikey_success, tests/i9n/test_key_digest_uvicorn.py::test_create_response_fields)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2332076c8326bb7094c33ea2fc06