### PR TITLE
feat: expose kernel plan labels

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_kernel_plan_labels.py
+++ b/pkgs/standards/autoapi/tests/unit/test_kernel_plan_labels.py
@@ -1,0 +1,40 @@
+from autoapi.v3.runtime import events as _ev
+from autoapi.v3.runtime.kernel import Kernel
+
+
+def _mk_atom(module: str):
+    def run(obj, ctx):
+        return None
+
+    run.__module__ = module
+    return run
+
+
+def test_plan_labels_reflect_kernel_injection():
+    atoms = [
+        (_ev.RESOLVE_VALUES, _mk_atom("autoapi.v3.runtime.atoms.resolve.values")),
+        (_ev.PRE_FLUSH, _mk_atom("autoapi.v3.runtime.atoms.pre.flush")),
+    ]
+    k = Kernel(atoms=atoms)
+
+    class Model:
+        pass
+
+    labels = k.plan_labels(Model, "create")
+    assert labels == [
+        "atom:resolve:values@resolve:values",
+        "atom:pre:flush@pre:flush",
+    ]
+
+
+def test_plan_labels_prune_non_persistent():
+    atoms = [
+        (_ev.RESOLVE_VALUES, _mk_atom("autoapi.v3.runtime.atoms.resolve.values")),
+    ]
+    k = Kernel(atoms=atoms)
+
+    class Model:
+        pass
+
+    labels = k.plan_labels(Model, "read")
+    assert labels == []


### PR DESCRIPTION
## Summary
- label injected atoms with canonical identifiers and expose flattened plan labels
- surface plan labels through `Kernel.plan_labels` and tracing
- add unit tests for plan label behavior

## Testing
- `uv run --package autoapi --directory . ruff format .`
- `uv run --package autoapi --directory . ruff check . --fix`
- `uv run --package autoapi --directory . pytest tests/unit/test_kernel_plan_labels.py -q`
- `uv run --package autoapi --directory . pytest` *(fails: tests/i9n/test_key_digest_uvicorn.py::test_create_apikey_success, tests/i9n/test_key_digest_uvicorn.py::test_create_response_fields)*

------
https://chatgpt.com/codex/tasks/task_e_68bd25ea6b2c8326b62f26bbbf751805