### PR TITLE
Refactor runtime context initialization in autoapi

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/runtime/kernel/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/kernel/__init__.py
@@ -62,7 +62,6 @@ def _discover_atoms() -> list[_DiscoveredAtom]:
     return out
 
 
-
 def _wrap_atom(run: _AtomRun, *, anchor: str) -> StepFn:
     async def _step(ctx: Any) -> Any:
         rv = run(None, ctx)
@@ -204,7 +203,7 @@ class Kernel:
         ctx: Optional[Mapping[str, Any]] = None,
     ) -> Any:
         phases = self.build(model, alias)
-        base_ctx = _Ctx.from_request(request, db=db, seed=ctx)
+        base_ctx = _Ctx.ensure(request=request, db=db, seed=ctx)
         try:
             base_ctx.method = alias
         except Exception:

--- a/pkgs/standards/autoapi/tests/unit/test_kernel_invoke_ctx.py
+++ b/pkgs/standards/autoapi/tests/unit/test_kernel_invoke_ctx.py
@@ -1,0 +1,14 @@
+import pytest
+
+from autoapi.v3.runtime.kernel import Kernel
+
+
+@pytest.mark.asyncio
+async def test_kernel_invoke_with_basic_ctx():
+    k = Kernel()
+
+    class Model:
+        pass
+
+    result = await k.invoke(model=Model, alias="read", db=None, request=None, ctx={})
+    assert result is None


### PR DESCRIPTION
## Summary
- Use `_Ctx.ensure` in runtime kernel to build context
- Add regression test for kernel invocation with basic context

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff format .`
- `uv run --directory standards/autoapi --package autoapi ruff check . --fix`
- `uv run --directory standards/autoapi --package autoapi pytest` *(fails: tests/i9n/test_key_digest_uvicorn.py::test_create_apikey_success, tests/i9n/test_key_digest_uvicorn.py::test_create_response_fields)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3ddd67608326a00a58587c54be40