### PR TITLE
docs(autoapi): document column-level configuration

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/README.md
+++ b/pkgs/standards/autoapi/autoapi/v3/README.md
@@ -19,3 +19,47 @@ exporting custom `get_async_db` helpers.
 
 These rules apply to all first-party applications, including
 `auto_kms`, `auto_authn`, and the `peagen` gateway.
+
+## Column-Level Configuration
+
+AutoAPI v3 models declare their database and API behavior through
+`ColumnSpec` helpers exposed in `autoapi.v3.column`.  Use `acol` for
+persisted columns and `vcol` for wire-only virtual values.  Each column
+can combine three optional specs:
+
+- `S` (`StorageSpec`) – database shape such as types, keys, indexes, and
+  other SQLAlchemy column arguments.
+- `F` (`FieldSpec`) – Python and schema metadata including validation
+  constraints or example values.
+- `IO` (`IOSpec`) – inbound/outbound exposure settings, aliases,
+  sensitivity flags, and filtering/sorting capabilities.
+
+Example:
+
+```python
+from autoapi.v3.column import acol, vcol, F, S, IO
+
+class Widget(Base):
+    __tablename__ = "widgets"
+
+    id: Mapped[int] = acol(storage=S(primary_key=True))
+    name: Mapped[str] = acol(
+        field=F(constraints={"max_length": 50}),
+        storage=S(nullable=False, index=True),
+        io=IO(
+            in_verbs=("create", "update"),
+            out_verbs=("read", "list"),
+            sortable=True,
+        ),
+    )
+    checksum: Mapped[str] = vcol(
+        field=F(),
+        io=IO(out_verbs=("read",)),
+        read_producer=lambda obj, ctx: f"{obj.name}:{obj.id}",
+    )
+```
+
+Virtual columns like `checksum` use a `read_producer` (or `producer`)
+function to compute values on the fly.  Leveraging these specs keeps
+column behavior declarative and consistent across the ORM, schema
+generation, and runtime I/O.


### PR DESCRIPTION
## Summary
- describe column-level configuration helpers in autoapi v3

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest` *(fails: tests/i9n/test_key_digest_uvicorn.py::test_create_apikey_success, tests/i9n/test_key_digest_uvicorn.py::test_create_response_fields)*

------
https://chatgpt.com/codex/tasks/task_e_68bd4688161c8326b9885c1562162d03