### PR TITLE
feat(autoapi): add table spec collector

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/table/collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/table/collect.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Mapping, Tuple
+
+from .table_spec import TableSpec
+
+logger = logging.getLogger("uvicorn")
+
+
+def _merge_seq_attr(model: type, attr: str) -> Tuple[Any, ...]:
+    values: list[Any] = []
+    for base in reversed(model.__mro__):
+        seq = getattr(base, attr, ()) or ()
+        try:
+            values.extend(seq)
+        except TypeError:  # pragma: no cover - non-iterable
+            values.append(seq)
+    return tuple(values)
+
+
+def collect_table_spec(model: type) -> TableSpec:
+    """Collect TableSpec-like declarations across the model's MRO.
+
+    Merges common spec attributes (OPS, COLUMNS, SCHEMAS, HOOKS, SECURITY_DEPS,
+    DEPS) declared on the class or any mixins. Engine bindings declared via
+    ``table_config`` use the same precedence: later classes in the MRO override
+    earlier ones.
+    """
+
+    logger.info("Collecting table spec for %s", model.__name__)
+
+    engine: Any | None = None
+    for base in reversed(model.__mro__):
+        cfg = getattr(base, "table_config", None)
+        if isinstance(cfg, Mapping):
+            eng = (
+                cfg.get("engine")
+                or cfg.get("db")
+                or cfg.get("database")
+                or cfg.get("engine_provider")
+                or cfg.get("db_provider")
+            )
+            if eng is not None:
+                engine = eng
+
+    spec = TableSpec(
+        model=model,
+        engine=engine,
+        ops=_merge_seq_attr(model, "OPS"),
+        columns=_merge_seq_attr(model, "COLUMNS"),
+        schemas=_merge_seq_attr(model, "SCHEMAS"),
+        hooks=_merge_seq_attr(model, "HOOKS"),
+        security_deps=_merge_seq_attr(model, "SECURITY_DEPS"),
+        deps=_merge_seq_attr(model, "DEPS"),
+    )
+
+    logger.debug(
+        "Collected table spec for %s: %d ops, %d columns",
+        model.__name__,
+        len(spec.ops),
+        len(spec.columns),
+    )
+    return spec
+
+
+__all__ = ["collect_table_spec"]

--- a/pkgs/standards/autoapi/tests/unit/test_table_collect_spec.py
+++ b/pkgs/standards/autoapi/tests/unit/test_table_collect_spec.py
@@ -1,0 +1,41 @@
+from autoapi.v3.table.collect import collect_table_spec
+from autoapi.v3.table.shortcuts import defineTableSpec
+from autoapi.v3.orm.tables import Base
+from autoapi.v3.orm.mixins import GUIDPk
+
+
+SpecA = defineTableSpec(
+    engine="db_a",
+    ops=["a"],
+    columns=["col_a"],
+    schemas=["SchemaA"],
+    hooks=["hook_a"],
+    security_deps=["sec_a"],
+    deps=["dep_a"],
+)
+
+SpecB = defineTableSpec(
+    engine="db_b",
+    ops=["b"],
+    columns=["col_b"],
+    schemas=["SchemaB"],
+    hooks=["hook_b"],
+    security_deps=["sec_b"],
+    deps=["dep_b"],
+)
+
+
+class Model(SpecA, SpecB, Base, GUIDPk):
+    __tablename__ = "collect_spec_model"
+
+
+def test_collect_table_spec_merges_mro():
+    spec = collect_table_spec(Model)
+    assert spec.model is Model
+    assert spec.engine == "db_b"
+    assert spec.ops == ("a", "b")
+    assert spec.columns == ("col_a", "col_b")
+    assert spec.schemas == ("SchemaA", "SchemaB")
+    assert spec.hooks == ("hook_a", "hook_b")
+    assert spec.security_deps == ("sec_a", "sec_b")
+    assert spec.deps == ("dep_a", "dep_b")


### PR DESCRIPTION
## Summary
- add `collect_table_spec` to gather table-level spec attributes across mixins
- test `collect_table_spec` merges engine, ops, columns, schemas, hooks, and deps

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68bd586f9e1483269ad8f987311eb55c