### PR TITLE
Raise errors when runtime atoms skipped

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/emit/paired_post.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/emit/paired_post.py
@@ -42,8 +42,9 @@ def run(obj: Optional[object], ctx: Any) -> None:
     # but guard anyway for robustness.
     logger.debug("Running emit:paired_post")
     if getattr(ctx, "persist", True) is False:
-        logger.debug("Skipping emit:paired_post; ctx.persist is False")
-        return
+        msg = "ctx.persist is False; emit:paired_post cannot run"
+        logger.debug(msg)
+        raise RuntimeError(msg)
 
     temp = _ensure_temp(ctx)
     emit_buf = _ensure_emit_buf(temp)

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/emit/paired_pre.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/emit/paired_pre.py
@@ -43,8 +43,9 @@ def run(obj: Optional[object], ctx: Any) -> None:
     # but guard anyway for robustness.
     logger.debug("Running emit:paired_pre")
     if getattr(ctx, "persist", True) is False:
-        logger.debug("Skipping emit:paired_pre; ctx.persist is False")
-        return
+        msg = "ctx.persist is False; emit:paired_pre cannot run"
+        logger.debug(msg)
+        raise RuntimeError(msg)
 
     temp = _ensure_temp(ctx)
     emit_buf = _ensure_emit_buf(temp)

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/emit/readtime_alias.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/emit/readtime_alias.py
@@ -55,8 +55,9 @@ def run(obj: Optional[object], ctx: Any) -> None:
         get_cached_specs(model) if model else {}
     )
     if not specs:
-        logger.debug("No specs available; skipping read-time alias emission")
-        return
+        msg = "ctx.specs is required for emit:readtime_alias"
+        logger.debug(msg)
+        raise RuntimeError(msg)
 
     for field, colspec in specs.items():
         alias = _infer_alias_from_spec(field, colspec)

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/out/masking.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/out/masking.py
@@ -49,8 +49,9 @@ def run(obj: Optional[object], ctx: Any) -> None:
         get_cached_specs(model) if model else {}
     )
     if not specs:
-        logger.debug("No specs provided; skipping masking")
-        return
+        msg = "ctx.specs is required for out:masking"
+        logger.debug(msg)
+        raise RuntimeError(msg)
 
     temp = _ensure_temp(ctx)
     payload = temp.get("response_payload")

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/refresh/demand.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/refresh/demand.py
@@ -41,8 +41,9 @@ def run(obj: Optional[object], ctx: Any) -> None:
     """
     logger.debug("Running refresh:demand")
     if getattr(ctx, "persist", True) is False:
-        logger.debug("Skipping refresh:demand; ctx.persist is False")
-        return
+        msg = "ctx.persist is False; refresh:demand cannot run"
+        logger.debug(msg)
+        raise RuntimeError(msg)
 
     temp = _ensure_temp(ctx)
     model = (

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/resolve/assemble.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/resolve/assemble.py
@@ -43,8 +43,9 @@ def run(obj: Optional[object], ctx: Any) -> None:
     """
     # Non-persisting ops should have pruned this anchor; retain guard for safety.
     if getattr(ctx, "persist", True) is False:
-        logger.debug("Skipping resolve:assemble; ctx.persist is False")
-        return
+        msg = "ctx.persist is False; resolve:assemble cannot run"
+        logger.debug(msg)
+        raise RuntimeError(msg)
 
     logger.debug("Running resolve:assemble")
     model = (
@@ -56,8 +57,9 @@ def run(obj: Optional[object], ctx: Any) -> None:
         get_cached_specs(model) if model else {}
     )
     if not specs:
-        logger.debug("No specs provided; nothing to assemble")
-        return
+        msg = "ctx.specs is required for resolve:assemble"
+        logger.debug(msg)
+        raise RuntimeError(msg)
 
     inbound = _coerce_inbound(getattr(ctx, "temp", {}).get("in_values", None), ctx)
 

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/resolve/paired_gen.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/resolve/paired_gen.py
@@ -48,8 +48,9 @@ def run(obj: Optional[object], ctx: Any) -> None:
     """
     # Non-persisting ops should have pruned this anchor; keep guard for safety.
     if getattr(ctx, "persist", True) is False:
-        logger.debug("Skipping resolve:paired_gen; ctx.persist is False")
-        return
+        msg = "ctx.persist is False; resolve:paired_gen cannot run"
+        logger.debug(msg)
+        raise RuntimeError(msg)
 
     logger.debug("Running resolve:paired_gen")
     model = (
@@ -61,8 +62,9 @@ def run(obj: Optional[object], ctx: Any) -> None:
         get_cached_specs(model) if model else {}
     )
     if not specs:
-        logger.debug("No specs provided; nothing to generate")
-        return
+        msg = "ctx.specs is required for resolve:paired_gen"
+        logger.debug(msg)
+        raise RuntimeError(msg)
 
     temp = _ensure_temp(ctx)
     assembled = _ensure_dict(temp, "assembled_values")

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/schema/collect_in.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/schema/collect_in.py
@@ -63,8 +63,9 @@ def run(obj: Optional[object], ctx: Any) -> None:
         get_cached_specs(model) if model else {}
     )
     if not specs:
-        logger.debug("No specs provided; skipping schema collection")
-        return
+        msg = "ctx.specs is required for schema:collect_in"
+        logger.debug(msg)
+        raise RuntimeError(msg)
 
     temp = _ensure_temp(ctx)
     if "schema_in" in temp:

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/schema/collect_out.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/schema/collect_out.py
@@ -64,8 +64,9 @@ def run(obj: Optional[object], ctx: Any) -> None:
         get_cached_specs(model) if model else {}
     )
     if not specs:
-        logger.debug("No specs provided; skipping schema collection")
-        return
+        msg = "ctx.specs is required for schema:collect_out"
+        logger.debug(msg)
+        raise RuntimeError(msg)
 
     temp = _ensure_temp(ctx)
     if "schema_out" in temp:

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/storage/to_stored.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/storage/to_stored.py
@@ -31,13 +31,15 @@ def run(obj: Optional[object], ctx: Any) -> None:
     """
     logger.debug("Running storage:to_stored")
     if getattr(ctx, "persist", True) is False:
-        logger.debug("Skipping storage:to_stored; ctx.persist is False")
-        return
+        msg = "ctx.persist is False; storage:to_stored cannot run"
+        logger.debug(msg)
+        raise RuntimeError(msg)
 
     specs: Mapping[str, Any] = getattr(ctx, "specs", {}) or {}
     if not specs:
-        logger.debug("No specs provided; skipping")
-        return
+        msg = "ctx.specs is required for storage:to_stored"
+        logger.debug(msg)
+        raise RuntimeError(msg)
 
     temp = _ensure_temp(ctx)
     assembled = _ensure_dict(temp, "assembled_values")


### PR DESCRIPTION
## Summary
- raise errors when runtime atoms are skipped due to persistence disabled
- enforce ctx.specs presence across runtime atom modules

## Testing
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff format .`
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68bd72587224832683153b63ce435e9c