### PR TITLE
fix(api key generation): enforce label requirement

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_apikey_generation.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_apikey_generation.py
@@ -11,7 +11,7 @@ from autoapi.v3.orm.mixins import (
     ValidityWindow,
 )
 from autoapi.v3.orm.tables._base import Base
-from autoapi.v3.specs import F, S, acol
+from autoapi.v3.specs import F, IO, S, acol
 
 
 class ConcreteApiKey(Base, GUIDPk, Created, LastUsed, ValidityWindow, KeyDigest):
@@ -23,7 +23,8 @@ class ConcreteApiKey(Base, GUIDPk, Created, LastUsed, ValidityWindow, KeyDigest)
 
     label: Mapped[str] = acol(
         storage=S(String, nullable=False),
-        field=F(constraints={"max_length": 120}),
+        field=F(required_in=("create",), constraints={"max_length": 120}),
+        io=IO(in_verbs=("create",)),
     )
 
 


### PR DESCRIPTION
## Summary
- ensure API key `label` is required for creation in integration test

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_apikey_generation.py`

------
https://chatgpt.com/codex/tasks/task_e_68bd79828b8083268b53b669370e7b0f