### PR TITLE
Handle missing context error in autoapi

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/runtime/errors/converters.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/errors/converters.py
@@ -114,6 +114,8 @@ def _classify_exception(
         return status.HTTP_501_NOT_IMPLEMENTED, _stringify_exc(exc), None
     if isinstance(exc, TimeoutError):
         return status.HTTP_504_GATEWAY_TIMEOUT, _stringify_exc(exc), None
+    if isinstance(exc, RuntimeError) and str(exc) == "ctx_missing_app_model_or_op":
+        return status.HTTP_422_UNPROCESSABLE_ENTITY, _stringify_exc(exc), None
 
     # 4) ORM/DB mapping
     if (NoResultFound is not None) and isinstance(exc, NoResultFound):


### PR DESCRIPTION
## Summary
- map `ctx_missing_app_model_or_op` runtime errors to HTTP 422

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_apikey_generation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bd79828b8083268b53b669370e7b0f