### PR TITLE
Fix context injection for AutoAPI auth provider

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/app/app_spec.py
+++ b/pkgs/standards/autoapi/autoapi/v3/app/app_spec.py
@@ -7,7 +7,7 @@ from ..engine.engine_spec import EngineCfg
 from ..response.types import ResponseSpec
 
 
-@dataclass
+@dataclass(eq=False)
 class AppSpec:
     """
     Used to *produce an App subclass* via App.from_spec().

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/api/resource_proxy.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/api/resource_proxy.py
@@ -68,6 +68,13 @@ class _ResourceProxy:
             if request is not None:
                 logger.debug("Request provided for %s.%s", self._model.__name__, alias)
                 base_ctx.setdefault("request", request)
+            # surface contextual metadata for runtime atoms
+            base_ctx.setdefault("app", getattr(request, "app", None))
+            base_ctx.setdefault("api", getattr(request, "app", None))
+            base_ctx.setdefault("model", self._model)
+            base_ctx.setdefault("op", alias)
+            base_ctx.setdefault("method", alias)
+            base_ctx.setdefault("target", alias)
             base_ctx.setdefault(
                 "env",
                 SimpleNamespace(

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest/collection.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest/collection.py
@@ -43,6 +43,13 @@ def _ctx(model, alias, target, request, db, payload, parent_kw):
         "db": db,
         "payload": payload,
         "path_params": parent_kw,
+        # surface key metadata for runtime atoms
+        "app": getattr(request, "app", None),
+        "api": getattr(request, "app", None),
+        "model": model,
+        "op": alias,
+        "method": alias,
+        "target": target,
         "env": SimpleNamespace(
             method=alias, params=payload, target=target, model=model
         ),

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest/member.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest/member.py
@@ -71,6 +71,13 @@ def _make_member_endpoint(
                 "db": db,
                 "payload": payload,
                 "path_params": path_params,
+                # expose contextual metadata for downstream atoms
+                "app": getattr(request, "app", None),
+                "api": getattr(request, "app", None),
+                "model": model,
+                "op": alias,
+                "method": alias,
+                "target": target,
                 "env": SimpleNamespace(
                     method=alias, params=payload, target=target, model=model
                 ),
@@ -145,6 +152,13 @@ def _make_member_endpoint(
                 "db": db,
                 "payload": payload,
                 "path_params": path_params,
+                # expose contextual metadata for downstream atoms
+                "app": getattr(request, "app", None),
+                "api": getattr(request, "app", None),
+                "model": model,
+                "op": alias,
+                "method": alias,
+                "target": target,
                 "env": SimpleNamespace(
                     method=alias, params=payload, target=target, model=model
                 ),
@@ -240,6 +254,13 @@ def _make_member_endpoint(
             "db": db,
             "payload": payload,
             "path_params": path_params,
+            # expose contextual metadata for downstream atoms
+            "app": getattr(request, "app", None),
+            "api": getattr(request, "app", None),
+            "model": model,
+            "op": alias,
+            "method": alias,
+            "target": target,
             "env": SimpleNamespace(
                 method=alias, params=payload, target=target, model=model
             ),

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rpc.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rpc.py
@@ -274,6 +274,13 @@ def _build_rpc_callable(model: type, sp: OpSpec) -> Callable[..., Awaitable[Any]
         base_ctx.setdefault("db", db)
         if request is not None:
             base_ctx.setdefault("request", request)
+        # surface contextual metadata for runtime atoms
+        base_ctx.setdefault("app", getattr(request, "app", None))
+        base_ctx.setdefault("api", getattr(request, "app", None))
+        base_ctx.setdefault("model", model)
+        base_ctx.setdefault("op", alias)
+        base_ctx.setdefault("method", alias)
+        base_ctx.setdefault("target", target)
         # helpful env metadata
         base_ctx.setdefault(
             "env",


### PR DESCRIPTION
## Summary
- expose app, model, and operation metadata in REST, RPC, and proxy contexts
- make `AppSpec` hashable so kernel caches can use the app instance

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --directory standards/autoapi --package autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_authn_provider_integration.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_68bd7988c2c083269f125bffcfba3757