### PR TITLE
feat(autoapi): separate MRO collectors

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/api/mro_collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/api/mro_collect.py
@@ -1,0 +1,41 @@
+# autoapi/v3/api/mro_collect.py
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Dict, Iterable, Mapping
+
+from ..config.constants import AUTOAPI_API_HOOKS_ATTR
+
+logger = logging.getLogger("uvicorn")
+
+
+def mro_collect_api_hooks(api: type) -> Dict[str, Dict[str, list[Callable[..., Any]]]]:
+    """Collect API-level hook declarations across ``api``'s MRO.
+
+    The accepted shape mirrors the hooks mapping used by the bindings:
+        {alias: {phase: Iterable[callable]}}
+    Hooks from base classes are merged with subclass definitions taking precedence.
+    """
+    logger.info("Collecting API hooks for %s", api.__name__)
+    out: Dict[str, Dict[str, list[Callable[..., Any]]]] = {}
+    for base in reversed(api.__mro__):
+        mapping = getattr(base, AUTOAPI_API_HOOKS_ATTR, None)
+        if not isinstance(mapping, Mapping):
+            continue
+        for alias, phase_map in mapping.items():
+            bucket = out.setdefault(str(alias), {})
+            if not isinstance(phase_map, Mapping):
+                continue
+            for phase, items in phase_map.items():
+                lst = bucket.setdefault(str(phase), [])
+                if isinstance(items, Iterable):
+                    for fn in items:
+                        if callable(fn):
+                            lst.append(fn)
+                elif callable(items):
+                    lst.append(items)
+    logger.debug("Collected API hooks for aliases: %s", list(out.keys()))
+    return out
+
+
+__all__ = ["mro_collect_api_hooks"]

--- a/pkgs/standards/autoapi/autoapi/v3/app/mro_collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/app/mro_collect.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Tuple
+
+from .app_spec import AppSpec
+
+logger = logging.getLogger("uvicorn")
+
+
+def _merge_seq_attr(app: type, attr: str) -> Tuple[Any, ...]:
+    values: list[Any] = []
+    for base in reversed(app.__mro__):
+        seq = getattr(base, attr, ()) or ()
+        try:
+            values.extend(seq)
+        except TypeError:  # non-iterable
+            values.append(seq)
+    return tuple(values)
+
+
+def mro_collect_app_spec(app: type) -> AppSpec:
+    """Collect AppSpec-like declarations across the app's MRO."""
+    logger.info("Collecting app spec for %s", app.__name__)
+
+    title = "AutoAPI"
+    version = "0.1.0"
+    engine: Any | None = None
+    response = None
+    jsonrpc_prefix = "/rpc"
+    system_prefix = "/system"
+    lifespan = None
+
+    for base in reversed(app.__mro__):
+        title = getattr(base, "TITLE", title)
+        version = getattr(base, "VERSION", version)
+        eng = getattr(base, "ENGINE", None)
+        if eng is not None:
+            engine = eng
+        response = getattr(base, "RESPONSE", response)
+        jsonrpc_prefix = getattr(base, "JSONRPC_PREFIX", jsonrpc_prefix)
+        system_prefix = getattr(base, "SYSTEM_PREFIX", system_prefix)
+        lifespan = getattr(base, "LIFESPAN", lifespan)
+
+    spec = AppSpec(
+        title=title,
+        version=version,
+        engine=engine,
+        apis=_merge_seq_attr(app, "APIS"),
+        ops=_merge_seq_attr(app, "OPS"),
+        models=_merge_seq_attr(app, "MODELS"),
+        schemas=_merge_seq_attr(app, "SCHEMAS"),
+        hooks=_merge_seq_attr(app, "HOOKS"),
+        security_deps=_merge_seq_attr(app, "SECURITY_DEPS"),
+        deps=_merge_seq_attr(app, "DEPS"),
+        response=response,
+        jsonrpc_prefix=jsonrpc_prefix,
+        system_prefix=system_prefix,
+        middlewares=_merge_seq_attr(app, "MIDDLEWARES"),
+        lifespan=lifespan,
+    )
+    return spec
+
+
+__all__ = ["mro_collect_app_spec"]

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/model.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/model.py
@@ -6,7 +6,8 @@ from dataclasses import replace
 from types import SimpleNamespace
 from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple
 
-from ..op import OpSpec, alias_map_for, collect_decorated_ops
+from ..op import OpSpec
+from ..op.mro_collect import mro_alias_map_for, mro_collect_decorated_ops
 from ..op import resolve as resolve_ops
 from ..op.types import PHASES  # phase allowlist for hook merges
 
@@ -86,7 +87,7 @@ def bind(model: type, *, only_keys: Optional[Set[_Key]] = None) -> Tuple[OpSpec,
     base_specs: List[OpSpec] = list(resolve_ops(model))
 
     # 2) Add ctx-only ops discovered via decorators (tables + mixins)
-    ctx_specs: List[OpSpec] = list(collect_decorated_ops(model))
+    ctx_specs: List[OpSpec] = list(mro_collect_decorated_ops(model))
 
     # 2a) Inherit canonical schemas for aliased ops lacking explicit schemas
     base_by_target: Dict[str, OpSpec] = {sp.target: sp for sp in base_specs}
@@ -157,7 +158,7 @@ def bind(model: type, *, only_keys: Optional[Set[_Key]] = None) -> Tuple[OpSpec,
 
     # (Optional) expose resolved alias map for diagnostics
     try:
-        model.alias_map = alias_map_for(model)
+        model.alias_map = mro_alias_map_for(model)
     except Exception:  # defensive
         pass
 

--- a/pkgs/standards/autoapi/autoapi/v3/column/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/column/__init__.py
@@ -23,7 +23,6 @@ from ._column import Column
 from .field_spec import FieldSpec as F
 from .storage_spec import StorageSpec as S
 from .io_spec import IOSpec as IO
-from .collect import collect_columns
 
 # Ergonomic constructors
 from .shortcuts import makeColumn, makeVirtualColumn, acol, vcol
@@ -61,7 +60,6 @@ __all__ = [
     "InferenceError",
     "UnsupportedType",
     "is_virtual",
-    "collect_columns",
 ]
 
 

--- a/pkgs/standards/autoapi/autoapi/v3/column/mro_collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/column/mro_collect.py
@@ -8,8 +8,8 @@ from .column_spec import ColumnSpec
 logger = logging.getLogger("uvicorn")
 
 
-def collect_columns(model: type) -> Dict[str, ColumnSpec]:
-    """Gather ColumnSpecs declared on *model* and all mixins.
+def mro_collect_columns(model: type) -> Dict[str, ColumnSpec]:
+    """Collect ColumnSpecs declared on *model* and all mixins.
 
     Iterates across the model's MRO so that mixin-defined columns are included
     in the resulting mapping. Later definitions take precedence over earlier
@@ -28,4 +28,4 @@ def collect_columns(model: type) -> Dict[str, ColumnSpec]:
     return out
 
 
-__all__ = ["collect_columns"]
+__all__ = ["mro_collect_columns"]

--- a/pkgs/standards/autoapi/autoapi/v3/core/crud/helpers/model.py
+++ b/pkgs/standards/autoapi/autoapi/v3/core/crud/helpers/model.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Mapping, Tuple
 
 import logging
 
-from ....column.collect import collect_columns
+from ....column.mro_collect import mro_collect_columns
 
 logging.getLogger("uvicorn").setLevel(logging.DEBUG)
 logger = logging.getLogger("uvicorn")
@@ -67,7 +67,7 @@ def _model_columns(model: type) -> Tuple[str, ...]:
 
 def _colspecs(model: type) -> Mapping[str, Any]:
     logger.info("_colspecs called with model=%s", model)
-    specs = collect_columns(model)
+    specs = mro_collect_columns(model)
     logger.info("_colspecs returning %s", specs)
     return specs
 

--- a/pkgs/standards/autoapi/autoapi/v3/engine/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/engine/__init__.py
@@ -1,7 +1,7 @@
 """Engine utilities for collecting and binding database providers."""
 
 from .bind import bind, install_from_objects
-from .collect import collect_from_objects
+from .collect import collect_engine_config
 from .builders import (
     async_postgres_engine,
     async_sqlite_engine,
@@ -13,7 +13,7 @@ from ._engine import Engine
 from .shortcuts import engine
 
 __all__ = [
-    "collect_from_objects",
+    "collect_engine_config",
     "bind",
     "install_from_objects",
     "blocking_sqlite_engine",

--- a/pkgs/standards/autoapi/autoapi/v3/engine/bind.py
+++ b/pkgs/standards/autoapi/autoapi/v3/engine/bind.py
@@ -27,7 +27,7 @@ def install_from_objects(
     *, app: Any | None = None, api: Any | None = None, models: Iterable[Any] = ()
 ) -> None:
     """Collect engine config from objects and bind them to the resolver."""
-    from .collect import collect_from_objects
+    from .collect import collect_engine_config
 
-    collected = collect_from_objects(app=app, api=api, models=models)
+    collected = collect_engine_config(app=app, api=api, models=models)
     bind(collected)

--- a/pkgs/standards/autoapi/autoapi/v3/engine/collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/engine/collect.py
@@ -69,7 +69,7 @@ def _iter_declared_ops(model: Any) -> Dict[Tuple[Any, str], Mapping[str, Any]]:
     return out
 
 
-def collect_from_objects(
+def collect_engine_config(
     *, app: Any | None = None, api: Any | None = None, models: Iterable[Any] = ()
 ) -> Dict[str, Any]:
     """Collect engine configuration from objects without binding them."""
@@ -107,3 +107,6 @@ def collect_from_objects(
         "tables": tables,
         "ops": ops,
     }
+
+
+__all__ = ["collect_engine_config"]

--- a/pkgs/standards/autoapi/autoapi/v3/hook/collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/hook/collect.py
@@ -6,7 +6,8 @@ import logging
 from typing import Any, Callable, Dict, Iterable, Union
 
 from ..runtime.executor import _Ctx
-from ..op.collect import alias_map_for, apply_alias
+from ..op.collect import apply_alias
+from ..op.mro_collect import mro_alias_map_for
 from ..op.decorators import _maybe_await, _unwrap
 from .decorators import HOOK_DECLS_ATTR, Hook
 
@@ -53,7 +54,7 @@ def collect_decorated_hooks(
 
     logger.info("Collecting hooks for %s", table.__name__)
     mapping: Dict[str, Dict[str, list[Callable[..., Any]]]] = {}
-    aliases = alias_map_for(table)
+    aliases = mro_alias_map_for(table)
 
     def _resolve_ops(spec: Union[str, Iterable[str]]) -> Iterable[str]:
         if spec == "*":

--- a/pkgs/standards/autoapi/autoapi/v3/op/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/op/__init__.py
@@ -14,12 +14,7 @@ from .types import (
     PHASES,
     VerbAliasPolicy,
 )
-from .collect import (
-    resolve,
-    collect_decorated_ops,
-    alias_map_for,
-    apply_alias,
-)
+from .collect import resolve, apply_alias
 from .model_registry import (
     OpspecRegistry,
     get_registry,
@@ -41,8 +36,6 @@ __all__ = [
     "PHASES",
     "VerbAliasPolicy",
     "resolve",
-    "collect_decorated_ops",
-    "alias_map_for",
     "apply_alias",
     "OpspecRegistry",
     "get_registry",

--- a/pkgs/standards/autoapi/autoapi/v3/op/collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/op/collect.py
@@ -1,26 +1,14 @@
-# autoapi/v3/ops/collect.py
 from __future__ import annotations
 
-from dataclasses import replace
 import logging
 import re
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Iterable,
-    List,
-    Mapping,
-    Optional,
-    Sequence,
-    Tuple,
-)
+from dataclasses import replace
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
 from .types import OpSpec, TargetOp
 from ..config.constants import AUTOAPI_OPS_ATTR
 from .canonical import should_wire_canonical
-from .decorators import _maybe_await, _OpDecl, _infer_arity, _normalize_persist, _unwrap
-from ..runtime.executor import _Ctx
+from .mro_collect import mro_alias_map_for
 
 try:
     # Per-model registry (observable, triggers rebind elsewhere)
@@ -36,98 +24,14 @@ logger = logging.getLogger("uvicorn")
 _ALIAS_RE = re.compile(r"^[a-z][a-z0-9_]*$")
 
 
-def _merge_mro_dict(cls: type, attr: str) -> Dict[str, Any]:
-    merged: Dict[str, Any] = {}
-    for base in reversed(cls.__mro__):
-        merged.update(getattr(base, attr, {}) or {})
-    return merged
-
-
-def alias_map_for(table: type) -> Dict[str, str]:
-    """Merge aliases across MRO; subclass wins."""
-    return _merge_mro_dict(table, "__autoapi_aliases__")
-
-
 def apply_alias(verb: str, alias_map: Dict[str, str]) -> str:
     """Resolve canonical verb → alias (falls back to verb)."""
     return alias_map.get(verb, verb)
 
 
-def _wrap_ctx_core(table: type, func: Callable[..., Any]) -> Callable[..., Any]:
-    """Adapt `(cls, ctx)` op to `(p, *, db, request, ctx)` handler signature."""
-
-    async def core(p=None, *, db=None, request=None, ctx: Dict[str, Any] | None = None):
-        ctx = _Ctx.ensure(request=request, db=db, seed=ctx)
-        if p is not None:
-            ctx["payload"] = p
-        bound = func.__get__(table, table)
-        res = await _maybe_await(bound(ctx))
-        return res if res is not None else ctx.get("result")
-
-    core.__name__ = getattr(func, "__name__", "core")
-    core.__qualname__ = getattr(func, "__qualname__", core.__name__)
-    return core
-
-
-def collect_decorated_ops(table: type) -> list[OpSpec]:
-    """Scan MRO for ctx-only op declarations (@op_ctx) and build OpSpecs."""
-
-    logger.info("Collecting decorated ops for %s", table.__name__)
-    out: list[OpSpec] = []
-
-    for base in reversed(table.__mro__):
-        names = list(getattr(base, "__dict__", {}).keys())
-        for name in dir(base):
-            if name not in names:
-                names.append(name)
-        for name in names:
-            attr = getattr(base, name, None)
-            func = _unwrap(attr)
-            decl: _OpDecl | None = getattr(func, "__autoapi_op_decl__", None)
-            if not decl:
-                continue
-
-            target = decl.target or "custom"
-            arity = decl.arity or _infer_arity(target)
-            persist = _normalize_persist(decl.persist)
-            alias = decl.alias or name
-
-            expose_kwargs: dict[str, Any] = {}
-            extra: dict[str, Any] = {}
-            if decl.rest is not None:
-                expose_kwargs["expose_routes"] = bool(decl.rest)
-            elif alias != target and target in {
-                "read",
-                "update",
-                "delete",
-                "list",
-                "clear",
-            }:
-                expose_kwargs["expose_routes"] = False
-
-            spec = OpSpec(
-                table=table,
-                alias=alias,
-                target=target,
-                arity=arity,
-                persist=persist,
-                handler=_wrap_ctx_core(table, func),
-                request_model=decl.request_schema,
-                response_model=decl.response_schema,
-                hooks=(),
-                status_code=decl.status_code,
-                extra=extra,
-                **expose_kwargs,
-            )
-            out.append(spec)
-
-    logger.debug("Collected %d ops for %s", len(out), table.__name__)
-    return out
-
-
-# ───────────────────────────────────────────────────────────────────────────────
+# ──────────────────────────────────────────────────────────────────────────────
 # Helpers
-# ───────────────────────────────────────────────────────────────────────────────
+# ──────────────────────────────────────────────────────────────────────────────
 
 
 def _ensure_spec_table(spec: OpSpec, table: type) -> OpSpec:
@@ -283,7 +187,7 @@ def _apply_alias_ctx_to_canon(specs: List[OpSpec], model: type) -> List[OpSpec]:
     We do NOT support any `returns` override. If no response schema is set,
     binders should treat the op as returning raw.
     """
-    aliases = alias_map_for(model)  # {verb: alias}
+    aliases = mro_alias_map_for(model)  # {verb: alias}
     overrides: Mapping[str, Mapping[str, Any]] = (
         getattr(model, "__autoapi_alias_overrides__", {}) or {}
     )
@@ -395,4 +299,4 @@ def resolve(model: type) -> List[OpSpec]:
     return specs
 
 
-__all__ = ["resolve", "collect_decorated_ops", "alias_map_for", "apply_alias"]
+__all__ = ["resolve", "apply_alias"]

--- a/pkgs/standards/autoapi/autoapi/v3/op/mro_collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/op/mro_collect.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Dict
+
+from .types import OpSpec
+from .decorators import _maybe_await, _OpDecl, _infer_arity, _normalize_persist, _unwrap
+from ..runtime.executor import _Ctx
+
+logger = logging.getLogger("uvicorn")
+
+
+def _merge_mro_dict(cls: type, attr: str) -> Dict[str, Any]:
+    merged: Dict[str, Any] = {}
+    for base in reversed(cls.__mro__):
+        merged.update(getattr(base, attr, {}) or {})
+    return merged
+
+
+def mro_alias_map_for(table: type) -> Dict[str, str]:
+    """Collect alias overrides across the table's MRO."""
+    return _merge_mro_dict(table, "__autoapi_aliases__")
+
+
+def _wrap_ctx_core(table: type, func: Callable[..., Any]) -> Callable[..., Any]:
+    """Adapt `(cls, ctx)` op to `(p, *, db, request, ctx)` handler signature."""
+
+    async def core(p=None, *, db=None, request=None, ctx: Dict[str, Any] | None = None):
+        ctx = _Ctx.ensure(request=request, db=db, seed=ctx)
+        if p is not None:
+            ctx["payload"] = p
+        bound = func.__get__(table, table)
+        res = await _maybe_await(bound(ctx))
+        return res if res is not None else ctx.get("result")
+
+    core.__name__ = getattr(func, "__name__", "core")
+    core.__qualname__ = getattr(func, "__qualname__", core.__name__)
+    return core
+
+
+def mro_collect_decorated_ops(table: type) -> list[OpSpec]:
+    """Collect ctx-only op declarations across the table's MRO."""
+
+    logger.info("Collecting decorated ops for %s", table.__name__)
+    out: list[OpSpec] = []
+
+    for base in reversed(table.__mro__):
+        names = list(getattr(base, "__dict__", {}).keys())
+        for name in dir(base):
+            if name not in names:
+                names.append(name)
+        for name in names:
+            attr = getattr(base, name, None)
+            func = _unwrap(attr)
+            decl: _OpDecl | None = getattr(func, "__autoapi_op_decl__", None)
+            if not decl:
+                continue
+
+            target = decl.target or "custom"
+            arity = decl.arity or _infer_arity(target)
+            persist = _normalize_persist(decl.persist)
+            alias = decl.alias or name
+
+            expose_kwargs: dict[str, Any] = {}
+            extra: dict[str, Any] = {}
+            if decl.rest is not None:
+                expose_kwargs["expose_routes"] = bool(decl.rest)
+            elif alias != target and target in {
+                "read",
+                "update",
+                "delete",
+                "list",
+                "clear",
+            }:
+                expose_kwargs["expose_routes"] = False
+
+            spec = OpSpec(
+                table=table,
+                alias=alias,
+                target=target,
+                arity=arity,
+                persist=persist,
+                handler=_wrap_ctx_core(table, func),
+                request_model=decl.request_schema,
+                response_model=decl.response_schema,
+                hooks=(),
+                status_code=decl.status_code,
+                extra=extra,
+                **expose_kwargs,
+            )
+            out.append(spec)
+
+    logger.debug("Collected %d ops for %s", len(out), table.__name__)
+    return out
+
+
+__all__ = ["mro_alias_map_for", "mro_collect_decorated_ops"]

--- a/pkgs/standards/autoapi/autoapi/v3/orm/mixins/key_digest.py
+++ b/pkgs/standards/autoapi/autoapi/v3/orm/mixins/key_digest.py
@@ -26,8 +26,8 @@ class KeyDigest:
             alias="api_key",
             verbs=("create",),
             emit="post_refresh",
-            alias_field=F(py_type=str),    # include alias in the response schema
-            mask_last=None,                # set an int if you want masking
+            alias_field=F(py_type=str),  # include alias in the response schema
+            mask_last=None,  # set an int if you want masking
         ),
     )
 

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/kernel.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/kernel.py
@@ -22,7 +22,7 @@ from typing import (
 from .executor import _invoke, _Ctx
 from . import events as _ev
 from ..op.types import PHASES, StepFn
-from ..column.collect import collect_columns
+from ..column.mro_collect import mro_collect_columns
 
 logger = logging.getLogger(__name__)
 
@@ -105,7 +105,7 @@ class _SpecsOnceCache:
         with self._lock:
             rv = self._d.get(model)
             if rv is None:
-                rv = collect_columns(model)
+                rv = mro_collect_columns(model)
                 self._d[model] = rv
         return rv
 

--- a/pkgs/standards/autoapi/autoapi/v3/schema/builder/build_schema.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/builder/build_schema.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, Iterable, Mapping, Set, Tuple, Type, Union
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, create_model
 
 from ..utils import namely_model
-from ...column.collect import collect_columns
+from ...column.mro_collect import mro_collect_columns
 from .cache import _SchemaCache
 from .compat import _info_check, hybrid_property
 from .extras import _merge_request_extras, _merge_response_extras
@@ -51,7 +51,7 @@ def _build_schema(
     # ── PASS 1: table-backed columns only (avoid mapper relationships)
     table = getattr(orm_cls, "__table__", None)
     table_cols: Iterable[Any] = tuple(table.columns) if table is not None else ()
-    specs: Dict[str, Any] = collect_columns(orm_cls)
+    specs: Dict[str, Any] = mro_collect_columns(orm_cls)
 
     for col in table_cols:
         attr_name = col.key or col.name

--- a/pkgs/standards/autoapi/autoapi/v3/schema/builder/list_params.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/builder/list_params.py
@@ -9,7 +9,7 @@ from typing import Any, Type
 from pydantic import BaseModel, ConfigDict, Field, create_model
 
 from ..utils import namely_model
-from ...column.collect import collect_columns
+from ...column.mro_collect import mro_collect_columns
 
 logger = logging.getLogger(__name__)
 
@@ -79,7 +79,7 @@ def _build_list_params(model: type) -> Type[BaseModel]:
             continue
         py_t = getattr(c.type, "python_type", Any)
         if py_t in _scalars:
-            spec_map = collect_columns(model)
+            spec_map = mro_collect_columns(model)
             spec = spec_map.get(c.name)
             io = getattr(spec, "io", None)
             ops_raw = set(getattr(io, "filter_ops", ()) or [])

--- a/pkgs/standards/autoapi/autoapi/v3/system/diagnostics/planz.py
+++ b/pkgs/standards/autoapi/autoapi/v3/system/diagnostics/planz.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 
 from ...op.types import PHASES
 from ...runtime import plan as _plan
-from ...column.collect import collect_columns
+from ...column.mro_collect import mro_collect_columns
 
 
 def build_planz_endpoint(api: Any):
@@ -32,7 +32,7 @@ def build_planz_endpoint(api: Any):
                 getattr(model, "runtime", SimpleNamespace()), "plan", None
             )
             if compiled_plan is None:
-                specs = collect_columns(model)
+                specs = mro_collect_columns(model)
                 if specs:
                     try:
                         compiled_plan = _plan.attach_atoms_for_model(model, specs)

--- a/pkgs/standards/autoapi/autoapi/v3/table/mro_collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/table/mro_collect.py
@@ -19,7 +19,7 @@ def _merge_seq_attr(model: type, attr: str) -> Tuple[Any, ...]:
     return tuple(values)
 
 
-def collect_table_spec(model: type) -> TableSpec:
+def mro_collect_table_spec(model: type) -> TableSpec:
     """Collect TableSpec-like declarations across the model's MRO.
 
     Merges common spec attributes (OPS, COLUMNS, SCHEMAS, HOOKS, SECURITY_DEPS,
@@ -64,4 +64,4 @@ def collect_table_spec(model: type) -> TableSpec:
     return spec
 
 
-__all__ = ["collect_table_spec"]
+__all__ = ["mro_collect_table_spec"]

--- a/pkgs/standards/autoapi/tests/unit/response_utils.py
+++ b/pkgs/standards/autoapi/tests/unit/response_utils.py
@@ -7,7 +7,7 @@ from autoapi.v3.bindings import (
     build_schemas,
     register_rpc,
 )
-from autoapi.v3.op import collect_decorated_ops
+from autoapi.v3.op.mro_collect import mro_collect_decorated_ops
 from autoapi.v3.response import response_ctx, render_template
 from autoapi.v3.response.shortcuts import (
     as_file,
@@ -38,7 +38,7 @@ def build_ping_model():
         def ping(cls, ctx):
             return {"pong": True}
 
-    specs = list(collect_decorated_ops(Widget))
+    specs = list(mro_collect_decorated_ops(Widget))
     build_schemas(Widget, specs)
     build_hooks(Widget, specs)
     build_handlers(Widget, specs)
@@ -75,7 +75,7 @@ def build_model_for_response(kind: str, tmp_path) -> tuple[type, str | None]:
                 return as_redirect("/redirected")
             return {"pong": True}
 
-    specs = list(collect_decorated_ops(Widget))
+    specs = list(mro_collect_decorated_ops(Widget))
     build_schemas(Widget, specs)
     build_hooks(Widget, specs)
     build_handlers(Widget, specs)
@@ -111,7 +111,7 @@ def build_model_for_response_non_alias(kind: str, tmp_path) -> tuple[type, str |
                 return as_redirect("/redirected")
             return {"pong": True}
 
-    specs = list(collect_decorated_ops(Widget))
+    specs = list(mro_collect_decorated_ops(Widget))
     build_schemas(Widget, specs)
     build_hooks(Widget, specs)
     build_handlers(Widget, specs)
@@ -137,7 +137,7 @@ def build_model_for_jinja_response(tmp_path) -> type:
             )
             return as_html(html)
 
-    specs = list(collect_decorated_ops(Widget))
+    specs = list(mro_collect_decorated_ops(Widget))
     build_schemas(Widget, specs)
     build_hooks(Widget, specs)
     build_handlers(Widget, specs)

--- a/pkgs/standards/autoapi/tests/unit/test_column_collect_mixins.py
+++ b/pkgs/standards/autoapi/tests/unit/test_column_collect_mixins.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from autoapi.v3.column.collect import collect_columns
+from autoapi.v3.column.mro_collect import mro_collect_columns
 from autoapi.v3.orm.mixins import GUIDPk
 from autoapi.v3.orm.tables._base import Base
 from autoapi.v3.specs import S, acol
@@ -16,6 +16,6 @@ class Thing(Base, GUIDPk, NameMixin):
 
 
 def test_collect_columns_includes_mixin_fields():
-    specs = collect_columns(Thing)
+    specs = mro_collect_columns(Thing)
     assert "id" in specs
     assert "name" in specs

--- a/pkgs/standards/autoapi/tests/unit/test_file_response.py
+++ b/pkgs/standards/autoapi/tests/unit/test_file_response.py
@@ -3,7 +3,8 @@ from pathlib import Path
 
 from fastapi.testclient import TestClient
 
-from autoapi.v3.op import collect_decorated_ops, op_ctx
+from autoapi.v3.op.mro_collect import mro_collect_decorated_ops
+from autoapi.v3.op import op_ctx
 from autoapi.v3.response.shortcuts import as_file
 from autoapi.v3.bindings import (
     build_hooks,
@@ -43,7 +44,7 @@ def _build_model(base: type, file_path: Path, *, bind: bool = True) -> type:
                 return as_file(file_path)
 
     if bind:
-        specs = list(collect_decorated_ops(Widget))
+        specs = list(mro_collect_decorated_ops(Widget))
         build_schemas(Widget, specs)
         build_hooks(Widget, specs)
         build_handlers(Widget, specs)

--- a/pkgs/standards/autoapi/tests/unit/test_op_ctx_arity_paths.py
+++ b/pkgs/standards/autoapi/tests/unit/test_op_ctx_arity_paths.py
@@ -1,6 +1,6 @@
 from autoapi.v3.types import App
 from autoapi.v3 import op_ctx
-from autoapi.v3.op import collect_decorated_ops
+from autoapi.v3.op.mro_collect import mro_collect_decorated_ops
 from autoapi.v3.bindings.rest.router import _build_router
 from autoapi.v3.orm.tables import Base
 from autoapi.v3.orm.mixins import GUIDPk
@@ -18,7 +18,7 @@ def test_member_arity_rest_path_includes_pk():
         def do(cls, ctx):
             return None
 
-    spec = collect_decorated_ops(MemberModel)[0]
+    spec = mro_collect_decorated_ops(MemberModel)[0]
     router = _build_router(MemberModel, [spec])
     paths = {route.path for route in router.routes}
     assert f"/{MemberModel.__name__.lower()}/{{item_id}}/do" in paths
@@ -35,7 +35,7 @@ def test_collection_arity_rest_path_excludes_pk():
         def do(cls, ctx):
             return None
 
-    spec = collect_decorated_ops(CollectionModel)[0]
+    spec = mro_collect_decorated_ops(CollectionModel)[0]
     router = _build_router(CollectionModel, [spec])
     paths = {route.path for route in router.routes}
     assert f"/{CollectionModel.__name__.lower()}/do" in paths
@@ -52,7 +52,7 @@ def test_member_arity_openapi_has_path_param():
         def do(cls, ctx):
             return None
 
-    spec = collect_decorated_ops(MemberModel)[0]
+    spec = mro_collect_decorated_ops(MemberModel)[0]
     router = _build_router(MemberModel, [spec])
     app = App()
     app.include_router(router)
@@ -73,7 +73,7 @@ def test_collection_arity_openapi_has_no_path_param():
         def do(cls, ctx):
             return None
 
-    spec = collect_decorated_ops(CollectionModel)[0]
+    spec = mro_collect_decorated_ops(CollectionModel)[0]
     router = _build_router(CollectionModel, [spec])
     app = App()
     app.include_router(router)

--- a/pkgs/standards/autoapi/tests/unit/test_op_ctx_attributes.py
+++ b/pkgs/standards/autoapi/tests/unit/test_op_ctx_attributes.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, patch
 from pydantic import BaseModel
 
 from autoapi.v3 import op_ctx
-from autoapi.v3.op import collect_decorated_ops
+from autoapi.v3.op.mro_collect import mro_collect_decorated_ops
 from autoapi.v3.schema.decorators import schema_ctx
 from autoapi.v3.op import resolve
 from autoapi.v3.bindings import build_schemas, build_hooks, build_handlers, build_rest
@@ -12,7 +12,7 @@ from autoapi.v3.bindings import build_schemas, build_hooks, build_handlers, buil
 
 def _build_all(model):
     canon = resolve(model)
-    custom = collect_decorated_ops(model)
+    custom = mro_collect_decorated_ops(model)
     specs = canon + custom
     build_schemas(model, specs)
     build_hooks(model, specs)
@@ -27,7 +27,7 @@ def test_op_ctx_alias_attribute():
         def op(cls, ctx):
             return None
 
-    specs = collect_decorated_ops(Widget)
+    specs = mro_collect_decorated_ops(Widget)
     assert specs[0].alias == "foo"
 
 
@@ -143,5 +143,5 @@ def test_op_ctx_persist_attribute():
         def op(cls, ctx):
             return None
 
-    specs = collect_decorated_ops(Gadget)
+    specs = mro_collect_decorated_ops(Gadget)
     assert specs[0].persist == "skip"

--- a/pkgs/standards/autoapi/tests/unit/test_op_ctx_persist_options.py
+++ b/pkgs/standards/autoapi/tests/unit/test_op_ctx_persist_options.py
@@ -1,7 +1,8 @@
 import pytest
 from types import SimpleNamespace
 
-from autoapi.v3.op import collect_decorated_ops, op_ctx
+from autoapi.v3.op.mro_collect import mro_collect_decorated_ops
+from autoapi.v3.op import op_ctx
 from autoapi.v3.bindings import handlers
 from autoapi.v3.system import diagnostics as _diag
 
@@ -14,7 +15,7 @@ def _build_model(persist: str):
         def custom(cls, ctx):  # pragma: no cover - execution not needed
             return None
 
-    specs = collect_decorated_ops(Model)
+    specs = mro_collect_decorated_ops(Model)
     Model.opspecs = SimpleNamespace(all=tuple(specs))
     handlers.build_and_attach(Model, specs)
     return Model

--- a/pkgs/standards/autoapi/tests/unit/test_table_collect_spec.py
+++ b/pkgs/standards/autoapi/tests/unit/test_table_collect_spec.py
@@ -1,4 +1,4 @@
-from autoapi.v3.table.collect import collect_table_spec
+from autoapi.v3.table.mro_collect import mro_collect_table_spec
 from autoapi.v3.table.shortcuts import defineTableSpec
 from autoapi.v3.orm.tables import Base
 from autoapi.v3.orm.mixins import GUIDPk
@@ -30,7 +30,7 @@ class Model(SpecA, SpecB, Base, GUIDPk):
 
 
 def test_collect_table_spec_merges_mro():
-    spec = collect_table_spec(Model)
+    spec = mro_collect_table_spec(Model)
     assert spec.model is Model
     assert spec.engine == "db_b"
     assert spec.ops == ("a", "b")

--- a/pkgs/standards/autoapi/tests/unit/test_v3_op_ctx_attributes.py
+++ b/pkgs/standards/autoapi/tests/unit/test_v3_op_ctx_attributes.py
@@ -1,5 +1,5 @@
 from autoapi.v3 import op_ctx
-from autoapi.v3.op import collect_decorated_ops
+from autoapi.v3.op.mro_collect import mro_collect_decorated_ops
 
 
 def test_op_ctx_alias_sets_alias():
@@ -8,7 +8,7 @@ def test_op_ctx_alias_sets_alias():
         def do(cls, ctx):
             return None
 
-    spec = collect_decorated_ops(Model)[0]
+    spec = mro_collect_decorated_ops(Model)[0]
     assert spec.alias == "custom_alias"
 
 
@@ -18,7 +18,7 @@ def test_op_ctx_target_sets_target():
         def do(cls, ctx):
             return None
 
-    spec = collect_decorated_ops(Model)[0]
+    spec = mro_collect_decorated_ops(Model)[0]
     assert spec.target == "create"
 
 
@@ -28,7 +28,7 @@ def test_op_ctx_arity_sets_arity():
         def do(cls, ctx):
             return None
 
-    spec = collect_decorated_ops(Model)[0]
+    spec = mro_collect_decorated_ops(Model)[0]
     assert spec.arity == "collection"
 
 
@@ -38,7 +38,7 @@ def test_op_ctx_rest_controls_exposure():
         def do(cls, ctx):
             return None
 
-    spec = collect_decorated_ops(Model)[0]
+    spec = mro_collect_decorated_ops(Model)[0]
     assert spec.expose_routes is False
 
 
@@ -48,7 +48,7 @@ def test_op_ctx_request_schema_attached():
         def do(cls, ctx):
             return None
 
-    spec = collect_decorated_ops(Model)[0]
+    spec = mro_collect_decorated_ops(Model)[0]
     assert spec.request_model == "InputSchema"
 
 
@@ -58,7 +58,7 @@ def test_op_ctx_response_schema_attached():
         def do(cls, ctx):
             return None
 
-    spec = collect_decorated_ops(Model)[0]
+    spec = mro_collect_decorated_ops(Model)[0]
     assert spec.response_model == "OutputSchema"
 
 
@@ -68,7 +68,7 @@ def test_op_ctx_persist_policy_override():
         def do(cls, ctx):
             return None
 
-    spec = collect_decorated_ops(Model)[0]
+    spec = mro_collect_decorated_ops(Model)[0]
     assert spec.persist == "skip"
 
 
@@ -90,7 +90,7 @@ def test_op_ctx_core_crud_order():
         def delete(cls, ctx, obj):
             return None
 
-    specs = collect_decorated_ops(Model)
+    specs = mro_collect_decorated_ops(Model)
     assert [sp.target for sp in specs] == [
         "create",
         "read",

--- a/pkgs/standards/autoapi/tests/unit/test_v3_schemas_and_decorators.py
+++ b/pkgs/standards/autoapi/tests/unit/test_v3_schemas_and_decorators.py
@@ -8,7 +8,7 @@ from autoapi.v3 import (
     SchemaRef,
 )
 from autoapi.v3.op import resolve
-from autoapi.v3.op import collect_decorated_ops
+from autoapi.v3.op.mro_collect import mro_collect_decorated_ops
 from autoapi.v3.bindings import build_schemas, build_hooks, build_handlers, build_rest
 
 # REST test client
@@ -60,7 +60,7 @@ def _build_all(model):
     canonical CRUD cores during the test.
     """
     canon = resolve(model)  # canonical specs (alias_ctx applied)
-    custom = collect_decorated_ops(model)  # ctx-only specs
+    custom = mro_collect_decorated_ops(model)  # ctx-only specs
     specs = canon + custom
 
     # Schemas first (seeds schema_ctx, then defaults, then overrides)


### PR DESCRIPTION
## Summary
- rename MRO-based helpers with `mro_collect_*` naming and drop re-exports from `collect` modules
- gather engine configuration via new `collect_engine_config` helper
- update imports and tests to use the dedicated `mro_collect` helpers

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68bd5d1780ec8326aecf777510da6346