### PR TITLE
chore(autoapi): dispose Base registry in hook ctx tests

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_hook_ctx_v3_i9n.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_hook_ctx_v3_i9n.py
@@ -44,6 +44,7 @@ def create_client(model_cls):
 @pytest.mark.asyncio
 async def test_hook_ctx_binding_i9n():
     Base.metadata.clear()
+    Base.registry.dispose()
 
     class Item(Base, GUIDPk):
         __tablename__ = "items"
@@ -67,6 +68,7 @@ async def test_hook_ctx_binding_i9n():
 @pytest.mark.asyncio
 async def test_hook_ctx_request_response_schema_i9n():
     Base.metadata.clear()
+    Base.registry.dispose()
 
     class Item(Base, GUIDPk):
         __tablename__ = "items"
@@ -92,6 +94,7 @@ async def test_hook_ctx_request_response_schema_i9n():
 @pytest.mark.asyncio
 async def test_hook_ctx_columns_i9n():
     Base.metadata.clear()
+    Base.registry.dispose()
 
     class Item(Base, GUIDPk):
         __tablename__ = "items"
@@ -120,6 +123,7 @@ async def test_hook_ctx_columns_i9n():
 @pytest.mark.asyncio
 async def test_hook_ctx_defaults_resolution_i9n():
     Base.metadata.clear()
+    Base.registry.dispose()
 
     class Item(Base, GUIDPk):
         __tablename__ = "items"
@@ -146,6 +150,7 @@ async def test_hook_ctx_defaults_resolution_i9n():
 @pytest.mark.asyncio
 async def test_hook_ctx_internal_model_i9n():
     Base.metadata.clear()
+    Base.registry.dispose()
 
     class Item(Base, GUIDPk):
         __tablename__ = "items"
@@ -174,6 +179,7 @@ async def test_hook_ctx_internal_model_i9n():
 @pytest.mark.asyncio
 async def test_hook_ctx_openapi_json_i9n():
     Base.metadata.clear()
+    Base.registry.dispose()
 
     class Item(Base, GUIDPk):
         __tablename__ = "items"
@@ -198,6 +204,7 @@ async def test_hook_ctx_openapi_json_i9n():
 @pytest.mark.asyncio
 async def test_hook_ctx_storage_sqlalchemy_i9n():
     Base.metadata.clear()
+    Base.registry.dispose()
 
     class Item(Base, GUIDPk):
         __tablename__ = "items"
@@ -227,6 +234,7 @@ async def test_hook_ctx_storage_sqlalchemy_i9n():
 @pytest.mark.asyncio
 async def test_hook_ctx_rest_call_i9n():
     Base.metadata.clear()
+    Base.registry.dispose()
 
     class Item(Base, GUIDPk):
         __tablename__ = "items"
@@ -251,6 +259,7 @@ async def test_hook_ctx_rest_call_i9n():
 @pytest.mark.asyncio
 async def test_hook_ctx_rpc_method_i9n():
     Base.metadata.clear()
+    Base.registry.dispose()
 
     class Item(Base, GUIDPk):
         __tablename__ = "items"
@@ -283,6 +292,7 @@ async def test_hook_ctx_rpc_method_i9n():
 @pytest.mark.asyncio
 async def test_hook_ctx_core_crud_i9n():
     Base.metadata.clear()
+    Base.registry.dispose()
 
     class Item(Base, GUIDPk):
         __tablename__ = "items"
@@ -308,6 +318,7 @@ async def test_hook_ctx_core_crud_i9n():
 @pytest.mark.asyncio
 async def test_hook_ctx_hookz_i9n():
     Base.metadata.clear()
+    Base.registry.dispose()
 
     class Item(Base, GUIDPk):
         __tablename__ = "items"
@@ -334,6 +345,7 @@ async def test_hook_ctx_hookz_i9n():
 @pytest.mark.asyncio
 async def test_hook_ctx_atomz_i9n():
     Base.metadata.clear()
+    Base.registry.dispose()
 
     class Item(Base, GUIDPk):
         __tablename__ = "items"
@@ -362,6 +374,7 @@ async def test_hook_ctx_atomz_i9n():
 @pytest.mark.asyncio
 async def test_hook_ctx_system_steps_i9n():
     Base.metadata.clear()
+    Base.registry.dispose()
 
     class Item(Base, GUIDPk):
         __tablename__ = "items"


### PR DESCRIPTION
## Summary
- clear SQLAlchemy declarative registry between AutoAPI hook context tests to avoid class name collisions

## Testing
- `uv run --package autoapi --directory standards pytest autoapi/tests/i9n/test_hook_ctx_v3_i9n.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd81bd28f8832688ea13d9feea62da