### PR TITLE
Ensure AutoAPI requests include app context

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/app/app_spec.py
+++ b/pkgs/standards/autoapi/autoapi/v3/app/app_spec.py
@@ -7,7 +7,7 @@ from ..engine.engine_spec import EngineCfg
 from ..response.types import ResponseSpec
 
 
-@dataclass
+@dataclass(eq=False)
 class AppSpec:
     """
     Used to *produce an App subclass* via App.from_spec().

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest/collection.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest/collection.py
@@ -46,6 +46,10 @@ def _ctx(model, alias, target, request, db, payload, parent_kw):
         "env": SimpleNamespace(
             method=alias, params=payload, target=target, model=model
         ),
+        "app": request.app,
+        "api": request.app,
+        "model": model,
+        "op": alias,
     }
     ac = getattr(request.state, AUTOAPI_AUTH_CONTEXT_ATTR, None)
     if ac is not None:

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest/member.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest/member.py
@@ -74,6 +74,10 @@ def _make_member_endpoint(
                 "env": SimpleNamespace(
                     method=alias, params=payload, target=target, model=model
                 ),
+                "app": request.app,
+                "api": request.app,
+                "model": model,
+                "op": alias,
             }
             ac = getattr(request.state, AUTOAPI_AUTH_CONTEXT_ATTR, None)
             if ac is not None:
@@ -148,6 +152,10 @@ def _make_member_endpoint(
                 "env": SimpleNamespace(
                     method=alias, params=payload, target=target, model=model
                 ),
+                "app": request.app,
+                "api": request.app,
+                "model": model,
+                "op": alias,
             }
             ac = getattr(request.state, AUTOAPI_AUTH_CONTEXT_ATTR, None)
             if ac is not None:
@@ -243,6 +251,10 @@ def _make_member_endpoint(
             "env": SimpleNamespace(
                 method=alias, params=payload, target=target, model=model
             ),
+            "app": request.app,
+            "api": request.app,
+            "model": model,
+            "op": alias,
         }
         ac = getattr(request.state, AUTOAPI_AUTH_CONTEXT_ATTR, None)
         if ac is not None:


### PR DESCRIPTION
## Summary
- attach app, model, and operation metadata to REST request context
- make `AppSpec` hashable so AutoApp can be used as a cache key

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_authn_provider_integration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd7c57865883268ea84ac8ea548b55