### PR TITLE
feat: centralize OpView resolution and schema caching

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/resolve/assemble.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/resolve/assemble.py
@@ -1,11 +1,11 @@
 # autoapi/v3/runtime/atoms/resolve/assemble.py
 from __future__ import annotations
 
-from typing import Any, Mapping, MutableMapping, Optional, Dict, Tuple
+from typing import Any, Mapping, Optional, Dict, Tuple
 import logging
 
 from ... import events as _ev
-from ...kernel import _default_kernel as K
+from ...opview import opview_from_ctx, ensure_schema_in, _ensure_temp
 
 # Runs in HANDLER phase, before pre:flush and any storage transforms.
 ANCHOR = _ev.RESOLVE_VALUES  # "resolve:values"
@@ -46,20 +46,8 @@ def run(obj: Optional[object], ctx: Any) -> None:
         return
 
     logger.debug("Running resolve:assemble")
-    app = getattr(ctx, "app", None)
-    model = getattr(ctx, "model", None) or type(getattr(ctx, "obj", None))
-    alias = getattr(ctx, "op", None) or getattr(ctx, "method", None)
-    if app and model and alias:
-        ov = K.get_opview(app, model, alias)
-    else:
-        if not (model and alias):
-            logger.debug(
-                "resolve:assemble: missing ctx.app/model/op and no specs; skipping"
-            )
-            return
-        specs = getattr(ctx, "specs", None) or K.get_specs(model)
-        ov = K._compile_opview_from_specs(specs, None)
-
+    ov = opview_from_ctx(ctx)
+    schema_in = ensure_schema_in(ctx, ov)
     inbound = _coerce_inbound(getattr(ctx, "temp", {}).get("in_values", None), ctx)
 
     temp = _ensure_temp(ctx)
@@ -69,8 +57,8 @@ def run(obj: Optional[object], ctx: Any) -> None:
     used_default: list[str] = []
 
     # Iterate fields in a stable order
-    for field in sorted(ov.schema_in.fields):
-        meta = ov.schema_in.by_field.get(field, {})
+    for field in sorted(schema_in["fields"]):
+        meta = schema_in["by_field"].get(field, {})
         in_enabled = meta.get("in_enabled", True)
         is_virtual = meta.get("virtual", False)
 
@@ -114,14 +102,6 @@ def run(obj: Optional[object], ctx: Any) -> None:
 # ──────────────────────────────────────────────────────────────────────────────
 # Internals
 # ──────────────────────────────────────────────────────────────────────────────
-
-
-def _ensure_temp(ctx: Any) -> MutableMapping[str, Any]:
-    tmp = getattr(ctx, "temp", None)
-    if not isinstance(tmp, dict):
-        tmp = {}
-        setattr(ctx, "temp", tmp)
-    return tmp
 
 
 def _coerce_inbound(candidate: Any, ctx: Any) -> Mapping[str, Any]:

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/resolve/paired_gen.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/resolve/paired_gen.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any, Dict, MutableMapping, Optional
 
 from ... import events as _ev
-from ...kernel import _default_kernel as K
+from ...opview import opview_from_ctx, _ensure_temp
 
 # Runs in HANDLER phase, before pre:flush (and before storage transforms).
 ANCHOR = _ev.RESOLVE_VALUES  # "resolve:values"
@@ -51,20 +51,7 @@ def run(obj: Optional[object], ctx: Any) -> None:
         return
 
     logger.debug("Running resolve:paired_gen")
-    app = getattr(ctx, "app", None)
-    model = getattr(ctx, "model", None) or type(getattr(ctx, "obj", None))
-    alias = getattr(ctx, "op", None) or getattr(ctx, "method", None)
-    if app and model and alias:
-        ov = K.get_opview(app, model, alias)
-    else:
-        if not (model and alias):
-            logger.debug(
-                "resolve:paired_gen: missing ctx.app/model/op and no specs; skipping"
-            )
-            return
-        specs = getattr(ctx, "specs", None) or K.get_specs(model)
-        ov = K._compile_opview_from_specs(specs, None)
-
+    ov = opview_from_ctx(ctx)
     temp = _ensure_temp(ctx)
     assembled = _ensure_dict(temp, "assembled_values")
     virtual_in = _ensure_dict(temp, "virtual_in")
@@ -122,14 +109,6 @@ def run(obj: Optional[object], ctx: Any) -> None:
 # ──────────────────────────────────────────────────────────────────────────────
 # Internals
 # ──────────────────────────────────────────────────────────────────────────────
-
-
-def _ensure_temp(ctx: Any) -> MutableMapping[str, Any]:
-    tmp = getattr(ctx, "temp", None)
-    if not isinstance(tmp, dict):
-        tmp = {}
-        setattr(ctx, "temp", tmp)
-    return tmp
 
 
 def _ensure_dict(temp: MutableMapping[str, Any], key: str) -> Dict[str, Any]:

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/schema/collect_in.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/schema/collect_in.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from typing import Any, MutableMapping, Optional
+from typing import Any, Optional
 import logging
 
 from ... import events as _ev
-from ...kernel import _default_kernel as K
+from ...opview import opview_from_ctx, ensure_schema_in
 
 # Runs at the very beginning of the lifecycle, before in-model build/validation.
 ANCHOR = _ev.SCHEMA_COLLECT_IN  # "schema:collect_in"
@@ -14,58 +14,8 @@ logger = logging.getLogger("uvicorn")
 
 def run(obj: Optional[object], ctx: Any) -> None:
     """Load precompiled inbound schema into ctx.temp."""
-    app = getattr(ctx, "app", None)
-    model = getattr(ctx, "model", None)
-    alias = getattr(ctx, "op", None) or getattr(ctx, "method", None)
-
-    if app and model and alias:
-        ov = K.get_opview(app, model, alias)
-        temp = _ensure_temp(ctx)
-        temp["schema_in"] = {
-            "fields": ov.schema_in.fields,
-            "by_field": ov.schema_in.by_field,
-            "required": tuple(
-                f for f, meta in ov.schema_in.by_field.items() if meta.get("required")
-            ),
-        }
-        return
-
-    # Fallback: compile minimal schema from collected specs
-    model = model or (
-        type(getattr(ctx, "obj", None)) if getattr(ctx, "obj", None) else None
-    )
-    specs = getattr(ctx, "specs", None) or (K.get_specs(model) if model else None)
-    if specs is None or alias is None:
-        logger.debug("collect_in: missing ctx.app/model/op and no specs; skipping")
-        return
-
-    fields = tuple(sorted(specs.keys()))
-    by_field: dict[str, dict] = {}
-    required: list[str] = []
-    for name, spec in specs.items():
-        meta: dict[str, Any] = {}
-        field_spec = getattr(spec, "field", None)
-        if field_spec and alias in getattr(field_spec, "required_in", ()):
-            meta["required"] = True
-            required.append(name)
-        if field_spec and alias in getattr(field_spec, "allow_null_in", ()):
-            meta["nullable"] = True
-        by_field[name] = meta
-
-    temp = _ensure_temp(ctx)
-    temp["schema_in"] = {
-        "fields": fields,
-        "by_field": by_field,
-        "required": tuple(required),
-    }
-
-
-def _ensure_temp(ctx: Any) -> MutableMapping[str, Any]:
-    tmp = getattr(ctx, "temp", None)
-    if not isinstance(tmp, dict):
-        tmp = {}
-        setattr(ctx, "temp", tmp)
-    return tmp
+    ov = opview_from_ctx(ctx)
+    ensure_schema_in(ctx, ov)
 
 
 __all__ = ["ANCHOR", "run"]

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/schema/collect_out.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/schema/collect_out.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from typing import Any, MutableMapping, Optional
+from typing import Any, Optional
 import logging
 
 from ... import events as _ev
-from ...kernel import _default_kernel as K
+from ...opview import opview_from_ctx, ensure_schema_out
 
 # Runs late in POST_HANDLER, before out model build and dumping.
 ANCHOR = _ev.SCHEMA_COLLECT_OUT  # "schema:collect_out"
@@ -14,35 +14,8 @@ logger = logging.getLogger("uvicorn")
 
 def run(obj: Optional[object], ctx: Any) -> None:
     """Load precompiled outbound schema into ctx.temp."""
-    app = getattr(ctx, "app", None)
-    model = getattr(ctx, "model", None)
-    alias = getattr(ctx, "op", None) or getattr(ctx, "method", None)
-
-    ov = None
-    if app and model and alias:
-        ov = K.get_opview(app, model, alias)
-    else:
-        model = model or type(getattr(ctx, "obj", None))
-        if not (model and alias):
-            logger.debug("collect_out: missing ctx.app/model/op and no specs; skipping")
-            return
-        specs = getattr(ctx, "specs", None) or K.get_specs(model)
-        ov = K._compile_opview_from_specs(specs, None)
-
-    temp = _ensure_temp(ctx)
-    temp["schema_out"] = {
-        "fields": ov.schema_out.fields,
-        "by_field": ov.schema_out.by_field,
-        "expose": ov.schema_out.expose,
-    }
-
-
-def _ensure_temp(ctx: Any) -> MutableMapping[str, Any]:
-    tmp = getattr(ctx, "temp", None)
-    if not isinstance(tmp, dict):
-        tmp = {}
-        setattr(ctx, "temp", tmp)
-    return tmp
+    ov = opview_from_ctx(ctx)
+    ensure_schema_out(ctx, ov)
 
 
 __all__ = ["ANCHOR", "run"]

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/storage/to_stored.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/storage/to_stored.py
@@ -5,7 +5,7 @@ import logging
 from typing import Any, Dict, Mapping, MutableMapping, Optional
 
 from ... import events as _ev
-from ...kernel import _default_kernel as K
+from ...opview import opview_from_ctx, ensure_schema_in, _ensure_temp
 
 # Runs right before the handler flushes to the DB.
 ANCHOR = _ev.PRE_FLUSH  # "pre:flush"
@@ -34,19 +34,8 @@ def run(obj: Optional[object], ctx: Any) -> None:
         logger.debug("Skipping storage:to_stored; ctx.persist is False")
         return
 
-    app = getattr(ctx, "app", None)
-    model = getattr(ctx, "model", None) or type(getattr(ctx, "obj", None))
-    alias = getattr(ctx, "op", None) or getattr(ctx, "method", None)
-    ov = None
-    if app and model and alias:
-        ov = K.get_opview(app, model, alias)
-    else:
-        if not (model and alias):
-            logger.debug("to_stored: missing ctx.app/model/op and no specs; skipping")
-            return
-        specs = getattr(ctx, "specs", None) or K.get_specs(model)
-        ov = K._compile_opview_from_specs(specs, None)
-
+    ov = opview_from_ctx(ctx)
+    schema_in = ensure_schema_in(ctx, ov)
     temp = _ensure_temp(ctx)
     assembled = _ensure_dict(temp, "assembled_values")
     paired_values = _ensure_dict(temp, "paired_values")
@@ -57,7 +46,7 @@ def run(obj: Optional[object], ctx: Any) -> None:
     # Prefer explicit obj (hydrated instance), else ctx.model if adapter provided it
     target_obj = obj or getattr(ctx, "model", None)
 
-    for field in sorted(ov.schema_in.fields):
+    for field in sorted(schema_in["fields"]):
         if field in ov.paired_index:
             if field in pf_paired or field in paired_values:
                 raw = None
@@ -86,7 +75,7 @@ def run(obj: Optional[object], ctx: Any) -> None:
                 logger.debug("Derived stored value for paired field %s", field)
                 continue
 
-            nullable = ov.schema_in.by_field.get(field, {}).get("nullable", True)
+            nullable = schema_in["by_field"].get(field, {}).get("nullable", True)
             if (
                 not nullable
                 and field not in assembled
@@ -140,14 +129,6 @@ def _has_attr_with_value(target: Optional[object], field: str) -> bool:
         return getattr(target, field) is not None
     except Exception:
         return False
-
-
-def _ensure_temp(ctx: Any) -> MutableMapping[str, Any]:
-    tmp = getattr(ctx, "temp", None)
-    if not isinstance(tmp, dict):
-        tmp = {}
-        setattr(ctx, "temp", tmp)
-    return tmp
 
 
 def _ensure_dict(temp: MutableMapping[str, Any], key: str) -> Dict[str, Any]:

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/executor/invoke.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/executor/invoke.py
@@ -23,6 +23,14 @@ async def _invoke(
     """Execute an operation through explicit phases with strict write policies."""
 
     ctx = _Ctx.ensure(request=request, db=db, seed=ctx)
+    if getattr(ctx, "app", None) is None and getattr(ctx, "api", None) is not None:
+        ctx.app = ctx.api
+    if getattr(ctx, "op", None) is None and getattr(ctx, "method", None) is not None:
+        ctx.op = ctx.method
+    if getattr(ctx, "model", None) is None:
+        obj = getattr(ctx, "obj", None)
+        if obj is not None:
+            ctx.model = type(obj)
     if db is not None and _in_tx(db):
         try:
             if _is_async_db(db):

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/opview.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/opview.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+from typing import Any, Mapping, Dict
+from .kernel import _default_kernel as K  # single, app-scoped kernel
+
+
+def _ensure_temp(ctx: Any) -> Dict[str, Any]:
+    tmp = getattr(ctx, "temp", None)
+    if not isinstance(tmp, dict):
+        tmp = {}
+        setattr(ctx, "temp", tmp)
+    return tmp
+
+
+def opview_from_ctx(ctx: Any):
+    """
+    Resolve the OpView for this request context, or raise a runtime error.
+    Requirements:
+      - ctx.app (or ctx.api), ctx.model (or derived from ctx.obj), ctx.op (or ctx.method)
+    """
+    app = getattr(ctx, "app", None) or getattr(ctx, "api", None)
+    model = getattr(ctx, "model", None)
+    if model is None:
+        obj = getattr(ctx, "obj", None)
+        if obj is not None:
+            model = type(obj)
+    alias = getattr(ctx, "op", None) or getattr(ctx, "method", None)
+
+    missing = [
+        name for name, val in (("app", app), ("model", model), ("op", alias)) if not val
+    ]
+    if missing:
+        # runtime-error policy: eject loudly; no skip
+        raise RuntimeError(f"ctx_missing:{','.join(missing)}")
+
+    # One-kernel-per-app, prime once; raises if not compiled
+    return K.get_opview(app, model, alias)
+
+
+def ensure_schema_in(ctx: Any, ov) -> Mapping[str, Any]:
+    """
+    Load precompiled inbound schema from OpView into ctx.temp['schema_in'] if absent.
+    """
+    temp = _ensure_temp(ctx)
+    if "schema_in" not in temp:
+        bf = ov.schema_in.by_field
+        req = tuple(n for n, e in bf.items() if e.get("required"))
+        temp["schema_in"] = {
+            "fields": ov.schema_in.fields,
+            "by_field": bf,
+            "required": req,
+        }
+    return temp["schema_in"]
+
+
+def ensure_schema_out(ctx: Any, ov) -> Mapping[str, Any]:
+    """
+    Load precompiled outbound schema from OpView into ctx.temp['schema_out'] if absent.
+    """
+    temp = _ensure_temp(ctx)
+    if "schema_out" not in temp:
+        temp["schema_out"] = {
+            "fields": ov.schema_out.fields,
+            "by_field": ov.schema_out.by_field,
+            "expose": ov.schema_out.expose,
+        }
+    return temp["schema_out"]
+
+
+__all__ = ["opview_from_ctx", "ensure_schema_in", "ensure_schema_out", "_ensure_temp"]


### PR DESCRIPTION
## Summary
- add shared runtime helper for resolving OpView and caching schemas
- replace per-atom OpView plumbing with unified helper
- normalize critical context fields once in executor

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68bd81bd52d0832682456a50b45cbb73