### PR TITLE
autoapi: correct op context app resolution and create arity

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/api/include.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/api/include.py
@@ -107,6 +107,7 @@ def _attach_to_api(api: ApiLike, model: type) -> None:
     # Index model object
     api.models[mname] = model
     api.tables[mname] = getattr(model, "__table__", None)
+    setattr(model, "__autoapi_app__", api)
 
     # Direct references to model namespaces
     setattr(api.schemas, mname, getattr(model, "schemas", SimpleNamespace()))

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest/collection.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest/collection.py
@@ -44,8 +44,8 @@ def _ctx(model, alias, target, request, db, payload, parent_kw, api):
         "payload": payload,
         "path_params": parent_kw,
         # surface key metadata for runtime atoms
-        "app": getattr(request, "app", None),
-        "api": getattr(request, "app", None),
+        "app": api or getattr(request, "app", None),
+        "api": api or getattr(request, "app", None),
         "model": model,
         "op": alias,
         "method": alias,
@@ -53,9 +53,6 @@ def _ctx(model, alias, target, request, db, payload, parent_kw, api):
         "env": SimpleNamespace(
             method=alias, params=payload, target=target, model=model
         ),
-        "api": api,
-        "model": model,
-        "op": alias,
     }
     ac = getattr(request.state, AUTOAPI_AUTH_CONTEXT_ATTR, None)
     if ac is not None:

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest/member.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest/member.py
@@ -73,8 +73,8 @@ def _make_member_endpoint(
                 "payload": payload,
                 "path_params": path_params,
                 # expose contextual metadata for downstream atoms
-                "app": getattr(request, "app", None),
-                "api": getattr(request, "app", None),
+                "app": api or getattr(request, "app", None),
+                "api": api or getattr(request, "app", None),
                 "model": model,
                 "op": alias,
                 "method": alias,
@@ -82,9 +82,6 @@ def _make_member_endpoint(
                 "env": SimpleNamespace(
                     method=alias, params=payload, target=target, model=model
                 ),
-                "api": api,
-                "model": model,
-                "op": alias,
             }
             ac = getattr(request.state, AUTOAPI_AUTH_CONTEXT_ATTR, None)
             if ac is not None:
@@ -157,8 +154,8 @@ def _make_member_endpoint(
                 "payload": payload,
                 "path_params": path_params,
                 # expose contextual metadata for downstream atoms
-                "app": getattr(request, "app", None),
-                "api": getattr(request, "app", None),
+                "app": api or getattr(request, "app", None),
+                "api": api or getattr(request, "app", None),
                 "model": model,
                 "op": alias,
                 "method": alias,
@@ -166,9 +163,6 @@ def _make_member_endpoint(
                 "env": SimpleNamespace(
                     method=alias, params=payload, target=target, model=model
                 ),
-                "api": api,
-                "model": model,
-                "op": alias,
             }
             ac = getattr(request.state, AUTOAPI_AUTH_CONTEXT_ATTR, None)
             if ac is not None:
@@ -262,8 +256,8 @@ def _make_member_endpoint(
             "payload": payload,
             "path_params": path_params,
             # expose contextual metadata for downstream atoms
-            "app": getattr(request, "app", None),
-            "api": getattr(request, "app", None),
+            "app": api or getattr(request, "app", None),
+            "api": api or getattr(request, "app", None),
             "model": model,
             "op": alias,
             "method": alias,

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rpc.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rpc.py
@@ -275,8 +275,9 @@ def _build_rpc_callable(model: type, sp: OpSpec) -> Callable[..., Awaitable[Any]
         if request is not None:
             base_ctx.setdefault("request", request)
         # surface contextual metadata for runtime atoms
-        base_ctx.setdefault("app", getattr(request, "app", None))
-        base_ctx.setdefault("api", getattr(request, "app", None))
+        host = getattr(model, "__autoapi_app__", None)
+        base_ctx.setdefault("app", host or getattr(request, "app", None))
+        base_ctx.setdefault("api", host or getattr(request, "app", None))
         base_ctx.setdefault("model", model)
         base_ctx.setdefault("op", alias)
         base_ctx.setdefault("method", alias)

--- a/pkgs/standards/autoapi/autoapi/v3/op/resolver.py
+++ b/pkgs/standards/autoapi/autoapi/v3/op/resolver.py
@@ -92,7 +92,9 @@ def _generate_canonical(table: type) -> List[OpSpec]:
                 table=table,
                 alias=alias,
                 target=target,
-                arity="collection" if target in {"list", "clear"} else "member",
+                arity="collection"
+                if target in {"create", "list", "clear"}
+                else "member",
                 persist="default",
                 handler=None,
                 request_model=None,


### PR DESCRIPTION
## Summary
- ensure canonical create ops are collection-level
- resolve Op context using the AutoApp instead of host request app
- carry AutoApp reference for RPC calls

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_op_ctx_behavior.py::test_op_ctx_rest_call -q`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_op_ctx_behavior.py::test_op_ctx_request_response_schemas -q`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_op_ctx_behavior.py::test_op_ctx_rpc_method -q`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_op_ctx_behavior.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd88644ebc83268790b16e5c007dba