### PR TITLE
Fix AutoAPI create operation arity and RPC context handling

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/model.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/model.py
@@ -149,7 +149,7 @@ def bind(
     _schemas_binding.build_and_attach(model, specs, only_keys=only_keys)
     _hooks_binding.normalize_and_attach(model, specs, only_keys=only_keys)
     _handlers_binding.build_and_attach(model, specs, only_keys=only_keys)
-    _rpc_binding.register_and_attach(model, specs, only_keys=only_keys)
+    _rpc_binding.register_and_attach(model, specs, api=api, only_keys=only_keys)
     _rest_binding.build_router_and_attach(model, specs, api=api, only_keys=only_keys)
 
     # 6) Index on the model (always overwrite with fresh views)

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rpc.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rpc.py
@@ -215,7 +215,9 @@ def _serialize_output(model: type, alias: str, target: str, result: Any) -> Any:
 # ───────────────────────────────────────────────────────────────────────────────
 
 
-def _build_rpc_callable(model: type, sp: OpSpec) -> Callable[..., Awaitable[Any]]:
+def _build_rpc_callable(
+    model: type, sp: OpSpec, *, api: Any | None = None
+) -> Callable[..., Awaitable[Any]]:
     """
     Create an async callable that:
       1) validates payload (if schema present),
@@ -276,7 +278,7 @@ def _build_rpc_callable(model: type, sp: OpSpec) -> Callable[..., Awaitable[Any]
             base_ctx.setdefault("request", request)
         # surface contextual metadata for runtime atoms
         base_ctx.setdefault("app", getattr(request, "app", None))
-        base_ctx.setdefault("api", getattr(request, "app", None))
+        base_ctx.setdefault("api", api or getattr(request, "app", None))
         base_ctx.setdefault("model", model)
         base_ctx.setdefault("op", alias)
         base_ctx.setdefault("method", alias)
@@ -311,9 +313,9 @@ def _build_rpc_callable(model: type, sp: OpSpec) -> Callable[..., Awaitable[Any]
     return _rpc_method
 
 
-def _attach_one(model: type, sp: OpSpec) -> None:
+def _attach_one(model: type, sp: OpSpec, api: Any | None) -> None:
     rpc_root = _ns(model, "rpc")
-    fn = _build_rpc_callable(model, sp)
+    fn = _build_rpc_callable(model, sp, api=api)
     setattr(rpc_root, sp.alias, fn)
     logger.debug("rpc: %s.%s registered", model.__name__, sp.alias)
 
@@ -324,7 +326,11 @@ def _attach_one(model: type, sp: OpSpec) -> None:
 
 
 def register_and_attach(
-    model: type, specs: Sequence[OpSpec], *, only_keys: Optional[Sequence[_Key]] = None
+    model: type,
+    specs: Sequence[OpSpec],
+    *,
+    api: Any | None = None,
+    only_keys: Optional[Sequence[_Key]] = None,
 ) -> None:
     """
     Register async callables under `model.rpc.<alias>` for each OpSpec.
@@ -335,7 +341,7 @@ def register_and_attach(
         key = (sp.alias, sp.target)
         if wanted and key not in wanted:
             continue
-        _attach_one(model, sp)
+        _attach_one(model, sp, api)
 
 
 __all__ = ["register_and_attach"]

--- a/pkgs/standards/autoapi/autoapi/v3/op/resolver.py
+++ b/pkgs/standards/autoapi/autoapi/v3/op/resolver.py
@@ -92,7 +92,9 @@ def _generate_canonical(table: type) -> List[OpSpec]:
                 table=table,
                 alias=alias,
                 target=target,
-                arity="collection" if target in {"list", "clear"} else "member",
+                arity="collection"
+                if target in {"create", "list", "clear"}
+                else "member",
                 persist="default",
                 handler=None,
                 request_model=None,

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/opview.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/opview.py
@@ -19,7 +19,7 @@ def opview_from_ctx(ctx: Any):
     Requirements:
       - ctx.app (or ctx.api), ctx.model (or derived from ctx.obj), ctx.op (or ctx.method)
     """
-    app = getattr(ctx, "app", None) or getattr(ctx, "api", None)
+    app = getattr(ctx, "api", None) or getattr(ctx, "app", None)
     model = getattr(ctx, "model", None)
     if model is None:
         obj = getattr(ctx, "obj", None)


### PR DESCRIPTION
## Summary
- treat canonical `create` ops as collection routes
- resolve OpView using AutoApp and pass API to RPC executor context

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_iospec_integration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd8b8eccdc83269daff66815486d57