### PR TITLE
refactor atom tests to use opview

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_emit_paired_pre.py
+++ b/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_emit_paired_pre.py
@@ -1,11 +1,37 @@
 from types import SimpleNamespace
 
 from autoapi.v3.runtime.atoms.emit import paired_pre
+from autoapi.v3.runtime.kernel import (
+    SchemaIn,
+    SchemaOut,
+    OpView,
+    _default_kernel as K,
+)
 
 
 def test_paired_pre_records_descriptor() -> None:
+    class App:
+        pass
+
+    app = App()
+
+    class Model:
+        pass
+
+    alias = "create"
+    ov = OpView(
+        schema_in=SchemaIn(fields=(), by_field={}),
+        schema_out=SchemaOut(fields=(), by_field={}, expose=()),
+        paired_index={"token": {"alias": "t"}},
+        virtual_producers={},
+        to_stored_transforms={},
+        refresh_hints=(),
+    )
+    K._opviews[app] = {(Model, alias): ov}
+    K._primed[app] = True
+
     temp = {"paired_values": {"token": {"raw": "abc", "alias": "t"}}}
-    ctx = SimpleNamespace(persist=True, specs={}, temp=temp)
+    ctx = SimpleNamespace(app=app, model=Model, op=alias, persist=True, temp=temp)
     paired_pre.run(None, ctx)
     pre = ctx.temp["emit_aliases"]["pre"]
     assert pre[0]["field"] == "token"

--- a/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_emit_readtime_alias.py
+++ b/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_emit_readtime_alias.py
@@ -1,17 +1,41 @@
 from types import SimpleNamespace
 
 from autoapi.v3.runtime.atoms.emit import readtime_alias
-
-
-class Col:
-    emit_alias = "hint"
-    sensitive = True
+from autoapi.v3.runtime.kernel import (
+    SchemaIn,
+    SchemaOut,
+    OpView,
+    _default_kernel as K,
+)
 
 
 def test_readtime_alias_masks_sensitive_value() -> None:
-    specs = {"secret": Col()}
+    class App:
+        pass
+
+    app = App()
+
+    class Model:
+        pass
+
+    alias = "read"
+    ov = OpView(
+        schema_in=SchemaIn(fields=(), by_field={}),
+        schema_out=SchemaOut(
+            fields=("secret",),
+            by_field={"secret": {"alias_out": "hint", "sensitive": True}},
+            expose=("secret",),
+        ),
+        paired_index={},
+        virtual_producers={},
+        to_stored_transforms={},
+        refresh_hints=(),
+    )
+    K._opviews[app] = {(Model, alias): ov}
+    K._primed[app] = True
+
     temp = {"response_extras": {}, "emit_aliases": {"pre": [], "post": [], "read": []}}
-    ctx = SimpleNamespace(specs=specs, temp=temp)
+    ctx = SimpleNamespace(app=app, model=Model, op=alias, temp=temp)
     obj = SimpleNamespace(secret="abcd1234")
     readtime_alias.run(obj, ctx)
     assert ctx.temp["response_extras"]["hint"] == "••••1234"

--- a/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_out_masking.py
+++ b/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_out_masking.py
@@ -1,23 +1,44 @@
 from types import SimpleNamespace
 
 from autoapi.v3.runtime.atoms.out import masking
-
-
-class SensitiveCol:
-    sensitive = True
-
-
-class PlainCol:
-    sensitive = False
+from autoapi.v3.runtime.kernel import (
+    SchemaIn,
+    SchemaOut,
+    OpView,
+    _default_kernel as K,
+)
 
 
 def test_out_masking_applies_to_sensitive_fields() -> None:
-    specs = {"secret": SensitiveCol(), "public": PlainCol()}
+    class App:
+        pass
+
+    app = App()
+
+    class Model:
+        pass
+
+    alias = "read"
+    ov = OpView(
+        schema_in=SchemaIn(fields=(), by_field={}),
+        schema_out=SchemaOut(
+            fields=("secret", "public"),
+            by_field={"secret": {"sensitive": True}, "public": {}},
+            expose=("secret", "public"),
+        ),
+        paired_index={},
+        virtual_producers={},
+        to_stored_transforms={},
+        refresh_hints=(),
+    )
+    K._opviews[app] = {(Model, alias): ov}
+    K._primed[app] = True
+
     temp = {
         "response_payload": {"secret": "abcd1234", "token": "abc", "public": "x"},
         "emit_aliases": {"pre": [], "post": [{"alias": "token"}], "read": []},
     }
-    ctx = SimpleNamespace(specs=specs, temp=temp)
+    ctx = SimpleNamespace(app=app, model=Model, op=alias, temp=temp)
     masking.run(None, ctx)
     assert ctx.temp["response_payload"]["secret"] == "••••1234"
     assert ctx.temp["response_payload"]["token"] == "abc"

--- a/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_refresh_demand.py
+++ b/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_refresh_demand.py
@@ -1,23 +1,42 @@
 from types import SimpleNamespace
 
 from autoapi.v3.runtime.atoms.refresh import demand
-
-
-class Storage:
-    def __init__(self) -> None:
-        self.server_default = True
-        self.autoincrement = False
-        self.primary_key = False
-
-
-class Col:
-    def __init__(self) -> None:
-        self.storage = Storage()
+from autoapi.v3.runtime.kernel import (
+    SchemaIn,
+    SchemaOut,
+    OpView,
+    _default_kernel as K,
+)
 
 
 def test_refresh_demand_marks_need() -> None:
+    class App:
+        pass
+
+    app = App()
+
+    class Model:
+        pass
+
+    alias = "create"
+    ov = OpView(
+        schema_in=SchemaIn(fields=(), by_field={}),
+        schema_out=SchemaOut(fields=(), by_field={}, expose=()),
+        paired_index={},
+        virtual_producers={},
+        to_stored_transforms={},
+        refresh_hints=("id",),
+    )
+    K._opviews[app] = {(Model, alias): ov}
+    K._primed[app] = True
+
     ctx = SimpleNamespace(
-        persist=True, specs={"id": Col()}, temp={}, cfg=SimpleNamespace()
+        app=app,
+        model=Model,
+        op=alias,
+        persist=True,
+        temp={},
+        cfg=SimpleNamespace(),
     )
     demand.run(None, ctx)
     assert ctx.temp["refresh_demand"] is True

--- a/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_resolve_assemble.py
+++ b/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_resolve_assemble.py
@@ -1,21 +1,44 @@
 from types import SimpleNamespace
 
 from autoapi.v3.runtime.atoms.resolve import assemble
-
-
-class PersistCol:
-    def __init__(self) -> None:
-        self.storage = object()
-
-
-class VirtualCol:
-    storage = None
+from autoapi.v3.runtime.kernel import (
+    SchemaIn,
+    SchemaOut,
+    OpView,
+    _default_kernel as K,
+)
 
 
 def test_assemble_separates_virtual_and_persisted() -> None:
-    specs = {"name": PersistCol(), "v": VirtualCol()}
+    class App:
+        pass
+
+    app = App()
+
+    class Model:
+        pass
+
+    alias = "create"
+    ov = OpView(
+        schema_in=SchemaIn(
+            fields=("name", "v"),
+            by_field={"name": {"in_enabled": True}, "v": {"virtual": True}},
+        ),
+        schema_out=SchemaOut(fields=(), by_field={}, expose=()),
+        paired_index={},
+        virtual_producers={},
+        to_stored_transforms={},
+        refresh_hints=(),
+    )
+    K._opviews[app] = {(Model, alias): ov}
+    K._primed[app] = True
+
     ctx = SimpleNamespace(
-        persist=True, specs=specs, temp={"in_values": {"name": "Alice", "v": "x"}}
+        app=app,
+        model=Model,
+        op=alias,
+        persist=True,
+        temp={"in_values": {"name": "Alice", "v": "x"}},
     )
     assemble.run(None, ctx)
     assert ctx.temp["assembled_values"] == {"name": "Alice"}

--- a/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_schema_collect_in.py
+++ b/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_schema_collect_in.py
@@ -1,26 +1,42 @@
 from types import SimpleNamespace
 
 from autoapi.v3.runtime.atoms.schema import collect_in
-
-
-class Storage:
-    def __init__(self) -> None:
-        self.nullable = False
-
-
-class Col:
-    def __init__(self) -> None:
-        self.storage = Storage()
-        self.alias_in = "alias"
-
-
-class VirtCol:
-    storage = None
+from autoapi.v3.runtime.kernel import (
+    SchemaIn,
+    SchemaOut,
+    OpView,
+    _default_kernel as K,
+)
 
 
 def test_collect_in_builds_schema() -> None:
-    specs = {"name": Col(), "v": VirtCol()}
-    ctx = SimpleNamespace(specs=specs, op="create", temp={})
+    class App:
+        pass
+
+    app = App()
+
+    class Model:
+        pass
+
+    alias = "create"
+    ov = OpView(
+        schema_in=SchemaIn(
+            fields=("name", "v"),
+            by_field={
+                "name": {"alias_in": "alias", "required": True},
+                "v": {"virtual": True},
+            },
+        ),
+        schema_out=SchemaOut(fields=(), by_field={}, expose=()),
+        paired_index={},
+        virtual_producers={},
+        to_stored_transforms={},
+        refresh_hints=(),
+    )
+    K._opviews[app] = {(Model, alias): ov}
+    K._primed[app] = True
+
+    ctx = SimpleNamespace(app=app, model=Model, op=alias, temp={})
     collect_in.run(None, ctx)
     schema = ctx.temp["schema_in"]
     assert schema["by_field"]["name"]["alias_in"] == "alias"

--- a/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_schema_collect_out.py
+++ b/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_schema_collect_out.py
@@ -10,7 +10,10 @@ from autoapi.v3.runtime.kernel import (
 
 
 def test_collect_out_loads_schema() -> None:
-    app = object()
+    class App:
+        pass
+
+    app = App()
 
     class Model:
         pass
@@ -35,6 +38,6 @@ def test_collect_out_loads_schema() -> None:
     ctx = SimpleNamespace(app=app, model=Model, op=alias, temp={})
     collect_out.run(None, ctx)
     schema = ctx.temp["schema_out"]
-    assert schema.by_field["name"]["sensitive"] is True
-    assert schema.by_field["name"]["alias_out"] == "alias"
-    assert "name" in schema.expose
+    assert schema["by_field"]["name"]["sensitive"] is True
+    assert schema["by_field"]["name"]["alias_out"] == "alias"
+    assert "name" in schema["expose"]

--- a/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_storage_to_stored.py
+++ b/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_storage_to_stored.py
@@ -1,22 +1,45 @@
 from types import SimpleNamespace
 
 from autoapi.v3.runtime.atoms.storage import to_stored
-
-
-class Col:
-    def derive_from_raw(
-        self, raw: str, ctx: object
-    ) -> str:  # pragma: no cover - simple
-        return raw.upper()
+from autoapi.v3.runtime.kernel import (
+    SchemaIn,
+    SchemaOut,
+    OpView,
+    _default_kernel as K,
+)
 
 
 def test_to_stored_derives_from_paired_raw() -> None:
+    class App:
+        pass
+
+    app = App()
+
+    class Model:
+        pass
+
+    alias = "create"
+
+    def deriver(raw: str, ctx: object) -> str:  # pragma: no cover - simple
+        return raw.upper()
+
+    ov = OpView(
+        schema_in=SchemaIn(fields=("token",), by_field={"token": {}}),
+        schema_out=SchemaOut(fields=(), by_field={}, expose=()),
+        paired_index={"token": {"store": deriver}},
+        virtual_producers={},
+        to_stored_transforms={},
+        refresh_hints=(),
+    )
+    K._opviews[app] = {(Model, alias): ov}
+    K._primed[app] = True
+
     temp = {
         "paired_values": {"token": {"raw": "abc"}},
         "persist_from_paired": {"token": {"source": ("paired_values", "token", "raw")}},
         "assembled_values": {},
     }
-    ctx = SimpleNamespace(persist=True, specs={"token": Col()}, temp=temp)
+    ctx = SimpleNamespace(app=app, model=Model, op=alias, persist=True, temp=temp)
     to_stored.run(None, ctx)
     assert ctx.temp["assembled_values"]["token"] == "ABC"
     assert ctx.temp["storage_log"][0]["action"] == "derived_from_paired"

--- a/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_wire_build_out.py
+++ b/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_wire_build_out.py
@@ -1,26 +1,40 @@
 from types import SimpleNamespace
 
 from autoapi.v3.runtime.atoms.wire import build_out
-
-
-class PersistCol:
-    def __init__(self) -> None:
-        self.storage = object()
-
-
-class VirtualCol:
-    storage = None
-
-    def read_producer(
-        self, obj: object, ctx: object
-    ) -> str:  # pragma: no cover - simple
-        return "v"
+from autoapi.v3.runtime.kernel import (
+    SchemaIn,
+    SchemaOut,
+    OpView,
+    _default_kernel as K,
+)
 
 
 def test_build_out_reads_and_produces() -> None:
-    specs = {"id": PersistCol(), "virtual": VirtualCol()}
-    schema_out = {"by_field": {"id": {}, "virtual": {}}, "expose": ("id", "virtual")}
-    ctx = SimpleNamespace(temp={"schema_out": schema_out}, specs=specs)
+    class App:
+        pass
+
+    app = App()
+
+    class Model:
+        pass
+
+    alias = "read"
+    ov = OpView(
+        schema_in=SchemaIn(fields=(), by_field={}),
+        schema_out=SchemaOut(
+            fields=("id", "virtual"),
+            by_field={"id": {}, "virtual": {"virtual": True}},
+            expose=("id", "virtual"),
+        ),
+        paired_index={},
+        virtual_producers={"virtual": lambda obj, ctx: "v"},
+        to_stored_transforms={},
+        refresh_hints=(),
+    )
+    K._opviews[app] = {(Model, alias): ov}
+    K._primed[app] = True
+
+    ctx = SimpleNamespace(app=app, model=Model, op=alias, temp={})
     obj = SimpleNamespace(id=1)
     build_out.run(obj, ctx)
     assert ctx.temp["out_values"] == {"id": 1, "virtual": "v"}

--- a/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_wire_validate_in.py
+++ b/pkgs/standards/autoapi/tests/unit/runtime/atoms/test_wire_validate_in.py
@@ -4,29 +4,65 @@ import pytest
 
 from autoapi.v3.runtime.atoms.wire import validate_in
 from autoapi.v3.runtime.errors import HTTPException
+from autoapi.v3.runtime.kernel import (
+    SchemaIn,
+    SchemaOut,
+    OpView,
+    _default_kernel as K,
+)
 
 
 def test_validate_in_missing_required() -> None:
-    schema_in = {"by_field": {}, "required": ("name",)}
-    ctx = SimpleNamespace(temp={"schema_in": schema_in, "in_values": {}}, specs={})
+    class App:
+        pass
+
+    app = App()
+
+    class Model:
+        pass
+
+    alias = "create"
+    ov = OpView(
+        schema_in=SchemaIn(fields=("name",), by_field={"name": {"required": True}}),
+        schema_out=SchemaOut(fields=(), by_field={}, expose=()),
+        paired_index={},
+        virtual_producers={},
+        to_stored_transforms={},
+        refresh_hints=(),
+    )
+    K._opviews[app] = {(Model, alias): ov}
+    K._primed[app] = True
+
+    ctx = SimpleNamespace(app=app, model=Model, op=alias, temp={"in_values": {}})
     with pytest.raises(HTTPException) as exc:
         validate_in.run(None, ctx)
     assert exc.value.status_code == 422
     assert ctx.temp["in_invalid"] is True
 
 
-class Field:
-    py_type = int
-
-
-class Col:
-    field = Field()
-
-
 def test_validate_in_coerces_types() -> None:
-    schema_in = {"by_field": {"age": {}}, "required": ()}
+    class App:
+        pass
+
+    app = App()
+
+    class Model:
+        pass
+
+    alias = "create"
+    ov = OpView(
+        schema_in=SchemaIn(fields=("age",), by_field={"age": {"py_type": int}}),
+        schema_out=SchemaOut(fields=(), by_field={}, expose=()),
+        paired_index={},
+        virtual_producers={},
+        to_stored_transforms={},
+        refresh_hints=(),
+    )
+    K._opviews[app] = {(Model, alias): ov}
+    K._primed[app] = True
+
     ctx = SimpleNamespace(
-        temp={"schema_in": schema_in, "in_values": {"age": "5"}}, specs={"age": Col()}
+        app=app, model=Model, op=alias, temp={"in_values": {"age": "5"}}
     )
     validate_in.run(None, ctx)
     assert ctx.temp["in_values"]["age"] == 5


### PR DESCRIPTION
## Summary
- update validate_in atom to rely on opview instead of ctx.specs
- adapt runtime atom tests to build OpView fixtures instead of ctx.specs
- ensure kernel app references are weak-ref compatible

## Testing
- `uv run --package autoapi --directory . ruff check autoapi/v3/runtime/atoms/wire/validate_in.py tests/unit/runtime/atoms/test_emit_paired_pre.py tests/unit/runtime/atoms/test_emit_readtime_alias.py tests/unit/runtime/atoms/test_out_masking.py tests/unit/runtime/atoms/test_refresh_demand.py tests/unit/runtime/atoms/test_resolve_assemble.py tests/unit/runtime/atoms/test_resolve_paired_gen.py tests/unit/runtime/atoms/test_schema_collect_in.py tests/unit/runtime/atoms/test_storage_to_stored.py tests/unit/runtime/atoms/test_wire_build_out.py tests/unit/runtime/atoms/test_wire_validate_in.py tests/unit/runtime/atoms/test_schema_collect_out.py --fix`
- `uv run --package autoapi --directory . pytest tests/unit/runtime/atoms`

------
https://chatgpt.com/codex/tasks/task_e_68bd8df62d608326be39834898f6059f