### PR TITLE
Compile autoapi opviews on demand

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/runtime/kernel.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/kernel.py
@@ -295,11 +295,22 @@ class Kernel:
             self._primed[app] = True
 
     def get_opview(self, app: Any, model: type, alias: str) -> OpView:
-        """Return OpView for (model, alias); eject with RuntimeError if missing."""
+        """Return OpView for (model, alias); compile on-demand if missing."""
         self.ensure_primed(app)
+        ov_map = self._opviews.setdefault(app, {})
+        key = (model, alias)
+        if key not in ov_map:
+            from ..system.diagnostics.utils import opspecs as _opspecs
+
+            specs = self._specs_cache.get(model)
+            for sp in _opspecs(model):
+                ov_map[(model, sp.alias)] = self._compile_opview_from_specs(specs, sp)
+            # rebuild kernelz payload to include new model ops
+            self._kernelz_payload[app] = self._build_kernelz_payload_internal(app)
+
         try:
-            return self._opviews[app][(model, alias)]
-        except Exception:
+            return ov_map[key]
+        except KeyError:
             raise RuntimeError(
                 f"opview_missing: app={app!r} model={getattr(model, '__name__', model)!r} alias={alias!r}"
             )

--- a/pkgs/standards/autoapi/tests/unit/test_kernel_opview_on_demand.py
+++ b/pkgs/standards/autoapi/tests/unit/test_kernel_opview_on_demand.py
@@ -1,0 +1,42 @@
+from autoapi.v3.autoapp import AutoApp
+from autoapi.v3.bindings.model import bind
+from autoapi.v3.runtime.kernel import _default_kernel as K
+from autoapi.v3.specs import S, IO, acol
+from autoapi.v3.orm.tables import Base
+from autoapi.v3.types import Integer as IntType
+
+
+def test_compiles_opview_for_new_model_after_prime():
+    Base.metadata.clear()
+
+    class A(Base):
+        __tablename__ = "kernel_on_demand_a"
+        __allow_unmapped__ = True
+        id = acol(
+            storage=S(type_=IntType, primary_key=True), io=IO(out_verbs=("read",))
+        )
+
+    bind(A)
+    app = AutoApp()
+    app.include_model(A, mount_router=False)
+    # prime kernel for first model
+    K.get_opview(app, A, "read")
+
+    class B(Base):
+        __tablename__ = "kernel_on_demand_b"
+        __allow_unmapped__ = True
+        id = acol(
+            storage=S(type_=IntType, primary_key=True), io=IO(out_verbs=("read",))
+        )
+
+    bind(B)
+    app.include_model(B, mount_router=False)
+
+    # should compile opview without raising
+    ov = K.get_opview(app, B, "read")
+    assert ov is not None
+
+    # cleanup
+    K._opviews.pop(app, None)
+    K._kernelz_payload.pop(app, None)
+    K._primed.pop(app, None)


### PR DESCRIPTION
## Summary
- compile missing opviews when new models are bound after priming
- cover opview compilation with new unit test

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_kernel_opview_on_demand.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd9135f5f08326aaca14371b55fe04