### PR TITLE
Fix RPC context defaults and enable replace op

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/op/resolver.py
+++ b/pkgs/standards/autoapi/autoapi/v3/op/resolver.py
@@ -80,6 +80,9 @@ def _generate_canonical(table: type) -> List[OpSpec]:
         ("create", "create"),
         ("read", "read"),
         ("update", "update"),
+        # Include canonical "replace" so RPC callers get full CRUD semantics
+        # without opting into the Replaceable mixin.
+        ("replace", "replace"),
         ("delete", "delete"),
         ("list", "list"),
         ("clear", "clear"),


### PR DESCRIPTION
## Summary
- ensure rpc_call injects app context and derives path params from payload
- register replace as canonical op so models get full CRUD support

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format autoapi/v3/bindings/api/rpc.py autoapi/v3/op/resolver.py`
- `uv run --package autoapi --directory standards/autoapi ruff check autoapi/v3/bindings/api/rpc.py autoapi/v3/op/resolver.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_rpc_default_ops.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd956ec8508326b8745ed1d237c5e5