### PR TITLE
Fix autoapi RPC default verbs test

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/api/rpc.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/api/rpc.py
@@ -72,7 +72,10 @@ async def rpc_call(
 
     try:
         logger.debug("Executing rpc_call %s.%s", getattr(mdl, "__name__", mdl), method)
-        return await fn(payload, db=db, request=request, ctx=ctx)
+        seeded_ctx = dict(ctx or {})
+        seeded_ctx.setdefault("app", api)
+        seeded_ctx.setdefault("api", api)
+        return await fn(payload, db=db, request=request, ctx=seeded_ctx)
     finally:
         if _release_db is not None:
             try:

--- a/pkgs/standards/autoapi/autoapi/v3/op/resolver.py
+++ b/pkgs/standards/autoapi/autoapi/v3/op/resolver.py
@@ -80,6 +80,7 @@ def _generate_canonical(table: type) -> List[OpSpec]:
         ("create", "create"),
         ("read", "read"),
         ("update", "update"),
+        ("replace", "replace"),
         ("delete", "delete"),
         ("list", "list"),
         ("clear", "clear"),


### PR DESCRIPTION
## Summary
- automatically seed `app` and `api` into RPC call contexts
- include `replace` in canonical op resolution so default verbs cover it
- revert test adjustments to rely on runtime defaults

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format autoapi/v3/bindings/api/rpc.py autoapi/v3/op/resolver.py tests/unit/test_rpc_all_default_op_verbs.py`
- `uv run --package autoapi --directory standards/autoapi ruff check autoapi/v3/bindings/api/rpc.py autoapi/v3/op/resolver.py tests/unit/test_rpc_all_default_op_verbs.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_68bd9569121483268d100c67d5c7e14a