### PR TITLE
fix: default app context for rpc

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/api/resource_proxy.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/api/resource_proxy.py
@@ -69,8 +69,9 @@ class _ResourceProxy:
                 logger.debug("Request provided for %s.%s", self._model.__name__, alias)
                 base_ctx.setdefault("request", request)
             # surface contextual metadata for runtime atoms
-            base_ctx.setdefault("app", getattr(request, "app", None))
-            base_ctx.setdefault("api", getattr(request, "app", None))
+            app_ref = getattr(request, "app", None) or base_ctx.get("app") or self._api
+            base_ctx.setdefault("app", app_ref)
+            base_ctx.setdefault("api", base_ctx.get("api") or self._api or app_ref)
             base_ctx.setdefault("model", self._model)
             base_ctx.setdefault("op", alias)
             base_ctx.setdefault("method", alias)
@@ -81,9 +82,6 @@ class _ResourceProxy:
                     method=alias, params=norm_payload, target=alias, model=self._model
                 ),
             )
-            base_ctx.setdefault("api", self._api)
-            base_ctx.setdefault("model", self._model)
-            base_ctx.setdefault("op", alias)
             if self._serialize:
                 logger.debug(
                     "Serialization enabled for %s.%s", self._model.__name__, alias

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rpc.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rpc.py
@@ -275,8 +275,14 @@ def _build_rpc_callable(model: type, sp: OpSpec) -> Callable[..., Awaitable[Any]
         if request is not None:
             base_ctx.setdefault("request", request)
         # surface contextual metadata for runtime atoms
-        base_ctx.setdefault("app", getattr(request, "app", None))
-        base_ctx.setdefault("api", getattr(request, "app", None))
+        app_ref = (
+            getattr(request, "app", None)
+            or base_ctx.get("app")
+            or getattr(model, "api", None)
+            or model
+        )
+        base_ctx.setdefault("app", app_ref)
+        base_ctx.setdefault("api", base_ctx.get("api") or app_ref)
         base_ctx.setdefault("model", model)
         base_ctx.setdefault("op", alias)
         base_ctx.setdefault("method", alias)


### PR DESCRIPTION
## Summary
- ensure RPC handlers supply an app/api context when request is absent
- ensure core helper proxy defaults app context for opview resolution

## Testing
- `uv run --package autoapi --directory standards pytest autoapi/tests/i9n/test_iospec_attributes.py::test_rpc_call_uses_schemas autoapi/tests/i9n/test_iospec_attributes.py::test_core_crud_helpers_operate autoapi/tests/i9n/test_iospec_attributes.py::test_hooks_trigger_with_iospec -q`

------
https://chatgpt.com/codex/tasks/task_e_68bd9a181fc48326a02b002122597943