### PR TITLE
fix: bind bulk ops schemas and handlers

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/op/resolver.py
+++ b/pkgs/standards/autoapi/autoapi/v3/op/resolver.py
@@ -86,6 +86,12 @@ def _generate_canonical(table: type) -> List[OpSpec]:
         ("delete", "delete"),
         ("list", "list"),
         ("clear", "clear"),
+        # Bulk operations (enabled via mixins such as BulkCapable/Replaceable)
+        ("bulk_create", "bulk_create"),
+        ("bulk_update", "bulk_update"),
+        ("bulk_replace", "bulk_replace"),
+        ("bulk_merge", "bulk_merge"),
+        ("bulk_delete", "bulk_delete"),
     ]
     for alias, target in targets:
         if not should_wire_canonical(table, target):


### PR DESCRIPTION
## Summary
- generate canonical specs for bulk ops so their schemas and handlers are bound

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_bulk_response_schema.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd9a39461c8326b41518cefa6966f2