### PR TITLE
Add canonical bulk operation specs

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/op/resolver.py
+++ b/pkgs/standards/autoapi/autoapi/v3/op/resolver.py
@@ -83,10 +83,25 @@ def _generate_canonical(table: type) -> List[OpSpec]:
         # Include canonical "replace" so RPC callers get full CRUD semantics
         # without opting into the Replaceable mixin.
         ("replace", "replace"),
+        ("merge", "merge"),
         ("delete", "delete"),
         ("list", "list"),
         ("clear", "clear"),
+        ("bulk_create", "bulk_create"),
+        ("bulk_update", "bulk_update"),
+        ("bulk_replace", "bulk_replace"),
+        ("bulk_merge", "bulk_merge"),
+        ("bulk_delete", "bulk_delete"),
     ]
+    collection_targets = {
+        "list",
+        "clear",
+        "bulk_create",
+        "bulk_update",
+        "bulk_replace",
+        "bulk_merge",
+        "bulk_delete",
+    }
     for alias, target in targets:
         if not should_wire_canonical(table, target):
             continue
@@ -95,7 +110,7 @@ def _generate_canonical(table: type) -> List[OpSpec]:
                 table=table,
                 alias=alias,
                 target=target,
-                arity="collection" if target in {"list", "clear"} else "member",
+                arity="collection" if target in collection_targets else "member",
                 persist="default",
                 handler=None,
                 request_model=None,


### PR DESCRIPTION
## Summary
- include merge and bulk verbs when generating canonical OpSpecs
- treat bulk verbs as collection-level operations

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_bulk_response_schema.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd9a39461c8326b41518cefa6966f2