### PR TITLE
fix: resolve missing opview context

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/runtime/opview.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/opview.py
@@ -32,8 +32,15 @@ def opview_from_ctx(ctx: Any):
         return K.get_opview(app, model, alias)
 
     specs = getattr(ctx, "specs", None)
-    if alias and specs is not None:
-        return K._compile_opview_from_specs(specs, SimpleNamespace(alias=alias))
+    if alias:
+        if specs is not None:
+            return K._compile_opview_from_specs(specs, SimpleNamespace(alias=alias))
+        if model and not app:
+            try:
+                specs = K._specs_cache.get(model)
+                return K._compile_opview_from_specs(specs, SimpleNamespace(alias=alias))
+            except Exception:
+                pass
 
     missing = []
     if not alias:


### PR DESCRIPTION
## Summary
- resolve missing opview when app context is absent by compiling from specs cache

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_iospec_attributes.py`

------
https://chatgpt.com/codex/tasks/task_e_68bd9a1be16883269f1470ece97ddef9