### PR TITLE
autoapi: include default ColumnSpecs for bare columns

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/column/mro_collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/column/mro_collect.py
@@ -4,8 +4,24 @@ import logging
 from typing import Dict
 
 from .column_spec import ColumnSpec
+from .io_spec import IOSpec as IO
+from .storage_spec import StorageSpec as S
 
 logger = logging.getLogger("uvicorn")
+
+
+# Default inbound/outbound verbs for columns lacking an explicit ColumnSpec.
+#
+# Without this, plain SQLAlchemy ``Column`` definitions are omitted from the
+# collected spec map, causing downstream components to treat their values as
+# unknown.  By seeding such columns with a permissive IO spec we ensure they
+# participate in canonical CRUD operations just like columns defined via
+# ``acol``.
+_DEFAULT_IO = IO(
+    in_verbs=("create", "update", "replace"),
+    out_verbs=("read", "list"),
+    mutable_verbs=("create", "update", "replace"),
+)
 
 
 def mro_collect_columns(model: type) -> Dict[str, ColumnSpec]:
@@ -13,7 +29,8 @@ def mro_collect_columns(model: type) -> Dict[str, ColumnSpec]:
 
     Iterates across the model's MRO so that mixin-defined columns are included
     in the resulting mapping. Later definitions take precedence over earlier
-    ones in the MRO.
+    ones in the MRO.  Any table-backed columns lacking a spec are populated with
+    a default ColumnSpec so they participate in opviews and schema generation.
     """
     logger.info("Collecting columns for %s", model.__name__)
     out: Dict[str, ColumnSpec] = {}
@@ -24,6 +41,13 @@ def mro_collect_columns(model: type) -> Dict[str, ColumnSpec]:
         mapping = getattr(base, "__autoapi_cols__", None)
         if isinstance(mapping, dict):
             out.update(mapping)
+
+    table = getattr(model, "__table__", None)
+    if table is not None:
+        for col in table.columns:
+            name = col.key or col.name
+            out.setdefault(name, ColumnSpec(storage=S(), io=_DEFAULT_IO))
+
     logger.info("Collected %d columns for %s", len(out), model.__name__)
     return out
 


### PR DESCRIPTION
## Summary
- ensure bare SQLAlchemy columns receive a default ColumnSpec and CRUD IO verbs
- fix missing opview errors in AutoAPI when models use plain Column definitions

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_hook_lifecycle.py::test_hook_phases_execution_order --maxfail=1 -q`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_hook_lifecycle.py::test_hook_parity_crud_vs_rpc --maxfail=1 -q`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_hook_lifecycle.py::test_hook_error_handling --maxfail=1 -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd9ab93840832689a9b94417d5cb70