### PR TITLE
fix: ensure opview columns and core context

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/api/resource_proxy.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/api/resource_proxy.py
@@ -68,9 +68,10 @@ class _ResourceProxy:
             if request is not None:
                 logger.debug("Request provided for %s.%s", self._model.__name__, alias)
                 base_ctx.setdefault("request", request)
-            # surface contextual metadata for runtime atoms
-            base_ctx.setdefault("app", getattr(request, "app", None))
-            base_ctx.setdefault("api", getattr(request, "app", None))
+                base_ctx.setdefault("app", getattr(request, "app", None))
+            else:
+                base_ctx.setdefault("app", self._api)
+            base_ctx.setdefault("api", self._api)
             base_ctx.setdefault("model", self._model)
             base_ctx.setdefault("op", alias)
             base_ctx.setdefault("method", alias)
@@ -81,9 +82,6 @@ class _ResourceProxy:
                     method=alias, params=norm_payload, target=alias, model=self._model
                 ),
             )
-            base_ctx.setdefault("api", self._api)
-            base_ctx.setdefault("model", self._model)
-            base_ctx.setdefault("op", alias)
             if self._serialize:
                 logger.debug(
                     "Serialization enabled for %s.%s", self._model.__name__, alias

--- a/pkgs/standards/autoapi/autoapi/v3/column/mro_collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/column/mro_collect.py
@@ -4,6 +4,25 @@ import logging
 from typing import Dict
 
 from .column_spec import ColumnSpec
+from .io_spec import IOSpec
+from .storage_spec import StorageSpec
+
+CANONICAL_VERBS = (
+    "create",
+    "read",
+    "update",
+    "replace",
+    "merge",
+    "delete",
+    "list",
+    "clear",
+    "bulk_create",
+    "bulk_update",
+    "bulk_replace",
+    "bulk_merge",
+    "bulk_delete",
+    "custom",
+)
 
 logger = logging.getLogger("uvicorn")
 
@@ -24,6 +43,28 @@ def mro_collect_columns(model: type) -> Dict[str, ColumnSpec]:
         mapping = getattr(base, "__autoapi_cols__", None)
         if isinstance(mapping, dict):
             out.update(mapping)
+
+    table = getattr(model, "__table__", None)
+    if table is not None:
+        for col in getattr(table, "columns", []):
+            name = getattr(col, "key", None) or getattr(col, "name", None)
+            if not name or name in out:
+                continue
+            io = IOSpec(in_verbs=CANONICAL_VERBS, out_verbs=CANONICAL_VERBS)
+            storage = StorageSpec(
+                type_=getattr(col, "type", None),
+                nullable=getattr(col, "nullable", None),
+                unique=bool(getattr(col, "unique", False)),
+                index=bool(getattr(col, "index", False)),
+                primary_key=bool(getattr(col, "primary_key", False)),
+                autoincrement=getattr(col, "autoincrement", None),
+                default=getattr(getattr(col, "default", None), "arg", None),
+                onupdate=getattr(col, "onupdate", None),
+                server_default=getattr(col, "server_default", None),
+                comment=getattr(col, "comment", None),
+            )
+            out[name] = ColumnSpec(storage=storage, io=io)
+
     logger.info("Collected %d columns for %s", len(out), model.__name__)
     return out
 


### PR DESCRIPTION
## Summary
- include plain SQLAlchemy columns when collecting specs for opview compilation
- seed app/api metadata in core proxy contexts to satisfy opview resolution

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format autoapi/v3/column/mro_collect.py`
- `uv run --package autoapi --directory standards/autoapi ruff check autoapi/v3/column/mro_collect.py --fix`
- `uv run --package autoapi --directory standards/autoapi ruff format autoapi/v3/bindings/api/resource_proxy.py`
- `uv run --package autoapi --directory standards/autoapi ruff check autoapi/v3/bindings/api/resource_proxy.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_hook_ctx_v3_i9n.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd9ac30bcc832698a09209df789f46