### PR TITLE
refactor: require opview for autoapi runtime contexts

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/runtime/opview.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/opview.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
+
 from typing import Any, Mapping, Dict
-from types import SimpleNamespace
 
 from .kernel import _default_kernel as K  # single, app-scoped kernel
 
@@ -30,17 +30,6 @@ def opview_from_ctx(ctx: Any):
     if app and model and alias:
         # One-kernel-per-app, prime once; raises if not compiled
         return K.get_opview(app, model, alias)
-
-    specs = getattr(ctx, "specs", None)
-    if alias:
-        if specs is not None:
-            return K._compile_opview_from_specs(specs, SimpleNamespace(alias=alias))
-        if model and not app:
-            try:
-                specs = K._specs_cache.get(model)
-                return K._compile_opview_from_specs(specs, SimpleNamespace(alias=alias))
-            except Exception:
-                pass
 
     missing = []
     if not alias:


### PR DESCRIPTION
## Summary
- require runtime contexts to include app, model and op
- remove specs-based opview fallback

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format autoapi/v3/runtime/opview.py`
- `uv run --package autoapi --directory standards/autoapi ruff check autoapi/v3/runtime/opview.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_hook_lifecycle.py`


------
https://chatgpt.com/codex/tasks/task_e_68bda01e11488326bf9708e687c7bb82