### PR TITLE
fix: compile storage transforms via opview

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/runtime/opview.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/opview.py
@@ -19,6 +19,10 @@ def opview_from_ctx(ctx: Any):
     Requirements:
       - ctx.app (or ctx.api), ctx.model (or derived from ctx.obj), ctx.op (or ctx.method)
     """
+    ov = getattr(ctx, "opview", None)
+    if ov is not None:
+        return ov
+
     app = getattr(ctx, "app", None) or getattr(ctx, "api", None)
     model = getattr(ctx, "model", None)
     if model is None:

--- a/pkgs/standards/autoapi/tests/unit/test_v3_storage_spec_attributes.py
+++ b/pkgs/standards/autoapi/tests/unit/test_v3_storage_spec_attributes.py
@@ -1,7 +1,7 @@
 from types import SimpleNamespace
 
 from autoapi.v3.runtime.atoms.storage import to_stored
-from autoapi.v3.specs import S, acol
+from autoapi.v3.specs import S, IO, acol
 from autoapi.v3.column.storage_spec import ForeignKeySpec, StorageTransform
 from autoapi.v3.orm.tables import Base
 from sqlalchemy import Integer, String, text
@@ -166,11 +166,16 @@ def test_transform_applied_during_persist():
         __allow_unmapped__ = True
 
         id: Mapped[int] = acol(storage=S(type_=Integer, primary_key=True))
-        name: Mapped[str] = acol(storage=S(type_=String, transform=transform))
+        name: Mapped[str] = acol(
+            io=IO(in_verbs=("create",)),
+            storage=S(type_=String, transform=transform),
+        )
 
-    specs = Thing.__autoapi_cols__
     ctx = SimpleNamespace(
-        persist=True, specs=specs, temp={"assembled_values": {"name": "abc"}}
+        persist=True,
+        model=Thing,
+        op="create",
+        temp={"assembled_values": {"name": "abc"}},
     )
     to_stored.run(None, ctx)
     assert ctx.temp["assembled_values"]["name"] == "ABC"


### PR DESCRIPTION
## Summary
- allow runtime to consume provided opview directly
- compile storage transform callbacks into op views
- update storage spec test to use opview context

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_v3_storage_spec_attributes.py::test_transform_applied_during_persist -q --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_68bda0d8b580832681a72095b1e4e135