### PR TITLE
fix: resolve opview lookup for file responses

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/app/_app.py
+++ b/pkgs/standards/autoapi/autoapi/v3/app/_app.py
@@ -13,14 +13,35 @@ class App(AppSpec, FastAPI):
     def __init__(
         self, *, engine: EngineCfg | None = None, **fastapi_kwargs: Any
     ) -> None:
+        # Manually mirror ``AppSpec`` fields so the dataclass-generated ``repr``
+        # and friends have expected attributes while runtime structures remain
+        # mutable dictionaries or lists as needed.
+        self.title = self.TITLE
+        self.version = self.VERSION
+        self.engine = engine if engine is not None else getattr(self, "ENGINE", None)
+        self.apis = tuple(getattr(self, "APIS", ()))
+        self.ops = tuple(getattr(self, "OPS", ()))
+        # Runtime registries use mutable containers (dict/namespace), but the
+        # dataclass fields expect sequences. Storing a dict here satisfies both.
+        self.models = {}
+        self.schemas = tuple(getattr(self, "SCHEMAS", ()))
+        self.hooks = tuple(getattr(self, "HOOKS", ()))
+        self.security_deps = tuple(getattr(self, "SECURITY_DEPS", ()))
+        self.deps = tuple(getattr(self, "DEPS", ()))
+        self.response = getattr(self, "RESPONSE", None)
+        self.jsonrpc_prefix = getattr(self, "JSONRPC_PREFIX", "/rpc")
+        self.system_prefix = getattr(self, "SYSTEM_PREFIX", "/system")
+        self.middlewares = tuple(getattr(self, "MIDDLEWARES", ()))
+        self.lifespan = self.LIFESPAN
+
         FastAPI.__init__(
             self,
-            title=self.TITLE,
-            version=self.VERSION,
-            lifespan=self.LIFESPAN,
+            title=self.title,
+            version=self.version,
+            lifespan=self.lifespan,
             **fastapi_kwargs,
         )
-        _engine_ctx = engine if engine is not None else getattr(self, "ENGINE", None)
+        _engine_ctx = self.engine
         if _engine_ctx is not None:
             _resolver.set_default(_engine_ctx)
             _resolver.resolve_provider()

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest/collection.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest/collection.py
@@ -43,8 +43,10 @@ def _ctx(model, alias, target, request, db, payload, parent_kw, api):
         "db": db,
         "payload": payload,
         "path_params": parent_kw,
-        # surface key metadata for runtime atoms
+        # expose both API router and FastAPI app; runtime opview resolution
+        # relies on the app object, which must be hashable.
         "api": api if api is not None else getattr(request, "app", None),
+        "app": getattr(request, "app", None),
         "model": model,
         "op": alias,
         "method": alias,

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest/member.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest/member.py
@@ -74,6 +74,7 @@ def _make_member_endpoint(
                 "path_params": path_params,
                 # expose contextual metadata for downstream atoms
                 "api": api if api is not None else getattr(request, "app", None),
+                "app": getattr(request, "app", None),
                 "model": model,
                 "op": alias,
                 "method": alias,
@@ -168,6 +169,7 @@ def _make_member_endpoint(
                 "path_params": path_params,
                 # expose contextual metadata for downstream atoms
                 "api": api if api is not None else getattr(request, "app", None),
+                "app": getattr(request, "app", None),
                 "model": model,
                 "op": alias,
                 "method": alias,


### PR DESCRIPTION
## Summary
- ensure Api and App initialize dataclass fields and runtime containers
- include FastAPI app in request context to allow opview lookup and avoid 400 errors

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_file_response.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bda0f231488326a41594bab067ba14