### PR TITLE
test: use opview contexts in iospec attribute tests

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_iospec_attributes.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_iospec_attributes.py
@@ -41,15 +41,16 @@ def test_request_and_response_schemas_respect_iospec_aliases():
         )
 
     bind(Thing)
-    specs = Thing.__autoapi_cols__
+    api = AutoApp()
+    api.include_model(Thing)
 
-    ctx_in = SimpleNamespace(specs=specs, op="create", temp={})
+    ctx_in = SimpleNamespace(app=api, model=Thing, op="create", temp={})
     collect_in.run(None, ctx_in)
     schema_in = ctx_in.temp["schema_in"]
     assert "id" not in schema_in["by_field"]
     assert schema_in["by_field"]["name"]["alias_in"] == "first_name"
 
-    ctx_out = SimpleNamespace(specs=specs, op="read", temp={})
+    ctx_out = SimpleNamespace(app=api, model=Thing, op="read", temp={})
     collect_out.run(None, ctx_out)
     schema_out = ctx_out.temp["schema_out"]
     assert "id" in schema_out["by_field"]
@@ -89,9 +90,10 @@ def test_default_factory_resolves_missing_value():
         )
 
     bind(Thing)
-    specs = Thing.__autoapi_cols__
+    api = AutoApp()
+    api.include_model(Thing)
     ctx = SimpleNamespace(
-        specs=specs, op="create", temp={"in_values": {}}, persist=True
+        app=api, model=Thing, op="create", temp={"in_values": {}}, persist=True
     )
     assemble.run(None, ctx)
     assembled = ctx.temp["assembled_values"]
@@ -325,9 +327,14 @@ def test_atoms_execute_with_iospec():
         )
 
     bind(Thing)
-    specs = Thing.__autoapi_cols__
+    api = AutoApp()
+    api.include_model(Thing)
     ctx = SimpleNamespace(
-        specs=specs, op="create", temp={"in_values": {"name": "x"}}, persist=True
+        app=api,
+        model=Thing,
+        op="create",
+        temp={"in_values": {"name": "x"}},
+        persist=True,
     )
     collect_in.run(None, ctx)
     assemble.run(None, ctx)


### PR DESCRIPTION
## Summary
- use AutoApp and opview-based contexts in iospec attribute tests

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff check tests/i9n/test_iospec_attributes.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_iospec_attributes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bda248931c8326820fc300a1409781