### PR TITLE
feat(autoapi): drop specs from runtime context

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/runtime/context.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/context.py
@@ -18,7 +18,6 @@ class Context:
     Minimal contract (consumed by atoms we’ve written so far):
       - op:        operation name (e.g., 'create' | 'update' | 'read' | 'list' | custom)
       - persist:   write vs. read (affects pruning of persist-tied anchors)
-      - specs:     mapping of field -> ColumnSpec (frozen at bind time)
       - cfg:       read-only config view (see config.resolver.CfgView)
       - temp:      dict scratchpad used by atoms to exchange data
 
@@ -34,7 +33,6 @@ class Context:
     # core
     op: str
     persist: bool
-    specs: Mapping[str, Any]
     cfg: Any
 
     # shared scratchpad
@@ -103,7 +101,6 @@ class Context:
             "op": self.op,
             "persist": self.persist,
             "model": self.model,
-            "specs": self.specs,
             "user": self.user,
             "tenant": self.tenant,
             "now": self.now,


### PR DESCRIPTION
## Summary
- remove `specs` from runtime `Context` and expose minimal safe view

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_mixins.py::test_slugged_mixin -q`


------
https://chatgpt.com/codex/tasks/task_e_68bda547981483269bc5197b5ba66ba6