### PR TITLE
Fix table spec MRO merge precedence

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/table/mro_collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/table/mro_collect.py
@@ -10,8 +10,8 @@ logger = logging.getLogger("uvicorn")
 
 def _merge_seq_attr(model: type, attr: str) -> Tuple[Any, ...]:
     values: list[Any] = []
-    for base in reversed(model.__mro__):
-        seq = getattr(base, attr, ()) or ()
+    for base in model.__mro__:
+        seq = base.__dict__.get(attr, ()) or ()
         try:
             values.extend(seq)
         except TypeError:  # pragma: no cover - non-iterable
@@ -31,8 +31,8 @@ def mro_collect_table_spec(model: type) -> TableSpec:
     logger.info("Collecting table spec for %s", model.__name__)
 
     engine: Any | None = None
-    for base in reversed(model.__mro__):
-        cfg = getattr(base, "table_config", None)
+    for base in model.__mro__:
+        cfg = base.__dict__.get("table_config")
         if isinstance(cfg, Mapping):
             eng = (
                 cfg.get("engine")


### PR DESCRIPTION
## Summary
- ensure table spec collection honors MRO order and avoids duplicate attributes

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format autoapi/v3/table/mro_collect.py`
- `uv run --package autoapi --directory standards/autoapi ruff check autoapi/v3/table/mro_collect.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_table_collect_spec.py::test_collect_table_spec_merges_mro -q`

------
https://chatgpt.com/codex/tasks/task_e_68bda57c338083268140c15eb86562ee