### PR TITLE
fix: retain identifiers in RPC payload

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/handlers/ctx.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/handlers/ctx.py
@@ -22,13 +22,18 @@ def _ctx_get(ctx: Mapping[str, Any], key: str, default: Any = None) -> Any:
 
 def _ctx_payload(ctx: Mapping[str, Any]) -> Any:
     temp = _ctx_get(ctx, "temp", None)
+    raw = _ctx_get(ctx, "payload", None)
     if isinstance(temp, Mapping):
         av = temp.get("assembled_values")
         if isinstance(av, Mapping):
-            logger.debug("Payload from assembled values: %s", av)
-            return av
+            merged = {}
+            if isinstance(raw, Mapping):
+                merged.update(raw)
+            merged.update(av)
+            logger.debug("Payload from assembled values: %s", merged)
+            return merged
 
-    v = _ctx_get(ctx, "payload", None)
+    v = raw
     if isinstance(v, Mapping):
         logger.debug("Payload is a mapping")
         logger.debug("Payload: %s", v)


### PR DESCRIPTION
## Summary
- preserve primary keys by merging raw payload with assembled values in RPC context handler

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_v3_default_rpc_ops.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bda5d0e35c83269cd3d219c02bfaab