### PR TITLE
Fix diagnostics kernel export and test expectations

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/system/diagnostics/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/system/diagnostics/__init__.py
@@ -1,4 +1,4 @@
-from ...runtime.kernel import build_phase_chains
+from ...runtime.kernel import _default_kernel, build_phase_chains
 from .router import mount_diagnostics
 from .methodz import build_methodz_endpoint as _build_methodz_endpoint
 from .hookz import build_hookz_endpoint as _build_hookz_endpoint
@@ -22,4 +22,5 @@ __all__ = [
     "_label_callable",
     "_label_hook",
     "build_phase_chains",
+    "_default_kernel",
 ]

--- a/pkgs/standards/autoapi/tests/unit/test_kernelz_endpoint.py
+++ b/pkgs/standards/autoapi/tests/unit/test_kernelz_endpoint.py
@@ -57,7 +57,9 @@ async def test_kernelz_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "create" in data["Model"]
     seq = data["Model"]["create"]
     assert seq == [
+        "START_TX:hook:sys:txn:begin@START_TX",
         f"PRE_HANDLER:{_diag._label_hook(sample_atom, 'PRE_HANDLER')}",
         f"PRE_HANDLER:{_diag._label_hook(sample_hook, 'PRE_HANDLER')}",
         f"HANDLER:{_diag._label_hook(handler, 'HANDLER')}",
+        "END_TX:hook:sys:txn:commit@END_TX",
     ]


### PR DESCRIPTION
## Summary
- expose `_default_kernel` from diagnostics for monkeypatching in tests
- adjust kernelz endpoint test to account for system transaction hooks

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format tests/unit/test_kernelz_endpoint.py autoapi/v3/system/diagnostics/__init__.py`
- `uv run --package autoapi --directory standards/autoapi ruff check tests/unit/test_kernelz_endpoint.py autoapi/v3/system/diagnostics/__init__.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_kernelz_endpoint.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bda46cdfd08326a8a04f2710bf3bc0