### PR TITLE
feat(autoapi): add kernel invoke method

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/runtime/kernel.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/kernel.py
@@ -316,6 +316,28 @@ class Kernel:
                     labels.append(lbl)
         return labels
 
+    async def invoke(
+        self,
+        model: type,
+        alias: str,
+        *,
+        db: Any,
+        request: Any | None = None,
+        ctx: Optional[Mapping[str, Any]] = None,
+    ) -> Any:
+        phases = self.build(model, alias)
+        base_ctx = _Ctx.ensure(request=request, db=db, seed=ctx)
+        base_ctx.model = model
+        base_ctx.op = alias
+        try:
+            from types import SimpleNamespace as _NS
+
+            specs = self.get_specs(model)
+            base_ctx.opview = self._compile_opview_from_specs(specs, _NS(alias=alias))
+        except Exception:
+            pass
+        return await _invoke(request=request, db=db, phases=phases, ctx=base_ctx)
+
     # ——— per-App autoprime (hidden) ———
     def ensure_primed(self, app: Any) -> None:
         """Autoprime once per App: specs → OpViews → /kernelz payload."""


### PR DESCRIPTION
## Summary
- add `Kernel.invoke` for direct runtime execution
- seed context with model, op, and opview without exposing specs

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format autoapi/v3/runtime/kernel.py`
- `uv run --package autoapi --directory standards/autoapi ruff check autoapi/v3/runtime/kernel.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_kernel_invoke_ctx.py::test_kernel_invoke_with_basic_ctx -q`


------
https://chatgpt.com/codex/tasks/task_e_68bda9abd1708326951fd67229c86a27