### PR TITLE
Fix AutoApp init in key digest test

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_key_digest_uvicorn.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_key_digest_uvicorn.py
@@ -39,7 +39,7 @@ async def running_app(sync_db_session):
     app = App()
     api = AutoApp(get_db=get_sync_db)
     api.include_models([ApiKey])
-    api.initialize()
+    await api.initialize()
     app.include_router(api.router)
 
     cfg = uvicorn.Config(app, host="127.0.0.1", port=8000, log_level="warning")


### PR DESCRIPTION
## Summary
- ensure AutoApp is fully initialized before serving requests in key digest tests

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_key_digest_uvicorn.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdac31799c83269f3ed1659fbe80f4