### PR TITLE
fix: hashable Api

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/api/_api.py
+++ b/pkgs/standards/autoapi/autoapi/v3/api/_api.py
@@ -16,6 +16,14 @@ class Api(APISpec, ApiRouter):
     MODELS: tuple[Any, ...] = ()
     TABLES: tuple[Any, ...] = ()
 
+    # dataclass inheritance makes instances unhashable; use identity semantics
+    # for both hashing and equality so objects can participate in sets/dicts
+    def __hash__(self) -> int:  # pragma: no cover - simple identity hash
+        return id(self)
+
+    def __eq__(self, other: object) -> bool:  # pragma: no cover - identity compare
+        return self is other
+
     def __init__(
         self, *, engine: EngineCfg | None = None, **router_kwargs: Any
     ) -> None:

--- a/pkgs/standards/autoapi/autoapi/v3/autoapi.py
+++ b/pkgs/standards/autoapi/autoapi/v3/autoapi.py
@@ -273,4 +273,7 @@ class AutoAPI(_Api):
     # ------------------------- repr -------------------------
 
     def __repr__(self) -> str:  # pragma: no cover
-        return f"<AutoAPI models={list(self.models)} rpc={list(getattr(self.rpc, '__dict__', {}).keys())}>"
+        models = list(getattr(self, "models", {}))
+        rpc_ns = getattr(self, "rpc", None)
+        rpc_keys = list(getattr(rpc_ns, "__dict__", {}).keys()) if rpc_ns else []
+        return f"<AutoAPI models={models} rpc={rpc_keys}>"


### PR DESCRIPTION
## Summary
- ensure Api instances are hashable with identity semantics
- harden AutoAPI repr against partially-initialized attributes

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_column_rest_rpc_results.py::test_make_column_only_rest_rpc[True] -q`

------
https://chatgpt.com/codex/tasks/task_e_68bdac1c7d848326a61bf27349bb1d36