### PR TITLE
Fix schema builder inbound verb handling

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/schema/builder/build_schema.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/builder/build_schema.py
@@ -85,10 +85,8 @@ def _build_schema(
                 # consumers can target the correct row.
                 pass
             else:
-                allowed_verbs = (
-                    getattr(io, "in_verbs", None) if io is not None else None
-                )
-                if allowed_verbs is not None and verb not in set(allowed_verbs):
+                allowed_verbs = getattr(io, "in_verbs", ()) if io is not None else ()
+                if allowed_verbs and verb not in set(allowed_verbs):
                     continue
 
         # Column.info["autoapi"]


### PR DESCRIPTION
## Summary
- allow schema builder to include columns when ColumnSpec omits inbound verbs

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_mixins.py::test_async_capable_mixin -q`

------
https://chatgpt.com/codex/tasks/task_e_68bdabe70e44832692dbf4689f96a883