### PR TITLE
fix runtime schema attribute handling

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/column/mro_collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/column/mro_collect.py
@@ -45,7 +45,7 @@ def mro_collect_columns(model: type) -> Dict[str, ColumnSpec]:
     table = getattr(model, "__table__", None)
     if table is not None:
         for col in table.columns:
-            name = col.key or col.name
+            name = getattr(col, "key", None) or col.name
             out.setdefault(name, ColumnSpec(storage=S(), io=_DEFAULT_IO))
 
     logger.info("Collected %d columns for %s", len(out), model.__name__)

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/kernel.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/kernel.py
@@ -440,8 +440,6 @@ class Kernel:
                 py_t = getattr(getattr(fs, "py_type", None), "__name__", None)
                 if py_t:
                     meta_out["py_type"] = py_t
-                if getattr(io, "sensitive", False):
-                    meta_out["sensitive"] = True
                 by_field_out[name] = meta_out
 
         schema_in = SchemaIn(


### PR DESCRIPTION
## Summary
- avoid AttributeError collecting columns without SQLAlchemy `key`
- drop automatic sensitive metadata from schema out
- update iospec tests to use opviews directly

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_io_spec_attributes.py`
- `uv run --package autoapi --directory standards/autoapi pytest` *(fails: httpx.HTTPStatusError, AttributeError, RuntimeError)*

------
https://chatgpt.com/codex/tasks/task_e_68bdac1012a083268aad22f8ae0b96ce