### PR TITLE
enforce opview-only runtime context in autoapi

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/runtime/opview.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/opview.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 from typing import Any, Mapping, Dict
-from types import SimpleNamespace
 
 from .kernel import _default_kernel as K  # single, app-scoped kernel
 
@@ -18,9 +17,9 @@ def opview_from_ctx(ctx: Any):
     Resolve the ``OpView`` for this request context or raise a runtime error.
 
     Preferred resolution path is via ``ctx.opview`` which should be attached by
-    the caller.  Falling back to kernel lookups requires ``ctx.app`` (or
-    ``ctx.api``), ``ctx.model`` (or derivable from ``ctx.obj``), and ``ctx.op``
-    (or ``ctx.method``).
+    the caller. Kernel lookups require ``ctx.app`` (or ``ctx.api``),
+    ``ctx.model`` (or derivable from ``ctx.obj``), and ``ctx.op`` (or
+    ``ctx.method``).
     """
     ov = getattr(ctx, "opview", None)
     if ov is not None:
@@ -37,11 +36,6 @@ def opview_from_ctx(ctx: Any):
     if app and model and alias:
         # One-kernel-per-app, prime once; raises if not compiled
         return K.get_opview(app, model, alias)
-
-    if alias:
-        specs = getattr(ctx, "specs", None)
-        if specs is not None:
-            return K._compile_opview_from_specs(specs, SimpleNamespace(alias=alias))
 
     missing = []
     if not alias:

--- a/pkgs/standards/autoapi/tests/i9n/test_iospec_integration.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_iospec_integration.py
@@ -13,6 +13,7 @@ from autoapi.v3.specs import IO, S, acol
 from autoapi.v3.types import App, String, UUID
 from autoapi.v3.core import crud
 from autoapi.v3.runtime.atoms.resolve import assemble
+from autoapi.v3.runtime.kernel import _default_kernel as K
 
 
 class Widget(Base, GUIDPk):
@@ -81,8 +82,9 @@ async def test_columns_store_io_spec(widget_setup):
 async def test_default_factory_resolution(widget_setup):
     _, _, _ = widget_setup
     specs = Widget.__autoapi_cols__
+    opview = K._compile_opview_from_specs(specs, SimpleNamespace(alias="create"))
     ctx = SimpleNamespace(
-        specs=specs, op="create", temp={"in_values": {}}, persist=True
+        op="create", temp={"in_values": {}}, persist=True, opview=opview
     )
     assemble.run(None, ctx)
     assert ctx.temp["assembled_values"]["created_at"] == "now"


### PR DESCRIPTION
## Summary
- Require explicit opview information in `opview_from_ctx` instead of compiling from raw specs
- Update default factory integration test to construct an opview for the runtime context

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_iospec_integration.py::test_columns_store_io_spec tests/i9n/test_iospec_integration.py::test_storage_persists_data tests/i9n/test_iospec_integration.py::test_rest_calls_honor_io_spec tests/i9n/test_iospec_integration.py::test_rpc_methods_honor_io_spec tests/i9n/test_iospec_integration.py::test_default_factory_resolution -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdb7448e04832699eb790345056403