### PR TITLE
Fix autoapi IO spec handling and tests

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/column/mro_collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/column/mro_collect.py
@@ -45,7 +45,11 @@ def mro_collect_columns(model: type) -> Dict[str, ColumnSpec]:
     table = getattr(model, "__table__", None)
     if table is not None:
         for col in table.columns:
-            name = col.key or col.name
+            col_key = getattr(col, "key", None)
+            col_name = getattr(col, "name", None)
+            name = col_key or col_name
+            if not name:
+                continue
             out.setdefault(name, ColumnSpec(storage=S(), io=_DEFAULT_IO))
 
     logger.info("Collected %d columns for %s", len(out), model.__name__)

--- a/pkgs/standards/autoapi/tests/unit/test_v3_storage_spec_attributes.py
+++ b/pkgs/standards/autoapi/tests/unit/test_v3_storage_spec_attributes.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 
 from autoapi.v3.runtime.atoms.storage import to_stored
+from autoapi.v3.runtime.kernel import _default_kernel as K
 from autoapi.v3.specs import S, acol
 from autoapi.v3.column.storage_spec import ForeignKeySpec, StorageTransform
 from autoapi.v3.orm.tables import Base
@@ -169,8 +170,9 @@ def test_transform_applied_during_persist():
         name: Mapped[str] = acol(storage=S(type_=String, transform=transform))
 
     specs = Thing.__autoapi_cols__
+    ov = K._compile_opview_from_specs(specs, SimpleNamespace(alias="create"))
     ctx = SimpleNamespace(
-        persist=True, specs=specs, temp={"assembled_values": {"name": "abc"}}
+        opview=ov, persist=True, temp={"assembled_values": {"name": "abc"}}
     )
     to_stored.run(None, ctx)
     assert ctx.temp["assembled_values"]["name"] == "ABC"


### PR DESCRIPTION
## Summary
- provide default CRUD verbs and enforce allow_in/out while compiling OpViews
- collect storage transforms during opview compilation
- handle columns missing `key` attribute
- update spec tests to use opview and verify masking and transform behavior

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_io_spec_attributes.py::test_alias_in_reflected_in_schema tests/unit/test_io_spec_attributes.py::test_alias_out_reflected_in_schema tests/unit/test_io_spec_attributes.py::test_sensitive_flag_triggers_masking tests/unit/test_io_spec_attributes.py::test_redact_last_flag_has_no_masking_effect tests/unit/test_io_spec_attributes.py::test_filter_ops_restricts_filters`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_v3_storage_spec_attributes.py::test_transform_applied_during_persist`


------
https://chatgpt.com/codex/tasks/task_e_68bdac1012a083268aad22f8ae0b96ce