### PR TITLE
Fix schema cache key handling

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/schema/builder/build_schema.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/builder/build_schema.py
@@ -27,11 +27,13 @@ def _build_schema(
     verb: str = "create",
 ) -> Type[BaseModel]:
     """Build (and cache) a verb-specific Pydantic schema for *orm_cls*."""
+    include_key = frozenset(include) if include is not None else None
+    exclude_key = frozenset(exclude) if exclude is not None else None
     cache_key = (
         orm_cls,
         verb,
-        frozenset(include or ()),
-        frozenset(exclude or ()),
+        include_key,
+        exclude_key,
         name,
     )
     cached = _SchemaCache.get(cache_key)

--- a/pkgs/standards/autoapi/autoapi/v3/schema/builder/cache.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/builder/cache.py
@@ -18,7 +18,7 @@ _SchemaVerb = Union[
 ]
 
 _SchemaCache: Dict[
-    Tuple[type, str, frozenset, frozenset, str | None], Type[BaseModel]
+    Tuple[type, str, frozenset | None, frozenset | None, str | None], Type[BaseModel]
 ] = {}
 
 __all__ = ["_SchemaVerb", "_SchemaCache"]


### PR DESCRIPTION
## Summary
- ensure schema cache differentiates missing and empty include/exclude sets
- update schema cache typing to allow optional frozensets

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_iospec_integration.py tests/i9n/test_mixins.py -q --disable-warnings >/tmp/log.txt && tail -n 20 /tmp/log.txt`


------
https://chatgpt.com/codex/tasks/task_e_68bdb6a7d4d88326901e140fc61d49cd