### PR TITLE
Clear schema cache in autoapi test fixtures

### DIFF
--- a/pkgs/standards/autoapi/tests/conftest.py
+++ b/pkgs/standards/autoapi/tests/conftest.py
@@ -105,6 +105,7 @@ def create_test_api():
     def _create_api(model_class):
         """Create AutoAPI instance with a single model for testing."""
         Base.metadata.clear()
+        v3_builder._SchemaCache.clear()
         api = AutoApp(engine=mem(async_=False))
         api.include_model(model_class)
         api.initialize()
@@ -119,6 +120,7 @@ async def create_test_api_async():
 
     def _create_api_async(model_class):
         Base.metadata.clear()
+        v3_builder._SchemaCache.clear()
         api = AutoApp(engine=mem())
         api.include_model(model_class)
         return api


### PR DESCRIPTION
## Summary
- ensure autoapi test fixtures reset the schema cache when building temporary APIs

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_mixins.py -q`
- `uv run --package autoapi --directory standards/autoapi pytest tests -q` *(fails: AttributeError: type object 'Widget' has no attribute '__table__', KeyError: 'id', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68bdbc4c1c94832681f3f900faf16081