### PR TITLE
fix: correct create routing for nested paths

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest/router.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest/router.py
@@ -69,6 +69,14 @@ def _build_router(
     if any(sp.target == "bulk_delete" for sp in specs):
         specs = [sp for sp in specs if sp.target != "clear"]
 
+    # Prefer the single-item create route when both create and bulk_create are
+    # available. The create handler already accepts lists, so exposing a
+    # separate bulk_create REST route would lead to conflicts.
+    if any(sp.target == "bulk_create" for sp in specs) and any(
+        sp.target == "create" for sp in specs
+    ):
+        specs = [sp for sp in specs if sp.target != "bulk_create"]
+
     # Register collection-level bulk routes before member routes so static paths
     # like "/resource/bulk" aren't captured by dynamic member routes such as
     # "/resource/{item_id}". FastAPI matches routes in the order they are

--- a/pkgs/standards/autoapi/autoapi/v3/op/resolver.py
+++ b/pkgs/standards/autoapi/autoapi/v3/op/resolver.py
@@ -94,6 +94,7 @@ def _generate_canonical(table: type) -> List[OpSpec]:
         ("bulk_delete", "bulk_delete"),
     ]
     collection_targets = {
+        "create",
         "list",
         "clear",
         "bulk_create",


### PR DESCRIPTION
## Summary
- ensure create is treated as a collection route
- avoid exposing duplicate bulk_create REST route when create exists

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_nested_path_schema_and_rpc.py::test_nested_path_schema_and_rpc -q`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_nested_routing_depth.py::test_nested_routing_depth -q`
- `uv run --package autoapi --directory standards/autoapi pytest` *(fails: tests/i9n/test_iospec_integration.py::test_rpc_methods_honor_io_spec, tests/i9n/test_iospec_integration.py::test_core_crud_binding, tests/i9n/test_key_digest_uvicorn.py::test_create_response_fields, and others)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbc66c6c88326a0acc56297b544fb