### PR TITLE
autoapi: remap models after registry dispose

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/api/include.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/api/include.py
@@ -173,6 +173,20 @@ def include_model(
     """
     logger.debug("Including model %s", model.__name__)
 
+    # If another test or call disposed the SQLAlchemy registry, previously
+    # imported models lose their table mapping.  Re-map on demand so tests that
+    # run after a registry dispose still have working models.
+    if not hasattr(model, "__table__"):
+        try:  # pragma: no cover - defensive path exercised in tests
+            from ...table import Base
+            from ...table._base import _materialize_colspecs_to_sqla
+
+            # Recreate mapped_column attributes from ColumnSpecs then map
+            _materialize_colspecs_to_sqla(model)
+            Base.registry.map_declaratively(model)
+        except Exception:  # pragma: no cover
+            logger.debug("Failed to remap model %s", model.__name__, exc_info=True)
+
     # 0) seed deps/security so binders can see them (transport-level only)
     _seed_security_and_deps(api, model)
 


### PR DESCRIPTION
## Summary
- ensure `include_model` remaps SQLAlchemy models if the registry was disposed, allowing tests to run after other tests call `Base.registry.dispose`

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_iospec_integration.py -q`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_allow_anon.py tests/i9n/test_hook_ctx_v3_i9n.py tests/i9n/test_iospec_integration.py tests/i9n/test_mixins.py::test_timestamped_mixin -q --log-cli-level=WARNING` *(fails: tests/i9n/test_mixins.py::test_timestamped_mixin)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbc92e4e483269fd6bc00fc1b437e