### PR TITLE
Handle bulk create REST route parity in tests

### DIFF
--- a/pkgs/standards/autoapi/tests/unit/test_rest_rpc_parity_default_ops.py
+++ b/pkgs/standards/autoapi/tests/unit/test_rest_rpc_parity_default_ops.py
@@ -59,6 +59,8 @@ def test_rest_rpc_parity_for_default_verbs(alias, target, path, methods):
     routes = _route_map(Item.rest.router)
     if alias == "clear" and "bulk_delete" in routes:
         assert alias not in routes
+    elif alias == "bulk_create" and "create" in routes:
+        assert alias not in routes
     else:
         assert alias in routes
         got_path, got_methods = routes[alias]


### PR DESCRIPTION
## Summary
- account for missing bulk_create REST route when create exists to keep RPC parity

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_rest_rpc_parity_default_ops.py -q -o log_cli=false`
- `uv run --package autoapi --directory standards/autoapi pytest -q --disable-warnings -o log_cli=false` *(fails: tests/i9n/test_mixins.py::test_timestamped_mixin, tests/i9n/test_mixins.py::test_last_used_mixin, tests/i9n/test_mixins.py::test_replaceable_mixin, tests/i9n/test_mixins.py::test_async_capable_mixin, tests/i9n/test_mixins.py::test_validity_window_default, tests/i9n/test_op_ctx_core_crud_order.py::test_op_ctx_override[update-patch-member-True])*

------
https://chatgpt.com/codex/tasks/task_e_68bdc0425f4c8326ad5ed7500c5f2c15