### PR TITLE
optimize autoapi v3 collectors

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/api/mro_collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/api/mro_collect.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from functools import lru_cache
 from typing import Any, Callable, Dict, Iterable, Mapping
 
 from ..config.constants import AUTOAPI_API_HOOKS_ATTR
@@ -9,6 +10,7 @@ from ..config.constants import AUTOAPI_API_HOOKS_ATTR
 logger = logging.getLogger("uvicorn")
 
 
+@lru_cache(maxsize=None)
 def mro_collect_api_hooks(api: type) -> Dict[str, Dict[str, list[Callable[..., Any]]]]:
     """Collect API-level hook declarations across ``api``'s MRO.
 

--- a/pkgs/standards/autoapi/autoapi/v3/app/mro_collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/app/mro_collect.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from functools import lru_cache
 from typing import Any, Tuple
 
 from .app_spec import AppSpec
@@ -19,6 +20,7 @@ def _merge_seq_attr(app: type, attr: str) -> Tuple[Any, ...]:
     return tuple(values)
 
 
+@lru_cache(maxsize=None)
 def mro_collect_app_spec(app: type) -> AppSpec:
     """Collect AppSpec-like declarations across the app's MRO."""
     logger.info("Collecting app spec for %s", app.__name__)

--- a/pkgs/standards/autoapi/autoapi/v3/column/mro_collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/column/mro_collect.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from functools import lru_cache
 from typing import Dict
 
 from .column_spec import ColumnSpec
@@ -24,6 +25,7 @@ _DEFAULT_IO = IO(
 )
 
 
+@lru_cache(maxsize=None)
 def mro_collect_columns(model: type) -> Dict[str, ColumnSpec]:
     """Collect ColumnSpecs declared on *model* and all mixins.
 

--- a/pkgs/standards/autoapi/autoapi/v3/op/mro_collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/op/mro_collect.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from functools import lru_cache
 from typing import Any, Callable, Dict
 
 from .types import OpSpec
@@ -17,6 +18,7 @@ def _merge_mro_dict(cls: type, attr: str) -> Dict[str, Any]:
     return merged
 
 
+@lru_cache(maxsize=None)
 def mro_alias_map_for(table: type) -> Dict[str, str]:
     """Collect alias overrides across the table's MRO."""
     return _merge_mro_dict(table, "__autoapi_aliases__")
@@ -38,6 +40,7 @@ def _wrap_ctx_core(table: type, func: Callable[..., Any]) -> Callable[..., Any]:
     return core
 
 
+@lru_cache(maxsize=None)
 def mro_collect_decorated_ops(table: type) -> list[OpSpec]:
     """Collect ctx-only op declarations across the table's MRO."""
 

--- a/pkgs/standards/autoapi/autoapi/v3/table/mro_collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/table/mro_collect.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from functools import lru_cache
 from typing import Any, Mapping, Tuple
 
 from .table_spec import TableSpec
@@ -19,6 +20,7 @@ def _merge_seq_attr(model: type, attr: str) -> Tuple[Any, ...]:
     return tuple(values)
 
 
+@lru_cache(maxsize=None)
 def mro_collect_table_spec(model: type) -> TableSpec:
     """Collect TableSpec-like declarations across the model's MRO.
 

--- a/pkgs/standards/autoapi/tests/perf/test_collect_performance.py
+++ b/pkgs/standards/autoapi/tests/perf/test_collect_performance.py
@@ -1,0 +1,107 @@
+from time import perf_counter, sleep
+
+
+
+from autoapi.v3.column.mro_collect import mro_collect_columns
+from autoapi.v3.column.column_spec import ColumnSpec
+from autoapi.v3.column.io_spec import IOSpec as IO
+from autoapi.v3.column.storage_spec import StorageSpec as S
+from autoapi.v3.op.mro_collect import mro_collect_decorated_ops
+from autoapi.v3.op import op_ctx
+from autoapi.v3.hook.mro_collect import mro_collect_decorated_hooks
+from autoapi.v3 import hook_ctx
+
+
+class _SlowCols:
+    def __init__(self, calls: dict):
+        self.calls = calls
+
+    def __get__(self, obj, cls):
+        self.calls["cols"] += 1
+        sleep(0.01)
+        return {"id": ColumnSpec(storage=S(), io=IO())}
+
+
+def test_mro_collect_columns_cached_call_faster():
+    calls = {"cols": 0}
+
+    class Model:
+        __autoapi_cols__ = _SlowCols(calls)
+
+    start = perf_counter()
+    mro_collect_columns(Model)
+    first = perf_counter() - start
+
+    start = perf_counter()
+    mro_collect_columns(Model)
+    second = perf_counter() - start
+
+    assert calls["cols"] == 1
+    assert second < first * 0.1
+    print(f"columns first={first:.6f}s second={second:.6f}s")
+
+
+def test_mro_collect_ops_cached_call_faster(monkeypatch):
+    calls = {"unwrap": 0}
+    from autoapi.v3.op import mro_collect as _mro
+
+    orig_unwrap = _mro._unwrap
+
+    def slow_unwrap(attr):
+        calls["unwrap"] += 1
+        sleep(0.01)
+        return orig_unwrap(attr)
+
+    monkeypatch.setattr(_mro, "_unwrap", slow_unwrap)
+
+    class Model:
+        @op_ctx()
+        def create(cls, ctx):
+            return None
+
+    start = perf_counter()
+    mro_collect_decorated_ops(Model)
+    first = perf_counter() - start
+    first_calls = calls["unwrap"]
+
+    start = perf_counter()
+    mro_collect_decorated_ops(Model)
+    second = perf_counter() - start
+
+    assert calls["unwrap"] == first_calls
+    assert second < first * 0.1
+    print(f"ops first={first:.6f}s second={second:.6f}s")
+
+
+def test_mro_collect_hooks_cached_call_faster(monkeypatch):
+    calls = {"unwrap": 0}
+    from autoapi.v3.hook import mro_collect as _mro
+
+    orig_unwrap = _mro._unwrap
+
+    def slow_unwrap(attr):
+        calls["unwrap"] += 1
+        sleep(0.01)
+        return orig_unwrap(attr)
+
+    monkeypatch.setattr(_mro, "_unwrap", slow_unwrap)
+
+    class Model:
+        @hook_ctx(ops="*", phase="POST_RESPONSE")
+        def _hook(cls, ctx):
+            return None
+
+    visible = {"create"}
+
+    start = perf_counter()
+    mro_collect_decorated_hooks(Model, visible_aliases=visible)
+    first = perf_counter() - start
+    first_calls = calls["unwrap"]
+
+    start = perf_counter()
+    mro_collect_decorated_hooks(Model, visible_aliases=visible)
+    second = perf_counter() - start
+
+    assert calls["unwrap"] == first_calls
+    assert second < first * 0.1
+    print(f"hooks first={first:.6f}s second={second:.6f}s")


### PR DESCRIPTION
## Summary
- memoize autoapi v3 MRO collectors to avoid repeated class traversal
- add performance tests covering column, op, and hook collectors

## Testing
- `uv run --directory . --package autoapi ruff format .`
- `uv run --directory . --package autoapi ruff check . --fix`
- `uv run --directory . --package autoapi pytest tests/perf/test_collect_performance.py tests/perf/test_methodz_performance.py::test_methodz_cached_call_faster tests/perf/test_planz_performance.py::test_planz_cached_call_faster tests/perf/test_hookz_performance.py::test_hookz_cached_call_faster`

------
https://chatgpt.com/codex/tasks/task_e_68bdc1311d788326be6e880449fec6ed