### PR TITLE
fix(autoapi): remove deprecated column metadata

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/table/_base.py
+++ b/pkgs/standards/autoapi/autoapi/v3/table/_base.py
@@ -160,7 +160,6 @@ def _materialize_colspecs_to_sqla(cls) -> None:
             server_default=getattr(storage, "server_default", None),
             comment=getattr(storage, "comment", None),
             autoincrement=getattr(storage, "autoincrement", None),
-            info={"autoapi": {"spec": spec}},
         )
 
         setattr(cls, name, mc)

--- a/pkgs/standards/autoapi/tests/i9n/test_iospec_integration.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_iospec_integration.py
@@ -72,8 +72,8 @@ async def test_response_schema_reflects_io_spec(widget_setup):
 @pytest.mark.asyncio
 async def test_columns_store_io_spec(widget_setup):
     _, _, _ = widget_setup
-    info = Widget.__table__.c.secret.info["autoapi"]["spec"].io
-    assert info.allow_out is False
+    spec = Widget.__autoapi_cols__["secret"].io
+    assert spec.allow_out is False
 
 
 @pytest.mark.i9n


### PR DESCRIPTION
## Summary
- stop storing ColumnSpec data in deprecated `col.info['autoapi']`
- adjust tests to inspect `__autoapi_cols__` directly

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_iospec_integration.py::test_columns_store_io_spec -q`

------
https://chatgpt.com/codex/tasks/task_e_68bdc173fd288326b30212b953d08482