### PR TITLE
feat(autoapi): ensure unique member operation ids

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest/member.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest/member.py
@@ -54,6 +54,16 @@ def _make_member_endpoint(
     pk_names = _pk_names(model)
     nested_vars = list(nested_vars or [])
 
+    def _endpoint_name() -> str:
+        parts = ["rest", model.__name__]
+        if resource:
+            parts.append(resource.replace("/", "_"))
+        parts.append(alias)
+        parts.append("member")
+        if nested_vars:
+            parts.extend(nested_vars)
+        return "_".join(parts)
+
     # --- No body on GET read / DELETE delete ---
     if target in {"read", "delete"}:
 
@@ -141,7 +151,7 @@ def _make_member_endpoint(
         )
         _endpoint.__signature__ = inspect.Signature(params)
 
-        _endpoint.__name__ = f"rest_{model.__name__}_{alias}_member"
+        _endpoint.__name__ = _endpoint_name()
         _endpoint.__qualname__ = _endpoint.__name__
         _endpoint.__doc__ = (
             f"REST member endpoint for {model.__name__}.{alias} ({target})"
@@ -236,7 +246,7 @@ def _make_member_endpoint(
         )
         _endpoint.__signature__ = inspect.Signature(params)
 
-        _endpoint.__name__ = f"rest_{model.__name__}_{alias}_member"
+        _endpoint.__name__ = _endpoint_name()
         _endpoint.__qualname__ = _endpoint.__name__
         _endpoint.__doc__ = (
             f"REST member endpoint for {model.__name__}.{alias} ({target})"
@@ -356,7 +366,7 @@ def _make_member_endpoint(
     )
     _endpoint.__signature__ = inspect.Signature(params)
 
-    _endpoint.__name__ = f"rest_{model.__name__}_{alias}_member"
+    _endpoint.__name__ = _endpoint_name()
     _endpoint.__qualname__ = _endpoint.__name__
     _endpoint.__doc__ = f"REST member endpoint for {model.__name__}.{alias} ({target})"
     _endpoint.__annotations__["body"] = body_annotation

--- a/pkgs/standards/autoapi/tests/unit/test_no_duplicate_operation_ids.py
+++ b/pkgs/standards/autoapi/tests/unit/test_no_duplicate_operation_ids.py
@@ -1,0 +1,34 @@
+import warnings
+from types import SimpleNamespace
+from sqlalchemy import String
+
+from autoapi.v3.engine.shortcuts import engine as engine_factory, mem
+from autoapi.v3.bindings.api.include import include_model
+from autoapi.v3.orm.tables import Base
+from autoapi.v3.orm.mixins import GUIDPk
+from autoapi.v3.specs import IO, S, acol
+
+
+class _Tenant(Base, GUIDPk):
+    __tablename__ = "tenant_dup"
+    __allow_unmapped__ = True
+    name = acol(
+        storage=S(type_=String, nullable=False),
+        io=IO(in_verbs=("create",), out_verbs=("read",)),
+    )
+
+
+def _make_api():
+    engine = engine_factory(mem(async_=False))
+    raw_engine, _ = engine.raw()
+    _Tenant.__table__.create(bind=raw_engine)
+    return SimpleNamespace(app=None)
+
+
+def test_include_model_twice_has_unique_operation_ids():
+    api = _make_api()
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        include_model(api, _Tenant, mount_router=False)
+        include_model(api, _Tenant, mount_router=False)
+    assert not any("Duplicate Operation ID" in str(warn.message) for warn in w)


### PR DESCRIPTION
## Summary
- avoid duplicate FastAPI operation IDs by deriving endpoint names from model, resource, and nesting
- add regression test preventing duplicate operation ID warnings when including a model twice

## Testing
- `uv run --directory standards/autoapi --package autoapi ruff format tests/unit/test_no_duplicate_operation_ids.py`
- `uv run --directory standards/autoapi --package autoapi ruff check tests/unit/test_no_duplicate_operation_ids.py --fix`
- `uv run --directory standards/autoapi --package autoapi pytest tests/unit/test_no_duplicate_operation_ids.py`

------
https://chatgpt.com/codex/tasks/task_e_68bdc1f5bde08326a57da97d94094928