### PR TITLE
test: clear caches to avoid cross-test contamination

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_op_ctx_core_crud_order.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_op_ctx_core_crud_order.py
@@ -10,10 +10,16 @@ from autoapi.v3.core import crud
 from autoapi.v3.engine.shortcuts import mem
 from autoapi.v3.engine.engine_spec import EngineSpec
 from autoapi.v3.engine._engine import Engine
+from autoapi.v3.runtime import kernel as runtime_kernel
+from autoapi.v3.schema import builder as v3_builder
+from autoapi.v3.op import model_registry
 
 
 def setup_api(model_cls):
     Base.metadata.clear()
+    v3_builder._SchemaCache.clear()
+    runtime_kernel._default_kernel = runtime_kernel.Kernel()
+    model_registry._REGISTRIES.clear()
     spec = EngineSpec.from_any(mem(async_=False))
     engine = Engine(spec)
     app = App(engine=engine)


### PR DESCRIPTION
## Summary
- clear AutoAPI caches before each run in CRUD order test to avoid cross-test contamination

## Testing
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68bdf75ee9a883268e23175dc4732529