### PR TITLE
Reset AutoAPI op registry between tests

### DIFF
--- a/pkgs/standards/autoapi/tests/conftest.py
+++ b/pkgs/standards/autoapi/tests/conftest.py
@@ -9,6 +9,7 @@ from autoapi.v3.schema import builder as v3_builder
 from autoapi.v3.runtime import kernel as runtime_kernel
 from autoapi.v3.engine.shortcuts import mem
 from autoapi.v3.engine import resolver as _resolver
+from autoapi.v3.op import model_registry
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import Column, ForeignKey, Integer, String
 from sqlalchemy.dialects.postgresql import UUID
@@ -32,10 +33,12 @@ def _reset_state():
     Base.metadata.clear()
     v3_builder._SchemaCache.clear()
     runtime_kernel._default_kernel = runtime_kernel.Kernel()
+    model_registry._REGISTRIES.clear()
     yield
     Base.metadata.clear()
     v3_builder._SchemaCache.clear()
     runtime_kernel._default_kernel = runtime_kernel.Kernel()
+    model_registry._REGISTRIES.clear()
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
## Summary
- clear op registry cache in AutoAPI tests to prevent cross-test contamination

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format tests/conftest.py`
- `uv run --package autoapi --directory standards/autoapi ruff check tests/conftest.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_v3_op_ctx_attributes.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdf75942b88326a7a9ab8d46ba95e9