### PR TITLE
fix: clear global metaclass patch

### DIFF
--- a/pkgs/conftest.py
+++ b/pkgs/conftest.py
@@ -1,5 +1,9 @@
 import pytest
 
+from standards.autoapi.autoapi.v3.bindings.model_registry import (
+    clear_op_ctx_attach_hook,
+)
+
 
 def pytest_configure(config):
     config.addinivalue_line(
@@ -23,3 +27,9 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(skip_infra)
         if "smoke" in item.keywords:
             item.add_marker(skip_smoke)
+
+
+@pytest.fixture(autouse=True)
+def _clear_autoapi_meta_patch():
+    yield
+    clear_op_ctx_attach_hook()


### PR DESCRIPTION
## Summary
- add cleanup util for metaclass patching
- reset global metaclass hook after each test

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory . ruff format conftest.py`
- `uv run --package autoapi --directory . ruff check conftest.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_68bdf66f9ccc8326b1a06c47c8ba0e7d