### PR TITLE
Ensure global metaclass hooks are cleared

### DIFF
--- a/pkgs/standards/autoapi/tests/conftest.py
+++ b/pkgs/standards/autoapi/tests/conftest.py
@@ -9,6 +9,7 @@ from autoapi.v3.schema import builder as v3_builder
 from autoapi.v3.runtime import kernel as runtime_kernel
 from autoapi.v3.engine.shortcuts import mem
 from autoapi.v3.engine import resolver as _resolver
+from autoapi.v3.bindings.model_registry import _clear_op_ctx_attach_hook
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import Column, ForeignKey, Integer, String
 from sqlalchemy.dialects.postgresql import UUID
@@ -32,10 +33,12 @@ def _reset_state():
     Base.metadata.clear()
     v3_builder._SchemaCache.clear()
     runtime_kernel._default_kernel = runtime_kernel.Kernel()
+    _clear_op_ctx_attach_hook()
     yield
     Base.metadata.clear()
     v3_builder._SchemaCache.clear()
     runtime_kernel._default_kernel = runtime_kernel.Kernel()
+    _clear_op_ctx_attach_hook()
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
## Summary
- track patched metaclasses and expose `_clear_op_ctx_attach_hook` to restore original `type.__setattr__`
- reset global metaclass hook around each test to avoid cross-test interference

## Testing
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff format .`
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68bdf66f9ccc8326b1a06c47c8ba0e7d