### PR TITLE
Ensure deterministic CRUD op ordering

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/op/mro_collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/op/mro_collect.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Callable, Dict
 
-from .types import OpSpec
+from .types import CANON, OpSpec
 from .decorators import _maybe_await, _OpDecl, _infer_arity, _normalize_persist, _unwrap
 from ..runtime.executor import _Ctx
 
@@ -90,6 +90,11 @@ def mro_collect_decorated_ops(table: type) -> list[OpSpec]:
             seen.add(name)
 
     logger.debug("Collected %d ops for %s", len(out), table.__name__)
+    out.sort(
+        key=lambda spec: CANON.index(spec.target)
+        if spec.target in CANON
+        else len(CANON)
+    )
     return out
 
 


### PR DESCRIPTION
## Summary
- enforce canonical CRUD order when collecting context-only operations

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_v3_op_ctx_attributes.py::test_op_ctx_core_crud_order -q`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit -q` *(fails: tests/unit/test_column_rest_rpc_results.py::test_make_virtual_column_only_rest_rpc[True], tests/unit/test_column_rest_rpc_results.py::test_make_virtual_column_only_rest_rpc[False], tests/unit/test_column_rest_rpc_results.py::test_make_virtual_column_with_aliases_rest_rpc[True], tests/unit/test_column_rest_rpc_results.py::test_make_virtual_column_with_aliases_rest_rpc[False], tests/unit/test_column_and_virtual_rest_rpc[True], tests/unit/test_make_column_and_virtual_rest_rpc[False], tests/unit/test_column_and_virtual_with_alias_rest_rpc[True], tests/unit/test_column_and_virtual_with_alias_rest_rpc[False])`

------
https://chatgpt.com/codex/tasks/task_e_68bdf9926cec8326b646318cec3e25ac