### PR TITLE
Fix indentation in validate workflow Python snippet

### DIFF
--- a/.github/workflows/v0.7.0_validate_changed_files.yaml
+++ b/.github/workflows/v0.7.0_validate_changed_files.yaml
@@ -171,22 +171,22 @@ jobs:
           uv run --directory "$PKG_PATH" --package "$PACKAGE_NAME" --isolated --active pytest -vvv | tee pytest.log
           STATUS=${PIPESTATUS[0]}
           python - <<'PY'
-            import re, pathlib
-            log = pathlib.Path('pytest.log').read_text().splitlines()[-1]
-            patterns = {
-                'passed': r'(\d+) passed',
-                'failed': r'(\d+) failed',
-                'xfailed': r'(\d+) xfailed',
-                'xpassed': r'(\d+) xpassed',
-                'skipped': r'(\d+) skipped',
-                'warnings': r'(\d+) warnings?',
-                'errors': r'(\d+) errors?'
-            }
-            counts = {k: 0 for k in patterns}
-            for key, pat in patterns.items():
-                m = re.search(pat, log)
-                if m:
-                    counts[key] = int(m.group(1))
-            print("::notice title=pytest summary::" + " ".join(f"{k}={v}" for k, v in counts.items()))
+          import re, pathlib
+          log = pathlib.Path('pytest.log').read_text().splitlines()[-1]
+          patterns = {
+              'passed': r'(\d+) passed',
+              'failed': r'(\d+) failed',
+              'xfailed': r'(\d+) xfailed',
+              'xpassed': r'(\d+) xpassed',
+              'skipped': r'(\d+) skipped',
+              'warnings': r'(\d+) warnings?',
+              'errors': r'(\d+) errors?'
+          }
+          counts = {k: 0 for k in patterns}
+          for key, pat in patterns.items():
+              m = re.search(pat, log)
+              if m:
+                  counts[key] = int(m.group(1))
+          print("::notice title=pytest summary::" + " ".join(f"{k}={v}" for k, v in counts.items()))
           PY
           exit $STATUS


### PR DESCRIPTION
## Summary
- fix indentation in workflow's Python snippet to prevent IndentationError during pytest summary processing

## Testing
- `yamllint .github/workflows/v0.7.0_validate_changed_files.yaml` *(fails: line length errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfd4d3d6c83268bde186462342c9e