### PR TITLE
Enable SQLite foreign key enforcement for AutoAPI v3

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/ddl/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/ddl/__init__.py
@@ -59,6 +59,10 @@ def _attach_sqlite_dbapi(dbapi_conn: Any, attachments: Mapping[str, str]) -> Non
     try:
         existing = _attached_names_sqlite(dbapi_conn)
         cur = dbapi_conn.cursor()
+        try:
+            cur.execute("PRAGMA foreign_keys=ON")
+        except Exception:
+            pass
         for schema, path in (attachments or {}).items():
             if not path or schema in existing:
                 continue

--- a/pkgs/standards/autoapi/tests/i9n/test_sqlite_attachments.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_sqlite_attachments.py
@@ -17,6 +17,8 @@ def test_initialize_sync_with_sqlite_attachments(tmp_path):
     sql_eng, _ = eng.raw()
     with sql_eng.connect() as conn:
         assert "logs" in _db_names(conn)
+        fk = conn.exec_driver_sql("PRAGMA foreign_keys").scalar()
+        assert fk == 1
 
 
 @pytest.mark.asyncio
@@ -29,4 +31,6 @@ async def test_initialize_async_with_sqlite_attachments(tmp_path):
     sql_eng, _ = eng.raw()
     async with sql_eng.connect() as conn:
         names = await conn.run_sync(_db_names)
+        fk = await conn.exec_driver_sql("PRAGMA foreign_keys")
+        assert fk.scalar() == 1
     assert "logs" in names

--- a/pkgs/standards/autoapi/tests/unit/test_sqlite_attachments.py
+++ b/pkgs/standards/autoapi/tests/unit/test_sqlite_attachments.py
@@ -13,6 +13,8 @@ def test_initialize_sync_without_sqlite_attachments(sync_db_session):
     api.initialize()
     with engine.connect() as conn:
         assert _db_names(conn) == {"main"}
+        fk = conn.exec_driver_sql("PRAGMA foreign_keys").scalar()
+        assert fk == 1
 
 
 def test_initialize_sync_with_sqlite_attachments(sync_db_session, tmp_path):
@@ -23,6 +25,8 @@ def test_initialize_sync_with_sqlite_attachments(sync_db_session, tmp_path):
     api.initialize(sqlite_attachments={"logs": str(attach_db)})
     with engine.connect() as conn:
         assert "logs" in _db_names(conn)
+        fk = conn.exec_driver_sql("PRAGMA foreign_keys").scalar()
+        assert fk == 1
 
 
 @pytest.mark.asyncio
@@ -33,6 +37,8 @@ async def test_initialize_async_without_sqlite_attachments(async_db_session):
     async with engine.connect() as conn:
         result = await conn.exec_driver_sql("PRAGMA database_list")
         names = {row[1] for row in result.fetchall()}
+        fk = await conn.exec_driver_sql("PRAGMA foreign_keys")
+        assert fk.scalar() == 1
     assert names == {"main"}
 
 
@@ -46,4 +52,6 @@ async def test_initialize_async_with_sqlite_attachments(async_db_session, tmp_pa
     async with engine.connect() as conn:
         result = await conn.exec_driver_sql("PRAGMA database_list")
         names = {row[1] for row in result.fetchall()}
+        fk = await conn.exec_driver_sql("PRAGMA foreign_keys")
+        assert fk.scalar() == 1
     assert "logs" in names


### PR DESCRIPTION
## Summary
- ensure foreign key enforcement is enabled for blocking and async SQLite engines
- enable foreign key pragma when attaching SQLite databases
- test foreign key enforcement for SQLite engines with and without attachments

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_sqlite_attachments.py tests/i9n/test_sqlite_attachments.py`


------
https://chatgpt.com/codex/tasks/task_e_68be257b2d588326863be5499f66fdf5