### PR TITLE
perf(autoapi): cache v3 collect helpers

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/api/mro_collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/api/mro_collect.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from functools import lru_cache
 from typing import Any, Callable, Dict, Iterable, Mapping
 
 from ..config.constants import AUTOAPI_API_HOOKS_ATTR
@@ -9,6 +10,7 @@ from ..config.constants import AUTOAPI_API_HOOKS_ATTR
 logger = logging.getLogger("uvicorn")
 
 
+@lru_cache(maxsize=None)
 def mro_collect_api_hooks(api: type) -> Dict[str, Dict[str, list[Callable[..., Any]]]]:
     """Collect API-level hook declarations across ``api``'s MRO.
 

--- a/pkgs/standards/autoapi/autoapi/v3/app/mro_collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/app/mro_collect.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from functools import lru_cache
 from typing import Any, Tuple
 
 from .app_spec import AppSpec
@@ -19,6 +20,7 @@ def _merge_seq_attr(app: type, attr: str) -> Tuple[Any, ...]:
     return tuple(values)
 
 
+@lru_cache(maxsize=None)
 def mro_collect_app_spec(app: type) -> AppSpec:
     """Collect AppSpec-like declarations across the app's MRO."""
     logger.info("Collecting app spec for %s", app.__name__)

--- a/pkgs/standards/autoapi/autoapi/v3/column/mro_collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/column/mro_collect.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from functools import lru_cache
 from typing import Dict
 
 from .column_spec import ColumnSpec
@@ -24,6 +25,7 @@ _DEFAULT_IO = IO(
 )
 
 
+@lru_cache(maxsize=None)
 def mro_collect_columns(model: type) -> Dict[str, ColumnSpec]:
     """Collect ColumnSpecs declared on *model* and all mixins.
 

--- a/pkgs/standards/autoapi/autoapi/v3/op/mro_collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/op/mro_collect.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from functools import lru_cache
 from typing import Any, Callable, Dict
 
 from .types import OpSpec
@@ -17,6 +18,7 @@ def _merge_mro_dict(cls: type, attr: str) -> Dict[str, Any]:
     return merged
 
 
+@lru_cache(maxsize=None)
 def mro_alias_map_for(table: type) -> Dict[str, str]:
     """Collect alias overrides across the table's MRO."""
     return _merge_mro_dict(table, "__autoapi_aliases__")
@@ -38,6 +40,7 @@ def _wrap_ctx_core(table: type, func: Callable[..., Any]) -> Callable[..., Any]:
     return core
 
 
+@lru_cache(maxsize=None)
 def mro_collect_decorated_ops(table: type) -> list[OpSpec]:
     """Collect ctx-only op declarations across the table's MRO."""
 

--- a/pkgs/standards/autoapi/autoapi/v3/schema/collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/collect.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import inspect
 import logging
+from functools import lru_cache
 from typing import Dict
 
 from ..config.constants import AUTOAPI_SCHEMA_DECLS_ATTR
@@ -13,6 +14,7 @@ logging.getLogger("uvicorn").setLevel(logging.DEBUG)
 logger = logging.getLogger("uvicorn")
 
 
+@lru_cache(maxsize=None)
 def collect_decorated_schemas(model: type) -> Dict[str, Dict[str, type]]:
     """Gather schema declarations for ``model`` across its MRO."""
     logger.info("Collecting decorated schemas for %s", model.__name__)

--- a/pkgs/standards/autoapi/autoapi/v3/table/mro_collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/table/mro_collect.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from functools import lru_cache
 from typing import Any, Mapping, Tuple
 
 from .table_spec import TableSpec
@@ -19,6 +20,7 @@ def _merge_seq_attr(model: type, attr: str) -> Tuple[Any, ...]:
     return tuple(values)
 
 
+@lru_cache(maxsize=None)
 def mro_collect_table_spec(model: type) -> TableSpec:
     """Collect TableSpec-like declarations across the model's MRO.
 

--- a/pkgs/standards/autoapi/tests/perf/test_collect_caching.py
+++ b/pkgs/standards/autoapi/tests/perf/test_collect_caching.py
@@ -1,0 +1,42 @@
+import logging
+import time
+
+from autoapi.v3.column.mro_collect import mro_collect_columns
+from autoapi.v3.schema.collect import collect_decorated_schemas
+
+
+logging.getLogger("uvicorn").setLevel(logging.WARNING)
+
+
+def _measure(func, obj, iterations=100):
+    cold = 0.0
+    for _ in range(iterations):
+        func.cache_clear()
+        start = time.perf_counter()
+        func(obj)
+        cold += time.perf_counter() - start
+    func.cache_clear()
+    start = time.perf_counter()
+    for _ in range(iterations):
+        func(obj)
+    cached = time.perf_counter() - start
+    return cold, cached
+
+
+def test_mro_collect_columns_cached():
+    class Base:
+        pass
+
+    class Model(Base):
+        pass
+
+    cold, cached = _measure(mro_collect_columns, Model, iterations=50)
+    assert cached <= cold * 0.75
+
+
+def test_collect_decorated_schemas_cached():
+    class Model:
+        pass
+
+    cold, cached = _measure(collect_decorated_schemas, Model, iterations=50)
+    assert cached <= cold * 0.75


### PR DESCRIPTION
## Summary
- cache v3 collect helpers to avoid repeated MRO traversals
- add performance tests verifying cached collect helpers reduce runtime

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/perf/test_collect_caching.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68be2611b9cc8326b6e104ed0a10ffc5