### PR TITLE
fix(autoapi): drop Column.info configs and refine v3 schemas

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/schemas/defaults.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/schemas/defaults.py
@@ -49,6 +49,7 @@ def _default_schemas_for_spec(
         model.__name__,
         read_schema.__name__ if read_schema else None,
     )
+    pk_name, pk_type = _pk_info(model)
 
     # Canonical targets
     logger.debug(
@@ -65,25 +66,21 @@ def _default_schemas_for_spec(
 
     elif target == "read":
         logger.debug("Using read defaults for %s.%s", model.__name__, sp.alias)
-        pk_name, pk_type = _pk_info(model)
         result["in_"] = _make_pk_model(model, "read", pk_name, pk_type)
         result["out"] = read_schema
 
     elif target == "update":
         logger.debug("Using update defaults for %s.%s", model.__name__, sp.alias)
-        pk_name, _ = _pk_info(model)
         result["in_"] = _build_schema(model, verb="update", exclude={pk_name})
         result["out"] = read_schema
 
     elif target == "replace":
         logger.debug("Using replace defaults for %s.%s", model.__name__, sp.alias)
-        pk_name, _ = _pk_info(model)
         result["in_"] = _build_schema(model, verb="replace", exclude={pk_name})
         result["out"] = read_schema
 
     elif target == "merge":
         logger.debug("Using merge defaults for %s.%s", model.__name__, sp.alias)
-        pk_name, _ = _pk_info(model)
         result["in_"] = _build_schema(model, verb="update", exclude={pk_name})
         result["out"] = read_schema
 
@@ -116,7 +113,7 @@ def _default_schemas_for_spec(
         result["in_item"] = item_in
         if read_schema:
             result["out"] = _make_bulk_rows_response_model(
-                model, "bulk_create", read_schema
+                model, "bulk_create", read_schema, pk_name=pk_name
             )
             result["out_item"] = read_schema
             logger.debug(
@@ -142,7 +139,7 @@ def _default_schemas_for_spec(
         result["in_item"] = item_in
         if read_schema:
             result["out"] = _make_bulk_rows_response_model(
-                model, "bulk_update", read_schema
+                model, "bulk_update", read_schema, pk_name=pk_name
             )
             result["out_item"] = read_schema
             logger.debug(
@@ -168,7 +165,7 @@ def _default_schemas_for_spec(
         result["in_item"] = item_in
         if read_schema:
             result["out"] = _make_bulk_rows_response_model(
-                model, "bulk_replace", read_schema
+                model, "bulk_replace", read_schema, pk_name=pk_name
             )
             result["out_item"] = read_schema
             logger.debug(
@@ -196,7 +193,7 @@ def _default_schemas_for_spec(
         result["in_item"] = item_in
         if read_schema:
             result["out"] = _make_bulk_rows_response_model(
-                model, "bulk_merge", read_schema
+                model, "bulk_merge", read_schema, pk_name=pk_name
             )
             result["out_item"] = read_schema
             logger.debug(
@@ -213,7 +210,6 @@ def _default_schemas_for_spec(
 
     elif target == "bulk_delete":
         logger.debug("Using bulk_delete defaults for %s.%s", model.__name__, sp.alias)
-        pk_name, pk_type = _pk_info(model)
         result["in_"] = _make_bulk_ids_model(model, "bulk_delete", pk_type)
         result["out"] = _make_deleted_response_model(model, "bulk_delete")
 

--- a/pkgs/standards/autoapi/autoapi/v3/config/constants.py
+++ b/pkgs/standards/autoapi/autoapi/v3/config/constants.py
@@ -9,8 +9,7 @@ Highlights
 ----------
 • Verbs/targets are *derived* from the v3 OpSpec canon so they always stay in sync.
 • Default HTTP method mapping for REST bindings lives here (used by bindings.rest).
-• Column / model config keys document the names we look for in SQLAlchemy
-  Column.info["autoapi"] and on model classes.
+• Model config keys document the attribute names we look for on ORM classes.
 
 Nothing in this module performs I/O.
 """

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/kernel.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/kernel.py
@@ -430,7 +430,7 @@ class Kernel:
             in_verbs = set(getattr(io, "in_verbs", ()) or ())
             out_verbs = set(getattr(io, "out_verbs", ()) or ())
 
-            if alias in in_verbs:
+            if not in_verbs or alias in in_verbs:
                 in_fields.append(name)
                 meta: Dict[str, object] = {"in_enabled": True}
                 if storage is None:
@@ -449,7 +449,7 @@ class Kernel:
                 meta["nullable"] = base_nullable
                 by_field_in[name] = meta
 
-            if alias in out_verbs:
+            if not out_verbs or alias in out_verbs:
                 out_fields.append(name)
                 meta_out: Dict[str, object] = {}
                 alias_out = getattr(io, "alias_out", None)


### PR DESCRIPTION
## Summary
- remove legacy Column.info references
- skip primary key fields in bulk response examples
- include unspecified fields by default when building op views
- avoid requiring primary keys on create requests

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_rest_no_schema_jsonable.py::test_rest_read_and_list_without_schema`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_request_response_examples.py::test_bulk_update_response_model_examples tests/unit/test_request_response_examples.py::test_bulk_merge_response_model_examples`


------
https://chatgpt.com/codex/tasks/task_e_68be2e9d1bac8326a1e0bcb81c091e59