### PR TITLE
fix: include response atoms in diagnostics plan

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/response/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/response/__init__.py
@@ -8,7 +8,7 @@ from .types import (
 )
 from .resolver import resolve_response_spec, infer_hints
 from .shortcuts import as_json, as_html, as_text, as_redirect, as_stream, as_file
-from ..runtime.atoms.response.render import ResponseHints, render
+from ..runtime.atoms.response.renderer import ResponseHints, render
 from ..runtime.atoms.response.templates import render_template
 
 __all__ = [

--- a/pkgs/standards/autoapi/autoapi/v3/response/resolver.py
+++ b/pkgs/standards/autoapi/autoapi/v3/response/resolver.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional
 
 from dataclasses import fields
 from .types import ResponseSpec, TemplateSpec
-from ..runtime.atoms.response.render import ResponseHints
+from ..runtime.atoms.response.renderer import ResponseHints
 
 
 def _merge_template(

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/response/__init__.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/response/__init__.py
@@ -1,100 +1,17 @@
 from __future__ import annotations
 from typing import Any, Callable, Dict, Optional, Tuple
-from ....deps.starlette import Response
-import logging
 
 from ... import events as _ev
-from . import render as _render
-from . import negotiation as _neg
-from . import templates as _tmpl
+from .template import run as _template
+from .negotiate import run as _negotiate
+from .render import run as _render
 
 RunFn = Callable[[Optional[object], Any], Any]
-
-logger = logging.getLogger("uvicorn")
-
-
-async def _template(obj: Optional[object], ctx: Any) -> None:
-    logger.debug("Running response:template")
-    resp_ns = getattr(ctx, "response", None)
-    req = getattr(ctx, "request", None)
-    if resp_ns is None or req is None:
-        return
-    tmpl = getattr(resp_ns, "template", None)
-    if not tmpl:
-        return
-    result = getattr(resp_ns, "result", None)
-    context = result if isinstance(result, dict) else {"data": result}
-    html = await _tmpl.render_template(
-        name=tmpl.name,
-        context=context,
-        search_paths=tmpl.search_paths,
-        package=tmpl.package,
-        auto_reload=bool(tmpl.auto_reload),
-        filters=tmpl.filters,
-        globals_=tmpl.globals,
-        request=req,
-    )
-    resp_ns.result = html
-    hints = getattr(resp_ns, "hints", None)
-    if hints is None:
-        hints = _render.ResponseHints()
-        resp_ns.hints = hints
-    if not hints.media_type:
-        hints.media_type = "text/html"
-
-
-def _negotiate(obj: Optional[object], ctx: Any) -> None:
-    logger.debug("Running response:negotiate")
-    resp_ns = getattr(ctx, "response", None)
-    req = getattr(ctx, "request", None)
-    if resp_ns is None or req is None:
-        return
-    hints = getattr(resp_ns, "hints", None)
-    if hints is None:
-        hints = _render.ResponseHints()
-        resp_ns.hints = hints
-    if not hints.media_type:
-        accept = getattr(req, "headers", {}).get("accept", "*/*")
-        default_media = getattr(resp_ns, "default_media", "application/json")
-        hints.media_type = _neg.negotiate_media_type(accept, default_media)
-
-
-def _render_run(
-    obj: Optional[object], ctx: Any
-) -> Response | None:  # pragma: no cover - glue code
-    """Render a payload into a concrete :class:`Response`.
-
-    Returning the rendered ``Response`` allows the runtime executor to update
-    ``ctx.result`` so later atoms or the final transport step don't overwrite
-    the rendered output.
-    """
-    logger.debug("Running response:render")
-    resp_ns = getattr(ctx, "response", None)
-    req = getattr(ctx, "request", None)
-    if resp_ns is None or req is None:
-        return None
-    result = getattr(resp_ns, "result", None)
-    if result is None:
-        return None
-    hints = getattr(resp_ns, "hints", None)
-    default_media = getattr(resp_ns, "default_media", "application/json")
-    envelope_default = getattr(resp_ns, "envelope_default", True)
-    resp = _render.render(
-        req,
-        result,
-        hints=hints,
-        default_media=default_media,
-        envelope_default=envelope_default,
-    )
-    resp_ns.result = resp
-    return resp
-
 
 REGISTRY: Dict[Tuple[str, str], Tuple[str, RunFn]] = {
     ("response", "template"): (_ev.OUT_DUMP, _template),
     ("response", "negotiate"): (_ev.OUT_DUMP, _negotiate),
-    ("response", "render"): (_ev.OUT_DUMP, _render_run),
+    ("response", "render"): (_ev.OUT_DUMP, _render),
 }
-
 
 __all__ = ["REGISTRY", "RunFn"]

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/response/negotiate.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/response/negotiate.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+from typing import Any, Optional
+
+from ... import events as _ev
+from .negotiation import negotiate_media_type
+from .renderer import ResponseHints
+
+ANCHOR = _ev.OUT_DUMP  # "out:dump"
+
+
+def run(obj: Optional[object], ctx: Any) -> None:
+    """response:negotiate@out:dump
+
+    Determine the response media type if not already set.
+    """
+    resp_ns = getattr(ctx, "response", None)
+    req = getattr(ctx, "request", None)
+    if resp_ns is None or req is None:
+        return
+    hints = getattr(resp_ns, "hints", None)
+    if hints is None:
+        hints = ResponseHints()
+        resp_ns.hints = hints
+    if not hints.media_type:
+        accept = getattr(req, "headers", {}).get("accept", "*/*")
+        default_media = getattr(resp_ns, "default_media", "application/json")
+        hints.media_type = negotiate_media_type(accept, default_media)
+
+
+__all__ = ["ANCHOR", "run"]

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/response/renderer.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/response/renderer.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, AsyncIterable, Iterable, Mapping, Optional, Union, cast
+import logging
+
+from ....deps.starlette import BackgroundTask, Response
+
+from ....response.shortcuts import (
+    as_file,
+    as_html,
+    as_json,
+    as_stream,
+    as_text,
+)
+
+JSON = Mapping[str, Any]
+
+logger = logging.getLogger("uvicorn")
+
+
+@dataclass
+class ResponseHints:
+    media_type: Optional[str] = None
+    status_code: int = 200
+    headers: dict[str, str] = field(default_factory=dict)
+    filename: Optional[str] = None
+    download: bool = False
+    etag: Optional[str] = None
+    last_modified: Optional[Any] = None
+    background: Optional[BackgroundTask] = None
+
+
+class ResponseKind:
+    JSON = "application/json"
+    HTML = "text/html"
+    TEXT = "text/plain"
+    FILE = "application/file"
+    STREAM = "application/stream"
+    REDIRECT = "application/redirect"
+
+
+ResponseLike = Union[
+    Response,
+    bytes,
+    bytearray,
+    memoryview,
+    str,
+    Path,
+    JSON,
+    Iterable[bytes],
+    AsyncIterable[bytes],
+]
+
+
+def render(
+    request: Any,
+    payload: ResponseLike,
+    *,
+    hints: Optional[ResponseHints] = None,
+    default_media: str = "application/json",
+    envelope_default: bool = True,
+) -> Response:
+    logger.debug("Rendering response with payload type %s", type(payload))
+    if isinstance(payload, Response):
+        return payload
+
+    hints = hints or ResponseHints()
+    chosen = hints.media_type or default_media
+
+    if isinstance(payload, Path):
+        return as_file(
+            payload,
+            filename=hints.filename,
+            download=hints.download,
+            status=hints.status_code,
+            headers=hints.headers,
+        )
+
+    if isinstance(payload, (bytes, bytearray, memoryview)):
+        return as_stream(
+            iter((bytes(payload),)),
+            media_type="application/octet-stream",
+            status=hints.status_code,
+            headers=hints.headers,
+        )
+
+    if hasattr(payload, "__aiter__") or (
+        hasattr(payload, "__iter__") and not isinstance(payload, (str, dict, list))
+    ):
+        return as_stream(
+            cast(Union[Iterable[bytes], AsyncIterable[bytes]], payload),
+            media_type="application/octet-stream",
+            status=hints.status_code,
+            headers=hints.headers,
+        )
+
+    if isinstance(payload, str):
+        if payload.lstrip().startswith("<") or chosen == "text/html":
+            return as_html(payload, status=hints.status_code, headers=hints.headers)
+        return as_text(payload, status=hints.status_code, headers=hints.headers)
+
+    return as_json(
+        payload,
+        status=hints.status_code,
+        headers=hints.headers,
+        envelope=envelope_default,
+    )
+
+
+__all__ = [
+    "ResponseHints",
+    "ResponseKind",
+    "ResponseLike",
+    "render",
+]

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/response/template.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/response/template.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+from typing import Any, Optional
+
+from ... import events as _ev
+from .templates import render_template
+from .renderer import ResponseHints
+
+ANCHOR = _ev.OUT_DUMP  # "out:dump"
+
+
+async def run(obj: Optional[object], ctx: Any) -> None:
+    """response:template@out:dump
+
+    Render a template if configured on ``ctx.response``.
+    """
+    resp_ns = getattr(ctx, "response", None)
+    req = getattr(ctx, "request", None)
+    if resp_ns is None or req is None:
+        return
+    tmpl = getattr(resp_ns, "template", None)
+    if not tmpl:
+        return
+    result = getattr(resp_ns, "result", None)
+    context = result if isinstance(result, dict) else {"data": result}
+    html = await render_template(
+        name=tmpl.name,
+        context=context,
+        search_paths=tmpl.search_paths,
+        package=tmpl.package,
+        auto_reload=bool(tmpl.auto_reload),
+        filters=tmpl.filters,
+        globals_=tmpl.globals,
+        request=req,
+    )
+    resp_ns.result = html
+    hints = getattr(resp_ns, "hints", None)
+    if hints is None:
+        hints = ResponseHints()
+        resp_ns.hints = hints
+    if not hints.media_type:
+        hints.media_type = "text/html"
+
+
+__all__ = ["ANCHOR", "run"]


### PR DESCRIPTION
## Summary
- add dedicated template, negotiate, and render response atoms so POST_RESPONSE diagnostics include them
- rename response renderer utilities and register new atoms

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_response_diagnostics_kernelz.py`


------
https://chatgpt.com/codex/tasks/task_e_68be3d3a7bc48326855599eeb2390b2f