### PR TITLE
fix: honor iospec inbound aliases

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/runtime/kernel.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/kernel.py
@@ -430,7 +430,10 @@ class Kernel:
             in_verbs = set(getattr(io, "in_verbs", ()) or ())
             out_verbs = set(getattr(io, "out_verbs", ()) or ())
 
-            if alias in in_verbs:
+            if not in_verbs and out_verbs:
+                # Field is read-only; expose in outbound schema only
+                pass
+            elif alias in in_verbs or (not in_verbs and not out_verbs):
                 in_fields.append(name)
                 meta: Dict[str, object] = {"in_enabled": True}
                 if storage is None:


### PR DESCRIPTION
## Summary
- ensure read-only columns are excluded from inbound schemas while still exposed outbound

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_iospec_attributes.py::test_request_and_response_schemas_respect_iospec_aliases -q`


------
https://chatgpt.com/codex/tasks/task_e_68be3db021f08326b608a745b077f781