### PR TITLE
handle autoapi class registry collisions

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/hook/mro_collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/hook/mro_collect.py
@@ -70,8 +70,7 @@ def _mro_collect_decorated_hooks_cached(
         return out
 
     for base in reversed(table.__mro__):
-        for name in dir(base):
-            attr = getattr(base, name, None)
+        for name, attr in base.__dict__.items():
             func = _unwrap(attr)
             decls: list[Hook] | None = getattr(func, HOOK_DECLS_ATTR, None)
             if not decls:

--- a/pkgs/standards/autoapi/autoapi/v3/schema/collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/collect.py
@@ -35,8 +35,7 @@ def collect_decorated_schemas(model: type) -> Dict[str, Dict[str, type]]:
 
     # Nested classes with __autoapi_schema_decl__
     for base in reversed(model.__mro__):
-        for name in dir(base):
-            obj = getattr(base, name, None)
+        for name, obj in base.__dict__.items():
             if not inspect.isclass(obj):
                 logger.debug("Skipping non-class attribute %s.%s", base.__name__, name)
                 continue

--- a/pkgs/standards/autoapi/autoapi/v3/table/_base.py
+++ b/pkgs/standards/autoapi/autoapi/v3/table/_base.py
@@ -174,8 +174,17 @@ class Base(DeclarativeBase):
     __allow_unmapped__ = True
 
     def __init_subclass__(cls, **kw):
+        # 0) Remove any previously registered class with the same name.
+        try:
+            existing = Base.registry._class_registry.get(cls.__name__)
+            if existing is not None:
+                Base.registry._dispose_cls(existing)
+        except Exception:
+            pass
+
         # 1) BEFORE SQLAlchemy maps: turn ColumnSpecs into real mapped_column(...)
         _materialize_colspecs_to_sqla(cls)
+
         # 2) Let SQLAlchemy map the class (PK now exists)
         super().__init_subclass__(**kw)
 

--- a/pkgs/standards/autoapi/tests/i9n/test_nested_path_schema_and_rpc.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_nested_path_schema_and_rpc.py
@@ -13,9 +13,9 @@ async def test_nested_path_schema_and_rpc(api_client):
 
     # Schema should mark parent identifiers optional
     create_model = Item.schemas.create.in_
-    fields = getattr(
-        create_model, "model_fields", getattr(create_model, "__fields__", {})
-    )
+    fields = getattr(create_model, "model_fields", None)
+    if fields is None:
+        fields = getattr(create_model, "__fields__", {})
     assert "tenant_id" not in fields
 
     # REST call should inject path params


### PR DESCRIPTION
## Summary
- dispose previously registered models before mapping new autoapi Base subclasses
- avoid SQLAlchemy attribute warnings when collecting hooks and schemas
- use lazy fallback to __fields__ in nested path schema RPC test

## Testing
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff format .`
- `uv run --package autoapi --directory pkgs/standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory pkgs/standards/autoapi pytest` *(failed: AttributeError and assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_68be3fcd805883269c5ac324030ab711