### PR TITLE
Fix AutoAPI list response envelope causing optional filter test failure

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/response/render.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/response/render.py
@@ -21,7 +21,7 @@ def run(obj: Optional[object], ctx: Any) -> Any:
         return None
     hints = getattr(resp_ns, "hints", None)
     default_media = getattr(resp_ns, "default_media", "application/json")
-    envelope_default = getattr(resp_ns, "envelope_default", True)
+    envelope_default = getattr(resp_ns, "envelope_default", False)
     resp = render(
         req,
         result,

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/response/renderer.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/response/renderer.py
@@ -59,7 +59,7 @@ def render(
     *,
     hints: Optional[ResponseHints] = None,
     default_media: str = "application/json",
-    envelope_default: bool = True,
+    envelope_default: bool = False,
 ) -> Response:
     logger.debug("Rendering response with payload type %s", type(payload))
     if isinstance(payload, Response):


### PR DESCRIPTION
## Summary
- stop wrapping AutoAPI responses in a `{data, ok}` envelope by default

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_list_filters_optional.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68be44b7488083268d43ee07b87fce41