### PR TITLE
fix: ensure assembled values used for outbound

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/wire/build_out.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/atoms/wire/build_out.py
@@ -81,6 +81,11 @@ def _read_current_value(obj: Optional[object], ctx: Any, field: str) -> Optional
     )  # type: ignore
     if isinstance(hv, Mapping):
         return hv.get(field)
+    av = getattr(getattr(ctx, "temp", {}), "get", lambda *a, **k: None)(
+        "assembled_values"
+    )  # type: ignore
+    if isinstance(av, Mapping):
+        return av.get(field)
     return None
 
 

--- a/pkgs/standards/autoapi/tests/i9n/test_iospec_attributes.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_iospec_attributes.py
@@ -207,7 +207,12 @@ def test_rest_call_respects_aliases():
         )
         name = acol(
             storage=S(type_=StrType, nullable=False),
-            io=IO(in_verbs=("create",), out_verbs=("read",)),
+            io=IO(
+                in_verbs=("create",),
+                out_verbs=("create", "read"),
+                alias_in="first_name",
+                alias_out="firstName",
+            ),
         )
 
     api = AutoApp(engine=eng)
@@ -215,9 +220,9 @@ def test_rest_call_respects_aliases():
     Base.metadata.create_all(eng.raw()[0])
     client = TestClient(api)
 
-    resp = client.post("/thing", json={"name": "Ada"})
+    resp = client.post("/thing", json={"first_name": "Ada"})
     data = resp.json()
-    assert data["name"] == "Ada"
+    assert data["data"]["firstName"] == "Ada"
 
 
 @pytest.mark.i9n


### PR DESCRIPTION
## Summary
- ensure build_out falls back to assembled values when hydrated values are missing
- verify REST alias handling for create operations

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_iospec_attributes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68be44ab00188326b3d9d3bd442cae96