### PR TITLE
fix: mark primary key column readonly

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_rest_row_serialization.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_rest_row_serialization.py
@@ -21,7 +21,8 @@ async def client_and_model():
         __allow_unmapped__ = True
 
         id: Mapped[int] = acol(
-            storage=S(type_=Integer, primary_key=True, autoincrement=True)
+            storage=S(type_=Integer, primary_key=True, autoincrement=True),
+            io=IO(out_verbs=("read", "list")),
         )
         name: Mapped[str] = acol(
             storage=S(type_=String, nullable=False),


### PR DESCRIPTION
## Summary
- ensure auto-generated IDs aren't required during widget creation in row serialization test

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_rest_row_serialization.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68be495cc4a08326892ed7fe38ef82a2