### PR TITLE
Fix virtual column serialization and alias caching in AutoAPI

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rpc.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rpc.py
@@ -181,7 +181,9 @@ def _serialize_output(model: type, alias: str, target: str, result: Any) -> Any:
     try:
         if target == "list" and isinstance(result, (list, tuple)):
             return [
-                out_model.model_validate(x).model_dump(exclude_none=True, by_alias=True)
+                out_model.model_validate(x).model_dump(
+                    exclude_none=False, by_alias=True
+                )
                 for x in result
             ]
         if target in {
@@ -191,12 +193,14 @@ def _serialize_output(model: type, alias: str, target: str, result: Any) -> Any:
             "bulk_merge",
         } and isinstance(result, (list, tuple)):
             return [
-                out_model.model_validate(x).model_dump(exclude_none=True, by_alias=True)
+                out_model.model_validate(x).model_dump(
+                    exclude_none=False, by_alias=True
+                )
                 for x in result
             ]
         # Single object case
         return out_model.model_validate(result).model_dump(
-            exclude_none=True, by_alias=True
+            exclude_none=False, by_alias=True
         )
     except Exception as e:
         # If serialization fails, let raw result through rather than failing the call

--- a/pkgs/standards/autoapi/autoapi/v3/op/decorators.py
+++ b/pkgs/standards/autoapi/autoapi/v3/op/decorators.py
@@ -86,6 +86,12 @@ def alias_ctx(**verb_to_alias_or_decl: Union[str, AliasDecl]):
 
         setattr(cls, "__autoapi_aliases__", amap)
         setattr(cls, "__autoapi_alias_overrides__", overrides)
+        try:  # clear cached alias maps so late-applied decorators take effect
+            from .mro_collect import mro_alias_map_for
+
+            mro_alias_map_for.cache_clear()
+        except Exception:  # pragma: no cover - best effort
+            pass
         return cls
 
     return deco

--- a/pkgs/standards/autoapi/autoapi/v3/schema/builder/build_schema.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/builder/build_schema.py
@@ -161,6 +161,7 @@ def _build_schema(
         py_t = getattr(fs, "py_type", Any) if fs is not None else Any
         required = bool(fs and verb in getattr(fs, "required_in", ()))
         allow_null = bool(fs and verb in getattr(fs, "allow_null_in", ()))
+        nullable = bool(getattr(spec, "nullable", True))
         field_kwargs: Dict[str, Any] = dict(getattr(fs, "constraints", {}) or {})
 
         default_factory = getattr(spec, "default_factory", None)
@@ -172,7 +173,7 @@ def _build_schema(
 
         fld = Field(**field_kwargs)
 
-        if allow_null and py_t is not Any:
+        if (allow_null or nullable) and py_t is not Any:
             py_t = Union[py_t, None]
 
         _add_field(fields, name=attr_name, py_t=py_t, field=fld)


### PR DESCRIPTION
## Summary
- ensure alias_ctx invalidates alias map cache
- include null fields in RPC serialization
- allow nullable virtual columns in schema builder

## Testing
- `uv run --package autoapi --directory standards pytest autoapi/tests/unit/test_column_rest_rpc_results.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68be5ad1d83c832681e6f0bd96fb1ccf