### PR TITLE
fix: skip response rendering for JSON-RPC ops

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rpc.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rpc.py
@@ -296,6 +296,12 @@ def _build_rpc_callable(model: type, sp: OpSpec) -> Callable[..., Awaitable[Any]
         )
 
         phases = _get_phase_chains(model, alias)
+        # RPC methods should return raw data for JSON-RPC envelopes;
+        # remove response rendering atoms (which produce Starlette responses)
+        # JSON-RPC endpoints handle rendering at the transport layer; skip
+        # response-related atoms entirely to preserve raw results for the RPC envelope.
+        phases["POST_RESPONSE"] = []
+
         base_ctx["response_serializer"] = lambda r: _serialize_output(
             model, alias, target, r
         )


### PR DESCRIPTION
## Summary
- skip response atoms for JSON-RPC endpoints so raw results propagate to RPC envelopes

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_op_ctx_behavior.py`

------
https://chatgpt.com/codex/tasks/task_e_68be5b058df88326a8bc6d3e174575b4