### PR TITLE
fix autoapi colspec cache busting

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/column/mro_collect.py
+++ b/pkgs/standards/autoapi/autoapi/v3/column/mro_collect.py
@@ -26,7 +26,9 @@ _DEFAULT_IO = IO(
 
 
 @lru_cache(maxsize=None)
-def mro_collect_columns(model: type) -> Dict[str, ColumnSpec]:
+def mro_collect_columns(
+    model: type, *, _cache_bust: int | None = None
+) -> Dict[str, ColumnSpec]:
     """Collect ColumnSpecs declared on *model* and all mixins.
 
     Iterates across the model's MRO so that mixin-defined columns are included

--- a/pkgs/standards/autoapi/autoapi/v3/core/crud/helpers/model.py
+++ b/pkgs/standards/autoapi/autoapi/v3/core/crud/helpers/model.py
@@ -67,7 +67,13 @@ def _model_columns(model: type) -> Tuple[str, ...]:
 
 def _colspecs(model: type) -> Mapping[str, Any]:
     logger.info("_colspecs called with model=%s", model)
-    specs = mro_collect_columns(model)
+    cache_bust = hash(
+        (
+            id(getattr(model, "__autoapi_colspecs__", None)),
+            id(getattr(model, "__autoapi_cols__", None)),
+        )
+    )
+    specs = mro_collect_columns(model, _cache_bust=cache_bust)
     logger.info("_colspecs returning %s", specs)
     return specs
 


### PR DESCRIPTION
## Summary
- ensure column spec cache honors updates by adding cache-busting parameter
- hash colspec mappings to invalidate cache when model specs change

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_io_spec_attributes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68be5ba25e148326bbb21ac55b88466a