### PR TITLE
fix autoapi fallback serialization test

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_rest_fallback_serialization.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_rest_fallback_serialization.py
@@ -20,7 +20,8 @@ async def client_and_model():
         __allow_unmapped__ = True
 
         id: Mapped[int] = acol(
-            storage=S(type_=Integer, primary_key=True, autoincrement=True)
+            storage=S(type_=Integer, primary_key=True, autoincrement=True),
+            io=IO(out_verbs=("read", "list")),
         )
         name: Mapped[str] = acol(
             storage=S(type_=String, nullable=False),


### PR DESCRIPTION
## Summary
- ensure primary key column is output-only so create requests don't require it

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards pytest autoapi/tests/i9n/test_rest_fallback_serialization.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68be5b1ee39c83269f7b68020ec23f81