### PR TITLE
fix: serialize JSON responses on modern Starlette

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/response/shortcuts.py
+++ b/pkgs/standards/autoapi/autoapi/v3/response/shortcuts.py
@@ -7,7 +7,6 @@ import os
 import mimetypes
 
 from ..deps.starlette import (
-    JSONResponse,
     HTMLResponse,
     PlainTextResponse,
     StreamingResponse,
@@ -51,18 +50,17 @@ def as_json(
 ) -> Response:
     payload = _maybe_envelope(data) if envelope else data
     try:
-        return JSONResponse(
-            payload,
-            status_code=status,
-            headers=dict(headers or {}),
-            dumps=lambda o: dumps(o).decode(),
-        )
-    except TypeError:  # pragma: no cover - starlette >= 0.44
-        return JSONResponse(
-            payload,
-            status_code=status,
-            headers=dict(headers or {}),
-        )
+        body = dumps(payload)
+    except TypeError:
+        body = json.dumps(payload, default=str).encode("utf-8")
+    if isinstance(body, str):
+        body = body.encode("utf-8")
+    return Response(
+        body,
+        status_code=status,
+        headers=dict(headers or {}),
+        media_type="application/json",
+    )
 
 
 def as_html(


### PR DESCRIPTION
## Summary
- render JSON responses manually to support newer Starlette

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format autoapi/v3/response/shortcuts.py`
- `uv run --package autoapi --directory standards/autoapi ruff check autoapi/v3/response/shortcuts.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_schema_ctx_op_ctx_integration.py`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_allow_anon.py::test_allow_anon_list_and_read_attr -q`


------
https://chatgpt.com/codex/tasks/task_e_68be639fe65c8326b59f3339275208c0