### PR TITLE
Ensure AsyncClient is closed in autoapi test

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_schema_ctx_op_ctx_integration.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_schema_ctx_op_ctx_integration.py
@@ -1,5 +1,5 @@
-import pytest
 import pytest_asyncio
+import pytest
 from pydantic import BaseModel
 from autoapi.v3.types import App
 from httpx import ASGITransport, AsyncClient
@@ -42,8 +42,10 @@ async def widget_client():
     await api.initialize()
     app.include_router(api.router)
 
-    client = AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
-    return client, api, Widget
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        yield client, api, Widget
 
 
 @pytest.mark.i9n


### PR DESCRIPTION
## Summary
- use async context manager to close `AsyncClient` in `widget_client` test fixture

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format tests/i9n/test_schema_ctx_op_ctx_integration.py`
- `uv run --package autoapi --directory standards/autoapi ruff check tests/i9n/test_schema_ctx_op_ctx_integration.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_schema_ctx_op_ctx_integration.py`

------
https://chatgpt.com/codex/tasks/task_e_68be639fe65c8326b59f3339275208c0