### PR TITLE
fix autoapi POST_RESPONSE serialization for hooks

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/response/shortcuts.py
+++ b/pkgs/standards/autoapi/autoapi/v3/response/shortcuts.py
@@ -26,9 +26,12 @@ try:
 except Exception:  # pragma: no cover - fallback
 
     def _dumps(obj: Any) -> bytes:
-        return json.dumps(obj, separators=(",", ":"), ensure_ascii=False).encode(
-            "utf-8"
-        )
+        return json.dumps(
+            obj,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            default=str,
+        ).encode("utf-8")
 
 
 def _maybe_envelope(data: Any) -> Any:
@@ -58,10 +61,11 @@ def as_json(
             dumps=lambda o: dumps(o).decode(),
         )
     except TypeError:  # pragma: no cover - starlette >= 0.44
-        return JSONResponse(
-            payload,
+        return Response(
+            dumps(payload),
             status_code=status,
             headers=dict(headers or {}),
+            media_type="application/json",
         )
 
 

--- a/pkgs/standards/autoapi/autoapi/v3/runtime/executor/invoke.py
+++ b/pkgs/standards/autoapi/autoapi/v3/runtime/executor/invoke.py
@@ -150,8 +150,8 @@ async def _invoke(
         in_tx=False,
         nonfatal=True,
     )
-    if ctx.get("result") is not None:
-        ctx.response.result = ctx.get("result")
+    if getattr(ctx, "response", None) is not None:
+        ctx["result"] = ctx.response.result
     if db is not None and _in_tx(db):
         try:
             if _is_async_db(db):


### PR DESCRIPTION
## Summary
- handle UUIDs when rendering JSON responses and support Starlette >=0.44
- preserve POST_RESPONSE hook mutations in executor
- retain POST_RESPONSE hooks for RPC calls while skipping response rendering atoms

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_hook_lifecycle.py::test_hook_phases_execution_order -q`

------
https://chatgpt.com/codex/tasks/task_e_68be6795064c8326b611f22f6f4b5cae