### PR TITLE
Fix autoincrement primary key handling in autoapi v3

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/schema/builder/helpers.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/builder/helpers.py
@@ -33,8 +33,12 @@ def _python_type(col: Any) -> type | Any:
 
 def _is_required(col: Any, verb: str) -> bool:
     """Decide if a column should be required for the given verb."""
-    if getattr(col, "primary_key", False) and verb in {"update", "replace", "delete"}:
-        return True
+    if getattr(col, "primary_key", False):
+        if verb in {"update", "replace", "delete"}:
+            return True
+        auto = getattr(col, "autoincrement", False)
+        if auto not in (False, None) or getattr(col, "identity", None) is not None:
+            return False
     if verb == "update":
         return False
     is_nullable = bool(getattr(col, "nullable", True))


### PR DESCRIPTION
## Summary
- treat autoincrement/identity primary keys as optional for create schemas

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_storage_spec_integration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68be67ce312c8326b15c010389f68e1f