### PR TITLE
fix: ensure id column excluded from create requests

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_v3_default_rest_ops.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_v3_default_rest_ops.py
@@ -19,7 +19,8 @@ async def client_and_model():
         __allow_unmapped__ = True
 
         id: Mapped[int] = acol(
-            storage=S(type_=Integer, primary_key=True, autoincrement=True)
+            storage=S(type_=Integer, primary_key=True, autoincrement=True),
+            io=IO(out_verbs=("read", "list")),
         )
         name: Mapped[str] = acol(
             storage=S(type_=String, nullable=False),


### PR DESCRIPTION
## Summary
- mark primary key `id` column as read-only for default REST tests

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_v3_default_rest_ops.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68be67d30c608326bdd61d516b2fe7f0