### PR TITLE
autoapi: fix bulk create validation and delete response

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/schemas/defaults.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/schemas/defaults.py
@@ -91,7 +91,7 @@ def _default_schemas_for_spec(
         logger.debug("Using delete defaults for %s.%s", model.__name__, sp.alias)
         # For RPC delete, a body with PK is allowed; REST delete ignores body.
         result["in_"] = _build_schema(model, verb="delete")
-        result["out"] = read_schema
+        result["out"] = _make_deleted_response_model(model, "delete")
 
     elif target == "list":
         logger.debug("Using list defaults for %s.%s", model.__name__, sp.alias)

--- a/pkgs/standards/autoapi/autoapi/v3/schema/builder/helpers.py
+++ b/pkgs/standards/autoapi/autoapi/v3/schema/builder/helpers.py
@@ -38,8 +38,11 @@ def _is_required(col: Any, verb: str) -> bool:
     if verb == "update":
         return False
     is_nullable = bool(getattr(col, "nullable", True))
-    has_default = (getattr(col, "default", None) is not None) or (
-        getattr(col, "server_default", None) is not None
+    has_default = (
+        getattr(col, "default", None) is not None
+        or getattr(col, "server_default", None) is not None
+        or getattr(col, "autoincrement", False) not in (False, "ignore")
+        or getattr(col, "identity", None) is not None
     )
     return not is_nullable and not has_default
 


### PR DESCRIPTION
## Summary
- allow auto-increment primary keys to be omitted from create/bulk payloads by detecting implicit defaults
- return deleted row count for RPC delete operations instead of empty read schema

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest` *(fails: KeyError 'required', KeyError 'phase', KeyError 'hook_completed', AssertionError 'tenant_id')*
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_v3_default_rpc_ops.py`


------
https://chatgpt.com/codex/tasks/task_e_68be67d955288326bcf311c090af2e06