### PR TITLE
fix: clear op cache on dynamic ctx attach

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/model_registry.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/model_registry.py
@@ -56,6 +56,7 @@ def _ensure_op_ctx_attach_hook(model: type) -> None:
 
     def _meta_setattr(cls, name, value):
         from .model import rebind
+        from ..op.mro_collect import mro_collect_decorated_ops
 
         orig_meta_setattr(cls, name, value)
         fn = getattr(value, "__func__", value)
@@ -63,6 +64,7 @@ def _ensure_op_ctx_attach_hook(model: type) -> None:
         if decl and getattr(cls, "__autoapi_op_ctx_watch__", False):
             alias = decl.alias or name
             target = decl.target or "custom"
+            mro_collect_decorated_ops.cache_clear()
             rebind(cls, changed_keys={(alias, target)})
 
     meta.__setattr__ = _meta_setattr  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary
- clear mro-based op cache when dynamically binding ctx op so AutoAPI rebind sees new operations

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_op_ctx_dynamic_attach.py`


------
https://chatgpt.com/codex/tasks/task_e_68be67e2eb7483269ea8228e7289a2c5