### PR TITLE
Fix UUID serialization in autoapi responses

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/response/shortcuts.py
+++ b/pkgs/standards/autoapi/autoapi/v3/response/shortcuts.py
@@ -26,9 +26,12 @@ try:
 except Exception:  # pragma: no cover - fallback
 
     def _dumps(obj: Any) -> bytes:
-        return json.dumps(obj, separators=(",", ":"), ensure_ascii=False).encode(
-            "utf-8"
-        )
+        return json.dumps(
+            obj,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            default=str,
+        ).encode("utf-8")
 
 
 def _maybe_envelope(data: Any) -> Any:
@@ -58,10 +61,11 @@ def as_json(
             dumps=lambda o: dumps(o).decode(),
         )
     except TypeError:  # pragma: no cover - starlette >= 0.44
-        return JSONResponse(
-            payload,
+        return Response(
+            dumps(payload),
             status_code=status,
             headers=dict(headers or {}),
+            media_type="application/json",
         )
 
 

--- a/pkgs/standards/autoapi/tests/unit/test_response_uuid.py
+++ b/pkgs/standards/autoapi/tests/unit/test_response_uuid.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import json
+from uuid import uuid4
+
+from autoapi.v3.response.shortcuts import as_json
+
+
+def test_as_json_serializes_uuid() -> None:
+    uid = uuid4()
+    resp = as_json({"id": uid}, envelope=False)
+    assert resp.media_type == "application/json"
+    assert json.loads(resp.body) == {"id": str(uid)}


### PR DESCRIPTION
## Summary
- handle UUID and other non-standard types by defaulting to string conversion in JSON dumps
- fall back to plain JSON response when Starlette lacks dumps support
- add regression test ensuring UUID values serialize correctly

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `uv run --directory pkgs/standards/autoapi --package autoapi python - <<'PY'
from autoapi.v3.response.shortcuts import as_json
from uuid import uuid4
import json
resp = as_json({'id': uuid4()}, envelope=False)
print(resp.media_type)
print(resp.body)
print(json.loads(resp.body))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68be735962e48326839b7720599b6e49