### PR TITLE
Ensure REST list endpoints serialize without output schemas

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest/collection.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest/collection.py
@@ -119,6 +119,9 @@ def _make_collection_endpoint(
             else:
                 payload = dict(parent_kw)
             ctx = _ctx(model, alias, target, request, db, payload, parent_kw, api)
+            ctx["response_serializer"] = lambda r: _serialize_output(
+                model, alias, target, sp, r
+            )
             phases = _get_phase_chains(model, alias)
             result = await _executor._invoke(
                 request=request, db=db, phases=phases, ctx=ctx
@@ -126,7 +129,7 @@ def _make_collection_endpoint(
             if isinstance(result, Response):
                 result.status_code = status_code
                 return result
-            return _serialize_output(model, alias, target, sp, result)
+            return result
 
         params = [
             inspect.Parameter(


### PR DESCRIPTION
## Summary
- handle REST collection results with a fallback serializer when an output schema is absent

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format .`
- `uv run --package autoapi --directory standards/autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_rest_fallback_serialization.py`


------
https://chatgpt.com/codex/tasks/task_e_68be7aa877d083269b82ad02220e0a7d