### PR TITLE
preserve explicit response status codes

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest/collection.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest/collection.py
@@ -124,7 +124,8 @@ def _make_collection_endpoint(
                 request=request, db=db, phases=phases, ctx=ctx
             )
             if isinstance(result, Response):
-                result.status_code = status_code
+                if sp.status_code is not None:
+                    result.status_code = status_code
                 return result
             return _serialize_output(model, alias, target, sp, result)
 
@@ -225,7 +226,8 @@ def _make_collection_endpoint(
                 request=request, db=db, phases=phases, ctx=ctx
             )
             if isinstance(result, Response):
-                result.status_code = status_code
+                if sp.status_code is not None:
+                    result.status_code = status_code
                 return result
             temp = ctx.get("temp", {}) if isinstance(ctx, Mapping) else {}
             extras = (

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest/member.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest/member.py
@@ -100,7 +100,8 @@ def _make_member_endpoint(
                 ctx=ctx,
             )
             if isinstance(result, Response):
-                result.status_code = status_code
+                if sp.status_code is not None:
+                    result.status_code = status_code
                 return result
             temp = ctx.get("temp", {}) if isinstance(ctx, Mapping) else {}
             extras = (
@@ -314,7 +315,8 @@ def _make_member_endpoint(
             ctx=ctx,
         )
         if isinstance(result, Response):
-            result.status_code = status_code
+            if sp.status_code is not None:
+                result.status_code = status_code
             return result
         temp = ctx.get("temp", {}) if isinstance(ctx, Mapping) else {}
         extras = temp.get("response_extras", {}) if isinstance(temp, Mapping) else {}


### PR DESCRIPTION
## Summary
- ensure REST member handlers honor explicit Response status codes
- ensure REST collection handlers honor explicit Response status codes

## Testing
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff format .`
- `uv run --directory pkgs/standards/autoapi --package autoapi ruff check . --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_response_rest.py::test_response_rest_alias_table[redirect] tests/unit/test_response_rest.py::test_response_rest_non_alias_table[redirect]`


------
https://chatgpt.com/codex/tasks/task_e_68be7b0165988326bc9fa0cc213db8b6