### PR TITLE
Use scalar API for row count in hook context test

### DIFF
--- a/pkgs/standards/autoapi/tests/i9n/test_hook_ctx_v3_i9n.py
+++ b/pkgs/standards/autoapi/tests/i9n/test_hook_ctx_v3_i9n.py
@@ -212,7 +212,7 @@ async def test_hook_ctx_storage_sqlalchemy_i9n():
 
         @hook_ctx(ops="create", phase="POST_COMMIT")
         async def count_rows(cls, ctx):
-            result = ctx["db"].execute(select(func.count()).select_from(cls)).scalar()
+            result = ctx["db"].scalar(select(func.count()).select_from(cls))
             ctx["count"] = result
 
         @hook_ctx(ops="create", phase="POST_RESPONSE")


### PR DESCRIPTION
## Summary
- use `Session.scalar` to count rows in hook context SQLAlchemy test

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff format tests/i9n/test_hook_ctx_v3_i9n.py`
- `uv run --package autoapi --directory standards/autoapi ruff check tests/i9n/test_hook_ctx_v3_i9n.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_hook_ctx_v3_i9n.py`


------
https://chatgpt.com/codex/tasks/task_e_68be81bb25dc8326bbb55b2ca23a03b8