### PR TITLE
Respect custom status codes for autoapi REST handlers

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest/collection.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest/collection.py
@@ -127,7 +127,8 @@ def _make_collection_endpoint(
                 request=request, db=db, phases=phases, ctx=ctx
             )
             if isinstance(result, Response):
-                result.status_code = status_code
+                if sp.status_code is not None or result.status_code == 200:
+                    result.status_code = status_code
                 return result
             return result
 
@@ -228,7 +229,8 @@ def _make_collection_endpoint(
                 request=request, db=db, phases=phases, ctx=ctx
             )
             if isinstance(result, Response):
-                result.status_code = status_code
+                if sp.status_code is not None or result.status_code == 200:
+                    result.status_code = status_code
                 return result
             temp = ctx.get("temp", {}) if isinstance(ctx, Mapping) else {}
             extras = (

--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest/member.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest/member.py
@@ -100,7 +100,8 @@ def _make_member_endpoint(
                 ctx=ctx,
             )
             if isinstance(result, Response):
-                result.status_code = status_code
+                if sp.status_code is not None or result.status_code == 200:
+                    result.status_code = status_code
                 return result
             temp = ctx.get("temp", {}) if isinstance(ctx, Mapping) else {}
             extras = (
@@ -314,7 +315,8 @@ def _make_member_endpoint(
             ctx=ctx,
         )
         if isinstance(result, Response):
-            result.status_code = status_code
+            if sp.status_code is not None or result.status_code == 200:
+                result.status_code = status_code
             return result
         temp = ctx.get("temp", {}) if isinstance(ctx, Mapping) else {}
         extras = temp.get("response_extras", {}) if isinstance(temp, Mapping) else {}


### PR DESCRIPTION
## Summary
- Preserve explicit Response status codes in REST collection and member handlers
- Avoid overriding redirect responses with default 200 OK

## Testing
- `uv run --package autoapi --directory standards/autoapi pytest tests/unit/test_response_rest.py`


------
https://chatgpt.com/codex/tasks/task_e_68be85145a4083268cb2479aae076156