### PR TITLE
autoapi: handle paired api key via runtime extras

### DIFF
--- a/pkgs/standards/autoapi/autoapi/v3/bindings/rest/member.py
+++ b/pkgs/standards/autoapi/autoapi/v3/bindings/rest/member.py
@@ -35,6 +35,8 @@ from .common import (
     _status_for,
 )
 
+from ...runtime.executor.types import _Ctx
+
 
 logger = logging.getLogger("uvicorn")
 logger.debug("Loaded module v3/bindings/rest/member")
@@ -89,9 +91,19 @@ def _make_member_endpoint(
             ac = getattr(request.state, AUTOAPI_AUTH_CONTEXT_ATTR, None)
             if ac is not None:
                 ctx["auth_context"] = ac
-            ctx["response_serializer"] = lambda r: _serialize_output(
-                model, alias, target, sp, r
-            )
+            ctx = _Ctx(ctx)
+
+            def _serializer(r, _ctx=ctx):
+                out = _serialize_output(model, alias, target, sp, r)
+                temp = getattr(_ctx, "temp", {}) if isinstance(_ctx, Mapping) else {}
+                extras = (
+                    temp.get("response_extras", {}) if isinstance(temp, Mapping) else {}
+                )
+                if isinstance(out, dict) and isinstance(extras, dict):
+                    out.update(extras)
+                return out
+
+            ctx["response_serializer"] = _serializer
             phases = _get_phase_chains(model, alias)
             result = await _executor._invoke(
                 request=request,
@@ -103,20 +115,6 @@ def _make_member_endpoint(
                 if sp.status_code is not None or result.status_code == 200:
                     result.status_code = status_code
                 return result
-            temp = ctx.get("temp", {}) if isinstance(ctx, Mapping) else {}
-            extras = (
-                temp.get("response_extras", {}) if isinstance(temp, Mapping) else {}
-            )
-            raw = (
-                temp.get("paired_values", {}).get("digest", {}).get("raw")
-                if isinstance(temp, Mapping)
-                else None
-            )
-            if isinstance(result, dict):
-                if isinstance(extras, dict):
-                    result.update(extras)
-                if raw is not None and "api_key" not in result:
-                    result["api_key"] = raw
             return result
 
         params = [
@@ -188,9 +186,19 @@ def _make_member_endpoint(
             ac = getattr(request.state, AUTOAPI_AUTH_CONTEXT_ATTR, None)
             if ac is not None:
                 ctx["auth_context"] = ac
-            ctx["response_serializer"] = lambda r: _serialize_output(
-                model, alias, target, sp, r
-            )
+            ctx = _Ctx(ctx)
+
+            def _serializer(r, _ctx=ctx):
+                out = _serialize_output(model, alias, target, sp, r)
+                temp = getattr(_ctx, "temp", {}) if isinstance(_ctx, Mapping) else {}
+                extras = (
+                    temp.get("response_extras", {}) if isinstance(temp, Mapping) else {}
+                )
+                if isinstance(out, dict) and isinstance(extras, dict):
+                    out.update(extras)
+                return out
+
+            ctx["response_serializer"] = _serializer
             phases = _get_phase_chains(model, alias)
             result = await _executor._invoke(
                 request=request,
@@ -198,20 +206,6 @@ def _make_member_endpoint(
                 phases=phases,
                 ctx=ctx,
             )
-            temp = ctx.get("temp", {}) if isinstance(ctx, Mapping) else {}
-            extras = (
-                temp.get("response_extras", {}) if isinstance(temp, Mapping) else {}
-            )
-            raw = (
-                temp.get("paired_values", {}).get("digest", {}).get("raw")
-                if isinstance(temp, Mapping)
-                else None
-            )
-            if isinstance(result, dict):
-                if isinstance(extras, dict):
-                    result.update(extras)
-                if raw is not None and "api_key" not in result:
-                    result["api_key"] = raw
             return result
 
         params = [
@@ -304,9 +298,19 @@ def _make_member_endpoint(
         ac = getattr(request.state, AUTOAPI_AUTH_CONTEXT_ATTR, None)
         if ac is not None:
             ctx["auth_context"] = ac
-        ctx["response_serializer"] = lambda r: _serialize_output(
-            model, alias, target, sp, r
-        )
+        ctx = _Ctx(ctx)
+
+        def _serializer(r, _ctx=ctx):
+            out = _serialize_output(model, alias, target, sp, r)
+            temp = getattr(_ctx, "temp", {}) if isinstance(_ctx, Mapping) else {}
+            extras = (
+                temp.get("response_extras", {}) if isinstance(temp, Mapping) else {}
+            )
+            if isinstance(out, dict) and isinstance(extras, dict):
+                out.update(extras)
+            return out
+
+        ctx["response_serializer"] = _serializer
         phases = _get_phase_chains(model, alias)
         result = await _executor._invoke(
             request=request,
@@ -314,22 +318,11 @@ def _make_member_endpoint(
             phases=phases,
             ctx=ctx,
         )
+
         if isinstance(result, Response):
             if sp.status_code is not None or result.status_code == 200:
                 result.status_code = status_code
             return result
-        temp = ctx.get("temp", {}) if isinstance(ctx, Mapping) else {}
-        extras = temp.get("response_extras", {}) if isinstance(temp, Mapping) else {}
-        raw = (
-            temp.get("paired_values", {}).get("digest", {}).get("raw")
-            if isinstance(temp, Mapping)
-            else None
-        )
-        if isinstance(result, dict):
-            if isinstance(extras, dict):
-                result.update(extras)
-            if raw is not None and "api_key" not in result:
-                result["api_key"] = raw
         return result
 
     params = [


### PR DESCRIPTION
## Summary
- rely on runtime to emit paired field aliases and merge response extras
- derive stored values for paired fields even when missing from inbound schema

## Testing
- `uv run --package autoapi --directory standards/autoapi ruff check autoapi/v3/bindings/rest/collection.py autoapi/v3/bindings/rest/member.py autoapi/v3/runtime/atoms/storage/to_stored.py --fix`
- `uv run --package autoapi --directory standards/autoapi pytest tests/i9n/test_key_digest_uvicorn.py`


------
https://chatgpt.com/codex/tasks/task_e_68be893c1ed883269a6224113c1c735b