### PR TITLE
fix: assign core step for tigrbl handlers

### DIFF
--- a/pkgs/standards/tigrbl/tigrbl/v3/bindings/handlers/builder.py
+++ b/pkgs/standards/tigrbl/tigrbl/v3/bindings/handlers/builder.py
@@ -81,23 +81,18 @@ def _attach_one(model: type, sp: OpSpec) -> None:
     setattr(handlers_ns, "raw", raw_step)
     setattr(handlers_ns, "handler", raw_step)
 
-    try:
-        if core_step is not None:
-            sp.core = core_step
-            sp.core_raw = core_step
-            logger.debug("Core step registered for %s.%s", model.__name__, alias)
-        else:
-            sp.core = raw_step
-            sp.core_raw = raw_step
-            logger.debug("Raw step registered as core for %s.%s", model.__name__, alias)
-    except Exception as exc:
-        logger.debug("Failed to set core step: %s", exc)
-        if core_step is not None:
-            setattr(handlers_ns, "core", core_step)
-            setattr(handlers_ns, "core_raw", core_step)
-        else:
-            setattr(handlers_ns, "core", raw_step)
-            setattr(handlers_ns, "core_raw", raw_step)
+    if core_step is not None:
+        object.__setattr__(sp, "core", core_step)
+        object.__setattr__(sp, "core_raw", core_step)
+        setattr(handlers_ns, "core", core_step)
+        setattr(handlers_ns, "core_raw", core_step)
+        logger.debug("Core step registered for %s.%s", model.__name__, alias)
+    else:
+        object.__setattr__(sp, "core", raw_step)
+        object.__setattr__(sp, "core_raw", raw_step)
+        setattr(handlers_ns, "core", raw_step)
+        setattr(handlers_ns, "core_raw", raw_step)
+        logger.debug("Raw step registered as core for %s.%s", model.__name__, alias)
 
     logger.debug(
         "handlers: %s.%s → handler chain updated (persist=%s)",


### PR DESCRIPTION
## Summary
- avoid `FrozenInstanceError` when storing core steps in `OpSpec`

## Testing
- `uv run --directory standards/tigrbl --package tigrbl ruff format .`
- `uv run --directory standards/tigrbl --package tigrbl ruff check . --fix`
- `python - <<'PY'
import logging
logging.basicConfig(level=logging.DEBUG)
from tigrbl.v3.bindings.handlers.builder import _attach_one
from tigrbl.v3.op.types import OpSpec

class M: ...
sp = OpSpec(alias='x', target='create', handler=lambda *a, **k: None)
_attach_one(M, sp)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68bff9a95b1c83268f9a4abd35b75f39