### PR TITLE
docs(tigrbl): document runtime phases

### DIFF
--- a/pkgs/standards/tigrbl/README.md
+++ b/pkgs/standards/tigrbl/README.md
@@ -23,6 +23,33 @@ A high-leverage meta-framework that turns plain SQLAlchemy models into a fully-f
 - Automated route creation: rest paths or nested rest paths, rpc dispatch, healthz, methodz, hookz
 - Support for AuthNProvider extensions
 
+## Phase Lifecycle
+
+Tigrbl operations execute through a fixed sequence of phases. Hook chains can
+attach handlers at any phase to customize behavior or enforce policy.
+
+| Phase | Description |
+|-------|-------------|
+| `PRE_TX_BEGIN` | Pre-transaction checks before a database session is used. |
+| `START_TX` | Open a new transaction when one is not already active. |
+| `PRE_HANDLER` | Validate the request and prepare resources for the handler. |
+| `HANDLER` | Execute the core operation logic within the transaction. |
+| `POST_HANDLER` | Post-processing while still inside the transaction. |
+| `PRE_COMMIT` | Final verification before committing; writes are frozen. |
+| `END_TX` | Commit and close the transaction. |
+| `POST_COMMIT` | Steps that run after commit but before the response is returned. |
+| `POST_RESPONSE` | Fire-and-forget work after the response has been sent. |
+| `ON_ERROR` | Fallback error handler when no phase-specific chain matches. |
+| `ON_PRE_TX_BEGIN_ERROR` | Handle errors raised during `PRE_TX_BEGIN`. |
+| `ON_START_TX_ERROR` | Handle errors raised during `START_TX`. |
+| `ON_PRE_HANDLER_ERROR` | Handle errors raised during `PRE_HANDLER`. |
+| `ON_HANDLER_ERROR` | Handle errors raised during `HANDLER`. |
+| `ON_POST_HANDLER_ERROR` | Handle errors raised during `POST_HANDLER`. |
+| `ON_PRE_COMMIT_ERROR` | Handle errors raised during `PRE_COMMIT`. |
+| `ON_END_TX_ERROR` | Handle errors raised during `END_TX`. |
+| `ON_POST_COMMIT_ERROR` | Handle errors raised during `POST_COMMIT`. |
+| `ON_POST_RESPONSE_ERROR` | Handle errors raised during `POST_RESPONSE`. |
+| `ON_ROLLBACK` | Run when the transaction rolls back to perform cleanup. |
 
 ## Configuration Overview
 


### PR DESCRIPTION
## Summary
- document every executor phase in the tigrbl package to clarify hook lifecycles

## Testing
- `uv run --directory pkgs/standards/tigrbl --package tigrbl ruff format .`
- `uv run --directory pkgs/standards/tigrbl --package tigrbl ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68bff9e454f08326bc586259b668621a