### PR TITLE
docs(tigrbl): document response and template specs

### DIFF
--- a/pkgs/standards/tigrbl/README.md
+++ b/pkgs/standards/tigrbl/README.md
@@ -128,6 +128,11 @@ owns the transaction. See the
 [runtime documentation](tigrbl/v3/runtime/README.md#db-guards) for the full
 matrix of phase policies.
 
+### Response and Template Specs
+Customize outbound responses with `ResponseSpec` and `TemplateSpec`. These dataclasses
+control headers, status codes, and optional template rendering. See
+[tigrbl/v3/response/README.md](tigrbl/v3/response/README.md) for field descriptions and examples.
+
 ### Dependencies
 - SQLAlchemy for ORM integration.
 - Pydantic for schema generation.

--- a/pkgs/standards/tigrbl/tigrbl/v3/response/README.md
+++ b/pkgs/standards/tigrbl/tigrbl/v3/response/README.md
@@ -1,0 +1,34 @@
+# Response and Template Specs
+
+Tigrbl exposes flexible response configuration through the `ResponseSpec` and `TemplateSpec` dataclasses in `tigrbl.v3.response.types`.
+
+## `ResponseSpec`
+
+`ResponseSpec` controls how an operation returns data:
+
+- **`kind`** – response mode: `"auto"`, `"json"`, `"html"`, `"text"`, `"file"`, `"stream"`, or `"redirect"`.
+- **`media_type`** – explicit `Content-Type` header.
+- **`status_code`** – HTTP status override.
+- **`headers`** – mapping of additional headers.
+- **`envelope`** – wrap payloads in a standard envelope when `True`.
+- **`template`** – optional [`TemplateSpec`](#templatespec) to render an HTML response.
+- **`filename`** – file name for `file` responses.
+- **`download`** – force browser downloads when `True`.
+- **`etag`** – ETag header value.
+- **`cache_control`** – `Cache-Control` header value.
+- **`redirect_to`** – target location for `redirect` responses.
+
+## `TemplateSpec`
+
+`TemplateSpec` defines how templates are resolved and rendered:
+
+- **`name`** – template identifier passed to the renderer.
+- **`search_paths`** – directories to search for template files.
+- **`package`** – Python package providing templates via `importlib.resources`.
+- **`auto_reload`** – when `True`, reload templates on each request (useful in development).
+- **`filters`** – custom Jinja2 filters.
+- **`globals`** – additional template globals.
+
+A `TemplateSpec` may be nested inside a `ResponseSpec`'s `template` field to render HTML output. When provided, the runtime invokes `render_template` and populates the response body with the rendered HTML.
+
+These specs offer a declarative way to tailor outbound responses and integrate server-side templates without manual response handling.


### PR DESCRIPTION
## Summary
- add README for ResponseSpec and TemplateSpec
- reference response docs from package README

## Testing
- `uv run --directory standards/tigrbl --package tigrbl ruff format .`
- `uv run --directory standards/tigrbl --package tigrbl ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c009ec8e94832691effc1dbdb8c254