### PR TITLE
docs(tigrbl): document transaction phases

### DIFF
--- a/pkgs/standards/tigrbl/README.md
+++ b/pkgs/standards/tigrbl/README.md
@@ -128,6 +128,13 @@ owns the transaction. See the
 [runtime documentation](tigrbl/v3/runtime/README.md#db-guards) for the full
 matrix of phase policies.
 
+The `START_TX` phase opens a transaction and disables `session.flush`,
+allowing validation and hooks to run before any statements hit the
+database. Once the transaction exists, `PRE_HANDLER`, `HANDLER`, and
+`POST_HANDLER` phases permit flushes so pending writes reach the database
+without committing. The workflow concludes in `END_TX`, which performs a
+final flush and commits the transaction when the runtime owns it.
+
 ### Dependencies
 - SQLAlchemy for ORM integration.
 - Pydantic for schema generation.

--- a/pkgs/standards/tigrbl/tigrbl/v3/runtime/README.md
+++ b/pkgs/standards/tigrbl/tigrbl/v3/runtime/README.md
@@ -50,6 +50,18 @@ raises an error.
 | POST_COMMIT | ✅ | ❌ | post-commit writes without commit |
 | POST_RESPONSE | ❌ | ❌ | background work, no writes |
 
+### Transaction Boundaries
+
+`start_tx` is a system step that opens a new database transaction when
+no transaction is active and marks the runtime as its owner. While this
+phase runs, both `session.flush` and `session.commit` are blocked. After a
+transaction is started, phases such as `PRE_HANDLER`, `HANDLER`, and
+`POST_HANDLER` allow flushes so SQL statements can be issued while the
+commit remains deferred. The `end_tx` step executes during the `END_TX`
+phase, performing a final flush and committing the transaction if the
+runtime owns it. Once this phase completes, guards restore the original
+session methods.
+
 If a phase fails, the guard restores the original methods and the executor rolls back when it owns the transaction. Optional `ON_<PHASE>_ERROR` chains can handle cleanup.
 
 ---


### PR DESCRIPTION
## Summary
- explain how `START_TX` manages transactions and disables flushes
- outline transaction boundaries and commit behavior in `END_TX`

## Testing
- `uv run --directory pkgs/standards/tigrbl --package tigrbl ruff format .`
- `uv run --directory pkgs/standards/tigrbl --package tigrbl ruff check . --fix`
- `cd pkgs && uv run --package tigrbl --directory standards/tigrbl pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c00a69039c83268bb25ab0339868be