### PR TITLE
docs(tigrbl): document default precedence

### DIFF
--- a/pkgs/standards/tigrbl/README.md
+++ b/pkgs/standards/tigrbl/README.md
@@ -120,6 +120,15 @@ attach handlers at any phase to customize behavior or enforce policy.
 - Pluggable `AuthNProvider` interface.
 - `__tigrbl_allow_anon__` to permit anonymous access.
 
+### Default Precedence
+When assembling values for persistence, defaults are resolved in this order:
+
+1. Client-supplied value
+2. API `default_factory`
+3. ORM default
+4. Database `server_default`
+5. HTTP 422 if the field is required and still missing
+
 ### Database Guards
 Tigrbl executes each phase under database guards that temporarily replace
 `commit` and `flush` on the SQLAlchemy session. Guards prevent writes or


### PR DESCRIPTION
## Summary
- document Tigrbl's default resolution precedence

## Testing
- `uv run --directory pkgs/standards/tigrbl --package tigrbl ruff format .`
- `uv run --directory pkgs/standards/tigrbl --package tigrbl ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c00b72ba4c8326ac075d95f21309ec