### PR TITLE
docs(tigrbl): illustrate request-response flow

### DIFF
--- a/pkgs/standards/tigrbl/README.md
+++ b/pkgs/standards/tigrbl/README.md
@@ -139,6 +139,53 @@ If a phase raises an exception, control transfers to the matching
 `ON_<PHASE>_ERROR` chain or falls back to `ON_ERROR`, with `ON_ROLLBACK`
 executing when the transaction is rolled back.
 
+## Request to Response Flow Examples
+
+The diagrams below illustrate how a request moves through Tigrbl and returns
+a response.
+
+### REST example
+
+```
+Client
+  |
+  v
+HTTP Request
+  |
+  v
+FastAPI Router
+  |
+  v
+Tigrbl Runtime
+  |
+  v
+Operation Handler
+  |
+  v
+HTTP Response
+```
+
+### RPC example
+
+```
+Client
+  |
+  v
+JSON-RPC Request
+  |
+  v
+RPC Dispatcher
+  |
+  v
+Tigrbl Runtime
+  |
+  v
+Operation Handler
+  |
+  v
+JSON-RPC Response
+```
+
 ## Hooks
 
 Hooks allow you to plug custom logic into any phase of a verb. Use the


### PR DESCRIPTION
## Summary
- document request-to-response flow with ASCII diagrams for REST and RPC examples

## Testing
- `uv run --package tigrbl --directory standards/tigrbl ruff format .`
- `uv run --package tigrbl --directory standards/tigrbl ruff check . --fix`
- `uv run --package tigrbl --directory standards/tigrbl pytest` *(partial, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68c01058c1f0832690f960ce9894c00c