### PR TITLE
Ensure transactional hooks commit

### DIFF
--- a/pkgs/standards/tigrbl/tigrbl/v3/runtime/system.py
+++ b/pkgs/standards/tigrbl/tigrbl/v3/runtime/system.py
@@ -79,11 +79,10 @@ def _sys_tx_begin(_obj: Optional[object], ctx: Any) -> None:
     """
     log.debug("system: begin_tx enter")
     _ensure_temp(ctx)
-    ctx.temp.setdefault("__sys_tx_open__", False)
+    ctx.temp["__sys_tx_open__"] = True
     try:
         if callable(INSTALLED.begin):
             INSTALLED.begin(ctx)
-            ctx.temp["__sys_tx_open__"] = True
             log.debug("system: begin_tx executed.")
         else:
             log.debug("system: begin_tx no-op (no adapter installed).")


### PR DESCRIPTION
## Summary
- ensure runtime kernel injects txn begin/commit steps for persistent operations
- mark transactions as open even without adapter to allow commit

## Testing
- `uv run --package tigrbl --directory standards/tigrbl ruff format .`
- `uv run --package tigrbl --directory standards/tigrbl ruff check . --fix`
- `uv run --package tigrbl --directory standards/tigrbl pytest tests/i9n/test_hook_lifecycle.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0139579788326ae72bd6408ea6068