### PR TITLE
test: use PgUUID in tigrbl hook lifecycle tests

### DIFF
--- a/pkgs/standards/tigrbl/tests/i9n/test_hook_lifecycle.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_hook_lifecycle.py
@@ -11,7 +11,7 @@ from tigrbl.v3.engine.shortcuts import mem
 from tigrbl.v3.orm.mixins import GUIDPk
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import Column, ForeignKey, String
-from sqlalchemy.dialects.postgresql import UUID
+from tigrbl.v3.types import PgUUID
 
 
 async def setup_client(db_mode, Tenant, Item):
@@ -48,7 +48,9 @@ async def test_hook_phases_execution_order(db_mode):
 
     class Item(Base, GUIDPk):
         __tablename__ = "items"
-        tenant_id = Column(UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False)
+        tenant_id = Column(
+            PgUUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False
+        )
         name = Column(String, nullable=False)
 
         @hook_ctx(ops="create", phase="PRE_TX_BEGIN")
@@ -130,7 +132,9 @@ async def test_hook_parity_crud_vs_rpc(db_mode):
 
     class Item(Base, GUIDPk):
         __tablename__ = "items"
-        tenant_id = Column(UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False)
+        tenant_id = Column(
+            PgUUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False
+        )
         name = Column(String, nullable=False)
 
         @hook_ctx(ops="create", phase="PRE_TX_BEGIN")
@@ -181,7 +185,9 @@ async def test_hook_error_handling(db_mode):
 
     class Item(Base, GUIDPk):
         __tablename__ = "items"
-        tenant_id = Column(UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False)
+        tenant_id = Column(
+            PgUUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False
+        )
         name = Column(String, nullable=False)
 
         @hook_ctx(ops="*", phase="ON_ERROR")
@@ -225,7 +231,9 @@ async def test_hook_early_termination_and_cleanup(db_mode):
 
     class Item(Base, GUIDPk):
         __tablename__ = "items"
-        tenant_id = Column(UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False)
+        tenant_id = Column(
+            PgUUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False
+        )
         name = Column(String, nullable=False)
 
         @hook_ctx(ops="create", phase="PRE_TX_BEGIN")
@@ -296,7 +304,9 @@ async def test_hook_context_modification(db_mode):
 
     class Item(Base, GUIDPk):
         __tablename__ = "items"
-        tenant_id = Column(UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False)
+        tenant_id = Column(
+            PgUUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False
+        )
         name = Column(String, nullable=False)
 
         @hook_ctx(ops="create", phase="PRE_TX_BEGIN")
@@ -356,7 +366,9 @@ async def test_catch_all_hooks(db_mode):
 
     class Item(CatchAllMixin, Base, GUIDPk):
         __tablename__ = "items"
-        tenant_id = Column(UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False)
+        tenant_id = Column(
+            PgUUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False
+        )
         name = Column(String, nullable=False)
 
     client, _ = await setup_client(db_mode, Tenant, Item)
@@ -408,7 +420,9 @@ async def test_multiple_hooks_same_phase(db_mode):
 
     class Item(Base, GUIDPk):
         __tablename__ = "items"
-        tenant_id = Column(UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False)
+        tenant_id = Column(
+            PgUUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False
+        )
         name = Column(String, nullable=False)
 
         @hook_ctx(ops="create", phase="POST_COMMIT")


### PR DESCRIPTION
## Summary
- replace use of sqlalchemy UUID with PgUUID in hook lifecycle tests

## Testing
- `uv run --package tigrbl --directory standards ruff format tigrbl/tests/i9n/test_hook_lifecycle.py`
- `uv run --package tigrbl --directory standards ruff check tigrbl/tests/i9n/test_hook_lifecycle.py --fix`
- `uv run --package tigrbl --directory standards pytest tigrbl/tests/i9n/test_hook_lifecycle.py`


------
https://chatgpt.com/codex/tasks/task_e_68c017a280808326ab3c32c5d893586c