### PR TITLE
chore: use dynamic dates in uvicorn key digest test

### DIFF
--- a/pkgs/standards/tigrbl/tests/i9n/test_key_digest_uvicorn.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_key_digest_uvicorn.py
@@ -7,7 +7,15 @@ import uvicorn
 import pytest_asyncio
 
 from tigrbl.v3 import AutoApp
-from tigrbl.v3.orm.mixins import GUIDPk, Created, LastUsed, ValidityWindow, KeyDigest
+from tigrbl.v3.orm.mixins import (
+    GUIDPk,
+    Created,
+    LastUsed,
+    ValidityWindow,
+    KeyDigest,
+    tzutcnow,
+    tzutcnow_plus_day,
+)
 from tigrbl.v3.orm.mixins.utils import CRUD_IO
 from tigrbl.v3.orm.tables._base import Base
 from tigrbl.v3.specs import F, S, acol
@@ -55,11 +63,12 @@ async def running_app(sync_db_session):
 
 
 def _payload() -> dict:
+    now = tzutcnow()
     return {
         "label": "test",
         "service_id": str(uuid4()),
-        "valid_from": "2024-01-01T00:00:00+00:00",
-        "valid_to": "2024-12-31T00:00:00+00:00",
+        "valid_from": now.isoformat(),
+        "valid_to": tzutcnow_plus_day().isoformat(),
     }
 
 


### PR DESCRIPTION
## Summary
- use timezone helpers for dynamic `valid_from` and `valid_to`

## Testing
- `uv run --directory pkgs/standards/tigrbl --package tigrbl ruff format .`
- `uv run --directory pkgs/standards/tigrbl --package tigrbl ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c018a467b0832681291040c9460783