### PR TITLE
test: await sys tx commit coroutine

### DIFF
--- a/pkgs/standards/tigrbl/tests/unit/test_sys_tx_async_begin.py
+++ b/pkgs/standards/tigrbl/tests/unit/test_sys_tx_async_begin.py
@@ -41,5 +41,5 @@ async def test_sys_tx_handles_async_begin_sync_commit(
 
     system._sys_tx_begin(None, ctx)
     await asyncio.sleep(0)
-    system._sys_tx_commit(None, ctx)
+    await system._sys_tx_commit(None, ctx)
     assert db.started and db.committed

--- a/pkgs/standards/tigrbl/tests/unit/test_sys_tx_commit.py
+++ b/pkgs/standards/tigrbl/tests/unit/test_sys_tx_commit.py
@@ -12,7 +12,8 @@ def test_registry_tx_commit_step() -> None:
     assert runner is system._sys_tx_commit
 
 
-def test_tx_commit_calls_installed_when_flag_set(
+@pytest.mark.asyncio
+async def test_tx_commit_calls_installed_when_flag_set(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     called = {}
@@ -23,12 +24,15 @@ def test_tx_commit_calls_installed_when_flag_set(
     monkeypatch.setattr(system.INSTALLED, "commit", fake_commit)
     ctx = SimpleNamespace(temp={"__sys_tx_open__": True})
     runner = system.get("txn", "commit")[1]
-    runner(None, ctx)
+    await runner(None, ctx)
     assert called.get("ran") is True
     assert ctx.temp["__sys_tx_open__"] is False
 
 
-def test_tx_commit_noop_when_flag_not_set(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.asyncio
+async def test_tx_commit_noop_when_flag_not_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     called = {}
 
     def fake_commit(ctx: SimpleNamespace) -> None:  # pragma: no cover - should not run
@@ -37,12 +41,13 @@ def test_tx_commit_noop_when_flag_not_set(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr(system.INSTALLED, "commit", fake_commit)
     ctx = SimpleNamespace(temp={"__sys_tx_open__": False})
     runner = system.get("txn", "commit")[1]
-    runner(None, ctx)
+    await runner(None, ctx)
     assert called == {}
     assert ctx.temp["__sys_tx_open__"] is False
 
 
-def test_tx_commit_wraps_exceptions(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.asyncio
+async def test_tx_commit_wraps_exceptions(monkeypatch: pytest.MonkeyPatch) -> None:
     def bad_commit(ctx: SimpleNamespace) -> None:
         raise ValueError("boom")
 
@@ -50,5 +55,5 @@ def test_tx_commit_wraps_exceptions(monkeypatch: pytest.MonkeyPatch) -> None:
     ctx = SimpleNamespace(temp={"__sys_tx_open__": True})
     runner = system.get("txn", "commit")[1]
     with pytest.raises(SystemStepError):
-        runner(None, ctx)
+        await runner(None, ctx)
     assert ctx.temp["__sys_tx_open__"] is False


### PR DESCRIPTION
## Summary
- await `system._sys_tx_commit` in async transaction test
- make commit tests async to run coroutine

## Testing
- `uv run --package tigrbl --directory standards/tigrbl pytest tests/unit/test_sys_tx_async_begin.py tests/unit/test_sys_tx_commit.py`


------
https://chatgpt.com/codex/tasks/task_e_68c017f90ba88326bd3d50ff5385527c