### PR TITLE
Check raw type before merging assembled payload

### DIFF
--- a/pkgs/standards/tigrbl/tigrbl/v3/bindings/handlers/ctx.py
+++ b/pkgs/standards/tigrbl/tigrbl/v3/bindings/handlers/ctx.py
@@ -25,10 +25,8 @@ def _ctx_payload(ctx: Mapping[str, Any]) -> Any:
     raw = _ctx_get(ctx, "payload", None)
     if isinstance(temp, Mapping):
         av = temp.get("assembled_values")
-        if isinstance(av, Mapping):
-            merged = {}
-            if isinstance(raw, Mapping):
-                merged.update(raw)
+        if isinstance(av, Mapping) and isinstance(raw, Mapping):
+            merged = dict(raw)
             merged.update(av)
             logger.debug("Payload from assembled values: %s", merged)
             return merged


### PR DESCRIPTION
## Summary
- ensure _ctx_payload only merges assembled values when raw payload is a mapping

## Testing
- `uv run --package tigrbl --directory . ruff format .`
- `uv run --package tigrbl --directory . ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c01d80800c8326aed9fb4c37a228a7