### PR TITLE
fix: enable persistence for bulk RPC operations

### DIFF
--- a/pkgs/standards/tigrbl/tigrbl/v3/bindings/handlers/ctx.py
+++ b/pkgs/standards/tigrbl/tigrbl/v3/bindings/handlers/ctx.py
@@ -23,6 +23,10 @@ def _ctx_get(ctx: Mapping[str, Any], key: str, default: Any = None) -> Any:
 def _ctx_payload(ctx: Mapping[str, Any]) -> Any:
     temp = _ctx_get(ctx, "temp", None)
     raw = _ctx_get(ctx, "payload", None)
+    if isinstance(raw, Sequence) and not isinstance(raw, (str, bytes)):
+        logger.debug("Payload is a non-string sequence")
+        logger.debug("Payload: %s", raw)
+        return raw
     if isinstance(temp, Mapping):
         av = temp.get("assembled_values")
         if isinstance(av, Mapping):
@@ -36,10 +40,6 @@ def _ctx_payload(ctx: Mapping[str, Any]) -> Any:
     v = raw
     if isinstance(v, Mapping):
         logger.debug("Payload is a mapping")
-        logger.debug("Payload: %s", v)
-        return v
-    if isinstance(v, Sequence) and not isinstance(v, (str, bytes)):
-        logger.debug("Payload is a non-string sequence")
         logger.debug("Payload: %s", v)
         return v
     logger.debug("Payload absent or unsupported; defaulting to empty dict")

--- a/pkgs/standards/tigrbl/tigrbl/v3/runtime/kernel.py
+++ b/pkgs/standards/tigrbl/tigrbl/v3/runtime/kernel.py
@@ -300,6 +300,14 @@ class Kernel:
             "update",
             "replace",
             "delete",
+            "merge",
+            "clear",
+            "bulk_create",
+            "bulk_update",
+            "bulk_replace",
+            "bulk_merge",
+            "bulk_delete",
+            "custom",
         } or _is_persistent(chains)
         try:
             _inject_atoms(chains, self._atoms() or (), persistent=persistent)


### PR DESCRIPTION
## Summary
- ensure runtime treats bulk verbs as persistent
- preserve list payloads in handler context

## Testing
- `uv run --package tigrbl --directory standards/tigrbl pytest tests/i9n/test_v3_default_rpc_ops.py::test_rpc_bulk_ops -q`


------
https://chatgpt.com/codex/tasks/task_e_68c01b27a9f48326b994e7d2ffac8a64