### PR TITLE
Fix tx begin flag when no runner installed

### DIFF
--- a/pkgs/standards/tigrbl/tigrbl/v3/runtime/system.py
+++ b/pkgs/standards/tigrbl/tigrbl/v3/runtime/system.py
@@ -79,10 +79,11 @@ def _sys_tx_begin(_obj: Optional[object], ctx: Any) -> None:
     """
     log.debug("system: begin_tx enter")
     _ensure_temp(ctx)
-    ctx.temp["__sys_tx_open__"] = True
+    ctx.temp["__sys_tx_open__"] = False
     try:
         if callable(INSTALLED.begin):
             INSTALLED.begin(ctx)
+            ctx.temp["__sys_tx_open__"] = True
             log.debug("system: begin_tx executed.")
         else:
             log.debug("system: begin_tx no-op (no adapter installed).")


### PR DESCRIPTION
## Summary
- ensure transaction open flag remains False when no begin runner is installed

## Testing
- `uv run --package tigrbl --directory standards/tigrbl pytest tests/unit/test_sys_tx_begin.py`


------
https://chatgpt.com/codex/tasks/task_e_68c01f003dd083269abc5f2ed0e6f70a