### PR TITLE
Fix tigrbl clear operation persistence

### DIFF
--- a/pkgs/standards/tigrbl/tigrbl/v3/runtime/kernel.py
+++ b/pkgs/standards/tigrbl/tigrbl/v3/runtime/kernel.py
@@ -302,7 +302,7 @@ class Kernel:
         persist_policy = getattr(sp, "persist", "default")
         persistent = (
             persist_policy != "skip"
-            and target in {"create", "update", "replace", "delete"}
+            and target in {"create", "update", "replace", "delete", "clear"}
         ) or _is_persistent(chains)
         try:
             _inject_atoms(chains, self._atoms() or (), persistent=persistent)


### PR DESCRIPTION
## Summary
- ensure clear operations participate in transaction commits by marking them persistent

## Testing
- `uv run --package tigrbl --directory standards/tigrbl pytest tests/i9n/test_v3_default_rest_ops.py::test_rest_clear tests/i9n/test_v3_default_rpc_ops.py::test_rpc_methods[clear]`

------
https://chatgpt.com/codex/tasks/task_e_68c01ef19b648326b9e1f2b07d069f5d