### PR TITLE
fix: guard tx begin flag when runner missing

### DIFF
--- a/pkgs/standards/tigrbl/tigrbl/v3/runtime/system.py
+++ b/pkgs/standards/tigrbl/tigrbl/v3/runtime/system.py
@@ -79,10 +79,11 @@ def _sys_tx_begin(_obj: Optional[object], ctx: Any) -> None:
     """
     log.debug("system: begin_tx enter")
     _ensure_temp(ctx)
-    ctx.temp["__sys_tx_open__"] = True
     try:
+        ctx.temp["__sys_tx_open__"] = False
         if callable(INSTALLED.begin):
             INSTALLED.begin(ctx)
+            ctx.temp["__sys_tx_open__"] = True
             log.debug("system: begin_tx executed.")
         else:
             log.debug("system: begin_tx no-op (no adapter installed).")


### PR DESCRIPTION
## Summary
- ensure tx begin flag stays false when no adapter runner is installed

## Testing
- `uv run --package tigrbl --directory standards/tigrbl ruff format .`
- `uv run --package tigrbl --directory standards/tigrbl ruff check . --fix`
- `uv run --package tigrbl --directory standards/tigrbl pytest tests/unit/test_sys_tx_begin.py::test_tx_begin_noop_without_installed_runner -q`

------
https://chatgpt.com/codex/tasks/task_e_68c022cf4fa8832684a1455d6b2de909