### PR TITLE
Ensure pytest notice prints even on failure

### DIFF
--- a/.github/workflows/v0.7.0_validate_changed_files.yaml
+++ b/.github/workflows/v0.7.0_validate_changed_files.yaml
@@ -168,8 +168,10 @@ jobs:
           echo "Running pytest in pkgs/$PKG_PATH"
           cd pkgs
           PACKAGE_NAME=$(python -c "import toml, pathlib, sys; print(toml.load(pathlib.Path('$PKG_PATH')/'pyproject.toml')['project']['name'])")
+          set +e
           uv run --directory "$PKG_PATH" --package "$PACKAGE_NAME" --isolated --active pytest -vvv | tee pytest.log
           STATUS=${PIPESTATUS[0]}
+          set -e
           python - <<'PY'
           import re, pathlib
           log = pathlib.Path('pytest.log').read_text().splitlines()[-1]


### PR DESCRIPTION
## Summary
- prevent shell from exiting before printing pytest summary

## Testing
- `pre-commit run --files .github/workflows/v0.7.0_validate_changed_files.yaml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c026f66b7c8326b86db4d3cac7db25