### PR TITLE
chore: mark peagen and tigrbl packages alpha

### DIFF
--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/swarmauri/swarmauri-sdk/pkgs/standards/peagen/p
 requires-python = ">=3.10,<3.13"
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
+    "Development Status :: 3 - Alpha",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/pkgs/standards/tigrbl/pyproject.toml
+++ b/pkgs/standards/tigrbl/pyproject.toml
@@ -8,6 +8,7 @@ repository = "http://github.com/swarmauri/swarmauri-sdk"
 requires-python = ">=3.10,<3.13"
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
+    "Development Status :: 3 - Alpha",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/pkgs/standards/tigrbl_auth/pyproject.toml
+++ b/pkgs/standards/tigrbl_auth/pyproject.toml
@@ -8,6 +8,7 @@ repository = "http://github.com/swarmauri/swarmauri-sdk"
 requires-python = ">=3.10,<3.13"
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
+    "Development Status :: 3 - Alpha",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/pkgs/standards/tigrbl_client/pyproject.toml
+++ b/pkgs/standards/tigrbl_client/pyproject.toml
@@ -8,6 +8,7 @@ repository = "http://github.com/swarmauri/swarmauri-sdk"
 requires-python = ">=3.10,<3.13"
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
+    "Development Status :: 3 - Alpha",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/pkgs/standards/tigrbl_kms/pyproject.toml
+++ b/pkgs/standards/tigrbl_kms/pyproject.toml
@@ -8,6 +8,7 @@ repository = "http://github.com/swarmauri/swarmauri-sdk"
 requires-python = ">=3.10,<3.13"
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
+    "Development Status :: 3 - Alpha",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
## Summary
- mark peagen as alpha release
- mark tigrbl packages as alpha releases

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`
- `uv run --package tigrbl --directory pkgs/standards/tigrbl ruff check . --fix`
- `uv run --package tigrbl-client --directory pkgs/standards/tigrbl_client ruff check . --fix`
- `uv run --package tigrbl-auth --directory pkgs/standards/tigrbl_auth ruff check . --fix`
- `uv run --package tigrbl-kms --directory pkgs/standards/tigrbl_kms ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c03035e7e48326aabc386900187dd8