### PR TITLE
fix(tigrbl-kms): adjust encrypt/decrypt roundtrip test for bulk creation

### DIFF
--- a/pkgs/standards/tigrbl_kms/tests/unit/test_encrypt_decrypt_roundtrip.py
+++ b/pkgs/standards/tigrbl_kms/tests/unit/test_encrypt_decrypt_roundtrip.py
@@ -8,10 +8,13 @@ from tigrbl.v3.orm.tables import Base
 
 
 def _create_key(client, name: str = "k1"):
-    payload = {"name": name, "algorithm": "AES256_GCM"}
+    payload = [{"name": name, "algorithm": "AES256_GCM"}]
     res = client.post("/kms/key", json=payload)
-    assert res.status_code == 201
-    return res.json()
+    assert res.status_code in {200, 201}
+    key = res.json()[0]
+    rot = client.post(f"/kms/key/{key['id']}/rotate")
+    assert rot.status_code in {200, 201}
+    return key
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- update encrypt/decrypt roundtrip test to create keys via bulk endpoint and rotate them before encryption

## Testing
- `uv run --package tigrbl-kms --directory standards/tigrbl_kms ruff format tests/unit/test_encrypt_decrypt_roundtrip.py`
- `uv run --package tigrbl-kms --directory standards/tigrbl_kms ruff check tests/unit/test_encrypt_decrypt_roundtrip.py --fix`
- `uv run --package tigrbl-kms --directory standards/tigrbl_kms pytest tests/unit/test_encrypt_decrypt_roundtrip.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0367448908326a9c90cd2ee841228