### PR TITLE
Fix key version seeding for bulk key creation

### DIFF
--- a/pkgs/standards/tigrbl_kms/tests/unit/test_key_creation_versions.py
+++ b/pkgs/standards/tigrbl_kms/tests/unit/test_key_creation_versions.py
@@ -7,15 +7,14 @@ from fastapi.testclient import TestClient
 from sqlalchemy import select
 
 from tigrbl.v3.orm.tables import Base
-
 from tigrbl_kms.orm import KeyVersion
 
 
 def _create_key(client, name: str = "k1"):
-    payload = {"name": name, "algorithm": "AES256_GCM"}
+    payload = [{"name": name, "algorithm": "AES256_GCM"}]
     res = client.post("/kms/key", json=payload)
-    assert res.status_code == 201
-    return res.json()
+    assert res.status_code in {200, 201}
+    return res.json()[0]
 
 
 @pytest.fixture

--- a/pkgs/standards/tigrbl_kms/tigrbl_kms/orm/key.py
+++ b/pkgs/standards/tigrbl_kms/tigrbl_kms/orm/key.py
@@ -163,39 +163,42 @@ class Key(Base, BulkCapable, Replaceable):
     )
 
     # ---- Hook: seed key material on create ----
-    @hook_ctx(ops="create", phase="POST_HANDLER")
+    @hook_ctx(ops=("create", "bulk_create"), phase="POST_HANDLER")
     async def _seed_primary_version(cls, ctx):
         import secrets
         from .key_version import KeyVersion
 
         db = ctx.get("db")
-        key_obj = ctx.get("result")
-        if db is None or key_obj is None:
+        result = ctx.get("result")
+        if db is None or result is None:
             raise HTTPException(status_code=500, detail="DB session missing")
 
-        if key_obj.algorithm != KeyAlg.AES256_GCM:
-            return  # only symmetric keys supported for now
+        keys = result if isinstance(result, list) else [result]
 
-        existing = await KeyVersion.handlers.list.core(
-            {
-                "db": db,
-                "payload": {
-                    "filters": {
-                        "key_id": key_obj.id,
-                        "version": key_obj.primary_version,
-                    }
-                },
-            }
-        )
-        if not existing:
-            material = secrets.token_bytes(32)
-            kv = KeyVersion(
-                key_id=key_obj.id,
-                version=key_obj.primary_version,
-                status="active",
-                public_material=material,
+        for key_obj in keys:
+            if key_obj.algorithm != KeyAlg.AES256_GCM:
+                continue  # only symmetric keys supported for now
+
+            existing = await KeyVersion.handlers.list.core(
+                {
+                    "db": db,
+                    "payload": {
+                        "filters": {
+                            "key_id": key_obj.id,
+                            "version": key_obj.primary_version,
+                        }
+                    },
+                }
             )
-            db.add(kv)
+            if not existing:
+                material = secrets.token_bytes(32)
+                kv = KeyVersion(
+                    key_id=key_obj.id,
+                    version=key_obj.primary_version,
+                    status="active",
+                    public_material=material,
+                )
+                db.add(kv)
 
     @hook_ctx(
         ops=("create", "read", "list", "update", "replace", "wrap", "unwrap"),


### PR DESCRIPTION
## Summary
- ensure Key._seed_primary_version handles bulk_create requests
- adjust key creation test to use list payloads returned from bulk create

## Testing
- `uv run --directory standards/tigrbl_kms --package tigrbl-kms ruff check tigrbl_kms/orm/key.py tests/unit/test_key_creation_versions.py --fix --output-format=full`
- `uv run --package tigrbl-kms --directory standards/tigrbl_kms pytest tests/unit/test_key_creation_versions.py`

------
https://chatgpt.com/codex/tasks/task_e_68c0367c617483269cfcc6cd494c883a