### PR TITLE
Fix key read/list test for bulk create API

### DIFF
--- a/pkgs/standards/tigrbl_kms/tests/unit/test_key_read_list.py
+++ b/pkgs/standards/tigrbl_kms/tests/unit/test_key_read_list.py
@@ -30,9 +30,9 @@ def client_app(tmp_path, monkeypatch):
 def test_key_read_and_list_without_versions(client_app):
     client = client_app
     payload = {"name": "k1", "algorithm": "AES256_GCM"}
-    res = client.post("/kms/key", json=payload)
-    assert res.status_code == 201
-    key = res.json()
+    res = client.post("/kms/key", json=[payload])
+    assert res.status_code in {200, 201}
+    key = res.json()[0]
 
     res = client.get(f"/kms/key/{key['id']}")
     assert res.status_code == 200


### PR DESCRIPTION
## Summary
- adapt key read/list unit test to use bulk create payload

## Testing
- `uv run --package tigrbl-kms --directory standards/tigrbl_kms ruff format tests/unit/test_key_read_list.py`
- `uv run --package tigrbl-kms --directory standards/tigrbl_kms ruff check tests/unit/test_key_read_list.py --fix`
- `uv run --package tigrbl-kms --directory standards/tigrbl_kms pytest tests/unit/test_key_read_list.py`


------
https://chatgpt.com/codex/tasks/task_e_68c03688858483269af21c1f47056de3