### PR TITLE
Ensure key rotation handles bulk-created keys

### DIFF
--- a/pkgs/standards/tigrbl_kms/tests/unit/test_key_rotate.py
+++ b/pkgs/standards/tigrbl_kms/tests/unit/test_key_rotate.py
@@ -34,9 +34,9 @@ def client_app(tmp_path, monkeypatch):
 def test_key_rotate_creates_new_version(client_app):
     client, app = client_app
     payload = {"name": "k1", "algorithm": "AES256_GCM"}
-    res = client.post("/kms/key", json=payload)
-    assert res.status_code == 201
-    key = res.json()
+    res = client.post("/kms/key", json=[payload])
+    assert res.status_code in {200, 201}
+    key = res.json()[0]
     assert key["primary_version"] == 1
 
     res = client.post(f"/kms/key/{key['id']}/rotate")


### PR DESCRIPTION
## Summary
- Seed initial key version when keys are created in bulk
- Return a 201 Created response from the rotate operation
- Update rotation tests to create keys via bulk endpoint

## Testing
- `uv run --package tigrbl_kms --directory standards/tigrbl_kms ruff format tigrbl_kms/orm/key.py tests/unit/test_key_rotate.py`
- `uv run --directory standards/tigrbl_kms --package tigrbl_kms ruff check tigrbl_kms/orm/key.py tests/unit/test_key_rotate.py --fix`
- `uv run --package tigrbl_kms --directory standards/tigrbl_kms pytest tests/unit/test_key_rotate.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0368d0e208326bc955bd49648a025