### PR TITLE
Rename Tigrbl to TigrblApi and expose Api

### DIFF
--- a/examples/book_api.ipynb
+++ b/examples/book_api.ipynb
@@ -37,7 +37,7 @@
     "\n",
     "from fastapi import FastAPI\n",
     "\n",
-    "from tigrbl.v3.tigrbl import Tigrbl\n",
+    "from tigrbl.v3.tigrbl import TigrblApi\n",
     "from tigrbl.v3.op import alias_ctx, op_ctx\n",
     "from tigrbl.v3.hook import hook_ctx\n",
     "from tigrbl.v3.schema.decorators import schema_ctx\n",
@@ -85,7 +85,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "api = Tigrbl(get_async_db=get_async_db)"
+    "api = TigrblApi(get_async_db=get_async_db)"
    ]
   },
   {

--- a/pkgs/standards/tigrbl/tests/unit/test_column_rest_rpc_results.py
+++ b/pkgs/standards/tigrbl/tests/unit/test_column_rest_rpc_results.py
@@ -1,7 +1,7 @@
 import pytest
 from fastapi.testclient import TestClient
 
-from tigrbl.v3 import Tigrbl, alias_ctx
+from tigrbl.v3 import TigrblApi, alias_ctx
 from tigrbl.v3.column import F, IO, S, makeColumn, makeVirtualColumn
 from tigrbl.v3.engine.shortcuts import engine as build_engine, mem
 from tigrbl.v3.orm.tables import Base
@@ -13,7 +13,7 @@ from tigrbl.v3.types import App, Integer, Mapped, String
 
 def _setup_api(model):
     eng = build_engine(mem(async_=False))
-    api = Tigrbl(engine=eng)
+    api = TigrblApi(engine=eng)
     api.include_model(model)
     api.initialize()
 

--- a/pkgs/standards/tigrbl/tests/unit/test_op_ctx_dynamic_attach.py
+++ b/pkgs/standards/tigrbl/tests/unit/test_op_ctx_dynamic_attach.py
@@ -1,9 +1,9 @@
-from tigrbl.v3 import Tigrbl, Base, op_ctx
+from tigrbl.v3 import TigrblApi, Base, op_ctx
 from sqlalchemy.orm import Mapped, mapped_column
 
 
 def test_op_ctx_dynamic_attach_auto_discovers_ops():
-    api = Tigrbl()
+    api = TigrblApi()
 
     class Book(Base):
         __tablename__ = "book"

--- a/pkgs/standards/tigrbl/tests/unit/test_response_alias_table_rpc.py
+++ b/pkgs/standards/tigrbl/tests/unit/test_response_alias_table_rpc.py
@@ -7,7 +7,7 @@ from tigrbl.v3.orm.mixins import GUIDPk
 from tigrbl.v3.orm.tables import Base
 from tigrbl.v3.specs import IO, S, F, acol as spec_acol
 from tigrbl.v3.types import String
-from tigrbl.v3.tigrbl import Tigrbl
+from tigrbl.v3.tigrbl import TigrblApi
 
 
 @pytest.mark.asyncio
@@ -25,7 +25,7 @@ async def test_response_ctx_alias_table_rpc():
         )
 
     eng = build_engine(mem(async_=False))
-    api = Tigrbl(engine=eng)
+    api = TigrblApi(engine=eng)
     api.include_model(Widget, mount_router=False)
     api.initialize()
     raw_eng, _ = eng.raw()

--- a/pkgs/standards/tigrbl/tigrbl/v3/__init__.py
+++ b/pkgs/standards/tigrbl/tigrbl/v3/__init__.py
@@ -76,7 +76,8 @@ from .ddl import ensure_schemas, register_sqlite_attach, bootstrap_dbschema
 # ── Config constants (defaults used by REST) ───────────────────────────────────
 from .config.constants import DEFAULT_HTTP_METHODS
 from .autoapp import AutoApp
-from .tigrbl import Tigrbl
+from .tigrbl import TigrblApi
+from .api._api import Api
 
 from .table import Base
 from .op import Op
@@ -85,7 +86,7 @@ from .types import App
 
 __all__: list[str] = []
 
-__all__ += ["AutoApp", "Tigrbl", "Base", "App", "Op"]
+__all__ += ["AutoApp", "TigrblApi", "Api", "Base", "App", "Op"]
 
 __all__ += [
     # OpSpec core

--- a/pkgs/standards/tigrbl/tigrbl/v3/tigrbl.py
+++ b/pkgs/standards/tigrbl/tigrbl/v3/tigrbl.py
@@ -34,7 +34,7 @@ from .system import mount_diagnostics as _mount_diagnostics
 from .op import get_registry, OpSpec
 
 
-class Tigrbl(_Api):
+class TigrblApi(_Api):
     """
     Canonical router-focused facade that owns:
       • containers (models, schemas, handlers, hooks, rpc, rest, routers, columns, table_config, core proxies)
@@ -174,7 +174,7 @@ class Tigrbl(_Api):
     # ------------------------- extras / mounting -------------------------
 
     def mount_jsonrpc(self, *, prefix: str | None = None) -> Any:
-        """Mount a JSON-RPC router onto this Tigrbl instance."""
+        """Mount a JSON-RPC router onto this TigrblApi instance."""
         px = prefix if prefix is not None else self.jsonrpc_prefix
         prov = _resolver.resolve_provider(api=self)
         get_db = prov.get_db if prov else None
@@ -189,7 +189,7 @@ class Tigrbl(_Api):
     def attach_diagnostics(
         self, *, prefix: str | None = None, app: Any | None = None
     ) -> Any:
-        """Mount a diagnostics router onto this Tigrbl instance or ``app``."""
+        """Mount a diagnostics router onto this TigrblApi instance or ``app``."""
         px = prefix if prefix is not None else self.system_prefix
         prov = _resolver.resolve_provider(api=self)
         get_db = prov.get_db if prov else None
@@ -283,4 +283,4 @@ class Tigrbl(_Api):
         models = list(getattr(self, "models", {}))
         rpc_ns = getattr(self, "rpc", None)
         rpc_keys = list(getattr(rpc_ns, "__dict__", {}).keys()) if rpc_ns else []
-        return f"<Tigrbl models={models} rpc={rpc_keys}>"
+        return f"<TigrblApi models={models} rpc={rpc_keys}>"

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/adapters/local_adapter.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/adapters/local_adapter.py
@@ -7,9 +7,9 @@ exist in *tigrbl_auth* so that Tigrbl can consume them automatically.
 
 Usage
 -----
->>> from tigrbl.v3 import Tigrbl
+>>> from tigrbl.v3 import TigrblApi
 >>> from tigrbl_auth.adapters import LocalAuthNAdapter
->>> api = Tigrbl(engine=ENGINE, authn=LocalAuthNAdapter())
+>>> api = TigrblApi(engine=ENGINE, authn=LocalAuthNAdapter())
 """
 
 from __future__ import annotations

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/surface.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/surface.py
@@ -5,7 +5,7 @@ Exports
 Base       : Declarative base for all models in **tigrbl_authn**.
 metadata   : Shared SQLAlchemy ``MetaData`` with a sane naming-convention.
 router     : FastAPI router combining Tigrbl resources and auth flows.
-tigrbl    : The ``Tigrbl`` instance used to produce *router*.
+tigrbl    : The ``TigrblApi`` instance used to produce *router*.
 
 The resulting ``surface_api`` exposes a symmetrical REST/RPC surface under
 namespaces like ``surface_api.core.User.create`` and
@@ -22,7 +22,7 @@ Notes
 
 from __future__ import annotations
 
-from tigrbl.v3 import Tigrbl
+from tigrbl.v3 import TigrblApi
 from tigrbl_auth.orm import (
     Tenant,
     User,
@@ -38,7 +38,7 @@ from .auth_flows import router as flows_router
 # ----------------------------------------------------------------------
 # 3.  Build Tigrbl instance & router
 # ----------------------------------------------------------------------
-surface_api = Tigrbl(engine=dsn)
+surface_api = TigrblApi(engine=dsn)
 
 surface_api.include_models(
     [Tenant, User, Client, ApiKey, Service, ServiceKey, AuthSession]


### PR DESCRIPTION
## Summary
- rename Tigrbl facade to TigrblApi
- re-export Api from tigrbl.v3
- update references in tests, auth adapter, and surface router

## Testing
- `uv run --directory pkgs/standards/tigrbl --package tigrbl ruff format .`
- `uv run --directory pkgs/standards/tigrbl --package tigrbl ruff check . --fix`
- `uv run --directory pkgs/standards/tigrbl_auth --package tigrbl_auth ruff format .`
- `uv run --directory pkgs/standards/tigrbl_auth --package tigrbl_auth ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c11f835f048326b8cf6c92cc21a5ef