### PR TITLE
refactor: rename AutoApp to TigrblApp

### DIFF
--- a/pkgs/standards/peagen/peagen/gateway/__init__.py
+++ b/pkgs/standards/peagen/peagen/gateway/__init__.py
@@ -19,7 +19,7 @@ import uuid
 
 
 # ─────────── Peagen internals ──────────────────────────────────────────
-from tigrbl.v3 import AutoApp, get_schema
+from tigrbl.v3 import TigrblApp, get_schema
 from tigrbl_auth.adapters import RemoteAuthNAdapter
 from fastapi import Request
 
@@ -154,9 +154,9 @@ sched_log = Logger(
 logging.getLogger("httpx").setLevel("WARNING")
 logging.getLogger("uvicorn.error").setLevel("INFO")
 
-# ─────────── AutoApp initialisation ─────────────────────────
+# ─────────── TigrblApp initialisation ─────────────────────────
 READY: bool = False
-app = AutoApp(
+app = TigrblApp(
     title="Peagen Pool-Manager Gateway",
     engine=ENGINE,
     api_hooks={"PRE_TX_BEGIN": [_shadow_principal]},

--- a/pkgs/standards/tigrbl/tests/conftest.py
+++ b/pkgs/standards/tigrbl/tests/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 import pytest_asyncio
-from tigrbl.v3 import AutoApp, Base
+from tigrbl.v3 import TigrblApp, Base
 from tigrbl.v3.types import App
 from tigrbl.v3.orm.mixins import BulkCapable, GUIDPk
 from tigrbl.v3.specs import F, IO, S, acol
@@ -105,7 +105,7 @@ def create_test_api():
     def _create_api(model_class):
         """Create Tigrbl instance with a single model for testing."""
         Base.metadata.clear()
-        api = AutoApp(engine=mem(async_=False))
+        api = TigrblApp(engine=mem(async_=False))
         api.include_model(model_class)
         api.initialize()
         return api
@@ -119,7 +119,7 @@ async def create_test_api_async():
 
     def _create_api_async(model_class):
         Base.metadata.clear()
-        api = AutoApp(engine=mem())
+        api = TigrblApp(engine=mem())
         api.include_model(model_class)
         return api
 
@@ -180,12 +180,12 @@ async def api_client(db_mode):
     fastapi_app = App()
 
     if db_mode == "async":
-        api = AutoApp(engine=mem())
+        api = TigrblApp(engine=mem())
         api.include_models([Tenant, Item])
         await api.initialize()
 
     else:
-        api = AutoApp(engine=mem(async_=False))
+        api = TigrblApp(engine=mem(async_=False))
         api.include_models([Tenant, Item])
         api.initialize()
 
@@ -258,7 +258,7 @@ async def api_client_v3():
 
     cfg = mem()
     fastapi_app = App()
-    api = AutoApp(engine=cfg)
+    api = TigrblApp(engine=cfg)
     api.include_model(Widget, prefix="")
     api.mount_jsonrpc()
     api.attach_diagnostics()

--- a/pkgs/standards/tigrbl/tests/i9n/test_allow_anon.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_allow_anon.py
@@ -4,7 +4,7 @@ from tigrbl.v3.engine import resolver as _resolver
 from tigrbl.v3.engine.shortcuts import mem
 from sqlalchemy.orm import sessionmaker
 
-from tigrbl.v3.autoapp import AutoApp
+from tigrbl.v3 import TigrblApp
 from tigrbl.v3.orm.mixins import GUIDPk
 from tigrbl.v3.orm.tables import Base
 from tigrbl.v3.config.constants import TIGRBL_AUTH_CONTEXT_ATTR
@@ -62,7 +62,7 @@ def _build_client():
 
     cfg = mem(async_=False)
     auth = DummyAuth()
-    api = AutoApp(engine=cfg)
+    api = TigrblApp(engine=cfg)
     api.set_auth(authn=auth.get_principal)
     api.include_models([Tenant, Item])
     api.initialize()
@@ -93,7 +93,7 @@ def _build_client_attr():
 
     cfg = mem(async_=False)
     auth = DummyAuth()
-    api = AutoApp(engine=cfg)
+    api = TigrblApp(engine=cfg)
     api.set_auth(authn=auth.get_principal)
     api.include_models([Tenant, Item])
     api.initialize()
@@ -155,7 +155,7 @@ def _build_client_create_noauth():
             return {"create", "bulk_create"}
 
     cfg = mem(async_=False)
-    api = AutoApp(engine=cfg)
+    api = TigrblApp(engine=cfg)
     api.include_models([Tenant, Item])
     api.initialize()
     app = App()
@@ -184,7 +184,7 @@ def _build_client_create_attr_noauth():
         __tigrbl_allow_anon__ = {"create", "bulk_create"}
 
     cfg = mem(async_=False)
-    api = AutoApp(engine=cfg)
+    api = TigrblApp(engine=cfg)
     api.include_models([Tenant, Item])
     api.initialize()
     app = App()

--- a/pkgs/standards/tigrbl/tests/i9n/test_apikey_generation.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_apikey_generation.py
@@ -2,7 +2,7 @@ import pytest
 from tigrbl.v3.types import App, Mapped, String
 from httpx import ASGITransport, AsyncClient
 
-from tigrbl.v3 import AutoApp
+from tigrbl.v3 import TigrblApp
 from tigrbl.v3.orm.mixins import (
     Created,
     GUIDPk,
@@ -35,7 +35,7 @@ async def test_api_key_creation_requires_valid_payload(sync_db_session):
     _, get_sync_db = sync_db_session
 
     app = App()
-    api = AutoApp(get_db=get_sync_db)
+    api = TigrblApp(get_db=get_sync_db)
     api.include_models([ConcreteApiKey])
     api.initialize()
     app.include_router(api.router)

--- a/pkgs/standards/tigrbl/tests/i9n/test_authn_provider_integration.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_authn_provider_integration.py
@@ -3,7 +3,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from fastapi.testclient import TestClient
 from tigrbl.v3.engine.shortcuts import mem
 
-from tigrbl.v3 import AutoApp, Base, hook_ctx
+from tigrbl.v3 import TigrblApp, Base, hook_ctx
 from tigrbl.v3.config.constants import TIGRBL_AUTH_CONTEXT_ATTR
 from tigrbl.v3.orm.mixins import GUIDPk
 from tigrbl.v3.types.authn_abc import AuthNProvider
@@ -39,7 +39,7 @@ def _build_client_with_auth():
         async def capture(cls, ctx):
             auth.ctx_principal = ctx.get("auth_context")
 
-    api = AutoApp(engine=mem(async_=False))
+    api = TigrblApp(engine=mem(async_=False))
     api.set_auth(authn=auth.get_principal)
     api.include_model(Tenant)
     api.initialize()

--- a/pkgs/standards/tigrbl/tests/i9n/test_core_access.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_core_access.py
@@ -4,7 +4,7 @@ from typing import Any, Mapping
 
 from tigrbl.v3.types import HTTPException, UUID, Column, Integer, String, uuid4
 
-from tigrbl.v3 import AutoApp, Base
+from tigrbl.v3 import TigrblApp, Base
 from tigrbl.v3.engine.shortcuts import engine as build_engine, mem
 from tigrbl.v3.orm.mixins import GUIDPk, BulkCapable, Replaceable
 
@@ -26,7 +26,7 @@ def sync_api():
     """Create a sync Tigrbl instance with CoreTestUser."""
     Base.metadata.clear()
     eng = build_engine(mem(async_=False))
-    api = AutoApp(engine=eng)
+    api = TigrblApp(engine=eng)
     api.include_model(CoreTestUser)
     api.initialize()
     return api, eng
@@ -37,7 +37,7 @@ async def async_api():
     """Create an async Tigrbl instance with CoreTestUser."""
     Base.metadata.clear()
     eng = build_engine(mem(async_=True))
-    api = AutoApp(engine=eng)
+    api = TigrblApp(engine=eng)
     api.include_model(CoreTestUser)
     await api.initialize()
     return api, eng

--- a/pkgs/standards/tigrbl/tests/i9n/test_field_spec_effects.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_field_spec_effects.py
@@ -8,7 +8,7 @@ from tigrbl.v3.engine import resolver as _resolver
 from tigrbl.v3.engine.shortcuts import mem
 from sqlalchemy.orm import sessionmaker
 
-from tigrbl.v3.autoapp import AutoApp
+from tigrbl.v3 import TigrblApp
 from tigrbl.v3.orm.tables import Base
 from tigrbl.v3.orm.mixins import GUIDPk
 from tigrbl.v3.specs import acol, F, IO, S
@@ -39,7 +39,7 @@ async def fs_app():
 
     Base.metadata.create_all(engine)
     app = App()
-    api = AutoApp(engine=cfg)
+    api = TigrblApp(engine=cfg)
     api.include_model(FSItem)
     api.initialize()
     app.include_router(api.router)

--- a/pkgs/standards/tigrbl/tests/i9n/test_hook_ctx_v3_i9n.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_hook_ctx_v3_i9n.py
@@ -3,7 +3,7 @@ from tigrbl.v3.types import App
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import func, select
 
-from tigrbl.v3.autoapp import AutoApp
+from tigrbl.v3 import TigrblApp
 from tigrbl.v3.types import Column, String
 from tigrbl.v3.orm.tables import Base
 from tigrbl.v3.orm.mixins import GUIDPk
@@ -18,7 +18,7 @@ from tigrbl.v3.hook import hook_ctx
 def create_client(model_cls):
     """Build a FastAPI app with Tigrbl v3 and return an AsyncClient."""
     app = App()
-    api = AutoApp(engine={"kind": "sqlite", "memory": True})
+    api = TigrblApp(engine={"kind": "sqlite", "memory": True})
     api.include_model(model_cls)
     api.mount_jsonrpc()
     api.attach_diagnostics()

--- a/pkgs/standards/tigrbl/tests/i9n/test_hook_lifecycle.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_hook_lifecycle.py
@@ -5,7 +5,8 @@ Tests all hook phases and their behavior across CRUD, nested CRUD, and RPC opera
 """
 
 import pytest
-from tigrbl.v3 import App, AutoApp, Base
+from fastapi import FastAPI
+from tigrbl.v3 import TigrblApp, Base
 from tigrbl.v3.hook import hook_ctx
 from tigrbl.v3.engine.shortcuts import mem
 from tigrbl.v3.orm.mixins import GUIDPk
@@ -16,14 +17,14 @@ from tigrbl.v3.types import PgUUID
 
 async def setup_client(db_mode, Tenant, Item):
     """Create an Tigrbl client for the provided models."""
-    fastapi_app = App()
+    fastapi_app = FastAPI()
 
     if db_mode == "async":
-        api = AutoApp(engine=mem())
+        api = TigrblApp(engine=mem())
         api.include_models([Tenant, Item])
         await api.initialize()
     else:
-        api = AutoApp(engine=mem(async_=False))
+        api = TigrblApp(engine=mem(async_=False))
         api.include_models([Tenant, Item])
         api.initialize()
 

--- a/pkgs/standards/tigrbl/tests/i9n/test_iospec_attributes.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_iospec_attributes.py
@@ -5,7 +5,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Mapped, sessionmaker
 from sqlalchemy.pool import StaticPool
 
-from tigrbl.v3.autoapp import AutoApp
+from tigrbl.v3 import TigrblApp
 from tigrbl.v3.engine.shortcuts import engine as engine_factory, mem
 from tigrbl.v3.bindings.model import bind
 from tigrbl.v3.bindings.rest.router import _build_router
@@ -123,7 +123,7 @@ def test_binding_attaches_internal_model_namespaces():
             io=IO(in_verbs=("create",), out_verbs=("read",)),
         )
 
-    api = AutoApp()
+    api = TigrblApp()
     api.include_model(Thing, mount_router=False)
     assert "Thing" in api.models
     assert hasattr(api.schemas, "Thing")
@@ -210,7 +210,7 @@ def test_rest_call_respects_aliases():
             io=IO(in_verbs=("create",), out_verbs=("read",)),
         )
 
-    api = AutoApp(engine=eng)
+    api = TigrblApp(engine=eng)
     api.include_model(Thing)
     Base.metadata.create_all(eng.raw()[0])
     client = TestClient(api)
@@ -271,7 +271,7 @@ async def test_core_crud_helpers_operate():
             io=IO(in_verbs=("create",), out_verbs=("read",)),
         )
 
-    api = AutoApp(engine=eng)
+    api = TigrblApp(engine=eng)
     api.include_model(Thing)
     Base.metadata.create_all(eng.raw()[0])
 

--- a/pkgs/standards/tigrbl/tests/i9n/test_iospec_integration.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_iospec_integration.py
@@ -4,7 +4,7 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy import select
 from types import SimpleNamespace
 
-from tigrbl.v3.autoapp import AutoApp
+from tigrbl.v3 import TigrblApp
 from tigrbl.v3.engine import resolver as _resolver
 from tigrbl.v3.engine.shortcuts import mem
 from tigrbl.v3.orm.tables import Base
@@ -36,7 +36,7 @@ class Widget(Base, GUIDPk):
 @pytest_asyncio.fixture
 async def widget_setup():
     app = App()
-    api = AutoApp(engine=mem(async_=False))
+    api = TigrblApp(engine=mem(async_=False))
     api.include_model(Widget, prefix="/widget")
     api.mount_jsonrpc(prefix="/rpc")
     api.attach_diagnostics(prefix="/system")

--- a/pkgs/standards/tigrbl/tests/i9n/test_key_digest_uvicorn.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_key_digest_uvicorn.py
@@ -6,7 +6,7 @@ import pytest
 import uvicorn
 import pytest_asyncio
 
-from tigrbl.v3 import AutoApp
+from tigrbl.v3 import TigrblApp
 from tigrbl.v3.orm.mixins import (
     GUIDPk,
     Created,
@@ -45,7 +45,7 @@ async def running_app(sync_db_session):
     engine, get_sync_db = sync_db_session
 
     app = App()
-    api = AutoApp(get_db=get_sync_db)
+    api = TigrblApp(get_db=get_sync_db)
     api.include_models([ApiKey])
     await api.initialize()
     app.include_router(api.router)

--- a/pkgs/standards/tigrbl/tests/i9n/test_nested_routing_depth.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_nested_routing_depth.py
@@ -1,6 +1,6 @@
 import pytest
 import pytest_asyncio
-from tigrbl.v3 import AutoApp, Base
+from tigrbl.v3 import TigrblApp, Base
 from tigrbl.v3.engine.shortcuts import mem
 from tigrbl.v3.orm.mixins import GUIDPk
 from tigrbl.v3.types import App
@@ -46,7 +46,7 @@ async def three_level_api_client(db_mode):
     if db_mode == "async":
         pytest.skip("async database mode is currently unsupported")
     else:
-        api = AutoApp(engine=mem(async_=False))
+        api = TigrblApp(engine=mem(async_=False))
         api.include_models([Company, Department, Employee])
         api.initialize()
 

--- a/pkgs/standards/tigrbl/tests/i9n/test_op_ctx_behavior.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_op_ctx_behavior.py
@@ -2,7 +2,7 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 from tigrbl.v3.types import App, BaseModel, Column, String, UUID
 
-from tigrbl.v3 import AutoApp, op_ctx, schema_ctx, hook_ctx
+from tigrbl.v3 import TigrblApp, op_ctx, schema_ctx, hook_ctx
 from tigrbl.v3.orm.tables import Base
 from tigrbl.v3.orm.mixins import GUIDPk
 from tigrbl.v3.runtime.kernel import build_phase_chains
@@ -14,7 +14,7 @@ from tigrbl.v3.runtime.kernel import build_phase_chains
 def setup_api(model_cls, get_db):
     Base.metadata.clear()
     app = App()
-    api = AutoApp(get_db=get_db)
+    api = TigrblApp(get_db=get_db)
     api.include_model(model_cls, prefix="")
     api.initialize()
     app.include_router(api.router)

--- a/pkgs/standards/tigrbl/tests/i9n/test_op_ctx_core_crud_order.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_op_ctx_core_crud_order.py
@@ -3,7 +3,7 @@ from tigrbl.v3.types import App
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import Column, String
 
-from tigrbl.v3 import AutoApp, op_ctx
+from tigrbl.v3 import TigrblApp, op_ctx
 from tigrbl.v3.orm.tables import Base
 from tigrbl.v3.orm.mixins import GUIDPk
 from tigrbl.v3.core import crud
@@ -18,7 +18,7 @@ def setup_api(model_cls):
     spec = EngineSpec.from_any(mem(async_=False))
     engine = Engine(spec)
     app = App(engine=engine)
-    api = AutoApp(engine=engine)
+    api = TigrblApp(engine=engine)
     api.include_model(model_cls, prefix="")
     api.initialize()
     app.include_router(api.router)

--- a/pkgs/standards/tigrbl/tests/i9n/test_openapi_clear_response_schema.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_openapi_clear_response_schema.py
@@ -1,7 +1,7 @@
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from tigrbl.v3.autoapp import AutoApp
+from tigrbl.v3 import TigrblApp
 from tigrbl.v3.orm.mixins import GUIDPk
 from tigrbl.v3.orm.tables import Base
 from tigrbl.v3.types import App, Column, String
@@ -16,7 +16,7 @@ async def test_openapi_clear_response_schema() -> None:
         name = Column(String, nullable=False)
 
     app = App()
-    api = AutoApp()
+    api = TigrblApp()
     api.include_model(Widget)
     app.include_router(api.router)
 

--- a/pkgs/standards/tigrbl/tests/i9n/test_openapi_schema_examples_presence.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_openapi_schema_examples_presence.py
@@ -1,5 +1,5 @@
 import pytest
-from tigrbl.v3 import AutoApp, Base
+from tigrbl.v3 import TigrblApp, Base
 from tigrbl.v3.engine.shortcuts import mem
 from tigrbl.v3.orm.mixins import GUIDPk
 from tigrbl.v3.specs import F, S, acol
@@ -33,7 +33,7 @@ def _resolve_schema(spec, schema):
 async def test_openapi_examples_and_schemas_present(db_mode):
     fastapi_app = App()
     engine = mem() if db_mode == "async" else mem(async_=False)
-    api = AutoApp(engine=engine)
+    api = TigrblApp(engine=engine)
     api.include_model(Widget)
     if db_mode == "async":
         await api.initialize()

--- a/pkgs/standards/tigrbl/tests/i9n/test_owner_tenant_policy.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_owner_tenant_policy.py
@@ -7,7 +7,7 @@ import pytest
 import uuid
 from sqlalchemy import Column, String
 
-from tigrbl.v3 import AutoApp, Base
+from tigrbl.v3 import TigrblApp, Base
 from tigrbl.v3.orm.mixins import GUIDPk
 from tigrbl.v3.orm.mixins.ownable import Ownable, OwnerPolicy
 from tigrbl.v3.orm.mixins.tenant_bound import TenantBound, TenantPolicy
@@ -67,7 +67,7 @@ def _client_for_owner(
         session.commit()
 
     authn = DummyAuth(user_id, tenant_id)
-    api = AutoApp(engine=engine)
+    api = TigrblApp(engine=engine)
     api.set_auth(authn=authn.get_principal)
     api.include_models([User, Item])
     app = App()
@@ -137,7 +137,7 @@ def _client_for_tenant(
         session.commit()
 
     authn = DummyAuth(user_id, tenant_id)
-    api = AutoApp(engine=engine)
+    api = TigrblApp(engine=engine)
     api.set_auth(authn=authn.get_principal)
     api.include_models([Tenant, Item])
     app = App()

--- a/pkgs/standards/tigrbl/tests/i9n/test_request_extras.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_request_extras.py
@@ -6,7 +6,7 @@ from pydantic import Field
 from sqlalchemy import Column, String
 from uuid import uuid4
 
-from tigrbl.v3 import AutoApp, Base
+from tigrbl.v3 import TigrblApp, Base
 from tigrbl.v3.engine.shortcuts import mem
 from tigrbl.v3.schema import _build_schema
 
@@ -26,11 +26,11 @@ async def api_client_with_extras(db_mode):
         }
 
     if db_mode == "async":
-        api = AutoApp(engine=mem())
+        api = TigrblApp(engine=mem())
         api.include_model(Widget)
         await api.initialize()
     else:
-        api = AutoApp(engine=mem(async_=False))
+        api = TigrblApp(engine=mem(async_=False))
         api.include_model(Widget)
         api.initialize()
 

--- a/pkgs/standards/tigrbl/tests/i9n/test_rest_fallback_serialization.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_rest_fallback_serialization.py
@@ -5,7 +5,7 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy import Integer, String
 from sqlalchemy.orm import Mapped
 
-from tigrbl.v3.autoapp import AutoApp as Tigrblv3
+from tigrbl.v3 import TigrblApp as Tigrblv3
 from tigrbl.v3.engine.shortcuts import mem
 from tigrbl.v3.specs import F, IO, S, acol
 from tigrbl.v3.orm.tables import Base as Base3

--- a/pkgs/standards/tigrbl/tests/i9n/test_rest_row_serialization.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_rest_row_serialization.py
@@ -5,7 +5,7 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy import Integer, String, select
 from sqlalchemy.orm import Mapped
 
-from tigrbl.v3.autoapp import AutoApp as Tigrblv3
+from tigrbl.v3 import TigrblApp as Tigrblv3
 from tigrbl.v3.engine.shortcuts import mem
 from tigrbl.v3.specs import F, IO, S, acol
 from tigrbl.v3.orm.tables import Base as Base3

--- a/pkgs/standards/tigrbl/tests/i9n/test_row_result_serialization.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_row_result_serialization.py
@@ -5,7 +5,7 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy import Integer, String, select
 from sqlalchemy.orm import Mapped
 
-from tigrbl.v3.autoapp import AutoApp as Tigrblv3
+from tigrbl.v3 import TigrblApp as Tigrblv3
 from tigrbl.v3.engine import resolver as _resolver
 from tigrbl.v3.engine.shortcuts import mem
 from tigrbl.v3.specs import S, acol

--- a/pkgs/standards/tigrbl/tests/i9n/test_schema_ctx_attributes_integration.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_schema_ctx_attributes_integration.py
@@ -5,7 +5,7 @@ from httpx import ASGITransport, AsyncClient
 
 from tigrbl.v3.types import App, BaseModel, Column, Integer, String
 
-from tigrbl.v3 import AutoApp, Base, schema_ctx
+from tigrbl.v3 import TigrblApp, Base, schema_ctx
 from tigrbl.v3.core import crud
 from tigrbl.v3.engine.shortcuts import mem
 from tigrbl.v3.engine import resolver as _resolver
@@ -33,7 +33,7 @@ async def schema_ctx_client():
 
     cfg = mem()
     app = App()
-    api = AutoApp(engine=cfg)
+    api = TigrblApp(engine=cfg)
     api.include_model(Widget, prefix="")
     api.mount_jsonrpc()
     api.attach_diagnostics()

--- a/pkgs/standards/tigrbl/tests/i9n/test_schema_ctx_op_ctx_integration.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_schema_ctx_op_ctx_integration.py
@@ -5,7 +5,7 @@ from tigrbl.v3.types import App
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import Column, String
 
-from tigrbl.v3 import AutoApp, Base, op_ctx, schema_ctx
+from tigrbl.v3 import TigrblApp, Base, op_ctx, schema_ctx
 from tigrbl.v3.engine.shortcuts import mem
 from tigrbl.v3.orm.mixins import GUIDPk
 
@@ -36,7 +36,7 @@ async def widget_client():
             return ctx["payload"]
 
     app = App()
-    api = AutoApp(engine=mem())
+    api = TigrblApp(engine=mem())
     api.include_model(Widget, prefix="")
     api.mount_jsonrpc()
     await api.initialize()

--- a/pkgs/standards/tigrbl/tests/i9n/test_schema_ctx_spec_integration.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_schema_ctx_spec_integration.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 from sqlalchemy import Integer, String
 from sqlalchemy.orm import Mapped
 
-from tigrbl.v3.autoapp import AutoApp as Tigrblv3
+from tigrbl.v3 import TigrblApp as Tigrblv3
 from tigrbl.v3.engine import resolver as _resolver
 from tigrbl.v3.engine.shortcuts import mem
 from tigrbl.v3.orm.tables import Base as Base3

--- a/pkgs/standards/tigrbl/tests/i9n/test_sqlite_attachments.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_sqlite_attachments.py
@@ -1,5 +1,5 @@
 import pytest
-from tigrbl.v3.autoapp import AutoApp
+from tigrbl.v3 import TigrblApp
 from tigrbl.v3.engine.shortcuts import engine as build_engine, mem
 
 
@@ -12,7 +12,7 @@ def test_initialize_sync_with_sqlite_attachments(tmp_path):
     eng = build_engine(mem(async_=False))
     attach_db = tmp_path / "logs.sqlite"
     attach_db.touch()
-    api = AutoApp(engine=eng)
+    api = TigrblApp(engine=eng)
     api.initialize(sqlite_attachments={"logs": str(attach_db)})
     sql_eng, _ = eng.raw()
     with sql_eng.connect() as conn:
@@ -26,7 +26,7 @@ async def test_initialize_async_with_sqlite_attachments(tmp_path):
     eng = build_engine(mem())
     attach_db = tmp_path / "logs.sqlite"
     attach_db.touch()
-    api = AutoApp(engine=eng)
+    api = TigrblApp(engine=eng)
     await api.initialize(sqlite_attachments={"logs": str(attach_db)})
     sql_eng, _ = eng.raw()
     async with sql_eng.connect() as conn:

--- a/pkgs/standards/tigrbl/tests/i9n/test_v3_bulk_rest_endpoints.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_v3_bulk_rest_endpoints.py
@@ -4,7 +4,7 @@ from typing import Iterator
 from tigrbl.v3.types import App
 from httpx import AsyncClient, ASGITransport
 
-from tigrbl.v3.autoapp import AutoApp
+from tigrbl.v3 import TigrblApp
 from tigrbl.v3.engine.shortcuts import mem
 from tigrbl.v3.orm.tables import Base
 from tigrbl.v3.orm.mixins import GUIDPk, BulkCapable, Replaceable
@@ -23,7 +23,7 @@ async def v3_client() -> Iterator[tuple[AsyncClient, type]]:
         description = Column(String, nullable=True)
 
     app = App()
-    api = AutoApp(engine=mem(async_=False))
+    api = TigrblApp(engine=mem(async_=False))
     api.include_model(Widget)
     api.initialize()
     app.include_router(api.router)

--- a/pkgs/standards/tigrbl/tests/i9n/test_v3_default_rest_ops.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_v3_default_rest_ops.py
@@ -4,7 +4,7 @@ from httpx import ASGITransport, AsyncClient
 
 from tigrbl.v3.types import App, Integer, Mapped, String
 
-from tigrbl.v3.autoapp import AutoApp as Tigrblv3
+from tigrbl.v3 import TigrblApp as Tigrblv3
 from tigrbl.v3.engine.shortcuts import mem
 from tigrbl.v3.specs import F, IO, S, acol
 from tigrbl.v3.orm.tables import Base as Base3
@@ -41,7 +41,7 @@ async def client_and_model():
         __tigrbl_cols__ = {"id": id, "name": name, "age": age}
 
     app = App()
-    # AutoApp/Tigrbl dropped the ``get_db`` attribute in favor of using the
+    # TigrblApp/Tigrbl dropped the ``get_db`` attribute in favor of using the
     # engine facade. Using an async SQLite engine in this test triggers a
     # ``MissingGreenlet`` error when SQLAlchemy performs I/O. Configure a
     # synchronous in-memory engine instead so the REST operations run without

--- a/pkgs/standards/tigrbl/tests/i9n/test_v3_default_rpc_ops.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_v3_default_rpc_ops.py
@@ -4,7 +4,7 @@ from tigrbl.v3.orm.mixins import BulkCapable, Replaceable, Mergeable
 from tigrbl.v3.types import App, Integer, Mapped, String, uuid4
 from httpx import AsyncClient, ASGITransport
 
-from tigrbl.v3.autoapp import AutoApp as Tigrblv3
+from tigrbl.v3 import TigrblApp as Tigrblv3
 from tigrbl.v3.engine.shortcuts import mem
 from tigrbl.v3.orm.tables import Base as Base3
 from tigrbl.v3.specs import F, IO, S, acol

--- a/pkgs/standards/tigrbl/tests/unit/test_api_level_set_auth.py
+++ b/pkgs/standards/tigrbl/tests/unit/test_api_level_set_auth.py
@@ -1,4 +1,4 @@
-from tigrbl.v3 import AutoApp
+from tigrbl.v3 import TigrblApp
 from tigrbl.v3.orm.tables import Base
 from tigrbl.v3.orm.mixins import GUIDPk
 from fastapi import FastAPI, Security
@@ -12,7 +12,7 @@ class Widget(Base, GUIDPk):
 
 def test_api_level_auth_dep_applied_per_route():
     app = FastAPI()
-    api = AutoApp()
+    api = TigrblApp()
     api.set_auth(authn=lambda cred=Security(HTTPBearer()): cred, allow_anon=False)
     api.include_models([Widget])
     app.include_router(api.router)

--- a/pkgs/standards/tigrbl/tests/unit/test_app_reexport.py
+++ b/pkgs/standards/tigrbl/tests/unit/test_app_reexport.py
@@ -1,6 +1,6 @@
 from tigrbl.v3 import App
-from tigrbl.v3.deps.fastapi import App as FastAPIApp
+from tigrbl.v3.app._app import App as InternalApp
 
 
 def test_app_reexport():
-    assert App is FastAPIApp
+    assert App is InternalApp

--- a/pkgs/standards/tigrbl/tests/unit/test_file_response.py
+++ b/pkgs/standards/tigrbl/tests/unit/test_file_response.py
@@ -18,7 +18,7 @@ from tigrbl.v3.types import App as FastApp
 from tigrbl.v3.types import Integer, Mapped, mapped_column
 from tigrbl.v3.table import Table
 from tigrbl.v3.api._api import Api
-from tigrbl.v3.app._app import App as AutoApp
+from tigrbl.v3.app._app import App as BaseApp
 
 
 def _build_model(base: type, file_path: Path, *, bind: bool = True) -> type:
@@ -131,7 +131,7 @@ def test_file_response_app(tmp_path):
     api.get_db = fake_db  # type: ignore[assignment]
     include_model(api, Widget)
 
-    class FilesApp(AutoApp):
+    class FilesApp(BaseApp):
         TITLE = "FilesApp"
         VERSION = "0.1.0"
         LIFESPAN = None

--- a/pkgs/standards/tigrbl/tests/unit/test_include_models_base_prefix.py
+++ b/pkgs/standards/tigrbl/tests/unit/test_include_models_base_prefix.py
@@ -1,6 +1,6 @@
 from tigrbl.v3.types import App
 
-from tigrbl.v3.autoapp import AutoApp
+from tigrbl.v3 import TigrblApp
 from tigrbl.v3.orm.tables import Base
 from tigrbl.v3.orm.mixins import GUIDPk
 from tigrbl.v3.types import Column, String
@@ -17,7 +17,7 @@ def test_include_models_base_prefix_avoids_duplicate_segments():
         __tablename__ = "key_versions"
         name = Column(String, nullable=False)
 
-    api = AutoApp()
+    api = TigrblApp()
     api.include_models([Key, KeyVersion], base_prefix="/kms")
     app.include_router(api.router)
 

--- a/pkgs/standards/tigrbl/tests/unit/test_initialize_cross_ddl.py
+++ b/pkgs/standards/tigrbl/tests/unit/test_initialize_cross_ddl.py
@@ -1,5 +1,5 @@
 import pytest
-from tigrbl.v3.autoapp import AutoApp
+from tigrbl.v3 import TigrblApp
 from tigrbl.v3 import Base
 from tigrbl.v3.specs import S, acol
 from tigrbl.v3.engine.shortcuts import mem
@@ -20,7 +20,7 @@ def _model():
 async def test_initialize_with_sync_engine():
     Base.metadata.clear()
     Widget = _model()
-    api = AutoApp(engine=mem(async_=False))
+    api = TigrblApp(engine=mem(async_=False))
     api.include_model(Widget)
     await api.initialize()
     assert getattr(api.tables, "Widget").name == "widgets"

--- a/pkgs/standards/tigrbl/tests/unit/test_kernel_opview_on_demand.py
+++ b/pkgs/standards/tigrbl/tests/unit/test_kernel_opview_on_demand.py
@@ -1,4 +1,4 @@
-from tigrbl.v3.autoapp import AutoApp
+from tigrbl.v3 import TigrblApp
 from tigrbl.v3.bindings.model import bind
 from tigrbl.v3.runtime.kernel import _default_kernel as K
 from tigrbl.v3.specs import S, IO, acol
@@ -17,7 +17,7 @@ def test_compiles_opview_for_new_model_after_prime():
         )
 
     bind(A)
-    app = AutoApp()
+    app = TigrblApp()
     app.include_model(A, mount_router=False)
     # prime kernel for first model
     K.get_opview(app, A, "read")

--- a/pkgs/standards/tigrbl/tests/unit/test_rest_no_schema_jsonable.py
+++ b/pkgs/standards/tigrbl/tests/unit/test_rest_no_schema_jsonable.py
@@ -3,7 +3,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy import Integer, String
 from sqlalchemy.orm import Mapped
 
-from tigrbl.v3.autoapp import AutoApp as Tigrblv3
+from tigrbl.v3 import TigrblApp as Tigrblv3
 from tigrbl.v3.engine.shortcuts import mem
 from tigrbl.v3.specs import F, IO, S, acol
 from tigrbl.v3.orm.tables import Base as Base3

--- a/pkgs/standards/tigrbl/tests/unit/test_rest_rpc_parity_default_ops.py
+++ b/pkgs/standards/tigrbl/tests/unit/test_rest_rpc_parity_default_ops.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-from tigrbl.v3.autoapp import AutoApp
+from tigrbl.v3 import TigrblApp
 from tigrbl.v3.orm.mixins import GUIDPk, BulkCapable, Mergeable
 from tigrbl.v3.orm.tables import Base
 from tigrbl.v3.op.types import CANON
@@ -52,7 +52,7 @@ def test_rest_rpc_parity_for_default_verbs(alias, target, path, methods):
 
     Item.__tigrbl_ops__ = {verb: {"target": verb} for verb in CANON if verb != "custom"}
 
-    api = AutoApp()
+    api = TigrblApp()
     api.include_model(Item, mount_router=False)
 
     routes = _route_map(Item.rest.router)
@@ -76,7 +76,7 @@ def test_non_bulkcapable_prefers_create() -> None:
         __tablename__ = "items"
         name = Column(String, nullable=False)
 
-    api = AutoApp()
+    api = TigrblApp()
     api.include_model(Item, mount_router=False)
 
     routes = _route_map(Item.rest.router)

--- a/pkgs/standards/tigrbl/tests/unit/test_rest_rpc_prefixes.py
+++ b/pkgs/standards/tigrbl/tests/unit/test_rest_rpc_prefixes.py
@@ -1,4 +1,4 @@
-from tigrbl.v3.autoapp import AutoApp
+from tigrbl.v3 import TigrblApp
 from tigrbl.v3.orm.tables import Base
 from tigrbl.v3.orm.mixins import GUIDPk
 from tigrbl.v3.types import Column, String
@@ -16,7 +16,7 @@ def test_default_resource_and_rpc_prefixes():
         __tablename__ = "items"
         name = Column(String, nullable=False)
 
-    api = AutoApp()
+    api = TigrblApp()
     api.include_model(Item, mount_router=False)
 
     paths = {p.lower() for p in _router_paths(api, "Item")}
@@ -32,7 +32,7 @@ def test_resource_override_affects_prefixes():
         __resource__ = "test"
         name = Column(String, nullable=False)
 
-    api = AutoApp()
+    api = TigrblApp()
     api.include_model(Item, mount_router=False)
 
     paths = {p.lower() for p in _router_paths(api, "Item")}

--- a/pkgs/standards/tigrbl/tests/unit/test_rest_rpc_symmetry.py
+++ b/pkgs/standards/tigrbl/tests/unit/test_rest_rpc_symmetry.py
@@ -1,6 +1,6 @@
 import inspect
 
-from tigrbl.v3 import AutoApp
+from tigrbl.v3 import TigrblApp
 from tigrbl.v3.orm.tables import Base
 from tigrbl.v3.orm.mixins import (
     GUIDPk,
@@ -24,7 +24,7 @@ def _rest_param_names(route):
 
 
 def _assert_symmetry(model, verbs, rest_params):
-    api = AutoApp()
+    api = TigrblApp()
     api.include_model(model, mount_router=False)
 
     expected_verbs = set(verbs)

--- a/pkgs/standards/tigrbl/tests/unit/test_rpc_all_default_op_verbs.py
+++ b/pkgs/standards/tigrbl/tests/unit/test_rpc_all_default_op_verbs.py
@@ -1,7 +1,7 @@
 import pytest
 from collections.abc import Iterator
 
-from tigrbl.v3.autoapp import AutoApp
+from tigrbl.v3 import TigrblApp
 from tigrbl.v3.engine import resolver as _resolver
 from tigrbl.v3.engine.shortcuts import mem
 from tigrbl.v3.op import OpSpec
@@ -12,7 +12,7 @@ from tigrbl.v3.types import Session, String, uuid4
 
 
 @pytest.fixture()
-def api_and_session() -> Iterator[tuple[AutoApp, Session]]:
+def api_and_session() -> Iterator[tuple[TigrblApp, Session]]:
     class Widget(Base, GUIDPk, BulkCapable, Replaceable):
         __tablename__ = "widgets_rpc_all_ops"
         __allow_unmapped__ = True
@@ -62,7 +62,7 @@ def api_and_session() -> Iterator[tuple[AutoApp, Session]]:
         )
 
     cfg = mem(async_=False)
-    api = AutoApp(engine=cfg)
+    api = TigrblApp(engine=cfg)
     api.include_model(Widget, mount_router=False)
     api.initialize()
 

--- a/pkgs/standards/tigrbl/tests/unit/test_rpc_default_ops.py
+++ b/pkgs/standards/tigrbl/tests/unit/test_rpc_default_ops.py
@@ -1,7 +1,7 @@
 import pytest
 from collections.abc import Iterator
 
-from tigrbl.v3.autoapp import AutoApp
+from tigrbl.v3 import TigrblApp
 from tigrbl.v3.orm.mixins import BulkCapable, GUIDPk
 from tigrbl.v3.specs import IO, S, F, acol as spec_acol
 from tigrbl.v3.orm.tables import Base
@@ -11,7 +11,7 @@ from tigrbl.v3.engine import resolver as _resolver
 
 
 @pytest.fixture()
-def api_and_session() -> Iterator[tuple[AutoApp, Session, type[Base]]]:
+def api_and_session() -> Iterator[tuple[TigrblApp, Session, type[Base]]]:
     class Widget(Base, GUIDPk, BulkCapable):
         __tablename__ = "widgets_rpc_ops"
         __allow_unmapped__ = True
@@ -26,7 +26,7 @@ def api_and_session() -> Iterator[tuple[AutoApp, Session, type[Base]]]:
             ),
         )
 
-    api = AutoApp(engine=mem(async_=False))
+    api = TigrblApp(engine=mem(async_=False))
     api.include_model(Widget, mount_router=False)
     api.initialize()
     prov = _resolver.resolve_provider()

--- a/pkgs/standards/tigrbl/tests/unit/test_security_per_route.py
+++ b/pkgs/standards/tigrbl/tests/unit/test_security_per_route.py
@@ -1,5 +1,5 @@
 from tigrbl.v3.op import OpSpec
-from tigrbl.v3.autoapp import AutoApp
+from tigrbl.v3 import TigrblApp
 from tigrbl.v3.orm.tables import Base
 from tigrbl.v3.orm.mixins import GUIDPk
 from tigrbl.v3.bindings.rest.router import _build_router
@@ -33,7 +33,7 @@ def test_set_auth_after_include_model_applies_security():
     class Gadget(Base, GUIDPk):
         __tablename__ = "gadgets_security"
 
-    api = AutoApp()
+    api = TigrblApp()
     api.include_model(Gadget)
     api.set_auth(authn=lambda cred=Security(HTTPBearer()): cred, allow_anon=False)
     app = FastAPI()

--- a/pkgs/standards/tigrbl/tests/unit/test_sqlite_attachments.py
+++ b/pkgs/standards/tigrbl/tests/unit/test_sqlite_attachments.py
@@ -1,5 +1,5 @@
 import pytest
-from tigrbl.v3.autoapp import AutoApp
+from tigrbl.v3 import TigrblApp
 
 
 def _db_names(conn):
@@ -9,7 +9,7 @@ def _db_names(conn):
 
 def test_initialize_sync_without_sqlite_attachments(sync_db_session):
     engine, get_db = sync_db_session
-    api = AutoApp(get_db=get_db)
+    api = TigrblApp(get_db=get_db)
     api.initialize()
     with engine.connect() as conn:
         assert _db_names(conn) == {"main"}
@@ -21,7 +21,7 @@ def test_initialize_sync_with_sqlite_attachments(sync_db_session, tmp_path):
     engine, get_db = sync_db_session
     attach_db = tmp_path / "logs.sqlite"
     attach_db.touch()
-    api = AutoApp(get_db=get_db)
+    api = TigrblApp(get_db=get_db)
     api.initialize(sqlite_attachments={"logs": str(attach_db)})
     with engine.connect() as conn:
         assert "logs" in _db_names(conn)
@@ -32,7 +32,7 @@ def test_initialize_sync_with_sqlite_attachments(sync_db_session, tmp_path):
 @pytest.mark.asyncio
 async def test_initialize_async_without_sqlite_attachments(async_db_session):
     engine, get_db = async_db_session
-    api = AutoApp(get_db=get_db)
+    api = TigrblApp(get_db=get_db)
     await api.initialize()
     async with engine.connect() as conn:
         result = await conn.exec_driver_sql("PRAGMA database_list")
@@ -47,7 +47,7 @@ async def test_initialize_async_with_sqlite_attachments(async_db_session, tmp_pa
     engine, get_db = async_db_session
     attach_db = tmp_path / "logs.sqlite"
     attach_db.touch()
-    api = AutoApp(get_db=get_db)
+    api = TigrblApp(get_db=get_db)
     await api.initialize(sqlite_attachments={"logs": str(attach_db)})
     async with engine.connect() as conn:
         result = await conn.exec_driver_sql("PRAGMA database_list")

--- a/pkgs/standards/tigrbl/tigrbl/v3/README.md
+++ b/pkgs/standards/tigrbl/tigrbl/v3/README.md
@@ -11,7 +11,7 @@ Instead, construct an engine via `Engine` or the helper `engine()` function:
 from tigrbl.v3.engine import engine
 
 DB = engine("sqlite+aiosqlite:///./app.db")
-app = AutoApp(engine=DB)
+app = TigrblApp(engine=DB)
 ```
 
 Use `DB.get_db` as the FastAPI dependency for acquiring sessions and avoid

--- a/pkgs/standards/tigrbl/tigrbl/v3/__init__.py
+++ b/pkgs/standards/tigrbl/tigrbl/v3/__init__.py
@@ -75,18 +75,18 @@ from .ddl import ensure_schemas, register_sqlite_attach, bootstrap_dbschema
 
 # ── Config constants (defaults used by REST) ───────────────────────────────────
 from .config.constants import DEFAULT_HTTP_METHODS
-from .autoapp import AutoApp
+from .app.tigrbl_app import TigrblApp
 from .tigrbl import TigrblApi
 from .api._api import Api
 
 from .table import Base
 from .op import Op
-from .types import App
+from .app._app import App
 
 
 __all__: list[str] = []
 
-__all__ += ["AutoApp", "TigrblApi", "Api", "Base", "App", "Op"]
+__all__ += ["TigrblApp", "TigrblApi", "Api", "Base", "App", "Op"]
 
 __all__ += [
     # OpSpec core

--- a/pkgs/standards/tigrbl/tigrbl/v3/app/tigrbl_app.py
+++ b/pkgs/standards/tigrbl/tigrbl/v3/app/tigrbl_app.py
@@ -1,4 +1,4 @@
-# tigrbl/v3/autoapp.py
+# tigrbl/v3/app/tigrbl_app.py
 from __future__ import annotations
 
 import copy
@@ -14,11 +14,11 @@ from typing import (
     Tuple,
 )
 
-from .app._app import App as _App
-from .engine.engine_spec import EngineCfg
-from .engine import resolver as _resolver
-from .ddl import initialize as _ddl_initialize
-from .bindings.api import (
+from ._app import App as _App
+from ..engine.engine_spec import EngineCfg
+from ..engine import resolver as _resolver
+from ..ddl import initialize as _ddl_initialize
+from ..bindings.api import (
     include_model as _include_model,
     include_models as _include_models,
     rpc_call as _rpc_call,
@@ -27,11 +27,11 @@ from .bindings.api import (
     _default_prefix,
     AttrDict,
 )
-from .bindings.model import rebind as _rebind, bind as _bind
-from .bindings.rest import build_router_and_attach as _build_router_and_attach
-from .transport import mount_jsonrpc as _mount_jsonrpc
-from .system import mount_diagnostics as _mount_diagnostics
-from .op import get_registry, OpSpec
+from ..bindings.model import rebind as _rebind, bind as _bind
+from ..bindings.rest import build_router_and_attach as _build_router_and_attach
+from ..transport import mount_jsonrpc as _mount_jsonrpc
+from ..system import mount_diagnostics as _mount_diagnostics
+from ..op import get_registry, OpSpec
 
 
 # optional compat: legacy transactional decorator
@@ -41,7 +41,7 @@ except Exception:  # pragma: no cover
     _txn_decorator = None
 
 
-class AutoApp(_App):
+class TigrblApp(_App):
     """
     Monolithic facade that owns:
       • containers (models, schemas, handlers, hooks, rpc, rest, routers, columns, table_config, core proxies)
@@ -52,7 +52,7 @@ class AutoApp(_App):
     It composes v3 primitives; you can still use the functions directly if you prefer.
     """
 
-    TITLE = "AutoApp"
+    TITLE = "TigrblApp"
     VERSION = "0.1.0"
     LIFESPAN = None
     MIDDLEWARES: Sequence[Any] = ()
@@ -311,4 +311,4 @@ class AutoApp(_App):
     # ------------------------- repr -------------------------
 
     def __repr__(self) -> str:  # pragma: no cover
-        return f"<AutoApp models={list(self.models)} rpc={list(getattr(self.rpc, '__dict__', {}).keys())}>"
+        return f"<TigrblApp models={list(self.models)} rpc={list(getattr(self.rpc, '__dict__', {}).keys())}>"

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/app.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/app.py
@@ -15,7 +15,7 @@ Features
 
 from __future__ import annotations
 
-from tigrbl.v3 import AutoApp
+from tigrbl.v3 import TigrblApp
 
 from .routers.surface import surface_api
 from .db import dsn
@@ -32,9 +32,9 @@ import logging
 
 logging.getLogger("uvicorn").setLevel(logging.DEBUG)
 # --------------------------------------------------------------------
-# AutoApp application
+# TigrblApp application
 # --------------------------------------------------------------------
-app = AutoApp(
+app = TigrblApp(
     title="Tigrbl-Auth",
     version="0.1.0",
     openapi_url="/openapi.json",

--- a/pkgs/standards/tigrbl_kms/tests/unit/test_model_bindings_before_mount.py
+++ b/pkgs/standards/tigrbl_kms/tests/unit/test_model_bindings_before_mount.py
@@ -3,7 +3,7 @@ import pytest
 
 @pytest.mark.asyncio
 async def test_bindings_before_mount(monkeypatch):
-    from tigrbl.v3.autoapp import AutoApp
+    from tigrbl.v3 import TigrblApp
     from tigrbl.v3.bindings import rest as rest_binding
 
     monkeypatch.setattr(
@@ -24,7 +24,7 @@ async def test_bindings_before_mount(monkeypatch):
 
     from tigrbl_kms.orm import Key
 
-    api = AutoApp()
+    api = TigrblApp()
     api.bind(Key)
 
     result = await Key.rpc.create(

--- a/pkgs/standards/tigrbl_kms/tigrbl_kms/app.py
+++ b/pkgs/standards/tigrbl_kms/tigrbl_kms/app.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 
-from tigrbl.v3 import AutoApp
+from tigrbl.v3 import TigrblApp
 from tigrbl.v3.engine import engine as build_engine
 from swarmauri_crypto_paramiko import ParamikoCrypto
 from swarmauri_standard.key_providers import InMemoryKeyProvider
@@ -27,7 +27,7 @@ async def _stash_ctx(ctx):
     ctx["key_provider"] = KEY_PROVIDER
 
 
-app = AutoApp(
+app = TigrblApp(
     title="Tigrbl-KMS",
     version="0.1.0",
     openapi_url="/openapi.json",


### PR DESCRIPTION
## Summary
- rename AutoApp to TigrblApp and relocate into tigrbl.v3.app
- re-export App and TigrblApp from tigrbl.v3
- update peagen, tigrbl-auth, and tigrbl-kms to use TigrblApp

## Testing
- `uv run --directory pkgs/standards/tigrbl --package tigrbl ruff check . --fix`
- `uv run --directory pkgs/standards/tigrbl_auth --package tigrbl-auth ruff check . --fix`
- `uv run --directory pkgs/standards/tigrbl_kms --package tigrbl-kms ruff check . --fix`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c12260c6b48326b611d7c0925cd99b