### PR TITLE
feat: add automatic README doc generation

### DIFF
--- a/pkgs/community/docsite_builder/docs/_gen_readmes.py
+++ b/pkgs/community/docsite_builder/docs/_gen_readmes.py
@@ -1,0 +1,3 @@
+from docsite_builder.scripts.gen_readmes import main
+
+main()

--- a/pkgs/community/docsite_builder/docsite_builder/cli.py
+++ b/pkgs/community/docsite_builder/docsite_builder/cli.py
@@ -39,6 +39,12 @@ def run_mkdocs_serve(
     subprocess.run(cmd, check=True, cwd=docs_dir)
 
 
+def run_gen_readmes(docs_dir: str = ".") -> None:
+    """Run the README generation script."""
+    cmd = [sys.executable, "-m", "docsite_builder.scripts.gen_readmes"]
+    subprocess.run(cmd, check=True, cwd=docs_dir)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(prog="docsite-builder")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -58,6 +64,10 @@ def main() -> None:
             changed_only=args.changed_only,
         )
     )
+
+    readmes = sub.add_parser("readmes", help="Generate documentation from README files")
+    readmes.add_argument("--docs-dir", default=".")
+    readmes.set_defaults(func=lambda args: run_gen_readmes(docs_dir=args.docs_dir))
 
     serve = sub.add_parser("serve", help="Serve the documentation with MkDocs")
     serve.add_argument("--docs-dir", default=".")

--- a/pkgs/community/docsite_builder/docsite_builder/scripts/gen_readmes.py
+++ b/pkgs/community/docsite_builder/docsite_builder/scripts/gen_readmes.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import mkdocs_gen_files
+from mkdocs_gen_files import Nav
+
+# Roots to scan; adapt to your repo
+ROOTS = ("pkgs", "packages", "apps", "libs", "services")
+
+# Static assets we'll copy alongside README content (allowlist)
+STATIC_EXTS = {
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".gif",
+    ".svg",
+    ".webp",
+    ".ico",
+    ".bmp",
+    ".css",
+    ".js",
+    ".json",
+    ".txt",
+    ".pdf",
+    ".toml",
+    ".yaml",
+    ".yml",
+}
+
+
+def main() -> None:
+    root = Path.cwd()
+    nav = Nav()
+
+    def write_binary(src: Path, dest: Path) -> None:
+        with mkdocs_gen_files.open(dest.as_posix(), "wb") as out:
+            out.write(src.read_bytes())
+
+    def write_text(src: Path, dest: Path) -> None:
+        with mkdocs_gen_files.open(dest.as_posix(), "w", encoding="utf-8") as out:
+            out.write(src.read_text(encoding="utf-8"))
+
+    for base in ROOTS:
+        base_path = root / base
+        if not base_path.exists():
+            continue
+
+        for readme in base_path.rglob("README.md"):
+            rel_from_repo = readme.relative_to(root)
+            doc_dir_parts = rel_from_repo.parts[:-1]
+            out_md = Path(*doc_dir_parts) / "index.md"
+
+            write_text(readme, out_md)
+            mkdocs_gen_files.set_edit_path(out_md.as_posix(), readme.as_posix())
+
+            nav[doc_dir_parts] = out_md.as_posix()
+
+            for p in readme.parent.rglob("*"):
+                if (
+                    p.is_file()
+                    and p.suffix.lower() in STATIC_EXTS
+                    and p.name != "index.md"
+                ):
+                    out_asset = Path(*p.relative_to(root).parts)
+                    write_binary(p, out_asset)
+
+    with mkdocs_gen_files.open("SUMMARY.md", "w") as f:
+        f.writelines(nav.build_literate_nav())
+
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/community/docsite_builder/mkdocs.insiders.yaml
+++ b/pkgs/community/docsite_builder/mkdocs.insiders.yaml
@@ -1,1 +1,27 @@
-# Placeholder for MkDocs Insiders configuration
+site_name: Docsite Builder
+repo_name: swarmauri/docsite-builder
+repo_url: https://github.com/swarmauri/swarmauri-sdk
+theme:
+  name: material
+plugins:
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            extensions:
+              - griffe_typingdoc
+  - search
+  - gen-files:
+      scripts:
+        - docs/_gen_readmes.py
+  - literate-nav:
+      nav_file: SUMMARY.md
+
+markdown_extensions:
+  - toc:
+      permalink: true
+  - admonition
+  - footnotes
+  - attr_list
+  - def_list
+  - tables

--- a/pkgs/community/docsite_builder/mkdocs.yml
+++ b/pkgs/community/docsite_builder/mkdocs.yml
@@ -11,5 +11,17 @@ plugins:
             extensions:
               - griffe_typingdoc
   - search
-nav:
-  - Home: index.md
+  - gen-files:
+      scripts:
+        - docs/_gen_readmes.py
+  - literate-nav:
+      nav_file: SUMMARY.md
+
+markdown_extensions:
+  - toc:
+      permalink: true
+  - admonition
+  - footnotes
+  - attr_list
+  - def_list
+  - tables

--- a/pkgs/community/docsite_builder/pyproject.toml
+++ b/pkgs/community/docsite_builder/pyproject.toml
@@ -8,6 +8,9 @@ requires-python = ">=3.12,<3.13"
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 keywords = ["mkdocs", "documentation", "swarmauri"]
 dependencies = [
+    "mkdocs",
+    "mkdocs-gen-files",
+    "mkdocs-literate-nav",
     "mkdocs-material>=9.6.4,<10.0.0",
     "mkdocstrings[python]>=0.28.1,<0.29.0",
     "mkdocs-autorefs",


### PR DESCRIPTION
## Summary
- install mkdocs, mkdocs-gen-files and mkdocs-literate-nav
- wire up README doc generation script and expose via CLI
- enable gen-files and literate-nav plugins in mkdocs configs

## Testing
- `uv run --directory pkgs/community/docsite_builder --package docsite_builder ruff format .`
- `uv run --directory pkgs/community/docsite_builder --package docsite_builder ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c131bc4a548326adb234d5287520b4