### PR TITLE
docs: add basic pages for peagen docs

### DIFF
--- a/infra/docs/peagen/docs/guide/index.md
+++ b/infra/docs/peagen/docs/guide/index.md
@@ -1,0 +1,5 @@
+# Peagen Guides
+
+This section provides tutorials and reference material to help you get the most out of Peagen.
+
+If you're new, start with the [Home](../home/index.md) page. For project updates, check the [News](../news/index.md) section.

--- a/infra/docs/peagen/docs/home/index.md
+++ b/infra/docs/peagen/docs/home/index.md
@@ -1,0 +1,6 @@
+# Peagen Home
+
+Welcome to the Peagen home page. Here you'll find high-level information and helpful links to learn more about the project.
+
+- [Guides](../guide/index.md) for step-by-step instructions
+- [News](../news/index.md) to stay updated

--- a/infra/docs/peagen/docs/index.md
+++ b/infra/docs/peagen/docs/index.md
@@ -1,0 +1,9 @@
+# Welcome to Peagen
+
+Peagen is a collection of utilities for generating project scaffolds and other development resources.
+
+Use the navigation below to explore more:
+
+- [Home](home/index.md) – background information about the project
+- [Guides](guide/index.md) – tutorials and reference material
+- [News](news/index.md) – latest announcements

--- a/infra/docs/peagen/docs/news/index.md
+++ b/infra/docs/peagen/docs/news/index.md
@@ -1,0 +1,3 @@
+# Peagen News
+
+Follow this section for the latest updates and announcements about Peagen.


### PR DESCRIPTION
## Summary
- add initial Peagen documentation root index
- introduce home, guide, and news sections

## Testing
- `find infra/docs/peagen/docs -type f | sort`

------
https://chatgpt.com/codex/tasks/task_e_68c13286c8c0832696b3880f62bb8d66