### PR TITLE
docs: add basic tigrbl documentation pages

### DIFF
--- a/infra/docs/tigrbl/docs/guide/index.md
+++ b/infra/docs/tigrbl/docs/guide/index.md
@@ -1,0 +1,3 @@
+# Tigrbl Guides
+
+Step-by-step guides for working with Tigrbl.

--- a/infra/docs/tigrbl/docs/home/index.md
+++ b/infra/docs/tigrbl/docs/home/index.md
@@ -1,0 +1,3 @@
+# Home
+
+Discover the purpose of Tigrbl and learn how to begin using it.

--- a/infra/docs/tigrbl/docs/index.md
+++ b/infra/docs/tigrbl/docs/index.md
@@ -1,0 +1,9 @@
+# Welcome to Tigrbl
+
+This site hosts the Tigrbl documentation and resources.
+
+## Sections
+
+- [Home](home/index.md) – project overview and getting started information
+- [Guide](guide/index.md) – tutorials and walkthroughs
+- [News](news/index.md) – updates and release notes

--- a/infra/docs/tigrbl/docs/news/index.md
+++ b/infra/docs/tigrbl/docs/news/index.md
@@ -1,0 +1,3 @@
+# Tigrbl News
+
+Latest announcements and changes in the Tigrbl project.


### PR DESCRIPTION
## Summary
- create initial documentation structure for tigrbl
- add home, guide, and news sections with stub content

## Testing
- `npx markdownlint-cli "infra/docs/tigrbl/docs/**/*.md"`

------
https://chatgpt.com/codex/tasks/task_e_68c13282ba748326bf06722ebf97b080