### PR TITLE
docs: add peagen mkdocs config

### DIFF
--- a/infra/docs/peagen/api_manifest.yaml
+++ b/infra/docs/peagen/api_manifest.yaml
@@ -1,0 +1,9 @@
+---
+targets:
+  - name: Peagen
+    package: peagen
+    search_path: ../../pkgs/standards/peagen
+    include:
+      - peagen.*
+    exclude:
+      - "*.tests.*"

--- a/infra/docs/peagen/mkdocs.insiders.yaml
+++ b/infra/docs/peagen/mkdocs.insiders.yaml
@@ -1,0 +1,11 @@
+---
+plugins:
+  social:
+    cards_layout_options:
+      logo: ../en/docs/img/icon-white.svg
+  typeset:
+markdown_extensions:
+  material.extensions.preview:
+    targets:
+      include:
+        - "*"

--- a/infra/docs/peagen/mkdocs.yml
+++ b/infra/docs/peagen/mkdocs.yml
@@ -1,0 +1,80 @@
+---
+site_name: Peagen
+repo_url: https://github.com/swarmauri/peagen
+repo_name: swarmauri/peagen
+theme:
+  name: material
+  logo: assets/swarmauri_logo_dark.jpeg
+  favicon: assets/swarmauri_logo_dark.jpeg
+  palette:
+    - scheme: slate
+      toggle:
+        icon: material/weather-sunny
+        name: Dark mode
+      primary: orange
+      accent: deep purple
+    - scheme: default
+      toggle:
+        icon: material/weather-night
+        name: Light mode
+      primary: orange
+      accent: deep orange
+  features:
+    - navigation.instant
+    - navigation.instant.prefetch
+    - navigation.instant.progress
+    - navigation.tracking
+    - navigation.tabs
+    - navigation.top
+    - search.highlight
+    - search.share
+    - search.suggest
+    - toc.follow
+  icon:
+    repo: fontawesome/brands/github
+plugins:
+  - mkdocstrings:
+      handlers:
+        python:
+          paths:
+            - ../../pkgs/standards/peagen
+          options:
+            extensions:
+              - griffe_typingdoc
+            show_root_heading: true
+            show_if_no_docstring: true
+            inherited_members: true
+            members_order: source
+            separate_signature: true
+            unwrap_annotated: true
+            filters:
+              - '!^_'
+            merge_init_into_class: true
+            docstring_section_style: spacy
+            signature_crossrefs: true
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+            show_source: true
+  - search: null
+  - autorefs: null
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: __PYTHON_TAG_0__
+  - pymdownx.tabbed:
+      alternate_style: true
+  - abbr
+  - attr_list
+  - pymdownx.snippets
+  - pymdownx.tasklist:
+      custom_checkbox: true
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/swarmauri/peagen
+nav:
+  - Home: index.md


### PR DESCRIPTION
## Summary
- add API manifest for Peagen package
- add insiders and main MkDocs configs to support docs build

## Testing
- `yamllint infra/docs/peagen`

------
https://chatgpt.com/codex/tasks/task_e_68c13201902c83269f929864f0bb255d