### PR TITLE
docs: add starter pages for peagen

### DIFF
--- a/infra/docs/peagen/docs/guide/index.md
+++ b/infra/docs/peagen/docs/guide/index.md
@@ -1,0 +1,5 @@
+# Guide
+
+This section collects tutorials and best practices for building with Peagen.
+
+Start with the basic usage to learn how to generate code and interact with plugins.

--- a/infra/docs/peagen/docs/guide/usage.md
+++ b/infra/docs/peagen/docs/guide/usage.md
@@ -1,0 +1,10 @@
+# Basic Usage
+
+```python
+from peagen import generate
+
+code = generate(template="hello")
+print(code)
+```
+
+This example shows how to generate code from a simple template using Peagen.

--- a/infra/docs/peagen/docs/home/contribute.md
+++ b/infra/docs/peagen/docs/home/contribute.md
@@ -1,0 +1,9 @@
+# Contributing
+
+We welcome contributions of all kinds. To get started:
+
+1. Fork the repository on GitHub.
+2. Create a feature branch.
+3. Submit a pull request with a clear description of your changes.
+
+Please follow the project's coding guidelines and style conventions.

--- a/infra/docs/peagen/docs/home/installation.md
+++ b/infra/docs/peagen/docs/home/installation.md
@@ -1,0 +1,15 @@
+# Installation
+
+Peagen is distributed as a Python package. Install it from PyPI:
+
+```bash
+pip install peagen
+```
+
+For development setup, clone the repository and install in editable mode:
+
+```bash
+git clone https://github.com/swarmauri/peagen.git
+cd peagen
+pip install -e .
+```

--- a/infra/docs/peagen/docs/index.md
+++ b/infra/docs/peagen/docs/index.md
@@ -1,0 +1,5 @@
+# Welcome to Peagen
+
+This documentation hub provides an overview, guides, and updates for the Peagen project.
+
+Use the navigation to explore installation instructions, developer guides, and the latest news.

--- a/infra/docs/peagen/docs/news/index.md
+++ b/infra/docs/peagen/docs/news/index.md
@@ -1,0 +1,5 @@
+# News
+
+Stay informed about the latest updates and releases for Peagen.
+
+Check back here for announcements and development milestones.


### PR DESCRIPTION
## Summary
- scaffold Peagen documentation with new index, home, guide, and news pages
- add installation, contribution, and basic usage examples

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68c13286c8c0832696b3880f62bb8d66