### PR TITLE
Rename docsite builder package to zdx

### DIFF
--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "swarmauri-docs"
+name = "zdx"
 version = "0.1.0"
 description = "Swarmauri Documentation"
 requires-python = ">=3.12,<3.13"


### PR DESCRIPTION
## Summary
- rename docsite builder package to `zdx`

## Testing
- `uv run --directory docs ruff format pyproject.toml`
- `uv run --directory docs ruff check pyproject.toml --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c13a9334ec83268ce1fe39069aa511