### PR TITLE
Fix docs search paths for tigrbl and peagen

### DIFF
--- a/infra/docs/peagen/api_manifest.yaml
+++ b/infra/docs/peagen/api_manifest.yaml
@@ -2,7 +2,7 @@
 targets:
   - name: Peagen
     package: peagen
-    search_path: ../../pkgs/standards/peagen
+    search_path: ../../../pkgs/standards/peagen
     include:
       - peagen.*
     exclude:

--- a/infra/docs/peagen/mkdocs.yml
+++ b/infra/docs/peagen/mkdocs.yml
@@ -37,7 +37,7 @@ plugins:
       handlers:
         python:
           paths:
-            - ../../pkgs/standards/peagen
+            - ../../../pkgs/standards/peagen
           options:
             extensions:
               - griffe_typingdoc

--- a/infra/docs/tigrbl/api_manifest.yaml
+++ b/infra/docs/tigrbl/api_manifest.yaml
@@ -1,7 +1,7 @@
 targets:
   - name: Tigrbl
     package: tigrbl
-    search_path: ../../pkgs/standards
+    search_path: ../../../pkgs/standards
     include:
       - tigrbl.*
     exclude:
@@ -10,18 +10,18 @@ targets:
 
   - name: Tigrbl_Auth
     package: tigrbl_auth
-    search_path: ../../pkgs/standards
+    search_path: ../../../pkgs/standards
     include:
       - tigrbl_auth.*
 
   - name: Tigrbl_Client
     package: tigrbl_client
-    search_path: ../../pkgs/standards
+    search_path: ../../../pkgs/standards
     include:
       - tigrbl_client.*
 
   - name: Tigrbl_Kms
     package: tigrbl_kms
-    search_path: ../../pkgs/standards
+    search_path: ../../../pkgs/standards
     include:
       - tigrbl_kms.*

--- a/infra/docs/tigrbl/mkdocs.yml
+++ b/infra/docs/tigrbl/mkdocs.yml
@@ -34,10 +34,10 @@ plugins:
     handlers:
       python:
         paths:
-        - ../../pkgs/standards/tigrbl
-        - ../../pkgs/standards/tigrbl_auth
-        - ../../pkgs/standards/tigrbl_client
-        - ../../pkgs/standards/tigrbl_kms
+        - ../../../pkgs/standards/tigrbl
+        - ../../../pkgs/standards/tigrbl_auth
+        - ../../../pkgs/standards/tigrbl_client
+        - ../../../pkgs/standards/tigrbl_kms
         options:
           extensions:
           - griffe_typingdoc


### PR DESCRIPTION
## Summary
- fix search_path to point to source packages for tigrbl docs
- correct mkdocstrings paths for tigrbl documentation
- fix search_path to point to source package for peagen docs
- correct mkdocstrings paths for peagen documentation

## Testing
- `uv run ruff format infra/docs/peagen/api_manifest.yaml infra/docs/peagen/mkdocs.yml infra/docs/tigrbl/api_manifest.yaml infra/docs/tigrbl/mkdocs.yml` (fails: Expected an expression)
- `uv run ruff check infra/docs/peagen/api_manifest.yaml` (fails: Expected an expression)


------
https://chatgpt.com/codex/tasks/task_e_68c16381c36c83268c153e0689e2b33f