### PR TITLE
Include package in pytest summary for validate changes workflow

### DIFF
--- a/.github/workflows/v0.7.0_validate_changed_files.yaml
+++ b/.github/workflows/v0.7.0_validate_changed_files.yaml
@@ -168,12 +168,15 @@ jobs:
           echo "Running pytest in pkgs/$PKG_PATH"
           cd pkgs
           PACKAGE_NAME=$(python -c "import toml, pathlib, sys; print(toml.load(pathlib.Path('$PKG_PATH')/'pyproject.toml')['project']['name'])")
+          export PKG_PATH PACKAGE_NAME
           set +e
           uv run --directory "$PKG_PATH" --package "$PACKAGE_NAME" --isolated --active pytest -vvv | tee pytest.log
           STATUS=${PIPESTATUS[0]}
           set -e
           python - <<'PY'
-          import re, pathlib
+          import os, re, pathlib
+          pkg_name = os.environ.get("PACKAGE_NAME", "unknown")
+          pkg_path = os.environ.get("PKG_PATH", "")
           log = pathlib.Path('pytest.log').read_text().splitlines()[-1]
           patterns = {
               'passed': r'(\d+) passed',
@@ -189,6 +192,7 @@ jobs:
               m = re.search(pat, log)
               if m:
                   counts[key] = int(m.group(1))
-          print("::notice title=pytest summary::" + " ".join(f"{k}={v}" for k, v in counts.items()))
+          summary = " ".join(f"{k}={v}" for k, v in counts.items())
+          print(f"::notice title=pytest summary ({pkg_name})::pkg_path={pkg_path} {summary}")
           PY
           exit $STATUS


### PR DESCRIPTION
## Summary
- include package name and path in pytest summary notices for changed packages workflow

## Testing
- `yamllint .github/workflows/v0.7.0_validate_changed_files.yaml` *(fails: line-length warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c175bc2b448326a47356c827121e62