### PR TITLE
test: update tigrbl kernel step assertions

### DIFF
--- a/pkgs/standards/tigrbl/tests/i9n/test_hook_ctx_v3_i9n.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_hook_ctx_v3_i9n.py
@@ -388,5 +388,5 @@ async def test_hook_ctx_system_steps_i9n():
     res = await client.get("/system/kernelz")
     data = res.json()
     steps = data["Item"]["create"]
-    assert "HANDLER:hook:wire:tigrbl:v3:core:crud:ops:create@HANDLER" in steps
+    assert "HANDLER:hook:wire:tigrbl:core:crud:ops:create@HANDLER" in steps
     await client.aclose()

--- a/pkgs/standards/tigrbl/tests/i9n/test_iospec_integration.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_iospec_integration.py
@@ -177,5 +177,5 @@ async def test_kernelz_lists_atoms_and_steps(widget_setup):
     client, _, _ = widget_setup
     data = (await client.get("/system/kernelz")).json()
     steps = data["Widget"]["create"]
-    assert "HANDLER:hook:wire:tigrbl:v3:core:crud:ops:create@HANDLER" in steps
+    assert "HANDLER:hook:wire:tigrbl:core:crud:ops:create@HANDLER" in steps
     assert any("hook:sys:txn:begin@START_TX" in s for s in steps)

--- a/pkgs/standards/tigrbl/tests/i9n/test_schema_ctx_attributes_integration.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_schema_ctx_attributes_integration.py
@@ -166,7 +166,7 @@ async def test_schema_ctx_atomz(schema_ctx_client):
     client, _, _, _ = schema_ctx_client
     kernelz = (await client.get("/system/kernelz")).json()
     steps = kernelz["Widget"]["create"]
-    assert "HANDLER:hook:wire:tigrbl:v3:core:crud:ops:create@HANDLER" in steps
+    assert "HANDLER:hook:wire:tigrbl:core:crud:ops:create@HANDLER" in steps
 
 
 @pytest.mark.i9n

--- a/pkgs/standards/tigrbl/tests/i9n/test_schema_ctx_spec_integration.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_schema_ctx_spec_integration.py
@@ -197,7 +197,7 @@ async def test_schema_ctx_atomz(schema_ctx_client):
     client, _, _, _ = schema_ctx_client
     kernelz = (await client.get("/system/kernelz")).json()
     steps = kernelz["Widget"]["create"]
-    assert "HANDLER:hook:wire:tigrbl:v3:core:crud:ops:create@HANDLER" in steps
+    assert "HANDLER:hook:wire:tigrbl:core:crud:ops:create@HANDLER" in steps
 
 
 @pytest.mark.i9n

--- a/pkgs/standards/tigrbl/tests/i9n/test_storage_spec_integration.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_storage_spec_integration.py
@@ -114,7 +114,7 @@ async def test_storage_spec_atomz(api_client_v3):
     client, _, _, _ = api_client_v3
     kernelz = (await client.get("/system/kernelz")).json()
     steps = kernelz["Widget"]["create"]
-    assert "HANDLER:hook:wire:tigrbl:v3:core:crud:ops:create@HANDLER" in steps
+    assert "HANDLER:hook:wire:tigrbl:core:crud:ops:create@HANDLER" in steps
 
 
 @pytest.mark.i9n


### PR DESCRIPTION
## Summary
- fix tigrbl integration tests that referenced legacy v3 hook paths

## Testing
- `uv run --directory standards/tigrbl --package tigrbl ruff format .`
- `uv run --directory standards/tigrbl --package tigrbl ruff check . --fix`

No tests were run due to user request.

------
https://chatgpt.com/codex/tasks/task_e_68c1773df1a8832693e6c35880c67490