### PR TITLE
Skip Redis benchmark when Redis is unavailable

### DIFF
--- a/pkgs/standards/peagen/tests/perf/test_publisher_benchmarks.py
+++ b/pkgs/standards/peagen/tests/perf/test_publisher_benchmarks.py
@@ -1,9 +1,11 @@
 import os
-import pytest
 
+import pytest
+import redis
+
+from peagen.plugins.publishers.rabbitmq_publisher import RabbitMQPublisher
 from peagen.plugins.publishers.redis_publisher import RedisPublisher
 from peagen.plugins.publishers.webhook_publisher import WebhookPublisher
-from peagen.plugins.publishers.rabbitmq_publisher import RabbitMQPublisher
 
 
 @pytest.mark.perf
@@ -28,4 +30,7 @@ def test_redis_publisher_benchmark(benchmark):
     if not redis_url:
         pytest.skip("REDIS_URL not set")
     pub = RedisPublisher(uri=redis_url)
-    benchmark(pub.publish, "chan", {"msg": "x"})
+    try:
+        benchmark(pub.publish, "chan", {"msg": "x"})
+    except redis.exceptions.RedisError:
+        pytest.skip("Redis not available")


### PR DESCRIPTION
## Summary
- ensure Redis publisher benchmark is skipped when Redis cannot be reached

## Testing
- `uv run --package peagen --directory pkgs/standards/peagen ruff format .`
- `uv run --package peagen --directory pkgs/standards/peagen ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c178acfb9c8326a14e225eb4b1383c