### PR TITLE
fix: update tigrbl kernel step expectations

### DIFF
--- a/pkgs/standards/tigrbl/tests/i9n/test_schema_ctx_attributes_integration.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_schema_ctx_attributes_integration.py
@@ -166,7 +166,7 @@ async def test_schema_ctx_atomz(schema_ctx_client):
     client, _, _, _ = schema_ctx_client
     kernelz = (await client.get("/system/kernelz")).json()
     steps = kernelz["Widget"]["create"]
-    assert "HANDLER:hook:wire:tigrbl:v3:core:crud:ops:create@HANDLER" in steps
+    assert "HANDLER:hook:wire:tigrbl:core:crud:ops:create@HANDLER" in steps
 
 
 @pytest.mark.i9n

--- a/pkgs/standards/tigrbl/tests/i9n/test_schema_ctx_spec_integration.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_schema_ctx_spec_integration.py
@@ -197,7 +197,7 @@ async def test_schema_ctx_atomz(schema_ctx_client):
     client, _, _, _ = schema_ctx_client
     kernelz = (await client.get("/system/kernelz")).json()
     steps = kernelz["Widget"]["create"]
-    assert "HANDLER:hook:wire:tigrbl:v3:core:crud:ops:create@HANDLER" in steps
+    assert "HANDLER:hook:wire:tigrbl:core:crud:ops:create@HANDLER" in steps
 
 
 @pytest.mark.i9n

--- a/pkgs/standards/tigrbl/tests/i9n/test_storage_spec_integration.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_storage_spec_integration.py
@@ -114,7 +114,7 @@ async def test_storage_spec_atomz(api_client_v3):
     client, _, _, _ = api_client_v3
     kernelz = (await client.get("/system/kernelz")).json()
     steps = kernelz["Widget"]["create"]
-    assert "HANDLER:hook:wire:tigrbl:v3:core:crud:ops:create@HANDLER" in steps
+    assert "HANDLER:hook:wire:tigrbl:core:crud:ops:create@HANDLER" in steps
 
 
 @pytest.mark.i9n


### PR DESCRIPTION
## Summary
- adjust tigrbl integration tests for collapsed v3 namespace

## Testing
- `uv run --package tigrbl --directory standards/tigrbl pytest tests/i9n/test_schema_ctx_attributes_integration.py::test_schema_ctx_atomz tests/i9n/test_schema_ctx_spec_integration.py::test_schema_ctx_atomz tests/i9n/test_storage_spec_integration.py::test_storage_spec_atomz -q`

------
https://chatgpt.com/codex/tasks/task_e_68c1785699948326920086d718b30ca1