### PR TITLE
chore: halt workflows on cancel

### DIFF
--- a/.github/workflows/0.7.0_mono_prepare_validate_publish.yaml
+++ b/.github/workflows/0.7.0_mono_prepare_validate_publish.yaml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   set-matrix:
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.get-matrix.outputs.matrix }}
@@ -54,6 +55,7 @@ jobs:
 
   test:
     needs: set-matrix
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJson(needs.set-matrix.outputs.matrix) }}
@@ -149,7 +151,7 @@ jobs:
     name: Commit Changes
     needs: test
     runs-on: ubuntu-latest
-    if: always()
+    if: ${{ !cancelled() && always() }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -205,7 +207,7 @@ jobs:
   release:
     needs: [commit, set-matrix]
     runs-on: ubuntu-latest
-    if: always()
+    if: ${{ !cancelled() && always() }}
     strategy:
       matrix: ${{ fromJson(needs.set-matrix.outputs.matrix) }}
       fail-fast: false

--- a/.github/workflows/docs-apps-deployment.yaml
+++ b/.github/workflows/docs-apps-deployment.yaml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   deploy-apps:
+    if: ${{ !cancelled() }}
     runs-on: [docs]
     steps:
       - name: Checkout repository

--- a/.github/workflows/docs-infra-deployment.yaml
+++ b/.github/workflows/docs-infra-deployment.yaml
@@ -4,6 +4,7 @@ on:
 
 jobs:
   deploy-infra:
+    if: ${{ !cancelled() }}
     runs-on: [docs]
     steps:
       - name: Checkout repository

--- a/.github/workflows/peagen_ci.yml
+++ b/.github/workflows/peagen_ci.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   deploy:
+    if: ${{ !cancelled() }}
     runs-on: peagenx
     env:
       # --- non-secret values ---

--- a/.github/workflows/peagen_infra_ci.yaml
+++ b/.github/workflows/peagen_infra_ci.yaml
@@ -11,6 +11,7 @@ concurrency:
 
 jobs:
   deploy:
+    if: ${{ !cancelled() }}
     runs-on: peagenx
     env:
       # --- non-secret values ---

--- a/.github/workflows/v0.7.0_matrix_test.yaml
+++ b/.github/workflows/v0.7.0_matrix_test.yaml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   set-matrix:
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.get-matrix.outputs.matrix }}
@@ -44,6 +45,7 @@ jobs:
 
   test:
     needs: set-matrix
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJson(needs.set-matrix.outputs.matrix) }}

--- a/.github/workflows/v0.7.0_mono_prepare_validate.yaml
+++ b/.github/workflows/v0.7.0_mono_prepare_validate.yaml
@@ -9,6 +9,7 @@ concurrency:
 
 jobs:
   set-matrix:
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.get-matrix.outputs.matrix }}
@@ -51,6 +52,7 @@ jobs:
 
   test:
     needs: set-matrix
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJson(needs.set-matrix.outputs.matrix) }}
@@ -140,7 +142,7 @@ jobs:
     name: Commit Changes
     needs: test
     runs-on: ubuntu-latest
-    if: always()
+    if: ${{ !cancelled() && always() }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/v0.7.0_validate_changed_files.yaml
+++ b/.github/workflows/v0.7.0_validate_changed_files.yaml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   detect-changed-files:
+    if: ${{ !cancelled() }}
     runs-on: [testing]
     outputs:
       matrix: ${{ steps.detect.outputs.matrix }}
@@ -91,7 +92,7 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────────────
   run-tests:
     needs: detect-changed-files
-    if: ${{ needs.detect-changed-files.outputs.matrix != '[]' }}
+    if: ${{ !cancelled() && needs.detect-changed-files.outputs.matrix != '[]' }}
     runs-on: [testing]
     strategy:
       fail-fast: false

--- a/.github/workflows/v0.7.3_single_prepare_validate.yaml
+++ b/.github/workflows/v0.7.3_single_prepare_validate.yaml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   test:
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     # We'll continue on error to ensure we capture all issues and still produce patches/artifacts
     continue-on-error: true
@@ -103,7 +104,7 @@ jobs:
     name: Commit Changes
     needs: test
     runs-on: ubuntu-latest
-    if: always()
+    if: ${{ !cancelled() && always() }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/v0.7.3_single_prepare_validate_publish.yaml
+++ b/.github/workflows/v0.7.3_single_prepare_validate_publish.yaml
@@ -20,6 +20,7 @@ concurrency:
 
 jobs:
   test:
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
@@ -110,7 +111,7 @@ jobs:
     name: Commit Changes
     needs: test
     runs-on: ubuntu-latest
-    if: always()
+    if: ${{ !cancelled() && always() }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -163,7 +164,7 @@ jobs:
   release:
     needs: [commit]
     runs-on: ubuntu-latest
-    if: always()
+    if: ${{ !cancelled() && always() }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
- ensure workflow jobs stop when run is cancelled while normal failures still proceed

## Testing
- `yamllint .github/workflows`

------
https://chatgpt.com/codex/tasks/task_e_68c344de6d28832680821e3a58212d63