### PR TITLE
docs: improve in-memory key provider documentation

### DIFF
--- a/pkgs/standards/swarmauri_keyprovider_inmemory/README.md
+++ b/pkgs/standards/swarmauri_keyprovider_inmemory/README.md
@@ -2,7 +2,7 @@
 
 # Swarmauri In‑Memory Key Provider
 
-Volatile, in‑memory key provider for Swarmauri. All key material is kept strictly in process memory (no disk writes). Ideal for testing, CI, and ephemeral gateways.
+Volatile, in‑memory key provider for Swarmauri. All key material is kept strictly in process memory (no disk writes). Ideal for testing, CI, and ephemeral gateways where persistence is not desired. Not intended for long‑term or production storage of secrets.
 
 ## Installation
 
@@ -79,6 +79,12 @@ asyncio.run(main())
 - Features: `create`, `import`, `rotate`, `destroy`, `list_versions`, `get_key`, `random_bytes`, `hkdf`
 - No persistence: data is lost when the process exits
 - Not supported: JWK/JWKS export (will raise `NotImplementedError`)
+
+## Security Considerations
+
+- Keys exist only for the lifetime of the Python process; restarting drops all material.
+- No hardware isolation or disk persistence is provided.
+- Use only for development, CI, or other ephemeral scenarios.
 
 ## Notes
 

--- a/pkgs/standards/swarmauri_keyprovider_inmemory/swarmauri_keyprovider_inmemory/InMemoryKeyProvider.py
+++ b/pkgs/standards/swarmauri_keyprovider_inmemory/swarmauri_keyprovider_inmemory/InMemoryKeyProvider.py
@@ -1,3 +1,5 @@
+"""In-memory key provider plugin storing keys solely in process memory."""
+
 from __future__ import annotations
 
 from typing import Dict, Iterable, Mapping, Optional, Tuple, Literal
@@ -11,15 +13,28 @@ from swarmauri_core.keys.types import KeySpec, KeyClass
 
 
 class InMemoryKeyProvider(KeyProviderBase):
-    """Simple in-memory key provider for testing or ephemeral usage."""
+    """In-memory key provider for testing or ephemeral environments.
+
+    Keys are held only in the Python process and disappear when the process
+    terminates. This makes the provider suitable for CI pipelines or local
+    development where persistence is undesirable.
+    """
 
     type: Literal["InMemoryKeyProvider"] = "InMemoryKeyProvider"
 
     def __init__(self, **kwargs) -> None:
+        """Initialize the provider.
+
+        **kwargs (Any): Additional arguments forwarded to the base class.
+        """
         super().__init__(**kwargs)
         self._store: Dict[str, Dict[int, KeyRef]] = {}
 
     def supports(self) -> Mapping[str, Iterable[str]]:
+        """Describe supported key classes, algorithms, and features.
+
+        RETURNS (Mapping[str, Iterable[str]]): Provider capability mapping.
+        """
         return {
             "class": ("sym", "asym"),
             "algs": (),
@@ -27,6 +42,11 @@ class InMemoryKeyProvider(KeyProviderBase):
         }
 
     async def create_key(self, spec: KeySpec) -> KeyRef:
+        """Create a new key.
+
+        spec (KeySpec): Specification for the key to create.
+        RETURNS (KeyRef): Reference to the created key.
+        """
         kid = secrets.token_hex(8)
         version = 1
         material = secrets.token_bytes(32)
@@ -53,6 +73,13 @@ class InMemoryKeyProvider(KeyProviderBase):
         *,
         public: Optional[bytes] = None,
     ) -> KeyRef:
+        """Import existing key material.
+
+        spec (KeySpec): Specification of the key to import.
+        material (bytes): Secret key material.
+        public (bytes): Optional public component.
+        RETURNS (KeyRef): Reference to the imported key.
+        """
         kid = secrets.token_hex(8)
         version = 1
         ref = KeyRef(
@@ -75,6 +102,13 @@ class InMemoryKeyProvider(KeyProviderBase):
     async def rotate_key(
         self, kid: str, *, spec_overrides: Optional[dict] = None
     ) -> KeyRef:
+        """Rotate an existing key to a new version.
+
+        kid (str): Identifier of the key to rotate.
+        spec_overrides (dict): Optional overrides for the key spec.
+        RETURNS (KeyRef): Reference to the rotated key.
+        RAISES (KeyError): If the key identifier is unknown.
+        """
         bucket = self._store.get(kid)
         if not bucket:
             raise KeyError(f"Unknown kid: {kid}")
@@ -97,6 +131,12 @@ class InMemoryKeyProvider(KeyProviderBase):
         return ref
 
     async def destroy_key(self, kid: str, version: Optional[int] = None) -> bool:
+        """Destroy key versions.
+
+        kid (str): Key identifier.
+        version (int): Specific version to delete. Deletes all if not provided.
+        RETURNS (bool): True if a key was removed.
+        """
         bucket = self._store.get(kid)
         if not bucket:
             return False
@@ -115,27 +155,63 @@ class InMemoryKeyProvider(KeyProviderBase):
         *,
         include_secret: bool = False,
     ) -> KeyRef:
+        """Retrieve a key version.
+
+        kid (str): Key identifier.
+        version (int): Specific version. Defaults to latest.
+        include_secret (bool): When False, secret material may be omitted.
+        RETURNS (KeyRef): Requested key reference.
+        """
         bucket = self._store[kid]
         v = version or max(bucket)
         return bucket[v]
 
     async def list_versions(self, kid: str) -> Tuple[int, ...]:
+        """List available versions for a key.
+
+        kid (str): Key identifier.
+        RETURNS (Tuple[int, ...]): Sorted tuple of versions.
+        RAISES (KeyError): If the key identifier is unknown.
+        """
         bucket = self._store.get(kid)
         if not bucket:
             raise KeyError(f"Unknown kid: {kid}")
         return tuple(sorted(bucket.keys()))
 
     async def get_public_jwk(self, kid: str, version: Optional[int] = None) -> dict:
+        """Export a public key in JWK format.
+
+        kid (str): Key identifier.
+        version (int): Specific version.
+        RAISES (NotImplementedError): JWK export is not supported.
+        """
         raise NotImplementedError("JWK export not supported")
 
     async def jwks(self, *, prefix_kids: Optional[str] = None) -> dict:
+        """Return all public keys in JWKS format.
+
+        prefix_kids (str): Optional key ID prefix filter.
+        RAISES (NotImplementedError): JWKS export is not supported.
+        """
         raise NotImplementedError("JWKS export not supported")
 
     async def random_bytes(self, n: int) -> bytes:
+        """Return cryptographically secure random bytes.
+
+        n (int): Number of bytes to generate.
+        RETURNS (bytes): Random byte string.
+        """
         return secrets.token_bytes(n)
 
     async def hkdf(self, ikm: bytes, *, salt: bytes, info: bytes, length: int) -> bytes:
-        """Derive key material using HKDF-SHA256."""
+        """Derive key material using HKDF-SHA256.
+
+        ikm (bytes): Input keying material.
+        salt (bytes): Salt value.
+        info (bytes): Context-specific information.
+        length (int): Desired output length in bytes.
+        RETURNS (bytes): Derived key material.
+        """
         prk = hmac.new(salt, ikm, hashlib.sha256).digest()
         t = b""
         okm = b""


### PR DESCRIPTION
## Summary
- clarify ephemeral usage and security notes for in-memory key provider
- add spaCy-style docstrings to InMemoryKeyProvider methods

## Testing
- `uv run --directory standards/swarmauri_keyprovider_inmemory --package swarmauri_keyprovider_inmemory ruff format .`
- `uv run --directory standards/swarmauri_keyprovider_inmemory --package swarmauri_keyprovider_inmemory ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c3580469e483268001530fc207778c