### PR TITLE
Fix docs generation for standards and community packages

### DIFF
--- a/infra/docs/swarmauri-sdk/api_manifest.yaml
+++ b/infra/docs/swarmauri-sdk/api_manifest.yaml
@@ -24,6 +24,7 @@ targets:
   # Discover all packages under standards
   - name: Standards
     search_path: /pkgs/standards
+    discover: true  # automatically include each package in this directory
     include:
       - "*.*"  # all modules within discovered packages
       - swarmauri_certs_composite.*
@@ -33,8 +34,9 @@ targets:
   # Discover all packages under community
   - name: Community
     search_path: /pkgs/community
+    discover: true  # ensures docs are generated for all community packages
     include:
-      - "*."
+      - "*.*"
     exclude:
       - "*.tests.*"
 

--- a/pkgs/community/zdx/README.md
+++ b/pkgs/community/zdx/README.md
@@ -45,3 +45,50 @@ zdx serve --docs-dir /path/to/docs
 ```bash
 zdx serve --generate --docs-dir /path/to/docs --manifest api_manifest.yaml
 ```
+
+## API Manifest
+
+`zdx` uses a YAML manifest to decide which Python packages to document and how
+those pages are organized. Each project keeps its manifest alongside the docs
+sources. This repository includes manifests for:
+
+| Path | Purpose |
+| --- | --- |
+| `infra/docs/swarmauri-sdk/api_manifest.yaml` | Generates API docs for the SDK packages. |
+| `infra/docs/peagen/api_manifest.yaml` | Drives documentation for the `peagen` tool. |
+| `infra/docs/tigrbl/api_manifest.yaml` | Builds docs for the `tigrbl` project. |
+| `pkgs/community/zdx/api_manifest.yaml` | Template manifest for new sites. |
+
+### Manifest Schema
+
+An `api_manifest.yaml` file defines a list of **targets**. Each target produces
+Markdown pages under `docs/api/<name>/` and a corresponding navigation entry in
+the MkDocs configuration.
+
+```yaml
+targets:
+  - name: Core
+    package: swarmauri_core
+    search_path: /pkgs/core
+    include:
+      - swarmauri_core.*
+    exclude:
+      - "*.tests.*"
+```
+
+Every field controls a different part of the generation process:
+
+| Field | Description |
+| --- | --- |
+| `name` | Label used for the top‑level navigation item and the folder under `docs/api/`. |
+| `search_path` | Directory containing the source package(s). The generator scans this path for modules. |
+| `package` | Root import name when documenting a single package. Omit when using `discover`. |
+| `discover` | When `true`, automatically finds all packages under `search_path` and builds docs for each. Generates separate folders and nav entries per package. |
+| `include` | Glob patterns of fully qualified modules to include. Classes from matching modules get individual Markdown files. |
+| `exclude` | Glob patterns of modules to skip. Use to drop tests or experimental code from the docs. |
+
+For each module that survives the include/exclude filters, `zdx` writes a page
+per public class. Pages land in
+`docs/api/<name>/<module path>/<Class>.md` and a simple `index.md` is created if
+one does not exist. The navigation section for the target is appended to
+`mkdocs.yml`, ensuring the new pages appear in the rendered site.

--- a/pkgs/community/zdx/api_manifest.yaml
+++ b/pkgs/community/zdx/api_manifest.yaml
@@ -1,2 +1,16 @@
-# Default API manifest placeholder
-# Add packages to generate API docs
+# API manifest template for zdx
+#
+# Configure a list of `targets` to control which Python packages are documented.
+# Each target becomes a section under `docs/api/<name>/` and is added to the
+# MkDocs navigation.
+
+targets:
+  - name: Example  # Navigation label and output folder name
+    search_path: /pkgs/example  # Directory containing the source package(s)
+    package: example_pkg  # Root import name when documenting a single package
+    # discover: true  # Uncomment to automatically include all packages under search_path
+    include:
+      - example_pkg.*  # Glob patterns of modules to document
+    exclude:
+      - "*.tests.*"  # Glob patterns of modules to skip
+

--- a/pkgs/community/zdx/tests/test_gen_api.py
+++ b/pkgs/community/zdx/tests/test_gen_api.py
@@ -1,0 +1,39 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "zdx"))
+from zdx.scripts.gen_api import Target, load_manifest, process_target
+
+
+def test_load_manifest_default_include(tmp_path):
+    manifest = tmp_path / "api_manifest.yaml"
+    manifest.write_text("targets:\n- name: Foo\n  search_path: pkgs/foo\n")
+    targets = load_manifest(str(manifest))
+    assert targets[0].include == ["*.*"]
+
+
+def test_process_target_discovers_packages(tmp_path):
+    docs_root = tmp_path
+    pkg_root = docs_root / "pkgs" / "community" / "test_pkg" / "test_pkg"
+    pkg_root.mkdir(parents=True)
+    (pkg_root / "__init__.py").write_text("")
+    (pkg_root / "mod.py").write_text("class MyClass:\n    pass\n")
+
+    target = Target(
+        name="Community",
+        search_path="pkgs/community",
+        discover=True,
+        include=["*.*"],
+        exclude=[],
+    )
+    cache = {}
+    module_classes = process_target(
+        docs_root=str(docs_root),
+        api_output_dir="api",
+        target=target,
+        cache=cache,
+        changed_only=False,
+    )
+    assert "test_pkg.mod" in module_classes
+    doc_file = docs_root / "docs" / "api" / "community" / "test_pkg" / "MyClass.md"
+    assert doc_file.is_file()

--- a/pkgs/community/zdx/zdx/scripts/gen_api.py
+++ b/pkgs/community/zdx/zdx/scripts/gen_api.py
@@ -35,7 +35,7 @@ def load_manifest(path: str) -> List[Target]:
                 search_path=t["search_path"],
                 package=t.get("package"),
                 discover=bool(t.get("discover", False)),
-                include=t.get("include", ["*."]),
+                include=t.get("include", ["*.*"]),
                 exclude=t.get("exclude", []),
             )
         )
@@ -256,13 +256,13 @@ def process_target(
         for entry in discover_packages(search_path):
             pkg_name = os.path.basename(entry[1])  # the inner dir name
             # entry[1] is search_path/<pkg>, package dir is the same basename
-            packages.append((pkg_name, search_path))
+            packages.append((pkg_name, entry[1]))
     else:
         if not target.package:
             return {}
         packages.append((target.package, search_path))
 
-    includes = target.include or ["*."]
+    includes = target.include or ["*.*"]
     excludes = target.exclude or []
 
     module_classes: Dict[str, List[str]] = {}


### PR DESCRIPTION
## Summary
- enable discovery for standards and community packages in docs manifest
- correct zdx generator to discover packages properly and default include pattern
- add tests covering manifest defaults and discovery
- clarify manifest comment about discovery requirement
- document API manifest schema and example configurations in zdx docs

## Testing
- `uv run --package zdx --directory pkgs/community/zdx ruff format .`
- `uv run --package zdx --directory pkgs/community/zdx ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c451368b1083269f0acab4424c0157