### PR TITLE
chore: replace Cloudinary logo links

### DIFF
--- a/infra/docs/swarmauri-sdk/docs/index.md
+++ b/infra/docs/swarmauri-sdk/docs/index.md
@@ -1,6 +1,6 @@
 # Welcome to Swarmauri
 
-![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri/">

--- a/pkgs/base/README.md
+++ b/pkgs/base/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri-base/">

--- a/pkgs/community/swarmauri_certs_acme/README.md
+++ b/pkgs/community/swarmauri_certs_acme/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_certs_acme/">

--- a/pkgs/community/swarmauri_certs_azure/README.md
+++ b/pkgs/community/swarmauri_certs_azure/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_certs_azure/">

--- a/pkgs/community/swarmauri_certs_cfssl/README.md
+++ b/pkgs/community/swarmauri_certs_cfssl/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_certs_cfssl/">

--- a/pkgs/community/swarmauri_certs_crlverifyservice/README.md
+++ b/pkgs/community/swarmauri_certs_crlverifyservice/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_certs_crlverifyservice/">

--- a/pkgs/community/swarmauri_certs_csronly/README.md
+++ b/pkgs/community/swarmauri_certs_csronly/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_certs_csronly/">

--- a/pkgs/community/swarmauri_certs_ocspverify/README.md
+++ b/pkgs/community/swarmauri_certs_ocspverify/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_certs_ocspverify/">

--- a/pkgs/community/swarmauri_certservice_aws_kms/README.md
+++ b/pkgs/community/swarmauri_certservice_aws_kms/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_certservice_aws_kms/">

--- a/pkgs/community/swarmauri_certservice_gcpkms/README.md
+++ b/pkgs/community/swarmauri_certservice_gcpkms/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_certservice_gcpkms/">

--- a/pkgs/community/swarmauri_certservice_ms_adcs/README.md
+++ b/pkgs/community/swarmauri_certservice_ms_adcs/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_certservice_ms_adcs/">

--- a/pkgs/community/swarmauri_certservice_scep/README.md
+++ b/pkgs/community/swarmauri_certservice_scep/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_certservice_scep/">

--- a/pkgs/community/swarmauri_certservice_stepca/README.md
+++ b/pkgs/community/swarmauri_certservice_stepca/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_certservice_stepca/">

--- a/pkgs/community/swarmauri_embedding_mlm/README.md
+++ b/pkgs/community/swarmauri_embedding_mlm/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_embedding_mlm/">

--- a/pkgs/community/swarmauri_keyprovider_aws_kms/README.md
+++ b/pkgs/community/swarmauri_keyprovider_aws_kms/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_keyprovider_aws_kms/">

--- a/pkgs/community/swarmauri_keyprovider_gcpkms/README.md
+++ b/pkgs/community/swarmauri_keyprovider_gcpkms/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_keyprovider_gcpkms/">

--- a/pkgs/community/swarmauri_keyprovider_vaulttransit/README.md
+++ b/pkgs/community/swarmauri_keyprovider_vaulttransit/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_keyprovider_vaulttransit/">

--- a/pkgs/community/swarmauri_llm_leptonai/README.md
+++ b/pkgs/community/swarmauri_llm_leptonai/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_llm_leptonai/">

--- a/pkgs/community/swarmauri_measurement_mutualinformation/README.md
+++ b/pkgs/community/swarmauri_measurement_mutualinformation/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_measurement_mutualinformation/">

--- a/pkgs/community/swarmauri_measurement_tokencountestimator/README.md
+++ b/pkgs/community/swarmauri_measurement_tokencountestimator/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_measurement_tokencountestimator/">

--- a/pkgs/community/swarmauri_middleware_circuitbreaker/README.md
+++ b/pkgs/community/swarmauri_middleware_circuitbreaker/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_middleware_circuitbreaker/">

--- a/pkgs/community/swarmauri_middleware_ratepolicy/README.md
+++ b/pkgs/community/swarmauri_middleware_ratepolicy/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_middleware_ratepolicy/">

--- a/pkgs/community/swarmauri_ocr_pytesseract/README.md
+++ b/pkgs/community/swarmauri_ocr_pytesseract/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_ocr_pytesseract/">

--- a/pkgs/community/swarmauri_parser_bertembedding/README.md
+++ b/pkgs/community/swarmauri_parser_bertembedding/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_parser_bertembedding/">

--- a/pkgs/community/swarmauri_parser_entityrecognition/README.md
+++ b/pkgs/community/swarmauri_parser_entityrecognition/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_parser_entityrecognition/">

--- a/pkgs/community/swarmauri_parser_fitzpdf/README.md
+++ b/pkgs/community/swarmauri_parser_fitzpdf/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_parser_fitzpdf/">

--- a/pkgs/community/swarmauri_parser_pypdf2/README.md
+++ b/pkgs/community/swarmauri_parser_pypdf2/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_parser_pypdf2/">

--- a/pkgs/community/swarmauri_parser_pypdftk/README.md
+++ b/pkgs/community/swarmauri_parser_pypdftk/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_parser_pypdftk/">

--- a/pkgs/community/swarmauri_parser_slate/README.md
+++ b/pkgs/community/swarmauri_parser_slate/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <div align="center">
 

--- a/pkgs/community/swarmauri_parser_textblob/README.md
+++ b/pkgs/community/swarmauri_parser_textblob/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_parser_textblob/">

--- a/pkgs/community/swarmauri_state_clipboard/README.md
+++ b/pkgs/community/swarmauri_state_clipboard/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_state_clipboard/">

--- a/pkgs/community/swarmauri_tool_captchagenerator/README.md
+++ b/pkgs/community/swarmauri_tool_captchagenerator/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_captchagenerator/">

--- a/pkgs/community/swarmauri_tool_dalechallreadability/README.md
+++ b/pkgs/community/swarmauri_tool_dalechallreadability/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_dalechallreadability/">

--- a/pkgs/community/swarmauri_tool_downloadpdf/README.md
+++ b/pkgs/community/swarmauri_tool_downloadpdf/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_downloadpdf/">

--- a/pkgs/community/swarmauri_tool_entityrecognition/README.md
+++ b/pkgs/community/swarmauri_tool_entityrecognition/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_entityrecognition/">

--- a/pkgs/community/swarmauri_tool_folium/README.md
+++ b/pkgs/community/swarmauri_tool_folium/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_folium/">

--- a/pkgs/community/swarmauri_tool_gmail/README.md
+++ b/pkgs/community/swarmauri_tool_gmail/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_gmail/">

--- a/pkgs/community/swarmauri_tool_jupyterclearoutput/README.md
+++ b/pkgs/community/swarmauri_tool_jupyterclearoutput/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupyterclearoutput/">

--- a/pkgs/community/swarmauri_tool_jupyterdisplay/README.md
+++ b/pkgs/community/swarmauri_tool_jupyterdisplay/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupyterdisplay/">

--- a/pkgs/community/swarmauri_tool_jupyterdisplayhtml/README.md
+++ b/pkgs/community/swarmauri_tool_jupyterdisplayhtml/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupyterdisplayhtml/">

--- a/pkgs/community/swarmauri_tool_jupyterexecuteandconvert/README.md
+++ b/pkgs/community/swarmauri_tool_jupyterexecuteandconvert/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupyterexecuteandconvert/">

--- a/pkgs/community/swarmauri_tool_jupyterexecutecell/README.md
+++ b/pkgs/community/swarmauri_tool_jupyterexecutecell/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupyterexecutecell/">

--- a/pkgs/community/swarmauri_tool_jupyterexecutenotebook/README.md
+++ b/pkgs/community/swarmauri_tool_jupyterexecutenotebook/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupyterexecutenotebook/">

--- a/pkgs/community/swarmauri_tool_jupyterexecutenotebookwithparameters/README.md
+++ b/pkgs/community/swarmauri_tool_jupyterexecutenotebookwithparameters/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupyterexecutenotebookwithparameters/">

--- a/pkgs/community/swarmauri_tool_jupyterexporthtml/README.md
+++ b/pkgs/community/swarmauri_tool_jupyterexporthtml/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupyterexporthtml/">

--- a/pkgs/community/swarmauri_tool_jupyterexportlatex/README.md
+++ b/pkgs/community/swarmauri_tool_jupyterexportlatex/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupyterexportlatex/">

--- a/pkgs/community/swarmauri_tool_jupyterexportmarkdown/README.md
+++ b/pkgs/community/swarmauri_tool_jupyterexportmarkdown/README.md
@@ -13,7 +13,7 @@
 
 
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupyterexportmarkdown/">

--- a/pkgs/community/swarmauri_tool_jupyterexportpython/README.md
+++ b/pkgs/community/swarmauri_tool_jupyterexportpython/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupyterexportpython/">

--- a/pkgs/community/swarmauri_tool_jupyterfromdict/README.md
+++ b/pkgs/community/swarmauri_tool_jupyterfromdict/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupyterfromdict/">

--- a/pkgs/community/swarmauri_tool_jupytergetiopubmessage/README.md
+++ b/pkgs/community/swarmauri_tool_jupytergetiopubmessage/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupytergetiopubmessage/">

--- a/pkgs/community/swarmauri_tool_jupytergetshellmessage/README.md
+++ b/pkgs/community/swarmauri_tool_jupytergetshellmessage/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupytergetshellmessage/">

--- a/pkgs/community/swarmauri_tool_jupyterreadnotebook/README.md
+++ b/pkgs/community/swarmauri_tool_jupyterreadnotebook/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupyterreadnotebook/">

--- a/pkgs/community/swarmauri_tool_jupyterruncell/README.md
+++ b/pkgs/community/swarmauri_tool_jupyterruncell/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupyterruncell/">

--- a/pkgs/community/swarmauri_tool_jupytershutdownkernel/README.md
+++ b/pkgs/community/swarmauri_tool_jupytershutdownkernel/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupytershutdownkernel/">

--- a/pkgs/community/swarmauri_tool_jupyterstartkernel/README.md
+++ b/pkgs/community/swarmauri_tool_jupyterstartkernel/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupyterstartkernel/">

--- a/pkgs/community/swarmauri_tool_jupytervalidatenotebook/README.md
+++ b/pkgs/community/swarmauri_tool_jupytervalidatenotebook/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupytervalidatenotebook/">

--- a/pkgs/community/swarmauri_tool_jupyterwritenotebook/README.md
+++ b/pkgs/community/swarmauri_tool_jupyterwritenotebook/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupyterwritenotebook/">

--- a/pkgs/community/swarmauri_tool_lexicaldensity/README.md
+++ b/pkgs/community/swarmauri_tool_lexicaldensity/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_lexicaldensity/">

--- a/pkgs/community/swarmauri_tool_psutil/README.md
+++ b/pkgs/community/swarmauri_tool_psutil/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_psutil/">

--- a/pkgs/community/swarmauri_tool_qrcodegenerator/README.md
+++ b/pkgs/community/swarmauri_tool_qrcodegenerator/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_qrcodegenerator/">

--- a/pkgs/community/swarmauri_tool_searchword/README.md
+++ b/pkgs/community/swarmauri_tool_searchword/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_searchword/">

--- a/pkgs/community/swarmauri_tool_sentencecomplexity/README.md
+++ b/pkgs/community/swarmauri_tool_sentencecomplexity/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_sentencecomplexity/">

--- a/pkgs/community/swarmauri_tool_sentimentanalysis/README.md
+++ b/pkgs/community/swarmauri_tool_sentimentanalysis/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_sentimentanalysis/">

--- a/pkgs/community/swarmauri_tool_smogindex/README.md
+++ b/pkgs/community/swarmauri_tool_smogindex/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_smogindex/">

--- a/pkgs/community/swarmauri_tool_textlength/README.md
+++ b/pkgs/community/swarmauri_tool_textlength/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_textlength/">

--- a/pkgs/community/swarmauri_tool_webscraping/README.md
+++ b/pkgs/community/swarmauri_tool_webscraping/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_webscraping/">

--- a/pkgs/community/swarmauri_tool_zapierhook/README.md
+++ b/pkgs/community/swarmauri_tool_zapierhook/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_zapierhook/">

--- a/pkgs/community/swarmauri_toolkit_github/README.md
+++ b/pkgs/community/swarmauri_toolkit_github/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_toolkit_github/">

--- a/pkgs/community/swarmauri_toolkit_jupytertoolkit/README.md
+++ b/pkgs/community/swarmauri_toolkit_jupytertoolkit/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_toolkit_jupytertoolkit/">

--- a/pkgs/community/swarmauri_vectorstore_annoy/README.md
+++ b/pkgs/community/swarmauri_vectorstore_annoy/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_vectorstore_annoy/">

--- a/pkgs/community/swarmauri_vectorstore_cloudweaviate/README.md
+++ b/pkgs/community/swarmauri_vectorstore_cloudweaviate/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_vectorstore_cloudweaviate/">

--- a/pkgs/community/swarmauri_vectorstore_duckdb/README.md
+++ b/pkgs/community/swarmauri_vectorstore_duckdb/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_vectorstore_duckdb/">

--- a/pkgs/community/swarmauri_vectorstore_mlm/README.md
+++ b/pkgs/community/swarmauri_vectorstore_mlm/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_vectorstore_mlm/">

--- a/pkgs/community/swarmauri_vectorstore_neo4j/README.md
+++ b/pkgs/community/swarmauri_vectorstore_neo4j/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_vectorstore_neo4j/">

--- a/pkgs/community/swarmauri_vectorstore_persistentchromadb/README.md
+++ b/pkgs/community/swarmauri_vectorstore_persistentchromadb/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_vectorstore_persistentchromadb/">

--- a/pkgs/community/swarmauri_vectorstore_pinecone/README.md
+++ b/pkgs/community/swarmauri_vectorstore_pinecone/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_vectorstore_pinecone/">

--- a/pkgs/community/swarmauri_vectorstore_qdrant/README.md
+++ b/pkgs/community/swarmauri_vectorstore_qdrant/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_vectorstore_qdrant/">

--- a/pkgs/community/swarmauri_vectorstore_redis/README.md
+++ b/pkgs/community/swarmauri_vectorstore_redis/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_vectorstore_redis/">

--- a/pkgs/community/swm_example_community_package/README.md
+++ b/pkgs/community/swm_example_community_package/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swm_example_community_package/">

--- a/pkgs/community/zdx/README.md
+++ b/pkgs/community/zdx/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 # ZDX
 

--- a/pkgs/core/README.md
+++ b/pkgs/core/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
 

--- a/pkgs/deprecated/swarmauri_documentstore_redis/README.md
+++ b/pkgs/deprecated/swarmauri_documentstore_redis/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_documentstore_redis/">

--- a/pkgs/deprecated/swarmauri_embedding_tfidf/README.md
+++ b/pkgs/deprecated/swarmauri_embedding_tfidf/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_embedding_tfidf/">

--- a/pkgs/deprecated/swarmauri_vectorstore_tfidf/README.md
+++ b/pkgs/deprecated/swarmauri_vectorstore_tfidf/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_vectorstore_tfidf/">

--- a/pkgs/experimental/6w/README.md
+++ b/pkgs/experimental/6w/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/sf/">

--- a/pkgs/experimental/6x/README.md
+++ b/pkgs/experimental/6x/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/sf/">

--- a/pkgs/experimental/6y/README.md
+++ b/pkgs/experimental/6y/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/sf/">

--- a/pkgs/experimental/6z/README.md
+++ b/pkgs/experimental/6z/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/sf/">

--- a/pkgs/experimental/77/README.md
+++ b/pkgs/experimental/77/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/sf/">

--- a/pkgs/experimental/9x/README.md
+++ b/pkgs/experimental/9x/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/sf/">

--- a/pkgs/experimental/CanonHttp/README.md
+++ b/pkgs/experimental/CanonHttp/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/http_client/">

--- a/pkgs/experimental/FastTokenizer/README.md
+++ b/pkgs/experimental/FastTokenizer/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/FastTokenizer/">

--- a/pkgs/experimental/catoml/README.md
+++ b/pkgs/experimental/catoml/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/catoml/">

--- a/pkgs/experimental/cayaml/README.md
+++ b/pkgs/experimental/cayaml/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/cayaml/">

--- a/pkgs/experimental/g9/README.md
+++ b/pkgs/experimental/g9/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/sf/">

--- a/pkgs/experimental/jaml/README.md
+++ b/pkgs/experimental/jaml/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/jaml/">

--- a/pkgs/experimental/jz/README.md
+++ b/pkgs/experimental/jz/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/sf/">

--- a/pkgs/experimental/ptree_dag_extension_example/README.md
+++ b/pkgs/experimental/ptree_dag_extension_example/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/ptree_dag_extension_example/">

--- a/pkgs/experimental/ptree_dag_extension_example/ptree_dag/templates/example_template_set/{{ PROJECT_ROOT }}/{{ PKG.NAME }}/README.md.j2
+++ b/pkgs/experimental/ptree_dag_extension_example/ptree_dag/templates/example_template_set/{{ PROJECT_ROOT }}/{{ PKG.NAME }}/README.md.j2
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/{{ PKG.NAME }}/">

--- a/pkgs/experimental/s_f/README.md
+++ b/pkgs/experimental/s_f/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/sf/">

--- a/pkgs/experimental/sfw/README.md
+++ b/pkgs/experimental/sfw/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/sf/">

--- a/pkgs/experimental/snt/README.md
+++ b/pkgs/experimental/snt/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/sf/">

--- a/pkgs/experimental/swarmauri_certs_pkcs11/README.md
+++ b/pkgs/experimental/swarmauri_certs_pkcs11/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 # Swarmauri Certs PKCS#11
 

--- a/pkgs/experimental/swarmauri_crypto_sodium/README.md
+++ b/pkgs/experimental/swarmauri_crypto_sodium/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_crypto_sodium/">

--- a/pkgs/experimental/swarmauri_keyprovider_pkcs11/README.md
+++ b/pkgs/experimental/swarmauri_keyprovider_pkcs11/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 # Swarmauri PKCS#11 Key Provider
 

--- a/pkgs/experimental/ye/README.md
+++ b/pkgs/experimental/ye/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/sf/">

--- a/pkgs/experimental/ymls/README.md
+++ b/pkgs/experimental/ymls/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/sf/">

--- a/pkgs/experimental/zr0/README.md
+++ b/pkgs/experimental/zr0/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/sf/">

--- a/pkgs/standards/peagen/README.md
+++ b/pkgs/standards/peagen/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/peagen/">

--- a/pkgs/standards/peagen/peagen/template_sets/component/{{ PROJECT_ROOT }}/{{ PACKAGE_ROOT }}/README.md.j2
+++ b/pkgs/standards/peagen/peagen/template_sets/component/{{ PROJECT_ROOT }}/{{ PACKAGE_ROOT }}/README.md.j2
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/{{ PACKAGE_ROOT }}/">

--- a/pkgs/standards/peagen/peagen/template_sets/no_requirements/{{ PROJECT_ROOT }}/{{ PKG.NAME }}/README.md.j2
+++ b/pkgs/standards/peagen/peagen/template_sets/no_requirements/{{ PROJECT_ROOT }}/{{ PKG.NAME }}/README.md.j2
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/{{ PKG.NAME }}/">

--- a/pkgs/standards/peagen/peagen/template_sets/swarmauri_community/{{ PROJ.ROOT }}/community/{{ PKG.NAME }}/README.md.j2
+++ b/pkgs/standards/peagen/peagen/template_sets/swarmauri_community/{{ PROJ.ROOT }}/community/{{ PKG.NAME }}/README.md.j2
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/{{ PKG.NAME }}/">

--- a/pkgs/standards/peagen/peagen/template_sets/swarmauri_standard_standalone/{{ PROJ.ROOT }}/standards/{{ PKG.NAME }}/README.md.j2
+++ b/pkgs/standards/peagen/peagen/template_sets/swarmauri_standard_standalone/{{ PROJ.ROOT }}/standards/{{ PKG.NAME }}/README.md.j2
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/{{ PKG.NAME }}/">

--- a/pkgs/standards/peagen/peagen/template_sets/test3/{{ PROJECT_ROOT }}/{{ PKG.NAME }}/README.md.j2
+++ b/pkgs/standards/peagen/peagen/template_sets/test3/{{ PROJECT_ROOT }}/{{ PKG.NAME }}/README.md.j2
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/{{ PKG.NAME }}/">

--- a/pkgs/standards/peagen/peagen/template_sets/test5/{{ PROJECT_ROOT }}/{{ PKG.NAME }}/README.md.j2
+++ b/pkgs/standards/peagen/peagen/template_sets/test5/{{ PROJECT_ROOT }}/{{ PKG.NAME }}/README.md.j2
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/{{ PKG.NAME }}/">

--- a/pkgs/standards/peagen_templset_vue/README.md
+++ b/pkgs/standards/peagen_templset_vue/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/peagen_templset_vue/">

--- a/pkgs/standards/swarmauri_certs_composite/README.md
+++ b/pkgs/standards/swarmauri_certs_composite/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_certs_composite/">

--- a/pkgs/standards/swarmauri_certs_local_ca/README.md
+++ b/pkgs/standards/swarmauri_certs_local_ca/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 # Swarmauri Certs Local CA
 

--- a/pkgs/standards/swarmauri_certs_remote_ca/README.md
+++ b/pkgs/standards/swarmauri_certs_remote_ca/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 # Swarmauri Remote CA Cert Service
 

--- a/pkgs/standards/swarmauri_certs_self_signed/README.md
+++ b/pkgs/standards/swarmauri_certs_self_signed/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 # Swarmauri Self-Signed Certificate Builder
 

--- a/pkgs/standards/swarmauri_certs_x509/README.md
+++ b/pkgs/standards/swarmauri_certs_x509/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_certs_x509/">

--- a/pkgs/standards/swarmauri_certs_x509verify/README.md
+++ b/pkgs/standards/swarmauri_certs_x509verify/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 # Swarmauri Certs X509 Verify
 

--- a/pkgs/standards/swarmauri_crypto_composite/README.md
+++ b/pkgs/standards/swarmauri_crypto_composite/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_crypto_composite/">

--- a/pkgs/standards/swarmauri_crypto_ecdh_es_a128kw/README.md
+++ b/pkgs/standards/swarmauri_crypto_ecdh_es_a128kw/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_crypto_ecdh_es_a128kw/">

--- a/pkgs/standards/swarmauri_crypto_jwe/README.md
+++ b/pkgs/standards/swarmauri_crypto_jwe/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_crypto_jwe/"><img src="https://img.shields.io/pypi/dm/swarmauri_crypto_jwe" alt="PyPI - Downloads"/></a>

--- a/pkgs/standards/swarmauri_crypto_nacl_pkcs11/README.md
+++ b/pkgs/standards/swarmauri_crypto_nacl_pkcs11/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_crypto_nacl_pkcs11/">

--- a/pkgs/standards/swarmauri_crypto_paramiko/README.md
+++ b/pkgs/standards/swarmauri_crypto_paramiko/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_crypto_paramiko/">

--- a/pkgs/standards/swarmauri_crypto_pgp/README.md
+++ b/pkgs/standards/swarmauri_crypto_pgp/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_crypto_pgp/">

--- a/pkgs/standards/swarmauri_crypto_rust/README.md
+++ b/pkgs/standards/swarmauri_crypto_rust/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_crypto_rust/">

--- a/pkgs/standards/swarmauri_distance_minkowski/README.md
+++ b/pkgs/standards/swarmauri_distance_minkowski/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_distance_minkowski/">

--- a/pkgs/standards/swarmauri_embedding_doc2vec/README.md
+++ b/pkgs/standards/swarmauri_embedding_doc2vec/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_embedding_doc2vec/">

--- a/pkgs/standards/swarmauri_embedding_nmf/README.md
+++ b/pkgs/standards/swarmauri_embedding_nmf/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_embedding_nmf/">

--- a/pkgs/standards/swarmauri_evaluator_abstractmethods/README.md
+++ b/pkgs/standards/swarmauri_evaluator_abstractmethods/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_evaluator_abstractmethods/">

--- a/pkgs/standards/swarmauri_evaluator_anyusage/README.md
+++ b/pkgs/standards/swarmauri_evaluator_anyusage/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_evaluator_anyusage/">

--- a/pkgs/standards/swarmauri_evaluator_constanttime/README.md
+++ b/pkgs/standards/swarmauri_evaluator_constanttime/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_evaluator_constanttime/">

--- a/pkgs/standards/swarmauri_evaluator_externalimports/README.md
+++ b/pkgs/standards/swarmauri_evaluator_externalimports/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_evaluator_externalimports/">

--- a/pkgs/standards/swarmauri_evaluator_subprocess/README.md
+++ b/pkgs/standards/swarmauri_evaluator_subprocess/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_evaluator_subprocess/">

--- a/pkgs/standards/swarmauri_evaluatorpool_accessibility/README.md
+++ b/pkgs/standards/swarmauri_evaluatorpool_accessibility/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_evaluatorpool_accessibility/">

--- a/pkgs/standards/swarmauri_gitfilter_file/README.md
+++ b/pkgs/standards/swarmauri_gitfilter_file/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_gitfilter_file/">

--- a/pkgs/standards/swarmauri_gitfilter_gh_release/README.md
+++ b/pkgs/standards/swarmauri_gitfilter_gh_release/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_gitfilter_gh_release/">

--- a/pkgs/standards/swarmauri_gitfilter_minio/README.md
+++ b/pkgs/standards/swarmauri_gitfilter_minio/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_gitfilter_minio/">

--- a/pkgs/standards/swarmauri_gitfilter_s3fs/README.md
+++ b/pkgs/standards/swarmauri_gitfilter_s3fs/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_gitfilter_s3fs/">

--- a/pkgs/standards/swarmauri_keyprovider_file/README.md
+++ b/pkgs/standards/swarmauri_keyprovider_file/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 # Swarmauri File Key Provider
 

--- a/pkgs/standards/swarmauri_keyprovider_hierarchical/README.md
+++ b/pkgs/standards/swarmauri_keyprovider_hierarchical/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 # Swarmauri Hierarchical Key Provider
 

--- a/pkgs/standards/swarmauri_keyprovider_inmemory/README.md
+++ b/pkgs/standards/swarmauri_keyprovider_inmemory/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 # Swarmauri In‑Memory Key Provider
 

--- a/pkgs/standards/swarmauri_keyprovider_local/README.md
+++ b/pkgs/standards/swarmauri_keyprovider_local/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_keyprovider_local/"><img src="https://img.shields.io/pypi/dm/swarmauri_keyprovider_local" alt="PyPI - Downloads"/></a>

--- a/pkgs/standards/swarmauri_keyprovider_remote_jwks/README.md
+++ b/pkgs/standards/swarmauri_keyprovider_remote_jwks/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 # Swarmauri Remote JWKS Key Provider
 

--- a/pkgs/standards/swarmauri_keyprovider_ssh/README.md
+++ b/pkgs/standards/swarmauri_keyprovider_ssh/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_keyprovider_ssh/"><img src="https://img.shields.io/pypi/dm/swarmauri_keyprovider_ssh" alt="PyPI - Downloads"/></a>

--- a/pkgs/standards/swarmauri_keyproviders_mirrored/README.md
+++ b/pkgs/standards/swarmauri_keyproviders_mirrored/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 # Swarmauri Mirrored Key Provider
 

--- a/pkgs/standards/swarmauri_middleware_auth/README.md
+++ b/pkgs/standards/swarmauri_middleware_auth/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri-middleware-auth/">

--- a/pkgs/standards/swarmauri_middleware_bulkhead/README.md
+++ b/pkgs/standards/swarmauri_middleware_bulkhead/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_middleware_bulkhead/">

--- a/pkgs/standards/swarmauri_middleware_cachecontrol/README.md
+++ b/pkgs/standards/swarmauri_middleware_cachecontrol/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_middleware_cachecontrol/">

--- a/pkgs/standards/swarmauri_middleware_cors/README.md
+++ b/pkgs/standards/swarmauri_middleware_cors/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_middleware_cors/">

--- a/pkgs/standards/swarmauri_middleware_exceptionhandling/README.md
+++ b/pkgs/standards/swarmauri_middleware_exceptionhandling/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_middleware_exceptionhadling/">

--- a/pkgs/standards/swarmauri_middleware_gzipcompression/README.md
+++ b/pkgs/standards/swarmauri_middleware_gzipcompression/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri-middleware-gzipcompression/">

--- a/pkgs/standards/swarmauri_middleware_httpsig/README.md
+++ b/pkgs/standards/swarmauri_middleware_httpsig/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_middleware_httpsig/">

--- a/pkgs/standards/swarmauri_middleware_jsonrpc/README.md
+++ b/pkgs/standards/swarmauri_middleware_jsonrpc/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_middleware_jsonrpc/">

--- a/pkgs/standards/swarmauri_middleware_jwksverifier/README.md
+++ b/pkgs/standards/swarmauri_middleware_jwksverifier/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 # Swarmauri Middleware JWKS Verifier
 

--- a/pkgs/standards/swarmauri_middleware_jwt/README.md
+++ b/pkgs/standards/swarmauri_middleware_jwt/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_middleware_jwt/">

--- a/pkgs/standards/swarmauri_middleware_llamaguard/README.md
+++ b/pkgs/standards/swarmauri_middleware_llamaguard/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri-middleware-llamaguard/">

--- a/pkgs/standards/swarmauri_middleware_logging/README.md
+++ b/pkgs/standards/swarmauri_middleware_logging/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_middleware_logging/">

--- a/pkgs/standards/swarmauri_middleware_ratelimit/README.md
+++ b/pkgs/standards/swarmauri_middleware_ratelimit/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_middleware_ratelimit/">

--- a/pkgs/standards/swarmauri_middleware_securityheaders/README.md
+++ b/pkgs/standards/swarmauri_middleware_securityheaders/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri-middleware-securityheaders/">

--- a/pkgs/standards/swarmauri_middleware_session/README.md
+++ b/pkgs/standards/swarmauri_middleware_session/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_middleware_session/">

--- a/pkgs/standards/swarmauri_middleware_stdio/README.md
+++ b/pkgs/standards/swarmauri_middleware_stdio/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_middleware_stdio/">

--- a/pkgs/standards/swarmauri_middleware_time/README.md
+++ b/pkgs/standards/swarmauri_middleware_time/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_middleware_time/">

--- a/pkgs/standards/swarmauri_mre_crypto_age/README.md
+++ b/pkgs/standards/swarmauri_mre_crypto_age/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_mre_crypto_age/">

--- a/pkgs/standards/swarmauri_mre_crypto_ecdh_es_kw/README.md
+++ b/pkgs/standards/swarmauri_mre_crypto_ecdh_es_kw/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_mre_crypto_ecdh_es_kw/">

--- a/pkgs/standards/swarmauri_mre_crypto_keyring/README.md
+++ b/pkgs/standards/swarmauri_mre_crypto_keyring/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 # Swarmauri MRE Crypto Keyring
 

--- a/pkgs/standards/swarmauri_mre_crypto_pgp/README.md
+++ b/pkgs/standards/swarmauri_mre_crypto_pgp/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_mre_crypto_pgp/">

--- a/pkgs/standards/swarmauri_mre_crypto_shamir/README.md
+++ b/pkgs/standards/swarmauri_mre_crypto_shamir/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_mre_crypto_shamir/">

--- a/pkgs/standards/swarmauri_parser_beautifulsoupelement/README.md
+++ b/pkgs/standards/swarmauri_parser_beautifulsoupelement/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_parser_beautifulsoupelement/">

--- a/pkgs/standards/swarmauri_parser_keywordextractor/README.md
+++ b/pkgs/standards/swarmauri_parser_keywordextractor/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_parser_keywordextractor/">

--- a/pkgs/standards/swarmauri_prompt_j2prompttemplate/README.md
+++ b/pkgs/standards/swarmauri_prompt_j2prompttemplate/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_j2prompttemplate/">

--- a/pkgs/standards/swarmauri_publisher_rabbitmq/README.md
+++ b/pkgs/standards/swarmauri_publisher_rabbitmq/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_publisher_rabbitmq/">

--- a/pkgs/standards/swarmauri_publisher_redis/README.md
+++ b/pkgs/standards/swarmauri_publisher_redis/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_publisher_redis/">

--- a/pkgs/standards/swarmauri_publisher_webhook/README.md
+++ b/pkgs/standards/swarmauri_publisher_webhook/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_publisher_webhook/">

--- a/pkgs/standards/swarmauri_signing_ca/README.md
+++ b/pkgs/standards/swarmauri_signing_ca/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 # Swarmauri Signing CA
 

--- a/pkgs/standards/swarmauri_signing_ecdsa/README.md
+++ b/pkgs/standards/swarmauri_signing_ecdsa/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 # Swarmauri Signing ECDSA
 

--- a/pkgs/standards/swarmauri_signing_ed25519/README.md
+++ b/pkgs/standards/swarmauri_signing_ed25519/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 # Swarmauri Signing Ed25519
 

--- a/pkgs/standards/swarmauri_signing_hmac/README.md
+++ b/pkgs/standards/swarmauri_signing_hmac/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri-signing-hmac/">

--- a/pkgs/standards/swarmauri_signing_jws/README.md
+++ b/pkgs/standards/swarmauri_signing_jws/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 # Swarmauri Signing JWS
 

--- a/pkgs/standards/swarmauri_signing_pgp/README.md
+++ b/pkgs/standards/swarmauri_signing_pgp/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_signing_pgp/">

--- a/pkgs/standards/swarmauri_signing_rsa/README.md
+++ b/pkgs/standards/swarmauri_signing_rsa/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 # Swarmauri Signing RSA
 

--- a/pkgs/standards/swarmauri_signing_secp256k1/README.md
+++ b/pkgs/standards/swarmauri_signing_secp256k1/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 # Swarmauri Signing Secp256k1
 

--- a/pkgs/standards/swarmauri_signing_ssh/README.md
+++ b/pkgs/standards/swarmauri_signing_ssh/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_signing_ssh/">

--- a/pkgs/standards/swarmauri_storage_file/README.md
+++ b/pkgs/standards/swarmauri_storage_file/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_storage_file/">

--- a/pkgs/standards/swarmauri_storage_github/README.md
+++ b/pkgs/standards/swarmauri_storage_github/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_storage_github/">

--- a/pkgs/standards/swarmauri_storage_github_release/README.md
+++ b/pkgs/standards/swarmauri_storage_github_release/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_storage_github_release/">

--- a/pkgs/standards/swarmauri_storage_minio/README.md
+++ b/pkgs/standards/swarmauri_storage_minio/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_storage_minio/">

--- a/pkgs/standards/swarmauri_tokens_composite/README.md
+++ b/pkgs/standards/swarmauri_tokens_composite/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tokens_composite/">

--- a/pkgs/standards/swarmauri_tokens_dpopboundjwt/README.md
+++ b/pkgs/standards/swarmauri_tokens_dpopboundjwt/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 # Swarmauri Tokens DPoP Bound JWT
 

--- a/pkgs/standards/swarmauri_tokens_introspection/README.md
+++ b/pkgs/standards/swarmauri_tokens_introspection/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri-token-introspection/">

--- a/pkgs/standards/swarmauri_tokens_jwt/README.md
+++ b/pkgs/standards/swarmauri_tokens_jwt/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tokens_jwt/">

--- a/pkgs/standards/swarmauri_tokens_paseto_v4/README.md
+++ b/pkgs/standards/swarmauri_tokens_paseto_v4/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 # Swarmauri Token Paseto V4
 

--- a/pkgs/standards/swarmauri_tokens_remoteoidc/README.md
+++ b/pkgs/standards/swarmauri_tokens_remoteoidc/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tokens_remoteoidc/">

--- a/pkgs/standards/swarmauri_tokens_rotatingjwt/README.md
+++ b/pkgs/standards/swarmauri_tokens_rotatingjwt/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tokens_rotatingjwt/">

--- a/pkgs/standards/swarmauri_tokens_sshcert/README.md
+++ b/pkgs/standards/swarmauri_tokens_sshcert/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tokens_sshcert/">

--- a/pkgs/standards/swarmauri_tokens_sshsig/README.md
+++ b/pkgs/standards/swarmauri_tokens_sshsig/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tokens_sshsig/">

--- a/pkgs/standards/swarmauri_tokens_tlsboundjwt/README.md
+++ b/pkgs/standards/swarmauri_tokens_tlsboundjwt/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 # Swarmauri Tokens TLS-Bound JWT
 

--- a/pkgs/standards/swarmauri_tool_containerfeedchars/README.md
+++ b/pkgs/standards/swarmauri_tool_containerfeedchars/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_containerfeedchars/">

--- a/pkgs/standards/swarmauri_tool_containermakepr/README.md
+++ b/pkgs/standards/swarmauri_tool_containermakepr/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_containermakepr/">

--- a/pkgs/standards/swarmauri_tool_containernewsession/README.md
+++ b/pkgs/standards/swarmauri_tool_containernewsession/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_containernewsession/">

--- a/pkgs/standards/swarmauri_tool_githubloader/README.md
+++ b/pkgs/standards/swarmauri_tool_githubloader/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_githubloader/">

--- a/pkgs/standards/swarmauri_tool_httploaded/README.md
+++ b/pkgs/standards/swarmauri_tool_httploaded/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_httploaded/">

--- a/pkgs/standards/swarmauri_tool_matplotlib/README.md
+++ b/pkgs/standards/swarmauri_tool_matplotlib/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_matplotlib/">

--- a/pkgs/standards/swarmauri_toolkit_containertoolkit/README.md
+++ b/pkgs/standards/swarmauri_toolkit_containertoolkit/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_toolkit_containertoolkit/">

--- a/pkgs/standards/swarmauri_vectorstore_doc2vec/README.md
+++ b/pkgs/standards/swarmauri_vectorstore_doc2vec/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_vectorstore_doc2vec/">

--- a/pkgs/standards/swm_example_package/README.md
+++ b/pkgs/standards/swm_example_package/README.md
@@ -1,5 +1,5 @@
 
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swm-example-package/">

--- a/pkgs/swarmauri/README.md
+++ b/pkgs/swarmauri/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri/">

--- a/pkgs/swarmauri_standard/README.md
+++ b/pkgs/swarmauri_standard/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri-standard/">

--- a/pkgs/swarmauri_standard/swarmauri_standard/README.md
+++ b/pkgs/swarmauri_standard/swarmauri_standard/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri-standard/">

--- a/pkgs/typing/README.md
+++ b/pkgs/typing/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://res.cloudinary.com/dbjmpekvl/image/upload/v1730099724/Swarmauri-logo-lockup-2048x757_hww01w.png)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri-typing/">


### PR DESCRIPTION
## Summary
- replace Cloudinary-hosted Swarmauri logo with repository asset across docs

## Testing
- `uv run --directory pkgs/community/swarmauri_certs_acme --package swarmauri_certs_acme ruff format .`
- `uv run --directory pkgs/community/swarmauri_certs_acme --package swarmauri_certs_acme ruff check . --fix`
- `uv run --directory pkgs/community/swarmauri_certs_azure --package swarmauri_certs_azure ruff format .`
- `uv run --directory pkgs/community/swarmauri_certs_azure --package swarmauri_certs_azure ruff check . --fix`
- `uv run --directory pkgs/community/swarmauri_certs_cfssl --package swarmauri_certs_cfssl ruff format .`
- `uv run --directory pkgs/community/swarmauri_certs_cfssl --package swarmauri_certs_cfssl ruff check . --fix`
- `uv run --directory pkgs/community/swarmauri_certs_crlverifyservice --package swarmauri_certs_crlverifyservice ruff format .`
- `uv run --directory pkgs/community/swarmauri_certs_crlverifyservice --package swarmauri_certs_crlverifyservice ruff check . --fix`
- `uv run --directory pkgs/community/swarmauri_certs_csronly --package swarmauri_certs_csronly ruff format .`
- `uv run --directory pkgs/community/swarmauri_certs_csronly --package swarmauri_certs_csronly ruff check . --fix`
- `uv run --directory pkgs/community/swarmauri_certs_ocspverify --package swarmauri_certs_ocspverify ruff format .`
- `uv run --directory pkgs/community/swarmauri_certs_ocspverify --package swarmauri_certs_ocspverify ruff check . --fix`
- ⚠️ `uv run --directory pkgs/community/swarmauri_embedding_mlm --package swarmauri_embedding_mlm ruff format .` *(dependency download exceeded environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_68c4e562c32083269686e4c898fe247b