### PR TITLE
feat: add missing badges to package readmes

### DIFF
--- a/pkgs/community/zdx/README.md
+++ b/pkgs/community/zdx/README.md
@@ -1,5 +1,21 @@
 ![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
+
+<p align="center">
+    <a href="https://pypi.org/project/zdx/">
+        <img src="https://img.shields.io/pypi/dm/zdx" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/community/zdx/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/community/zdx.svg"/></a>
+    <a href="https://pypi.org/project/zdx/">
+        <img src="https://img.shields.io/pypi/pyversions/zdx" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/zdx/">
+        <img src="https://img.shields.io/pypi/l/zdx" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/zdx/">
+        <img src="https://img.shields.io/pypi/v/zdx?label=zdx&color=green" alt="PyPI - zdx"/></a>
+</p>
+
+---
+
 # ZDX
 
 Z Doc Builder Experience by Swarmauri. Reusable tooling to build and serve MkDocs-based documentation sites for Swarmauri projects.

--- a/pkgs/experimental/RapidSimilarity/DistanceMetrics/README.md
+++ b/pkgs/experimental/RapidSimilarity/DistanceMetrics/README.md
@@ -1,5 +1,21 @@
 # DistanceMetrics
 
+<p align="center">
+    <a href="https://pypi.org/project/DistanceMetrics/">
+        <img src="https://img.shields.io/pypi/dm/DistanceMetrics" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/experimental/RapidSimilarity/DistanceMetrics/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/experimental/RapidSimilarity/DistanceMetrics.svg"/></a>
+    <a href="https://pypi.org/project/DistanceMetrics/">
+        <img src="https://img.shields.io/pypi/pyversions/DistanceMetrics" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/DistanceMetrics/">
+        <img src="https://img.shields.io/pypi/l/DistanceMetrics" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/DistanceMetrics/">
+        <img src="https://img.shields.io/pypi/v/DistanceMetrics?label=DistanceMetrics&color=green" alt="PyPI - DistanceMetrics"/></a>
+</p>
+
+---
+
+
 ## Purpose
 The `DistanceMetrics` package provides core distance and similarity measures, including implementations of various distance functions such as Euclidean distance and cosine similarity to evaluate similarity between high-dimensional vectors.
 

--- a/pkgs/experimental/RapidSimilarity/IndexBuilder/README.md
+++ b/pkgs/experimental/RapidSimilarity/IndexBuilder/README.md
@@ -1,5 +1,21 @@
 # IndexBuilder
 
+<p align="center">
+    <a href="https://pypi.org/project/IndexBuilder/">
+        <img src="https://img.shields.io/pypi/dm/IndexBuilder" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/experimental/RapidSimilarity/IndexBuilder/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/experimental/RapidSimilarity/IndexBuilder.svg"/></a>
+    <a href="https://pypi.org/project/IndexBuilder/">
+        <img src="https://img.shields.io/pypi/pyversions/IndexBuilder" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/IndexBuilder/">
+        <img src="https://img.shields.io/pypi/l/IndexBuilder" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/IndexBuilder/">
+        <img src="https://img.shields.io/pypi/v/IndexBuilder?label=IndexBuilder&color=green" alt="PyPI - IndexBuilder"/></a>
+</p>
+
+---
+
+
 ## Purpose
 
 The `IndexBuilder` package provides efficient algorithms for building indexes (e.g., tree-based or hash-based structures) to accelerate similarity queries over large datasets.

--- a/pkgs/experimental/RapidSimilarity/QueryEngine/README.md
+++ b/pkgs/experimental/RapidSimilarity/QueryEngine/README.md
@@ -1,5 +1,21 @@
 # QueryEngine
 
+<p align="center">
+    <a href="https://pypi.org/project/QueryEngine/">
+        <img src="https://img.shields.io/pypi/dm/QueryEngine" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/experimental/RapidSimilarity/QueryEngine/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/experimental/RapidSimilarity/QueryEngine.svg"/></a>
+    <a href="https://pypi.org/project/QueryEngine/">
+        <img src="https://img.shields.io/pypi/pyversions/QueryEngine" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/QueryEngine/">
+        <img src="https://img.shields.io/pypi/l/QueryEngine" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/QueryEngine/">
+        <img src="https://img.shields.io/pypi/v/QueryEngine?label=QueryEngine&color=green" alt="PyPI - QueryEngine"/></a>
+</p>
+
+---
+
+
 ## Description
 The `QueryEngine` package provides a Python interface for performing both exact and approximate similarity searches on indexes built by the `IndexBuilder`. The underlying implementation leverages C++ optimizations for enhanced speed and efficiency.
 

--- a/pkgs/experimental/swarmauri_certs_pkcs11/README.md
+++ b/pkgs/experimental/swarmauri_certs_pkcs11/README.md
@@ -1,5 +1,21 @@
 ![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_certs_pkcs11/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_certs_pkcs11" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/experimental/swarmauri_certs_pkcs11/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/experimental/swarmauri_certs_pkcs11.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_certs_pkcs11/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_certs_pkcs11" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_certs_pkcs11/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_certs_pkcs11" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_certs_pkcs11/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_certs_pkcs11?label=swarmauri_certs_pkcs11&color=green" alt="PyPI - swarmauri_certs_pkcs11"/></a>
+</p>
+
+---
+
 # Swarmauri Certs PKCS#11
 
 A PKCS#11-backed certificate service implementing `CertServiceBase`.

--- a/pkgs/experimental/swarmauri_experimental/README.md
+++ b/pkgs/experimental/swarmauri_experimental/README.md
@@ -1,1 +1,17 @@
 # Swarmauri Experimental
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri-experimental/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri-experimental" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/experimental/swarmauri_experimental/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/experimental/swarmauri_experimental.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri-experimental/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri-experimental" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri-experimental/">
+        <img src="https://img.shields.io/pypi/l/swarmauri-experimental" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri-experimental/">
+        <img src="https://img.shields.io/pypi/v/swarmauri-experimental?label=swarmauri-experimental&color=green" alt="PyPI - swarmauri-experimental"/></a>
+</p>
+
+---
+

--- a/pkgs/experimental/swarmauri_keyprovider_pkcs11/README.md
+++ b/pkgs/experimental/swarmauri_keyprovider_pkcs11/README.md
@@ -1,5 +1,21 @@
 ![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_keyprovider_pkcs11/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_keyprovider_pkcs11" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/experimental/swarmauri_keyprovider_pkcs11/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/experimental/swarmauri_keyprovider_pkcs11.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_keyprovider_pkcs11/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_keyprovider_pkcs11" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_keyprovider_pkcs11/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_keyprovider_pkcs11" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_keyprovider_pkcs11/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_keyprovider_pkcs11?label=swarmauri_keyprovider_pkcs11&color=green" alt="PyPI - swarmauri_keyprovider_pkcs11"/></a>
+</p>
+
+---
+
 # Swarmauri PKCS#11 Key Provider
 
 Hardware-backed key provider using PKCS#11 devices.

--- a/pkgs/experimental/swarmauri_workflow_statedriven/README.md
+++ b/pkgs/experimental/swarmauri_workflow_statedriven/README.md
@@ -1,0 +1,16 @@
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_workflow_statedriven/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_workflow_statedriven" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/experimental/swarmauri_workflow_statedriven/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/experimental/swarmauri_workflow_statedriven.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_workflow_statedriven/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_workflow_statedriven" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_workflow_statedriven/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_workflow_statedriven" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_workflow_statedriven/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_workflow_statedriven?label=swarmauri_workflow_statedriven&color=green" alt="PyPI - swarmauri_workflow_statedriven"/></a>
+</p>
+
+---
+

--- a/pkgs/plugins/example_plugin/README.md
+++ b/pkgs/plugins/example_plugin/README.md
@@ -1,1 +1,17 @@
 # Swarmauri Example Plugin
+
+<p align="center">
+    <a href="https://pypi.org/project/swm-example-plugin/">
+        <img src="https://img.shields.io/pypi/dm/swm-example-plugin" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/plugins/example_plugin/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/plugins/example_plugin.svg"/></a>
+    <a href="https://pypi.org/project/swm-example-plugin/">
+        <img src="https://img.shields.io/pypi/pyversions/swm-example-plugin" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swm-example-plugin/">
+        <img src="https://img.shields.io/pypi/l/swm-example-plugin" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swm-example-plugin/">
+        <img src="https://img.shields.io/pypi/v/swm-example-plugin?label=swm-example-plugin&color=green" alt="PyPI - swm-example-plugin"/></a>
+</p>
+
+---
+

--- a/pkgs/standards/swarmauri_certs_local_ca/README.md
+++ b/pkgs/standards/swarmauri_certs_local_ca/README.md
@@ -1,5 +1,21 @@
 ![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_certs_local_ca/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_certs_local_ca" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_certs_local_ca/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_certs_local_ca.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_certs_local_ca/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_certs_local_ca" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_certs_local_ca/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_certs_local_ca" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_certs_local_ca/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_certs_local_ca?label=swarmauri_certs_local_ca&color=green" alt="PyPI - swarmauri_certs_local_ca"/></a>
+</p>
+
+---
+
 # Swarmauri Certs Local CA
 
 A local certificate authority implementing the `ICertService` interface for issuing and verifying X.509 certificates. Useful for development and testing environments.

--- a/pkgs/standards/swarmauri_certs_remote_ca/README.md
+++ b/pkgs/standards/swarmauri_certs_remote_ca/README.md
@@ -1,5 +1,21 @@
 ![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_certs_remote_ca/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_certs_remote_ca" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_certs_remote_ca/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_certs_remote_ca.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_certs_remote_ca/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_certs_remote_ca" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_certs_remote_ca/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_certs_remote_ca" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_certs_remote_ca/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_certs_remote_ca?label=swarmauri_certs_remote_ca&color=green" alt="PyPI - swarmauri_certs_remote_ca"/></a>
+</p>
+
+---
+
 # Swarmauri Remote CA Cert Service
 
 A certificate enrollment bridge implementing the `ICertService` interface and

--- a/pkgs/standards/swarmauri_certs_self_signed/README.md
+++ b/pkgs/standards/swarmauri_certs_self_signed/README.md
@@ -1,5 +1,21 @@
 ![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_certs_self_signed/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_certs_self_signed" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_certs_self_signed/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_certs_self_signed.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_certs_self_signed/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_certs_self_signed" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_certs_self_signed/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_certs_self_signed" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_certs_self_signed/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_certs_self_signed?label=swarmauri_certs_self_signed&color=green" alt="PyPI - swarmauri_certs_self_signed"/></a>
+</p>
+
+---
+
 # Swarmauri Self-Signed Certificate Builder
 
 Standalone plugin providing utilities to issue self-signed X.509 certificates using the `SelfSignedCertificate` builder.

--- a/pkgs/standards/swarmauri_certs_x509verify/README.md
+++ b/pkgs/standards/swarmauri_certs_x509verify/README.md
@@ -1,5 +1,21 @@
 ![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_certs_x509verify/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_certs_x509verify" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_certs_x509verify/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_certs_x509verify.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_certs_x509verify/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_certs_x509verify" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_certs_x509verify/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_certs_x509verify" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_certs_x509verify/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_certs_x509verify?label=swarmauri_certs_x509verify&color=green" alt="PyPI - swarmauri_certs_x509verify"/></a>
+</p>
+
+---
+
 # Swarmauri Certs X509 Verify
 
 A verification-only service for X.509 certificates implementing

--- a/pkgs/standards/swarmauri_keyprovider_file/README.md
+++ b/pkgs/standards/swarmauri_keyprovider_file/README.md
@@ -1,5 +1,21 @@
 ![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_keyprovider_file/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_keyprovider_file" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_keyprovider_file/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_keyprovider_file.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_keyprovider_file/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_keyprovider_file" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_keyprovider_file/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_keyprovider_file" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_keyprovider_file/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_keyprovider_file?label=swarmauri_keyprovider_file&color=green" alt="PyPI - swarmauri_keyprovider_file"/></a>
+</p>
+
+---
+
 # Swarmauri File Key Provider
 
 A file-backed key provider implementing the `KeyProviderBase` interface.

--- a/pkgs/standards/swarmauri_keyprovider_hierarchical/README.md
+++ b/pkgs/standards/swarmauri_keyprovider_hierarchical/README.md
@@ -1,5 +1,21 @@
 ![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_keyprovider_hierarchical/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_keyprovider_hierarchical" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_keyprovider_hierarchical/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_keyprovider_hierarchical.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_keyprovider_hierarchical/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_keyprovider_hierarchical" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_keyprovider_hierarchical/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_keyprovider_hierarchical" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_keyprovider_hierarchical/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_keyprovider_hierarchical?label=swarmauri_keyprovider_hierarchical&color=green" alt="PyPI - swarmauri_keyprovider_hierarchical"/></a>
+</p>
+
+---
+
 # Swarmauri Hierarchical Key Provider
 
 Plugin providing a policy-driven composite key provider capable of routing

--- a/pkgs/standards/swarmauri_keyprovider_inmemory/README.md
+++ b/pkgs/standards/swarmauri_keyprovider_inmemory/README.md
@@ -1,5 +1,21 @@
 ![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_keyprovider_inmemory/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_keyprovider_inmemory" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_keyprovider_inmemory/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_keyprovider_inmemory.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_keyprovider_inmemory/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_keyprovider_inmemory" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_keyprovider_inmemory/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_keyprovider_inmemory" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_keyprovider_inmemory/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_keyprovider_inmemory?label=swarmauri_keyprovider_inmemory&color=green" alt="PyPI - swarmauri_keyprovider_inmemory"/></a>
+</p>
+
+---
+
 # Swarmauri In‑Memory Key Provider
 
 Volatile, in‑memory key provider for Swarmauri. All key material is kept strictly in process memory (no disk writes). Ideal for testing, CI, and ephemeral gateways where persistence is not desired. Not intended for long‑term or production storage of secrets.

--- a/pkgs/standards/swarmauri_keyprovider_remote_jwks/README.md
+++ b/pkgs/standards/swarmauri_keyprovider_remote_jwks/README.md
@@ -1,5 +1,21 @@
 ![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_keyprovider_remote_jwks/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_keyprovider_remote_jwks" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_keyprovider_remote_jwks/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_keyprovider_remote_jwks.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_keyprovider_remote_jwks/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_keyprovider_remote_jwks" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_keyprovider_remote_jwks/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_keyprovider_remote_jwks" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_keyprovider_remote_jwks/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_keyprovider_remote_jwks?label=swarmauri_keyprovider_remote_jwks&color=green" alt="PyPI - swarmauri_keyprovider_remote_jwks"/></a>
+</p>
+
+---
+
 # Swarmauri Remote JWKS Key Provider
 
 Key provider backed by a remote JWKS endpoint with local key management.

--- a/pkgs/standards/swarmauri_keyproviders_mirrored/README.md
+++ b/pkgs/standards/swarmauri_keyproviders_mirrored/README.md
@@ -1,5 +1,21 @@
 ![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_keyproviders_mirrored/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_keyproviders_mirrored" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_keyproviders_mirrored/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_keyproviders_mirrored.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_keyproviders_mirrored/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_keyproviders_mirrored" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_keyproviders_mirrored/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_keyproviders_mirrored" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_keyproviders_mirrored/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_keyproviders_mirrored?label=swarmauri_keyproviders_mirrored&color=green" alt="PyPI - swarmauri_keyproviders_mirrored"/></a>
+</p>
+
+---
+
 # Swarmauri Mirrored Key Provider
 
 A failover key provider that mirrors keys to a secondary provider for redundancy.

--- a/pkgs/standards/swarmauri_middleware_jwksverifier/README.md
+++ b/pkgs/standards/swarmauri_middleware_jwksverifier/README.md
@@ -1,5 +1,21 @@
 ![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_middleware_jwksverifier/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_middleware_jwksverifier" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_middleware_jwksverifier/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_middleware_jwksverifier.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_middleware_jwksverifier/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_middleware_jwksverifier" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_middleware_jwksverifier/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_middleware_jwksverifier" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_middleware_jwksverifier/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_middleware_jwksverifier?label=swarmauri_middleware_jwksverifier&color=green" alt="PyPI - swarmauri_middleware_jwksverifier"/></a>
+</p>
+
+---
+
 # Swarmauri Middleware JWKS Verifier
 
 A middleware component providing JWT verification using a cached JWKS with TTL and LRU eviction.

--- a/pkgs/standards/swarmauri_mre_crypto_keyring/README.md
+++ b/pkgs/standards/swarmauri_mre_crypto_keyring/README.md
@@ -1,5 +1,21 @@
 ![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_mre_crypto_keyring/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_mre_crypto_keyring" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_mre_crypto_keyring/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_mre_crypto_keyring.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_mre_crypto_keyring/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_mre_crypto_keyring" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_mre_crypto_keyring/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_mre_crypto_keyring" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_mre_crypto_keyring/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_mre_crypto_keyring?label=swarmauri_mre_crypto_keyring&color=green" alt="PyPI - swarmauri_mre_crypto_keyring"/></a>
+</p>
+
+---
+
 # Swarmauri MRE Crypto Keyring
 
 Multi-recipient encryption provider using external keyrings/HSMs.

--- a/pkgs/standards/swarmauri_signing_ca/README.md
+++ b/pkgs/standards/swarmauri_signing_ca/README.md
@@ -1,5 +1,21 @@
 ![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_signing_ca/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_signing_ca" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_signing_ca/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_signing_ca.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_signing_ca/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_signing_ca" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_signing_ca/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_signing_ca" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_signing_ca/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_signing_ca?label=swarmauri_signing_ca&color=green" alt="PyPI - swarmauri_signing_ca"/></a>
+</p>
+
+---
+
 # Swarmauri Signing CA
 
 A certificate-authority-capable signer implementing the `ISigning` interface for detached

--- a/pkgs/standards/swarmauri_signing_ecdsa/README.md
+++ b/pkgs/standards/swarmauri_signing_ecdsa/README.md
@@ -1,5 +1,21 @@
 ![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_signing_ecdsa/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_signing_ecdsa" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_signing_ecdsa/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_signing_ecdsa.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_signing_ecdsa/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_signing_ecdsa" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_signing_ecdsa/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_signing_ecdsa" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_signing_ecdsa/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_signing_ecdsa?label=swarmauri_signing_ecdsa&color=green" alt="PyPI - swarmauri_signing_ecdsa"/></a>
+</p>
+
+---
+
 # Swarmauri Signing ECDSA
 
 An ECDSA-based signer implementing the `ISigning` interface for detached

--- a/pkgs/standards/swarmauri_signing_ed25519/README.md
+++ b/pkgs/standards/swarmauri_signing_ed25519/README.md
@@ -1,5 +1,21 @@
 ![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_signing_ed25519/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_signing_ed25519" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_signing_ed25519/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_signing_ed25519.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_signing_ed25519/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_signing_ed25519" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_signing_ed25519/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_signing_ed25519" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_signing_ed25519/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_signing_ed25519?label=swarmauri_signing_ed25519&color=green" alt="PyPI - swarmauri_signing_ed25519"/></a>
+</p>
+
+---
+
 # Swarmauri Signing Ed25519
 
 An Ed25519-based signer implementing the `ISigning` interface for detached

--- a/pkgs/standards/swarmauri_signing_jws/README.md
+++ b/pkgs/standards/swarmauri_signing_jws/README.md
@@ -1,5 +1,21 @@
 ![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_signing_jws/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_signing_jws" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_signing_jws/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_signing_jws.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_signing_jws/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_signing_jws" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_signing_jws/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_signing_jws" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_signing_jws/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_signing_jws?label=swarmauri_signing_jws&color=green" alt="PyPI - swarmauri_signing_jws"/></a>
+</p>
+
+---
+
 # Swarmauri Signing JWS
 
 Composite JSON Web Signature (JWS) signer and verifier combining multiple

--- a/pkgs/standards/swarmauri_signing_rsa/README.md
+++ b/pkgs/standards/swarmauri_signing_rsa/README.md
@@ -1,5 +1,21 @@
 ![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_signing_rsa/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_signing_rsa" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_signing_rsa/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_signing_rsa.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_signing_rsa/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_signing_rsa" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_signing_rsa/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_signing_rsa" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_signing_rsa/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_signing_rsa?label=swarmauri_signing_rsa&color=green" alt="PyPI - swarmauri_signing_rsa"/></a>
+</p>
+
+---
+
 # Swarmauri Signing RSA
 
 An RSA-based signer implementing the `ISigning` interface for detached

--- a/pkgs/standards/swarmauri_signing_secp256k1/README.md
+++ b/pkgs/standards/swarmauri_signing_secp256k1/README.md
@@ -1,5 +1,21 @@
 ![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_signing_secp256k1/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_signing_secp256k1" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_signing_secp256k1/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_signing_secp256k1.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_signing_secp256k1/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_signing_secp256k1" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_signing_secp256k1/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_signing_secp256k1" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_signing_secp256k1/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_signing_secp256k1?label=swarmauri_signing_secp256k1&color=green" alt="PyPI - swarmauri_signing_secp256k1"/></a>
+</p>
+
+---
+
 # Swarmauri Signing Secp256k1
 
 A secp256k1 ECDSA signer implementing the `ISigning` interface for detached

--- a/pkgs/standards/swarmauri_tokens_dpopboundjwt/README.md
+++ b/pkgs/standards/swarmauri_tokens_dpopboundjwt/README.md
@@ -1,5 +1,21 @@
 ![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_tokens_dpopboundjwt/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_tokens_dpopboundjwt" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_tokens_dpopboundjwt/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_tokens_dpopboundjwt.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_tokens_dpopboundjwt/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_tokens_dpopboundjwt" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_tokens_dpopboundjwt/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_tokens_dpopboundjwt" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_tokens_dpopboundjwt/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_tokens_dpopboundjwt?label=swarmauri_tokens_dpopboundjwt&color=green" alt="PyPI - swarmauri_tokens_dpopboundjwt"/></a>
+</p>
+
+---
+
 # Swarmauri Tokens DPoP Bound JWT
 
 DPoP-bound JSON Web Token (JWT) service for Swarmauri implementing

--- a/pkgs/standards/swarmauri_tokens_paseto_v4/README.md
+++ b/pkgs/standards/swarmauri_tokens_paseto_v4/README.md
@@ -1,5 +1,21 @@
 ![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_tokens_paseto_v4/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_tokens_paseto_v4" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_tokens_paseto_v4/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_tokens_paseto_v4.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_tokens_paseto_v4/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_tokens_paseto_v4" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_tokens_paseto_v4/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_tokens_paseto_v4" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_tokens_paseto_v4/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_tokens_paseto_v4?label=swarmauri_tokens_paseto_v4&color=green" alt="PyPI - swarmauri_tokens_paseto_v4"/></a>
+</p>
+
+---
+
 # Swarmauri Token Paseto V4
 
 PASETO v4 token service implementing the `ITokenService` interface for

--- a/pkgs/standards/swarmauri_tokens_tlsboundjwt/README.md
+++ b/pkgs/standards/swarmauri_tokens_tlsboundjwt/README.md
@@ -1,5 +1,21 @@
 ![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_tokens_tlsboundjwt/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_tokens_tlsboundjwt" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_tokens_tlsboundjwt/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_tokens_tlsboundjwt.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_tokens_tlsboundjwt/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_tokens_tlsboundjwt" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_tokens_tlsboundjwt/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_tokens_tlsboundjwt" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_tokens_tlsboundjwt/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_tokens_tlsboundjwt?label=swarmauri_tokens_tlsboundjwt&color=green" alt="PyPI - swarmauri_tokens_tlsboundjwt"/></a>
+</p>
+
+---
+
 # Swarmauri Tokens TLS-Bound JWT
 
 A mutual-TLS bound JWT token service per [RFC 8705](https://www.rfc-editor.org/rfc/rfc8705).

--- a/scripts/add_missing_badges.py
+++ b/scripts/add_missing_badges.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Add standard badges to package README files lacking them."""
+
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PKGS_DIR = REPO_ROOT / "pkgs"
+
+BADGE_TEMPLATE = (
+    '<p align="center">\n'
+    '    <a href="https://pypi.org/project/{name}/">\n'
+    '        <img src="https://img.shields.io/pypi/dm/{name}" alt="PyPI - Downloads"/></a>\n'
+    '    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/{repo_path}/">\n'
+    '        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/{repo_path}.svg"/></a>\n'
+    '    <a href="https://pypi.org/project/{name}/">\n'
+    '        <img src="https://img.shields.io/pypi/pyversions/{name}" alt="PyPI - Python Version"/></a>\n'
+    '    <a href="https://pypi.org/project/{name}/">\n'
+    '        <img src="https://img.shields.io/pypi/l/{name}" alt="PyPI - License"/></a>\n'
+    '    <a href="https://pypi.org/project/{name}/">\n'
+    '        <img src="https://img.shields.io/pypi/v/{name}?label={name}&color=green" alt="PyPI - {name}"/></a>\n'
+    "</p>\n"
+)
+
+
+def add_badges(pkg_dir: Path) -> bool:
+    readme = pkg_dir / "README.md"
+    pyproject = pkg_dir / "pyproject.toml"
+    if not readme.exists() or not pyproject.exists():
+        return False
+
+    content = readme.read_text(encoding="utf-8")
+    if "img.shields.io" in content:
+        return False
+
+    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    project_name = data.get("project", {}).get("name") or data.get("tool", {}).get(
+        "poetry", {}
+    ).get("name")
+    if not project_name:
+        return False
+    repo_path = pkg_dir.relative_to(REPO_ROOT).as_posix()
+    badge_block = BADGE_TEMPLATE.format(name=project_name, repo_path=repo_path)
+
+    lines = content.splitlines(keepends=True)
+
+    insert_idx = 0
+    for i, line in enumerate(lines):
+        if line.startswith("![") or "Swamauri Logo" in line:
+            insert_idx = i + 1
+            while insert_idx < len(lines) and lines[insert_idx].strip() == "":
+                insert_idx += 1
+            break
+        if line.startswith("#"):
+            insert_idx = i + 1
+            break
+    new_content = (
+        "".join(lines[:insert_idx])
+        + "\n"
+        + badge_block
+        + "\n---\n\n"
+        + "".join(lines[insert_idx:])
+    )
+    readme.write_text(new_content, encoding="utf-8")
+    print(f"Added badges to {readme}")
+    return True
+
+
+def main():
+    for pyproject in PKGS_DIR.rglob("pyproject.toml"):
+        pkg_dir = pyproject.parent
+        if pkg_dir == PKGS_DIR:
+            continue
+        add_badges(pkg_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `add_missing_badges.py` to populate standard badges
- insert badge blocks into package READMEs lacking them

## Testing
- `uv run --directory pkgs/community/zdx --package zdx ruff format .`
- `uv run --directory pkgs/community/zdx --package zdx ruff check . --fix`
- `uv run --directory pkgs/experimental/RapidSimilarity/DistanceMetrics --package DistanceMetrics ruff format .`
- `uv run --directory pkgs/experimental/RapidSimilarity/DistanceMetrics --package DistanceMetrics ruff check . --fix` *(fails: F401 `DistanceMetrics.extensions` imported but unused)*

------
https://chatgpt.com/codex/tasks/task_e_68c516756a5483269528b5c97c6edfab