### PR TITLE
feat: install packages referenced by API manifest

### DIFF
--- a/pkgs/community/zdx/Dockerfile
+++ b/pkgs/community/zdx/Dockerfile
@@ -16,10 +16,11 @@ WORKDIR /app
 # 1. Copy only dependency-defining files first (better layer caching)
 COPY ./pkgs/ /pkgs
 
-RUN uv pip install --directory /pkgs/community/zdx --system .
+RUN uv pip install --directory /pkgs/community/zdx --system . && \
+    zdx install --manifest /pkgs/community/zdx/api_manifest.yaml
 
 EXPOSE 8000
 
-WORKDIR /docs 
+WORKDIR /docs
 
 CMD ["zdx", "serve", "--generate", "--docs-dir", "/docs", "--manifest", "api_manifest.yaml", "--changed-only"]


### PR DESCRIPTION
## Summary
- automatically install packages listed or discovered in api_manifest
- build docs image with those packages pre-installed
- skip installing directories without pyproject or setup.py to avoid errors

## Testing
- `uv run --directory community/zdx --package zdx ruff format .`
- `uv run --directory community/zdx --package zdx ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c52fe4ea84832697a7cc146ea334f7