### PR TITLE
fix: correct resolve_dependencies docstring

### DIFF
--- a/pkgs/base/swarmauri_base/chains/PromptContextChainBase.py
+++ b/pkgs/base/swarmauri_base/chains/PromptContextChainBase.py
@@ -150,8 +150,7 @@ class PromptContextChainBase(IChainDependencyResolver, ChainContextBase, Compone
         Resolve dependencies within a specific sequence of the prompt matrix.
 
         Args:
-            matrix (List[List[Optional[str]]]): The prompt matrix.
-            sequence_index (int): The index of the sequence to resolve dependencies for.
+            sequence (List[Optional[str]]): The sequence of prompts to resolve dependencies for.
 
         Returns:
             List[int]: The execution order of the agents for the given sequence.


### PR DESCRIPTION
## Summary
- align `resolve_dependencies` docstring parameters with function signature

## Testing
- `uv run --directory base --package swarmauri-base ruff format .`
- `uv run --directory base --package swarmauri-base ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c52ff9b63c8326af767df1362c6aea