### PR TITLE
fix: install docs dependencies without requiring system access

### DIFF
--- a/pkgs/community/zdx/zdx/cli.py
+++ b/pkgs/community/zdx/zdx/cli.py
@@ -67,18 +67,19 @@ def install_manifest_packages(manifest: str) -> None:
         ):
             print(f"Skipping {pkg_dir}: no pyproject.toml or setup.py found")
             continue
-        subprocess.run(
-            [
-                "uv",
-                "pip",
-                "install",
-                "--directory",
-                pkg_dir,
-                "--system",
-                ".",
-            ],
-            check=True,
-        )
+        cmd = [
+            "uv",
+            "pip",
+            "install",
+            "--directory",
+            pkg_dir,
+        ]
+        if os.environ.get("VIRTUAL_ENV") or sys.prefix != sys.base_prefix:
+            cmd.append("--system")
+        else:
+            cmd.append("--user")
+        cmd.append(".")
+        subprocess.run(cmd, check=True)
 
 
 def run_mkdocs_serve(


### PR DESCRIPTION
## Summary
- ensure `zdx` installs manifest packages with `--user` when not in a virtualenv

## Testing
- `uv run --directory pkgs/community/zdx --package zdx ruff format .`
- `uv run --directory pkgs/community/zdx --package zdx ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c544d5738883269f9009996b8b2a20