### PR TITLE
fix: install manifest packages in active environment

### DIFF
--- a/pkgs/community/zdx/zdx/cli.py
+++ b/pkgs/community/zdx/zdx/cli.py
@@ -67,6 +67,9 @@ def install_manifest_packages(manifest: str) -> None:
         ):
             print(f"Skipping {pkg_dir}: no pyproject.toml or setup.py found")
             continue
+        # Install into the active environment rather than the global system
+        # site-packages. This avoids requiring elevated permissions when
+        # running the docs tooling locally.
         subprocess.run(
             [
                 "uv",
@@ -74,7 +77,6 @@ def install_manifest_packages(manifest: str) -> None:
                 "install",
                 "--directory",
                 pkg_dir,
-                "--system",
                 ".",
             ],
             check=True,


### PR DESCRIPTION
## Summary
- avoid installing docs packages into system site-packages to prevent permission errors

## Testing
- `uv run --package zdx --directory pkgs/community/zdx ruff format .`
- `uv run --package zdx --directory pkgs/community/zdx ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c544d5738883269f9009996b8b2a20