### PR TITLE
fix: ensure zdx tests install pytest

### DIFF
--- a/pkgs/community/zdx/pyproject.toml
+++ b/pkgs/community/zdx/pyproject.toml
@@ -35,3 +35,17 @@ include = [
     { path = "api_manifest.yaml" },
     { path = "Dockerfile" },
 ]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "python-dotenv",
+    "requests>=2.32.3",
+    "flake8>=7.0",
+    "pytest-timeout>=2.3.1",
+    "ruff>=0.9.9",
+    "pytest-benchmark>=4.0.0",
+]


### PR DESCRIPTION
## Summary
- add dev dependency group with pytest and related tools for zdx

## Testing
- `uv run --package zdx --directory community/zdx ruff format .`
- `uv run --package zdx --directory community/zdx ruff check . --fix`
- `uv run --package zdx --directory community/zdx pytest` *(fails: test_process_target_speed)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a0c30fc48326ad040b277bd25c3d