### PR TITLE
refactor: align example plugin with uv project style

### DIFF
--- a/pkgs/plugins/example_plugin/README.md
+++ b/pkgs/plugins/example_plugin/README.md
@@ -1,4 +1,4 @@
-# Swarmauri Example Plugin
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swm-example-plugin/">
@@ -14,4 +14,8 @@
 </p>
 
 ---
+
+# Swarmauri Example Plugin
+
+An example plugin for the Swarmauri framework.
 

--- a/pkgs/plugins/example_plugin/pyproject.toml
+++ b/pkgs/plugins/example_plugin/pyproject.toml
@@ -1,43 +1,42 @@
-[tool.poetry]
+[project]
 name = "swm-example-plugin"
 version = "0.6.2.dev3"
 description = "This repository includes an example of a Swarmauri Plugin."
-authors = ["Jacob Stewart <jacob@swarmauri.com>"]
+authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 license = "Apache-2.0"
-readme = "README.md"
+readme = { file = "README.md", content-type = "text/markdown" }
 repository = "http://github.com/swarmauri/swarmauri-sdk"
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12"
+    "Programming Language :: Python :: 3.12",
 ]
+requires-python = ">=3.10,<3.13"
+dependencies = []
 
-[tool.poetry.dependencies]
-python = ">=3.10,<3.13"
+[project.entry-points."swarmauri.plugins"]
+example_agent = "swm_example_plugin.agents:ExampleAgent"
 
-[tool.poetry.group.dev.dependencies]
-flake8 = "^7.0"
-pytest = "^8.0"
-pytest-asyncio = ">=0.24.0"
-pytest-xdist = "^3.6.1"
-pytest-json-report = "^1.5.0"
-python-dotenv = "*"
-requests = "^2.32.3"
-
-[build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+[dependency-groups]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "python-dotenv>=1.0.0",
+    "requests>=2.32.3",
+    "ruff>=0.9.9",
+]
 
 [tool.pytest.ini_options]
 norecursedirs = ["combined", "scripts"]
-
 markers = [
     "test: standard test",
     "unit: Unit tests",
     "integration: Integration tests",
     "acceptance: Acceptance tests",
-    "experimental: Experimental tests"
+    "experimental: Experimental tests",
 ]
 log_cli = true
 log_cli_level = "INFO"
@@ -45,5 +44,7 @@ log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
 log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 asyncio_default_fixture_loop_scope = "function"
 
-[tool.poetry.plugins."swarmauri.plugins"]
-example_agent = "swm_example_plugin.agents:ExampleAgent"
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+


### PR DESCRIPTION
## Summary
- convert example plugin to uv-style `pyproject.toml` with poetry build backend
- include Swarmauri branding and badges in plugin README

## Testing
- `uv run --directory pkgs/plugins/example_plugin --package swm-example-plugin ruff format .`
- `uv run --directory pkgs/plugins/example_plugin --package swm-example-plugin ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c5a4e21dc88326b0ce090ee1107b06