### PR TITLE
Transition swarmauri_experimental to uv-style and mark inactive

### DIFF
--- a/pkgs/experimental/swarmauri_experimental/README.md
+++ b/pkgs/experimental/swarmauri_experimental/README.md
@@ -1,4 +1,4 @@
-# Swarmauri Experimental
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri-experimental/">
@@ -14,4 +14,10 @@
 </p>
 
 ---
+
+# Swarmauri Experimental
+
+> ⚠️ **Inactive Package**
+>
+> Experimental packages are now released as standalone distributions. Further support for the `swarmauri-experimental` namespace package is not planned.
 

--- a/pkgs/experimental/swarmauri_experimental/pyproject.toml
+++ b/pkgs/experimental/swarmauri_experimental/pyproject.toml
@@ -1,46 +1,48 @@
-[tool.poetry]
+[project]
 name = "swarmauri-experimental"
 version = "0.6.2.dev3"
-description = "This repository includes experimental components."
-authors = ["Jacob Stewart <jacob@swarmauri.com>"]
+description = "This repository includes experimental components. (Inactive: experimental packages are now standalone.)"
+authors = [
+    { name = "Jacob Stewart", email = "jacob@swarmauri.com" },
+]
 license = "Apache-2.0"
-readme = "README.md"
+readme = { file = "README.md", content-type = "text/markdown" }
 repository = "http://github.com/swarmauri/swarmauri-sdk"
 classifiers = [
+    "Development Status :: 7 - Inactive",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12"
+    "Programming Language :: Python :: 3.12",
+]
+requires-python = ">=3.10,<3.13"
+
+dependencies = [
+    "swarmauri==0.5.3.dev5",
+    "gensim",
+    "neo4j",
+    "numpy",
+    "openai",
+    "pydantic",
+    "requests",
+    "tensorflow",
+    "torch",
+    "transformers>=4.45.0",
+    "typing_extensions",
 ]
 
-[tool.poetry.dependencies]
-python = ">=3.10,<3.13"
-swarmauri = "==0.5.3.dev5"
-gensim = "*"
-neo4j = "*"
-numpy = "*"
-openai = "*"
-pydantic = "*"
-requests = "*"
-tensorflow = "*"
-torch = "*"
-transformers = ">=4.45.0"
-typing_extensions = "*"
-
-[tool.poetry.group.dev.dependencies]
-flake8 = "^7.0"  # Add flake8 as a development dependency
-pytest = "^8.0"  # Ensure pytest is also added if you run tests
-pytest-asyncio = ">=0.24.0"
-pytest-xdist = "^3.6.1"
-pytest-json-report = "^1.5.0"
-
-[build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+[dependency-groups]
+dev = [
+    "flake8>=7.0",
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "ruff>=0.9.9",
+]
 
 [tool.pytest.ini_options]
 norecursedirs = ["combined", "scripts"]
-
 markers = [
     "test: standard test",
     "unit: Unit tests",
@@ -48,10 +50,12 @@ markers = [
     "acceptance: Acceptance tests",
     "experimental: Experimental tests",
 ]
-
 log_cli = true
 log_cli_level = "INFO"
 log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
 log_cli_date_format = "%Y-%m-%d %H:%M:%S"
-
 asyncio_default_fixture_loop_scope = "function"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Summary
- convert swarmauri-experimental to uv-style pyproject using poetry build backend
- mark package as inactive via classifier and README notice
- add brand SVG and standard badges to README

## Testing
- `uv run --directory pkgs/experimental/swarmauri_experimental --package swarmauri-experimental --no-sync ruff format .`
- `uv run --directory pkgs/experimental/swarmauri_experimental --package swarmauri-experimental --no-sync ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c5a56e80f88326831694ec7291c984