### PR TITLE
fix: use 32-byte HMAC secrets

### DIFF
--- a/pkgs/standards/swarmauri_signing_jws/README.md
+++ b/pkgs/standards/swarmauri_signing_jws/README.md
@@ -39,9 +39,34 @@ pip install swarmauri_signing_jws
 from swarmauri_signing_jws import JwsSignerVerifier
 
 verifier = JwsSignerVerifier()
-compact = await verifier.sign_compact(payload={"msg": "hi"}, alg="HS256", key={"kind": "raw", "key": "secret"})
-result = await verifier.verify_compact(compact, hmac_keys=[{"kind": "raw", "key": "secret"}])
+compact = await verifier.sign_compact(
+    payload={"msg": "hi"},
+    alg="HS256",
+    key={"kind": "raw", "key": "0" * 32},
+)
+result = await verifier.verify_compact(
+    compact,
+    hmac_keys=[{"kind": "raw", "key": "0" * 32}],
+)
 ```
+
+## HMAC key requirements
+
+All HMAC-based operations **require a secret of at least 32 bytes (256 bits)**.  
+Shorter keys are rejected to avoid truncation mistakes and to keep forgery
+probabilities negligible even after many verification attempts.  
+
+Rationale:
+
+- Forgery success scales with tag length; a 256-bit tag keeps the chance
+  negligible even after many tries ([NIST SP 800‑107 Rev.1](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-107r1.pdf)).
+- [RFC 7518](https://datatracker.ietf.org/doc/html/rfc7518) already mandates
+  HS256 keys ≥ 256 bits; using the full HMAC-SHA-256 output avoids
+  inadvertent strength reduction.
+- A full 32-byte tag preserves ≈128-bit security even under generic quantum
+  search speedups ([NIST IR 8547](https://nvlpubs.nist.gov/nistpubs/ir/2024/NIST.IR.8547.ipd.pdf)).
+- Fixed-length tags simplify constant-time verification and prevent
+  configuration mismatches.
 
 ## Entry Point
 

--- a/pkgs/standards/swarmauri_signing_jws/tests/functional/test_jws_functional.py
+++ b/pkgs/standards/swarmauri_signing_jws/tests/functional/test_jws_functional.py
@@ -8,8 +8,8 @@ from swarmauri_core.crypto.types import JWAAlg
 
 async def _run() -> bool:
     jws = JwsSignerVerifier()
-    key1 = {"kind": "raw", "key": "one"}
-    key2 = {"kind": "raw", "key": "two"}
+    key1 = {"kind": "raw", "key": "a" * 32}
+    key2 = {"kind": "raw", "key": "b" * 32}
     payload = {"msg": "func"}
     general = await jws.sign_general_json(
         payload=payload,

--- a/pkgs/standards/swarmauri_signing_jws/tests/perf/test_jws_perf.py
+++ b/pkgs/standards/swarmauri_signing_jws/tests/perf/test_jws_perf.py
@@ -8,7 +8,7 @@ from swarmauri_core.crypto.types import JWAAlg
 @pytest.mark.perf
 def test_sign_compact_perf(benchmark) -> None:
     jws = JwsSignerVerifier()
-    key = {"kind": "raw", "key": "secret"}
+    key = {"kind": "raw", "key": "c" * 32}
     payload = {"msg": "perf"}
 
     async def _sign() -> None:

--- a/pkgs/standards/swarmauri_signing_jws/tests/unit/test_jws_unit.py
+++ b/pkgs/standards/swarmauri_signing_jws/tests/unit/test_jws_unit.py
@@ -6,7 +6,7 @@ from swarmauri_core.crypto.types import JWAAlg
 
 async def _sign_and_verify() -> bool:
     jws = JwsSignerVerifier()
-    key = {"kind": "raw", "key": "secret"}
+    key = {"kind": "raw", "key": "d" * 32}
     token = await jws.sign_compact(payload={"msg": "unit"}, alg=JWAAlg.HS256, key=key)
     res = await jws.verify_compact(token, hmac_keys=[key])
     return res.payload == b'{"msg":"unit"}'


### PR DESCRIPTION
## Summary
- use 32-byte secrets in JWS tests
- document 32-byte HMAC key requirement

## Testing
- `uv run --package swarmauri_signing_jws --directory standards/swarmauri_signing_jws pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5a5cc0c5483269cb55b2c73d18943