### PR TITLE
feat: add verbose worker hook logging

### DIFF
--- a/pkgs/standards/peagen/peagen/orm/workers.py
+++ b/pkgs/standards/peagen/peagen/orm/workers.py
@@ -104,145 +104,192 @@ class Worker(Base, GUIDPk, Timestamped, AllowAnonProvider):
         from peagen.gateway import log
 
         log.info("entering pre_worker_create_policy_gate")
-        params = ctx["env"].params
-        pool_id = params["pool_id"]
-        if isinstance(pool_id, str):
-            pool_id = UUID(pool_id)
-        ip = cls._client_ip(ctx["request"])
+        try:
+            params = ctx["env"].params
+            pool_id = params["pool_id"]
+            if isinstance(pool_id, str):
+                pool_id = UUID(pool_id)
+            ip = cls._client_ip(ctx["request"])
 
-        def _get_policy_and_count(session):
-            pool = session.get(Pool, pool_id)
-            count = session.query(cls).filter(cls.pool_id == pool_id).count()
-            return (pool.policy if pool else {}, count)
+            def _get_policy_and_count(session):
+                pool = session.get(Pool, pool_id)
+                count = session.query(cls).filter(cls.pool_id == pool_id).count()
+                return (pool.policy if pool else {}, count)
 
-        policy, count = await ctx["db"].run_sync(_get_policy_and_count)
-        cls._check_pool_policy(policy or {}, ip, count)
+            policy, count = await ctx["db"].run_sync(_get_policy_and_count)
+            log.info(
+                "pre_worker_create_policy_gate: policy=%s count=%s ip=%s",
+                policy,
+                count,
+                ip,
+            )
+            cls._check_pool_policy(policy or {}, ip, count)
+        except Exception as exc:  # noqa: BLE001
+            log.exception("pre_worker_create_policy_gate error: %s", exc)
+            raise
+        finally:
+            log.info("exiting pre_worker_create_policy_gate")
 
     @hook_ctx(ops="create", phase="POST_RESPONSE")
     async def _post_create_cache_pool(cls, ctx):
         from peagen.gateway import log, queue
 
-        created = cls.schemas.read.out.model_validate(
-            ctx["result"], from_attributes=True
-        )
-        log.info("worker %s joined pool_id %s", created.id, created.pool_id)
+        log.info("entering post_worker_create_cache_pool")
         try:
-            await queue.sadd(f"pool_id:{created.pool_id}:members", str(created.id))
-        except Exception as exc:  # noqa: BLE001
-            log.error("failure to add member to pool queue. err: %s", exc)
+            created = cls.schemas.read.out.model_validate(
+                ctx["result"], from_attributes=True
+            )
+            log.info("worker %s joined pool_id %s", created.id, created.pool_id)
+            try:
+                await queue.sadd(f"pool_id:{created.pool_id}:members", str(created.id))
+                log.info(
+                    "post_worker_create_cache_pool: cached member %s",
+                    created.id,
+                )
+            except Exception as exc:  # noqa: BLE001
+                log.error(
+                    "post_worker_create_cache_pool: add member failed: %s",
+                    exc,
+                )
+        finally:
+            log.info("exiting post_worker_create_cache_pool")
 
     @hook_ctx(ops="create", phase="POST_RESPONSE")
     async def _post_create_cache_worker(cls, ctx):
         from peagen.gateway import log, queue
 
-        created = cls.schemas.read.out.model_validate(
-            ctx["result"], from_attributes=True
-        )
+        log.info("entering post_worker_create_cache_worker")
         try:
-            key = WORKER_KEY.format(str(created.id))
-            await queue.hset(key, cls._as_redis_hash(created))
-            await queue.expire(key, WORKER_TTL)
-            log.info("cached `%s`", key)
-        except Exception as exc:  # noqa: BLE001
-            log.error("failure to add worker. err: %s", exc)
-        try:
-            from peagen.gateway._publish import _publish_event
+            created = cls.schemas.read.out.model_validate(
+                ctx["result"], from_attributes=True
+            )
+            try:
+                key = WORKER_KEY.format(str(created.id))
+                await queue.hset(key, cls._as_redis_hash(created))
+                await queue.expire(key, WORKER_TTL)
+                log.info("post_worker_create_cache_worker: cached %s", key)
+            except Exception as exc:  # noqa: BLE001
+                log.error("post_worker_create_cache_worker: cache err: %s", exc)
+            try:
+                from peagen.gateway._publish import _publish_event
 
-            await _publish_event(queue, "Worker.create", created)
-        except Exception as exc:  # noqa: BLE001
-            log.error("failure to _publish_event for: `Worker.create` err: %s", exc)
+                await _publish_event(queue, "Worker.create", created)
+                log.info("post_worker_create_cache_worker: published Worker.create")
+            except Exception as exc:  # noqa: BLE001
+                log.error("post_worker_create_cache_worker: publish err: %s", exc)
+        finally:
+            log.info("exiting post_worker_create_cache_worker")
 
     @hook_ctx(ops="create", phase="POST_COMMIT")
     async def _post_create_auto_register(cls, ctx):
         from peagen.gateway import authn_adapter, log
 
-        created = cls.schemas.read.out.model_validate(
-            ctx["result"], from_attributes=True
-        )
+        log.info("entering post_worker_create_auto_register")
         try:
-            base = authn_adapter.base_url
-
-            def _tenant_id(session):
-                pool = session.get(Pool, created.pool_id)
-                return str(pool.tenant_id) if pool else None
-
-            tenant_id = await ctx["db"].run_sync(_tenant_id)
-
-            svc_resp = await authn_adapter._client.post(
-                f"{base}/service",
-                json={"name": f"worker-{created.id}", "tenant_id": tenant_id},
+            created = cls.schemas.read.out.model_validate(
+                ctx["result"], from_attributes=True
             )
-            svc_resp.raise_for_status()
-            service_id = svc_resp.json()["id"]
-            key_resp = await authn_adapter._client.post(
-                f"{base}/servicekey",
-                json={
-                    "service_id": service_id,
-                    "label": "worker",
-                },
-            )
-            key_resp.raise_for_status()
-            body = key_resp.json()
-            ctx["raw_worker_key"] = body.get("api_key")
-        except Exception as exc:  # pragma: no cover
-            log.error("auto-registration failed: %s", exc)
-            ctx["raw_worker_key"] = None
+            try:
+                base = authn_adapter.base_url
+
+                def _tenant_id(session):
+                    pool = session.get(Pool, created.pool_id)
+                    return str(pool.tenant_id) if pool else None
+
+                tenant_id = await ctx["db"].run_sync(_tenant_id)
+                log.info("post_worker_create_auto_register: tenant_id=%s", tenant_id)
+                svc_resp = await authn_adapter._client.post(
+                    f"{base}/service",
+                    json={"name": f"worker-{created.id}", "tenant_id": tenant_id},
+                )
+                svc_resp.raise_for_status()
+                service_id = svc_resp.json()["id"]
+                log.info("post_worker_create_auto_register: service_id=%s", service_id)
+                key_resp = await authn_adapter._client.post(
+                    f"{base}/servicekey",
+                    json={"service_id": service_id, "label": "worker"},
+                )
+                key_resp.raise_for_status()
+                body = key_resp.json()
+                ctx["raw_worker_key"] = body.get("api_key")
+            except Exception as exc:  # pragma: no cover
+                log.error("post_worker_create_auto_register error: %s", exc)
+                ctx["raw_worker_key"] = None
+        finally:
+            log.info("exiting post_worker_create_auto_register")
 
     @hook_ctx(ops="create", phase="POST_RESPONSE")
     async def _post_create_inject_key(cls, ctx):
         from peagen.gateway import log
 
         log.info("entering post_worker_create_inject_key")
-        raw = ctx.get("raw_worker_key")
-        if not raw:
-            return
+        try:
+            raw = ctx.get("raw_worker_key")
+            if not raw:
+                log.info("post_worker_create_inject_key: no key to inject")
+                return
 
-        res = ctx.get("result")
-        if res is None:
-            return
+            res = ctx.get("result")
+            if res is None:
+                log.info("post_worker_create_inject_key: no result to modify")
+                return
 
-        # Normalize ctx["result"] -> plain dict
-        if isinstance(res, dict):
-            out = dict(res)  # copy
-        elif hasattr(res, "model_dump"):  # Pydantic model
-            out = res.model_dump(mode="json")
-        else:  # ORM instance
-            out = cls.schemas.read.out.model_validate(
-                res, from_attributes=True
-            ).model_dump(mode="json")
+            # Normalize ctx["result"] -> plain dict
+            if isinstance(res, dict):
+                out = dict(res)  # copy
+            elif hasattr(res, "model_dump"):  # Pydantic model
+                out = res.model_dump(mode="json")
+            else:  # ORM instance
+                out = cls.schemas.read.out.model_validate(
+                    res, from_attributes=True
+                ).model_dump(mode="json")
 
-        # Inject the key into the response payload only (not persisted)
-        out["api_key"] = raw
+            # Inject the key into the response payload only (not persisted)
+            out["api_key"] = raw
 
-        ctx["result"] = out
-        resp = ctx.get("response")
-        if resp is not None:
-            resp.result = out
+            ctx["result"] = out
+            resp = ctx.get("response")
+            if resp is not None:
+                resp.result = out
+        finally:
+            log.info("exiting post_worker_create_inject_key")
 
     @hook_ctx(ops="update", phase="PRE_TX_BEGIN")
     async def _pre_update_policy_gate(cls, ctx):
         from peagen.gateway import log
 
         log.info("entering pre_worker_update_policy_gate")
-        wu = ctx["env"].params
-        worker_id = str(wu["id"] or wu["item_id"])
-        pool_id = wu.get("pool_id")
-        if pool_id is None:
-            from peagen.gateway import queue
+        try:
+            wu = ctx["env"].params
+            worker_id = str(wu["id"] or wu["item_id"])
+            pool_id = wu.get("pool_id")
+            if pool_id is None:
+                from peagen.gateway import queue
 
-            pool_id = await queue.hget(WORKER_KEY.format(worker_id), "pool_id")
-        if isinstance(pool_id, str):
-            pool_id = UUID(pool_id)
+                pool_id = await queue.hget(WORKER_KEY.format(worker_id), "pool_id")
+            if isinstance(pool_id, str):
+                pool_id = UUID(pool_id)
 
-        ip = cls._client_ip(ctx["request"])
+            ip = cls._client_ip(ctx["request"])
 
-        def _get_policy_and_count(session):
-            pool = session.get(Pool, pool_id)
-            count = session.query(cls).filter(cls.pool_id == pool_id).count()
-            return (pool.policy if pool else {}, count)
+            def _get_policy_and_count(session):
+                pool = session.get(Pool, pool_id)
+                count = session.query(cls).filter(cls.pool_id == pool_id).count()
+                return (pool.policy if pool else {}, count)
 
-        policy, count = await ctx["db"].run_sync(_get_policy_and_count)
-        cls._check_pool_policy(policy or {}, ip, count)
+            policy, count = await ctx["db"].run_sync(_get_policy_and_count)
+            log.info(
+                "pre_worker_update_policy_gate: policy=%s count=%s ip=%s",
+                policy,
+                count,
+                ip,
+            )
+            cls._check_pool_policy(policy or {}, ip, count)
+        except Exception as exc:  # noqa: BLE001
+            log.exception("pre_worker_update_policy_gate error: %s", exc)
+            raise
+        finally:
+            log.info("exiting pre_worker_update_policy_gate")
 
     @hook_ctx(ops="update", phase="PRE_TX_BEGIN")
     async def _pre_update(cls, ctx):
@@ -250,76 +297,115 @@ class Worker(Base, GUIDPk, Timestamped, AllowAnonProvider):
         from peagen.transport.jsonrpc import RPCException
 
         log.info("entering pre_worker_update")
-        wu = ctx["env"].params
-        worker_id = str(wu["id"] or wu["item_id"])
-        cached = await queue.exists(WORKER_KEY.format(worker_id))
-        if not cached and wu["pool_id"] is None:
-            raise RPCException(code=-32602, message="unknown worker; pool_id required")
-        ctx["worker_id"] = worker_id
+        try:
+            wu = ctx["env"].params
+            worker_id = str(wu["id"] or wu["item_id"])
+            cached = await queue.exists(WORKER_KEY.format(worker_id))
+            log.info("pre_worker_update: worker_id=%s cached=%s", worker_id, cached)
+            if not cached and wu["pool_id"] is None:
+                raise RPCException(
+                    code=-32602, message="unknown worker; pool_id required"
+                )
+            ctx["worker_id"] = worker_id
+        except Exception as exc:  # noqa: BLE001
+            log.exception("pre_worker_update error: %s", exc)
+            raise
+        finally:
+            log.info("exiting pre_worker_update")
 
     @hook_ctx(ops="update", phase="POST_RESPONSE")
     async def _post_update_cache_pool(cls, ctx):
         from peagen.gateway import log, queue
 
-        worker_id = ctx["worker_id"]
+        log.info("entering post_worker_update_cache_pool")
         try:
-            updated = cls.schemas.read.out.model_validate(
-                ctx["result"], from_attributes=True
-            )
-            if updated.pool_id:
-                await queue.sadd(f"pool_id:{updated.pool_id}:members", worker_id)
-            log.info("cached member `%s` in `%s`", worker_id, updated.pool_id)
-        except Exception as exc:  # noqa: BLE001
-            log.info(
-                "pool member `%s` failed to cache in `%s` err: %s",
-                worker_id,
-                getattr(updated, "pool_id", ""),
-                exc,
-            )
+            worker_id = ctx["worker_id"]
+            try:
+                updated = cls.schemas.read.out.model_validate(
+                    ctx["result"], from_attributes=True
+                )
+                if updated.pool_id:
+                    await queue.sadd(f"pool_id:{updated.pool_id}:members", worker_id)
+                    log.info(
+                        "post_worker_update_cache_pool: cached member %s in %s",
+                        worker_id,
+                        updated.pool_id,
+                    )
+            except Exception as exc:  # noqa: BLE001
+                log.info(
+                    "post_worker_update_cache_pool: cache err for %s in %s: %s",
+                    worker_id,
+                    getattr(updated, "pool_id", ""),
+                    exc,
+                )
+        finally:
+            log.info("exiting post_worker_update_cache_pool")
 
     @hook_ctx(ops="update", phase="POST_RESPONSE")
     async def _post_update_cache_worker(cls, ctx):
         from peagen.gateway import log, queue
         from peagen.gateway._publish import _publish_event
 
-        worker_id = ctx["worker_id"]
+        log.info("entering post_worker_update_cache_worker")
         try:
-            updated = cls.schemas.read.out.model_validate(
-                ctx["result"], from_attributes=True
-            )
-            key = WORKER_KEY.format(worker_id)
-            await queue.hset(key, {"updated_at": str(updated.updated_at)})
-            await queue.expire(key, WORKER_TTL)
-            log.info("cached worker: `%s`", worker_id)
-        except Exception as exc:  # noqa: BLE001
-            log.info("cached failed for worker: `%s` err: %s", worker_id, exc)
-        try:
-            await _publish_event(queue, "Worker.update", updated)
-        except Exception as exc:  # noqa: BLE001
-            log.error("failure to _publish_event for: `Worker.update` err: %s", exc)
+            worker_id = ctx["worker_id"]
+            try:
+                updated = cls.schemas.read.out.model_validate(
+                    ctx["result"], from_attributes=True
+                )
+                key = WORKER_KEY.format(worker_id)
+                await queue.hset(key, {"updated_at": str(updated.updated_at)})
+                await queue.expire(key, WORKER_TTL)
+                log.info(
+                    "post_worker_update_cache_worker: cached worker %s",
+                    worker_id,
+                )
+            except Exception as exc:  # noqa: BLE001
+                log.info(
+                    "post_worker_update_cache_worker: cache err for %s: %s",
+                    worker_id,
+                    exc,
+                )
+            try:
+                await _publish_event(queue, "Worker.update", updated)
+                log.info("post_worker_update_cache_worker: published Worker.update")
+            except Exception as exc:  # noqa: BLE001
+                log.error("post_worker_update_cache_worker: publish err: %s", exc)
+        finally:
+            log.info("exiting post_worker_update_cache_worker")
 
     @hook_ctx(ops="list", phase="POST_HANDLER")
     async def _post_list(cls, ctx):
         from peagen.gateway import log
 
         log.info("entering post_workers_list")
+        log.info("exiting post_workers_list")
 
     @hook_ctx(ops="delete", phase="POST_HANDLER")
     async def _post_delete(cls, ctx):
         from peagen.gateway import log, queue
         from peagen.gateway._publish import _publish_event
 
-        wu = ctx["env"].params
-        worker_id = str(wu["id"] or wu["item_id"])
+        log.info("entering post_worker_delete")
         try:
-            await queue.expire(WORKER_KEY.format(worker_id), 0)
-            log.info("worker expired: `%s`", worker_id)
-        except Exception as exc:  # noqa: BLE001
-            log.info("worker expiration op failed: `%s` err: %s", worker_id, exc)
-        try:
-            await _publish_event(queue, "Worker.delete", {"id": worker_id})
-        except Exception as exc:  # noqa: BLE001
-            log.info("failure to _publish_event for: `Worker.delete` err: %s", exc)
+            wu = ctx["env"].params
+            worker_id = str(wu["id"] or wu["item_id"])
+            try:
+                await queue.expire(WORKER_KEY.format(worker_id), 0)
+                log.info("post_worker_delete: worker expired %s", worker_id)
+            except Exception as exc:  # noqa: BLE001
+                log.info(
+                    "post_worker_delete: expiration failed %s err: %s",
+                    worker_id,
+                    exc,
+                )
+            try:
+                await _publish_event(queue, "Worker.delete", {"id": worker_id})
+                log.info("post_worker_delete: published Worker.delete")
+            except Exception as exc:  # noqa: BLE001
+                log.info("post_worker_delete: publish err for %s: %s", worker_id, exc)
+        finally:
+            log.info("exiting post_worker_delete")
 
         # hooks registered via @hook_ctx
 


### PR DESCRIPTION
## Summary
- add detailed entry/exit logs around gateway worker hooks
- log key steps like policy checks, caching, publishing

## Testing
- `uv run --directory pkgs/standards/peagen --package peagen ruff format .`
- `uv run --directory pkgs/standards/peagen --package peagen ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c5e575eda88326bb4a25fdae6d3ef1