### PR TITLE
Expose discovery endpoints in tigrbl_auth OpenAPI

### DIFF
--- a/pkgs/standards/tigrbl_auth/tests/unit/test_openid_configuration.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_openid_configuration.py
@@ -28,3 +28,13 @@ async def test_openid_configuration_contains_required_fields(async_client) -> No
     assert "client_secret_basic" in data["token_endpoint_auth_methods_supported"]
     assert "S256" in data["code_challenge_methods_supported"]
     assert "query" in data["response_modes_supported"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_openapi_includes_well_known_endpoints(async_client) -> None:
+    resp = await async_client.get("/openapi.json")
+    assert resp.status_code == status.HTTP_200_OK
+    spec = resp.json()
+    assert "/.well-known/openid-configuration" in spec["paths"]
+    assert "/.well-known/jwks.json" in spec["paths"]

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/oidc_discovery.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/oidc_discovery.py
@@ -91,13 +91,13 @@ def refresh_discovery_cache() -> None:
 # ---------------------------------------------------------------------------
 # Routes
 # ---------------------------------------------------------------------------
-@router.get("/.well-known/openid-configuration", include_in_schema=False)
+@router.get("/.well-known/openid-configuration")
 async def openid_configuration():
     """Return OpenID Connect discovery metadata."""
     return _cached_openid_config(_settings_signature())
 
 
-@router.get(JWKS_PATH, include_in_schema=False)
+@router.get(JWKS_PATH)
 async def jwks():
     """Publish all public keys in RFC 7517 JWKS format."""
     from .oidc_id_token import ensure_rsa_jwt_key, rsa_key_provider


### PR DESCRIPTION
## Summary
- expose `/.well-known/openid-configuration` and `/.well-known/jwks.json` in OpenAPI schema
- test that OpenAPI spec lists both discovery endpoints

## Testing
- `uv run --directory pkgs/standards/tigrbl_auth --package tigrbl-auth ruff format .`
- `uv run --directory pkgs/standards/tigrbl_auth --package tigrbl-auth ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c5fa32c188832698bc4557494e94b2