### PR TITLE
feat: expose tigrbl_auth well-known endpoints in OpenAPI

### DIFF
--- a/pkgs/standards/tigrbl_auth/tests/unit/test_openapi_well_known_endpoints.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_openapi_well_known_endpoints.py
@@ -1,0 +1,26 @@
+import asyncio
+
+import pytest_asyncio
+
+from tigrbl_auth.app import app
+from tigrbl_auth.routers.surface import surface_api
+from tigrbl_auth.rfc8414_metadata import JWKS_PATH
+
+
+@pytest_asyncio.fixture()
+async def openapi_spec() -> dict:
+    """Generate an OpenAPI specification after initializing the API surface."""
+    init = surface_api.initialize()
+    if asyncio.iscoroutine(init):
+        await init
+    return app.openapi()
+
+
+def test_openapi_includes_openid_configuration(openapi_spec: dict) -> None:
+    """Ensure the discovery document is documented in OpenAPI."""
+    assert "/.well-known/openid-configuration" in openapi_spec["paths"]
+
+
+def test_openapi_includes_jwks(openapi_spec: dict) -> None:
+    """Ensure the JWKS endpoint is documented in OpenAPI."""
+    assert JWKS_PATH in openapi_spec["paths"]

--- a/pkgs/standards/tigrbl_auth/tests/unit/test_well_known_endpoints_behavior.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_well_known_endpoints_behavior.py
@@ -1,0 +1,29 @@
+import pytest
+from fastapi import status
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_openid_configuration_values(async_client) -> None:
+    """OpenID configuration should expose issuer and JWKS URI."""
+    resp = await async_client.get("/.well-known/openid-configuration")
+    assert resp.status_code == status.HTTP_200_OK
+    data = resp.json()
+    from tigrbl_auth.rfc8414_metadata import JWKS_PATH, ISSUER
+
+    assert data["issuer"] == ISSUER
+    assert data["jwks_uri"].endswith(JWKS_PATH)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_jwks_returns_public_keys(async_client) -> None:
+    """JWKS endpoint should publish at least one public key."""
+    resp = await async_client.get("/.well-known/jwks.json")
+    assert resp.status_code == status.HTTP_200_OK
+    data = resp.json()
+    keys = data.get("keys")
+    assert isinstance(keys, list) and keys
+    first = keys[0]
+    assert "kid" in first
+    assert "kty" in first

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/oidc_discovery.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/oidc_discovery.py
@@ -91,13 +91,13 @@ def refresh_discovery_cache() -> None:
 # ---------------------------------------------------------------------------
 # Routes
 # ---------------------------------------------------------------------------
-@router.get("/.well-known/openid-configuration", include_in_schema=False)
+@router.get("/.well-known/openid-configuration")
 async def openid_configuration():
     """Return OpenID Connect discovery metadata."""
     return _cached_openid_config(_settings_signature())
 
 
-@router.get(JWKS_PATH, include_in_schema=False)
+@router.get(JWKS_PATH)
 async def jwks():
     """Publish all public keys in RFC 7517 JWKS format."""
     from .oidc_id_token import ensure_rsa_jwt_key, rsa_key_provider


### PR DESCRIPTION
## Summary
- document `/.well-known/openid-configuration` and `/.well-known/jwks.json` in the tigrbl_auth OpenAPI spec
- add tests ensuring well-known endpoints appear in OpenAPI and return expected data

## Testing
- `uv run --package tigrbl_auth --directory standards/tigrbl_auth ruff format .`
- `uv run --package tigrbl_auth --directory standards/tigrbl_auth ruff check . --fix`
- `uv run --package tigrbl_auth --directory standards/tigrbl_auth pytest tests/unit/test_openapi_well_known_endpoints.py tests/unit/test_well_known_endpoints_behavior.py tests/unit/test_openid_configuration.py`

------
https://chatgpt.com/codex/tasks/task_e_68c5fa987894832680832dbfe2b8cda5