### PR TITLE
feat: add DPoP signing package

### DIFF
--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -119,6 +119,7 @@ members = [
     "standards/swarmauri_signing_ecdsa",
     "standards/swarmauri_signing_ca",
     "standards/swarmauri_signing_jws",
+    "standards/swarmauri_signing_dpop",
     "standards/swarmauri_certs_local_ca",
     "standards/swarmauri_certs_self_signed",
     "standards/swarmauri_tokens_jwt",
@@ -311,6 +312,7 @@ swarmauri_signing_ecdsa = { workspace = true }
 swarmauri_signing_ca = { workspace = true }
 swarmauri_certs_remote_ca = { workspace = true }
 swarmauri_signing_jws = { workspace = true }
+swarmauri_signing_dpop = { workspace = true }
 swarmauri_certs_pkcs11 = { workspace = true }
 swarmauri_certs_local_ca = { workspace = true }
 swarmauri_certs_self_signed = { workspace = true }

--- a/pkgs/standards/swarmauri_signing_dpop/LICENSE
+++ b/pkgs/standards/swarmauri_signing_dpop/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/standards/swarmauri_signing_dpop/README.md
+++ b/pkgs/standards/swarmauri_signing_dpop/README.md
@@ -1,0 +1,57 @@
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/main/assets/swarmauri.brand.theme.svg)
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_signing_dpop/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_signing_dpop" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_signing_dpop/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_signing_dpop.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_signing_dpop/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_signing_dpop" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_signing_dpop/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_signing_dpop" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_signing_dpop/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_signing_dpop?label=swarmauri_signing_dpop&color=green" alt="PyPI - swarmauri_signing_dpop"/></a>
+</p>
+
+# Swarmauri Signing DPoP
+
+DPoP proof signer/verifier implementing RFC 9449 for proof-of-possession over HTTP requests.
+
+Features:
+- Creates and validates `dpop+jwt` proofs with embedded JWK
+- Supports `ES256`, `RS256`, and `EdDSA`
+- Optional access-token hash binding (`ath`) and replay protection hooks
+
+## Installation
+
+```bash
+pip install swarmauri_signing_dpop
+```
+
+## Usage
+
+```python
+import asyncio
+from swarmauri_signing_dpop import DpopSigner
+
+async def main() -> None:
+    signer = DpopSigner()
+    key = {"kind": "pem", "priv": PRIV_PEM_BYTES, "alg": "EdDSA"}
+    sigs = await signer.sign_bytes(
+        key,
+        b"",
+        opts={"htm": "GET", "htu": "https://api.example/x"},
+    )
+    ok = await signer.verify_bytes(
+        b"",
+        sigs,
+        require={"htm": "GET", "htu": "https://api.example/x"},
+    )
+    assert ok
+
+asyncio.run(main())
+```
+
+## Entry Point
+
+The signer registers under the `swarmauri.signings` entry point as `DpopSigner`.

--- a/pkgs/standards/swarmauri_signing_dpop/README.md
+++ b/pkgs/standards/swarmauri_signing_dpop/README.md
@@ -1,4 +1,4 @@
-![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/main/assets/swarmauri.brand.theme.svg)
+![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_signing_dpop/">

--- a/pkgs/standards/swarmauri_signing_dpop/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_dpop/pyproject.toml
@@ -1,0 +1,68 @@
+[project]
+name = "swarmauri_signing_dpop"
+version = "0.1.0"
+description = "DPoP signer/verifier for Swarmauri"
+license = "Apache-2.0"
+readme = "README.md"
+requires-python = ">=3.10,<3.13"
+authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Development Status :: 3 - Alpha",
+    "Topic :: Security :: Cryptography",
+    "Intended Audience :: Developers",
+]
+dependencies = [
+    "swarmauri_core",
+    "swarmauri_base",
+    "pyjwt",
+    "cryptography",
+]
+
+[tool.uv.sources]
+swarmauri_core = { workspace = true }
+swarmauri_base = { workspace = true }
+
+[tool.pytest.ini_options]
+norecursedirs = ["combined", "scripts"]
+markers = [
+    "test: standard test",
+    "unit: Unit tests",
+    "i9n: Integration tests",
+    "r8n: Regression tests",
+    "acceptance: Acceptance tests",
+    "perf: Performance tests",
+]
+timeout = 300
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "pytest-timeout>=2.3.1",
+    "pytest-benchmark>=4.0.0",
+    "flake8>=7.0",
+    "ruff>=0.9.9",
+]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[project.entry-points.'swarmauri.signings']
+DpopSigner = "swarmauri_signing_dpop:DpopSigner"
+
+[project.entry-points."peagen.plugins.signings"]
+dpop = "swarmauri_signing_dpop:DpopSigner"

--- a/pkgs/standards/swarmauri_signing_dpop/swarmauri_signing_dpop/DpopSigner.py
+++ b/pkgs/standards/swarmauri_signing_dpop/swarmauri_signing_dpop/DpopSigner.py
@@ -1,0 +1,331 @@
+"""
+DPoP Signer / Verifier
+----------------------
+
+Implements RFC 9449 (DPoP) proof *signing* (client side) and *verification*
+(server side). Designed to plug into the same SigningBase/ISigning surface used
+by other signers (detached signatures), but note that DPoP is a *proof of
+possession* over request metadata (method+URL [+ token hash]), not a content
+signature. We therefore treat the "payload" as contextual and drive semantics
+via opts/require.
+
+Key points:
+- sign_bytes(): creates a 'dpop+jwt' proof with header {alg, typ, jwk}.
+- verify_bytes(): validates signature (using embedded JWK), claims, iat skew,
+  jti replay window, method/url binding, and (optional) 'ath' against a bearer
+  access token.
+- supports 'ES256', 'RS256', 'EdDSA' for practicality; extend as needed.
+
+KeyRef support:
+- {"kind": "pem", "priv": <PEM bytes|str>} — loads private key; derives JWK.
+- {"kind": "jwk", "priv": <private JWK dict>} — uses provided JWK (must include
+  private fields); derives public JWK for header embedding.
+
+Signature format returned (detached):
+{
+  "alg": "<JWS alg>",
+  "format": "dpop+jwt",
+  "sig": "<compact JWS string>",     # the DPoP proof JWT
+  "jkt": "<b64url SHA-256 JWK thumbprint>",  # convenience for RS checks
+}
+
+Verification options:
+- require = {
+    "htm": "POST",                   # required HTTP method
+    "htu": "https://api.example/x",  # required URL (scheme/host/path[?query])
+    "max_skew_s": 300,               # iat window (default 300s)
+    "algs": ["ES256","EdDSA"],       # optional allowlist of algs
+    "replay": {                      # optional replay store hooks
+       "seen": callable(jti)->bool,  # return True if already seen
+       "mark": callable(jti, ttl_s)  # persist jti with TTL
+    },
+    "nonce": "server-issued-nonce",  # optional DPoP-Nonce to enforce
+    "access_token": "<Bearer ...>",  # optional; if set, check 'ath'
+  }
+
+Notes:
+- For resource servers, compare the proof JWK thumbprint to access_token.cnf.jkt.
+- For authorization servers issuing sender-constrained tokens, bind cnf.jkt to
+  jwk_thumbprint(proof.header.jwk) at /token time.
+
+Dependencies: PyJWT, cryptography.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import time
+import typing as t
+from dataclasses import dataclass
+
+import jwt
+from jwt import algorithms as jwt_algs
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
+
+# Align with your base / interfaces
+from swarmauri_base.signing.SigningBase import SigningBase
+from swarmauri_core.signing.ISigning import Signature, Envelope, Canon  # types only
+
+# ────────────────────────── Helpers: base64url / JWK ──────────────────────────
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _sha256_b64url(data: bytes) -> str:
+    return _b64url(hashlib.sha256(data).digest())
+
+
+def _json_c14n(obj: t.Any) -> bytes:
+    return json.dumps(
+        obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
+
+
+def _jwk_thumbprint_b64url(jwk: dict) -> str:
+    # RFC 7638 canonicalization
+    kty = jwk["kty"]
+    if kty == "RSA":
+        ordered = {"e": jwk["e"], "kty": "RSA", "n": jwk["n"]}
+    elif kty == "EC":
+        ordered = {"crv": jwk["crv"], "kty": "EC", "x": jwk["x"], "y": jwk["y"]}
+    elif kty == "OKP":
+        ordered = {"crv": jwk["crv"], "kty": "OKP", "x": jwk["x"]}
+    else:
+        raise ValueError(f"Unsupported kty for thumbprint: {kty}")
+    return _sha256_b64url(_json_c14n(ordered))
+
+
+def _ath_from_access_token(tok: str) -> str:
+    # ath = b64url( SHA-256( access_token ) )
+    if tok.startswith("Bearer "):
+        tok = tok[7:]
+    return _sha256_b64url(tok.encode("ascii"))
+
+
+# ───────────────────────── KeyRef resolution (PEM / JWK) ──────────────────────
+
+
+@dataclass
+class _KeyMat:
+    priv: t.Any  # PyJWT accepts cryptography key object or PEM string
+    pub_jwk: dict  # public JWK (embedded into DPoP header)
+    alg: str  # JWS alg hint
+
+
+def _derive_public_jwk_from_priv_pem(pem_bytes: bytes, alg: str) -> dict:
+    key = load_pem_private_key(pem_bytes, password=None)
+    jwk = jwt_algs.get_default_algorithms()[alg].to_jwk(key.public_key())
+    return json.loads(jwk)
+
+
+def _resolve_keyref(key: dict, alg: t.Optional[str]) -> _KeyMat:
+    if not isinstance(key, dict):
+        raise TypeError("DPoP KeyRef must be a dict")
+    kind = key.get("kind")
+    if kind == "pem":
+        priv = key.get("priv")
+        if isinstance(priv, str):
+            priv = priv.encode("utf-8")
+        if not isinstance(priv, (bytes, bytearray)):
+            raise TypeError("KeyRef['priv'] must be PEM bytes|str for kind='pem'")
+        # Default alg if not provided: ES256 preferred; allow RS256/EdDSA via override
+        the_alg = alg or key.get("alg") or "ES256"
+        pub_jwk = _derive_public_jwk_from_priv_pem(bytes(priv), the_alg)
+        return _KeyMat(priv=bytes(priv), pub_jwk=pub_jwk, alg=the_alg)
+    if kind == "jwk":
+        priv_jwk = key.get("priv")
+        if not isinstance(priv_jwk, dict):
+            raise TypeError("KeyRef['priv'] must be a private JWK dict for kind='jwk'")
+        # alg hint from arg or jwk["alg"] or default ES256
+        the_alg = alg or priv_jwk.get("alg") or "ES256"
+        # Build a public JWK by dropping private params
+        pub_jwk = {
+            k: v for k, v in priv_jwk.items() if k in ("kty", "crv", "x", "y", "n", "e")
+        }
+        return _KeyMat(priv=priv_jwk, pub_jwk=pub_jwk, alg=the_alg)
+    raise TypeError(f"Unsupported KeyRef.kind: {kind}")
+
+
+# ─────────────────────────── DPoP proof builder/verifier ──────────────────────
+
+_ALLOWED_ALGS = {"ES256", "RS256", "EdDSA"}
+
+
+def _now() -> int:
+    return int(time.time())
+
+
+class DpopSigner(SigningBase):
+    """DPoP proof signer/verifier that conforms to the SigningBase/ISigning surface."""
+
+    def supports(self) -> dict[str, t.Iterable[str]]:
+        return {
+            "algs": tuple(sorted(_ALLOWED_ALGS)),
+            "canons": ("raw", "json"),
+            "features": ("detached_only",),
+        }
+
+    async def canonicalize_envelope(
+        self,
+        env: Envelope,
+        *,
+        canon: t.Optional[Canon] = None,
+        opts: t.Optional[dict[str, t.Any]] = None,
+    ) -> bytes:
+        if canon in (None, "raw"):
+            if isinstance(env, (bytes, bytearray)):
+                return bytes(env)
+            if isinstance(env, str):
+                return env.encode("utf-8")
+        if canon == "json" or not isinstance(env, (bytes, bytearray, str)):
+            return _json_c14n(env)  # type: ignore[arg-type]
+        raise ValueError(f"Unsupported canon: {canon}")
+
+    async def sign_bytes(
+        self,
+        key: dict,
+        payload: bytes,
+        *,
+        alg: t.Optional[str] = None,
+        opts: t.Optional[dict[str, t.Any]] = None,
+    ) -> t.Sequence[Signature]:
+        o = opts or {}
+        htm = (o.get("htm") or "").upper()
+        htu = o.get("htu") or ""
+        if not htm or not htu:
+            raise ValueError("DPoP signing requires opts['htm'] and opts['htu']")
+
+        km = _resolve_keyref(key, alg)
+        if km.alg not in _ALLOWED_ALGS:
+            raise ValueError(f"Unsupported alg for DPoP: {km.alg}")
+
+        iat = int(o.get("iat") or _now())
+        jti = o.get("jti") or _b64url(
+            hashlib.sha256(f"{iat}:{htm}:{htu}".encode()).digest()
+        )
+        nonce = o.get("nonce")
+        access_token = o.get("access_token")
+
+        claims: dict[str, t.Any] = {"htm": htm, "htu": htu, "iat": iat, "jti": jti}
+        if nonce:
+            claims["nonce"] = str(nonce)
+        if access_token:
+            claims["ath"] = _ath_from_access_token(access_token)
+
+        header = {"typ": "dpop+jwt", "alg": km.alg, "jwk": km.pub_jwk}
+
+        token = jwt.encode(
+            payload=claims,
+            key=km.priv,
+            algorithm=km.alg,
+            headers=header,
+        )
+        jkt = _jwk_thumbprint_b64url(km.pub_jwk)
+        return [{"alg": km.alg, "format": "dpop+jwt", "sig": token, "jkt": jkt}]
+
+    async def verify_bytes(
+        self,
+        payload: bytes,
+        signatures: t.Sequence[Signature],
+        *,
+        require: t.Optional[dict[str, t.Any]] = None,
+        opts: t.Optional[dict[str, t.Any]] = None,
+    ) -> bool:
+        if not signatures:
+            return False
+        req = require or {}
+        method_req = (req.get("htm") or "").upper()
+        url_req = req.get("htu") or ""
+        if not method_req or not url_req:
+            raise ValueError("DPoP verify requires require['htm'] and require['htu']")
+
+        max_skew = int(req.get("max_skew_s", 300))
+        allowed_algs = set(req.get("algs") or _ALLOWED_ALGS)
+        expect_nonce = req.get("nonce")
+        expect_ath = req.get("access_token")
+        replay = req.get("replay") or {}
+        seen = replay.get("seen")
+        mark = replay.get("mark")
+
+        now = _now()
+
+        for sig in signatures:
+            token = sig.get("sig")
+            if not isinstance(token, str):
+                continue
+            try:
+                header = jwt.get_unverified_header(token)
+                if header.get("typ") != "dpop+jwt":
+                    continue
+                alg = header.get("alg")
+                jwk = header.get("jwk")
+                if alg not in allowed_algs or not isinstance(jwk, dict):
+                    continue
+
+                key_obj = jwt_algs.get_default_algorithms()[alg].from_jwk(
+                    json.dumps(jwk)
+                )
+                claims = jwt.decode(
+                    token,
+                    key=key_obj,
+                    algorithms=[alg],
+                    options={"verify_aud": False, "verify_exp": False},
+                )
+
+                if (claims.get("htm") or "").upper() != method_req:
+                    continue
+                if claims.get("htu") != url_req:
+                    continue
+                iat = int(claims.get("iat", 0))
+                if abs(now - iat) > max_skew:
+                    continue
+                if expect_nonce is not None and claims.get("nonce") != expect_nonce:
+                    continue
+                if expect_ath is not None:
+                    ath = claims.get("ath")
+                    if not isinstance(ath, str) or ath != _ath_from_access_token(
+                        expect_ath
+                    ):
+                        continue
+
+                jti = claims.get("jti")
+                if isinstance(jti, str) and seen and seen(jti):
+                    continue
+                if isinstance(jti, str) and mark:
+                    try:
+                        mark(jti, max_skew)
+                    except Exception:
+                        pass
+
+                return True
+            except Exception:
+                continue
+        return False
+
+    async def sign_envelope(
+        self,
+        key: dict,
+        env: Envelope,
+        *,
+        alg: t.Optional[str] = None,
+        canon: t.Optional[Canon] = None,
+        opts: t.Optional[dict[str, t.Any]] = None,
+    ) -> t.Sequence[Signature]:
+        _ = await self.canonicalize_envelope(env, canon=canon, opts=opts)
+        return await self.sign_bytes(key, b"", alg=alg, opts=opts)
+
+    async def verify_envelope(
+        self,
+        env: Envelope,
+        signatures: t.Sequence[Signature],
+        *,
+        canon: t.Optional[Canon] = None,
+        require: t.Optional[dict[str, t.Any]] = None,
+        opts: t.Optional[dict[str, t.Any]] = None,
+    ) -> bool:
+        _ = await self.canonicalize_envelope(env, canon=canon, opts=opts)
+        return await self.verify_bytes(b"", signatures, require=require, opts=opts)

--- a/pkgs/standards/swarmauri_signing_dpop/swarmauri_signing_dpop/__init__.py
+++ b/pkgs/standards/swarmauri_signing_dpop/swarmauri_signing_dpop/__init__.py
@@ -1,0 +1,3 @@
+from .DpopSigner import DpopSigner
+
+__all__ = ["DpopSigner"]

--- a/pkgs/standards/swarmauri_signing_dpop/tests/unit/test_dpop_signer.py
+++ b/pkgs/standards/swarmauri_signing_dpop/tests/unit/test_dpop_signer.py
@@ -1,0 +1,27 @@
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ed25519
+
+from swarmauri_signing_dpop import DpopSigner
+
+
+@pytest.mark.asyncio
+async def test_sign_and_verify_dpop() -> None:
+    priv = ed25519.Ed25519PrivateKey.generate()
+    pem = priv.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+    keyref = {"kind": "pem", "priv": pem, "alg": "EdDSA"}
+    signer = DpopSigner()
+    sigs = await signer.sign_bytes(
+        keyref,
+        b"",
+        opts={"htm": "GET", "htu": "https://api.example/x"},
+    )
+    assert await signer.verify_bytes(
+        b"",
+        sigs,
+        require={"htm": "GET", "htu": "https://api.example/x"},
+    )


### PR DESCRIPTION
## Summary
- add `swarmauri_signing_dpop` implementing RFC 9449 proof-of-possession signer and verifier
- document package with Swarmauri branding and usage instructions
- register package in workspace configuration

## Testing
- `uv run --package swarmauri_signing_dpop --directory . ruff check . --fix`
- `uv run --package swarmauri-monorepo --directory pkgs ruff check pyproject.toml --fix`
- `uv run --package swarmauri_signing_dpop --directory standards/swarmauri_signing_dpop pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5fc5e90388326924cbe9800074972