### PR TITLE
test: cover unsupported dpop algs

### DIFF
--- a/pkgs/standards/swarmauri_signing_dpop/tests/unit/test_dpop_signer.py
+++ b/pkgs/standards/swarmauri_signing_dpop/tests/unit/test_dpop_signer.py
@@ -25,3 +25,17 @@ async def test_sign_and_verify_dpop() -> None:
         sigs,
         require={"htm": "GET", "htu": "https://api.example/x"},
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("alg", ["HS256", "HS384", "HS512", "none"])
+async def test_sign_rejects_unsupported_algs(alg: str) -> None:
+    signer = DpopSigner()
+    keyref = {"kind": "jwk", "priv": {"kty": "oct", "k": "secret"}}
+    with pytest.raises(ValueError, match="Unsupported alg"):
+        await signer.sign_bytes(
+            keyref,
+            b"",
+            alg=alg,
+            opts={"htm": "GET", "htu": "https://api.example/x"},
+        )


### PR DESCRIPTION
## Summary
- add parametrized tests for unsupported HS* and none algorithms in DPoP signer

## Testing
- `uv run --package swarmauri_signing_dpop --directory . ruff format .`
- `uv run --package swarmauri_signing_dpop --directory . ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c6009a98808326a1ac7ddbc9fd5e99