### PR TITLE
test: ensure DPoP signer RFC 9449 compliance

### DIFF
--- a/pkgs/standards/swarmauri_signing_dpop/swarmauri_signing_dpop/DpopSigner.py
+++ b/pkgs/standards/swarmauri_signing_dpop/swarmauri_signing_dpop/DpopSigner.py
@@ -293,9 +293,11 @@ class DpopSigner(SigningBase):
                         continue
 
                 jti = claims.get("jti")
-                if isinstance(jti, str) and seen and seen(jti):
+                if not isinstance(jti, str) or not jti:
                     continue
-                if isinstance(jti, str) and mark:
+                if seen and seen(jti):
+                    continue
+                if mark:
                     try:
                         mark(jti, max_skew)
                     except Exception:

--- a/pkgs/standards/swarmauri_signing_dpop/tests/unit/test_dpop_signer.py
+++ b/pkgs/standards/swarmauri_signing_dpop/tests/unit/test_dpop_signer.py
@@ -1,8 +1,14 @@
+import base64
+import time
+from uuid import uuid4
+
+import jwt
 import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ed25519
 
 from swarmauri_signing_dpop import DpopSigner
+from swarmauri_signing_dpop.DpopSigner import _jwk_thumbprint_b64url
 
 
 @pytest.mark.asyncio
@@ -23,5 +29,92 @@ async def test_sign_and_verify_dpop() -> None:
     assert await signer.verify_bytes(
         b"",
         sigs,
+        require={"htm": "GET", "htu": "https://api.example/x"},
+    )
+
+
+def _b64u(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+@pytest.mark.asyncio
+async def test_proof_contains_required_header_and_claims() -> None:
+    priv = ed25519.Ed25519PrivateKey.generate()
+    pem = priv.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+    signer = DpopSigner()
+    sigs = await signer.sign_bytes(
+        {"kind": "pem", "priv": pem, "alg": "EdDSA"},
+        b"",
+        opts={"htm": "POST", "htu": "https://api.example/resource"},
+    )
+    token = sigs[0]["sig"]
+    header = jwt.get_unverified_header(token)
+    assert header["typ"] == "dpop+jwt"
+    claims = jwt.decode(
+        token,
+        priv.public_key(),
+        algorithms=["EdDSA"],
+        options={"verify_aud": False, "verify_exp": False},
+    )
+    for field in ("htm", "htu", "iat", "jti"):
+        assert field in claims
+    assert claims["htm"] == "POST"
+    assert claims["htu"] == "https://api.example/resource"
+    assert sigs[0]["jkt"] == _jwk_thumbprint_b64url(header["jwk"])
+
+
+@pytest.mark.asyncio
+async def test_verify_rejects_proof_with_wrong_typ() -> None:
+    priv = ed25519.Ed25519PrivateKey.generate()
+    pub = priv.public_key().public_bytes(
+        serialization.Encoding.Raw, serialization.PublicFormat.Raw
+    )
+    jwk = {"kty": "OKP", "crv": "Ed25519", "x": _b64u(pub)}
+    payload = {
+        "htm": "GET",
+        "htu": "https://api.example/x",
+        "iat": int(time.time()),
+        "jti": str(uuid4()),
+    }
+    token = jwt.encode(
+        payload,
+        priv,
+        algorithm="EdDSA",
+        headers={"typ": "JWT", "jwk": jwk},
+    )
+    signer = DpopSigner()
+    assert not await signer.verify_bytes(
+        b"",
+        [{"sig": token}],
+        require={"htm": "GET", "htu": "https://api.example/x"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_verify_rejects_proof_missing_jti() -> None:
+    priv = ed25519.Ed25519PrivateKey.generate()
+    pub = priv.public_key().public_bytes(
+        serialization.Encoding.Raw, serialization.PublicFormat.Raw
+    )
+    jwk = {"kty": "OKP", "crv": "Ed25519", "x": _b64u(pub)}
+    payload = {
+        "htm": "GET",
+        "htu": "https://api.example/x",
+        "iat": int(time.time()),
+    }  # missing jti
+    token = jwt.encode(
+        payload,
+        priv,
+        algorithm="EdDSA",
+        headers={"typ": "dpop+jwt", "jwk": jwk},
+    )
+    signer = DpopSigner()
+    assert not await signer.verify_bytes(
+        b"",
+        [{"sig": token}],
         require={"htm": "GET", "htu": "https://api.example/x"},
     )


### PR DESCRIPTION
## Summary
- exercise DPoP signer against RFC 9449 requirements
- validate rejection of invalid proofs and required claims

## Testing
- `uv run --package swarmauri_signing_dpop --directory standards/swarmauri_signing_dpop ruff format .`
- `uv run --package swarmauri_signing_dpop --directory standards/swarmauri_signing_dpop ruff check . --fix`
- `uv run --package swarmauri_signing_dpop --directory standards/swarmauri_signing_dpop pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5ff9d513c832683559723d6c749d5