### PR TITLE
test: use tigrbl engine for auth code flow

### DIFF
--- a/pkgs/standards/tigrbl_auth/tests/i9n/test_authorization_code_flow.py
+++ b/pkgs/standards/tigrbl_auth/tests/i9n/test_authorization_code_flow.py
@@ -1,17 +1,16 @@
 import pytest
 from httpx import AsyncClient
-from urllib.parse import urlparse, parse_qs
-from sqlalchemy.ext.asyncio import AsyncSession
+from urllib.parse import parse_qs, urlparse
 
-from tigrbl_auth.orm import Tenant, User, Client
+from tigrbl.engine import HybridSession
 from tigrbl_auth.crypto import hash_pw
-from tigrbl_auth.rfc7636_pkce import create_code_verifier, create_code_challenge
+from tigrbl_auth.orm import Client, Tenant, User
+from tigrbl_auth.rfc7636_pkce import create_code_challenge, create_code_verifier
 
 
-@pytest.mark.integration
 @pytest.mark.asyncio
 async def test_authorization_code_pkce_flow(
-    async_client: AsyncClient, db_session: AsyncSession
+    async_client: AsyncClient, db_session: HybridSession
 ):
     tenant = Tenant(slug="t1", name="T1", email="t1@example.com")
     db_session.add(tenant)


### PR DESCRIPTION
## Summary
- refactor authorization code PKCE test to use tigrbl's HybridSession
- build test database with tigrbl async engine and register it with the app

## Testing
- `uv run --directory pkgs/standards/tigrbl_auth --package tigrbl-auth ruff format .`
- `uv run --directory pkgs/standards/tigrbl_auth --package tigrbl-auth ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c60875e1a48326932ebcfd9b7c758f