### PR TITLE
fix: generate uuid jti for dpop signer

### DIFF
--- a/pkgs/standards/swarmauri_signing_dpop/swarmauri_signing_dpop/DpopSigner.py
+++ b/pkgs/standards/swarmauri_signing_dpop/swarmauri_signing_dpop/DpopSigner.py
@@ -59,6 +59,7 @@ import json
 import time
 import typing as t
 from dataclasses import dataclass
+from uuid import uuid4
 
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
 from cryptography.hazmat.primitives import serialization
@@ -244,9 +245,7 @@ class DpopSigner(SigningBase):
             raise ValueError(f"Unsupported alg for DPoP: {km.alg.value}")
 
         iat = int(o.get("iat") or _now())
-        jti = o.get("jti") or _b64url(
-            hashlib.sha256(f"{iat}:{htm}:{htu}".encode()).digest()
-        )
+        jti = o.get("jti") or str(uuid4())
         nonce = o.get("nonce")
         access_token = o.get("access_token")
 


### PR DESCRIPTION
## Summary
- generate random UUID for DPoP jti to ensure replay markers receive standard identifiers

## Testing
- `uv run --package swarmauri_signing_dpop --directory standards/swarmauri_signing_dpop ruff format .`
- `uv run --package swarmauri_signing_dpop --directory standards/swarmauri_signing_dpop ruff check . --fix`
- `uv run --package swarmauri_signing_dpop --directory standards/swarmauri_signing_dpop pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c605e1e29083269b4c536228e2d993