### PR TITLE
test: add mismatched jkt proof of possession test

### DIFF
--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7800_proof_of_possession.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7800_proof_of_possession.py
@@ -32,6 +32,15 @@ def test_cnf_claim_round_trip():
 
 
 @pytest.mark.unit
+def test_cnf_claim_mismatch_rejected():
+    """verify_proof_of_possession fails when jkt does not match."""
+    payload = add_cnf_claim({"sub": "carol"}, JWK)
+    other_jwk = {"kty": "oct", "k": "GawgguFyGrWKav7AX4VKUg"}
+    assert jwk_thumbprint(other_jwk) != payload["cnf"]["jkt"]
+    assert not verify_proof_of_possession(payload, other_jwk, enabled=True)
+
+
+@pytest.mark.unit
 def test_feature_toggle(monkeypatch):
     """When disabled, verification always passes."""
     payload = {"sub": "bob"}


### PR DESCRIPTION
## Summary
- test cnf claim utilities reject mismatched jkt values

## Testing
- `uv run --package tigrbl_auth --directory standards/tigrbl_auth ruff format .`
- `uv run --package tigrbl_auth --directory standards/tigrbl_auth ruff check . --fix`
- `uv run --package tigrbl_auth --directory standards/tigrbl_auth pytest tests/unit/test_rfc7800_proof_of_possession.py`


------
https://chatgpt.com/codex/tasks/task_e_68c607ddd00c83268d824c66e7b1a3de