### PR TITLE
docs: add DPoP nonce usage examples

### DIFF
--- a/pkgs/standards/swarmauri_signing_dpop/README.md
+++ b/pkgs/standards/swarmauri_signing_dpop/README.md
@@ -52,6 +52,51 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
+### Nonce handling
+
+Servers may issue a `DPoP-Nonce` header to bind proofs to a specific
+challenge. Pass the nonce through `opts` when signing and require it during
+verification:
+
+```python
+proof = await signer.sign_bytes(
+    key,
+    b"",
+    opts={
+        "htm": "GET",
+        "htu": "https://api.example/x",
+        "nonce": "server-issued-nonce",
+    },
+)
+ok = await signer.verify_bytes(
+    b"",
+    proof,
+    require={
+        "htm": "GET",
+        "htu": "https://api.example/x",
+        "nonce": "server-issued-nonce",
+    },
+)
+assert ok
+```
+
+If no nonce is provided, the signer falls back to creating a proof without the
+`nonce` claim, and verification should omit the requirement:
+
+```python
+proof = await signer.sign_bytes(
+    key,
+    b"",
+    opts={"htm": "GET", "htu": "https://api.example/x"},
+)
+ok = await signer.verify_bytes(
+    b"",
+    proof,
+    require={"htm": "GET", "htu": "https://api.example/x"},
+)
+assert ok
+```
+
 ## Entry Point
 
 The signer registers under the `swarmauri.signings` entry point as `DpopSigner`.


### PR DESCRIPTION
## Summary
- document using a DPoP nonce and fallback when none is provided

## Testing
- `uv run --package swarmauri_signing_dpop --directory pkgs/standards/swarmauri_signing_dpop ruff format .`
- `uv run --package swarmauri_signing_dpop --directory pkgs/standards/swarmauri_signing_dpop ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c607984b9c83269d705be0d164d6f2