### PR TITLE
Use valid HMAC key in RFC9101 test

### DIFF
--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc9101_jwt_secured_authorization_request.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc9101_jwt_secured_authorization_request.py
@@ -17,8 +17,9 @@ def test_jwt_request_round_trip(monkeypatch):
     """RFC 9101 \u00a72.1 round-trips parameters through a Request Object."""
     monkeypatch.setattr(runtime_cfg.settings, "enable_rfc9101", True)
     params = {"client_id": "abc", "scope": "read", "response_type": "code"}
-    token = asyncio.run(rfc9101.create_request_object(params, secret="secret"))
-    decoded = asyncio.run(rfc9101.parse_request_object(token, secret="secret"))
+    secret = "0" * 32
+    token = asyncio.run(rfc9101.create_request_object(params, secret=secret))
+    decoded = asyncio.run(rfc9101.parse_request_object(token, secret=secret))
     assert decoded == params
 
 
@@ -28,5 +29,5 @@ def test_feature_toggle_disabled(monkeypatch):
     monkeypatch.setattr(runtime_cfg.settings, "enable_rfc9101", False)
     with pytest.raises(RuntimeError):
         asyncio.run(
-            rfc9101.create_request_object({"client_id": "abc"}, secret="secret")
+            rfc9101.create_request_object({"client_id": "abc"}, secret="0" * 32)
         )


### PR DESCRIPTION
## Summary
- ensure RFC9101 test uses 32-byte HMAC key

## Testing
- `uv run --package tigrbl_auth --directory standards/tigrbl_auth ruff format .`
- `uv run --package tigrbl_auth --directory standards/tigrbl_auth ruff check . --fix`
- `uv run --package tigrbl_auth --directory standards/tigrbl_auth pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c615171b448326bca567cdce81f122