### PR TITLE
Use PgUUID for auth codes and expand PKCE tests

### DIFF
--- a/pkgs/standards/tigrbl_auth/tests/i9n/test_authorization_code_flow.py
+++ b/pkgs/standards/tigrbl_auth/tests/i9n/test_authorization_code_flow.py
@@ -1,6 +1,7 @@
 import pytest
 from httpx import AsyncClient
 from urllib.parse import parse_qs, urlparse
+from uuid import UUID, uuid4
 
 from tigrbl.engine import HybridSession
 from tigrbl_auth.crypto import hash_pw
@@ -25,43 +26,109 @@ async def test_authorization_code_pkce_flow(
     db_session.add(user)
     await db_session.commit()
 
+    client_id = str(uuid4())
     client = Client.new(
         tenant_id=tenant.id,
-        client_id="client123",
+        client_id=client_id,
         client_secret="secret",
         redirects=["https://client.example.com/cb"],
     )
     db_session.add(client)
     await db_session.commit()
 
+    # Establish session via login
+    login_resp = await async_client.post(
+        "/login", json={"identifier": "alice", "password": "Passw0rd!"}
+    )
+    assert login_resp.status_code == 200
+
     verifier = create_code_verifier()
     challenge = create_code_challenge(verifier)
     params = {
         "response_type": "code",
-        "client_id": "client123",
+        "client_id": client_id,
         "redirect_uri": "https://client.example.com/cb",
         "scope": "openid",
         "state": "xyz",
         "code_challenge": challenge,
         "code_challenge_method": "S256",
-        "username": "alice",
-        "password": "Passw0rd!",
     }
     resp = await async_client.get("/authorize", params=params, follow_redirects=False)
     assert resp.status_code in {302, 307}
     location = resp.headers["location"]
     qs = parse_qs(urlparse(location).query)
     code = qs["code"][0]
+    assert UUID(code)
     assert qs.get("state", [None])[0] == "xyz"
 
     data = {
         "grant_type": "authorization_code",
         "code": code,
         "redirect_uri": "https://client.example.com/cb",
-        "client_id": "client123",
+        "client_id": client_id,
         "code_verifier": verifier,
     }
     token_resp = await async_client.post("/token", data=data)
     assert token_resp.status_code == 200
     body = token_resp.json()
     assert "access_token" in body and "refresh_token" in body
+
+
+@pytest.mark.asyncio
+async def test_authorization_code_pkce_invalid_verifier(
+    async_client: AsyncClient, db_session: HybridSession
+):
+    tenant = Tenant(slug="t1", name="T1", email="t1@example.com")
+    db_session.add(tenant)
+    await db_session.commit()
+
+    user = User(
+        tenant_id=tenant.id,
+        username="alice",
+        email="alice@example.com",
+        password_hash=hash_pw("Passw0rd!"),
+    )
+    db_session.add(user)
+    await db_session.commit()
+
+    client_id = str(uuid4())
+    client = Client.new(
+        tenant_id=tenant.id,
+        client_id=client_id,
+        client_secret="secret",
+        redirects=["https://client.example.com/cb"],
+    )
+    db_session.add(client)
+    await db_session.commit()
+
+    login_resp = await async_client.post(
+        "/login", json={"identifier": "alice", "password": "Passw0rd!"}
+    )
+    assert login_resp.status_code == 200
+
+    verifier = create_code_verifier()
+    challenge = create_code_challenge(verifier)
+    params = {
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": "https://client.example.com/cb",
+        "scope": "openid",
+        "state": "xyz",
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+    }
+    resp = await async_client.get("/authorize", params=params, follow_redirects=False)
+    assert resp.status_code in {302, 307}
+    qs = parse_qs(urlparse(resp.headers["location"]).query)
+    code = qs["code"][0]
+
+    data = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": "https://client.example.com/cb",
+        "client_id": client_id,
+        "code_verifier": "wrong",
+    }
+    token_resp = await async_client.post("/token", data=data)
+    assert token_resp.status_code == 400
+    assert token_resp.json()["error"] == "invalid_grant"

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/orm/auth_code.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/orm/auth_code.py
@@ -24,7 +24,7 @@ class AuthCode(Base, Timestamped, UserColumn, TenantColumn):
     __tablename__ = "auth_codes"
     __table_args__ = ({"schema": "authn"},)
 
-    code: Mapped[str] = acol(storage=S(String(128), primary_key=True))
+    code: Mapped[uuid.UUID] = acol(storage=S(PgUUID(as_uuid=True), primary_key=True))
     client_id: Mapped[uuid.UUID] = acol(
         storage=S(
             PgUUID(as_uuid=True),

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/authz/rfc6749.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/authz/rfc6749.py
@@ -4,6 +4,7 @@ import secrets
 
 from datetime import datetime
 from typing import Any
+from uuid import UUID
 
 from fastapi import Depends, HTTPException, Request, status
 from fastapi.responses import JSONResponse
@@ -131,7 +132,9 @@ async def token(request: Request, db: AsyncSession = Depends(get_db)) -> TokenPa
             parsed = AuthorizationCodeGrantForm(**data)
         except ValidationError as exc:
             raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, exc.errors())
-        auth_code = await AuthCode.handlers.read.core({"db": db, "obj_id": parsed.code})
+        auth_code = await AuthCode.handlers.read.core(
+            {"db": db, "obj_id": UUID(parsed.code)}
+        )
         if (
             auth_code is None
             or str(auth_code.client_id) != parsed.client_id


### PR DESCRIPTION
## Summary
- store authorization codes as PgUUID
- ensure OIDC authorize endpoint issues UUID codes
- validate code as UUID in token exchange and add PKCE failure test

## Testing
- `uv run --package tigrbl_auth --directory pkgs/standards/tigrbl_auth ruff format .`
- `uv run --package tigrbl_auth --directory pkgs/standards/tigrbl_auth ruff check . --fix`
- `uv run --package tigrbl_auth --directory pkgs/standards/tigrbl_auth pytest` *(fails: sqlite3.OperationalError: ...)*

------
https://chatgpt.com/codex/tasks/task_e_68c6165b45588326bb47a6d54761979a