### PR TITLE
Normalize client ID hex handling for PKCE

### DIFF
--- a/pkgs/standards/tigrbl_auth/tests/unit/test_auth_code_exchange_pkce.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_auth_code_exchange_pkce.py
@@ -1,0 +1,61 @@
+import uuid
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+from fastapi import Request
+
+from tigrbl_auth.orm import AuthCode
+from tigrbl_auth.rfc7636_pkce import create_code_challenge, create_code_verifier
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_exchange_accepts_hex_client_id(monkeypatch):
+    verifier = create_code_verifier()
+    challenge = create_code_challenge(verifier)
+    client_uuid = uuid.uuid4()
+
+    auth_code = AuthCode(
+        code="code",
+        client_id=client_uuid,
+        redirect_uri="https://client/cb",
+        code_challenge=challenge,
+        nonce=None,
+        scope=None,
+        expires_at=datetime.utcnow() + timedelta(minutes=5),
+        claims=None,
+        user_id=uuid.uuid4(),
+        tenant_id=uuid.uuid4(),
+    )
+
+    class DummyJWT:
+        async def async_sign_pair(self, **kwargs):  # pragma: no cover - trivial
+            return "access", "refresh"
+
+    async def fake_mint(**kwargs):  # pragma: no cover - trivial
+        return "id"
+
+    async def fake_delete(payload):  # pragma: no cover - trivial
+        return None
+
+    monkeypatch.setattr("tigrbl_auth.orm.auth_code._jwt", DummyJWT())
+    monkeypatch.setattr("tigrbl_auth.orm.auth_code.mint_id_token", fake_mint)
+    monkeypatch.setattr(
+        "tigrbl_auth.orm.auth_code.AuthCode.handlers.delete.core", fake_delete
+    )
+
+    request = Request(scope={"type": "http", "scheme": "https"})
+    db = SimpleNamespace(get=lambda *args, **kwargs: None)
+    payload = {
+        "client_id": client_uuid.hex,
+        "redirect_uri": "https://client/cb",
+        "code_verifier": verifier,
+    }
+
+    result = await AuthCode.exchange(
+        {"request": request, "db": db, "payload": payload}, auth_code
+    )
+    assert result["access_token"] == "access"
+    assert result["refresh_token"] == "refresh"
+    assert result["id_token"] == "id"


### PR DESCRIPTION
## Summary
- normalize client_id comparison in AuthCode.exchange using PgUUID
- add unit test for PKCE exchange with hex client_id

## Testing
- `uv run --package tigrbl_auth --directory standards/tigrbl_auth ruff format .`
- `uv run --package tigrbl_auth --directory standards/tigrbl_auth ruff check . --fix`
- `uv run --package tigrbl_auth --directory standards/tigrbl_auth pytest tests/unit/test_auth_code_exchange_pkce.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6165b45588326bb47a6d54761979a