### PR TITLE
test: cover long-lived worker flow

### DIFF
--- a/pkgs/standards/tigrbl_auth/tests/conftest.py
+++ b/pkgs/standards/tigrbl_auth/tests/conftest.py
@@ -59,6 +59,7 @@ async def test_db_engine():
 
     # Create all tables
     async with engine.begin() as conn:
+        await conn.exec_driver_sql('ATTACH DATABASE ":memory:" AS authn')
         await conn.run_sync(Base.metadata.create_all)
 
     yield engine, maker


### PR DESCRIPTION
## Summary
- patch SQLite test engine to attach `authn` schema
- add integration test verifying DPoP-bound long-lived worker flow

## Testing
- `uv run --package tigrbl_auth --directory standards/tigrbl_auth pytest tests/i9n/test_long_lived_worker_flow.py -m integration`


------
https://chatgpt.com/codex/tasks/task_e_68c6162bd03083269954034b7c89c80e