### PR TITLE
refactor: use tigrbl engine spec for tigrbl_auth tests

### DIFF
--- a/pkgs/standards/tigrbl_auth/tests/unit/test_engine_initialization.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_engine_initialization.py
@@ -1,0 +1,12 @@
+import pytest
+from sqlalchemy import text
+from tigrbl.engine import resolver as engine_resolver
+from tigrbl_auth.routers.surface import surface_api
+
+
+@pytest.mark.unit
+async def test_engine_initialization(db_session):
+    provider = engine_resolver.resolve_provider(api=surface_api)
+    assert provider is not None
+    result = await db_session.execute(text("PRAGMA foreign_keys"))
+    assert result.scalar() == 1


### PR DESCRIPTION
## Summary
- use tigrbl `EngineSpec` and `Engine` in tigrbl_auth test fixtures
- initialize database via `surface_api.initialize`
- add unit test confirming engine initialization

## Testing
- `uv run --directory standards/tigrbl_auth --package tigrbl-auth ruff format .`
- `uv run --directory standards/tigrbl_auth --package tigrbl-auth ruff check . --fix`
- `uv run --directory standards/tigrbl_auth --package tigrbl-auth pytest` *(fails: redirect URI not permitted for native apps; FOREIGN KEY constraint failed; no such table: authn.par_requests)*

------
https://chatgpt.com/codex/tasks/task_e_68c61cb414688326be05bc23e7def746