### PR TITLE
fix: use timezone-aware datetime in tigrbl_auth

### DIFF
--- a/pkgs/standards/tigrbl_auth/tests/unit/test_auth_code_exchange_pkce.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_auth_code_exchange_pkce.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
 import pytest
@@ -23,7 +23,7 @@ async def test_exchange_accepts_hex_client_id(monkeypatch):
         code_challenge=challenge,
         nonce=None,
         scope=None,
-        expires_at=datetime.utcnow() + timedelta(minutes=5),
+        expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
         claims=None,
         user_id=uuid.uuid4(),
         tenant_id=uuid.uuid4(),

--- a/pkgs/standards/tigrbl_auth/tests/unit/test_oidc_authorize_scope_nonce.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_oidc_authorize_scope_nonce.py
@@ -1,6 +1,6 @@
 import json
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from urllib.parse import parse_qs, urlparse
 
 import pytest
@@ -247,7 +247,7 @@ async def test_authorize_max_age_requires_recent_login(async_client, db_session)
     )
     sid = resp.cookies.get("sid")
     assert sid in SESSIONS
-    SESSIONS[sid]["auth_time"] = datetime.utcnow() - timedelta(seconds=31)
+    SESSIONS[sid]["auth_time"] = datetime.now(timezone.utc) - timedelta(seconds=31)
 
     params = {
         "response_type": "code",

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/orm/auth_code.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/orm/auth_code.py
@@ -42,7 +42,7 @@ class AuthCode(Base, Timestamped, UserColumn, TenantColumn):
     @op_ctx(alias="exchange", target="delete", arity="member")
     async def exchange(cls, ctx, obj):
         import secrets
-        from datetime import datetime
+        from datetime import datetime, timezone
 
         request = ctx.get("request")
         _require_tls(request)
@@ -67,7 +67,7 @@ class AuthCode(Base, Timestamped, UserColumn, TenantColumn):
             obj is None
             or obj.client_id.hex != _normalize(client_id)
             or obj.redirect_uri != redirect_uri
-            or datetime.utcnow() > obj.expires_at
+            or datetime.now(timezone.utc) > obj.expires_at
         ):
             raise HTTPException(status.HTTP_400_BAD_REQUEST, {"error": "invalid_grant"})
         if obj.code_challenge and not (

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/orm/device_code.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/orm/device_code.py
@@ -56,7 +56,7 @@ class DeviceCode(Base, Timestamped):
 
     @op_ctx(alias="device_authorization", target="create", arity="collection")
     async def device_authorization(cls, ctx):
-        from datetime import datetime, timedelta
+        from datetime import datetime, timedelta, timezone
         from uuid import uuid4
 
         if not settings.enable_rfc8628:
@@ -72,7 +72,9 @@ class DeviceCode(Base, Timestamped):
         user_code = uuid4().hex[:8]
         verification_uri = DEVICE_VERIFICATION_URI
         verification_uri_complete = f"{verification_uri}?user_code={user_code}"
-        expires_at = datetime.utcnow() + timedelta(seconds=DEVICE_CODE_EXPIRES_IN)
+        expires_at = datetime.now(timezone.utc) + timedelta(
+            seconds=DEVICE_CODE_EXPIRES_IN
+        )
         await cls.handlers.create.core(
             {
                 "db": db,

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/authz/oidc.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/authz/oidc.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
 from uuid import UUID, uuid4
 from urllib.parse import urlencode
@@ -68,7 +68,7 @@ async def authorize(
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, {"error": "login_required"})
     if max_age is not None:
         auth_time = session.get("auth_time")
-        if auth_time is None or datetime.utcnow() - auth_time > timedelta(
+        if auth_time is None or datetime.now(timezone.utc) - auth_time > timedelta(
             seconds=max_age
         ):
             raise HTTPException(
@@ -112,7 +112,7 @@ async def authorize(
             "code_challenge": code_challenge,
             "nonce": nonce,
             "scope": scope_str,
-            "expires_at": datetime.utcnow() + timedelta(minutes=10),
+            "expires_at": datetime.now(timezone.utc) + timedelta(minutes=10),
         }
         if requested_claims:
             payload["claims"] = requested_claims

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/authz/rfc6749.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/authz/rfc6749.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import secrets
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 from uuid import UUID
 
@@ -147,7 +147,7 @@ async def token(request: Request, db: AsyncSession = Depends(get_db)) -> TokenPa
             auth_code is None
             or str(auth_code.client_id) != parsed.client_id
             or auth_code.redirect_uri != parsed.redirect_uri
-            or datetime.utcnow() > auth_code.expires_at
+            or datetime.now(timezone.utc) > auth_code.expires_at
         ):
             return JSONResponse(
                 {"error": "invalid_grant"}, status_code=status.HTTP_400_BAD_REQUEST
@@ -197,7 +197,7 @@ async def token(request: Request, db: AsyncSession = Depends(get_db)) -> TokenPa
         )
         if not device_obj or str(device_obj.client_id) != parsed.client_id:
             raise HTTPException(status.HTTP_400_BAD_REQUEST, {"error": "invalid_grant"})
-        if datetime.utcnow() > device_obj.expires_at:
+        if datetime.now(timezone.utc) > device_obj.expires_at:
             await DeviceCode.handlers.delete.core({"db": db, "obj": device_obj})
             raise HTTPException(status.HTTP_400_BAD_REQUEST, {"error": "expired_token"})
         if not device_obj.authorized:


### PR DESCRIPTION
## Summary
- replace deprecated `datetime.utcnow()` with `datetime.now(timezone.utc)` in tigrbl_auth
- update tests to use timezone-aware datetimes

## Testing
- `uv run --package tigrbl-auth --directory pkgs/standards/tigrbl_auth ruff format .`
- `uv run --package tigrbl-auth --directory pkgs/standards/tigrbl_auth ruff check . --fix`
- `uv run --package tigrbl-auth --directory pkgs/standards/tigrbl_auth pytest` *(fails: OperationalError unknown database authn)*

------
https://chatgpt.com/codex/tasks/task_e_68c61d831a708326af2a99391ec7f46b