### PR TITLE
feat: improve license scan reporting

### DIFF
--- a/.github/workflows/license-scan.yml
+++ b/.github/workflows/license-scan.yml
@@ -22,14 +22,17 @@ jobs:
         continue-on-error: true
         run: |
           set -o pipefail
-          ./scripts/license_scan.py | tee license_report.log
+          ./scripts/license_scan.py
 
       # Step: Upload license report
       - name: Upload license report
         uses: actions/upload-artifact@v4
         with:
           name: license-report
-          path: license_report.log
+          path: |
+            license_report.md
+            license_report.csv
+            sbom.spdx
 
       # Step: Summarize and annotate
       - name: Summarize and annotate
@@ -37,13 +40,13 @@ jobs:
         run: |
           echo "## License Scan Report" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          cat license_report.log >> "$GITHUB_STEP_SUMMARY"
+          cat license_report.md >> "$GITHUB_STEP_SUMMARY"
           if [[ "${{ steps.scan.outcome }}" == "failure" ]]; then
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "### Disallowed licences" >> "$GITHUB_STEP_SUMMARY"
-            grep '^  - ' license_report.log >> "$GITHUB_STEP_SUMMARY"
-            grep '^  - ' license_report.log | while read -r line; do
-              pkg=$(echo "$line" | sed 's/  - //')
+            grep '^-' license_report.md >> "$GITHUB_STEP_SUMMARY"
+            grep '^-' license_report.md | while read -r line; do
+              pkg=$(echo "$line" | sed 's/- //')
               echo "::error title=Disallowed license::$pkg"
             done
             exit 1

--- a/scripts/license_scan.py
+++ b/scripts/license_scan.py
@@ -5,9 +5,11 @@
 """Scan project dependencies and validate licences.
 
 This script runs ``pip-licenses`` to generate a CSV report of all installed
-packages and their licences. It fails if any package uses a GPL or AGPL
-licence and optionally generates a Trivy SBOM if the ``trivy`` binary is
-available on the system.
+packages and their licences.  A Markdown summary is written to
+``license_report.md`` and the raw CSV output to ``license_report.csv``.
+
+The scan fails if any package uses a GPL or AGPL licence and optionally
+generates a Trivy SBOM if the ``trivy`` binary is available on the system.
 """
 
 from __future__ import annotations
@@ -16,6 +18,7 @@ import csv
 import shutil
 import subprocess
 import sys
+from collections import defaultdict
 from io import StringIO
 from pathlib import Path
 
@@ -30,15 +33,47 @@ def run_pip_licenses() -> str:
         ) from exc
 
 
-def check_for_gpl(csv_text: str) -> list[str]:
+def check_for_gpl(rows: list[dict[str, str]]) -> list[str]:
     """Return packages with GPL or AGPL licences."""
-    reader = csv.DictReader(StringIO(csv_text))
+
     bad: list[str] = []
-    for row in reader:
+    for row in rows:
         license_name = (row.get("License") or "").lower()
         if "gpl" in license_name and "lgpl" not in license_name:
             bad.append(f"{row.get('Name')} ({row.get('License')})")
     return bad
+
+
+def generate_markdown_report(
+    rows: list[dict[str, str]], csv_text: str, offending: list[str]
+) -> str:
+    """Create a Markdown summary and write report files."""
+
+    counts: dict[str, list[str]] = defaultdict(list)
+    for row in rows:
+        counts[row.get("License") or "Unknown"].append(row.get("Name") or "")
+
+    lines: list[str] = ["# License Scan Report", "", "## Licence Counts", ""]
+    lines.append("| Licence | Count |")
+    lines.append("| --- | ---: |")
+    for licence, pkgs in sorted(counts.items()):
+        lines.append(f"| {licence} | {len(pkgs)} |")
+
+    lines.extend(["", "## Packages", "", "| Package | Licence |", "| --- | --- |"])
+    for row in rows:
+        lines.append(f"| {row.get('Name')} | {row.get('License')} |")
+
+    if offending:
+        lines.extend(["", "## Disallowed licences", ""])
+        for pkg in offending:
+            lines.append(f"- {pkg}")
+    else:
+        lines.extend(["", "No disallowed licences found."])
+
+    report = "\n".join(lines) + "\n"
+    Path("license_report.md").write_text(report)
+    Path("license_report.csv").write_text(csv_text)
+    return report
 
 
 def maybe_generate_sbom() -> None:
@@ -59,12 +94,11 @@ def maybe_generate_sbom() -> None:
 
 def main() -> None:
     csv_text = run_pip_licenses()
-    print(csv_text)
-    offending = check_for_gpl(csv_text)
+    rows = list(csv.DictReader(StringIO(csv_text)))
+    offending = check_for_gpl(rows)
+    report = generate_markdown_report(rows, csv_text, offending)
+    print(report)
     if offending:
-        print("Disallowed licences found:")
-        for pkg in offending:
-            print(f"  - {pkg}")
         sys.exit(1)
 
     maybe_generate_sbom()


### PR DESCRIPTION
## Summary
- generate markdown and csv license reports with offending package summary
- upload license reports and surface disallowed licenses in workflow summary

## Testing
- `uv run ruff format scripts/license_scan.py`
- `uv run ruff check scripts/license_scan.py`
- `./scripts/license_scan.py`


------
https://chatgpt.com/codex/tasks/task_e_68c621810c1c8326a761b20901b4b31e