### PR TITLE
Fix license scan to detect installed packages

### DIFF
--- a/scripts/license_scan.py
+++ b/scripts/license_scan.py
@@ -22,8 +22,13 @@ from pathlib import Path
 
 def run_pip_licenses() -> str:
     """Return CSV output from ``pip-licenses``."""
+    python = Path(shutil.which("pip") or sys.executable).with_name("python")
+    # ``pip-licenses`` runs in a minimal uv environment; point it at the
+    # system Python so installed packages are detected.
     try:
-        return subprocess.check_output(["pip-licenses", "--format=csv"], text=True)
+        return subprocess.check_output(
+            ["pip-licenses", "--format=csv", "--python", str(python)], text=True
+        )
     except FileNotFoundError as exc:
         raise RuntimeError(
             "pip-licenses is required; run this script with 'uv run' to install it."


### PR DESCRIPTION
## Summary
- ensure license scan examines installed packages by pointing pip-licenses at system Python

## Testing
- `uvx ruff format scripts/license_scan.py`
- `uvx ruff check scripts/license_scan.py --fix`
- `scripts/license_scan.py | head`


------
https://chatgpt.com/codex/tasks/task_e_68c623d85478832696b047cec8552a0a