### PR TITLE
Handle naive expiration datetimes in tigrbl_auth

### DIFF
--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/rfc9126.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/rfc9126.py
@@ -86,7 +86,10 @@ async def get_par_request(request_uri: str, db: AsyncSession) -> Dict[str, Any] 
     obj = await db.get(PushedAuthorizationRequest, request_uri)
     if not obj:
         return None
-    if datetime.now(tz=timezone.utc) > obj.expires_at:
+    expires_at = obj.expires_at
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    if datetime.now(tz=timezone.utc) > expires_at:
         await PushedAuthorizationRequest.handlers.delete.core({"db": db, "obj": obj})
         return None
     return obj.params

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/authz/rfc6749.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/authz/rfc6749.py
@@ -151,11 +151,14 @@ async def token(request: Request, db: AsyncSession = Depends(get_db)) -> TokenPa
         except ValidationError as exc:
             raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, exc.errors())
         auth_code = await db.get(AuthCode, UUID(parsed.code))
+        expires_at = auth_code.expires_at if auth_code else None
+        if expires_at and expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
         if (
             auth_code is None
             or str(auth_code.client_id) != parsed.client_id
             or auth_code.redirect_uri != parsed.redirect_uri
-            or datetime.now(timezone.utc) > auth_code.expires_at
+            or datetime.now(timezone.utc) > (expires_at or datetime.now(timezone.utc))
         ):
             return JSONResponse(
                 {"error": "invalid_grant"}, status_code=status.HTTP_400_BAD_REQUEST
@@ -193,7 +196,8 @@ async def token(request: Request, db: AsyncSession = Depends(get_db)) -> TokenPa
             issuer=ISSUER,
             **extra_claims,
         )
-        await AuthCode.handlers.exchange.core({"db": db, "obj": auth_code})
+        await db.delete(auth_code)
+        await db.commit()
         return TokenPair(access_token=access, refresh_token=refresh, id_token=id_token)
     if grant_type == "urn:ietf:params:oauth:grant-type:device_code":
         try:
@@ -205,7 +209,10 @@ async def token(request: Request, db: AsyncSession = Depends(get_db)) -> TokenPa
         )
         if not device_obj or str(device_obj.client_id) != parsed.client_id:
             raise HTTPException(status.HTTP_400_BAD_REQUEST, {"error": "invalid_grant"})
-        if datetime.now(timezone.utc) > device_obj.expires_at:
+        expires_at = device_obj.expires_at
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
+        if datetime.now(timezone.utc) > expires_at:
             await DeviceCode.handlers.delete.core({"db": db, "obj": device_obj})
             raise HTTPException(status.HTTP_400_BAD_REQUEST, {"error": "expired_token"})
         if not device_obj.authorized:


### PR DESCRIPTION
## Summary
- normalize expiration datetime handling in PAR retrieval and authorization code validation
- ensure authorization codes are removed with direct DB operations

## Testing
- `uv run --package tigrbl_auth --directory standards/tigrbl_auth pytest tests/i9n/test_authorization_code_flow.py::test_authorization_code_pkce_flow tests/i9n/test_authorization_code_flow.py::test_authorization_code_pkce_invalid_verifier -q`


------
https://chatgpt.com/codex/tasks/task_e_68c624f9cf8c8326bc651061dca92307