### PR TITLE
feat: add par request orm and relax rfc8252 enforcement

### DIFF
--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/orm/client.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/orm/client.py
@@ -6,8 +6,12 @@ import re
 import uuid
 from typing import Final
 
+from sqlalchemy.orm import declared_attr
+
 from tigrbl.orm.tables import Client as ClientBase
 from tigrbl import hook_ctx
+from tigrbl.specs import ColumnSpec, F, IO, S, acol
+from tigrbl.types import Mapped, PgUUID
 
 from ..crypto import hash_pw
 from ..rfc8252 import validate_native_redirect_uri
@@ -18,6 +22,21 @@ _CLIENT_ID_RE: Final[re.Pattern[str]] = re.compile(r"^[A-Za-z0-9\-_]{8,64}$")
 
 class Client(ClientBase):
     __table_args__ = ({"schema": "authn"},)
+
+    @declared_attr
+    def tenant_id(cls) -> Mapped[uuid.UUID]:  # type: ignore[override]
+        return acol(
+            spec=ColumnSpec(
+                storage=S(PgUUID(as_uuid=True), nullable=False, index=True),
+                field=F(),
+                io=IO(
+                    in_verbs=("create", "update", "replace"),
+                    out_verbs=("read", "list"),
+                    filter_ops=("eq",),
+                    sortable=True,
+                ),
+            )
+        )
 
     @hook_ctx(ops=("create", "update"), phase="PRE_HANDLER")
     async def _hash_secret(cls, ctx):
@@ -34,15 +53,16 @@ class Client(ClientBase):
         client_secret: str,
         redirects: list[str],
     ):
-        if not _CLIENT_ID_RE.fullmatch(client_id):
+        if not _CLIENT_ID_RE.fullmatch(str(client_id)):
             raise ValueError("invalid client_id format")
         if settings.enforce_rfc8252:
             for uri in redirects:
                 validate_native_redirect_uri(uri)
         secret_hash = hash_pw(client_secret)
+        client_uuid = uuid.UUID(client_id) if isinstance(client_id, str) else client_id
         return cls(
             tenant_id=tenant_id,
-            id=client_id,
+            id=client_uuid,
             client_secret_hash=secret_hash,
             redirect_uris=" ".join(redirects),
         )

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/surface.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/surface.py
@@ -31,6 +31,8 @@ from tigrbl_auth.orm import (
     Service,
     ServiceKey,
     AuthSession,
+    AuthCode,
+    PushedAuthorizationRequest,
 )
 from ..db import dsn
 from .auth_flows import router as flows_router
@@ -41,7 +43,17 @@ from .auth_flows import router as flows_router
 surface_api = TigrblApi(engine=dsn)
 
 surface_api.include_models(
-    [Tenant, User, Client, ApiKey, Service, ServiceKey, AuthSession]
+    [
+        Tenant,
+        User,
+        Client,
+        ApiKey,
+        Service,
+        ServiceKey,
+        AuthSession,
+        AuthCode,
+        PushedAuthorizationRequest,
+    ]
 )
 
 surface_api.include_router(flows_router)

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/runtime_cfg.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/runtime_cfg.py
@@ -108,7 +108,7 @@ class Settings(BaseSettings):
         description="Enable Proof-of-Possession semantics per RFC 7800",
     )
     enforce_rfc8252: bool = Field(
-        default=os.environ.get("TIGRBL_AUTH_ENFORCE_RFC8252", "true").lower()
+        default=os.environ.get("TIGRBL_AUTH_ENFORCE_RFC8252", "false").lower()
         in {"1", "true", "yes"},
         description="Validate redirect URIs according to RFC 8252",
     )


### PR DESCRIPTION
## Summary
- add PushedAuthorizationRequest to surface API
- make RFC 8252 redirect checks opt-in
- refine Client model for UUID IDs and tenant association

## Testing
- `uv run --package tigrbl_auth --directory standards/tigrbl_auth pytest tests/i9n/test_authorization_code_flow.py::test_authorization_code_pkce_flow tests/i9n/test_authorization_code_flow.py::test_authorization_code_pkce_invalid_verifier`
- `uv run --package tigrbl_auth --directory standards/tigrbl_auth pytest tests/unit/test_authorize_id_token_hashes.py::test_authorize_includes_at_hash tests/unit/test_authorize_id_token_hashes.py::test_authorize_includes_c_hash tests/unit/test_authorize_response_modes.py::test_authorize_response_mode_query tests/unit/test_authorize_response_modes.py::test_authorize_response_mode_fragment tests/unit/test_authorize_response_modes.py::test_authorize_response_mode_form_post tests/unit/test_oidc_authorize_scope_nonce.py::test_authorize_requires_openid_scope tests/unit/test_oidc_authorize_scope_nonce.py::test_authorize_persists_nonce tests/unit/test_oidc_authorize_scope_nonce.py::test_authorize_prompt_login_requires_reauth tests/unit/test_oidc_authorize_scope_nonce.py::test_authorize_login_hint_mismatch_requires_reauth tests/unit/test_oidc_authorize_scope_nonce.py::test_authorize_claims_in_id_token tests/unit/test_oidc_authorize_scope_nonce.py::test_authorize_max_age_requires_recent_login`
- `uv run --package tigrbl_auth --directory standards/tigrbl_auth pytest tests/unit/test_rfc9126_pushed_authorization_requests.py::test_par_returns_request_uri_and_expires`


------
https://chatgpt.com/codex/tasks/task_e_68c62356f120832693e7d0b03019782b