### PR TITLE
docs: add branded readme for state-driven workflow

### DIFF
--- a/pkgs/experimental/swarmauri_workflow_statedriven/README.md
+++ b/pkgs/experimental/swarmauri_workflow_statedriven/README.md
@@ -1,3 +1,4 @@
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_workflow_statedriven/">
@@ -14,3 +15,24 @@
 
 ---
 
+# Swarmauri Workflow Statedriven
+
+An experimental state-driven workflow engine for building graph-based processes using nodes and transitions. It supports conditions, join strategies, merge strategies and input modes to control execution flow.
+
+## Installation
+
+```bash
+pip install swarmauri_workflow_statedriven
+```
+
+## Usage
+
+```python
+from swarmauri_workflow_statedriven.graph import WorkflowGraph
+
+workflow = WorkflowGraph()
+# Define nodes and transitions...
+result = workflow.execute(start="start", initial_input={})
+```
+
+For more details, see the `docs` directory.


### PR DESCRIPTION
## Summary
- add branded readme for `swarmauri_workflow_statedriven`

## Testing
- `uv run --directory pkgs/experimental/swarmauri_workflow_statedriven --package swarmauri_workflow_statedriven ruff format .`
- `uv run --directory pkgs/experimental/swarmauri_workflow_statedriven --package swarmauri_workflow_statedriven ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c627e30ad883268caaf3431614bbbc