### PR TITLE
docs: add branded README for sodium crypto

### DIFF
--- a/pkgs/experimental/swarmauri_crypto_sodium/README.md
+++ b/pkgs/experimental/swarmauri_crypto_sodium/README.md
@@ -1,27 +1,34 @@
-![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_crypto_sodium/">
-        <img src="https://img.shields.io/pypi/dm/swarmauri_crypto_sodium" alt="PyPI - Downloads"/></a>
-    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_crypto_sodium/">
-        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_crypto_sodium.svg"/></a>
+        <img src="https://img.shields.io/pypi/dm/swarmauri_crypto_sodium" alt="PyPI - Downloads"/>
+    </a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/experimental/swarmauri_crypto_sodium/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/experimental/swarmauri_crypto_sodium.svg"/>
+    </a>
     <a href="https://pypi.org/project/swarmauri_crypto_sodium/">
-        <img src="https://img.shields.io/pypi/pyversions/swarmauri_crypto_sodium" alt="PyPI - Python Version"/></a>
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_crypto_sodium" alt="PyPI - Python Version"/>
+    </a>
     <a href="https://pypi.org/project/swarmauri_crypto_sodium/">
-        <img src="https://img.shields.io/pypi/l/swarmauri_crypto_sodium" alt="PyPI - License"/></a>
+        <img src="https://img.shields.io/pypi/l/swarmauri_crypto_sodium" alt="PyPI - License"/>
+    </a>
     <a href="https://pypi.org/project/swarmauri_crypto_sodium/">
-        <img src="https://img.shields.io/pypi/v/swarmauri_crypto_sodium?label=swarmauri_crypto_sodium&color=green" alt="PyPI - swarmauri_crypto_sodium"/></a>
+        <img src="https://img.shields.io/pypi/v/swarmauri_crypto_sodium?label=swarmauri_crypto_sodium&color=green" alt="PyPI - swarmauri_crypto_sodium"/>
+    </a>
 </p>
 
 ---
 
-## Swarmauri Crypto Sodium
+# Swarmauri Crypto Sodium
 
-Libsodium-backed crypto provider implementing the `ICrypto` contract via `CryptoBase`.
+`Swarmauri Crypto Sodium` is a high-performance cryptography provider powered by [libsodium](https://github.com/jedisct1/libsodium). It implements the `ICrypto` contract via `CryptoBase`, enabling fast and secure cryptographic operations inside the Swarmauri ecosystem.
 
-- XChaCha20-Poly1305 symmetric encrypt/decrypt
-- X25519 sealed boxes for data sealing and key wrapping
-- Multi-recipient envelopes using XChaCha20-Poly1305 + X25519 sealed wrap
+## Features
+
+- **XChaCha20-Poly1305** symmetric encryption and decryption
+- **X25519 sealed boxes** for data sealing and key wrapping
+- **Multi-recipient envelopes** combining XChaCha20-Poly1305 and X25519
 
 ## Installation
 
@@ -50,6 +57,11 @@ ct = await crypto.encrypt(sym, b"hello")
 pt = await crypto.decrypt(sym, ct)
 ```
 
-## Entry point
+## Entry Point
 
-The provider is registered under the `swarmauri.cryptos` entry-point as `SodiumCrypto`.
+The provider registers under the `swarmauri.cryptos` entry point as `SodiumCrypto`.
+
+## License
+
+This project is licensed under the terms of the [MIT License](LICENSE).
+


### PR DESCRIPTION
## Summary
- add branded and stylized README for `swarmauri_crypto_sodium`

## Testing
- `uvx ruff format .`
- `uvx ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c627f1f6c88326855b9486dd0fff1d