### PR TITLE
docs: add branded README for constant time evaluator package

### DIFF
--- a/pkgs/standards/swarmauri_evaluator_constanttime/README.md
+++ b/pkgs/standards/swarmauri_evaluator_constanttime/README.md
@@ -2,20 +2,35 @@
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_evaluator_constanttime/">
-        <img src="https://img.shields.io/pypi/dm/swarmauri_evaluator_constanttime" alt="PyPI - Downloads"/></a>
+        <img src="https://img.shields.io/pypi/dm/swarmauri_evaluator_constanttime" alt="PyPI - Downloads"/>
+    </a>
     <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_evaluator_constanttime/">
-        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_evaluator_constanttime.svg"/></a>
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_evaluator_constanttime.svg"/>
+    </a>
     <a href="https://pypi.org/project/swarmauri_evaluator_constanttime/">
-        <img src="https://img.shields.io/pypi/pyversions/swarmauri_evaluator_constanttime" alt="PyPI - Python Version"/></a>
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_evaluator_constanttime" alt="PyPI - Python Version"/>
+    </a>
     <a href="https://pypi.org/project/swarmauri_evaluator_constanttime/">
-        <img src="https://img.shields.io/pypi/l/swarmauri_evaluator_constanttime" alt="PyPI - License"/></a>
+        <img src="https://img.shields.io/pypi/l/swarmauri_evaluator_constanttime" alt="PyPI - License"/>
+    </a>
     <a href="https://pypi.org/project/swarmauri_evaluator_constanttime/">
-        <img src="https://img.shields.io/pypi/v/swarmauri_evaluator_constanttime?label=swarmauri_evaluator_constanttime&color=green" alt="PyPI - swarmauri_evaluator_constanttime"/></a>
-
+        <img src="https://img.shields.io/pypi/v/swarmauri_evaluator_constanttime?label=swarmauri_evaluator_constanttime&color=green" alt="PyPI - swarmauri_evaluator_constanttime"/>
+    </a>
 </p>
 
 ---
 
-# swarmauri_evaluator_constanttime
+# Swarmauri Evaluator Constanttime
 
 Evaluator that detects timing side channels using a simple fixed-vs-random test.
+
+## Installation
+
+```bash
+pip install swarmauri_evaluator_constanttime
+```
+
+## Want to help?
+
+If you want to contribute to swarmauri-sdk, read up on our [guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/contributing.md) that will help you get started.
+


### PR DESCRIPTION
## Summary
- add branded, badge-rich README for constant-time evaluator package

## Testing
- `uv run --directory standards --package swarmauri_evaluator_constanttime ruff format swarmauri_evaluator_constanttime`
- `uv run --directory standards --package swarmauri_evaluator_constanttime ruff check swarmauri_evaluator_constanttime --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c62873ec348326a20eab6edd04b70a