### PR TITLE
docs: brand external imports evaluator readme

### DIFF
--- a/pkgs/standards/swarmauri_evaluator_externalimports/README.md
+++ b/pkgs/standards/swarmauri_evaluator_externalimports/README.md
@@ -2,23 +2,48 @@
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_evaluator_externalimports/">
-        <img src="https://img.shields.io/pypi/dm/swarmauri_evaluator_externalimports" alt="PyPI - Downloads"/></a>
+        <img src="https://img.shields.io/pypi/dm/swarmauri_evaluator_externalimports" alt="PyPI - Downloads"/>
+    </a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_evaluator_externalimports/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_evaluator_externalimports.svg"/>
+    </a>
     <a href="https://pypi.org/project/swarmauri_evaluator_externalimports/">
-        <img src="https://img.shields.io/pypi/pyversions/swarmauri_evaluator_externalimports" alt="PyPI - Python Version"/></a>
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_evaluator_externalimports" alt="PyPI - Python Version"/>
+    </a>
     <a href="https://pypi.org/project/swarmauri_evaluator_externalimports/">
-        <img src="https://img.shields.io/pypi/l/swarmauri_evaluator_externalimports" alt="PyPI - License"/></a>
+        <img src="https://img.shields.io/pypi/l/swarmauri_evaluator_externalimports" alt="PyPI - License"/>
+    </a>
+    <br />
     <a href="https://pypi.org/project/swarmauri_evaluator_externalimports/">
-        <img src="https://img.shields.io/pypi/v/swarmauri_evaluator_externalimports?label=swarmauri_evaluator_externalimports&color=green" alt="PyPI - swarmauri_evaluator_externalimports"/></a>
+        <img src="https://img.shields.io/pypi/v/swarmauri_evaluator_externalimports?label=swarmauri_evaluator_externalimports&color=green" alt="PyPI - swarmauri_evaluator_externalimports"/>
+    </a>
 </p>
 
 ---
 
-# Swarmauri Evaluator Externalimports
+# Swarmauri Evaluator External Imports
 
-Evaluator that detects and penalizes non-built-in Python imports in source files.
+Evaluator that detects and penalizes non–standard-library imports in Python source files.
+
+## Purpose
+
+This evaluator helps gauge dependency hygiene by examining import statements and flagging modules that are not part of the Python standard library.
 
 ## Installation
 
 ```bash
 pip install swarmauri_evaluator_externalimports
 ```
+
+## Usage
+
+```python
+from swarmauri_evaluator_externalimports import ExternalImportsEvaluator
+
+evaluator = ExternalImportsEvaluator()
+score, details = evaluator.evaluate(program)  # `program` is an instance of swarmauri_core.programs.IProgram
+```
+
+## Want to help?
+
+If you want to contribute to swarmauri-sdk, read up on our [guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/CONTRIBUTING.md).


### PR DESCRIPTION
## Summary
- add Swarmauri-branded README for External Imports evaluator package

## Testing
- `uv run --directory . --package swarmauri_evaluator_externalimports ruff format .`
- `uv run --directory . --package swarmauri_evaluator_externalimports ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c62877d4c88326aac95b1ee59a11c1