### PR TITLE
docs: brand subprocess evaluator README

### DIFF
--- a/pkgs/standards/swarmauri_evaluator_subprocess/README.md
+++ b/pkgs/standards/swarmauri_evaluator_subprocess/README.md
@@ -3,6 +3,8 @@
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_evaluator_subprocess/">
         <img src="https://img.shields.io/pypi/dm/swarmauri_evaluator_subprocess" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_evaluator_subprocess/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_evaluator_subprocess.svg"/></a>
     <a href="https://pypi.org/project/swarmauri_evaluator_subprocess/">
         <img src="https://img.shields.io/pypi/pyversions/swarmauri_evaluator_subprocess" alt="PyPI - Python Version"/></a>
     <a href="https://pypi.org/project/swarmauri_evaluator_subprocess/">
@@ -22,3 +24,20 @@ A subprocess-based evaluator for executing and measuring program performance in 
 ```bash
 pip install swarmauri_evaluator_subprocess
 ```
+
+## Usage
+
+```python
+from swarmauri_evaluator_subprocess import SubprocessEvaluator
+
+# `program` should implement `get_path()` and `is_executable()` and point to a script on disk.
+evaluator = SubprocessEvaluator()
+score, metadata = evaluator.evaluate(
+    program,
+    expected_output="hello\n",
+)
+
+print("Score:", score)
+print("Stdout:", metadata["stdout"])
+```
+


### PR DESCRIPTION
## Summary
- add hits badge to subprocess evaluator README
- document basic usage example

## Testing
- `uv run --directory pkgs/standards/swarmauri_evaluator_subprocess --package swarmauri_evaluator_subprocess ruff format .`
- `uv run --directory pkgs/standards/swarmauri_evaluator_subprocess --package swarmauri_evaluator_subprocess ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c6287bc82483269ba7e0600ec8489a