### PR TITLE
docs: add branded readme for accessibility evaluator pool

### DIFF
--- a/pkgs/standards/swarmauri_evaluatorpool_accessibility/README.md
+++ b/pkgs/standards/swarmauri_evaluatorpool_accessibility/README.md
@@ -2,23 +2,49 @@
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_evaluatorpool_accessibility/">
-        <img src="https://img.shields.io/pypi/dm/swarmauri_evaluatorpool_accessibility" alt="PyPI - Downloads"/></a>
+        <img src="https://img.shields.io/pypi/dm/swarmauri_evaluatorpool_accessibility" alt="PyPI - Downloads"/>
+    </a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_evaluatorpool_accessibility/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_evaluatorpool_accessibility.svg"/>
+    </a>
     <a href="https://pypi.org/project/swarmauri_evaluatorpool_accessibility/">
-        <img src="https://img.shields.io/pypi/pyversions/swarmauri_evaluatorpool_accessibility" alt="PyPI - Python Version"/></a>
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_evaluatorpool_accessibility" alt="PyPI - Python Version"/>
+    </a>
     <a href="https://pypi.org/project/swarmauri_evaluatorpool_accessibility/">
-        <img src="https://img.shields.io/pypi/l/swarmauri_evaluatorpool_accessibility" alt="PyPI - License"/></a>
+        <img src="https://img.shields.io/pypi/l/swarmauri_evaluatorpool_accessibility" alt="PyPI - License"/>
+    </a>
     <a href="https://pypi.org/project/swarmauri_evaluatorpool_accessibility/">
-        <img src="https://img.shields.io/pypi/v/swarmauri_evaluatorpool_accessibility?label=swarmauri_evaluatorpool_accessibility&color=green" alt="PyPI - swarmauri_evaluatorpool_accessibility"/></a>
+        <img src="https://img.shields.io/pypi/v/swarmauri_evaluatorpool_accessibility?label=swarmauri_evaluatorpool_accessibility&color=green" alt="PyPI - swarmauri_evaluatorpool_accessibility"/>
+    </a>
 </p>
 
 ---
 
 # Swarmauri Evaluatorpool Accessibility
 
-A package providing accessibility and readability evaluators for Swarmauri.
+A package providing accessibility and readability evaluators for Swarmauri, aggregating classic readability metrics into a single pool.
 
 ## Installation
 
 ```bash
 pip install swarmauri_evaluatorpool_accessibility
 ```
+
+## Usage
+
+```python
+from swarmauri_evaluatorpool_accessibility.AccessibilityEvaluatorPool import AccessibilityEvaluatorPool
+from swarmauri_standard.programs.Program import Program
+
+program = Program(content={"example.txt": "This is a simple sentence. Here is another one."})
+pool = AccessibilityEvaluatorPool()
+result = pool.evaluate(program)
+
+print(result.score)       # aggregated accessibility score
+print(result.metadata)    # details from individual evaluators
+```
+
+## Want to help?
+
+If you want to contribute to swarmauri-sdk, read up on our [guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/contributing.md) that will help you get started.
+


### PR DESCRIPTION
## Summary
- add branded badges and usage example to swarmauri_evaluatorpool_accessibility README

## Testing
- `uv run --package swarmauri_evaluatorpool_accessibility --directory standards/swarmauri_evaluatorpool_accessibility ruff format .`
- `uv run --package swarmauri_evaluatorpool_accessibility --directory standards/swarmauri_evaluatorpool_accessibility ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c6287ed7c8832690447753275b4a46