### PR TITLE
docs: add branded auth middleware readme

### DIFF
--- a/pkgs/standards/swarmauri_middleware_auth/README.md
+++ b/pkgs/standards/swarmauri_middleware_auth/README.md
@@ -1,34 +1,62 @@
-![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
-    <a href="https://pypi.org/project/swarmauri-middleware-auth/">
-        <img src="https://img.shields.io/pypi/dm/swarmauri-middleware-auth" alt="PyPI - Downloads"/>
+    <a href="https://pypi.org/project/swarmauri_middleware_auth/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_middleware_auth" alt="PyPI - Downloads"/>
     </a>
-    <a href="https://github.com/swarmauri/swarmauri-sdk/pkgs/pkgs/swarmauri-middleware-auth">
-        <img src="https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https://github.com/swarmauri/swarmauri-sdk/pkgs/pkgs/swarmauri-middleware-auth&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=hits&edge_flat=false" alt="GitHub Hits"/>
+    <a href="https://github.com/swarmauri/swarmauri-sdk/pkgs/pkgs/swarmauri_middleware_auth">
+        <img src="https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https://github.com/swarmauri/swarmauri-sdk/pkgs/pkgs/swarmauri_middleware_auth&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=hits&edge_flat=false" alt="GitHub Hits"/>
     </a>
-    <a href="https://pypi.org/project/swarmauri-middleware-auth/">
-        <img src="https://img.shields.io/pypi/pyversions/swarmauri-middleware-auth" alt="PyPI - Python Version"/>
+    <a href="https://pypi.org/project/swarmauri_middleware_auth/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_middleware_auth" alt="PyPI - Python Version"/>
     </a>
-    <a href="https://pypi.org/project/swarmauri-middleware-auth/">
-        <img src="https://img.shields.io/pypi/l/swarmauri-middleware-auth" alt="PyPI - License"/>
+    <a href="https://pypi.org/project/swarmauri_middleware_auth/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_middleware_auth" alt="PyPI - License"/>
     </a>
     <br />
-    <a href="https://pypi.org/project/swarmauri-middleware-auth/">
-        <img src="https://img.shields.io/pypi/v/swarmauri-middleware-auth?label=swarmauri-middleware-auth&color=green" alt="PyPI - swarmauri-middleware-auth"/>
+    <a href="https://pypi.org/project/swarmauri_middleware_auth/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_middleware_auth?label=swarmauri_middleware_auth&color=green" alt="PyPI - swarmauri_middleware_auth"/>
     </a>
 </p>
 
 ---
 
-# `swarmauri-middleware-auth`
+# `swarmauri_middleware_auth`
 
-Authentication middleware for validating request headers and tokens in Swarmauri applications.
+JWT authentication middleware for Swarmauri and FastAPI applications.
 
-## Purpose
+## Features
 
-This package provides middleware for handling request authentication in Swarmauri applications. It validates authentication headers or tokens before allowing requests to proceed through the application stack.
+- Validates `Bearer` tokens in incoming requests
+- Verifies signatures using `swarmauri_signing_jws`
+- Supports expiration, audience and issuer checks
+- Provides hooks for custom claim validation
+- Offers a utility to verify tokens outside the middleware
 
 ## Installation
 
-To install `swarmauri-middleware-auth`, you can use Poetry or pip:
+```bash
+pip install swarmauri_middleware_auth
+# or
+poetry add swarmauri_middleware_auth
+```
+
+## Usage
+
+```python
+from fastapi import FastAPI
+from swarmauri_middleware_auth import AuthMiddleware
+
+app = FastAPI()
+app.add_middleware(
+    AuthMiddleware,
+    secret_key="supersecret",
+    issuer="my-service",
+    audience="my-audience",
+)
+```
+
+## Want to help?
+
+If you want to contribute to swarmauri-sdk, read our [guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/CONTRIBUTING.md).
+


### PR DESCRIPTION
## Summary
- add styled and branded docs for auth middleware

## Testing
- `uv run --directory pkgs/standards/swarmauri_middleware_auth --package swarmauri_middleware_auth ruff format .`
- `uv run --directory pkgs/standards/swarmauri_middleware_auth --package swarmauri_middleware_auth ruff check . --fix`

------
https://chatgpt.com/codex/tasks/task_e_68c628ae9a948326b7766878b3312ceb