### PR TITLE
docs: add branded README for bulkhead middleware

### DIFF
--- a/pkgs/standards/swarmauri_middleware_bulkhead/README.md
+++ b/pkgs/standards/swarmauri_middleware_bulkhead/README.md
@@ -2,41 +2,43 @@
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_middleware_bulkhead/">
-        <img src="https://img.shields.io/pypi/dm/swarmauri_middleware_bulkhead" alt="PyPI - Downloads"/></a>
-    <a href="https://github.com/swarmauri/swarmauri-sdk/pkgs/pkgs/swarmauri_middleware_bulkhead">
-        <img src="https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https://github.com/swarmauri/swarmauri-sdk/pkgs/pkgs/swarmauri_middleware_bulkhead&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=hits&edge_flat=false" alt="GitHub Hits"/></a>
-    <a href="https://pypi.org/project/swarmauri/swarmauri_middleware_bulkhead">
-        <img src="https://img.shields.io/pypi/pyversions/swarmauri_middleware_bulkhead" alt="PyPI - Python Version"/></a>
-    <a href="https://pypi.org/project/swarmauri/swarmauri_middleware_bulkhead">
-        <img src="https://img.shields.io/pypi/l/swarmauri_middleware_bulkhead" alt="PyPI - License"/></a>
-    <br />
-    <a href="https://pypi.org/project/swarmauri/swarmauri_middleware_bulkhead">
-        <img src="https://img.shields.io/pypi/v/swarmauri_middleware_bulkhead?label=swarmauri_middleware_bulkhead&color=green" alt="PyPI - swarmauri_middleware_bulkhead"/></a>
+        <img src="https://img.shields.io/pypi/dm/swarmauri_middleware_bulkhead" alt="PyPI - Downloads"/>
+    </a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_middleware_bulkhead/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_middleware_bulkhead.svg"/>
+    </a>
+    <a href="https://pypi.org/project/swarmauri_middleware_bulkhead/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_middleware_bulkhead" alt="PyPI - Python Version"/>
+    </a>
+    <a href="https://pypi.org/project/swarmauri_middleware_bulkhead/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_middleware_bulkhead" alt="PyPI - License"/>
+    </a>
+    <a href="https://pypi.org/project/swarmauri_middleware_bulkhead/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_middleware_bulkhead?label=swarmauri_middleware_bulkhead&color=green" alt="PyPI - swarmauri_middleware_bulkhead"/>
+    </a>
 </p>
 
 ---
 
-# `swarmauri_middleware_bulkhead`
+# Swarmauri Middleware Bulkhead
 
-## Overview
-
-The `swarmauri_middleware_bulkhead` package provides a middleware implementation for controlling concurrency isolation in FastAPI applications. It uses a semaphore-based approach to limit the number of concurrent requests, preventing resource overload and ensuring reliable service operation.
+Concurrency isolation middleware for FastAPI applications. Limit the number of simultaneous requests to protect resources from overload and ensure reliable service operation.
 
 ## Features
 
-- **Concurrency Control**: Restricts the maximum number of simultaneous requests
-- **Semaphore-based Management**: Efficiently manages request queuing and processing
-- **Logging Integration**: Provides detailed logging for request processing and errors
-- **Configurable**: Allows customizing the maximum concurrency level
-- **Compatibility**: Works seamlessly with FastAPI applications
-
-## Requirements
-
-- Python 3.10+
-- FastAPI
-- `swarmauri_core` package
-- `swarmauri_base` package
+- **Concurrency control** to restrict the maximum number of in-flight requests
+- **Semaphore-based management** for efficient request queuing and processing
+- **Logging integration** to provide visibility into request flow and errors
+- **Configurable limits** to match your service capacity
+- **FastAPI compatibility** for seamless integration
 
 ## Installation
 
-To install the package, use Poetry or pip:
+```bash
+pip install swarmauri_middleware_bulkhead
+```
+
+## Want to help?
+
+If you want to contribute to swarmauri-sdk, read up on our [guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/contributing.md).
+


### PR DESCRIPTION
## Summary
- add stylized README for `swarmauri_middleware_bulkhead`

## Testing
- `uv run --directory standards --package swarmauri_middleware_bulkhead ruff format swarmauri_middleware_bulkhead`
- `uv run --directory standards --package swarmauri_middleware_bulkhead ruff check swarmauri_middleware_bulkhead --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c628b37c6c83269fc76ece205ea594