### PR TITLE
docs: add branded README for exception handling middleware

### DIFF
--- a/pkgs/standards/swarmauri_middleware_exceptionhandling/README.md
+++ b/pkgs/standards/swarmauri_middleware_exceptionhandling/README.md
@@ -1,33 +1,43 @@
 ![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
-    <a href="https://pypi.org/project/swarmauri_middleware_exceptionhadling/">
-        <img src="https://img.shields.io/pypi/dm/swarmauri_middleware_exceptionhadling" alt="PyPI - Downloads"/>
+    <a href="https://pypi.org/project/swarmauri_middleware_exceptionhandling/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_middleware_exceptionhandling" alt="PyPI - Downloads"/>
     </a>
-    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_middleware_exceptionhadling/">
-        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_middleware_exceptionhadling.svg"/>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_middleware_exceptionhandling/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_middleware_exceptionhandling.svg"/>
     </a>
-    <a href="https://pypi.org/project/swarmauri_middleware_exceptionhadling/">
-        <img src="https://img.shields.io/pypi/pyversions/swarmauri_middleware_exceptionhadling" alt="PyPI - Python Version"/>
+    <a href="https://pypi.org/project/swarmauri_middleware_exceptionhandling/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_middleware_exceptionhandling" alt="PyPI - Python Version"/>
     </a>
-    <a href="https://pypi.org/project/swarmauri_middleware_exceptionhadling/">
-        <img src="https://img.shields.io/pypi/l/swarmauri_middleware_exceptionhadling" alt="PyPI - License"/>
+    <a href="https://pypi.org/project/swarmauri_middleware_exceptionhandling/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_middleware_exceptionhandling" alt="PyPI - License"/>
     </a>
-    <a href="https://pypi.org/project/swarmauri_middleware_exceptionhadling/">
-        <img src="https://img.shields.io/pypi/v/swarmauri_middleware_exceptionhadling?label=swarmauri_middleware_exceptionhadling&color=green" alt="PyPI - swarmauri_middleware_exceptionhadling"/>
+    <a href="https://pypi.org/project/swarmauri_middleware_exceptionhandling/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_middleware_exceptionhandling?label=swarmauri_middleware_exceptionhandling&color=green" alt="PyPI - swarmauri_middleware_exceptionhandling"/>
     </a>
 </p>
 
 ---
 
-# Swarmauri Middleware Exceptionhadling
+# Swarmauri Middleware Exception Handling
 
-Middleware for handling exceptions and errors in Swarmauri applications.
+Centralized exception and error handling for Swarmauri applications built on FastAPI.
 
 ## Installation
 
 ```bash
-pip install swarmauri_middleware_exceptionhadling
+pip install swarmauri_middleware_exceptionhandling
+```
+
+## Usage
+
+```python
+from fastapi import FastAPI
+from swarmauri_middleware_exceptionhandling import ExceptionHandlingMiddleware
+
+app = FastAPI()
+app.middleware("http")(ExceptionHandlingMiddleware())
 ```
 
 ## Want to help?


### PR DESCRIPTION
## Summary
- add branded README for swarmauri exception handling middleware

## Testing
- `uv run --directory pkgs/standards/swarmauri_middleware_exceptionhandling --package swarmauri_middleware_exceptionhandling ruff format .`
- `uv run --directory pkgs/standards/swarmauri_middleware_exceptionhandling --package swarmauri_middleware_exceptionhandling ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c628bdadbc8326830812e5dfc2b22b