### PR TITLE
docs: add branded README for LlamaGuard middleware

### DIFF
--- a/pkgs/standards/swarmauri_middleware_llamaguard/README.md
+++ b/pkgs/standards/swarmauri_middleware_llamaguard/README.md
@@ -1,25 +1,53 @@
 ![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
-    <a href="https://pypi.org/project/swarmauri-middleware-llamaguard/">
-        <img src="https://img.shields.io/pypi/dm/swarmauri-middleware-llamaguard" alt="PyPI - Downloads"/></a>
-    <a href="https://github.com/swarmauri/swarmauri-sdk/pkgs/pkgs/swarmauri-middleware-llamaguard">
-        <img src="https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https://github.com/swarmauri/swarmauri-sdk/pkgs/pkgs/swarmauri-middleware-llamaguard&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=hits&edge_flat=false" alt="GitHub Hits"/></a>
-    <a href="https://pypi.org/project/swarmauri-middleware-llamaguard/">
-        <img src="https://img.shields.io/pypi/pyversions/swarmauri-middleware-llamaguard" alt="PyPI - Python Version"/></a>
-    <a href="https://pypi.org/project/swarmauri-middleware-llamaguard/">
-        <img src="https://img.shields.io/pypi/l/swarmauri-middleware-llamaguard" alt="PyPI - License"/></a>
-    <br />
-    <a href="https://pypi.org/project/swarmauri-middleware-llamaguard/">
-        <img src="https://img.shields.io/pypi/v/swarmauri-middleware-llamaguard?label=swarmauri-middleware-llamaguard&color=green" alt="PyPI - swarmauri-middleware-llamaguard"/></a>
+    <a href="https://pypi.org/project/swarmauri_middleware_llamaguard/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_middleware_llamaguard" alt="PyPI - Downloads"/>
+    </a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_middleware_llamaguard/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_middleware_llamaguard.svg"/>
+    </a>
+    <a href="https://pypi.org/project/swarmauri_middleware_llamaguard/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_middleware_llamaguard" alt="PyPI - Python Version"/>
+    </a>
+    <a href="https://pypi.org/project/swarmauri_middleware_llamaguard/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_middleware_llamaguard" alt="PyPI - License"/>
+    </a>
+    <a href="https://pypi.org/project/swarmauri_middleware_llamaguard/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_middleware_llamaguard?label=swarmauri_middleware_llamaguard&color=green" alt="PyPI - swarmauri_middleware_llamaguard"/>
+    </a>
 </p>
 
 ---
 
-# `swarmauri-middleware-llamaguard`
+# Swarmauri Middleware LlamaGuard
 
-A FastAPI middleware that integrates LlamaGuard for comprehensive content inspection and filtering. This middleware ensures both incoming requests and outgoing responses are free from unsafe or malicious content.
+A FastAPI middleware that integrates LlamaGuard for comprehensive content inspection and filtering, ensuring requests and responses are free from unsafe or malicious content.
+
+## Features
+
+- Real-time scanning of incoming and outgoing payloads.
+- Configurable safety policies and thresholds.
+- Seamless drop-in middleware for any FastAPI application.
 
 ## Installation
 
-To install the package, use pip:
+```bash
+pip install swarmauri_middleware_llamaguard
+```
+
+## Usage
+
+```python
+from fastapi import FastAPI
+from swarmauri_middleware_llamaguard import LlamaGuardMiddleware
+
+app = FastAPI()
+
+# Add LlamaGuard with default settings
+app.add_middleware(LlamaGuardMiddleware)
+```
+
+## Want to help?
+
+If you want to contribute to swarmauri-sdk, read up on our [guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/contributing.md) that will help you get started.


### PR DESCRIPTION
## Summary
- add Swarmauri-branded README for `swarmauri_middleware_llamaguard`

## Testing
- `uv run --package swarmauri_middleware_llamaguard --directory standards/swarmauri_middleware_llamaguard ruff format .`
- `uv run --package swarmauri_middleware_llamaguard --directory standards/swarmauri_middleware_llamaguard ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c628c1af948326973d6dca1cfc1c92