### PR TITLE
docs: add branded README for security headers middleware

### DIFF
--- a/pkgs/standards/swarmauri_middleware_securityheaders/README.md
+++ b/pkgs/standards/swarmauri_middleware_securityheaders/README.md
@@ -1,25 +1,45 @@
-![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri-middleware-securityheaders/">
-        <img src="https://img.shields.io/pypi/dm/swarmauri-middleware-securityheaders" alt="PyPI - Downloads"/></a>
-    <a href="https://github.com/swarmauri/swarmauri-sdk/pkgs/pkgs/swarmauri-middleware-securityheaders">
-        <img src="https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https://github.com/swarmauri/swarmauri-sdk/pkgs/pkgs/swarmauri-middleware-securityheaders&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=hits&edge_flat=false" alt="GitHub Hits"/></a>
+        <img src="https://img.shields.io/pypi/dm/swarmauri-middleware-securityheaders" alt="PyPI - Downloads"/>
+    </a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_middleware_securityheaders/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_middleware_securityheaders.svg"/>
+    </a>
     <a href="https://pypi.org/project/swarmauri-middleware-securityheaders/">
-        <img src="https://img.shields.io/pypi/pyversions/swarmauri-middleware-securityheaders" alt="PyPI - Python Version"/></a>
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri-middleware-securityheaders" alt="PyPI - Python Version"/>
+    </a>
     <a href="https://pypi.org/project/swarmauri-middleware-securityheaders/">
-        <img src="https://img.shields.io/pypi/l/swarmauri-middleware-securityheaders" alt="PyPI - License"/></a>
-    <br />
+        <img src="https://img.shields.io/pypi/l/swarmauri-middleware-securityheaders" alt="PyPI - License"/>
+    </a>
     <a href="https://pypi.org/project/swarmauri-middleware-securityheaders/">
-        <img src="https://img.shields.io/pypi/v/swarmauri-middleware-securityheaders?label=swarmauri-middleware-securityheaders&color=green" alt="PyPI - swarmauri-middleware-securityheaders"/></a>
+        <img src="https://img.shields.io/pypi/v/swarmauri-middleware-securityheaders?label=swarmauri-middleware-securityheaders&color=green" alt="PyPI - swarmauri-middleware-securityheaders"/>
+    </a>
 </p>
 
 ---
 
-# `swarmauri-middleware-securityheaders`
+# Swarmauri Middleware Security Headers
 
-A middleware library for adding security headers to HTTP responses in FastAPI applications. This middleware helps protect against common web vulnerabilities by setting appropriate security headers.
+Middleware for adding security-focused HTTP headers to FastAPI responses, helping shield applications from common web vulnerabilities.
 
 ## Installation
 
-To install the package, use pip:
+```bash
+pip install swarmauri-middleware-securityheaders
+```
+
+## Usage
+
+```python
+from fastapi import FastAPI
+from swarmauri_middleware_securityheaders import SecurityHeadersMiddleware
+
+app = FastAPI()
+app.add_middleware(SecurityHeadersMiddleware)
+```
+
+## Want to help?
+
+If you want to contribute to swarmauri-sdk, read up on our [guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/CONTRIBUTING.md) that will help you get started.


### PR DESCRIPTION
## Summary
- add Swarmauri-branded README with badges and logo
- document installation and usage of security header middleware

## Testing
- `uv run --package swarmauri_middleware_securityheaders --directory pkgs/standards/swarmauri_middleware_securityheaders ruff format .`
- `uv run --package swarmauri_middleware_securityheaders --directory pkgs/standards/swarmauri_middleware_securityheaders ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c628c645d4832691364ac9bd962027