### PR TITLE
docs: add branded README for introspection tokens

### DIFF
--- a/pkgs/standards/swarmauri_tokens_introspection/README.md
+++ b/pkgs/standards/swarmauri_tokens_introspection/README.md
@@ -1,40 +1,41 @@
-![Swamauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
-    <a href="https://pypi.org/project/swarmauri-token-introspection/">
-        <img src="https://img.shields.io/pypi/dm/swarmauri-token-introspection" alt="PyPI - Downloads"/>
+    <a href="https://pypi.org/project/swarmauri_tokens_introspection/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_tokens_introspection" alt="PyPI - Downloads"/>
     </a>
-    <a href="https://github.com/swarmauri/swarmauri-sdk/pkgs/pkgs/swarmauri-token-introspection">
-        <img src="https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https://github.com/swarmauri/swarmauri-sdk/pkgs/pkgs/swarmauri-token-introspection&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=hits&edge_flat=false" alt="GitHub Hits"/>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_tokens_introspection/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_tokens_introspection.svg"/>
     </a>
-    <a href="https://pypi.org/project/swarmauri-token-introspection/">
-        <img src="https://img.shields.io/pypi/pyversions/swarmauri-token-introspection" alt="PyPI - Python Version"/>
+    <a href="https://pypi.org/project/swarmauri_tokens_introspection/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_tokens_introspection" alt="PyPI - Python Version"/>
     </a>
-    <a href="https://pypi.org/project/swarmauri-token-introspection/">
-        <img src="https://img.shields.io/pypi/l/swarmauri-token-introspection" alt="PyPI - License"/>
+    <a href="https://pypi.org/project/swarmauri_tokens_introspection/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_tokens_introspection" alt="PyPI - License"/>
     </a>
-    <br />
-    <a href="https://pypi.org/project/swarmauri-token-introspection/">
-        <img src="https://img.shields.io/pypi/v/swarmauri-token-introspection?label=swarmauri-token-introspection&color=green" alt="PyPI - swarmauri-token-introspection"/>
+    <a href="https://pypi.org/project/swarmauri_tokens_introspection/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_tokens_introspection?label=swarmauri_tokens_introspection&color=green" alt="PyPI - swarmauri_tokens_introspection"/>
     </a>
 </p>
 
 ---
 
-# `swarmauri-token-introspection`
+# swarmauri_tokens_introspection
 
 An OAuth 2.0 token introspection service plugin implementing RFC 7662 for verifying opaque access tokens.
 
-## Purpose
+## Features
 
-This package provides an asynchronous token service that validates opaque tokens against a remote introspection endpoint and enforces standard claim checks.
+- Asynchronous token verification against a remote introspection endpoint
+- Supports `client_secret_basic`, `client_secret_post`, and bearer authentication
+- Caches positive and negative introspection results with configurable TTLs
+- Validates standard claims (`exp`, `nbf`, `iat`) with optional issuer and audience checks
+- Optional JWKS passthrough for issuers that also publish signing keys
 
 ## Installation
 
-To install `swarmauri-token-introspection`, you can use Poetry or pip:
-
 ```bash
-pip install swarmauri-token-introspection
+pip install swarmauri_tokens_introspection
 ```
 
 ## Usage
@@ -42,7 +43,11 @@ pip install swarmauri-token-introspection
 ```python
 from swarmauri_tokens_introspection import IntrospectionTokenService
 
-service = IntrospectionTokenService("https://auth.example.com/introspect", client_id="id", client_secret="secret")
+service = IntrospectionTokenService(
+    "https://auth.example.com/introspect",
+    client_id="id",
+    client_secret="secret",
+)
 claims = await service.verify("opaque-token")
 ```
 


### PR DESCRIPTION
## Summary
- add branded README to token introspection package

## Testing
- `uv run --directory pkgs/standards/swarmauri_tokens_introspection --package swarmauri_tokens_introspection ruff format .`
- `uv run --directory pkgs/standards/swarmauri_tokens_introspection --package swarmauri_tokens_introspection ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c628d914b083269cde7d1897937cc1