### PR TITLE
docs: use tigrbl brand svg in readmes

### DIFF
--- a/pkgs/standards/tigrbl/README.md
+++ b/pkgs/standards/tigrbl/README.md
@@ -1,4 +1,4 @@
-![Tigrbl Logo](../../../assets/tigrbl_full_logo.png)
+![Tigrbl Logo](../../../assets/tigrbl.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/tigrbl/">

--- a/pkgs/standards/tigrbl_auth/README.md
+++ b/pkgs/standards/tigrbl_auth/README.md
@@ -1,4 +1,4 @@
-![Tigrbl Logo](../../../assets/tigrbl_full_logo.png)
+![Tigrbl Logo](../../../assets/tigrbl.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/tigrbl_auth/">

--- a/pkgs/standards/tigrbl_client/README.md
+++ b/pkgs/standards/tigrbl_client/README.md
@@ -1,4 +1,4 @@
-![Tigrbl Logo](../../../assets/tigrbl_full_logo.png)
+![Tigrbl Logo](../../../assets/tigrbl.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/tigrbl_client/">

--- a/pkgs/standards/tigrbl_kms/README.md
+++ b/pkgs/standards/tigrbl_kms/README.md
@@ -1,4 +1,4 @@
-![Tigrbl Logo](../../../assets/tigrbl_full_logo.png)
+![Tigrbl Logo](../../../assets/tigrbl.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/tigrbl_kms/">


### PR DESCRIPTION
## Summary
- update tigrbl-related README files to reference theme brand SVG logo

## Testing
- `uv run --directory pkgs/standards/tigrbl --package tigrbl ruff format .`
- `uv run --directory pkgs/standards/tigrbl --package tigrbl ruff check . --fix`
- `uv run --directory pkgs/standards/tigrbl_client --package tigrbl-client ruff format .`
- `uv run --directory pkgs/standards/tigrbl_client --package tigrbl-client ruff check . --fix`
- `uv run --directory pkgs/standards/tigrbl_kms --package tigrbl-kms ruff format .`
- `uv run --directory pkgs/standards/tigrbl_kms --package tigrbl-kms ruff check . --fix`
- `uv run --directory pkgs/standards/tigrbl_auth --package tigrbl-auth ruff format .`
- `uv run --directory pkgs/standards/tigrbl_auth --package tigrbl-auth ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c75e968d5c83268ec838cb959d4cac