### PR TITLE
docs: update tigrbl README logo links

### DIFF
--- a/pkgs/standards/tigrbl/README.md
+++ b/pkgs/standards/tigrbl/README.md
@@ -1,4 +1,4 @@
-![Tigrbl Logo](../../../assets/tigrbl.brand.theme.svg)
+![Tigrbl Logo](https://github.com/swarmauri/swarmauri-sdk/blob/a170683ecda8ca1c4f912c966d4499649ffb8224/assets/tigrbl.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/tigrbl/">

--- a/pkgs/standards/tigrbl_auth/README.md
+++ b/pkgs/standards/tigrbl_auth/README.md
@@ -1,4 +1,4 @@
-![Tigrbl Logo](../../../assets/tigrbl.brand.theme.svg)
+![Tigrbl Logo](https://github.com/swarmauri/swarmauri-sdk/blob/a170683ecda8ca1c4f912c966d4499649ffb8224/assets/tigrbl.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/tigrbl_auth/">

--- a/pkgs/standards/tigrbl_client/README.md
+++ b/pkgs/standards/tigrbl_client/README.md
@@ -1,4 +1,4 @@
-![Tigrbl Logo](../../../assets/tigrbl.brand.theme.svg)
+![Tigrbl Logo](https://github.com/swarmauri/swarmauri-sdk/blob/a170683ecda8ca1c4f912c966d4499649ffb8224/assets/tigrbl.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/tigrbl_client/">

--- a/pkgs/standards/tigrbl_kms/README.md
+++ b/pkgs/standards/tigrbl_kms/README.md
@@ -1,4 +1,4 @@
-![Tigrbl Logo](../../../assets/tigrbl.brand.theme.svg)
+![Tigrbl Logo](https://github.com/swarmauri/swarmauri-sdk/blob/a170683ecda8ca1c4f912c966d4499649ffb8224/assets/tigrbl.brand.theme.svg)
 
 <p align="center">
     <a href="https://pypi.org/project/tigrbl_kms/">


### PR DESCRIPTION
## Summary
- link all tigrbl READMEs to the hosted brand SVG

## Testing
- `uv run --directory pkgs/standards/tigrbl --package tigrbl ruff format .`
- `uv run --directory pkgs/standards/tigrbl --package tigrbl ruff check . --fix`
- `uv run --directory pkgs/standards/tigrbl_auth --package tigrbl_auth ruff format .`
- `uv run --directory pkgs/standards/tigrbl_auth --package tigrbl_auth ruff check . --fix`
- `uv run --directory pkgs/standards/tigrbl_kms --package tigrbl_kms ruff format .`
- `uv run --directory pkgs/standards/tigrbl_kms --package tigrbl_kms ruff check . --fix`
- `uv run --directory pkgs/standards/tigrbl_client --package tigrbl_client ruff format .`
- `uv run --directory pkgs/standards/tigrbl_client --package tigrbl_client ruff check . --fix`

------
https://chatgpt.com/codex/tasks/task_e_68c76d2c9c5c832693faca243bf23b46