### PR TITLE
feat: add LOC tensity pytest plugin

### DIFF
--- a/pkgs/experimental/swarmauri_tests_loc_tersity/LICENSE
+++ b/pkgs/experimental/swarmauri_tests_loc_tersity/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/experimental/swarmauri_tests_loc_tersity/README.md
+++ b/pkgs/experimental/swarmauri_tests_loc_tersity/README.md
@@ -14,3 +14,68 @@
 </p>
 
 ---
+
+## Overview
+
+`swarmauri_tests_loc_tersity` is a [pytest](https://docs.pytest.org/) plugin that
+keeps modules small and readable. It scans a package for Python files and
+asserts that each file stays under a configurable line‑of‑code (LOC) limit
+(docstrings included). The default limit is **400 lines**.
+
+The plugin runs in *parameterized* mode by default, turning every file into an
+individual test case. You can also switch to an *aggregate* mode that reports
+all failures as a single test.
+
+## Installation
+
+```bash
+pip install swarmauri_tests_loc_tersity
+```
+
+`pytest` automatically discovers the plugin once it is installed.
+
+## Usage
+
+### Parameterized (default)
+
+Run `pytest` normally to create one LOC check per Python file:
+
+```bash
+pytest
+```
+
+Example failure:
+
+```
+E   AssertionError: pkg/example.py has 425 lines (>400)
+```
+
+### Aggregate
+
+Use the `--loc-mode=aggregate` flag to consolidate checks into one test that
+lists every file exceeding the threshold:
+
+```bash
+pytest --loc-mode=aggregate
+```
+
+Example output:
+
+```
+E   pkg/example.py has 425 lines (>400)
+E   pkg/other.py has 410 lines (>400)
+```
+
+### Customizing
+
+* `--loc-root PATH` – directory to scan (defaults to the package root)
+* `--loc-max-lines N` – change the maximum line count
+
+```bash
+pytest --loc-root=src --loc-max-lines=200
+```
+
+## License
+
+Licensed under the [Apache 2.0 License](LICENSE).
+

--- a/pkgs/experimental/swarmauri_tests_loc_tersity/README.md
+++ b/pkgs/experimental/swarmauri_tests_loc_tersity/README.md
@@ -1,0 +1,16 @@
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_tests_loc_tersity/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_tests_loc_tersity" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/experimental/swarmauri_tests_loc_tersity/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/experimental/swarmauri_tests_loc_tersity.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_tests_loc_tersity/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_tests_loc_tersity" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_tests_loc_tersity/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_tests_loc_tersity" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_tests_loc_tersity/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_tests_loc_tersity?label=swarmauri_tests_loc_tersity&color=green" alt="PyPI - swarmauri_tests_loc_tersity"/></a>
+</p>
+
+---

--- a/pkgs/experimental/swarmauri_tests_loc_tersity/pyproject.toml
+++ b/pkgs/experimental/swarmauri_tests_loc_tersity/pyproject.toml
@@ -8,8 +8,10 @@ readme = "README.md"
 repository = "https://github.com/swarmauri/swarmauri-sdk/pkgs/experimental/swarmauri_tests_loc_tersity"
 requires-python = ">=3.10,<3.13"
 classifiers = [
+    "Development Status :: 1 - Planning",
     "License :: OSI Approved :: Apache Software License",
     "Framework :: Pytest",
+    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/pkgs/experimental/swarmauri_tests_loc_tersity/pyproject.toml
+++ b/pkgs/experimental/swarmauri_tests_loc_tersity/pyproject.toml
@@ -1,0 +1,35 @@
+[project]
+name = "swarmauri_tests_loc_tersity"
+version = "0.1.0.dev0"
+description = "Pytest plugin enforcing line count limits"
+authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
+license = "Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/swarmauri/swarmauri-sdk/pkgs/experimental/swarmauri_tests_loc_tersity"
+requires-python = ">=3.10,<3.13"
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Framework :: Pytest",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+
+[project.entry-points.pytest11]
+swarmauri_tests_loc_tersity = "swarmauri_tests_loc_tersity"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "python-dotenv",
+    "pytest-timeout>=2.3.1",
+    "ruff>=0.9.9",
+    "pytest-benchmark>=4.0.0",
+]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/pkgs/experimental/swarmauri_tests_loc_tersity/swarmauri_tests_loc_tersity/__init__.py
+++ b/pkgs/experimental/swarmauri_tests_loc_tersity/swarmauri_tests_loc_tersity/__init__.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+DEFAULT_MAX_LINES = 400
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Register command-line options for LOC testing."""
+    group = parser.getgroup("loc")
+    group.addoption(
+        "--loc-mode",
+        action="store",
+        default="parameterized",
+        choices=["parameterized", "aggregate"],
+        help="Run LOC checks per file or as a single aggregate test.",
+    )
+    group.addoption(
+        "--loc-root",
+        action="store",
+        default=None,
+        help="Root directory to scan for .py files (defaults to package root).",
+    )
+    group.addoption(
+        "--loc-max-lines",
+        action="store",
+        type=int,
+        default=DEFAULT_MAX_LINES,
+        help="Maximum allowed lines per file.",
+    )
+
+
+def _collect_files(config: pytest.Config) -> list[Path]:
+    root = config.getoption("--loc-root")
+    base = Path(root) if root else Path(__file__).resolve().parents[1]
+    return sorted(p for p in base.rglob("*.py") if p.is_file())
+
+
+class LocItem(pytest.Item):
+    def __init__(self, name: str, parent: pytest.Collector, path: Path, max_lines: int):
+        super().__init__(name, parent)
+        self.path = path
+        self.max_lines = max_lines
+
+    def runtest(self) -> None:
+        count = sum(1 for _ in self.path.open())
+        if count > self.max_lines:
+            raise AssertionError(f"{self.path} has {count} lines (>{self.max_lines})")
+
+    def reportinfo(self) -> tuple[Path, None, str]:
+        return self.path, None, f"loc check for {self.path.name}"
+
+
+class LocAggregateItem(pytest.Item):
+    def __init__(
+        self, name: str, parent: pytest.Collector, files: list[Path], max_lines: int
+    ):
+        super().__init__(name, parent)
+        self.files = files
+        self.max_lines = max_lines
+
+    def runtest(self) -> None:
+        failures = []
+        for file in self.files:
+            count = sum(1 for _ in file.open())
+            if count > self.max_lines:
+                failures.append(f"{file} has {count} lines (>{self.max_lines})")
+        if failures:
+            pytest.fail("\n".join(failures))
+
+    def reportinfo(self) -> tuple[str, None, str]:
+        return "loc aggregate", None, "loc aggregate check"
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line("markers", "loc: line count checks")
+    config._loc_files = _collect_files(config)
+
+
+def pytest_collection_modifyitems(
+    session: pytest.Session, config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    if getattr(config, "_loc_items_added", False):
+        return
+    config._loc_items_added = True
+    files: list[Path] = config._loc_files
+    max_lines: int = config.getoption("--loc-max-lines")
+    mode: str = config.getoption("--loc-mode")
+    if mode == "parameterized":
+        for file in files:
+            item = LocItem.from_parent(
+                session, name=f"loc:{file}", path=file, max_lines=max_lines
+            )
+            items.append(item)
+    else:
+        item = LocAggregateItem.from_parent(
+            session, name="loc-aggregate", files=files, max_lines=max_lines
+        )
+        items.append(item)

--- a/pkgs/experimental/swarmauri_tests_loc_tersity/tests/test_plugin.py
+++ b/pkgs/experimental/swarmauri_tests_loc_tersity/tests/test_plugin.py
@@ -1,4 +1,4 @@
-
+pytest_plugins = ["pytester"]
 
 
 def _make_files(tmp_path):

--- a/pkgs/experimental/swarmauri_tests_loc_tersity/tests/test_plugin.py
+++ b/pkgs/experimental/swarmauri_tests_loc_tersity/tests/test_plugin.py
@@ -1,0 +1,33 @@
+
+
+
+def _make_files(tmp_path):
+    good = tmp_path / "good.py"
+    good.write_text("print('ok')\n")
+    bad = tmp_path / "bad.py"
+    bad.write_text("x = 0\n" * 401)
+    return tmp_path
+
+
+def test_parameterized_mode(pytester):
+    pkg = _make_files(pytester.mkdir("pkg"))
+    result = pytester.runpytest(
+        "-p",
+        "swarmauri_tests_loc_tersity",
+        "--loc-root",
+        str(pkg),
+    )
+    result.assert_outcomes(passed=1, failed=1)
+
+
+def test_aggregate_mode(pytester):
+    pkg = _make_files(pytester.mkdir("pkg"))
+    result = pytester.runpytest(
+        "-p",
+        "swarmauri_tests_loc_tersity",
+        "--loc-root",
+        str(pkg),
+        "--loc-mode=aggregate",
+    )
+    result.assert_outcomes(failed=1)
+    assert "bad.py has" in result.stdout.str()

--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -100,6 +100,7 @@ members = [
     "standards/swarmauri_keyprovider_inmemory",
     "experimental/swarmauri_certs_pkcs11",
     "experimental/swarmauri_keyprovider_pkcs11",
+    "experimental/swarmauri_tests_loc_tersity",
     "standards/swarmauri_crypto_paramiko",
     "standards/swarmauri_crypto_pgp",
     "standards/swarmauri_crypto_rust",


### PR DESCRIPTION
## Summary
- add experimental `swarmauri_tests_loc_tersity` plugin to enforce file line-count limits
- document package with logo and badges
- register package in workspace

## Testing
- `uv run --directory experimental/swarmauri_tests_loc_tersity --package swarmauri_tests_loc_tersity ruff format .`
- `uv run --directory experimental/swarmauri_tests_loc_tersity --package swarmauri_tests_loc_tersity ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c777bd0a708326bb0267b158b4c7c6