### PR TITLE
fix: update rfc imports after module relocation

### DIFF
--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7591_dynamic_client_registration.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7591_dynamic_client_registration.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 import pytest
 
-from tigrbl_auth import rfc7591
+from tigrbl_auth.rfc import rfc7591
 
 
 def test_register_client_when_enabled() -> None:

--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7592_client_registration_management.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7592_client_registration_management.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 import pytest
 
-from tigrbl_auth import rfc7591, rfc7592
+from tigrbl_auth.rfc import rfc7591, rfc7592
 
 
 def test_update_and_delete_client_when_enabled() -> None:

--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7662_unit.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7662_unit.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from tigrbl_auth import rfc7662
+from tigrbl_auth.rfc import rfc7662
 from tigrbl_auth.runtime_cfg import settings
 
 RFC_7662 = "RFC 7662"

--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc9101_jwt_secured_authorization_request.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc9101_jwt_secured_authorization_request.py
@@ -9,7 +9,8 @@ feature is disabled.
 import asyncio
 import pytest
 
-from tigrbl_auth import runtime_cfg, rfc9101
+from tigrbl_auth import runtime_cfg
+from tigrbl_auth.rfc import rfc9101
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- fix broken tests by importing RFC helpers from the new `tigrbl_auth.rfc` package path

## Testing
- `uv run --directory pkgs/standards/tigrbl_auth --package tigrbl_auth ruff format .`
- `uv run --directory pkgs/standards/tigrbl_auth --package tigrbl_auth ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c797b97afc8326936859681747b496