### PR TITLE
refactor: update RFC imports for tigrbl_auth relocation

### DIFF
--- a/pkgs/standards/tigrbl_auth/tests/i9n/test_long_lived_worker_flow.py
+++ b/pkgs/standards/tigrbl_auth/tests/i9n/test_long_lived_worker_flow.py
@@ -5,7 +5,7 @@ from httpx import AsyncClient
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from cryptography.hazmat.primitives import serialization
 
-from tigrbl_auth import encode_jwt, decode_jwt
+from tigrbl_auth.rfc.rfc7519 import encode_jwt, decode_jwt
 from tigrbl_auth.crypto import hash_pw
 from tigrbl_auth.orm import Tenant, User
 from tigrbl_auth.rfc.rfc9449_dpop import (

--- a/pkgs/standards/tigrbl_auth/tests/i9n/test_rfc8693_token_exchange_endpoint.py
+++ b/pkgs/standards/tigrbl_auth/tests/i9n/test_rfc8693_token_exchange_endpoint.py
@@ -9,7 +9,7 @@ import pytest
 from fastapi import status
 from httpx import AsyncClient
 
-from tigrbl_auth import encode_jwt
+from tigrbl_auth.rfc.rfc7519 import encode_jwt
 from tigrbl_auth.rfc.rfc8693 import TOKEN_EXCHANGE_GRANT_TYPE, TokenType
 
 

--- a/pkgs/standards/tigrbl_auth/tests/i9n/test_token_exchange_flow.py
+++ b/pkgs/standards/tigrbl_auth/tests/i9n/test_token_exchange_flow.py
@@ -5,7 +5,7 @@ import time
 import pytest
 from httpx import AsyncClient
 
-from tigrbl_auth import encode_jwt, decode_jwt
+from tigrbl_auth.rfc.rfc7519 import encode_jwt, decode_jwt
 from tigrbl_auth.rfc.rfc8693 import TOKEN_EXCHANGE_GRANT_TYPE, TokenType
 
 

--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7515_jws.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7515_jws.py
@@ -4,7 +4,7 @@ import base64
 import secrets
 import asyncio
 
-from tigrbl_auth import sign_jws, verify_jws
+from tigrbl_auth.rfc.rfc7515 import sign_jws, verify_jws
 
 
 def test_sign_and_verify_jws() -> None:

--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7516_jwe.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7516_jwe.py
@@ -3,7 +3,7 @@
 import asyncio
 from secrets import token_bytes
 
-from tigrbl_auth import decrypt_jwe, encrypt_jwe
+from tigrbl_auth.rfc.rfc7516 import decrypt_jwe, encrypt_jwe
 
 
 def test_encrypt_and_decrypt_jwe() -> None:

--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7517_jwk.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7517_jwk.py
@@ -1,6 +1,6 @@
 """Tests for RFC 7517: JSON Web Key (JWK)."""
 
-from tigrbl_auth import load_signing_jwk, load_public_jwk
+from tigrbl_auth.rfc.rfc7517 import load_signing_jwk, load_public_jwk
 
 
 def test_jwk_contains_required_fields() -> None:

--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7518_jwa.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7518_jwa.py
@@ -1,6 +1,6 @@
 """Tests for RFC 7518: JSON Web Algorithms (JWA)."""
 
-from tigrbl_auth import supported_algorithms
+from tigrbl_auth.rfc.rfc7518 import supported_algorithms
 
 
 def test_supported_algorithms_contains_eddsa() -> None:

--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7519_jwt.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7519_jwt.py
@@ -1,6 +1,6 @@
 """Tests for RFC 7519: JSON Web Token (JWT)."""
 
-from tigrbl_auth import encode_jwt, decode_jwt
+from tigrbl_auth.rfc.rfc7519 import encode_jwt, decode_jwt
 
 
 def test_encode_and_decode_jwt() -> None:

--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7520_examples.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7520_examples.py
@@ -13,7 +13,7 @@ import asyncio
 import pytest
 
 import tigrbl_auth.rfc.rfc7520 as rfc7520
-from tigrbl_auth import (
+from tigrbl_auth.rfc.rfc7520 import (
     RFC7520_SPEC_URL,
     jws_then_jwe,
     jwe_then_jws,

--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7521_assertion_framework.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7521_assertion_framework.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 import pytest
 
-from tigrbl_auth import encode_jwt
+from tigrbl_auth.rfc.rfc7519 import encode_jwt
 from tigrbl_auth.errors import InvalidTokenError
 from tigrbl_auth.rfc.rfc7521 import (
     RFC7521_SPEC_URL,

--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7523_jwt_profile.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7523_jwt_profile.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 import pytest
 
-from tigrbl_auth import encode_jwt
+from tigrbl_auth.rfc.rfc7519 import encode_jwt
 from tigrbl_auth.errors import InvalidTokenError
 from tigrbl_auth.rfc.rfc7523 import (
     RFC7523_SPEC_URL,

--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7591_dynamic_client_registration.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7591_dynamic_client_registration.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 import pytest
 
-from tigrbl_auth import rfc7591
+from tigrbl_auth.rfc import rfc7591
 
 
 def test_register_client_when_enabled() -> None:

--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7592_client_registration_management.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7592_client_registration_management.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 import pytest
 
-from tigrbl_auth import rfc7591, rfc7592
+from tigrbl_auth.rfc import rfc7591, rfc7592
 
 
 def test_update_and_delete_client_when_enabled() -> None:

--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7636_pkce.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7636_pkce.py
@@ -12,7 +12,7 @@ with a minimum length of 43 characters and a maximum length of 128 characters.
 
 import pytest
 
-from tigrbl_auth import (
+from tigrbl_auth.rfc.rfc7636_pkce import (
     create_code_challenge,
     create_code_verifier,
     verify_code_challenge,

--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7662_unit.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7662_unit.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from tigrbl_auth import rfc7662
+from tigrbl_auth.rfc import rfc7662
 from tigrbl_auth.runtime_cfg import settings
 
 RFC_7662 = "RFC 7662"

--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc8628_device_authorization.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc8628_device_authorization.py
@@ -9,7 +9,7 @@ digits.
 
 import pytest
 
-from tigrbl_auth import (
+from tigrbl_auth.rfc.rfc8628 import (
     RFC8628_SPEC_URL,
     generate_device_code,
     generate_user_code,

--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc8812_webauthn_algorithms.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc8812_webauthn_algorithms.py
@@ -7,7 +7,8 @@ is disabled.
 
 import pytest
 
-from tigrbl_auth import runtime_cfg, supported_algorithms
+from tigrbl_auth import runtime_cfg
+from tigrbl_auth.rfc.rfc7518 import supported_algorithms
 from tigrbl_auth.rfc.rfc8812 import WEBAUTHN_ALGORITHMS, is_webauthn_algorithm
 
 EXPECTED_ALGORITHMS = {

--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc8932_dns_privacy.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc8932_dns_privacy.py
@@ -12,7 +12,7 @@ validate the stated requirements.
 
 import pytest
 
-from tigrbl_auth import RFC8932_SPEC_URL, enforce_encrypted_dns
+from tigrbl_auth.rfc.rfc8932 import RFC8932_SPEC_URL, enforce_encrypted_dns
 from tigrbl_auth.runtime_cfg import settings
 
 

--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc9101_jwt_secured_authorization_request.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc9101_jwt_secured_authorization_request.py
@@ -9,7 +9,8 @@ feature is disabled.
 import asyncio
 import pytest
 
-from tigrbl_auth import runtime_cfg, rfc9101
+from tigrbl_auth import runtime_cfg
+from tigrbl_auth.rfc import rfc9101
 
 
 @pytest.mark.unit

--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc9207_issuer_identification.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc9207_issuer_identification.py
@@ -13,7 +13,7 @@ validate the stated requirements.
 
 import pytest
 
-from tigrbl_auth import RFC9207_SPEC_URL, extract_issuer
+from tigrbl_auth.rfc.rfc9207 import RFC9207_SPEC_URL, extract_issuer
 from tigrbl_auth.runtime_cfg import settings
 
 

--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc9396_authorization_details.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc9396_authorization_details.py
@@ -13,7 +13,7 @@ conditionally enabled or disabled via runtime configuration.
 
 import pytest
 
-from tigrbl_auth import (
+from tigrbl_auth.rfc.rfc9396 import (
     AuthorizationDetail,
     RFC9396_SPEC_URL,
     parse_authorization_details,

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/oidc_id_token.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/oidc_id_token.py
@@ -29,7 +29,7 @@ from .deps import (
 )
 from .errors import InvalidTokenError
 from .runtime_cfg import settings
-from .rfc7516 import encrypt_jwe, decrypt_jwe
+from .rfc.rfc7516 import encrypt_jwe, decrypt_jwe
 
 # ---------------------------------------------------------------------------
 # Signing key management

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/auth_flows.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/auth_flows.py
@@ -11,7 +11,7 @@ from ..fastapi_deps import get_db
 from ..oidc_id_token import mint_id_token
 from ..orm.auth_session import AuthSession
 from ..routers.schemas import CredsIn, TokenPair
-from ..rfc8414_metadata import ISSUER
+from ..rfc.rfc8414_metadata import ISSUER
 from .authz import router as router
 from .shared import _jwt, _pwd_backend, AUTH_CODES, SESSIONS
 

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/authz/__init__.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/authz/__init__.py
@@ -2,4 +2,5 @@ from fastapi import APIRouter
 
 router = APIRouter()
 
-from . import rfc6749, rfc7662, oidc  # noqa: E402,F401
+from tigrbl_auth.rfc import rfc6749, rfc7662  # noqa: E402,F401
+from . import oidc  # noqa: E402,F401

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/authz/oidc.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/authz/oidc.py
@@ -13,8 +13,8 @@ from tigrbl.engine import HybridSession as AsyncSession
 from ...fastapi_deps import get_db
 from ...orm import AuthCode, Client, User
 from ...oidc_id_token import mint_id_token, oidc_hash
-from ...rfc8414_metadata import ISSUER
-from ...rfc8252 import is_native_redirect_uri
+from ...rfc.rfc8414_metadata import ISSUER
+from ...rfc.rfc8252 import is_native_redirect_uri
 from ..shared import _require_tls, SESSIONS, AUTH_CODES
 from . import router
 

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/authz/rfc6749.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/authz/rfc6749.py
@@ -16,19 +16,19 @@ from pydantic import ValidationError
 from ...backends import AuthError
 from ...fastapi_deps import get_db
 from ...orm import AuthCode, Client, DeviceCode, User
-from ...rfc8707 import extract_resource
+from ...rfc.rfc8707 import extract_resource
 from ...runtime_cfg import settings
-from ...rfc6749 import (
+from ...rfc.rfc6749 import (
     RFC6749Error,
     enforce_authorization_code_grant,
     enforce_grant_type,
     enforce_password_grant,
     is_enabled as rfc6749_enabled,
 )
-from ...rfc7636_pkce import verify_code_challenge
-from ...rfc8628 import DeviceGrantForm
+from ...rfc.rfc7636_pkce import verify_code_challenge
+from ...rfc.rfc8628 import DeviceGrantForm
 from ...oidc_id_token import mint_id_token, oidc_hash
-from ...rfc8414_metadata import ISSUER
+from ...rfc.rfc8414_metadata import ISSUER
 
 from ..schemas import (
     AuthorizationCodeGrantForm,

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/authz/rfc7662.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/authz/rfc7662.py
@@ -5,7 +5,7 @@ from fastapi import HTTPException, Request, status
 from ...runtime_cfg import settings
 from ..schemas import IntrospectOut
 from ..shared import _require_tls
-from ...rfc7662 import introspect_token
+from ...rfc.rfc7662 import introspect_token
 
 from . import router
 


### PR DESCRIPTION
## Summary
- update imports to use tigrbl_auth.rfc.* after RFC module relocation
- adjust routers and tests to reference new namespace

## Testing
- `uv run --directory standards/tigrbl_auth --package tigrbl-auth ruff check . --fix`
- `uv run --package tigrbl-auth --directory standards/tigrbl_auth pytest` *(fails: assert 404 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_68c797b97afc8326936859681747b496