### PR TITLE
Add LOC tersity plugin to DPoP signer tests

### DIFF
--- a/pkgs/experimental/swarmauri_tests_loc_tersity/swarmauri_tests_loc_tersity/__init__.py
+++ b/pkgs/experimental/swarmauri_tests_loc_tersity/swarmauri_tests_loc_tersity/__init__.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 DEFAULT_MAX_LINES = 400
+PLUGIN_NAME = __name__.split(".")[0]
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -91,11 +92,17 @@ def pytest_collection_modifyitems(
     if mode == "parameterized":
         for file in files:
             item = LocItem.from_parent(
-                session, name=f"loc:{file}", path=file, max_lines=max_lines
+                session,
+                name=f"{PLUGIN_NAME}:loc::{file}",
+                path=file,
+                max_lines=max_lines,
             )
             items.append(item)
     else:
         item = LocAggregateItem.from_parent(
-            session, name="loc-aggregate", files=files, max_lines=max_lines
+            session,
+            name=f"{PLUGIN_NAME}:loc-aggregate",
+            files=files,
+            max_lines=max_lines,
         )
         items.append(item)

--- a/pkgs/experimental/swarmauri_tests_loc_tersity/tests/test_plugin.py
+++ b/pkgs/experimental/swarmauri_tests_loc_tersity/tests/test_plugin.py
@@ -18,6 +18,7 @@ def test_parameterized_mode(pytester):
         str(pkg),
     )
     result.assert_outcomes(passed=1, failed=1)
+    assert "swarmauri_tests_loc_tersity:loc::" in result.stdout.str()
 
 
 def test_aggregate_mode(pytester):

--- a/pkgs/standards/swarmauri_signing_dpop/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_dpop/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
 swarmauri_core = { workspace = true }
 swarmauri_base = { workspace = true }
 swarmauri_signing_jws = { workspace = true }
+swarmauri_tests_loc_tersity = { workspace = true }
 
 [tool.pytest.ini_options]
 norecursedirs = ["combined", "scripts"]
@@ -56,6 +57,7 @@ dev = [
     "pytest-benchmark>=4.0.0",
     "flake8>=7.0",
     "ruff>=0.9.9",
+    "swarmauri_tests_loc_tersity",
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary
- include `swarmauri_tests_loc_tersity` in DPoP signer dev dependencies
- configure `uv` to source the LOC tersity plugin from the workspace
- prefix LOC tersity checks with the plugin name for clearer test output

## Testing
- `uv run --directory experimental/swarmauri_tests_loc_tersity --package swarmauri_tests_loc_tersity ruff format .`
- `uv run --directory experimental/swarmauri_tests_loc_tersity --package swarmauri_tests_loc_tersity ruff check . --fix`
- `uv run --package swarmauri_tests_loc_tersity --directory experimental/swarmauri_tests_loc_tersity pytest`
- `uv run --package swarmauri_signing_dpop --directory standards/swarmauri_signing_dpop pytest --loc-root swarmauri_signing_dpop`


------
https://chatgpt.com/codex/tasks/task_e_68c7977c35548326b3146b0265b74680