### PR TITLE
refactor: relocate RFC endpoints into rfc package

### DIFF
--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/__init__.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/__init__.py
@@ -5,6 +5,7 @@ RFC 7636 (PKCE), RFC 8705 (mutual-TLS client authentication), and RFC 9396
 (Rich Authorization Requests).
 """
 
+from .rfc import rfc7591, rfc7592, rfc7662, rfc9101
 from .rfc.rfc7636_pkce import (
     create_code_challenge,
     create_code_verifier,
@@ -206,4 +207,8 @@ __all__ = [
     "RFC8932_SPEC_URL",
     "mint_id_token",
     "verify_id_token",
+    "rfc7591",
+    "rfc7592",
+    "rfc7662",
+    "rfc9101",
 ]

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/oidc_id_token.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/oidc_id_token.py
@@ -29,7 +29,7 @@ from .deps import (
 )
 from .errors import InvalidTokenError
 from .runtime_cfg import settings
-from .rfc7516 import encrypt_jwe, decrypt_jwe
+from .rfc.rfc7516 import encrypt_jwe, decrypt_jwe
 
 # ---------------------------------------------------------------------------
 # Signing key management

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/rfc/rfc6749_token.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/rfc/rfc6749_token.py
@@ -13,31 +13,36 @@ from sqlalchemy import select
 from tigrbl.engine import HybridSession as AsyncSession
 from pydantic import ValidationError
 
-from ...backends import AuthError
-from ...fastapi_deps import get_db
-from ...orm import AuthCode, Client, DeviceCode, User
-from ...rfc8707 import extract_resource
-from ...runtime_cfg import settings
-from ...rfc6749 import (
+from ..backends import AuthError
+from ..fastapi_deps import get_db
+from ..orm import AuthCode, Client, DeviceCode, User
+from .rfc8707 import extract_resource
+from ..runtime_cfg import settings
+from .rfc6749 import (
     RFC6749Error,
     enforce_authorization_code_grant,
     enforce_grant_type,
     enforce_password_grant,
     is_enabled as rfc6749_enabled,
 )
-from ...rfc7636_pkce import verify_code_challenge
-from ...rfc8628 import DeviceGrantForm
-from ...oidc_id_token import mint_id_token, oidc_hash
-from ...rfc8414_metadata import ISSUER
+from .rfc7636_pkce import verify_code_challenge
+from .rfc8628 import DeviceGrantForm
+from ..oidc_id_token import mint_id_token, oidc_hash
+from .rfc8414_metadata import ISSUER
 
-from ..schemas import (
+from ..routers.schemas import (
     AuthorizationCodeGrantForm,
     PasswordGrantForm,
     RefreshIn,
     TokenPair,
 )
-from ..shared import _require_tls, _jwt, _pwd_backend, _ALLOWED_GRANT_TYPES
-from . import router
+from ..routers.shared import (
+    _require_tls,
+    _jwt,
+    _pwd_backend,
+    _ALLOWED_GRANT_TYPES,
+)
+from ..routers.authz import router
 
 
 @router.post("/token", response_model=TokenPair)

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/rfc/rfc7662_introspection.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/rfc/rfc7662_introspection.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from fastapi import HTTPException, Request, status
 
-from ...runtime_cfg import settings
-from ..schemas import IntrospectOut
-from ..shared import _require_tls
-from ...rfc7662 import introspect_token
+from ..runtime_cfg import settings
+from ..routers.schemas import IntrospectOut
+from ..routers.shared import _require_tls
+from .rfc7662 import introspect_token
 
-from . import router
+from ..routers.authz import router
 
 
 @router.post("/introspect", response_model=IntrospectOut)

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/auth_flows.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/auth_flows.py
@@ -11,7 +11,7 @@ from ..fastapi_deps import get_db
 from ..oidc_id_token import mint_id_token
 from ..orm.auth_session import AuthSession
 from ..routers.schemas import CredsIn, TokenPair
-from ..rfc8414_metadata import ISSUER
+from ..rfc.rfc8414_metadata import ISSUER
 from .authz import router as router
 from .shared import _jwt, _pwd_backend, AUTH_CODES, SESSIONS
 

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/authz/__init__.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/authz/__init__.py
@@ -2,4 +2,5 @@ from fastapi import APIRouter
 
 router = APIRouter()
 
-from . import rfc6749, rfc7662, oidc  # noqa: E402,F401
+from ...rfc import rfc6749_token, rfc7662_introspection  # noqa: E402,F401
+from . import oidc  # noqa: E402,F401

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/authz/oidc.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/authz/oidc.py
@@ -13,8 +13,8 @@ from tigrbl.engine import HybridSession as AsyncSession
 from ...fastapi_deps import get_db
 from ...orm import AuthCode, Client, User
 from ...oidc_id_token import mint_id_token, oidc_hash
-from ...rfc8414_metadata import ISSUER
-from ...rfc8252 import is_native_redirect_uri
+from ...rfc.rfc8414_metadata import ISSUER
+from ...rfc.rfc8252 import is_native_redirect_uri
 from ..shared import _require_tls, SESSIONS, AUTH_CODES
 from . import router
 


### PR DESCRIPTION
## Summary
- move OAuth RFC endpoints into `tigrbl_auth.rfc` package
- update imports and expose RFC modules from package root

## Testing
- `uv run --package tigrbl-auth --directory standards/tigrbl_auth ruff check . --fix`
- `uv run --package tigrbl-auth --directory standards/tigrbl_auth pytest tests/unit/test_rfc6749_token_endpoint.py tests/unit/test_rfc7662_unit.py`


------
https://chatgpt.com/codex/tasks/task_e_68c79dd8d1cc8326bc93ecb87d3ff2ab