### PR TITLE
refactor(tigrbl_auth): update rfc module imports

### DIFF
--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7591_dynamic_client_registration.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7591_dynamic_client_registration.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 import pytest
 
-from tigrbl_auth import rfc7591
+from tigrbl_auth.rfc import rfc7591
 
 
 def test_register_client_when_enabled() -> None:

--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7592_client_registration_management.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7592_client_registration_management.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 import pytest
 
-from tigrbl_auth import rfc7591, rfc7592
+from tigrbl_auth.rfc import rfc7591, rfc7592
 
 
 def test_update_and_delete_client_when_enabled() -> None:

--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7662_unit.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7662_unit.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from tigrbl_auth import rfc7662
+from tigrbl_auth.rfc import rfc7662
 from tigrbl_auth.runtime_cfg import settings
 
 RFC_7662 = "RFC 7662"

--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc9101_jwt_secured_authorization_request.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc9101_jwt_secured_authorization_request.py
@@ -9,7 +9,8 @@ feature is disabled.
 import asyncio
 import pytest
 
-from tigrbl_auth import runtime_cfg, rfc9101
+from tigrbl_auth import runtime_cfg
+from tigrbl_auth.rfc import rfc9101
 
 
 @pytest.mark.unit

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/oidc_id_token.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/oidc_id_token.py
@@ -29,7 +29,7 @@ from .deps import (
 )
 from .errors import InvalidTokenError
 from .runtime_cfg import settings
-from .rfc7516 import encrypt_jwe, decrypt_jwe
+from .rfc.rfc7516 import encrypt_jwe, decrypt_jwe
 
 # ---------------------------------------------------------------------------
 # Signing key management

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/auth_flows.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/auth_flows.py
@@ -10,7 +10,7 @@ from ..fastapi_deps import get_db
 from ..oidc_id_token import mint_id_token
 from ..orm.auth_session import AuthSession
 from ..routers.schemas import CredsIn, TokenPair
-from ..rfc8414_metadata import ISSUER
+from ..rfc.rfc8414_metadata import ISSUER
 from .authz import router as router
 from .shared import _jwt, _pwd_backend, AUTH_CODES, SESSIONS
 

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/authz/oidc.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/authz/oidc.py
@@ -19,8 +19,8 @@ from tigrbl_auth.deps import (
 from ...fastapi_deps import get_db
 from ...orm import AuthCode, Client, User
 from ...oidc_id_token import mint_id_token, oidc_hash
-from ...rfc8414_metadata import ISSUER
-from ...rfc8252 import is_native_redirect_uri
+from ...rfc.rfc8414_metadata import ISSUER
+from ...rfc.rfc8252 import is_native_redirect_uri
 from ..shared import _require_tls, SESSIONS, AUTH_CODES
 from . import router
 

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/authz/rfc6749.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/authz/rfc6749.py
@@ -21,19 +21,19 @@ from tigrbl_auth.deps import (
 from ...backends import AuthError
 from ...fastapi_deps import get_db
 from ...orm import AuthCode, Client, DeviceCode, User
-from ...rfc8707 import extract_resource
+from ...rfc.rfc8707 import extract_resource
 from ...runtime_cfg import settings
-from ...rfc6749 import (
+from ...rfc.rfc6749 import (
     RFC6749Error,
     enforce_authorization_code_grant,
     enforce_grant_type,
     enforce_password_grant,
     is_enabled as rfc6749_enabled,
 )
-from ...rfc7636_pkce import verify_code_challenge
-from ...rfc8628 import DeviceGrantForm
+from ...rfc.rfc7636_pkce import verify_code_challenge
+from ...rfc.rfc8628 import DeviceGrantForm
 from ...oidc_id_token import mint_id_token, oidc_hash
-from ...rfc8414_metadata import ISSUER
+from ...rfc.rfc8414_metadata import ISSUER
 
 from ..schemas import (
     AuthorizationCodeGrantForm,

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/authz/rfc7662.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/authz/rfc7662.py
@@ -5,7 +5,7 @@ from tigrbl_auth.deps import HTTPException, Request, status
 from ...runtime_cfg import settings
 from ..schemas import IntrospectOut
 from ..shared import _require_tls
-from ...rfc7662 import introspect_token
+from ...rfc.rfc7662 import introspect_token
 
 from . import router
 


### PR DESCRIPTION
## Summary
- relocate RFC imports to use `tigrbl_auth.rfc` subpackage
- adjust tests to import RFC helpers from new subpackage

## Testing
- `uv run --package tigrbl-auth --directory standards/tigrbl_auth ruff format .`
- `uv run --package tigrbl-auth --directory standards/tigrbl_auth ruff check . --fix`
- `uv run --package tigrbl-auth --directory standards/tigrbl_auth pytest` *(fails: AttributeError: type object 'KeyUse' has no attribute 'sign')*


------
https://chatgpt.com/codex/tasks/task_e_68c7a0d451c4832695576087f1ee3bb8