### PR TITLE
refactor: centralize rfc modules and key deps

### DIFF
--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc9449_dpop.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc9449_dpop.py
@@ -30,14 +30,13 @@ def test_dpop_proof_verification():
     spec = KeySpec(
         klass=KeyClass.asymmetric,
         alg=KeyAlg.ED25519,
-        uses=(KeyUse.sign,),
-        export_policy=ExportPolicy.KEYPAIR,
+        uses=(KeyUse.SIGN,),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
     )
     ref = asyncio.run(kp.create_key(spec))
-    private_pem = ref.material or b""
     jwk = jwk_from_public_key(ref.public or b"")
     jkt = jwk_thumbprint(jwk)
-    proof = create_proof(private_pem, "POST", "https://rs.example.com/resource")
+    proof = create_proof(ref, "POST", "https://rs.example.com/resource")
     assert (
         verify_proof(proof, "POST", "https://rs.example.com/resource", jkt=jkt) == jkt
     )
@@ -50,12 +49,11 @@ def test_mismatched_method_rejected():
     spec = KeySpec(
         klass=KeyClass.asymmetric,
         alg=KeyAlg.ED25519,
-        uses=(KeyUse.sign,),
-        export_policy=ExportPolicy.KEYPAIR,
+        uses=(KeyUse.SIGN,),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
     )
     ref = asyncio.run(kp.create_key(spec))
-    private_pem = ref.material or b""
-    proof = create_proof(private_pem, "GET", "https://rs.example.com/data")
+    proof = create_proof(ref, "GET", "https://rs.example.com/data")
     with pytest.raises(ValueError):
         verify_proof(proof, "POST", "https://rs.example.com/data")
 
@@ -67,14 +65,11 @@ def test_feature_toggle_disabled():
     spec = KeySpec(
         klass=KeyClass.asymmetric,
         alg=KeyAlg.ED25519,
-        uses=(KeyUse.sign,),
-        export_policy=ExportPolicy.KEYPAIR,
+        uses=(KeyUse.SIGN,),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
     )
     ref = asyncio.run(kp.create_key(spec))
-    private_pem = ref.material or b""
-    proof = create_proof(
-        private_pem, "GET", "https://rs.example.com/data", enabled=False
-    )
+    proof = create_proof(ref, "GET", "https://rs.example.com/data", enabled=False)
     assert proof == ""
     assert verify_proof("", "GET", "https://rs.example.com/data", enabled=False) == ""
 

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/__init__.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/__init__.py
@@ -23,6 +23,7 @@ from .rfc.rfc9396 import (
 )
 
 from .rfc.rfc6750 import extract_bearer_token
+from .rfc import rfc7662, rfc7591, rfc7592, rfc9101
 from .rfc.rfc7662 import introspect_token, register_token, reset_tokens
 from .rfc.rfc9207 import RFC9207_SPEC_URL, extract_issuer
 from .rfc.rfc8932 import RFC8932_SPEC_URL, enforce_encrypted_dns
@@ -204,6 +205,10 @@ __all__ = [
     "validate_metadata_consistency",
     "get_capability_matrix",
     "RFC8932_SPEC_URL",
+    "rfc7591",
+    "rfc7592",
+    "rfc7662",
+    "rfc9101",
     "mint_id_token",
     "verify_id_token",
 ]

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/deps/__init__.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/deps/__init__.py
@@ -28,7 +28,7 @@ from .fastapi import (
     RedirectResponse,
     APIKeyHeader,
 )
-from .sqlalchemy import Select, select, or_, delete
+from .sqlalchemy import IntegrityError, Select, select, or_, delete
 from .tigrbl import (
     TigrblApp,
     TigrblApi,
@@ -38,7 +38,6 @@ from .tigrbl import (
     build_engine,
     TIGRBL_AUTH_CONTEXT_ATTR,
     AuthNProvider,
-    IntegrityError,
     ForeignKeySpec,
     UserBase,
     TenantBase,
@@ -111,6 +110,7 @@ __all__ = [
     "select",
     "or_",
     "delete",
+    "IntegrityError",
     # tigrbl
     "TigrblApp",
     "TigrblApi",
@@ -120,7 +120,6 @@ __all__ = [
     "build_engine",
     "TIGRBL_AUTH_CONTEXT_ATTR",
     "AuthNProvider",
-    "IntegrityError",
     "ForeignKeySpec",
     "UserBase",
     "TenantBase",

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/deps/sqlalchemy.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/deps/sqlalchemy.py
@@ -1,8 +1,10 @@
 from sqlalchemy import Select, select, or_, delete
+from sqlalchemy.exc import IntegrityError
 
 __all__ = [
     "Select",
     "select",
     "or_",
     "delete",
+    "IntegrityError",
 ]

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/deps/tigrbl.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/deps/tigrbl.py
@@ -2,7 +2,6 @@ from tigrbl import TigrblApp, TigrblApi, op_ctx, hook_ctx
 from tigrbl.engine import HybridSession as AsyncSession, engine as build_engine
 from tigrbl.config.constants import TIGRBL_AUTH_CONTEXT_ATTR
 from tigrbl.types.authn_abc import AuthNProvider
-from tigrbl.error import IntegrityError
 from tigrbl.column.storage_spec import ForeignKeySpec
 from tigrbl.orm.tables import (
     User as UserBase,
@@ -47,7 +46,6 @@ __all__ = [
     "build_engine",
     "TIGRBL_AUTH_CONTEXT_ATTR",
     "AuthNProvider",
-    "IntegrityError",
     "ForeignKeySpec",
     "UserBase",
     "TenantBase",

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/oidc_id_token.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/oidc_id_token.py
@@ -29,7 +29,7 @@ from .deps import (
 )
 from .errors import InvalidTokenError
 from .runtime_cfg import settings
-from .rfc7516 import encrypt_jwe, decrypt_jwe
+from .rfc.rfc7516 import encrypt_jwe, decrypt_jwe
 
 # ---------------------------------------------------------------------------
 # Signing key management

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/orm/user.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/orm/user.py
@@ -114,7 +114,7 @@ class User(UserBase):
         from ..routers.shared import _jwt, _require_tls, SESSIONS
         from .auth_session import AuthSession
         from .tenant import Tenant
-        from tigrbl.error import IntegrityError
+        from tigrbl_auth.deps import IntegrityError
 
         request = ctx.get("request")
         _require_tls(request)

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/rfc/rfc6749_token.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/rfc/rfc6749_token.py
@@ -1,48 +1,53 @@
 from __future__ import annotations
 
+import inspect
 import secrets
-
 from datetime import datetime, timezone
 from typing import Any
-import inspect
 from uuid import UUID
 
 from tigrbl_auth.deps import (
+    APIRouter,
+    AsyncSession,
     Depends,
     HTTPException,
-    Request,
-    status,
     JSONResponse,
-    select,
-    AsyncSession,
+    Request,
     ValidationError,
+    select,
+    status,
 )
 
-from ...backends import AuthError
-from ...fastapi_deps import get_db
-from ...orm import AuthCode, Client, DeviceCode, User
-from ...rfc8707 import extract_resource
-from ...runtime_cfg import settings
-from ...rfc6749 import (
+from ..backends import AuthError
+from ..fastapi_deps import get_db
+from ..oidc_id_token import mint_id_token, oidc_hash
+from ..orm import AuthCode, Client, DeviceCode, User
+from ..rfc.rfc8414_metadata import ISSUER
+from ..rfc.rfc8707 import extract_resource
+from ..rfc.rfc6749 import (
     RFC6749Error,
     enforce_authorization_code_grant,
     enforce_grant_type,
     enforce_password_grant,
     is_enabled as rfc6749_enabled,
 )
-from ...rfc7636_pkce import verify_code_challenge
-from ...rfc8628 import DeviceGrantForm
-from ...oidc_id_token import mint_id_token, oidc_hash
-from ...rfc8414_metadata import ISSUER
-
-from ..schemas import (
+from ..rfc.rfc7636_pkce import verify_code_challenge
+from ..rfc.rfc8628 import DeviceGrantForm
+from ..routers.schemas import (
     AuthorizationCodeGrantForm,
     PasswordGrantForm,
     RefreshIn,
     TokenPair,
 )
-from ..shared import _require_tls, _jwt, _pwd_backend, _ALLOWED_GRANT_TYPES
-from . import router
+from ..routers.shared import (
+    _ALLOWED_GRANT_TYPES,
+    _jwt,
+    _pwd_backend,
+    _require_tls,
+)
+from ..runtime_cfg import settings
+
+router = APIRouter()
 
 
 @router.post("/token", response_model=TokenPair)

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/rfc/rfc7662_introspection.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/rfc/rfc7662_introspection.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-from tigrbl_auth.deps import HTTPException, Request, status
+from tigrbl_auth.deps import APIRouter, HTTPException, Request, status
 
-from ...runtime_cfg import settings
-from ..schemas import IntrospectOut
-from ..shared import _require_tls
-from ...rfc7662 import introspect_token
+from ..runtime_cfg import settings
+from ..routers.schemas import IntrospectOut
+from ..routers.shared import _require_tls
+from ..rfc.rfc7662 import introspect_token
 
-from . import router
+router = APIRouter()
 
 
 @router.post("/introspect", response_model=IntrospectOut)

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/auth_flows.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/auth_flows.py
@@ -10,7 +10,7 @@ from ..fastapi_deps import get_db
 from ..oidc_id_token import mint_id_token
 from ..orm.auth_session import AuthSession
 from ..routers.schemas import CredsIn, TokenPair
-from ..rfc8414_metadata import ISSUER
+from ..rfc.rfc8414_metadata import ISSUER
 from .authz import router as router
 from .shared import _jwt, _pwd_backend, AUTH_CODES, SESSIONS
 

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/authz/__init__.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/authz/__init__.py
@@ -1,5 +1,8 @@
 from tigrbl_auth.deps import APIRouter
+from tigrbl_auth.rfc import rfc6749_token, rfc7662_introspection
 
 router = APIRouter()
+router.include_router(rfc6749_token.router)
+router.include_router(rfc7662_introspection.router)
 
-from . import rfc6749, rfc7662, oidc  # noqa: E402,F401
+from . import oidc  # noqa: E402,F401

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/authz/oidc.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/authz/oidc.py
@@ -19,8 +19,8 @@ from tigrbl_auth.deps import (
 from ...fastapi_deps import get_db
 from ...orm import AuthCode, Client, User
 from ...oidc_id_token import mint_id_token, oidc_hash
-from ...rfc8414_metadata import ISSUER
-from ...rfc8252 import is_native_redirect_uri
+from ...rfc.rfc8414_metadata import ISSUER
+from ...rfc.rfc8252 import is_native_redirect_uri
 from ..shared import _require_tls, SESSIONS, AUTH_CODES
 from . import router
 


### PR DESCRIPTION
## Summary
- relocate RFC 6749 token and RFC 7662 introspection handlers under tigrbl_auth.rfc
- funnel SQLAlchemy and tigrbl imports through deps; expose IntegrityError
- build DPoP proofs using provider-managed keys

## Testing
- `uv run --package tigrbl-auth --directory standards/tigrbl_auth ruff format .`
- `uv run --package tigrbl-auth --directory standards/tigrbl_auth ruff check . --fix`
- `uv run --package tigrbl-auth --directory standards/tigrbl_auth pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7a45119748326ba2fad4b6adae314