### PR TITLE
fix: ensure tigrbl-auth uses workspace tigrbl package

### DIFF
--- a/pkgs/standards/tigrbl_auth/pyproject.toml
+++ b/pkgs/standards/tigrbl_auth/pyproject.toml
@@ -44,6 +44,7 @@ keywords = ["oidc", "oauth2", "fastapi", "identity-provider", "jwks", "jwt"]
 swarmauri_core = { workspace = true }
 swarmauri_base = { workspace = true }
 swarmauri_standard = { workspace = true }
+tigrbl = { workspace = true }
 
 swarmauri_crypto_jwe  = { workspace = true }
 swarmauri_tokens_jwt = { workspace = true }


### PR DESCRIPTION
## Summary
- add tigrbl workspace mapping in tigrbl-auth pyproject

## Testing
- `uv run --directory pkgs/standards/tigrbl_auth --package tigrbl-auth ruff format .`
- `uv run --directory pkgs/standards/tigrbl_auth --package tigrbl-auth ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c7ab63fc9c8326a924742966bb58a1