### PR TITLE
feat: add dependency license pytest plugin

### DIFF
--- a/pkgs/base/pyproject.toml
+++ b/pkgs/base/pyproject.toml
@@ -34,20 +34,22 @@ pyopenssl = ["pyopenssl>=23.2.0"]
 [tool.uv.sources]
 swarmauri_core = { workspace = true }
 swarmauri_typing = { workspace = true }
+swarmauri_tests_pylicense = { workspace = true }
 
 [dependency-groups]
 dev = [
-"toml>=0.10.2",
-"pytest>=8.0.0",
-"pytest-xdist>=3.6.1",
-"pytest-asyncio>=0.24.0",
-"pytest-timeout>=2.3.1",
-"pytest-json-report>=1.5.0",
-"python-dotenv>=1.0.0",
-"pytest-mock>=3.14.0",
-"jsonschema>=4.18.5",
-"ruff>=0.9.9",
-"pytest-benchmark>=4.0.0",
+    "toml>=0.10.2",
+    "pytest>=8.0.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-asyncio>=0.24.0",
+    "pytest-timeout>=2.3.1",
+    "pytest-json-report>=1.5.0",
+    "python-dotenv>=1.0.0",
+    "pytest-mock>=3.14.0",
+    "jsonschema>=4.18.5",
+    "ruff>=0.9.9",
+    "pytest-benchmark>=4.0.0",
+    "swarmauri_tests_pylicense",
 ]
 
 [tool.pytest.ini_options]

--- a/pkgs/experimental/swarmauri_tests_pylicense/LICENSE
+++ b/pkgs/experimental/swarmauri_tests_pylicense/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/experimental/swarmauri_tests_pylicense/README.md
+++ b/pkgs/experimental/swarmauri_tests_pylicense/README.md
@@ -1,0 +1,57 @@
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_tests_pylicense/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_tests_pylicense" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/experimental/swarmauri_tests_pylicense/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/experimental/swarmauri_tests_pylicense.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_tests_pylicense/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_tests_pylicense" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_tests_pylicense/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_tests_pylicense" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_tests_pylicense/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_tests_pylicense?label=swarmauri_tests_pylicense&color=green" alt="PyPI - swarmauri_tests_pylicense"/></a>
+</p>
+
+---
+
+## Overview
+
+`swarmauri_tests_pylicense` is a [pytest](https://docs.pytest.org/) plugin that
+scans a package's full dependency tree and ensures each dependency declares a
+license. The plugin resolves dependencies recursively, checking every
+transitive requirement.
+
+By default, the plugin runs in *parameterized* mode which creates one test per
+dependency. An *aggregate* mode is also available that reports all missing
+licenses in a single test.
+
+## Installation
+
+```bash
+pip install swarmauri_tests_pylicense
+```
+
+`pytest` automatically discovers the plugin once it is installed.
+
+## Usage
+
+### Parameterized (default)
+
+Run `pytest` with the package name to scan its dependency licenses:
+
+```bash
+pytest --pylicense-package=<your-package>
+```
+
+### Aggregate
+
+Use the `--pylicense-mode=aggregate` flag to consolidate checks into one test:
+
+```bash
+pytest --pylicense-package=<your-package> --pylicense-mode=aggregate
+```
+
+## License
+
+Licensed under the [Apache 2.0 License](LICENSE).

--- a/pkgs/experimental/swarmauri_tests_pylicense/pyproject.toml
+++ b/pkgs/experimental/swarmauri_tests_pylicense/pyproject.toml
@@ -1,0 +1,37 @@
+[project]
+name = "swarmauri_tests_pylicense"
+version = "0.1.0.dev0"
+description = "Pytest plugin reporting dependency licenses"
+authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
+license = "Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/swarmauri/swarmauri-sdk/pkgs/experimental/swarmauri_tests_pylicense"
+requires-python = ">=3.10,<3.13"
+classifiers = [
+    "Development Status :: 1 - Planning",
+    "License :: OSI Approved :: Apache Software License",
+    "Framework :: Pytest",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+
+[project.entry-points.pytest11]
+swarmauri_tests_pylicense = "swarmauri_tests_pylicense"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "python-dotenv",
+    "pytest-timeout>=2.3.1",
+    "ruff>=0.9.9",
+    "pytest-benchmark>=4.0.0",
+]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/pkgs/experimental/swarmauri_tests_pylicense/swarmauri_tests_pylicense/__init__.py
+++ b/pkgs/experimental/swarmauri_tests_pylicense/swarmauri_tests_pylicense/__init__.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from collections import deque
+from pathlib import Path
+from typing import Dict
+
+import pytest
+from importlib.metadata import PackageNotFoundError, distribution
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+
+try:  # Python 3.11+
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10
+    import tomli as tomllib  # type: ignore
+
+PLUGIN_NAME = __name__.split(".")[0]
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Register command-line options for license scanning."""
+    group = parser.getgroup("pylicense")
+    group.addoption(
+        "--pylicense-mode",
+        action="store",
+        default="parameterized",
+        choices=["parameterized", "aggregate"],
+        help="Report licenses per dependency or as a single aggregate test.",
+    )
+    group.addoption(
+        "--pylicense-package",
+        action="store",
+        default=None,
+        help="Package name to inspect (defaults to project name in pyproject.toml).",
+    )
+
+
+def _default_package(config: pytest.Config) -> str:
+    pkg = config.getoption("--pylicense-package")
+    if pkg:
+        return pkg
+    inifile = getattr(config, "inifile", None)
+    if inifile and Path(inifile).suffix == ".toml":
+        data = tomllib.loads(Path(inifile).read_text())
+        project = data.get("project") or {}
+        name = project.get("name")
+        if name:
+            return str(name)
+    raise pytest.UsageError(
+        "Could not determine package name; use --pylicense-package."
+    )
+
+
+def _collect_licenses(pkg: str) -> Dict[str, str]:
+    """Return mapping of dependency names to their licenses."""
+    licenses: Dict[str, str] = {}
+    queue: deque[str] = deque([pkg])
+    while queue:
+        name = queue.popleft()
+        canon = canonicalize_name(name)
+        if canon in licenses:
+            continue
+        try:
+            dist = distribution(name)
+        except PackageNotFoundError:
+            licenses[canon] = "UNKNOWN"
+            continue
+        meta = dist.metadata
+        license_str = meta.get("License", "").strip()
+        if not license_str:
+            license_str = meta.get("License-Expression", "").strip()
+        if not license_str:
+            classifiers = meta.get_all("Classifier", [])
+            license_classifiers = [c for c in classifiers if c.startswith("License ::")]
+            if license_classifiers:
+                license_str = license_classifiers[0].split("::")[-1].strip()
+        if not license_str:
+            license_str = "UNKNOWN"
+        licenses[canon] = license_str
+        for req in dist.requires or []:
+            queue.append(Requirement(req).name)
+    return licenses
+
+
+class LicenseItem(pytest.Item):
+    def __init__(self, name: str, parent: pytest.Collector, dep: str, license: str):
+        super().__init__(name, parent)
+        self.dep = dep
+        self.license = license
+
+    def runtest(self) -> None:  # pragma: no cover - simple assertion
+        if self.license == "UNKNOWN":
+            raise AssertionError(f"{self.dep} has unknown license")
+
+    def reportinfo(self) -> tuple[Path, None, str]:
+        return Path(self.dep), None, f"license check for {self.dep}"
+
+
+class LicenseAggregateItem(pytest.Item):
+    def __init__(self, name: str, parent: pytest.Collector, licenses: Dict[str, str]):
+        super().__init__(name, parent)
+        self.licenses = licenses
+
+    def runtest(self) -> None:  # pragma: no cover - simple aggregation
+        failures = [
+            f"{dep} has unknown license"
+            for dep, lic in self.licenses.items()
+            if lic == "UNKNOWN"
+        ]
+        if failures:
+            pytest.fail("\n".join(failures))
+
+    def reportinfo(self) -> tuple[str, None, str]:
+        return "license aggregate", None, "license aggregate check"
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line("markers", "pylicense: dependency license checks")
+    pkg = _default_package(config)
+    config._pylicense_licenses = _collect_licenses(pkg)
+
+
+def pytest_collection_modifyitems(
+    session: pytest.Session, config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    if getattr(config, "_pylicense_items_added", False):
+        return
+    config._pylicense_items_added = True
+    licenses: Dict[str, str] = config._pylicense_licenses
+    mode: str = config.getoption("--pylicense-mode")
+    if mode == "parameterized":
+        for dep, lic in sorted(licenses.items()):
+            item = LicenseItem.from_parent(
+                session,
+                name=f"{PLUGIN_NAME}:license::{dep}",
+                dep=dep,
+                license=lic,
+            )
+            items.append(item)
+    else:
+        item = LicenseAggregateItem.from_parent(
+            session,
+            name=f"{PLUGIN_NAME}:license-aggregate",
+            licenses=licenses,
+        )
+        items.append(item)
+
+
+__all__ = ["_collect_licenses"]

--- a/pkgs/experimental/swarmauri_tests_pylicense/tests/test_plugin.py
+++ b/pkgs/experimental/swarmauri_tests_pylicense/tests/test_plugin.py
@@ -1,0 +1,27 @@
+from swarmauri_tests_pylicense import _collect_licenses
+
+pytest_plugins = ["pytester"]
+
+
+def test_parameterized_mode(pytester):
+    licenses = _collect_licenses("pytest")
+    assert all(lic != "UNKNOWN" for lic in licenses.values())
+    count = len(licenses)
+    result = pytester.runpytest(
+        "-p",
+        "swarmauri_tests_pylicense",
+        "--pylicense-package=pytest",
+    )
+    result.assert_outcomes(passed=count)
+    assert "swarmauri_tests_pylicense:license::pytest" in result.stdout.str()
+
+
+def test_aggregate_mode(pytester):
+    result = pytester.runpytest(
+        "-p",
+        "swarmauri_tests_pylicense",
+        "--pylicense-package=pytest",
+        "--pylicense-mode=aggregate",
+    )
+    result.assert_outcomes(passed=1)
+    assert "license aggregate check" in result.stdout.str()

--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -101,6 +101,7 @@ members = [
     "experimental/swarmauri_certs_pkcs11",
     "experimental/swarmauri_keyprovider_pkcs11",
     "experimental/swarmauri_tests_loc_tersity",
+    "experimental/swarmauri_tests_pylicense",
     "standards/swarmauri_crypto_paramiko",
     "standards/swarmauri_crypto_pgp",
     "standards/swarmauri_crypto_rust",


### PR DESCRIPTION
## Summary
- add swarmauri_tests_pylicense plugin to scan dependency licenses recursively
- wire plugin into swarmauri_base dev dependencies
- register plugin package in monorepo workspace
- fall back to license expression and classifier metadata when explicit license field is missing

## Testing
- `uv run --directory pkgs/experimental/swarmauri_tests_pylicense --package swarmauri_tests_pylicense ruff format .`
- `uv run --directory pkgs/experimental/swarmauri_tests_pylicense --package swarmauri_tests_pylicense ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c7a3566c6083268b41fe575afb212d