### PR TITLE
feat: add dependency license pytest plugin

### DIFF
--- a/pkgs/base/pyproject.toml
+++ b/pkgs/base/pyproject.toml
@@ -34,20 +34,22 @@ pyopenssl = ["pyopenssl>=23.2.0"]
 [tool.uv.sources]
 swarmauri_core = { workspace = true }
 swarmauri_typing = { workspace = true }
+swarmauri_tests_pylicense = { workspace = true }
 
 [dependency-groups]
 dev = [
-"toml>=0.10.2",
-"pytest>=8.0.0",
-"pytest-xdist>=3.6.1",
-"pytest-asyncio>=0.24.0",
-"pytest-timeout>=2.3.1",
-"pytest-json-report>=1.5.0",
-"python-dotenv>=1.0.0",
-"pytest-mock>=3.14.0",
-"jsonschema>=4.18.5",
-"ruff>=0.9.9",
-"pytest-benchmark>=4.0.0",
+    "toml>=0.10.2",
+    "pytest>=8.0.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-asyncio>=0.24.0",
+    "pytest-timeout>=2.3.1",
+    "pytest-json-report>=1.5.0",
+    "python-dotenv>=1.0.0",
+    "pytest-mock>=3.14.0",
+    "jsonschema>=4.18.5",
+    "ruff>=0.9.9",
+    "pytest-benchmark>=4.0.0",
+    "swarmauri_tests_pylicense",
 ]
 
 [tool.pytest.ini_options]

--- a/pkgs/experimental/swarmauri_tests_pylicense/LICENSE
+++ b/pkgs/experimental/swarmauri_tests_pylicense/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/experimental/swarmauri_tests_pylicense/README.md
+++ b/pkgs/experimental/swarmauri_tests_pylicense/README.md
@@ -1,0 +1,90 @@
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_tests_pylicense/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_tests_pylicense" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/experimental/swarmauri_tests_pylicense/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/experimental/swarmauri_tests_pylicense.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_tests_pylicense/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_tests_pylicense" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_tests_pylicense/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_tests_pylicense" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_tests_pylicense/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_tests_pylicense?label=swarmauri_tests_pylicense&color=green" alt="PyPI - swarmauri_tests_pylicense"/></a>
+</p>
+
+---
+
+## Overview
+
+`swarmauri_tests_pylicense` is a [pytest](https://docs.pytest.org/) plugin that
+scans a package's full dependency tree and ensures each dependency declares a
+license. The plugin resolves dependencies recursively, checking every
+transitive requirement. It inspects both the `License` metadata field and
+any `Classifier` entries that declare a license.
+
+By default, the plugin runs in *parameterized* mode which creates one test per
+dependency. An *aggregate* mode is also available that reports all missing
+licenses in a single test.
+
+## Installation
+
+```bash
+pip install swarmauri_tests_pylicense
+```
+
+`pytest` automatically discovers the plugin once it is installed.
+
+## Usage
+
+### Parameterized (default)
+
+Run `pytest` with the package name to scan its dependency licenses:
+
+```bash
+pytest --pylicense-package=<your-package>
+```
+
+Each generated test encodes the full dependency path, the resolved version,
+and the detected license of the terminal package. For example:
+
+```
+swarmauri_tests_pylicense:license::pkg::depA::depB==1.2.3 [Apache-2.0]
+```
+
+### Aggregate
+
+Use the `--pylicense-mode=aggregate` flag to consolidate checks into one test:
+
+```bash
+pytest --pylicense-package=<your-package> --pylicense-mode=aggregate
+```
+
+### Allow and Disallow Lists
+
+To restrict acceptable licenses, provide a comma-separated allow list or
+disallow list. These can be passed via command-line options or environment
+variables.
+
+Command-line:
+
+```bash
+pytest --pylicense-package=<your-package> --pylicense-allow-list=MIT,Apache-2.0
+pytest --pylicense-package=<your-package> --pylicense-disallow-list=GPL
+```
+
+Environment variables:
+
+```bash
+export PYLICENSE_ALLOW_LIST="MIT,Apache-2.0"
+export PYLICENSE_DISALLOW_LIST="GPL"
+pytest --pylicense-package=<your-package>
+```
+
+If both are provided, any license not in the allow list or explicitly present
+in the disallow list will cause a test failure. By default, all licenses are
+allowed and none are disallowed.
+
+## License
+
+Licensed under the [Apache 2.0 License](LICENSE).

--- a/pkgs/experimental/swarmauri_tests_pylicense/pyproject.toml
+++ b/pkgs/experimental/swarmauri_tests_pylicense/pyproject.toml
@@ -1,0 +1,37 @@
+[project]
+name = "swarmauri_tests_pylicense"
+version = "0.1.0.dev0"
+description = "Pytest plugin reporting dependency licenses"
+authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
+license = "Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/swarmauri/swarmauri-sdk/pkgs/experimental/swarmauri_tests_pylicense"
+requires-python = ">=3.10,<3.13"
+classifiers = [
+    "Development Status :: 1 - Planning",
+    "License :: OSI Approved :: Apache Software License",
+    "Framework :: Pytest",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+
+[project.entry-points.pytest11]
+swarmauri_tests_pylicense = "swarmauri_tests_pylicense"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "python-dotenv",
+    "pytest-timeout>=2.3.1",
+    "ruff>=0.9.9",
+    "pytest-benchmark>=4.0.0",
+]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/pkgs/experimental/swarmauri_tests_pylicense/swarmauri_tests_pylicense/__init__.py
+++ b/pkgs/experimental/swarmauri_tests_pylicense/swarmauri_tests_pylicense/__init__.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Set, Tuple
+
+import os
+import pytest
+from importlib.metadata import PackageNotFoundError, distribution
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+
+try:  # Python 3.11+
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10
+    import tomli as tomllib  # type: ignore
+
+PLUGIN_NAME = __name__.split(".")[0]
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Register command-line options for license scanning."""
+    group = parser.getgroup("pylicense")
+    group.addoption(
+        "--pylicense-mode",
+        action="store",
+        default="parameterized",
+        choices=["parameterized", "aggregate"],
+        help="Report licenses per dependency or as a single aggregate test.",
+    )
+    group.addoption(
+        "--pylicense-package",
+        action="store",
+        default=None,
+        help="Package name to inspect (defaults to project name in pyproject.toml).",
+    )
+    group.addoption(
+        "--pylicense-allow-list",
+        action="store",
+        default=None,
+        help="Comma-separated list of allowed license names.",
+    )
+    group.addoption(
+        "--pylicense-disallow-list",
+        action="store",
+        default=None,
+        help="Comma-separated list of forbidden license names.",
+    )
+
+
+def _default_package(config: pytest.Config) -> str:
+    pkg = config.getoption("--pylicense-package")
+    if pkg:
+        return pkg
+    inifile = getattr(config, "inifile", None)
+    if inifile and Path(inifile).suffix == ".toml":
+        data = tomllib.loads(Path(inifile).read_text())
+        project = data.get("project") or {}
+        name = project.get("name")
+        if name:
+            return str(name)
+    raise pytest.UsageError(
+        "Could not determine package name; use --pylicense-package."
+    )
+
+
+@dataclass
+class PackageLicense:
+    license: str
+    version: str
+
+
+@dataclass
+class DependencyPath:
+    path: Tuple[str, ...]
+    license: str
+    version: str
+
+
+def _license_from_dist(dist) -> str:
+    meta = dist.metadata
+    license_str = meta.get("License", "").strip()
+    if not license_str or license_str == "UNKNOWN":
+        classifiers = [
+            c for c in meta.get_all("Classifier", []) if c.startswith("License ::")
+        ]
+        if classifiers:
+            license_str = " / ".join(c.split("::")[-1].strip() for c in classifiers)
+    if not license_str or license_str == "UNKNOWN":
+        for file in dist.files or []:
+            name = file.name.upper()
+            if "LICENSE" in name or "COPYING" in name:
+                try:
+                    text = file.locate().read_text(encoding="utf-8")
+                except Exception:  # pragma: no cover - best effort
+                    continue
+                for pattern in [
+                    "MIT License",
+                    "Apache License",
+                    "BSD",
+                    "Python Software Foundation License",
+                    "GNU General Public License",
+                    "GNU Lesser General Public License",
+                    "Mozilla Public License",
+                    "ISC License",
+                ]:
+                    if pattern.lower() in text.lower():
+                        license_str = pattern
+                        break
+            if license_str and license_str != "UNKNOWN":
+                break
+    return license_str or "UNKNOWN"
+
+
+def _collect_dependency_paths(pkg: str) -> List[DependencyPath]:
+    paths: List[DependencyPath] = []
+    queue: deque[Tuple[str, Tuple[str, ...]]] = deque([(pkg, (pkg,))])
+    seen: Set[str] = set()
+    while queue:
+        name, path = queue.popleft()
+        canon = canonicalize_name(name)
+        if canon in seen:
+            continue
+        seen.add(canon)
+        try:
+            dist = distribution(name)
+        except PackageNotFoundError:
+            continue
+        lic = _license_from_dist(dist)
+        ver = dist.version
+        if len(path) > 1:
+            paths.append(DependencyPath(path, lic, ver))
+        for req_str in dist.requires or []:
+            req = Requirement(req_str)
+            if req.marker and not req.marker.evaluate({"extra": ""}):
+                continue
+            try:
+                distribution(req.name)
+            except PackageNotFoundError:
+                continue
+            queue.append((req.name, path + (req.name,)))
+    return paths
+
+
+def _collect_licenses(pkg: str) -> Dict[str, PackageLicense]:
+    paths = _collect_dependency_paths(pkg)
+    return {
+        canonicalize_name(p.path[-1]): PackageLicense(p.license, p.version)
+        for p in paths
+    }
+
+
+class LicenseItem(pytest.Item):
+    def __init__(
+        self,
+        name: str,
+        parent: pytest.Collector,
+        dep: str,
+        version: str,
+        license: str,
+    ):
+        super().__init__(name, parent)
+        self.dep = dep
+        self.version = version
+        self.license = license
+
+    def runtest(self) -> None:  # pragma: no cover - simple assertion
+        allow: Set[str] = getattr(self.config, "_pylicense_allow", set())
+        disallow: Set[str] = getattr(self.config, "_pylicense_disallow", set())
+        lic = self.license
+        if lic == "UNKNOWN":
+            pytest.fail(
+                f"{self.dep}=={self.version} has unknown license", pytrace=False
+            )
+        if disallow and lic in disallow:
+            pytest.fail(
+                f"{self.dep}=={self.version} uses forbidden license {lic}",
+                pytrace=False,
+            )
+        if allow and lic not in allow:
+            pytest.fail(
+                f"{self.dep}=={self.version} has disallowed license {lic}",
+                pytrace=False,
+            )
+
+    def reportinfo(self) -> tuple[Path, None, str]:
+        return (
+            Path.cwd(),
+            None,
+            f"license check for {self.dep}=={self.version} [{self.license}]",
+        )
+
+
+class LicenseAggregateItem(pytest.Item):
+    def __init__(
+        self, name: str, parent: pytest.Collector, licenses: Dict[str, PackageLicense]
+    ):
+        super().__init__(name, parent)
+        self.licenses = licenses
+
+    def runtest(self) -> None:  # pragma: no cover - simple aggregation
+        allow: Set[str] = getattr(self.config, "_pylicense_allow", set())
+        disallow: Set[str] = getattr(self.config, "_pylicense_disallow", set())
+        failures = []
+        for dep, info in self.licenses.items():
+            lic = info.license
+            ver = info.version
+            if lic == "UNKNOWN":
+                failures.append(f"{dep}=={ver} has unknown license")
+            elif disallow and lic in disallow:
+                failures.append(f"{dep}=={ver} uses forbidden license {lic}")
+            elif allow and lic not in allow:
+                failures.append(f"{dep}=={ver} has disallowed license {lic}")
+        if failures:
+            pytest.fail("\n".join(failures))
+
+    def reportinfo(self) -> tuple[Path, None, str]:
+        pkg = getattr(self.config, "_pylicense_pkg", "package")
+        return Path.cwd(), None, f"license aggregate check for {pkg}"
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line("markers", "pylicense: dependency license checks")
+    pkg = _default_package(config)
+    config._pylicense_pkg = pkg
+    paths = _collect_dependency_paths(pkg)
+    config._pylicense_paths = paths
+    config._pylicense_licenses = {
+        canonicalize_name(p.path[-1]): PackageLicense(p.license, p.version)
+        for p in paths
+    }
+    allow = _parse_list(
+        config.getoption("--pylicense-allow-list"), "PYLICENSE_ALLOW_LIST"
+    )
+    disallow = _parse_list(
+        config.getoption("--pylicense-disallow-list"), "PYLICENSE_DISALLOW_LIST"
+    )
+    config._pylicense_allow = allow
+    config._pylicense_disallow = disallow
+
+
+def pytest_collection_modifyitems(
+    session: pytest.Session, config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    if getattr(config, "_pylicense_items_added", False):
+        return
+    config._pylicense_items_added = True
+    mode: str = config.getoption("--pylicense-mode")
+    if mode == "parameterized":
+        paths: List[DependencyPath] = config._pylicense_paths
+        for dp in sorted(paths, key=lambda p: p.path):
+            path_str = "::".join(dp.path)
+            item = LicenseItem.from_parent(
+                session,
+                name=f"{PLUGIN_NAME}:license::{path_str}=={dp.version} [{dp.license}]",
+                dep=dp.path[-1],
+                version=dp.version,
+                license=dp.license,
+            )
+            items.append(item)
+    else:
+        item = LicenseAggregateItem.from_parent(
+            session,
+            name=f"{PLUGIN_NAME}:license-aggregate::{config._pylicense_pkg}",
+            licenses=config._pylicense_licenses,
+        )
+        items.append(item)
+
+
+def _parse_list(value: str | None, env: str) -> Set[str]:
+    val = value or os.getenv(env)
+    if not val:
+        return set()
+    return {v.strip() for v in val.split(",") if v.strip()}
+
+
+__all__ = [
+    "_collect_licenses",
+    "_collect_dependency_paths",
+    "PackageLicense",
+    "DependencyPath",
+]

--- a/pkgs/experimental/swarmauri_tests_pylicense/tests/test_plugin.py
+++ b/pkgs/experimental/swarmauri_tests_pylicense/tests/test_plugin.py
@@ -1,0 +1,82 @@
+from email.message import Message
+from importlib.metadata import PackageNotFoundError
+
+from swarmauri_tests_pylicense import DependencyPath, _collect_licenses
+
+pytest_plugins = ["pytester"]
+
+
+def test_parameterized_mode(pytester, monkeypatch):
+    monkeypatch.setattr(
+        "swarmauri_tests_pylicense._collect_dependency_paths",
+        lambda pkg: [DependencyPath(("dummy", "dep"), "MIT", "1.0")],
+    )
+    result = pytester.runpytest(
+        "-p",
+        "swarmauri_tests_pylicense",
+        "--pylicense-package=dummy",
+    )
+    result.assert_outcomes(passed=1)
+    assert (
+        "swarmauri_tests_pylicense:license::dummy::dep==1.0 [MIT]"
+        in result.stdout.str()
+    )
+
+
+def test_aggregate_mode(pytester, monkeypatch):
+    monkeypatch.setattr(
+        "swarmauri_tests_pylicense._collect_dependency_paths",
+        lambda pkg: [
+            DependencyPath(("dummy", "dep"), "MIT", "1.0"),
+            DependencyPath(("dummy", "dep2"), "Apache-2.0", "2.0"),
+        ],
+    )
+    result = pytester.runpytest(
+        "-p",
+        "swarmauri_tests_pylicense",
+        "--pylicense-package=dummy",
+        "--pylicense-mode=aggregate",
+    )
+    result.assert_outcomes(passed=1)
+    assert "license aggregate check for dummy" in result.stdout.str()
+
+
+def test_classifier_fallback(monkeypatch):
+    class DummyDist:
+        def __init__(self) -> None:
+            self.metadata = Message()
+            self.metadata.add_header(
+                "Classifier", "License :: OSI Approved :: MIT License"
+            )
+            self.requires = None
+            self.version = "0"
+
+    def fake_distribution(name):
+        if name == "foo":
+            return DummyDist()
+        raise PackageNotFoundError
+
+    monkeypatch.setattr("swarmauri_tests_pylicense.distribution", fake_distribution)
+    licenses = _collect_licenses("foo")
+    assert licenses["foo"].license == "MIT License"
+
+
+def test_allow_disallow_lists(pytester, monkeypatch):
+    monkeypatch.setattr(
+        "swarmauri_tests_pylicense._collect_dependency_paths",
+        lambda pkg: [DependencyPath(("dummy", "dep"), "GPL", "1.0")],
+    )
+    result = pytester.runpytest(
+        "-p",
+        "swarmauri_tests_pylicense",
+        "--pylicense-package=dummy",
+        "--pylicense-allow-list=MIT",
+    )
+    result.assert_outcomes(failed=1)
+    result = pytester.runpytest(
+        "-p",
+        "swarmauri_tests_pylicense",
+        "--pylicense-package=dummy",
+        "--pylicense-disallow-list=GPL",
+    )
+    result.assert_outcomes(failed=1)

--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -101,6 +101,7 @@ members = [
     "experimental/swarmauri_certs_pkcs11",
     "experimental/swarmauri_keyprovider_pkcs11",
     "experimental/swarmauri_tests_loc_tersity",
+    "experimental/swarmauri_tests_pylicense",
     "standards/swarmauri_crypto_paramiko",
     "standards/swarmauri_crypto_pgp",
     "standards/swarmauri_crypto_rust",


### PR DESCRIPTION
## Summary
- augment license scanning pytest plugin with package-versioned parameterized tests and aggregate tests that name the target package
- support allow and disallow lists via CLI options or environment variables, failing gracefully when licenses violate policy
- document new allow_list and disallow_list settings in plugin README and extend tests accordingly
- include full dependency paths, resolved versions, and detected licenses in parameterized test names
- skip optional dependencies and heuristically detect licenses from bundled license files

## Testing
- `uv run --directory pkgs/experimental/swarmauri_tests_pylicense --package swarmauri_tests_pylicense ruff format .`
- `uv run --directory pkgs/experimental/swarmauri_tests_pylicense --package swarmauri_tests_pylicense ruff check . --fix`
- `uv run --package swarmauri_base --directory pkgs/base pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7a3566c6083268b41fe575afb212d