### PR TITLE
feat: use crypto plugin for rfc8291 webpush

### DIFF
--- a/pkgs/standards/tigrbl_auth/pyproject.toml
+++ b/pkgs/standards/tigrbl_auth/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "swarmauri_signing_ed25519",
     "swarmauri_signing_dpop",
     "swarmauri_crypto_jwe",
+    "swarmauri_crypto_paramiko",
     "swarmauri_keyprovider_file",
     "swarmauri_keyprovider_local",
     "python-multipart>=0.0.9",
@@ -47,6 +48,7 @@ swarmauri_standard = { workspace = true }
 tigrbl = { workspace = true }
 
 swarmauri_crypto_jwe  = { workspace = true }
+swarmauri_crypto_paramiko  = { workspace = true }
 swarmauri_tokens_jwt = { workspace = true }
 swarmauri_signing_jws  = { workspace = true }
 swarmauri_signing_ed25519  = { workspace = true }

--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc8291_webpush_encryption.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc8291_webpush_encryption.py
@@ -17,51 +17,57 @@ from tigrbl_auth.runtime_cfg import settings
 
 
 @pytest.mark.unit
-def test_encrypt_decrypt_round_trip():
+@pytest.mark.asyncio
+async def test_encrypt_decrypt_round_trip():
     """Encryption and decryption work when the feature is enabled."""
     key = os.urandom(16)
     nonce = os.urandom(12)
     plaintext = b"hello"
-    ciphertext = encrypt_push_message(plaintext, key, nonce, enabled=True)
+    ciphertext = await encrypt_push_message(plaintext, key, nonce, enabled=True)
     assert ciphertext != plaintext
-    assert decrypt_push_message(ciphertext, key, nonce, enabled=True) == plaintext
+    assert await decrypt_push_message(ciphertext, key, nonce, enabled=True) == plaintext
 
 
 @pytest.mark.unit
-def test_disabled_returns_plain():
+@pytest.mark.asyncio
+async def test_disabled_returns_plain():
     """When disabled, messages are left unencrypted."""
     key = os.urandom(16)
     nonce = os.urandom(12)
     plaintext = b"data"
-    ciphertext = encrypt_push_message(plaintext, key, nonce, enabled=False)
+    ciphertext = await encrypt_push_message(plaintext, key, nonce, enabled=False)
     assert ciphertext == plaintext
-    assert decrypt_push_message(ciphertext, key, nonce, enabled=False) == ciphertext
+    assert (
+        await decrypt_push_message(ciphertext, key, nonce, enabled=False) == ciphertext
+    )
 
 
 @pytest.mark.unit
-def test_respects_runtime_setting(monkeypatch):
+@pytest.mark.asyncio
+async def test_respects_runtime_setting(monkeypatch):
     """Default behaviour follows the runtime configuration toggle."""
     key = os.urandom(16)
     nonce = os.urandom(12)
     plaintext = b"hello"
     monkeypatch.setattr(settings, "enable_rfc8291", False)
-    assert encrypt_push_message(plaintext, key, nonce) == plaintext
+    assert await encrypt_push_message(plaintext, key, nonce) == plaintext
     monkeypatch.setattr(settings, "enable_rfc8291", True)
-    ciphertext = encrypt_push_message(plaintext, key, nonce)
-    assert decrypt_push_message(ciphertext, key, nonce) == plaintext
+    ciphertext = await encrypt_push_message(plaintext, key, nonce)
+    assert await decrypt_push_message(ciphertext, key, nonce) == plaintext
 
 
 @pytest.mark.unit
-def test_invalid_key_or_nonce_length():
+@pytest.mark.asyncio
+async def test_invalid_key_or_nonce_length():
     """Incorrect key or nonce lengths raise errors when enabled."""
     key = os.urandom(15)
     nonce = os.urandom(12)
     with pytest.raises(ValueError):
-        encrypt_push_message(b"data", key, nonce, enabled=True)
+        await encrypt_push_message(b"data", key, nonce, enabled=True)
     key = os.urandom(16)
     nonce = os.urandom(11)
     with pytest.raises(ValueError):
-        decrypt_push_message(b"data", key, nonce, enabled=True)
+        await decrypt_push_message(b"data", key, nonce, enabled=True)
 
 
 @pytest.mark.unit

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/rfc/rfc8291.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/rfc/rfc8291.py
@@ -10,18 +10,43 @@ See RFC 8291: https://www.rfc-editor.org/rfc/rfc8291
 
 from __future__ import annotations
 
-from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from typing import Final
+
+from swarmauri_core.crypto.types import (
+    AEADCiphertext,
+    ExportPolicy,
+    KeyRef,
+    KeyType,
+    KeyUse,
+)
+from swarmauri_crypto_paramiko import ParamikoCrypto
 
 from ..runtime_cfg import settings
 
 RFC8291_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc8291"
+_ALG: Final = "AES-256-GCM"
 
 
-def encrypt_push_message(
+_crypto = ParamikoCrypto()
+
+
+def _key_ref(key: bytes) -> KeyRef:
+    """Return a minimal :class:`KeyRef` for *key* bytes."""
+
+    return KeyRef(
+        kid="rfc8291-key",
+        version=1,
+        type=KeyType.SYMMETRIC,
+        uses=(KeyUse.ENCRYPT, KeyUse.DECRYPT),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+        material=key,
+    )
+
+
+async def encrypt_push_message(
     plaintext: bytes, key: bytes, nonce: bytes, *, enabled: bool | None = None
 ) -> bytes:
-    """Return ciphertext for *plaintext* using AES-128-GCM per :rfc:`8291`.
+    """Return ciphertext for *plaintext* using AES-GCM per :rfc:`8291`.
 
     When ``enabled`` is ``False`` the plaintext is returned unchanged.  The
     *key* must be 16 bytes and *nonce* 12 bytes as required by the spec.
@@ -35,11 +60,12 @@ def encrypt_push_message(
         raise ValueError("RFC 8291 requires a 16-byte key")
     if len(nonce) != 12:
         raise ValueError("RFC 8291 requires a 12-byte nonce")
-    aesgcm = AESGCM(key)
-    return aesgcm.encrypt(nonce, plaintext, associated_data=None)
+    key_ref = _key_ref(key)
+    res = await _crypto.encrypt(key=key_ref, pt=plaintext, nonce=nonce)
+    return res.ct + res.tag
 
 
-def decrypt_push_message(
+async def decrypt_push_message(
     ciphertext: bytes, key: bytes, nonce: bytes, *, enabled: bool | None = None
 ) -> bytes:
     """Return plaintext for *ciphertext* encrypted by :func:`encrypt_push_message`.
@@ -55,8 +81,16 @@ def decrypt_push_message(
         raise ValueError("RFC 8291 requires a 16-byte key")
     if len(nonce) != 12:
         raise ValueError("RFC 8291 requires a 12-byte nonce")
-    aesgcm = AESGCM(key)
-    return aesgcm.decrypt(nonce, ciphertext, associated_data=None)
+    key_ref = _key_ref(key)
+    ct = AEADCiphertext(
+        kid=key_ref.kid,
+        version=key_ref.version,
+        alg=_ALG,
+        nonce=nonce,
+        ct=ciphertext[:-16],
+        tag=ciphertext[-16:],
+    )
+    return await _crypto.decrypt(key=key_ref, ct=ct)
 
 
 __all__ = ["encrypt_push_message", "decrypt_push_message", "RFC8291_SPEC_URL"]


### PR DESCRIPTION
## Summary
- use ParamikoCrypto plugin for RFC 8291 web push helpers
- test web push encryption with async crypto integration
- include swarmauri_crypto_paramiko dependency

## Testing
- `uv run --package tigrbl_auth --directory standards/tigrbl_auth ruff format .`
- `uv run --package tigrbl_auth --directory standards/tigrbl_auth ruff check . --fix`
- `uv run --package tigrbl_auth --directory standards/tigrbl_auth pytest tests/unit/test_rfc8291_webpush_encryption.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7b60834788326a0e627b45fd6aaa1