### PR TITLE
chore(pylicense): set asyncio fixture loop scope

### DIFF
--- a/pkgs/experimental/swarmauri_tests_pylicense/pyproject.toml
+++ b/pkgs/experimental/swarmauri_tests_pylicense/pyproject.toml
@@ -32,6 +32,9 @@ dev = [
     "pytest-benchmark>=4.0.0",
 ]
 
+[tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Summary
- silence PytestDeprecationWarning by configuring `asyncio_default_fixture_loop_scope` for pylicense tests

## Testing
- `uv run --package swarmauri_tests_pylicense --directory experimental/swarmauri_tests_pylicense ruff format .`
- `uv run --package swarmauri_tests_pylicense --directory experimental/swarmauri_tests_pylicense ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c7b8ed7cc083268a4d65528f6dc920