### PR TITLE
Fail on non-standard licenses and allow dependency exceptions

### DIFF
--- a/pkgs/base/pyproject.toml
+++ b/pkgs/base/pyproject.toml
@@ -49,6 +49,7 @@ dev = [
 
 [tool.pytest.ini_options]
 timeout = 300
+addopts = "--pylicense-accept-deps=numpy"
 
 markers = [
     "test: standard test",

--- a/pkgs/experimental/swarmauri_tests_pylicense/README.md
+++ b/pkgs/experimental/swarmauri_tests_pylicense/README.md
@@ -21,7 +21,8 @@
 scans a package's full dependency tree and ensures each dependency declares a
 license. The plugin resolves dependencies recursively, checking every
 transitive requirement. It inspects both the `License` metadata field and
-any `Classifier` entries that declare a license.
+any `Classifier` entries that declare a license. Dependencies with
+non‑standard licenses cause the test to fail unless explicitly accepted.
 
 By default, the plugin runs in *parameterized* mode which creates one test per
 dependency. An *aggregate* mode is also available that reports all missing
@@ -84,6 +85,18 @@ pytest --pylicense-package=<your-package>
 If both are provided, any license not in the allow list or explicitly present
 in the disallow list will cause a test failure. By default, all licenses are
 allowed and none are disallowed.
+
+### Accepting Specific Dependencies
+
+To allow a dependency with a non-standard license, list it via
+`--pylicense-accept-deps` or the `PYLICENSE_ACCEPT_DEPS` environment
+variable:
+
+```bash
+pytest --pylicense-package=<your-package> --pylicense-accept-deps=foo,bar
+```
+
+These dependencies will be ignored by the non-standard license check.
 
 ## License
 

--- a/pkgs/experimental/swarmauri_tests_pylicense/tests/test_plugin.py
+++ b/pkgs/experimental/swarmauri_tests_pylicense/tests/test_plugin.py
@@ -80,3 +80,23 @@ def test_allow_disallow_lists(pytester, monkeypatch):
         "--pylicense-disallow-list=GPL",
     )
     result.assert_outcomes(failed=1)
+
+
+def test_nonstandard_acceptance(pytester, monkeypatch):
+    monkeypatch.setattr(
+        "swarmauri_tests_pylicense._collect_dependency_paths",
+        lambda pkg: [DependencyPath(("dummy", "dep"), "Custom", "1.0")],
+    )
+    result = pytester.runpytest(
+        "-p",
+        "swarmauri_tests_pylicense",
+        "--pylicense-package=dummy",
+    )
+    result.assert_outcomes(failed=1)
+    result = pytester.runpytest(
+        "-p",
+        "swarmauri_tests_pylicense",
+        "--pylicense-package=dummy",
+        "--pylicense-accept-deps=dep",
+    )
+    result.assert_outcomes(passed=1)


### PR DESCRIPTION
## Summary
- fail swarmauri_tests_pylicense tests when a dependency has a non-standard license
- allow opting-in specific dependencies to bypass non-standard license failures
- configure swarmauri-base tests to accept numpy's license

## Testing
- `uv run --package swarmauri_tests_pylicense --directory experimental/swarmauri_tests_pylicense ruff check . --fix`
- `uv run --package swarmauri-base --directory base ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c7ba0f3d848326b6713c17c45337d3