### PR TITLE
feat(pylicense): enforce standard licenses and allow deps

### DIFF
--- a/pkgs/base/pyproject.toml
+++ b/pkgs/base/pyproject.toml
@@ -49,6 +49,7 @@ dev = [
 
 [tool.pytest.ini_options]
 timeout = 300
+addopts = "--pylicense-accept-dependencies=numpy"
 
 markers = [
     "test: standard test",

--- a/pkgs/experimental/swarmauri_tests_pylicense/README.md
+++ b/pkgs/experimental/swarmauri_tests_pylicense/README.md
@@ -85,6 +85,20 @@ If both are provided, any license not in the allow list or explicitly present
 in the disallow list will cause a test failure. By default, all licenses are
 allowed and none are disallowed.
 
+### Accept Specific Dependencies
+
+Sometimes a dependency reports a non-standard license string. Provide a
+comma-separated list of dependency names to accept without validation using
+the `--pylicense-accept-dependencies` option or the
+`PYLICENSE_ACCEPT_DEPENDENCIES` environment variable:
+
+```bash
+pytest --pylicense-package=<your-package> --pylicense-accept-dependencies=numpy
+
+export PYLICENSE_ACCEPT_DEPENDENCIES="dep1,dep2"
+pytest --pylicense-package=<your-package>
+```
+
 ## License
 
 Licensed under the [Apache 2.0 License](LICENSE).

--- a/pkgs/experimental/swarmauri_tests_pylicense/pyproject.toml
+++ b/pkgs/experimental/swarmauri_tests_pylicense/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
+dependencies = ["license-expression>=30.4.4"]
 
 [project.entry-points.pytest11]
 swarmauri_tests_pylicense = "swarmauri_tests_pylicense"

--- a/pkgs/experimental/swarmauri_tests_pylicense/tests/test_plugin.py
+++ b/pkgs/experimental/swarmauri_tests_pylicense/tests/test_plugin.py
@@ -80,3 +80,30 @@ def test_allow_disallow_lists(pytester, monkeypatch):
         "--pylicense-disallow-list=GPL",
     )
     result.assert_outcomes(failed=1)
+
+
+def test_nonstandard_license_fails(pytester, monkeypatch):
+    monkeypatch.setattr(
+        "swarmauri_tests_pylicense._collect_dependency_paths",
+        lambda pkg: [DependencyPath(("dummy", "dep"), "MIT License", "1.0")],
+    )
+    result = pytester.runpytest(
+        "-p",
+        "swarmauri_tests_pylicense",
+        "--pylicense-package=dummy",
+    )
+    result.assert_outcomes(failed=1)
+
+
+def test_accept_dependency(pytester, monkeypatch):
+    monkeypatch.setattr(
+        "swarmauri_tests_pylicense._collect_dependency_paths",
+        lambda pkg: [DependencyPath(("dummy", "numpy"), "Custom", "1.0")],
+    )
+    result = pytester.runpytest(
+        "-p",
+        "swarmauri_tests_pylicense",
+        "--pylicense-package=dummy",
+        "--pylicense-accept-dependencies=numpy",
+    )
+    result.assert_outcomes(passed=1)


### PR DESCRIPTION
## Summary
- fail when dependencies declare non-standard licenses
- add `--pylicense-accept-dependencies` to bypass license checks for specified packages
- skip numpy license check in swarmauri-base

## Testing
- `uv run --package swarmauri_tests_pylicense --directory experimental/swarmauri_tests_pylicense ruff format .`
- `uv run --package swarmauri_tests_pylicense --directory experimental/swarmauri_tests_pylicense ruff check . --fix`
- `uv run --package swarmauri-base --directory base ruff format .`
- `uv run --package swarmauri-base --directory base ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c7ba0f3d848326b6713c17c45337d3