### PR TITLE
feat: use tigrbl autoapp

### DIFF
--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc6749_auth_flow_endpoints.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc6749_auth_flow_endpoints.py
@@ -1,12 +1,12 @@
 """Tests for presence of core OAuth2 endpoints and missing authorization endpoint per RFC 6749."""
 
 import pytest
-from fastapi import FastAPI
+from tigrbl_auth.deps import TigrblApp
 
 from tigrbl_auth.routers.auth_flows import router
 
 
-def _collect_paths(app: FastAPI) -> set[str]:
+def _collect_paths(app: TigrblApp) -> set[str]:
     """Return the set of route paths registered on ``app``."""
     return {route.path for route in app.routes}
 
@@ -14,7 +14,7 @@ def _collect_paths(app: FastAPI) -> set[str]:
 @pytest.mark.unit
 def test_rfc6749_core_endpoints_present() -> None:
     """Verify implemented credential endpoints exist."""
-    app = FastAPI()
+    app = TigrblApp()
     app.include_router(router)
     paths = _collect_paths(app)
     assert {
@@ -27,7 +27,7 @@ def test_rfc6749_core_endpoints_present() -> None:
 @pytest.mark.unit
 def test_rfc6749_authorization_endpoint_present() -> None:
     """The `/authorize` endpoint is now implemented."""
-    app = FastAPI()
+    app = TigrblApp()
     app.include_router(router)
     paths = _collect_paths(app)
     assert "/authorize" in paths

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/oidc_discovery.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/oidc_discovery.py
@@ -11,7 +11,7 @@ import json
 from functools import lru_cache
 from typing import Any
 
-from tigrbl_auth.deps import APIRouter, FastAPI
+from tigrbl_auth.deps import APIRouter, TigrblApp
 
 from .rfc.rfc8414_metadata import ISSUER, JWKS_PATH
 from .runtime_cfg import settings
@@ -116,7 +116,7 @@ async def jwks():
 # ---------------------------------------------------------------------------
 
 
-def include_oidc_discovery(app: FastAPI) -> None:
+def include_oidc_discovery(app: TigrblApp) -> None:
     """Attach OIDC discovery routes to *app* if not already present."""
     if not any(
         route.path == "/.well-known/openid-configuration" for route in app.routes

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/oidc_userinfo.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/oidc_userinfo.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from tigrbl_auth.deps import (
     APIRouter,
     Depends,
-    FastAPI,
+    TigrblApp,
     HTTPException,
     Request,
     Response,
@@ -78,7 +78,7 @@ async def userinfo(
 # ---------------------------------------------------------------------------
 
 
-def include_oidc_userinfo(app: FastAPI) -> None:
+def include_oidc_userinfo(app: TigrblApp) -> None:
     """Attach the UserInfo endpoint to *app* if not already present."""
 
     if not any(route.path == "/userinfo" for route in app.routes):

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/rfc/rfc7009.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/rfc/rfc7009.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from typing import Final, Set
 
-from tigrbl_auth.deps import APIRouter, FastAPI, Form, HTTPException, status
+from tigrbl_auth.deps import APIRouter, TigrblApp, Form, HTTPException, status
 
 from ..runtime_cfg import settings
 
@@ -65,7 +65,7 @@ async def revoke(token: str = Form(...)) -> dict[str, str]:
     return {}
 
 
-def include_rfc7009(app: FastAPI) -> None:
+def include_rfc7009(app: TigrblApp) -> None:
     """Attach revocation routes to *app* if enabled."""
     if settings.enable_rfc7009 and not any(
         route.path == "/revoked_tokens/revoke" for route in app.routes

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/rfc/rfc7591.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/rfc/rfc7591.py
@@ -15,7 +15,7 @@ from urllib.parse import urlparse
 
 from tigrbl_auth.deps import (
     APIRouter,
-    FastAPI,
+    TigrblApp,
     HTTPException,
     status,
     AnyHttpUrl,
@@ -116,7 +116,7 @@ def reset_client_registry() -> None:
     _CLIENT_REGISTRY.clear()
 
 
-def include_rfc7591(app: FastAPI) -> None:
+def include_rfc7591(app: TigrblApp) -> None:
     """Attach the RFC 7591 router to *app* if enabled."""
 
     if settings.enable_rfc7591 and not any(

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/rfc/rfc8414.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/rfc/rfc8414.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from typing import Final
 
-from tigrbl_auth.deps import APIRouter, FastAPI, HTTPException, status
+from tigrbl_auth.deps import APIRouter, TigrblApp, HTTPException, status
 
 from ..runtime_cfg import settings
 from ..oidc_discovery import (
@@ -43,7 +43,7 @@ async def authorization_server_metadata():
     return _cached_openid_config(_settings_signature())
 
 
-def include_rfc8414(app: FastAPI) -> None:
+def include_rfc8414(app: TigrblApp) -> None:
     """Attach discovery routes to *app* if enabled."""
     if settings.enable_rfc8414 and not any(
         route.path == "/.well-known/oauth-authorization-server" for route in app.routes

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/rfc/rfc8693.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/rfc/rfc8693.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, List, Optional, Union
 from enum import Enum
 from tigrbl_auth.deps import (
     APIRouter,
-    FastAPI,
+    TigrblApp,
     Form,
     HTTPException,
     Request,
@@ -34,7 +34,7 @@ TOKEN_EXCHANGE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange"
 router = APIRouter()
 
 
-def include_rfc8693(app: FastAPI) -> None:
+def include_rfc8693(app: TigrblApp) -> None:
     """Attach the RFC 8693 router to *app* if enabled."""
 
     if runtime_cfg.settings.enable_rfc8693 and not any(


### PR DESCRIPTION
## Summary
- use TigrblApp in unit tests
- switch discovery and RFC helpers to TigrblApp

## Testing
- `uv run --package tigrbl_auth --directory standards/tigrbl_auth pytest -q tests/unit/test_rfc6749_auth_flow_endpoints.py tests/unit/test_rfc7009_token_revocation.py tests/unit/test_rfc7591_client_registration_endpoint.py tests/unit/test_rfc8414_authorization_server_metadata.py tests/unit/test_rfc8693_token_exchange.py tests/unit/test_openid_userinfo_endpoint.py tests/unit/test_openid_configuration.py`

------
https://chatgpt.com/codex/tasks/task_e_68c7d27bb6908326add979ae87d526ef