### PR TITLE
refactor: align tigrbl_auth docs with tigrbl

### DIFF
--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/app.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/app.py
@@ -1,8 +1,8 @@
 """
-tigrbl_authn.app
-=================
+tigrbl_auth.app
+===============
 
-FastAPI application factory for the **tigrbl-authn** service.
+FastAPI application factory for the **tigrbl-auth** service.
 
 Features
 --------

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/backends.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/backends.py
@@ -1,6 +1,6 @@
 """
-tigrbl_authn.backends
-======================
+tigrbl_auth.backends
+====================
 
 Framework-agnostic credential verification helpers.
 

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/crypto.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/crypto.py
@@ -1,6 +1,6 @@
 """
-tigrbl_authn.crypto
-====================
+tigrbl_auth.crypto
+==================
 
 Password hashing and JWT signing key management backed by swarmauri plugins.
 """

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/fastapi_deps.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/fastapi_deps.py
@@ -1,6 +1,6 @@
 """
-tigrbl_authn.fastapi_deps
-==========================
+tigrbl_auth.fastapi_deps
+========================
 
 FastAPI dependency helpers used by the AuthN service itself
 and by *any* downstream service that wishes to rely on AuthN’s

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/surface.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/surface.py
@@ -1,8 +1,12 @@
-"""ORM-backed API surface for the authentication service.
+"""
+tigrbl_auth.routers.surface
+===========================
+
+ORM-backed API surface for the authentication service.
 
 Exports
 -------
-Base       : Declarative base for all models in **tigrbl_authn**.
+Base       : Declarative base for all models in **tigrbl_auth**.
 metadata   : Shared SQLAlchemy ``MetaData`` with a sane naming-convention.
 router     : FastAPI router combining Tigrbl resources and auth flows.
 tigrbl    : The ``TigrblApi`` instance used to produce *router*.

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/typing.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/typing.py
@@ -1,6 +1,6 @@
 """
-tigrbl_authn.typing
-====================
+tigrbl_auth.typing
+==================
 
 Pure-typing utilities for the AuthN service.
 No runtime dependencies outside stdlib.


### PR DESCRIPTION
## Summary
- update tigrbl_auth module headers to reference tigrbl_auth package
- align router docs with tigrbl naming

## Testing
- `uv run --directory . --package tigrbl_auth ruff format .`
- `uv run --directory . --package tigrbl_auth ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c7d375452883269227b5f838c4b1cf