### PR TITLE
refactor: adopt tigrbl naming in tigrbl_auth

### DIFF
--- a/pkgs/standards/tigrbl_auth/tests/i9n/test_authorization_code_flow.py
+++ b/pkgs/standards/tigrbl_auth/tests/i9n/test_authorization_code_flow.py
@@ -6,7 +6,7 @@ from uuid import UUID, uuid4
 from tigrbl.engine import HybridSession
 from tigrbl_auth.crypto import hash_pw
 from tigrbl_auth.orm import Client, Tenant, User
-from tigrbl_auth.rfc.rfc7636_pkce import create_code_challenge, create_code_verifier
+from tigrbl_auth.rfc.rfc7636_pkce import makeCodeChallenge, makeCodeVerifier
 
 
 @pytest.mark.asyncio
@@ -42,8 +42,8 @@ async def test_authorization_code_pkce_flow(
     )
     assert login_resp.status_code == 200
 
-    verifier = create_code_verifier()
-    challenge = create_code_challenge(verifier)
+    verifier = makeCodeVerifier()
+    challenge = makeCodeChallenge(verifier)
     params = {
         "response_type": "code",
         "client_id": client_id,
@@ -106,8 +106,8 @@ async def test_authorization_code_pkce_invalid_verifier(
     )
     assert login_resp.status_code == 200
 
-    verifier = create_code_verifier()
-    challenge = create_code_challenge(verifier)
+    verifier = makeCodeVerifier()
+    challenge = makeCodeChallenge(verifier)
     params = {
         "response_type": "code",
         "client_id": client_id,

--- a/pkgs/standards/tigrbl_auth/tests/i9n/test_long_lived_worker_flow.py
+++ b/pkgs/standards/tigrbl_auth/tests/i9n/test_long_lived_worker_flow.py
@@ -15,7 +15,7 @@ from tigrbl_auth import encode_jwt, decode_jwt
 from tigrbl_auth.crypto import hash_pw
 from tigrbl_auth.orm import Tenant, User
 from tigrbl_auth.rfc.rfc9449_dpop import (
-    create_proof,
+    makeProof,
     jwk_from_public_key,
     jwk_thumbprint,
 )
@@ -53,7 +53,7 @@ async def test_worker_enrollment_flow_dpop(
     ref = await kp.create_key(spec)
     jwk = jwk_from_public_key(ref.public or b"")
     jkt = jwk_thumbprint(jwk)
-    proof = create_proof(ref, "POST", "http://test/token/exchange")
+    proof = makeProof(ref, "POST", "http://test/token/exchange")
 
     resp = await async_client.post(
         "/token/exchange",
@@ -70,7 +70,7 @@ async def test_worker_enrollment_flow_dpop(
     claims = decode_jwt(token)
     assert claims.get("cnf", {}).get("jkt") == jkt
 
-    proof2 = create_proof(ref, "GET", "http://test/userinfo")
+    proof2 = makeProof(ref, "GET", "http://test/userinfo")
     headers = {"Authorization": f"Bearer {token}", "DPoP": proof2}
     ok = await async_client.get("/userinfo", headers=headers)
     assert ok.status_code == status.HTTP_200_OK

--- a/pkgs/standards/tigrbl_auth/tests/unit/test_auth_code_exchange_pkce.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_auth_code_exchange_pkce.py
@@ -6,14 +6,14 @@ import pytest
 from fastapi import Request
 
 from tigrbl_auth.orm import AuthCode
-from tigrbl_auth.rfc.rfc7636_pkce import create_code_challenge, create_code_verifier
+from tigrbl_auth.rfc.rfc7636_pkce import makeCodeChallenge, makeCodeVerifier
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_exchange_accepts_hex_client_id(monkeypatch):
-    verifier = create_code_verifier()
-    challenge = create_code_challenge(verifier)
+    verifier = makeCodeVerifier()
+    challenge = makeCodeChallenge(verifier)
     client_uuid = uuid.uuid4()
 
     auth_code = AuthCode(

--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7636_pkce.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7636_pkce.py
@@ -13,8 +13,8 @@ with a minimum length of 43 characters and a maximum length of 128 characters.
 import pytest
 
 from tigrbl_auth import (
-    create_code_challenge,
-    create_code_verifier,
+    makeCodeChallenge,
+    makeCodeVerifier,
     verify_code_challenge,
 )
 import tigrbl_auth.rfc.rfc7636_pkce as pkce_mod
@@ -24,7 +24,7 @@ import tigrbl_auth.rfc.rfc7636_pkce as pkce_mod
 def test_code_verifier_meets_rfc7636_requirements():
     """Generated verifier satisfies RFC 7636 §4.1."""
 
-    verifier = create_code_verifier()
+    verifier = makeCodeVerifier()
     assert 43 <= len(verifier) <= 128
     allowed = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
     assert all(ch in allowed for ch in verifier)
@@ -36,15 +36,15 @@ def test_code_challenge_s256_matches_known_example():
 
     verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
     expected = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
-    assert create_code_challenge(verifier) == expected
+    assert makeCodeChallenge(verifier) == expected
 
 
 @pytest.mark.unit
 def test_verify_code_challenge_round_trip():
     """Challenge derived from verifier validates correctly."""
 
-    verifier = create_code_verifier(60)
-    challenge = create_code_challenge(verifier)
+    verifier = makeCodeVerifier(60)
+    challenge = makeCodeChallenge(verifier)
     assert verify_code_challenge(verifier, challenge)
 
 
@@ -52,8 +52,8 @@ def test_verify_code_challenge_round_trip():
 def test_verify_code_challenge_mismatch_fails():
     """Mismatched challenge fails when RFC 7636 is enabled."""
 
-    verifier = create_code_verifier()
-    other = create_code_challenge(create_code_verifier())
+    verifier = makeCodeVerifier()
+    other = makeCodeChallenge(makeCodeVerifier())
     assert not verify_code_challenge(verifier, other)
 
 
@@ -62,7 +62,7 @@ def test_invalid_verifier_rejected():
     """Invalid verifier raises ValueError."""
 
     with pytest.raises(ValueError):
-        create_code_challenge("short")
+        makeCodeChallenge("short")
 
 
 @pytest.mark.unit

--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7952_security_event_token.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7952_security_event_token.py
@@ -10,12 +10,12 @@ import pytest
 
 from tigrbl_auth.rfc.rfc7952 import (
     RFC7952_SPEC_URL,
-    create_security_event_token,
+    makeSecurityEventToken,
     validate_security_event_token,
     extract_event_data,
     get_set_subject_identifiers,
-    create_account_disabled_set,
-    create_session_revoked_set,
+    makeAccountDisabledSet,
+    makeSessionRevokedSet,
     SET_EVENT_TYPES,
 )
 from tigrbl_auth.runtime_cfg import settings
@@ -23,10 +23,10 @@ from tigrbl_auth.rfc.rfc7519 import decode_jwt
 
 
 @pytest.mark.unit
-def test_create_security_event_token_basic():
+def test_make_security_event_token_basic():
     """RFC 7952: Create basic Security Event Token."""
     with patch.object(settings, "enable_rfc7952", True):
-        set_token = create_security_event_token(
+        set_token = makeSecurityEventToken(
             issuer="https://auth.example.com",
             audience="https://rp.example.com",
             event_type="https://example.com/event-type/account-disabled",
@@ -55,11 +55,11 @@ def test_create_security_event_token_basic():
 
 
 @pytest.mark.unit
-def test_create_security_event_token_multiple_audiences():
+def test_make_security_event_token_multiple_audiences():
     """RFC 7952: Create SET with multiple audiences."""
     with patch.object(settings, "enable_rfc7952", True):
         audiences = ["https://rp1.example.com", "https://rp2.example.com"]
-        set_token = create_security_event_token(
+        set_token = makeSecurityEventToken(
             issuer="https://auth.example.com",
             audience=audiences,
             event_type="https://example.com/event-type/session-revoked",
@@ -71,11 +71,11 @@ def test_create_security_event_token_multiple_audiences():
 
 
 @pytest.mark.unit
-def test_create_security_event_token_missing_event_type():
+def test_make_security_event_token_missing_event_type():
     """RFC 7952: Missing event_type should raise ValueError."""
     with patch.object(settings, "enable_rfc7952", True):
         with pytest.raises(ValueError, match="event_type is required"):
-            create_security_event_token(
+            makeSecurityEventToken(
                 issuer="https://auth.example.com",
                 audience="https://rp.example.com",
                 event_type="",  # Empty event type
@@ -84,11 +84,11 @@ def test_create_security_event_token_missing_event_type():
 
 
 @pytest.mark.unit
-def test_create_security_event_token_missing_subject():
+def test_make_security_event_token_missing_subject():
     """RFC 7952: Missing subject should raise ValueError."""
     with patch.object(settings, "enable_rfc7952", True):
         with pytest.raises(ValueError, match="subject is required"):
-            create_security_event_token(
+            makeSecurityEventToken(
                 issuer="https://auth.example.com",
                 audience="https://rp.example.com",
                 event_type="https://example.com/event-type/account-disabled",
@@ -97,11 +97,11 @@ def test_create_security_event_token_missing_subject():
 
 
 @pytest.mark.unit
-def test_create_security_event_token_disabled():
+def test_make_security_event_token_disabled():
     """RFC 7952: Creating SET when disabled should raise RuntimeError."""
     with patch.object(settings, "enable_rfc7952", False):
         with pytest.raises(RuntimeError, match="RFC 7952 support disabled"):
-            create_security_event_token(
+            makeSecurityEventToken(
                 issuer="https://auth.example.com",
                 audience="https://rp.example.com",
                 event_type="https://example.com/event-type/account-disabled",
@@ -114,7 +114,7 @@ def test_validate_security_event_token_success():
     """RFC 7952: Validate valid Security Event Token."""
     with patch.object(settings, "enable_rfc7952", True):
         # Create a SET first
-        set_token = create_security_event_token(
+        set_token = makeSecurityEventToken(
             issuer="https://auth.example.com",
             audience="https://rp.example.com",
             event_type="https://example.com/event-type/account-disabled",
@@ -137,7 +137,7 @@ def test_validate_security_event_token_success():
 def test_validate_security_event_token_wrong_issuer():
     """RFC 7952: Wrong issuer should raise ValueError."""
     with patch.object(settings, "enable_rfc7952", True):
-        set_token = create_security_event_token(
+        set_token = makeSecurityEventToken(
             issuer="https://auth.example.com",
             audience="https://rp.example.com",
             event_type="https://example.com/event-type/account-disabled",
@@ -155,7 +155,7 @@ def test_validate_security_event_token_wrong_issuer():
 def test_validate_security_event_token_wrong_audience():
     """RFC 7952: Wrong audience should raise ValueError."""
     with patch.object(settings, "enable_rfc7952", True):
-        set_token = create_security_event_token(
+        set_token = makeSecurityEventToken(
             issuer="https://auth.example.com",
             audience="https://rp.example.com",
             event_type="https://example.com/event-type/account-disabled",
@@ -174,7 +174,7 @@ def test_validate_security_event_token_expired():
     """RFC 7952: Expired SET should raise ValueError."""
     with patch.object(settings, "enable_rfc7952", True):
         # Create SET with very short expiry
-        set_token = create_security_event_token(
+        set_token = makeSecurityEventToken(
             issuer="https://auth.example.com",
             audience="https://rp.example.com",
             event_type="https://example.com/event-type/account-disabled",
@@ -201,7 +201,7 @@ def test_validate_security_event_token_disabled():
 def test_extract_event_data():
     """RFC 7952: Extract event data from SET claims."""
     with patch.object(settings, "enable_rfc7952", True):
-        set_token = create_security_event_token(
+        set_token = makeSecurityEventToken(
             issuer="https://auth.example.com",
             audience="https://rp.example.com",
             event_type="https://example.com/event-type/account-disabled",
@@ -226,7 +226,7 @@ def test_extract_event_data():
 def test_extract_event_data_nonexistent():
     """RFC 7952: Extract non-existent event data should return None."""
     with patch.object(settings, "enable_rfc7952", True):
-        set_token = create_security_event_token(
+        set_token = makeSecurityEventToken(
             issuer="https://auth.example.com",
             audience="https://rp.example.com",
             event_type="https://example.com/event-type/account-disabled",
@@ -246,7 +246,7 @@ def test_get_set_subject_identifiers():
     """RFC 7952: Get subject identifiers from SET claims."""
     with patch.object(settings, "enable_rfc7952", True):
         subject = {"format": "opaque", "id": "user123", "email": "user@example.com"}
-        set_token = create_security_event_token(
+        set_token = makeSecurityEventToken(
             issuer="https://auth.example.com",
             audience="https://rp.example.com",
             event_type="https://example.com/event-type/account-disabled",
@@ -260,10 +260,10 @@ def test_get_set_subject_identifiers():
 
 
 @pytest.mark.unit
-def test_create_account_disabled_set():
+def test_make_account_disabled_set():
     """RFC 7952: Create account disabled SET using helper function."""
     with patch.object(settings, "enable_rfc7952", True):
-        set_token = create_account_disabled_set(
+        set_token = makeAccountDisabledSet(
             issuer="https://auth.example.com",
             audience="https://rp.example.com",
             subject_id="user123",
@@ -279,10 +279,10 @@ def test_create_account_disabled_set():
 
 
 @pytest.mark.unit
-def test_create_session_revoked_set():
+def test_make_session_revoked_set():
     """RFC 7952: Create session revoked SET using helper function."""
     with patch.object(settings, "enable_rfc7952", True):
-        set_token = create_session_revoked_set(
+        set_token = makeSessionRevokedSet(
             issuer="https://auth.example.com",
             audience="https://rp.example.com",
             subject_id="user123",

--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc8523_jwt_client_auth.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc8523_jwt_client_auth.py
@@ -12,7 +12,7 @@ from tigrbl_auth.errors import InvalidTokenError
 from tigrbl_auth.rfc.rfc8523 import (
     RFC8523_SPEC_URL,
     validate_enhanced_jwt_bearer,
-    create_client_assertion_jwt,
+    makeClientAssertionJwt,
     is_jwt_replay,
 )
 from tigrbl_auth.runtime_cfg import settings
@@ -127,10 +127,10 @@ def test_validate_enhanced_jwt_bearer_empty_jti():
 
 
 @pytest.mark.unit
-def test_create_client_assertion_jwt():
+def test_make_client_assertion_jwt():
     """RFC 8523: Create valid client assertion JWT."""
     with patch.object(settings, "enable_rfc8523", True):
-        jwt_token = create_client_assertion_jwt(
+        jwt_token = makeClientAssertionJwt(
             client_id="test-client",
             audience="https://auth.example.com/token",
             expires_in=300,
@@ -150,11 +150,11 @@ def test_create_client_assertion_jwt():
 
 
 @pytest.mark.unit
-def test_create_client_assertion_jwt_with_additional_claims():
+def test_make_client_assertion_jwt_with_additional_claims():
     """RFC 8523: Create JWT with additional claims."""
     with patch.object(settings, "enable_rfc8523", True):
         additional = {"custom_claim": "custom_value", "scope": "read write"}
-        jwt_token = create_client_assertion_jwt(
+        jwt_token = makeClientAssertionJwt(
             client_id="test-client",
             audience="https://auth.example.com/token",
             additional_claims=additional,
@@ -169,11 +169,11 @@ def test_create_client_assertion_jwt_with_additional_claims():
 
 
 @pytest.mark.unit
-def test_create_client_assertion_jwt_disabled():
+def test_make_client_assertion_jwt_disabled():
     """RFC 8523: Creating JWT when disabled should raise RuntimeError."""
     with patch.object(settings, "enable_rfc8523", False):
         with pytest.raises(RuntimeError, match="RFC 8523 support disabled"):
-            create_client_assertion_jwt(
+            makeClientAssertionJwt(
                 client_id="test-client",
                 audience="https://auth.example.com/token",
             )

--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc8693_token_exchange.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc8693_token_exchange.py
@@ -16,8 +16,8 @@ from tigrbl_auth.rfc.rfc8693 import (
     validate_token_exchange_request,
     validate_subject_token,
     exchange_token,
-    create_impersonation_token,
-    create_delegation_token,
+    makeImpersonationToken,
+    makeDelegationToken,
     TOKEN_EXCHANGE_GRANT_TYPE,
     include_rfc8693,
 )
@@ -292,7 +292,7 @@ def test_exchange_token_with_actor():
 
 
 @pytest.mark.unit
-def test_create_impersonation_token():
+def test_make_impersonation_token():
     """RFC 8693: Create impersonation token."""
     subject_jwt = encode_jwt(sub="user123", tid="tenant-1", exp=int(time.time()) + 3600)
     actor_jwt = encode_jwt(sub="admin456", tid="tenant-1", exp=int(time.time()) + 3600)
@@ -301,7 +301,7 @@ def test_create_impersonation_token():
         mock_response = TokenExchangeResponse(access_token="impersonation-token")
         mock_exchange.return_value = mock_response
 
-        response = create_impersonation_token(
+        response = makeImpersonationToken(
             subject_token=subject_jwt,
             actor_token=actor_jwt,
             audience="https://api.example.com",
@@ -320,7 +320,7 @@ def test_create_impersonation_token():
 
 
 @pytest.mark.unit
-def test_create_delegation_token():
+def test_make_delegation_token():
     """RFC 8693: Create delegation token."""
     subject_jwt = encode_jwt(
         sub="user123",
@@ -335,7 +335,7 @@ def test_create_delegation_token():
         )
         mock_exchange.return_value = mock_response
 
-        response = create_delegation_token(
+        response = makeDelegationToken(
             subject_token=subject_jwt,
             audience="https://api.example.com",
             scope="read",  # Narrower scope for delegation
@@ -366,27 +366,27 @@ def test_exchange_token_disabled():
 
 
 @pytest.mark.unit
-def test_create_impersonation_token_disabled():
-    """RFC 8693: create_impersonation_token should honor feature flag."""
+def test_make_impersonation_token_disabled():
+    """RFC 8693: makeImpersonationToken should honor feature flag."""
     subject_jwt = encode_jwt(sub="user123", tid="tenant-1", exp=int(time.time()) + 3600)
     actor_jwt = encode_jwt(sub="admin456", tid="tenant-1", exp=int(time.time()) + 3600)
 
     with patch.object(settings, "enable_rfc8693", False):
         with pytest.raises(RuntimeError, match="RFC 8693 support disabled"):
-            create_impersonation_token(
+            makeImpersonationToken(
                 subject_token=subject_jwt,
                 actor_token=actor_jwt,
             )
 
 
 @pytest.mark.unit
-def test_create_delegation_token_disabled():
-    """RFC 8693: create_delegation_token should honor feature flag."""
+def test_make_delegation_token_disabled():
+    """RFC 8693: makeDelegationToken should honor feature flag."""
     subject_jwt = encode_jwt(sub="user123", tid="tenant-1", exp=int(time.time()) + 3600)
 
     with patch.object(settings, "enable_rfc8693", False):
         with pytest.raises(RuntimeError, match="RFC 8693 support disabled"):
-            create_delegation_token(subject_token=subject_jwt)
+            makeDelegationToken(subject_token=subject_jwt)
 
 
 @pytest.mark.unit

--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc9101_jwt_secured_authorization_request.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc9101_jwt_secured_authorization_request.py
@@ -18,7 +18,7 @@ def test_jwt_request_round_trip(monkeypatch):
     monkeypatch.setattr(runtime_cfg.settings, "enable_rfc9101", True)
     params = {"client_id": "abc", "scope": "read", "response_type": "code"}
     secret = "s" * 32
-    token = asyncio.run(rfc9101.create_request_object(params, secret=secret))
+    token = asyncio.run(rfc9101.makeRequestObject(params, secret=secret))
     decoded = asyncio.run(rfc9101.parse_request_object(token, secret=secret))
     assert decoded == params
 
@@ -28,6 +28,4 @@ def test_feature_toggle_disabled(monkeypatch):
     """When disabled, helpers raise a runtime error."""
     monkeypatch.setattr(runtime_cfg.settings, "enable_rfc9101", False)
     with pytest.raises(RuntimeError):
-        asyncio.run(
-            rfc9101.create_request_object({"client_id": "abc"}, secret="0" * 32)
-        )
+        asyncio.run(rfc9101.makeRequestObject({"client_id": "abc"}, secret="0" * 32))

--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc9449_dpop.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc9449_dpop.py
@@ -16,7 +16,7 @@ from tigrbl_auth.deps import (
 )
 from tigrbl_auth.rfc.rfc9449_dpop import (
     RFC9449_SPEC_URL,
-    create_proof,
+    makeProof,
     verify_proof,
     jwk_from_public_key,
     jwk_thumbprint,
@@ -36,7 +36,7 @@ def test_dpop_proof_verification():
     ref = asyncio.run(kp.create_key(spec))
     jwk = jwk_from_public_key(ref.public or b"")
     jkt = jwk_thumbprint(jwk)
-    proof = create_proof(ref, "POST", "https://rs.example.com/resource")
+    proof = makeProof(ref, "POST", "https://rs.example.com/resource")
     assert (
         verify_proof(proof, "POST", "https://rs.example.com/resource", jkt=jkt) == jkt
     )
@@ -53,7 +53,7 @@ def test_mismatched_method_rejected():
         export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
     )
     ref = asyncio.run(kp.create_key(spec))
-    proof = create_proof(ref, "GET", "https://rs.example.com/data")
+    proof = makeProof(ref, "GET", "https://rs.example.com/data")
     with pytest.raises(ValueError):
         verify_proof(proof, "POST", "https://rs.example.com/data")
 
@@ -69,7 +69,7 @@ def test_feature_toggle_disabled():
         export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
     )
     ref = asyncio.run(kp.create_key(spec))
-    proof = create_proof(ref, "GET", "https://rs.example.com/data", enabled=False)
+    proof = makeProof(ref, "GET", "https://rs.example.com/data", enabled=False)
     assert proof == ""
     assert verify_proof("", "GET", "https://rs.example.com/data", enabled=False) == ""
 

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/__init__.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/__init__.py
@@ -6,9 +6,11 @@ RFC 7636 (PKCE), RFC 8705 (mutual-TLS client authentication), and RFC 9396
 """
 
 from .rfc.rfc7636_pkce import (
+    makeCodeChallenge,
+    makeCodeVerifier,
+    verify_code_challenge,
     create_code_challenge,
     create_code_verifier,
-    verify_code_challenge,
 )
 from .rfc.rfc8628 import (
     generate_device_code,
@@ -72,19 +74,23 @@ from .rfc.rfc7523 import validate_client_jwt_bearer, RFC7523_SPEC_URL
 # New RFC implementations
 from .rfc.rfc8523 import (
     validate_enhanced_jwt_bearer,
-    create_client_assertion_jwt,
+    makeClientAssertionJwt,
     is_jwt_replay,
     RFC8523_SPEC_URL,
+    create_client_assertion_jwt,
 )
 from .rfc.rfc7952 import (
-    create_security_event_token,
+    makeSecurityEventToken,
     validate_security_event_token,
     extract_event_data,
     get_set_subject_identifiers,
-    create_account_disabled_set,
-    create_session_revoked_set,
+    makeAccountDisabledSet,
+    makeSessionRevokedSet,
     SET_EVENT_TYPES,
     RFC7952_SPEC_URL,
+    create_security_event_token,
+    create_account_disabled_set,
+    create_session_revoked_set,
 )
 from .rfc.rfc8693 import (
     TokenExchangeRequest,
@@ -93,11 +99,13 @@ from .rfc.rfc8693 import (
     validate_token_exchange_request,
     validate_subject_token,
     exchange_token,
-    create_impersonation_token,
-    create_delegation_token,
+    makeImpersonationToken,
+    makeDelegationToken,
     TOKEN_EXCHANGE_GRANT_TYPE,
     RFC8693_SPEC_URL,
     include_rfc8693,
+    create_impersonation_token,
+    create_delegation_token,
 )
 from .rfc.rfc8932 import (
     get_enhanced_authorization_server_metadata,
@@ -108,9 +116,11 @@ from .rfc.rfc8932 import (
 from .oidc_id_token import mint_id_token, verify_id_token
 
 __all__ = [
+    "makeCodeVerifier",
+    "makeCodeChallenge",
+    "verify_code_challenge",
     "create_code_verifier",
     "create_code_challenge",
-    "verify_code_challenge",
     "generate_user_code",
     "validate_user_code",
     "generate_device_code",
@@ -179,15 +189,15 @@ __all__ = [
     "RFC7523_SPEC_URL",
     # New RFC implementations
     "validate_enhanced_jwt_bearer",
-    "create_client_assertion_jwt",
+    "makeClientAssertionJwt",
     "is_jwt_replay",
     "RFC8523_SPEC_URL",
-    "create_security_event_token",
+    "makeSecurityEventToken",
     "validate_security_event_token",
     "extract_event_data",
     "get_set_subject_identifiers",
-    "create_account_disabled_set",
-    "create_session_revoked_set",
+    "makeAccountDisabledSet",
+    "makeSessionRevokedSet",
     "SET_EVENT_TYPES",
     "RFC7952_SPEC_URL",
     "TokenExchangeRequest",
@@ -196,11 +206,17 @@ __all__ = [
     "validate_token_exchange_request",
     "validate_subject_token",
     "exchange_token",
-    "create_impersonation_token",
-    "create_delegation_token",
+    "makeImpersonationToken",
+    "makeDelegationToken",
     "TOKEN_EXCHANGE_GRANT_TYPE",
     "RFC8693_SPEC_URL",
     "include_rfc8693",
+    "create_client_assertion_jwt",
+    "create_security_event_token",
+    "create_account_disabled_set",
+    "create_session_revoked_set",
+    "create_impersonation_token",
+    "create_delegation_token",
     "get_enhanced_authorization_server_metadata",
     "validate_metadata_consistency",
     "get_capability_matrix",

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/rfc/rfc7636_pkce.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/rfc/rfc7636_pkce.py
@@ -15,6 +15,7 @@ import base64
 import hashlib
 import re
 import secrets
+import warnings
 from typing import Final
 
 from ..runtime_cfg import settings
@@ -30,7 +31,7 @@ _VERIFIER_CHARSET: Final = (
 _VERIFIER_RE: Final = re.compile(r"^[A-Za-z0-9\-._~]{43,128}$")
 
 
-def create_code_verifier(length: int = 43) -> str:
+def makeCodeVerifier(length: int = 43) -> str:
     """Return a high-entropy ``code_verifier`` string.
 
     RFC 7636 §4.1 specifies that a ``code_verifier`` MUST be between 43 and
@@ -43,7 +44,7 @@ def create_code_verifier(length: int = 43) -> str:
     return "".join(secrets.choice(_VERIFIER_CHARSET) for _ in range(length))
 
 
-def create_code_challenge(verifier: str) -> str:
+def makeCodeChallenge(verifier: str) -> str:
     """Derive an ``S256`` ``code_challenge`` from *verifier*.
 
     The verifier is first validated against the RFC 7636 §4.1 character and
@@ -72,15 +73,35 @@ def verify_code_challenge(
     if not enabled:
         return True
     try:
-        expected = create_code_challenge(verifier)
+        expected = makeCodeChallenge(verifier)
     except ValueError:
         return False
     return secrets.compare_digest(expected, challenge)
 
 
+def create_code_verifier(length: int = 43) -> str:
+    warnings.warn(
+        "create_code_verifier is deprecated, use makeCodeVerifier",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return makeCodeVerifier(length)
+
+
+def create_code_challenge(verifier: str) -> str:
+    warnings.warn(
+        "create_code_challenge is deprecated, use makeCodeChallenge",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return makeCodeChallenge(verifier)
+
+
 __all__ = [
-    "create_code_verifier",
-    "create_code_challenge",
+    "makeCodeVerifier",
+    "makeCodeChallenge",
     "verify_code_challenge",
     "RFC7636_SPEC_URL",
+    "create_code_verifier",
+    "create_code_challenge",
 ]

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/rfc/rfc7952.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/rfc/rfc7952.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import time
 import uuid
+import warnings
 from typing import Dict, Any, Optional, List, Union
 
 
@@ -36,7 +37,7 @@ SET_EVENT_TYPES = {
 }
 
 
-def create_security_event_token(
+def makeSecurityEventToken(
     issuer: str,
     audience: Union[str, List[str]],
     event_type: str,
@@ -202,7 +203,7 @@ def get_set_subject_identifiers(set_claims: Dict[str, Any]) -> Dict[str, Any]:
     return set_claims.get("sub", {})
 
 
-def create_account_disabled_set(
+def makeAccountDisabledSet(
     issuer: str,
     audience: Union[str, List[str]],
     subject_id: str,
@@ -224,7 +225,7 @@ def create_account_disabled_set(
     subject = {"format": "opaque", "id": subject_id}
     event_data = {"reason": reason} if reason else {}
 
-    return create_security_event_token(
+    return makeSecurityEventToken(
         issuer=issuer,
         audience=audience,
         event_type=SET_EVENT_TYPES["account-disabled"],
@@ -234,7 +235,7 @@ def create_account_disabled_set(
     )
 
 
-def create_session_revoked_set(
+def makeSessionRevokedSet(
     issuer: str,
     audience: Union[str, List[str]],
     subject_id: str,
@@ -256,7 +257,7 @@ def create_session_revoked_set(
     subject = {"format": "opaque", "id": subject_id}
     event_data = {"session_id": session_id} if session_id else {}
 
-    return create_security_event_token(
+    return makeSecurityEventToken(
         issuer=issuer,
         audience=audience,
         event_type=SET_EVENT_TYPES["session-revoked"],
@@ -266,13 +267,84 @@ def create_session_revoked_set(
     )
 
 
+def create_security_event_token(
+    issuer: str,
+    audience: Union[str, List[str]],
+    event_type: str,
+    subject: Dict[str, Any],
+    *,
+    event_data: Optional[Dict[str, Any]] = None,
+    expires_in: int = 3600,
+    additional_claims: Optional[Dict[str, Any]] = None,
+) -> str:
+    warnings.warn(
+        "create_security_event_token is deprecated, use makeSecurityEventToken",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return makeSecurityEventToken(
+        issuer,
+        audience,
+        event_type,
+        subject,
+        event_data=event_data,
+        expires_in=expires_in,
+        additional_claims=additional_claims,
+    )
+
+
+def create_account_disabled_set(
+    issuer: str,
+    audience: Union[str, List[str]],
+    subject_id: str,
+    reason: Optional[str] = None,
+    **kwargs,
+) -> str:
+    warnings.warn(
+        "create_account_disabled_set is deprecated, use makeAccountDisabledSet",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return makeAccountDisabledSet(
+        issuer,
+        audience,
+        subject_id,
+        reason=reason,
+        **kwargs,
+    )
+
+
+def create_session_revoked_set(
+    issuer: str,
+    audience: Union[str, List[str]],
+    subject_id: str,
+    session_id: Optional[str] = None,
+    **kwargs,
+) -> str:
+    warnings.warn(
+        "create_session_revoked_set is deprecated, use makeSessionRevokedSet",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return makeSessionRevokedSet(
+        issuer,
+        audience,
+        subject_id,
+        session_id=session_id,
+        **kwargs,
+    )
+
+
 __all__ = [
-    "create_security_event_token",
+    "makeSecurityEventToken",
     "validate_security_event_token",
     "extract_event_data",
     "get_set_subject_identifiers",
-    "create_account_disabled_set",
-    "create_session_revoked_set",
+    "makeAccountDisabledSet",
+    "makeSessionRevokedSet",
     "SET_EVENT_TYPES",
     "RFC7952_SPEC_URL",
+    "create_security_event_token",
+    "create_account_disabled_set",
+    "create_session_revoked_set",
 ]

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/rfc/rfc8523.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/rfc/rfc8523.py
@@ -10,6 +10,7 @@ See RFC 8523: https://www.rfc-editor.org/rfc/rfc8523
 from __future__ import annotations
 
 import time
+import warnings
 from typing import Any, Dict, Iterable, Optional, Set, Union
 
 from ..errors import InvalidTokenError
@@ -85,7 +86,7 @@ def validate_enhanced_jwt_bearer(
     return claims
 
 
-def create_client_assertion_jwt(
+def makeClientAssertionJwt(
     client_id: str,
     audience: str,
     *,
@@ -128,6 +129,26 @@ def create_client_assertion_jwt(
     return encode_jwt(**claims)
 
 
+def create_client_assertion_jwt(
+    client_id: str,
+    audience: str,
+    *,
+    expires_in: int = 300,
+    additional_claims: Optional[Dict[str, Any]] = None,
+) -> str:
+    warnings.warn(
+        "create_client_assertion_jwt is deprecated, use makeClientAssertionJwt",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return makeClientAssertionJwt(
+        client_id,
+        audience,
+        expires_in=expires_in,
+        additional_claims=additional_claims,
+    )
+
+
 def is_jwt_replay(jti: str, iat: int, max_age_seconds: int = 300) -> bool:
     """Check if a JWT ID indicates a replay attack.
 
@@ -149,7 +170,8 @@ def is_jwt_replay(jti: str, iat: int, max_age_seconds: int = 300) -> bool:
 
 __all__ = [
     "validate_enhanced_jwt_bearer",
-    "create_client_assertion_jwt",
+    "makeClientAssertionJwt",
     "is_jwt_replay",
     "RFC8523_SPEC_URL",
+    "create_client_assertion_jwt",
 ]

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/rfc/rfc8693.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/rfc/rfc8693.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Union
 from enum import Enum
+import warnings
 from tigrbl_auth.deps import (
     APIRouter,
     FastAPI,
@@ -330,7 +331,7 @@ async def token_exchange_endpoint(
     return response.to_dict()
 
 
-def create_impersonation_token(
+def makeImpersonationToken(
     subject_token: str,
     actor_token: str,
     *,
@@ -365,7 +366,7 @@ def create_impersonation_token(
     return exchange_token(request, issuer="impersonation-service")
 
 
-def create_delegation_token(
+def makeDelegationToken(
     subject_token: str,
     *,
     audience: Optional[str] = None,
@@ -396,6 +397,44 @@ def create_delegation_token(
     return exchange_token(request, issuer="delegation-service")
 
 
+def create_impersonation_token(
+    subject_token: str,
+    actor_token: str,
+    *,
+    audience: Optional[str] = None,
+    scope: Optional[str] = None,
+) -> TokenExchangeResponse:
+    warnings.warn(
+        "create_impersonation_token is deprecated, use makeImpersonationToken",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return makeImpersonationToken(
+        subject_token,
+        actor_token,
+        audience=audience,
+        scope=scope,
+    )
+
+
+def create_delegation_token(
+    subject_token: str,
+    *,
+    audience: Optional[str] = None,
+    scope: Optional[str] = None,
+) -> TokenExchangeResponse:
+    warnings.warn(
+        "create_delegation_token is deprecated, use makeDelegationToken",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return makeDelegationToken(
+        subject_token,
+        audience=audience,
+        scope=scope,
+    )
+
+
 __all__ = [
     "TokenExchangeRequest",
     "TokenExchangeResponse",
@@ -403,6 +442,8 @@ __all__ = [
     "validate_token_exchange_request",
     "validate_subject_token",
     "exchange_token",
+    "makeImpersonationToken",
+    "makeDelegationToken",
     "create_impersonation_token",
     "create_delegation_token",
     "TOKEN_EXCHANGE_GRANT_TYPE",

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/rfc/rfc9101.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/rfc/rfc9101.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, Final, Iterable
 import json
+import warnings
 
 from ..deps import JWAAlg, JwsSignerVerifier
 
@@ -20,7 +21,7 @@ RFC9101_SPEC_URL: Final = "https://www.rfc-editor.org/rfc/rfc9101"
 _signer = JwsSignerVerifier()
 
 
-async def create_request_object(
+async def makeRequestObject(
     params: Dict[str, Any], *, secret: str, algorithm: str = "HS256"
 ) -> str:
     """Return a JWT request object representing ``params``.
@@ -35,6 +36,17 @@ async def create_request_object(
     alg = JWAAlg(algorithm)
     key = {"kind": "raw", "key": secret.encode()}
     return await _signer.sign_compact(payload=params, alg=alg, key=key, typ="JWT")
+
+
+async def create_request_object(
+    params: Dict[str, Any], *, secret: str, algorithm: str = "HS256"
+) -> str:
+    warnings.warn(
+        "create_request_object is deprecated, use makeRequestObject",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return await makeRequestObject(params, secret=secret, algorithm=algorithm)
 
 
 async def parse_request_object(
@@ -61,4 +73,9 @@ async def parse_request_object(
     return json.loads(result.payload.decode())
 
 
-__all__ = ["create_request_object", "parse_request_object", "RFC9101_SPEC_URL"]
+__all__ = [
+    "makeRequestObject",
+    "parse_request_object",
+    "RFC9101_SPEC_URL",
+    "create_request_object",
+]

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/rfc/rfc9449_dpop.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/rfc/rfc9449_dpop.py
@@ -7,6 +7,7 @@ import base64
 import hashlib
 import json
 from typing import Any, Dict, Final
+import warnings
 from cryptography.hazmat.primitives.serialization import load_pem_public_key
 from cryptography.hazmat.primitives import serialization
 from swarmauri_signing_dpop import DpopSigner
@@ -50,7 +51,7 @@ def jwk_thumbprint(jwk: Dict[str, str]) -> str:
 # ---------------------------------------------------------------------------
 
 
-def create_proof(
+def makeProof(
     keyref: Any, method: str, url: str, *, enabled: bool | None = None
 ) -> str:
     """Create a DPoP proof for *method* and *url* using *keyref*.
@@ -78,6 +79,17 @@ def create_proof(
         )
     )
     return sigs[0]["sig"]
+
+
+def create_proof(
+    keyref: Any, method: str, url: str, *, enabled: bool | None = None
+) -> str:
+    warnings.warn(
+        "create_proof is deprecated, use makeProof",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return makeProof(keyref, method, url, enabled=enabled)
 
 
 def verify_proof(
@@ -123,8 +135,9 @@ def verify_proof(
 
 __all__ = [
     "RFC9449_SPEC_URL",
-    "create_proof",
+    "makeProof",
     "verify_proof",
     "jwk_from_public_key",
     "jwk_thumbprint",
+    "create_proof",
 ]


### PR DESCRIPTION
## Summary
- align tigrbl_auth helper names with Tigrbl "make" convention
- deprecate old create_* helpers in favor of make* replacements
- update tests to use new helper names

## Testing
- `uv run --directory pkgs/standards/tigrbl_auth --package tigrbl_auth ruff format .`
- `uv run --directory pkgs/standards/tigrbl_auth --package tigrbl_auth ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c7d375452883269227b5f838c4b1cf