### PR TITLE
refactor: deduplicate tigrbl_auth auth context helper

### DIFF
--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/adapters/auth_context.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/adapters/auth_context.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from tigrbl_auth.deps import Request, TIGRBL_AUTH_CONTEXT_ATTR
+
+
+def set_auth_context(request: Request, principal: dict | None) -> None:
+    """Populate request.state with the auth context expected by Tigrbl.
+
+    Parameters
+    ----------
+    request:
+        Incoming FastAPI request whose state should be populated.
+    principal:
+        Principal dictionary containing ``tenant_id`` (``tid``) and ``user_id``
+        (``sub``). May be ``None`` when no authenticated principal is present.
+    """
+    ctx: dict[str, str] = {}
+    if principal:
+        tid = principal.get("tid") or principal.get("tenant_id")
+        uid = principal.get("sub") or principal.get("user_id")
+        if tid is not None:
+            ctx["tenant_id"] = tid
+        if uid is not None:
+            ctx["user_id"] = uid
+    setattr(request.state, TIGRBL_AUTH_CONTEXT_ATTR, ctx)
+
+
+__all__ = ["set_auth_context"]

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/adapters/local_adapter.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/adapters/local_adapter.py
@@ -14,21 +14,10 @@ Usage
 
 from __future__ import annotations
 
-from tigrbl_auth.deps import Request, TIGRBL_AUTH_CONTEXT_ATTR, AuthNProvider
+from tigrbl_auth.deps import AuthNProvider, Request
 from ..fastapi_deps import get_principal
 from ..principal_ctx import principal_var  # noqa: F401  # ensure ContextVar is initialised
-
-
-def _set_auth_context(request: Request, principal: dict) -> None:
-    """Populate request.state with the auth context expected by Tigrbl."""
-    ctx: dict[str, str] = {}
-    tid = principal.get("tid") or principal.get("tenant_id")
-    uid = principal.get("sub") or principal.get("user_id")
-    if tid is not None:
-        ctx["tenant_id"] = tid
-    if uid is not None:
-        ctx["user_id"] = uid
-    setattr(request.state, TIGRBL_AUTH_CONTEXT_ATTR, ctx)
+from .auth_context import set_auth_context
 
 
 class LocalAuthNAdapter(AuthNProvider):
@@ -51,7 +40,7 @@ class LocalAuthNAdapter(AuthNProvider):
             If the API‑key / bearer token is invalid or expired.
         """
         principal = await get_principal(request)  # type: ignore[arg-type]
-        _set_auth_context(request, principal)
+        set_auth_context(request, principal)
         return principal
 
 


### PR DESCRIPTION
## Summary
- move duplicate auth context code into adapters.auth_context
- reuse helper in local and remote adapters

## Testing
- `uv run --directory pkgs/standards/tigrbl_auth --package tigrbl_auth ruff format .`
- `uv run --directory pkgs/standards/tigrbl_auth --package tigrbl_auth ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c7d3b736348326a35c579e889c9449