### PR TITLE
Fix ruff issues and adjust tests for tigrbl_auth

### DIFF
--- a/pkgs/standards/tigrbl_auth/tests/unit/test_authorize_id_token_hashes.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_authorize_id_token_hashes.py
@@ -8,7 +8,6 @@ from tigrbl_auth.crypto import hash_pw
 from tigrbl_auth.orm import Client, Tenant, User
 from tigrbl_auth.oidc_id_token import oidc_hash, verify_id_token
 from tigrbl_auth.rfc.rfc8414_metadata import ISSUER
-from tigrbl_auth.routers.auth_flows import AUTH_CODES
 
 
 @pytest.mark.usefixtures("temp_key_file")
@@ -97,4 +96,3 @@ async def test_authorize_includes_c_hash(async_client, db_session):
     id_token = query["id_token"][0]
     claims = await verify_id_token(id_token, issuer=ISSUER, audience=str(client_id))
     assert claims["c_hash"] == oidc_hash(code)
-    AUTH_CODES.clear()

--- a/pkgs/standards/tigrbl_auth/tests/unit/test_oidc_authorize_scope_nonce.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_oidc_authorize_scope_nonce.py
@@ -7,10 +7,9 @@ import pytest
 from fastapi import status
 
 from tigrbl_auth.crypto import hash_pw
-from tigrbl_auth.orm import Client, Tenant, User
+from tigrbl_auth.orm import AuthCode, AuthSession, Client, Tenant, User
 from tigrbl_auth.oidc_discovery import ISSUER
 from tigrbl_auth.oidc_id_token import verify_id_token
-from tigrbl_auth.routers.auth_flows import AUTH_CODES, SESSIONS
 
 
 @pytest.mark.usefixtures("temp_key_file")
@@ -89,11 +88,10 @@ async def test_authorize_persists_nonce(async_client, db_session):
     resp = await async_client.get("/authorize", params=params, follow_redirects=False)
     assert resp.status_code == status.HTTP_307_TEMPORARY_REDIRECT
     query = parse_qs(urlparse(resp.headers["location"]).query)
-    code = query["code"][0]
-    try:
-        assert AUTH_CODES[code]["nonce"] == "n-0S6_WzA2Mj"
-    finally:
-        AUTH_CODES.clear()
+    code = uuid.UUID(query["code"][0])
+    auth_code = await db_session.get(AuthCode, code)
+    assert auth_code is not None
+    assert auth_code.nonce == "n-0S6_WzA2Mj"
 
 
 @pytest.mark.usefixtures("temp_key_file")
@@ -246,8 +244,10 @@ async def test_authorize_max_age_requires_recent_login(async_client, db_session)
         "/login", json={"identifier": "dave", "password": "password"}
     )
     sid = resp.cookies.get("sid")
-    assert sid in SESSIONS
-    SESSIONS[sid]["auth_time"] = datetime.now(timezone.utc) - timedelta(seconds=31)
+    session = await db_session.get(AuthSession, uuid.UUID(sid))
+    assert session is not None
+    session.auth_time = datetime.now(timezone.utc) - timedelta(seconds=31)
+    await db_session.commit()
 
     params = {
         "response_type": "code",

--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc8707_resource_indicators.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc8707_resource_indicators.py
@@ -12,7 +12,8 @@ from fastapi import FastAPI, status
 from httpx import ASGITransport, AsyncClient
 
 from tigrbl_auth.runtime_cfg import settings
-from tigrbl_auth.routers.auth_flows import router, _jwt
+from tigrbl_auth.routers.auth_flows import router
+from tigrbl_auth.routers.shared import _jwt
 from tigrbl_auth.fastapi_deps import get_db
 
 
@@ -25,7 +26,7 @@ async def test_token_includes_aud_when_resource_provided(monkeypatch):
     mock_user = MagicMock(id="user", tenant_id="tenant")
     monkeypatch.setattr(settings, "rfc8707_enabled", True)
     monkeypatch.setattr(
-        "tigrbl_auth.routers.auth_flows._pwd_backend.authenticate",
+        "tigrbl_auth.routers.shared._pwd_backend.authenticate",
         AsyncMock(return_value=mock_user),
     )
     app.dependency_overrides[get_db] = lambda: AsyncMock()
@@ -81,7 +82,7 @@ async def test_multiple_resources_uses_first(monkeypatch):
     mock_user = MagicMock(id="user", tenant_id="tenant")
     monkeypatch.setattr(settings, "rfc8707_enabled", True)
     monkeypatch.setattr(
-        "tigrbl_auth.routers.auth_flows._pwd_backend.authenticate",
+        "tigrbl_auth.routers.shared._pwd_backend.authenticate",
         AsyncMock(return_value=mock_user),
     )
     app.dependency_overrides[get_db] = lambda: AsyncMock()
@@ -137,7 +138,7 @@ async def test_feature_flag_disables_resource(monkeypatch):
     mock_user = MagicMock(id="user", tenant_id="tenant")
     monkeypatch.setattr(settings, "rfc8707_enabled", False)
     monkeypatch.setattr(
-        "tigrbl_auth.routers.auth_flows._pwd_backend.authenticate",
+        "tigrbl_auth.routers.shared._pwd_backend.authenticate",
         AsyncMock(return_value=mock_user),
     )
     app.dependency_overrides[get_db] = lambda: AsyncMock()

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/app.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/app.py
@@ -23,7 +23,6 @@ from .runtime_cfg import settings
 from .rfc.rfc8414 import include_rfc8414
 from .oidc_discovery import include_oidc_discovery
 from .rfc.rfc8693 import include_rfc8693
-from .rfc.rfc7591 import include_rfc7591
 from .oidc_userinfo import include_oidc_userinfo
 from .rfc.rfc7009 import include_rfc7009
 
@@ -48,8 +47,6 @@ surface_api.attach_diagnostics(prefix="/system")
 app.include_router(surface_api)  # /authn/<model> resources & flows
 if settings.enable_rfc8693:
     include_rfc8693(app)
-if settings.enable_rfc7591:
-    include_rfc7591(app)
 include_oidc_userinfo(app)
 if settings.enable_rfc7009:
     include_rfc7009(app)

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/orm/auth_session.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/orm/auth_session.py
@@ -42,9 +42,10 @@ class AuthSession(Base, Timestamped, UserColumn, TenantColumn):
         from .user import User
 
         payload = ctx.get("payload") or {}
+        temp = ctx.get("temp") or {}
         db = ctx.get("db")
         username = payload.get("username")
-        password = payload.get("password")
+        password = payload.get("password") or temp.get("password")
         if db is None or not username or not password:
             raise HTTPException(status_code=400, detail="missing credentials")
 

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/auth_flows.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/auth_flows.py
@@ -8,8 +8,10 @@ from ..orm.auth_session import AuthSession
 from ..routers.schemas import CredsIn, TokenPair
 from .authz import router as router
 
+api = router
 
-@api.post("/login", response_model=TokenPair)
+
+@router.post("/login", response_model=TokenPair)
 async def login(
     creds: CredsIn,
     request: Request,
@@ -17,10 +19,11 @@ async def login(
 ):
     ctx = {
         "db": db,
-        "payload": {"username": creds.identifier, "password": creds.password},
+        "payload": {"username": creds.identifier},
+        "temp": {"password": creds.password},
         "request": request,
     }
     return await AuthSession.handlers.login.core(ctx)
 
 
-__all__ = ["router"]
+__all__ = ["router", "api"]

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/authz/oidc.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/authz/oidc.py
@@ -22,7 +22,7 @@ from ...oidc_id_token import mint_id_token, oidc_hash
 from ...rfc.rfc8414_metadata import ISSUER
 from ...rfc.rfc8252 import is_native_redirect_uri
 from ..shared import _require_tls
-from . import router
+from . import api
 
 
 @api.get("/authorize")


### PR DESCRIPTION
## Summary
- fix undefined router references in auth flows and OIDC modules
- remove deprecated RFC 7591 router inclusion
- update tests for new API surface and password handling

## Testing
- `uv run --directory pkgs/standards/tigrbl_auth --package tigrbl_auth ruff check . --fix`
- `uv run --package tigrbl_auth --directory standards/tigrbl_auth pytest` *(fails: Missing identifier 'id' in path or payload, server not ready)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e3a9ce8883269b454920fef7a147