### PR TITLE
feat(tigrbl): add column header io support

### DIFF
--- a/pkgs/standards/tigrbl/tests/i9n/test_header_io_uvicorn.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_header_io_uvicorn.py
@@ -1,0 +1,76 @@
+import asyncio
+import httpx
+import pytest
+import pytest_asyncio
+import uvicorn
+
+from tigrbl import TigrblApp
+from tigrbl.orm.mixins import GUIDPk
+from tigrbl.orm.tables._base import Base
+from tigrbl.specs import F, S, IO, acol
+from tigrbl.types import App, Mapped, String
+
+
+class Item(Base, GUIDPk):
+    __tablename__ = "items_hdr"
+    __resource__ = "item"
+
+    name: Mapped[str] = acol(
+        storage=S(String, nullable=False),
+        field=F(py_type=str),
+        io=IO(in_verbs=("create",), out_verbs=("create", "read")),
+    )
+    worker_key: Mapped[str] = acol(
+        storage=S(String, nullable=False),
+        field=F(py_type=str),
+        io=IO(
+            in_verbs=("create",),
+            out_verbs=("create", "read"),
+            header_in="X-Worker-Key",
+            header_required_in=True,
+        ),
+    )
+    __tigrbl_cols__ = {
+        "id": GUIDPk.id,
+        "name": name,
+        "worker_key": worker_key,
+    }
+
+
+@pytest_asyncio.fixture()
+async def running_app(sync_db_session):
+    engine, get_sync_db = sync_db_session
+
+    app = App()
+    api = TigrblApp(get_db=get_sync_db)
+    api.include_models([Item])
+    await api.initialize()
+    app.include_router(api.router)
+
+    cfg = uvicorn.Config(app, host="127.0.0.1", port=8000, log_level="warning")
+    server = uvicorn.Server(cfg)
+    task = asyncio.create_task(server.serve())
+    while not server.started:
+        await asyncio.sleep(0.1)
+    try:
+        yield "http://127.0.0.1:8000"
+    finally:
+        server.should_exit = True
+        await task
+
+
+@pytest.mark.i9n
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "headers, status",
+    [({}, 422), ({"X-Worker-Key": "alpha"}, 201)],
+)
+async def test_header_in_out(running_app, headers, status):
+    base_url = running_app
+    payload = {"name": "foo", "worker_key": "body"}
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(f"{base_url}/item", json=payload, headers=headers)
+    assert resp.status_code == status
+    if status == 201:
+        body = resp.json()
+        assert body["worker_key"] == "alpha"

--- a/pkgs/standards/tigrbl/tigrbl/bindings/rest/io_headers.py
+++ b/pkgs/standards/tigrbl/tigrbl/bindings/rest/io_headers.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import inspect
+from typing import Mapping, Any
+
+from fastapi import Header
+
+
+def _build_signature_with_header_params(
+    hdr_fields: list[tuple[str, str, bool]],
+) -> inspect.Signature:
+    params: list[inspect.Parameter] = []
+    for _field, header, required in hdr_fields:
+        param = header.lower().replace("-", "_")
+        default = Header(... if required else None, alias=header)
+        params.append(
+            inspect.Parameter(
+                name=param,
+                kind=inspect.Parameter.KEYWORD_ONLY,
+                default=default,
+                annotation=str | None,
+            )
+        )
+    return inspect.Signature(parameters=params, return_annotation=Mapping[str, object])
+
+
+def _make_header_dep(model: type, alias: str):
+    hdr_fields: list[tuple[str, str, bool]] = []
+    for name, spec in getattr(model, "__tigrbl_cols__", {}).items():
+        io = getattr(spec, "io", None)
+        if not io or not getattr(io, "header_in", None):
+            continue
+        if alias not in set(getattr(io, "in_verbs", ()) or ()):  # honor IO.in_verbs
+            continue
+        hdr_fields.append(
+            (name, io.header_in, bool(getattr(io, "header_required_in", False)))
+        )
+
+    async def _dep(**kw: Any) -> Mapping[str, object]:
+        out: dict[str, object] = {}
+        for field, header, _req in hdr_fields:
+            param = header.lower().replace("-", "_")
+            v = kw.get(param)
+            if v is not None:
+                out[field] = v
+        return out
+
+    _dep.__signature__ = _build_signature_with_header_params(hdr_fields)
+    return _dep

--- a/pkgs/standards/tigrbl/tigrbl/bindings/rest/member.py
+++ b/pkgs/standards/tigrbl/tigrbl/bindings/rest/member.py
@@ -35,6 +35,8 @@ from .common import (
     _status_for,
 )
 
+from .io_headers import _make_header_dep
+
 from ...runtime.executor.types import _Ctx
 
 
@@ -58,6 +60,7 @@ def _make_member_endpoint(
     real_pk = _pk_name(model)
     pk_names = _pk_names(model)
     nested_vars = list(nested_vars or [])
+    hdr_dep = _make_header_dep(model, alias)
 
     # --- No body on GET read / DELETE delete ---
     if target in {"read", "delete"}:
@@ -66,11 +69,14 @@ def _make_member_endpoint(
             item_id: Any,
             request: Request,
             db: Any = Depends(db_dep),
+            h: Mapping[str, Any] = Depends(hdr_dep),
             **kw: Any,
         ):
             parent_kw = {k: kw[k] for k in nested_vars if k in kw}
             _coerce_parent_kw(model, parent_kw)
             payload: Mapping[str, Any] = dict(parent_kw)
+            if isinstance(h, Mapping):
+                payload = {**payload, **dict(h)}
             path_params = {real_pk: item_id, pk_param: item_id, **parent_kw}
             ctx: Dict[str, Any] = {
                 "request": request,
@@ -141,6 +147,11 @@ def _make_member_endpoint(
                     "db",
                     inspect.Parameter.POSITIONAL_OR_KEYWORD,
                     annotation=Annotated[Any, Depends(db_dep)],
+                ),
+                inspect.Parameter(
+                    "h",
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    annotation=Annotated[Mapping[str, Any], Depends(hdr_dep)],
                 ),
             ]
         )
@@ -257,12 +268,15 @@ def _make_member_endpoint(
         item_id: Any,
         request: Request,
         db: Any = Depends(db_dep),
+        h: Mapping[str, Any] = Depends(hdr_dep),
         body=body_default,
         **kw: Any,
     ):
         parent_kw = {k: kw[k] for k in nested_vars if k in kw}
         _coerce_parent_kw(model, parent_kw)
         payload = _validate_body(model, alias, target, body)
+        if isinstance(h, Mapping):
+            payload = {**payload, **dict(h)}
 
         # Enforce path-PK canonicality. If body echoes PK: drop if equal, 409 if mismatch.
         for k in pk_names:
@@ -349,6 +363,11 @@ def _make_member_endpoint(
                 "db",
                 inspect.Parameter.POSITIONAL_OR_KEYWORD,
                 annotation=Annotated[Any, Depends(db_dep)],
+            ),
+            inspect.Parameter(
+                "h",
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                annotation=Annotated[Mapping[str, Any], Depends(hdr_dep)],
             ),
             inspect.Parameter(
                 "body",

--- a/pkgs/standards/tigrbl/tigrbl/column/io_spec.py
+++ b/pkgs/standards/tigrbl/tigrbl/column/io_spec.py
@@ -57,6 +57,9 @@ class IOSpec:
     mutable_verbs: Tuple[str, ...] = ()
     alias_in: str | None = None
     alias_out: str | None = None
+    header_in: str | None = None  # e.g., "X-Worker-Key"
+    header_out: str | None = None  # e.g., "ETag"
+    header_required_in: bool = False
     sensitive: bool = False
     redact_last: int | None = None
     filter_ops: Tuple[str, ...] = ()

--- a/pkgs/standards/tigrbl/tigrbl/runtime/atoms/response/__init__.py
+++ b/pkgs/standards/tigrbl/tigrbl/runtime/atoms/response/__init__.py
@@ -5,12 +5,14 @@ from ... import events as _ev
 from .template import run as _template
 from .negotiate import run as _negotiate
 from .render import run as _render
+from . import headers_from_payload as _hdr_payload
 
 RunFn = Callable[[Optional[object], Any], Any]
 
 REGISTRY: Dict[Tuple[str, str], Tuple[str, RunFn]] = {
     ("response", "template"): (_ev.OUT_DUMP, _template),
     ("response", "negotiate"): (_ev.OUT_DUMP, _negotiate),
+    ("response", "headers_from_payload"): (_hdr_payload.ANCHOR, _hdr_payload.run),
     ("response", "render"): (_ev.OUT_DUMP, _render),
 }
 

--- a/pkgs/standards/tigrbl/tigrbl/runtime/atoms/response/headers_from_payload.py
+++ b/pkgs/standards/tigrbl/tigrbl/runtime/atoms/response/headers_from_payload.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from ... import events as _ev
+from typing import Mapping
+
+ANCHOR = _ev.OUT_BUILD  # run after payload is prepared, before render
+
+
+def run(_, ctx) -> None:
+    """Mirror fields configured with ``io.header_out`` into HTTP response headers.
+
+    - Does NOT remove fields from the response body (no header-only behavior).
+    - Honors op-specific exposure via ``io.out_verbs``.
+    Complexity: O(#fields in opview).
+    """
+    from tigrbl.response import ResponseHints
+
+    resp = getattr(ctx, "response", None)
+    if resp is None:
+        return
+
+    hints = getattr(resp, "hints", None)
+    if hints is None:
+        hints = ResponseHints()
+        resp.hints = hints
+
+    payload = getattr(resp, "result", None)
+    if payload is None:
+        temp = getattr(ctx, "temp", None)
+        if isinstance(temp, Mapping):
+            payload = temp.get("response_payload")
+    if not isinstance(payload, dict):
+        return
+
+    specs = getattr(ctx, "specs", None)
+    if not isinstance(specs, Mapping):
+        model = getattr(ctx, "model", None)
+        specs = getattr(model, "__tigrbl_cols__", {}) if model is not None else {}
+
+    op = getattr(ctx, "op", None)
+    for field_name, spec in specs.items():
+        io = getattr(spec, "io", None)
+        if not io:
+            continue
+
+        header_name = getattr(io, "header_out", None)
+        if not header_name:
+            continue
+
+        out_verbs = set(getattr(io, "out_verbs", ()) or ())
+        if op not in out_verbs:
+            continue
+
+        if field_name in payload:
+            value = payload[field_name]
+            if value is not None:
+                hints.headers[header_name] = str(value)


### PR DESCRIPTION
## Summary
- allow column IO specs to declare input and output HTTP headers
- merge configured headers into REST endpoint payloads
- test header-driven input validation via uvicorn server

## Testing
- `uv run --directory pkgs/standards/tigrbl --package tigrbl ruff format .`
- `uv run --directory pkgs/standards/tigrbl --package tigrbl ruff check . --fix`
- `uv run --directory pkgs/standards/tigrbl --package tigrbl pytest tests/i9n/test_header_io_uvicorn.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7f625a1a88326ac4e3d21962a5f31