### PR TITLE
Fix login session creation and adjust PKCE test

### DIFF
--- a/pkgs/standards/tigrbl_auth/tests/unit/test_auth_code_exchange_pkce.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_auth_code_exchange_pkce.py
@@ -17,7 +17,7 @@ async def test_exchange_accepts_hex_client_id(monkeypatch):
     client_uuid = uuid.uuid4()
 
     auth_code = AuthCode(
-        code="code",
+        id=uuid.uuid4(),
         client_id=client_uuid,
         redirect_uri="https://client/cb",
         code_challenge=challenge,

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/auth_flows.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/auth_flows.py
@@ -1,11 +1,25 @@
 from __future__ import annotations
 
 
-from tigrbl_auth.deps import AsyncSession, Depends, Request
+import secrets
+
+from tigrbl_auth.deps import (
+    AsyncSession,
+    Depends,
+    Request,
+    HTTPException,
+    select,
+    status,
+    JSONResponse,
+)
 
 from ..fastapi_deps import get_db
 from ..orm.auth_session import AuthSession
+from ..orm.user import User
+from ..oidc_id_token import mint_id_token
 from ..routers.schemas import CredsIn, TokenPair
+from ..routers.shared import _jwt, _require_tls
+from ..rfc.rfc8414_metadata import ISSUER
 from .authz import router as router
 
 api = router
@@ -17,13 +31,40 @@ async def login(
     request: Request,
     db: AsyncSession = Depends(get_db),
 ):
-    ctx = {
-        "db": db,
-        "payload": {"username": creds.identifier},
-        "temp": {"password": creds.password},
-        "request": request,
+    stmt = select(User).where(User.username == creds.identifier)
+    user = await db.scalar(stmt)
+    if user is None or not user.verify_password(creds.password):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="invalid credentials"
+        )
+
+    _require_tls(request)
+    payload = {
+        "username": user.username,
+        "user_id": user.id,
+        "tenant_id": user.tenant_id,
     }
-    return await AuthSession.handlers.login.core(ctx)
+    session = await AuthSession.handlers.create.core({"db": db, "payload": payload})
+    access, refresh = await _jwt.async_sign_pair(
+        sub=str(session.user_id),
+        tid=str(session.tenant_id),
+        scope="openid profile email",
+    )
+    id_token = await mint_id_token(
+        sub=str(session.user_id),
+        aud=ISSUER,
+        nonce=secrets.token_urlsafe(8),
+        issuer=ISSUER,
+        sid=str(session.id),
+    )
+    pair = {
+        "access_token": access,
+        "refresh_token": refresh,
+        "id_token": id_token,
+    }
+    response = JSONResponse(pair)
+    response.set_cookie("sid", str(session.id), httponly=True, samesite="lax")
+    return response
 
 
 __all__ = ["router", "api"]


### PR DESCRIPTION
## Summary
- ensure `/login` endpoint verifies credentials and mints tokens directly
- allow AuthCode PKCE test to construct codes using UUID id

## Testing
- `uv run --package tigrbl_auth --directory standards/tigrbl_auth pytest tests/unit/test_auth_code_exchange_pkce.py::test_exchange_accepts_hex_client_id -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7fdbc4a348326b57a7a4eefcb642b