### PR TITLE
fix: remove invalid code argument in PKCE test

### DIFF
--- a/pkgs/standards/tigrbl_auth/tests/unit/test_auth_code_exchange_pkce.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_auth_code_exchange_pkce.py
@@ -17,7 +17,6 @@ async def test_exchange_accepts_hex_client_id(monkeypatch):
     client_uuid = uuid.uuid4()
 
     auth_code = AuthCode(
-        code="code",
         client_id=client_uuid,
         redirect_uri="https://client/cb",
         code_challenge=challenge,


### PR DESCRIPTION
## Summary
- remove invalid `code` keyword from AuthCode instantiation in PKCE exchange test

## Testing
- `uv run --package tigrbl_auth --directory standards ruff format tigrbl_auth/tests/unit/test_auth_code_exchange_pkce.py`
- `uv run --package tigrbl_auth --directory standards ruff check tigrbl_auth/tests/unit/test_auth_code_exchange_pkce.py --fix`
- `uv run --package tigrbl_auth --directory standards pytest tigrbl_auth/tests/unit/test_auth_code_exchange_pkce.py`

------
https://chatgpt.com/codex/tasks/task_e_68c800a1042483268718fc9450a18b32