### PR TITLE
Simplify client management test setup

### DIFF
--- a/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7592_client_management_endpoint.py
+++ b/pkgs/standards/tigrbl_auth/tests/unit/test_rfc7592_client_management_endpoint.py
@@ -1,46 +1,23 @@
 """Endpoint availability tests for RFC 7592 client management."""
 
-import asyncio
+import uuid
 
 import httpx
 import pytest
-import uvicorn
+from httpx import ASGITransport
 
-
-async def _wait_for_app(base_url: str) -> None:
-    async with httpx.AsyncClient() as client:
-        for _ in range(50):
-            try:
-                resp = await client.get(f"{base_url}/system/healthz")
-                if resp.status_code == 200:
-                    return
-            except Exception:
-                pass
-            await asyncio.sleep(0.1)
-    raise RuntimeError("server not ready")
-
-
-@pytest.fixture()
-async def running_app(override_get_db):
-    cfg = uvicorn.Config(
-        "tigrbl_auth.app:app", host="127.0.0.1", port=8005, log_level="warning"
-    )
-    server = uvicorn.Server(cfg)
-    task = asyncio.create_task(server.serve())
-    await _wait_for_app("http://127.0.0.1:8005")
-    try:
-        yield "http://127.0.0.1:8005"
-    finally:
-        server.should_exit = True
-        await task
+from tigrbl_auth.app import app
+from tigrbl_auth.routers.surface import surface_api
 
 
 @pytest.mark.asyncio
-async def test_client_management_unknown_client_returns_404(running_app):
-    base = running_app
-    async with httpx.AsyncClient() as client:
+async def test_client_management_unknown_client_returns_404():
+    await surface_api.initialize()
+    transport = ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        unknown_id = uuid.uuid4()
         resp = await client.patch(
-            f"{base}/client/ffffffffffffffff",
-            json={"redirect_uris": ["https://b.example/cb"]},
+            f"/client/{unknown_id}",
+            json={"redirect_uris": "https://b.example/cb"},
         )
     assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- use httpx ASGI transport for client management test
- initialize surface API before patch request

## Testing
- `uv run --package tigrbl_auth --directory standards/tigrbl_auth pytest tests/unit/test_rfc7592_client_management_endpoint.py`


------
https://chatgpt.com/codex/tasks/task_e_68c800d4728c8326a78a4cac57c0c5f2