### PR TITLE
Fix tigrbl_auth fastapi deps tests and router aliases

### DIFF
--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/auth_flows.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/auth_flows.py
@@ -8,8 +8,10 @@ from ..orm.auth_session import AuthSession
 from ..routers.schemas import CredsIn, TokenPair
 from .authz import router as router
 
+api = router
 
-@api.post("/login", response_model=TokenPair)
+
+@router.post("/login", response_model=TokenPair)
 async def login(
     creds: CredsIn,
     request: Request,
@@ -23,4 +25,4 @@ async def login(
     return await AuthSession.handlers.login.core(ctx)
 
 
-__all__ = ["router"]
+__all__ = ["router", "api"]

--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/authz/oidc.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/routers/authz/oidc.py
@@ -25,7 +25,7 @@ from ..shared import _require_tls
 from . import router
 
 
-@api.get("/authorize")
+@router.get("/authorize")
 async def authorize(
     response_type: str,
     client_id: str,


### PR DESCRIPTION
## Summary
- fix authz OIDC router decorator
- alias router for auth flows login
- update fastapi deps tests to mock handler calls

## Testing
- `uv run --package tigrbl_auth --directory standards/tigrbl_auth ruff check . --fix`
- `uv run --package tigrbl_auth --directory standards/tigrbl_auth pytest tests/unit/test_fastapi_deps.py`


------
https://chatgpt.com/codex/tasks/task_e_68c80d8721108326bcab35f46fcdec00