### PR TITLE
Ensure tigrbl auth dependencies use DB context

### DIFF
--- a/pkgs/standards/tigrbl_auth/tigrbl_auth/fastapi_deps.py
+++ b/pkgs/standards/tigrbl_auth/tigrbl_auth/fastapi_deps.py
@@ -58,7 +58,10 @@ async def _user_from_jwt(token: str, db: AsyncSession) -> User | None:
         return None
 
     users = await User.handlers.list.core(
-        {"payload": {"filters": {"id": payload["sub"], "is_active": True}}}
+        {
+            "db": db,
+            "payload": {"filters": {"id": payload["sub"], "is_active": True}},
+        }
     )
     return users.items[0] if getattr(users, "items", None) else None
 


### PR DESCRIPTION
## Summary
- attach app-level `engine_ctx` to tigrbl-auth application
- pass DB session through handler context when resolving users from JWTs
- align fastapi dependency tests with handler-based DB access
- keep `engine=dsn` configuration for Tigrbl app initialization

## Testing
- `uv run --package tigrbl-auth --directory standards/tigrbl_auth ruff format .`
- `uv run --package tigrbl-auth --directory standards/tigrbl_auth ruff check . --fix`
- `uv run --package tigrbl-auth --directory standards/tigrbl_auth pytest tests/unit/test_fastapi_deps.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c81371b7148326bc01b2e9c6f303e4