### PR TITLE
Fix custom op_ctx routes missing from REST docs

### DIFF
--- a/pkgs/standards/tigrbl/tests/i9n/test_op_ctx_behavior.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_op_ctx_behavior.py
@@ -165,6 +165,24 @@ def test_op_ctx_openapi_json(sync_db_session):
     assert "post" in spec["paths"]["/widget/ping"]
 
 
+def test_op_ctx_alias_name_mismatch_still_in_docs(sync_db_session):
+    _, get_sync_db = sync_db_session
+
+    class Widget(Base, GUIDPk):
+        __tablename__ = "widgets"
+        __resource__ = "widget"
+        name = Column(String)
+
+        @op_ctx(alias="heartbeat", target="custom", arity="collection")
+        def ping(cls, ctx):  # alias intentionally differs from function name
+            return {}
+
+    app, _ = setup_api(Widget, get_sync_db)
+    spec = app.openapi()
+    assert "/widget/heartbeat" in spec["paths"]
+    assert "post" in spec["paths"]["/widget/heartbeat"]
+
+
 @pytest.mark.i9n
 @pytest.mark.asyncio
 async def test_op_ctx_preserves_canon_schemas(sync_db_session):

--- a/pkgs/standards/tigrbl/tigrbl/bindings/rest/router.py
+++ b/pkgs/standards/tigrbl/tigrbl/bindings/rest/router.py
@@ -274,6 +274,7 @@ def _build_router(
         if (
             sp.alias != sp.target
             and sp.target in CANON
+            and sp.target != "custom"
             and sp.alias != getattr(sp.handler, "__name__", sp.alias)
         ):
             route_kwargs["include_in_schema"] = False


### PR DESCRIPTION
## Summary
- ensure op_ctx operations targeting `custom` remain included in REST docs even when the handler name differs from the alias
- add a regression test that asserts the custom route appears in the generated OpenAPI specification

## Testing
- uv run --directory pkgs/standards/tigrbl --package tigrbl pytest tests/i9n/test_op_ctx_behavior.py::test_op_ctx_alias_name_mismatch_still_in_docs

------
https://chatgpt.com/codex/tasks/task_e_68ccea090c788326893f2eda78283af9