### PR TITLE
Fix op_ctx custom alias REST exposure

### DIFF
--- a/pkgs/standards/tigrbl/tests/i9n/test_op_ctx_behavior.py
+++ b/pkgs/standards/tigrbl/tests/i9n/test_op_ctx_behavior.py
@@ -166,6 +166,25 @@ def test_op_ctx_openapi_json(sync_db_session):
 
 
 @pytest.mark.i9n
+def test_op_ctx_custom_alias_openapi_json(sync_db_session):
+    _, get_sync_db = sync_db_session
+
+    class Widget(Base, GUIDPk):
+        __tablename__ = "widgets"
+        __resource__ = "widget"
+        name = Column(String)
+
+        @op_ctx(alias="custom", target="custom", arity="collection")
+        def custom(cls, ctx):
+            return {}
+
+    app, _ = setup_api(Widget, get_sync_db)
+    spec = app.openapi()
+    assert "/widget/custom" in spec["paths"]
+    assert "post" in spec["paths"]["/widget/custom"]
+
+
+@pytest.mark.i9n
 @pytest.mark.asyncio
 async def test_op_ctx_preserves_canon_schemas(sync_db_session):
     _, get_sync_db = sync_db_session

--- a/pkgs/standards/tigrbl/tigrbl/bindings/rest/routing.py
+++ b/pkgs/standards/tigrbl/tigrbl/bindings/rest/routing.py
@@ -79,9 +79,9 @@ _DEFAULT_METHODS: Dict[str, Tuple[str, ...]] = {
 def _default_path_suffix(sp: OpSpec) -> str | None:
     if sp.target.startswith("bulk_"):
         return None
-    if sp.alias != sp.target and (
-        sp.target in {"create", "custom"} or sp.target not in CANON
-    ):
+    if sp.target == "custom":
+        return f"/{sp.alias}"
+    if sp.alias != sp.target and (sp.target == "create" or sp.target not in CANON):
         return f"/{sp.alias}"
     return None
 


### PR DESCRIPTION
## Summary
- ensure custom op_ctx operations always receive a unique REST path suffix so they appear in OpenAPI docs
- add integration coverage confirming a custom alias targeting `custom` is exposed under /resource/custom

## Testing
- uv run --directory standards/tigrbl --package tigrbl pytest tests/i9n/test_op_ctx_behavior.py::test_op_ctx_custom_alias_openapi_json


------
https://chatgpt.com/codex/tasks/task_e_68ccea090c788326893f2eda78283af9