### PR TITLE
fix(schema): promote schema_ctx classes to pydantic models

### DIFF
--- a/pkgs/standards/tigrbl/tests/unit/test_schema_ctx_plain_class.py
+++ b/pkgs/standards/tigrbl/tests/unit/test_schema_ctx_plain_class.py
@@ -1,0 +1,34 @@
+from tigrbl import Base, schema_ctx
+from tigrbl.orm.mixins import GUIDPk
+from tigrbl.schema import collect_decorated_schemas
+from tigrbl.types import BaseModel
+
+
+def test_schema_ctx_promotes_plain_classes_to_pydantic():
+    collect_decorated_schemas.cache_clear()
+
+    class Widget(Base, GUIDPk):
+        __tablename__ = "plain_widget"
+
+        @schema_ctx(alias="Ping", kind="in")
+        class Ping:
+            message: str | None = None
+            attempts: int = 1
+
+        @schema_ctx(alias="Ping", kind="out")
+        class Pong:
+            ok: bool = True
+
+    mapping = collect_decorated_schemas(Widget)
+    ping_model = mapping["Ping"]["in"]
+    pong_model = mapping["Ping"]["out"]
+
+    assert issubclass(ping_model, BaseModel)
+    assert issubclass(pong_model, BaseModel)
+
+    inst = ping_model()
+    assert inst.attempts == 1
+    assert inst.model_dump() == {"message": None, "attempts": 1}
+
+    out = pong_model()
+    assert out.model_dump() == {"ok": True}

--- a/pkgs/standards/tigrbl/tigrbl/schema/decorators.py
+++ b/pkgs/standards/tigrbl/tigrbl/schema/decorators.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Dict, Optional
+from typing import Any, ClassVar, Dict, Optional, get_type_hints, get_origin
+
+from pydantic import BaseModel, create_model
 
 from ..config.constants import TIGRBL_SCHEMA_DECLS_ATTR
 
@@ -40,6 +42,41 @@ def _register_schema_decl(
     logger.debug("Registered schema %s for alias '%s'", schema_cls, alias)
 
 
+def _ensure_pydantic_model(schema_cls: type) -> type:
+    """Promote plain classes to Pydantic models for schema declarations."""
+
+    if isinstance(schema_cls, type) and issubclass(schema_cls, BaseModel):
+        return schema_cls
+
+    hints = get_type_hints(schema_cls, include_extras=True)
+    fields: Dict[str, tuple[Any, Any]] = {}
+
+    for name, hint in hints.items():
+        if get_origin(hint) is ClassVar:
+            continue
+        default: Any = ...
+        if name in schema_cls.__dict__:
+            default = schema_cls.__dict__[name]
+        fields[name] = (hint, default)
+
+    model = create_model(schema_cls.__name__, __base__=BaseModel, **fields)
+    model.__module__ = getattr(schema_cls, "__module__", model.__module__)
+    model.__qualname__ = getattr(schema_cls, "__qualname__", model.__name__)
+    model.__doc__ = getattr(schema_cls, "__doc__", model.__doc__)
+
+    extra_attrs = {
+        name: value
+        for name, value in schema_cls.__dict__.items()
+        if name not in fields
+        and name not in {"__dict__", "__weakref__", "__annotations__"}
+        and not name.startswith("__")
+    }
+    for name, value in extra_attrs.items():
+        setattr(model, name, value)
+
+    return model
+
+
 def schema_ctx(*, alias: str, kind: str = "out", for_: Optional[type] = None):
     """Register a named schema for a model."""
 
@@ -47,20 +84,23 @@ def schema_ctx(*, alias: str, kind: str = "out", for_: Optional[type] = None):
         if not isinstance(schema_cls, type):
             logger.debug("schema_ctx applied to non-class %r", schema_cls)
             raise TypeError("@schema_ctx must decorate a class")
+        schema_model = _ensure_pydantic_model(schema_cls)
         if for_ is not None:
             logger.debug(
                 "Registering schema %s for model %s via decorator",
-                schema_cls,
+                schema_model,
                 for_.__name__,
             )
-            _register_schema_decl(for_, alias, kind, schema_cls)
+            _register_schema_decl(for_, alias, kind, schema_model)
         setattr(
-            schema_cls, "__tigrbl_schema_decl__", _SchemaDecl(alias=alias, kind=kind)
+            schema_model,
+            "__tigrbl_schema_decl__",
+            _SchemaDecl(alias=alias, kind=kind),
         )
         logger.debug(
-            "Attached schema decl to %s: alias=%s kind=%s", schema_cls, alias, kind
+            "Attached schema decl to %s: alias=%s kind=%s", schema_model, alias, kind
         )
-        return schema_cls
+        return schema_model
 
     return deco
 


### PR DESCRIPTION
## Summary
- promote plain @schema_ctx classes to Pydantic BaseModel instances during registration
- preserve extra attributes and reuse the generated models when binding schemas
- add a regression test confirming that non-BaseModel schema declarations work end-to-end

## Testing
- uv run --directory pkgs/standards/tigrbl --package tigrbl ruff format .
- uv run --directory pkgs/standards/tigrbl --package tigrbl ruff check . --fix
- uv run --directory pkgs/standards/tigrbl --package tigrbl pytest tests/unit/test_schema_ctx_plain_class.py


------
https://chatgpt.com/codex/tasks/task_e_68ccf433570c8326a8ce61ee8cb4bf8e