### PR TITLE
Ensure JWT tests use minimum length HMAC secrets

### DIFF
--- a/pkgs/standards/swarmauri_tokens_jwt/tests/functional/test_jwttokenservice_functional.py
+++ b/pkgs/standards/swarmauri_tokens_jwt/tests/functional/test_jwttokenservice_functional.py
@@ -14,7 +14,7 @@ from swarmauri_core.keys import IKeyProvider
 
 class DummyKeyProvider(IKeyProvider):
     def __init__(self) -> None:
-        self.secret = b"secret"
+        self.secret = b"0123456789abcdef" * 2
         self.kid = "sym"
         self.version = 1
 

--- a/pkgs/standards/swarmauri_tokens_jwt/tests/perf/test_jwttokenservice_perf.py
+++ b/pkgs/standards/swarmauri_tokens_jwt/tests/perf/test_jwttokenservice_perf.py
@@ -15,7 +15,7 @@ from swarmauri_core.keys import IKeyProvider
 
 class DummyKeyProvider(IKeyProvider):
     def __init__(self) -> None:
-        self.secret = b"secret"
+        self.secret = b"0123456789abcdef" * 2
         self.kid = "sym"
         self.version = 1
 

--- a/pkgs/standards/swarmauri_tokens_jwt/tests/unit/test_jwttokenservice_unit.py
+++ b/pkgs/standards/swarmauri_tokens_jwt/tests/unit/test_jwttokenservice_unit.py
@@ -15,7 +15,7 @@ from swarmauri_core.keys import IKeyProvider
 
 class DummyKeyProvider(IKeyProvider):
     def __init__(self) -> None:
-        self.secret = b"secret"
+        self.secret = b"0123456789abcdef" * 2
         self.kid = "sym"
         self.version = 1
 

--- a/pkgs/standards/swarmauri_tokens_jwt/tests/unit/test_rfc7515_jws.py
+++ b/pkgs/standards/swarmauri_tokens_jwt/tests/unit/test_rfc7515_jws.py
@@ -14,7 +14,7 @@ from swarmauri_core.keys import IKeyProvider
 
 class DummyKeyProvider(IKeyProvider):
     def __init__(self) -> None:
-        self.secret = b"secret"
+        self.secret = b"0123456789abcdef" * 2
         self.kid = "sym"
         self.version = 1
 

--- a/pkgs/standards/swarmauri_tokens_jwt/tests/unit/test_rfc7519_jwt.py
+++ b/pkgs/standards/swarmauri_tokens_jwt/tests/unit/test_rfc7519_jwt.py
@@ -13,7 +13,7 @@ from swarmauri_core.keys import IKeyProvider
 
 class DummyKeyProvider(IKeyProvider):
     def __init__(self) -> None:
-        self.secret = b"secret"
+        self.secret = b"0123456789abcdef" * 2
         self.kid = "sym"
         self.version = 1
 

--- a/pkgs/standards/swarmauri_tokens_jwt/tests/unit/test_usage_example.py
+++ b/pkgs/standards/swarmauri_tokens_jwt/tests/unit/test_usage_example.py
@@ -15,7 +15,7 @@ from swarmauri_core.keys import (
 
 class InMemoryKeyProvider(IKeyProvider):
     def __init__(self) -> None:
-        self.secret = b"secret"
+        self.secret = b"0123456789abcdef" * 2
         self.kid = "sym"
         self.version = 1
 


### PR DESCRIPTION
## Summary
- update the in-memory key providers used in JWT token service tests to supply 32-byte HMAC secrets
- keep the sample JWKS material valid under the stricter signing secret length requirement

## Testing
- uv run --package swarmauri_tokens_jwt --directory standards/swarmauri_tokens_jwt pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd3fb3138883268d205710a3665773