### PR TITLE
Support ddl initialize on base facades

### DIFF
--- a/pkgs/standards/tigrbl/tests/unit/test_base_facade_initialize.py
+++ b/pkgs/standards/tigrbl/tests/unit/test_base_facade_initialize.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import Column, Integer
+
+from tigrbl.app._app import App as _App
+from tigrbl.api._api import Api as _Api
+from tigrbl.engine import resolver as _resolver
+from tigrbl.engine.shortcuts import mem
+from tigrbl.table import Base
+
+
+class Widget(Base):
+    __tablename__ = "widgets"
+
+    id = Column(Integer, primary_key=True)
+
+
+class SimpleApp(_App):
+    TITLE = "TestApp"
+    VERSION = "0.0"
+    LIFESPAN = None
+    APIS: tuple = ()
+    MODELS: tuple = ()
+    MIDDLEWARES: tuple = ()
+
+
+class SimpleApi(_Api):
+    PREFIX = ""
+    TAGS: list[str] = []
+
+
+def test_base_app_supports_initialize():
+    app = SimpleApp(engine=mem(async_=False))
+    app.models["Widget"] = Widget
+
+    try:
+        app.initialize()
+    finally:
+        _resolver.set_default(None)
+
+    assert getattr(app, "_ddl_executed", False) is True
+    tables = getattr(app, "tables", None)
+    assert tables is not None
+    assert getattr(tables, "Widget", None) is Widget.__table__
+
+
+def test_base_api_supports_initialize_sync():
+    api = SimpleApi(engine=mem(async_=False))
+    api.models["Widget"] = Widget
+
+    api.initialize()
+
+    assert getattr(api, "_ddl_executed", False) is True
+    assert api.tables["Widget"] is Widget.__table__
+
+
+@pytest.mark.asyncio
+async def test_base_api_supports_initialize_async():
+    class Gadget(Base):
+        __tablename__ = "gadgets"
+
+        id = Column(Integer, primary_key=True)
+
+    api = SimpleApi(engine=mem())
+    api.models["Gadget"] = Gadget
+
+    await api.initialize()
+
+    assert getattr(api, "_ddl_executed", False) is True
+    assert api.tables["Gadget"] is Gadget.__table__

--- a/pkgs/standards/tigrbl/tigrbl/api/_api.py
+++ b/pkgs/standards/tigrbl/tigrbl/api/_api.py
@@ -7,6 +7,7 @@ from ..deps.fastapi import APIRouter as ApiRouter
 from ..engine.engine_spec import EngineCfg
 from ..engine import install_from_objects
 from ..engine import resolver as _resolver
+from ..ddl import initialize as _ddl_initialize
 from ..app._model_registry import initialize_model_registry
 from .api_spec import APISpec
 
@@ -73,3 +74,16 @@ class Api(APISpec, ApiRouter):
                 install_from_objects(app=self, api=a, models=models)
         else:
             install_from_objects(app=self, api=None, models=models)
+
+    def _collect_tables(self) -> list[Any]:
+        """Return the unique SQLAlchemy tables for registered models."""
+        seen: set[Any] = set()
+        tables: list[Any] = []
+        for model in getattr(self, "models", {}).values():
+            table = getattr(model, "__table__", None)
+            if table is not None and table not in seen:
+                seen.add(table)
+                tables.append(table)
+        return tables
+
+    initialize = _ddl_initialize

--- a/pkgs/standards/tigrbl/tigrbl/app/_app.py
+++ b/pkgs/standards/tigrbl/tigrbl/app/_app.py
@@ -6,6 +6,7 @@ from ..deps.fastapi import FastAPI
 from ..engine.engine_spec import EngineCfg
 from ..engine import resolver as _resolver
 from ..engine import install_from_objects
+from ..ddl import initialize as _ddl_initialize
 from .app_spec import AppSpec
 from ._model_registry import initialize_model_registry
 
@@ -61,3 +62,16 @@ class App(AppSpec, FastAPI):
                 install_from_objects(app=self, api=a, models=models)
         else:
             install_from_objects(app=self, api=None, models=models)
+
+    def _collect_tables(self) -> list[Any]:
+        """Return the unique SQLAlchemy tables for registered models."""
+        seen: set[Any] = set()
+        tables: list[Any] = []
+        for model in getattr(self, "models", {}).values():
+            table = getattr(model, "__table__", None)
+            if table is not None and table not in seen:
+                seen.add(table)
+                tables.append(table)
+        return tables
+
+    initialize = _ddl_initialize


### PR DESCRIPTION
## Summary
- expose the ddl initialize helper on the base App and Api facades
- add shared table collection logic so DDL bootstrap works for registered models
- cover the new behavior with sync and async unit tests

## Testing
- uv run --directory standards/tigrbl --package tigrbl pytest tests/unit/test_base_facade_initialize.py

------
https://chatgpt.com/codex/tasks/task_e_68cd3f277b3c8326a8622b656671f114