### PR TITLE
Refactor PoP base architecture and register implementations

### DIFF
--- a/pkgs/base/swarmauri_base/pop/PopSigningBase.py
+++ b/pkgs/base/swarmauri_base/pop/PopSigningBase.py
@@ -1,0 +1,108 @@
+"""Base helpers for proof-of-possession signers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Mapping, Optional
+from uuid import uuid4
+
+from pydantic import ConfigDict, Field, PrivateAttr
+
+from swarmauri_core.pop import (
+    IPoPSigner as IPopSigning,
+    PoPKind,
+    VerifyPolicy,
+)
+from swarmauri_base.ComponentBase import ComponentBase, ResourceTypes
+
+from .util import canon_htm_htu, sha256_b64u
+
+
+@dataclass(frozen=True)
+class RequestContext:
+    method: str
+    htu: str
+    policy: VerifyPolicy
+
+
+@ComponentBase.register_model()
+class PopSigningBase(IPopSigning, ComponentBase):
+    """Common helpers for PoP signers."""
+
+    resource: Optional[str] = Field(default=ResourceTypes.CRYPTO.value, frozen=True)
+    type: str = "PopSigningBase"
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    _kind: PoPKind = PrivateAttr()
+    _header_name: str = PrivateAttr()
+    _include_query: bool = PrivateAttr(default=False)
+
+    def __init__(
+        self,
+        *,
+        kind: PoPKind,
+        header_name: str,
+        include_query: bool = False,
+        **data,
+    ) -> None:
+        super().__init__(**data)
+        self._kind = kind
+        self._header_name = header_name
+        self._include_query = include_query
+
+    @property
+    def kind(self) -> PoPKind:
+        return self._kind
+
+    def header_name(self) -> str:
+        return self._header_name
+
+    def _canon(self, method: str, url: str) -> tuple[str, str]:
+        return canon_htm_htu(method, url, include_query=self._include_query)
+
+    def _now(self) -> int:
+        return int(datetime.now(timezone.utc).timestamp())
+
+    def _new_jti(self) -> str:
+        return uuid4().hex
+
+    def _base_claims(
+        self,
+        method: str,
+        url: str,
+        *,
+        jti: Optional[str],
+        ath_b64u: Optional[str],
+    ) -> dict[str, object]:
+        htm, htu = self._canon(method, url)
+        claims: dict[str, object] = {
+            "htm": htm,
+            "htu": htu,
+            "iat": self._now(),
+            "jti": jti or self._new_jti(),
+        }
+        if ath_b64u is not None:
+            claims["ath"] = ath_b64u
+        return claims
+
+    def _merge_claims(
+        self,
+        base_claims: Mapping[str, object],
+        extra_claims: Mapping[str, object] | None,
+    ) -> dict[str, object]:
+        merged = dict(base_claims)
+        if extra_claims:
+            merged.update(extra_claims)
+        return merged
+
+    def ath_from_token(self, token: bytes | str) -> str:
+        if isinstance(token, str):
+            token_bytes = token.encode("utf-8")
+        else:
+            token_bytes = token
+        return sha256_b64u(token_bytes)
+
+
+# Backwards compatibility alias
+PopSignerBase = PopSigningBase

--- a/pkgs/base/swarmauri_base/pop/PopVerifierMixin.py
+++ b/pkgs/base/swarmauri_base/pop/PopVerifierMixin.py
@@ -1,16 +1,18 @@
+"""Mixin providing shared verification helpers for PoP verifiers."""
+
 from __future__ import annotations
-from dataclasses import dataclass
+
 from datetime import datetime, timezone
 from typing import Iterable, Mapping, Optional
-from uuid import uuid4
+
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 
 from swarmauri_core.pop import (
     BindType,
     CnfBinding,
     Feature,
     HttpParts,
-    IPoPSigner,
-    IPoPVerifier,
+    IPoPVerifier as IPopVerifier,
     KeyResolver,
     PoPBindingError,
     PoPParseError,
@@ -19,83 +21,24 @@ from swarmauri_core.pop import (
     ReplayHooks,
     VerifyPolicy,
 )
+from swarmauri_base import register_model
+from swarmauri_base.ComponentBase import ComponentBase, ResourceTypes
 
+from .PopSigningBase import RequestContext
 from .binding import normalize_cnf
 from .util import canon_htm_htu, sha256_b64u
 
 
-@dataclass(frozen=True)
-class RequestContext:
-    method: str
-    htu: str
-    policy: VerifyPolicy
+@register_model()
+class PopVerifierMixin(BaseModel, IPopVerifier):
+    """Provide default behaviours for IPoPVerifier implementations."""
 
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
-class PopSignerBase(IPoPSigner):
-    """Common helpers for PoP signers."""
-
-    def __init__(
-        self, *, kind: PoPKind, header_name: str, include_query: bool = False
-    ) -> None:
-        self._kind = kind
-        self._header_name = header_name
-        self._include_query = include_query
-
-    @property
-    def kind(self) -> PoPKind:
-        return self._kind
-
-    def header_name(self) -> str:
-        return self._header_name
-
-    def _canon(self, method: str, url: str) -> tuple[str, str]:
-        return canon_htm_htu(method, url, include_query=self._include_query)
-
-    def _now(self) -> int:
-        return int(datetime.now(timezone.utc).timestamp())
-
-    def _new_jti(self) -> str:
-        return uuid4().hex
-
-    def _base_claims(
-        self,
-        method: str,
-        url: str,
-        *,
-        jti: Optional[str],
-        ath_b64u: Optional[str],
-    ) -> dict[str, object]:
-        htm, htu = self._canon(method, url)
-        claims: dict[str, object] = {
-            "htm": htm,
-            "htu": htu,
-            "iat": self._now(),
-            "jti": jti or self._new_jti(),
-        }
-        if ath_b64u is not None:
-            claims["ath"] = ath_b64u
-        return claims
-
-    def _merge_claims(
-        self,
-        base_claims: Mapping[str, object],
-        extra_claims: Mapping[str, object] | None,
-    ) -> dict[str, object]:
-        merged = dict(base_claims)
-        if extra_claims:
-            merged.update(extra_claims)
-        return merged
-
-    def ath_from_token(self, token: bytes | str) -> str:
-        if isinstance(token, str):
-            token_bytes = token.encode("utf-8")
-        else:
-            token_bytes = token
-        return sha256_b64u(token_bytes)
-
-
-class PopVerifierBase(IPoPVerifier):
-    """Base class providing shared verification helpers."""
+    _kind: PoPKind = PrivateAttr()
+    _header_name: str = PrivateAttr()
+    _features: Feature = PrivateAttr()
+    _algorithms: tuple[str, ...] = PrivateAttr()
 
     def __init__(
         self,
@@ -104,7 +47,9 @@ class PopVerifierBase(IPoPVerifier):
         header_name: str,
         features: Feature,
         algorithms: Iterable[str],
+        **data,
     ) -> None:
+        super().__init__(**data)
         self._kind = kind
         self._header_name = header_name
         self._features = features
@@ -173,7 +118,11 @@ class PopVerifierBase(IPoPVerifier):
             raise PoPVerificationError(f"Algorithm {alg} not permitted")
 
     def _enforce_bind_type(
-        self, cnf: CnfBinding, policy: VerifyPolicy, *, expected: BindType | None = None
+        self,
+        cnf: CnfBinding,
+        policy: VerifyPolicy,
+        *,
+        expected: BindType | None = None,
     ) -> None:
         if policy.require_bind and cnf.bind_type is not policy.require_bind:
             raise PoPBindingError(
@@ -236,3 +185,15 @@ class PopVerifierBase(IPoPVerifier):
 
     def _load_cnf(self, cnf_claim: Mapping[str, object]) -> CnfBinding:
         return normalize_cnf(cnf_claim)
+
+
+@ComponentBase.register_model()
+class PopVerifierBase(PopVerifierMixin, ComponentBase):
+    """Component base for PoP verifiers."""
+
+    resource: Optional[str] = Field(default=ResourceTypes.CRYPTO.value, frozen=True)
+    type: str = "PopVerifierBase"
+
+
+# Backwards compatibility alias
+PopVerifier = PopVerifierBase

--- a/pkgs/base/swarmauri_base/pop/__init__.py
+++ b/pkgs/base/swarmauri_base/pop/__init__.py
@@ -1,11 +1,14 @@
 """Base helpers for proof-of-possession implementations."""
 
-from .base import PopSignerBase, PopVerifierBase, RequestContext
+from .PopSigningBase import PopSigningBase, PopSignerBase, RequestContext
+from .PopVerifierMixin import PopVerifierBase, PopVerifierMixin
 from .binding import make_cnf_cose, make_cnf_jkt, make_cnf_x5t, normalize_cnf
 from .util import canon_htm_htu, sha256_b64u
 
 __all__ = [
+    "PopSigningBase",
     "PopSignerBase",
+    "PopVerifierMixin",
     "PopVerifierBase",
     "RequestContext",
     "canon_htm_htu",

--- a/pkgs/standards/swarmauri_pop_cwt/swarmauri_pop_cwt/cwt.py
+++ b/pkgs/standards/swarmauri_pop_cwt/swarmauri_pop_cwt/cwt.py
@@ -30,8 +30,9 @@ from swarmauri_core.pop import (
     PoPVerificationError,
     PoPKind,
 )
+from swarmauri_base.ComponentBase import ComponentBase
 from swarmauri_base.pop import (
-    PopSignerBase,
+    PopSigningBase,
     PopVerifierBase,
     RequestContext,
     sha256_b64u,
@@ -82,6 +83,7 @@ def _alg_name(alg_obj: SignatureAlg) -> str:
     return alg_obj.name if hasattr(alg_obj, "name") else str(alg_obj)
 
 
+@ComponentBase.register_type(PopVerifierBase, "CwtPoPVerifier")
 class CwtPoPVerifier(PopVerifierBase):
     """Verifier for COSE Sign1-based PoP proofs."""
 
@@ -186,7 +188,8 @@ class CwtPoPVerifier(PopVerifierBase):
         )
 
 
-class CwtPoPSigner(PopSignerBase):
+@ComponentBase.register_type(PopSigningBase, "CwtPoPSigner")
+class CwtPoPSigner(PopSigningBase):
     """Signer that emits COSE Sign1 PoP proofs."""
 
     def __init__(

--- a/pkgs/standards/swarmauri_pop_dpop/swarmauri_pop_dpop/dpop.py
+++ b/pkgs/standards/swarmauri_pop_dpop/swarmauri_pop_dpop/dpop.py
@@ -16,8 +16,9 @@ from swarmauri_core.pop import (
     PoPVerificationError,
     PoPKind,
 )
+from swarmauri_base.ComponentBase import ComponentBase
 from swarmauri_base.pop import (
-    PopSignerBase,
+    PopSigningBase,
     PopVerifierBase,
     RequestContext,
     sha256_b64u,
@@ -51,6 +52,7 @@ def _resolve_kid(kid: Optional[str]) -> Optional[bytes]:
     return kid.encode("utf-8")
 
 
+@ComponentBase.register_type(PopVerifierBase, "DPoPVerifier")
 class DPoPVerifier(PopVerifierBase):
     """Verifier for RFC 9449 DPoP proofs."""
 
@@ -164,7 +166,8 @@ class DPoPVerifier(PopVerifierBase):
         )
 
 
-class DPoPSigner(PopSignerBase):
+@ComponentBase.register_type(PopSigningBase, "DPoPSigner")
+class DPoPSigner(PopSigningBase):
     """Signer that emits `dpop+jwt` proofs."""
 
     def __init__(

--- a/pkgs/standards/swarmauri_pop_x509/swarmauri_pop_x509/x509.py
+++ b/pkgs/standards/swarmauri_pop_x509/swarmauri_pop_x509/x509.py
@@ -10,9 +10,11 @@ from swarmauri_core.pop import (
     PoPParseError,
     PoPKind,
 )
+from swarmauri_base.ComponentBase import ComponentBase
 from swarmauri_base.pop import PopVerifierBase, RequestContext, sha256_b64u
 
 
+@ComponentBase.register_type(PopVerifierBase, "X509PoPVerifier")
 class X509PoPVerifier(PopVerifierBase):
     """Verifier for TLS client-certificate proof-of-possession."""
 


### PR DESCRIPTION
## Summary
- add a ComponentBase-backed `PopSigningBase` to replace the old PoP signer helper and keep the request context dataclass
- introduce a `PopVerifierMixin` plus `PopVerifierBase` component and re-export the new helpers for consumers
- update the DPoP, CWT, and X509 PoP implementations to use the new bases and register themselves with `register_type`

## Testing
- uv run --package swarmauri_base --directory swarmauri_base ruff check . --fix
- uv run --package swarmauri_pop_dpop --directory swarmauri_pop_dpop ruff check . --fix
- uv run --package swarmauri_pop_cwt --directory swarmauri_pop_cwt ruff check . --fix
- uv run --package swarmauri_pop_x509 --directory swarmauri_pop_x509 ruff check . --fix


------
https://chatgpt.com/codex/tasks/task_e_68daf489e35883268820fe0a82434514