### PR TITLE
feat: extend signing interface and add SignerNameTBD plugin

### DIFF
--- a/pkgs/base/swarmauri_base/signing/SigningBase.py
+++ b/pkgs/base/swarmauri_base/signing/SigningBase.py
@@ -2,14 +2,40 @@
 
 from __future__ import annotations
 
-from typing import Iterable, Mapping, Optional, Sequence
+from collections.abc import AsyncIterable, Iterable
+from typing import Mapping, Optional, Sequence
 
 from pydantic import Field
 
-from swarmauri_core.signing.ISigning import ISigning, Canon, Envelope
+from swarmauri_core.signing.ISigning import ISigning, Canon, Envelope, ByteStream
 from swarmauri_core.signing.types import Signature
 from swarmauri_core.crypto.types import Alg, KeyRef
 from swarmauri_base.ComponentBase import ComponentBase, ResourceTypes
+
+
+async def _stream_to_bytes(stream: ByteStream) -> bytes:
+    """Collect a synchronous or asynchronous byte stream into a single buffer."""
+
+    if isinstance(stream, (bytes, bytearray)):
+        return bytes(stream)
+
+    chunks = bytearray()
+
+    if isinstance(stream, AsyncIterable):
+        async for chunk in stream:
+            if not isinstance(chunk, (bytes, bytearray)):
+                raise TypeError("Stream yielded non-bytes chunk")
+            chunks.extend(chunk)
+        return bytes(chunks)
+
+    if isinstance(stream, Iterable):
+        for chunk in stream:
+            if not isinstance(chunk, (bytes, bytearray)):
+                raise TypeError("Stream yielded non-bytes chunk")
+            chunks.extend(chunk)
+        return bytes(chunks)
+
+    raise TypeError("Unsupported stream type; expected bytes or iterable of bytes")
 
 
 @ComponentBase.register_model()
@@ -35,6 +61,17 @@ class SigningBase(ISigning, ComponentBase):
         raise NotImplementedError("sign_bytes() must be implemented by subclass")
 
     # ------------------------------------------------------------------
+    async def sign_digest(
+        self,
+        key: KeyRef,
+        digest: bytes,
+        *,
+        alg: Optional[Alg] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> Sequence[Signature]:
+        return await self.sign_bytes(key, digest, alg=alg, opts=opts)
+
+    # ------------------------------------------------------------------
     async def verify_bytes(
         self,
         payload: bytes,
@@ -44,6 +81,41 @@ class SigningBase(ISigning, ComponentBase):
         opts: Optional[Mapping[str, object]] = None,
     ) -> bool:
         raise NotImplementedError("verify_bytes() must be implemented by subclass")
+
+    # ------------------------------------------------------------------
+    async def verify_digest(
+        self,
+        digest: bytes,
+        signatures: Sequence[Signature],
+        *,
+        require: Optional[Mapping[str, object]] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bool:
+        return await self.verify_bytes(digest, signatures, require=require, opts=opts)
+
+    # ------------------------------------------------------------------
+    async def sign_stream(
+        self,
+        key: KeyRef,
+        payload: ByteStream,
+        *,
+        alg: Optional[Alg] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> Sequence[Signature]:
+        data = await _stream_to_bytes(payload)
+        return await self.sign_bytes(key, data, alg=alg, opts=opts)
+
+    # ------------------------------------------------------------------
+    async def verify_stream(
+        self,
+        payload: ByteStream,
+        signatures: Sequence[Signature],
+        *,
+        require: Optional[Mapping[str, object]] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bool:
+        data = await _stream_to_bytes(payload)
+        return await self.verify_bytes(data, signatures, require=require, opts=opts)
 
     # ------------------------------------------------------------------
     async def canonicalize_envelope(

--- a/pkgs/core/swarmauri_core/signing/__init__.py
+++ b/pkgs/core/swarmauri_core/signing/__init__.py
@@ -1,6 +1,6 @@
 """Signing interfaces and types."""
 
-from .ISigning import ISigning, Canon, Envelope
+from .ISigning import ISigning, Canon, Envelope, ByteStream
 from .types import Signature
 
-__all__ = ["ISigning", "Canon", "Envelope", "Signature"]
+__all__ = ["ISigning", "Canon", "Envelope", "ByteStream", "Signature"]

--- a/pkgs/plugins/SignerNameTBD/README.md
+++ b/pkgs/plugins/SignerNameTBD/README.md
@@ -1,0 +1,74 @@
+# SignerNameTBD Plugin
+
+![Swarmauri brand theme](../../../assets/swarmauri.brand.theme.svg)
+
+[![License: Apache-2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](../..)
+[![Python Versions](https://img.shields.io/badge/python-3.10%20%E2%80%93%203.12-3776AB.svg)](https://www.python.org/)
+[![uv Enabled](https://img.shields.io/badge/uv-ready-8A2BE2.svg)](https://github.com/astral-sh/uv)
+
+## Overview
+
+`SignerNameTBD` packages a composite [`ISigning`](../../base/README.md) implementation that can
+route signing and verification requests to one or more concrete Swarmauri signers. It is intended to
+act as a lightweight compatibility layer when you need to federate algorithms, or when you want a
+single interface that can gracefully fall back to the first available signer in your environment.
+The plugin registers a `Signer` component that understands the extended signing surface (bytes,
+digests, envelopes, and streams) introduced by the Swarmauri core interfaces.
+
+## Installation
+
+The project ships with extras that pull in common signer implementations for CMS, JWS, OpenPGP, and
+PAdES scenarios. Choose the path that matches your tooling preferences:
+
+### Using `uv`
+
+```bash
+uv add swm-signernametbd[cms]
+```
+
+The example above installs the plugin alongside the CMS-focused signers. Swap `cms` for `jws`,
+`openpgp`, or `pades` (or combine them, e.g. `uv add swm-signernametbd[cms,jws]`) to tailor the set
+of dependencies. If you only need the aggregator surface, omit the extras entirely: `uv add
+swm-signernametbd`.
+
+### Using `pip`
+
+```bash
+pip install "swm-signernametbd[openpgp]"
+```
+
+`pip` consumers can request the same extras. The quoted form ensures shells do not interpret the
+brackets. Installing without extras keeps the footprint minimal while still exposing the aggregated
+signing interface.
+
+## Usage
+
+```python
+from swarmauri_core.signing import ISigning
+from swarmauri_base.signing.SigningBase import SigningBase
+from SignerNameTBD.Signer import Signer
+
+from swarmauri_signing_ed25519 import Ed25519EnvelopeSigner
+from swarmauri_signing_hmac import HmacEnvelopeSigner
+
+# Instantiate the concrete providers you want to delegate to.
+ed25519 = Ed25519EnvelopeSigner()
+hmac = HmacEnvelopeSigner()
+
+# The aggregator discovers capabilities from ``supports()``.
+composite = Signer(providers=[ed25519, hmac], default_alg="Ed25519")
+
+payload = b"example"
+keyref = {"kind": "raw_ed25519_sk", "bytes": b"\x00" * 32}
+
+signatures = await composite.sign_bytes(keyref, payload)
+assert await composite.verify_bytes(payload, signatures)
+```
+
+The `Signer` evaluates every registered provider's `supports()` declaration to decide how to handle
+incoming requests. When the caller specifies an `alg` parameter the matching provider is selected;
+otherwise, the aggregator falls back to the configured `default_alg` or the sole registered
+implementation. Stream inputs are buffered automatically, allowing existing byte-oriented signers to
+participate without additional code. Because the composite preserves each provider's feature flags
+you can still introspect capabilities (for example, which canonicalization formats are available) by
+calling `Signer.supports()`.

--- a/pkgs/plugins/SignerNameTBD/SignerNameTBD/Signer.py
+++ b/pkgs/plugins/SignerNameTBD/SignerNameTBD/Signer.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any, Optional
+
+from pydantic import PrivateAttr
+
+from swarmauri_base.signing.SigningBase import SigningBase
+from swarmauri_core.crypto.types import Alg, KeyRef
+from swarmauri_core.signing import Canon, Envelope, ISigning
+from swarmauri_core.signing.types import Signature
+
+DEFAULT_OPS = ("bytes", "digest", "envelope", "stream")
+
+
+class Signer(SigningBase):
+    """Aggregate multiple :class:`ISigning` providers behind a single interface."""
+
+    type: str = "Signer"
+
+    _providers: list[ISigning] = PrivateAttr(default_factory=list)
+    _providers_without_alg: list[ISigning] = PrivateAttr(default_factory=list)
+    _alg_index: dict[str, ISigning] = PrivateAttr(default_factory=dict)
+    _alg_tokens: dict[str, Any] = PrivateAttr(default_factory=dict)
+    _default_alg_token: Optional[str] = PrivateAttr(default=None)
+
+    def __init__(
+        self,
+        *,
+        providers: Optional[Iterable[ISigning]] = None,
+        default_alg: Optional[Alg] = None,
+        **data: Any,
+    ) -> None:
+        super().__init__(**data)
+        self._default_alg_token = self._normalize_alg_token(default_alg)
+        if providers:
+            for provider in providers:
+                self.add_provider(provider)
+
+    # ------------------------------------------------------------------
+    def add_provider(self, provider: ISigning) -> None:
+        """Register an :class:`ISigning` implementation with the aggregator."""
+
+        if provider in self._providers:
+            return
+
+        self._providers.append(provider)
+        caps = provider.supports() or {}
+        algs = caps.get("algs", ()) or ()
+        added_alg = False
+        for alg in algs:
+            normalized = self._normalize_alg_token(alg)
+            if normalized is None:
+                continue
+            self._alg_index[normalized] = provider
+            self._alg_tokens[normalized] = alg
+            added_alg = True
+        if not added_alg:
+            self._providers_without_alg.append(provider)
+
+    # ------------------------------------------------------------------
+    def providers(self) -> Sequence[ISigning]:
+        """Return the registered providers in insertion order."""
+
+        return tuple(self._providers)
+
+    # ------------------------------------------------------------------
+    def supports(self) -> Mapping[str, Iterable[str]]:
+        algs: list[Any] = []
+        canons: list[str] = []
+        signs: list[str] = []
+        verifies: list[str] = []
+        envelopes: list[str] = []
+        features: list[str] = []
+
+        for provider in self._providers or self._providers_without_alg:
+            caps = provider.supports() or {}
+            self._extend_unique(algs, caps.get("algs", ()))
+            self._extend_unique(canons, caps.get("canons", ()))
+            self._extend_unique(signs, caps.get("signs", DEFAULT_OPS))
+            self._extend_unique(verifies, caps.get("verifies", DEFAULT_OPS))
+            self._extend_unique(envelopes, caps.get("envelopes", ()))
+            self._extend_unique(features, caps.get("features", ()))
+
+        return {
+            "algs": tuple(algs),
+            "canons": tuple(canons),
+            "signs": tuple(signs or DEFAULT_OPS),
+            "verifies": tuple(verifies or DEFAULT_OPS),
+            "envelopes": tuple(envelopes),
+            "features": tuple(features),
+        }
+
+    # ------------------------------------------------------------------
+    async def canonicalize_envelope(
+        self,
+        env: Envelope,
+        *,
+        canon: Optional[Canon] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bytes:
+        provider = self._provider_for_canon(canon)
+        return await provider.canonicalize_envelope(env, canon=canon, opts=opts)
+
+    # ------------------------------------------------------------------
+    async def sign_bytes(
+        self,
+        key: KeyRef,
+        payload: bytes,
+        *,
+        alg: Optional[Alg] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> Sequence[Signature]:
+        provider, resolved_alg = self._provider_for_alg(alg)
+        return await provider.sign_bytes(
+            key, payload, alg=resolved_alg or alg, opts=opts
+        )
+
+    # ------------------------------------------------------------------
+    async def sign_digest(
+        self,
+        key: KeyRef,
+        digest: bytes,
+        *,
+        alg: Optional[Alg] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> Sequence[Signature]:
+        provider, resolved_alg = self._provider_for_alg(alg)
+        return await provider.sign_digest(
+            key, digest, alg=resolved_alg or alg, opts=opts
+        )
+
+    # ------------------------------------------------------------------
+    async def sign_envelope(
+        self,
+        key: KeyRef,
+        env: Envelope,
+        *,
+        alg: Optional[Alg] = None,
+        canon: Optional[Canon] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> Sequence[Signature]:
+        provider, resolved_alg = self._provider_for_alg(alg)
+        return await provider.sign_envelope(
+            key,
+            env,
+            alg=resolved_alg or alg,
+            canon=canon,
+            opts=opts,
+        )
+
+    # ------------------------------------------------------------------
+    async def verify_bytes(
+        self,
+        payload: bytes,
+        signatures: Sequence[Signature],
+        *,
+        require: Optional[Mapping[str, object]] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bool:
+        providers = self._providers_for_verification(signatures, require)
+        if not providers:
+            raise ValueError("Signer has no providers available for verification")
+
+        verified = False
+        for provider in providers:
+            if not await provider.verify_bytes(
+                payload, signatures, require=require, opts=opts
+            ):
+                return False
+            verified = True
+        return verified
+
+    # ------------------------------------------------------------------
+    async def verify_digest(
+        self,
+        digest: bytes,
+        signatures: Sequence[Signature],
+        *,
+        require: Optional[Mapping[str, object]] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bool:
+        providers = self._providers_for_verification(signatures, require)
+        if not providers:
+            raise ValueError("Signer has no providers available for verification")
+
+        verified = False
+        for provider in providers:
+            if not await provider.verify_digest(
+                digest, signatures, require=require, opts=opts
+            ):
+                return False
+            verified = True
+        return verified
+
+    # ------------------------------------------------------------------
+    async def verify_envelope(
+        self,
+        env: Envelope,
+        signatures: Sequence[Signature],
+        *,
+        canon: Optional[Canon] = None,
+        require: Optional[Mapping[str, object]] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bool:
+        providers = self._providers_for_verification(signatures, require)
+        if not providers:
+            raise ValueError("Signer has no providers available for verification")
+
+        verified = False
+        for provider in providers:
+            if not await provider.verify_envelope(
+                env,
+                signatures,
+                canon=canon,
+                require=require,
+                opts=opts,
+            ):
+                return False
+            verified = True
+        return verified
+
+    # ------------------------------------------------------------------
+    def _provider_for_canon(self, canon: Optional[Canon]) -> ISigning:
+        if canon is not None:
+            for provider in self._providers:
+                caps = provider.supports() or {}
+                if canon in tuple(caps.get("canons", ())):
+                    return provider
+        if self._providers:
+            return self._providers[0]
+        if self._providers_without_alg:
+            return self._providers_without_alg[0]
+        raise ValueError("Signer has no registered providers")
+
+    # ------------------------------------------------------------------
+    def _provider_for_alg(self, alg: Optional[Alg]) -> tuple[ISigning, Optional[Any]]:
+        if alg is not None:
+            normalized = self._normalize_alg_token(alg)
+            if normalized and normalized in self._alg_index:
+                return self._alg_index[normalized], self._alg_tokens.get(
+                    normalized, alg
+                )
+            raise ValueError(f"No provider registered for algorithm '{alg}'")
+
+        if self._default_alg_token and self._default_alg_token in self._alg_index:
+            provider = self._alg_index[self._default_alg_token]
+            return provider, self._alg_tokens.get(self._default_alg_token)
+
+        if len(self._providers) == 1:
+            provider = self._providers[0]
+            alg_choice = next(iter(provider.supports().get("algs", ())), None)
+            return provider, alg_choice
+
+        if self._providers_without_alg:
+            return self._providers_without_alg[0], None
+
+        if self._providers:
+            provider = self._providers[0]
+            alg_choice = next(iter(provider.supports().get("algs", ())), None)
+            return provider, alg_choice
+
+        raise ValueError("Signer has no registered providers")
+
+    # ------------------------------------------------------------------
+    def _providers_for_verification(
+        self,
+        signatures: Sequence[Signature],
+        require: Optional[Mapping[str, object]],
+    ) -> list[ISigning]:
+        required_tokens: list[str] = []
+
+        if require and require.get("algs"):
+            for token in require["algs"]:  # type: ignore[index]
+                normalized = self._normalize_alg_token(token)
+                if normalized is not None:
+                    required_tokens.append(normalized)
+
+        for sig in signatures:
+            normalized = self._normalize_alg_token(sig.get("alg"))
+            if normalized is not None:
+                required_tokens.append(normalized)
+
+        providers: list[ISigning] = []
+        for token in required_tokens:
+            provider = self._alg_index.get(token)
+            if provider and provider not in providers:
+                providers.append(provider)
+
+        if not providers:
+            providers.extend(self._providers)
+        if not providers:
+            providers.extend(self._providers_without_alg)
+
+        return providers
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _extend_unique(target: list, values: Iterable[Any]) -> None:
+        for value in values:
+            if value not in target:
+                target.append(value)
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _normalize_alg_token(token: Any) -> Optional[str]:
+        if token is None:
+            return None
+        if hasattr(token, "value"):
+            token = getattr(token, "value")
+        return str(token)

--- a/pkgs/plugins/SignerNameTBD/SignerNameTBD/__init__.py
+++ b/pkgs/plugins/SignerNameTBD/SignerNameTBD/__init__.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from importlib import metadata
+from pathlib import Path
+
+import tomllib
+
+PACKAGE_NAME = "swm-signernametbd"
+
+try:
+    __version__ = metadata.version(PACKAGE_NAME)
+except metadata.PackageNotFoundError:  # pragma: no cover
+    pyproject_path = Path(__file__).resolve().parent.parent / "pyproject.toml"
+    with pyproject_path.open("rb") as fh:
+        __version__ = tomllib.load(fh)["project"]["version"]
+
+__all__ = ["__version__"]

--- a/pkgs/plugins/SignerNameTBD/pyproject.toml
+++ b/pkgs/plugins/SignerNameTBD/pyproject.toml
@@ -1,0 +1,53 @@
+[project]
+name = "swm-signernametbd"
+version = "0.1.0.dev0"
+description = "Composite signer aggregator for Swarmauri"
+readme = { file = "README.md", content-type = "text/markdown" }
+license = "Apache-2.0"
+requires-python = ">=3.10,<3.13"
+authors = [{ name = "Swarmauri Contributors", email = "oss@swarmauri.com" }]
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+dependencies = []
+
+[project.optional-dependencies]
+cms = ["swarmauri_signing_ca", "swarmauri_cipher_suite_cades"]
+jws = ["swarmauri_signing_jws", "swarmauri_cipher_suite_jws"]
+openpgp = ["swarmauri_signing_pgp"]
+pades = ["swarmauri_signing_rsa", "swarmauri_cipher_suite_pades"]
+
+[project.entry-points.'swarmauri.signings']
+SignerNameTBD = "SignerNameTBD.Signer:Signer"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "python-dotenv>=1.0.0",
+    "requests>=2.32.3",
+    "ruff>=0.9.9",
+]
+
+[tool.pytest.ini_options]
+norecursedirs = ["combined", "scripts"]
+markers = [
+    "test: standard test",
+    "unit: Unit tests",
+    "integration: Integration tests",
+    "acceptance: Acceptance tests",
+]
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/pkgs/plugins/SignerNameTBD/swm_signernametbd/__init__.py
+++ b/pkgs/plugins/SignerNameTBD/swm_signernametbd/__init__.py
@@ -1,0 +1,5 @@
+"""Compatibility module exposing the Signer aggregator."""
+
+from SignerNameTBD.Signer import Signer
+
+__all__ = ["Signer"]

--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -233,7 +233,8 @@ members = [
     "community/swarmauri_certservice_gcpkms",
     "standards/swarmauri_tool_githubloader",
     "standards/swarmauri_toolkit_containertoolkit",
-    "experimental/swarmauri_workflow_statedriven"
+    "experimental/swarmauri_workflow_statedriven",
+    "plugins/SignerNameTBD"
 
 ]
 
@@ -246,6 +247,9 @@ typing = { workspace = true }
 cayaml = { workspace = true }
 catoml = { workspace = true }
 jaml = { workspace = true }
+
+
+"swm-signernametbd" = { workspace = true }
 
 
 swarmauri_vectorstore_doc2vec = { workspace = true }
@@ -339,6 +343,9 @@ swarmauri_tokens_sshcert = { workspace = true }
 swarmauri_signing_pgp = { workspace = true }
 swarmauri_signing_rsa = { workspace = true }
 swarmauri_signing_ssh = { workspace = true }
+swarmauri_cipher_suite_cades = { workspace = true }
+swarmauri_cipher_suite_jws = { workspace = true }
+swarmauri_cipher_suite_pades = { workspace = true }
 swarmauri_certs_x509verify = { workspace = true }
 
 swarmauri_tokens_introspection = { workspace = true }

--- a/pkgs/standards/swarmauri_signing_ca/swarmauri_signing_ca/CASigner.py
+++ b/pkgs/standards/swarmauri_signing_ca/swarmauri_signing_ca/CASigner.py
@@ -248,6 +248,9 @@ class CASigner(SigningBase):
                 "RS256",
             ),
             "canons": ("json",),
+            "signs": ("bytes", "digest", "envelope", "stream"),
+            "verifies": ("bytes", "digest", "envelope", "stream"),
+            "envelopes": ("mapping",),
             "features": ("multi", "detached_only", "x509"),
         }
 

--- a/pkgs/standards/swarmauri_signing_dpop/swarmauri_signing_dpop/DpopSigner.py
+++ b/pkgs/standards/swarmauri_signing_dpop/swarmauri_signing_dpop/DpopSigner.py
@@ -207,6 +207,9 @@ class DpopSigner(SigningBase):
         return {
             "algs": tuple(sorted(a.value for a in _ALLOWED_ALGS)),
             "canons": ("raw", "json"),
+            "signs": ("bytes", "digest", "envelope", "stream"),
+            "verifies": ("bytes", "digest", "envelope", "stream"),
+            "envelopes": ("raw", "mapping"),
             "features": ("detached_only",),
         }
 

--- a/pkgs/standards/swarmauri_signing_ecdsa/swarmauri_signing_ecdsa/EcdsaEnvelopeSigner.py
+++ b/pkgs/standards/swarmauri_signing_ecdsa/swarmauri_signing_ecdsa/EcdsaEnvelopeSigner.py
@@ -186,7 +186,14 @@ class EcdsaEnvelopeSigner(SigningBase):
     def supports(self) -> Mapping[str, Iterable[str]]:
         algs = tuple(_EC_ALGS.keys()) + tuple(_ALIAS.keys())
         canons = ("json", "cbor") if _CBOR_OK else ("json",)
-        return {"algs": algs, "canons": canons, "features": ("multi", "detached_only")}
+        return {
+            "algs": algs,
+            "canons": canons,
+            "signs": ("bytes", "digest", "envelope", "stream"),
+            "verifies": ("bytes", "digest", "envelope", "stream"),
+            "envelopes": ("mapping",),
+            "features": ("multi", "detached_only"),
+        }
 
     async def sign_bytes(
         self,

--- a/pkgs/standards/swarmauri_signing_ed25519/swarmauri_signing_ed25519/Ed25519EnvelopeSigner.py
+++ b/pkgs/standards/swarmauri_signing_ed25519/swarmauri_signing_ed25519/Ed25519EnvelopeSigner.py
@@ -108,7 +108,14 @@ class Ed25519EnvelopeSigner(SigningBase):
     def supports(self) -> Mapping[str, Iterable[str]]:
         algs = ("Ed25519",)
         canons = ("json", "cbor") if _CBOR_OK else ("json",)
-        return {"algs": algs, "canons": canons, "features": ("multi", "detached_only")}
+        return {
+            "algs": algs,
+            "canons": canons,
+            "signs": ("bytes", "digest", "envelope", "stream"),
+            "verifies": ("bytes", "digest", "envelope", "stream"),
+            "envelopes": ("mapping",),
+            "features": ("multi", "detached_only"),
+        }
 
     # ------------------------------------------------------------------
     async def sign_bytes(

--- a/pkgs/standards/swarmauri_signing_hmac/swarmauri_signing_hmac/HmacEnvelopeSigner.py
+++ b/pkgs/standards/swarmauri_signing_hmac/swarmauri_signing_hmac/HmacEnvelopeSigner.py
@@ -137,6 +137,9 @@ class HmacEnvelopeSigner(SigningBase):
         return {
             "algs": (JWAAlg.HS256, JWAAlg.HS384, JWAAlg.HS512),
             "canons": canons,
+            "signs": ("bytes", "digest", "envelope", "stream"),
+            "verifies": ("bytes", "digest", "envelope", "stream"),
+            "envelopes": ("mapping",),
             "features": ("multi", "detached_only"),
         }
 

--- a/pkgs/standards/swarmauri_signing_pgp/swarmauri_signing_pgp/pgp_signer.py
+++ b/pkgs/standards/swarmauri_signing_pgp/swarmauri_signing_pgp/pgp_signer.py
@@ -132,6 +132,9 @@ class PgpEnvelopeSigner(SigningBase):
         return {
             "algs": ("OpenPGP",),
             "canons": canons,
+            "signs": ("bytes", "digest", "envelope", "stream"),
+            "verifies": ("bytes", "digest", "envelope", "stream"),
+            "envelopes": ("mapping",),
             "features": ("multi", "detached_only"),
         }
 

--- a/pkgs/standards/swarmauri_signing_rsa/swarmauri_signing_rsa/RSAEnvelopeSigner.py
+++ b/pkgs/standards/swarmauri_signing_rsa/swarmauri_signing_rsa/RSAEnvelopeSigner.py
@@ -244,7 +244,14 @@ class RSAEnvelopeSigner(SigningBase):
     def supports(self) -> Mapping[str, Iterable[str]]:
         algs = ("RSA-PSS-SHA256", "RS256")
         canons = ("json", "cbor") if _CBOR_OK else ("json",)
-        return {"algs": algs, "canons": canons, "features": ("multi", "detached_only")}
+        return {
+            "algs": algs,
+            "canons": canons,
+            "signs": ("bytes", "digest", "envelope", "stream"),
+            "verifies": ("bytes", "digest", "envelope", "stream"),
+            "envelopes": ("mapping",),
+            "features": ("multi", "detached_only"),
+        }
 
     async def sign_bytes(
         self,

--- a/pkgs/standards/swarmauri_signing_secp256k1/swarmauri_signing_secp256k1/Secp256k1EnvelopeSigner.py
+++ b/pkgs/standards/swarmauri_signing_secp256k1/swarmauri_signing_secp256k1/Secp256k1EnvelopeSigner.py
@@ -296,7 +296,14 @@ class Secp256k1EnvelopeSigner(ISigning):
     def supports(self) -> Mapping[str, Iterable[str]]:
         algs = ("ES256K", "ECDSA-SHA256")
         canons = ("json", "cbor") if _CBOR_OK else ("json",)
-        return {"algs": algs, "canons": canons, "features": ("multi", "detached_only")}
+        return {
+            "algs": algs,
+            "canons": canons,
+            "signs": ("bytes", "digest", "envelope", "stream"),
+            "verifies": ("bytes", "digest", "envelope", "stream"),
+            "envelopes": ("mapping",),
+            "features": ("multi", "detached_only"),
+        }
 
     # ── bytes ────────────────────────────────────────────────────────────────
 

--- a/pkgs/standards/swarmauri_signing_ssh/swarmauri_signing_ssh/SshEnvelopeSigner.py
+++ b/pkgs/standards/swarmauri_signing_ssh/swarmauri_signing_ssh/SshEnvelopeSigner.py
@@ -206,7 +206,14 @@ class SshEnvelopeSigner(SigningBase):
             "ecdsa-sha2-nistp384",
             "ecdsa-sha2-nistp521",
         )
-        return {"algs": algs, "canons": canons, "features": ("multi", "detached_only")}
+        return {
+            "algs": algs,
+            "canons": canons,
+            "signs": ("bytes", "digest", "envelope", "stream"),
+            "verifies": ("bytes", "digest", "envelope", "stream"),
+            "envelopes": ("mapping",),
+            "features": ("multi", "detached_only"),
+        }
 
     async def sign_bytes(
         self,


### PR DESCRIPTION
## Summary
- extend `ISigning` with digest and stream helpers and publish the new `ByteStream` alias alongside richer capability metadata
- add the SignerNameTBD plugin with a composite `Signer`, packaging metadata, and user-facing README content and extras
- update signing providers and workspace configuration so `supports()` enumerates supported operations and the plugin participates in the workspace

## Testing
- `uv run --directory core --package swarmauri_core ruff check . --fix`
- `uv run --directory base --package swarmauri_base ruff check . --fix`
- `uv run --directory standards/swarmauri_signing_ed25519 --package swarmauri_signing_ed25519 ruff check . --fix`
- `uv run --directory standards/swarmauri_signing_secp256k1 --package swarmauri_signing_secp256k1 ruff check . --fix`
- `uv run --directory standards/swarmauri_signing_hmac --package swarmauri_signing_hmac ruff check . --fix`
- `uv run --directory standards/swarmauri_signing_ecdsa --package swarmauri_signing_ecdsa ruff check . --fix`
- `uv run --directory standards/swarmauri_signing_rsa --package swarmauri_signing_rsa ruff check . --fix`
- `uv run --directory standards/swarmauri_signing_ssh --package swarmauri_signing_ssh ruff check . --fix`
- `uv run --directory standards/swarmauri_signing_pgp --package swarmauri_signing_pgp ruff check . --fix`
- `uv run --directory standards/swarmauri_signing_dpop --package swarmauri_signing_dpop ruff check . --fix`
- `uv run --directory standards/swarmauri_signing_ca --package swarmauri_signing_ca ruff check . --fix`
- `uv run --directory plugins/SignerNameTBD --package swm-signernametbd ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68dafbcc67a8832695631cce5d3a38e2