### PR TITLE
Refactor signing facade into plugin package

### DIFF
--- a/pkgs/base/swarmauri_base/signing/SigningBase.py
+++ b/pkgs/base/swarmauri_base/signing/SigningBase.py
@@ -6,7 +6,7 @@ from typing import Iterable, Mapping, Optional, Sequence
 
 from pydantic import Field
 
-from swarmauri_core.signing.ISigning import ISigning, Canon, Envelope
+from swarmauri_core.signing.ISigning import ByteStream, Canon, Envelope, ISigning
 from swarmauri_core.signing.types import Signature
 from swarmauri_core.crypto.types import Alg, KeyRef
 from swarmauri_base.ComponentBase import ComponentBase, ResourceTypes
@@ -20,7 +20,7 @@ class SigningBase(ISigning, ComponentBase):
     type: str = "SigningBase"
 
     # ------------------------------------------------------------------
-    def supports(self) -> Mapping[str, Iterable[str]]:
+    def supports(self, key_ref: Optional[str] = None) -> Mapping[str, Iterable[str]]:
         raise NotImplementedError("supports() must be implemented by subclass")
 
     # ------------------------------------------------------------------
@@ -35,6 +35,28 @@ class SigningBase(ISigning, ComponentBase):
         raise NotImplementedError("sign_bytes() must be implemented by subclass")
 
     # ------------------------------------------------------------------
+    async def sign_digest(
+        self,
+        key: KeyRef,
+        digest: bytes,
+        *,
+        alg: Optional[Alg] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> Sequence[Signature]:
+        raise NotImplementedError("sign_digest() must be implemented by subclass")
+
+    # ------------------------------------------------------------------
+    async def sign_stream(
+        self,
+        key: KeyRef,
+        stream: ByteStream,
+        *,
+        alg: Optional[Alg] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> Sequence[Signature]:
+        raise NotImplementedError("sign_stream() must be implemented by subclass")
+
+    # ------------------------------------------------------------------
     async def verify_bytes(
         self,
         payload: bytes,
@@ -44,6 +66,28 @@ class SigningBase(ISigning, ComponentBase):
         opts: Optional[Mapping[str, object]] = None,
     ) -> bool:
         raise NotImplementedError("verify_bytes() must be implemented by subclass")
+
+    # ------------------------------------------------------------------
+    async def verify_digest(
+        self,
+        digest: bytes,
+        signatures: Sequence[Signature],
+        *,
+        require: Optional[Mapping[str, object]] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bool:
+        raise NotImplementedError("verify_digest() must be implemented by subclass")
+
+    # ------------------------------------------------------------------
+    async def verify_stream(
+        self,
+        stream: ByteStream,
+        signatures: Sequence[Signature],
+        *,
+        require: Optional[Mapping[str, object]] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bool:
+        raise NotImplementedError("verify_stream() must be implemented by subclass")
 
     # ------------------------------------------------------------------
     async def canonicalize_envelope(

--- a/pkgs/plugins/SignerNameTBD/README.md
+++ b/pkgs/plugins/SignerNameTBD/README.md
@@ -1,0 +1,55 @@
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri.brand.theme.svg)
+
+<p align="center">
+    <a href="https://pypi.org/project/signer-name-tbd/">
+        <img src="https://img.shields.io/pypi/v/signer-name-tbd?label=SignerNameTBD&color=blue" alt="PyPI - Version"/></a>
+    <a href="https://pypi.org/project/signer-name-tbd/">
+        <img src="https://img.shields.io/pypi/pyversions/signer-name-tbd" alt="PyPI - Python Version"/></a>
+    <a href="https://github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/plugins/SignerNameTBD">
+        <img src="https://img.shields.io/github/license/swarmauri/swarmauri-sdk" alt="License"/></a>
+</p>
+
+---
+
+# SignerNameTBD Plugin
+
+`SignerNameTBD` packages the Swarmauri signing facade so it can be consumed like any other plugin. The facade dynamically discovers `SigningBase` implementations that register themselves with the Swarmauri component registry and provides a high-level API for the most common signing and verification workflows.
+
+## Installation
+
+### Using `uv`
+
+```bash
+uv add signer-name-tbd
+```
+
+The `uv add` command installs the facade along with the Swarmauri base and core packages that provide the shared component registry and cryptographic type definitions.
+
+### Using `pip`
+
+```bash
+pip install signer-name-tbd
+```
+
+This performs the same installation using the default Python package index. Ensure that your active environment already contains the Swarmauri workspace packages or that they are installed as dependencies alongside the facade.
+
+## Usage
+
+```python
+from SignerNameTBD import Signer
+from swarmauri_core.crypto.types import KeyRef
+
+signer = Signer()
+supported = signer.supported_formats()
+print("Available formats:", supported)
+
+# Example signing flow (async context required)
+# signatures = await signer.sign_bytes("Ed25519Key" as KeyRef, b"payload", fmt="jws")
+```
+
+1. Import the facade directly from the plugin package.
+2. Instantiate `Signer` optionally passing an `IKeyProvider` so that downstream plugins have access to shared key material.
+3. Call capability helpers such as `supported_formats()` or `supports(fmt)` to inspect what each registered plugin advertises.
+4. Execute signing or verification calls by selecting a registered format identifier (e.g., `"jws"`, `"cms"`). Each call defers to the underlying plugin and forwards options, canonicalization hints, and policy requirements unchanged.
+
+Because the facade loads plugins lazily from the global registry, additional signer packages can be installed without modifying the facade itself. Simply install the desired signer (for example `swarmauri_signer_jws`) and rerun your program; the plugin will self-register when imported and the facade will automatically expose its capabilities.

--- a/pkgs/plugins/SignerNameTBD/SignerNameTBD/__init__.py
+++ b/pkgs/plugins/SignerNameTBD/SignerNameTBD/__init__.py
@@ -1,0 +1,5 @@
+"""SignerNameTBD plugin package exposing the Signer facade."""
+
+from .Signer import Signer
+
+__all__ = ["Signer"]

--- a/pkgs/plugins/SignerNameTBD/pyproject.toml
+++ b/pkgs/plugins/SignerNameTBD/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "signer-name-tbd"
+version = "0.1.0.dev0"
+description = "Swarmauri signing facade packaged as a plugin"
+license = "Apache-2.0"
+readme = "README.md"
+requires-python = ">=3.10,<3.13"
+authors = [{ name = "Swarmauri", email = "hello@swarmauri.com" }]
+dependencies = [
+    "swarmauri_base",
+    "swarmauri_core",
+]
+
+[tool.uv.sources]
+swarmauri_base = { workspace = true }
+swarmauri_core = { workspace = true }
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/pkgs/plugins/SignerNameTBD/signer_name_tbd/__init__.py
+++ b/pkgs/plugins/SignerNameTBD/signer_name_tbd/__init__.py
@@ -1,0 +1,5 @@
+"""PEP 503 normalized package exposing the Signer facade."""
+
+from SignerNameTBD import Signer
+
+__all__ = ["Signer"]

--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -198,6 +198,7 @@ members = [
     "community/swarmauri_parser_entityrecognition",
     "community/swarmauri_parser_bertembedding",
     "community/swarmauri_parser_pypdf2",
+    "plugins/SignerNameTBD",
     "community/swarmauri_parser_pypdftk",
     "community/swarmauri_measurement_mutualinformation",
     "community/swarmauri_measurement_tokencountestimator",

--- a/pkgs/standards/swarmauri_signer_cms/swarmauri_signer_cms/cms_signer.py
+++ b/pkgs/standards/swarmauri_signer_cms/swarmauri_signer_cms/cms_signer.py
@@ -8,11 +8,11 @@ from swarmauri_base import register_type
 from swarmauri_base.signing.SigningBase import SigningBase
 from swarmauri_core.crypto.types import Alg, KeyRef
 from swarmauri_core.keys.IKeyProvider import IKeyProvider
-from swarmauri_core.signing.ISigning import Canon, Envelope
+from swarmauri_core.signing.ISigning import ByteStream, Canon, Envelope
 from swarmauri_core.signing.types import Signature
 
 
-@register_type(resource_type=SigningBase, type_name="cms")
+@register_type(resource_type=SigningBase)
 class CMSSigner(SigningBase):
     """Placeholder CMS signer that advertises CMS support in the registry."""
 
@@ -28,14 +28,16 @@ class CMSSigner(SigningBase):
         base_caps: Mapping[str, Iterable[str]] = {
             "algs": ("rsa-pss", "rsa-pkcs1", "ecdsa"),
             "canons": ("der", "ber"),
+            "formats": ("cms", "pkcs7", self.__class__.__name__),
+            "envelopes": ("cms", "pkcs7"),
+            "signs": ("bytes", "digest", "stream", "envelope"),
+            "verifies": ("bytes", "digest", "stream", "envelope"),
             "features": ("detached", "attached"),
+            "notes": ("Implementation pending",),
         }
         if key_ref is None:
             return base_caps
-        return {
-            **base_caps,
-            "key_refs": (key_ref,),
-        }
+        return {**base_caps, "key_refs": (key_ref,)}
 
     async def sign_bytes(
         self,
@@ -47,6 +49,26 @@ class CMSSigner(SigningBase):
     ) -> Sequence[Signature]:
         raise NotImplementedError("CMSSigner.sign_bytes is not implemented yet")
 
+    async def sign_digest(
+        self,
+        key: KeyRef,
+        digest: bytes,
+        *,
+        alg: Optional[Alg] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> Sequence[Signature]:
+        raise NotImplementedError("CMSSigner.sign_digest is not implemented yet")
+
+    async def sign_stream(
+        self,
+        key: KeyRef,
+        stream: ByteStream,
+        *,
+        alg: Optional[Alg] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> Sequence[Signature]:
+        raise NotImplementedError("CMSSigner.sign_stream is not implemented yet")
+
     async def verify_bytes(
         self,
         payload: bytes,
@@ -56,6 +78,26 @@ class CMSSigner(SigningBase):
         opts: Optional[Mapping[str, object]] = None,
     ) -> bool:
         raise NotImplementedError("CMSSigner.verify_bytes is not implemented yet")
+
+    async def verify_digest(
+        self,
+        digest: bytes,
+        signatures: Sequence[Signature],
+        *,
+        require: Optional[Mapping[str, object]] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bool:
+        raise NotImplementedError("CMSSigner.verify_digest is not implemented yet")
+
+    async def verify_stream(
+        self,
+        stream: ByteStream,
+        signatures: Sequence[Signature],
+        *,
+        require: Optional[Mapping[str, object]] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bool:
+        raise NotImplementedError("CMSSigner.verify_stream is not implemented yet")
 
     async def canonicalize_envelope(
         self,

--- a/pkgs/standards/swarmauri_signer_jws/swarmauri_signer_jws/jws_signer.py
+++ b/pkgs/standards/swarmauri_signer_jws/swarmauri_signer_jws/jws_signer.py
@@ -8,11 +8,11 @@ from swarmauri_base import register_type
 from swarmauri_base.signing.SigningBase import SigningBase
 from swarmauri_core.crypto.types import Alg, KeyRef
 from swarmauri_core.keys.IKeyProvider import IKeyProvider
-from swarmauri_core.signing.ISigning import Canon, Envelope
+from swarmauri_core.signing.ISigning import ByteStream, Canon, Envelope
 from swarmauri_core.signing.types import Signature
 
 
-@register_type(resource_type=SigningBase, type_name="jws")
+@register_type(resource_type=SigningBase)
 class JWSSigner(SigningBase):
     """Placeholder JWS signer that will be fleshed out in future revisions."""
 
@@ -26,7 +26,12 @@ class JWSSigner(SigningBase):
         base_caps: Mapping[str, Iterable[str]] = {
             "algs": ("PS256", "ES256", "EdDSA"),
             "canons": ("json",),
+            "formats": ("jws", "jwt", self.__class__.__name__),
+            "envelopes": ("jws", "jwt"),
+            "signs": ("bytes", "digest", "stream", "envelope"),
+            "verifies": ("bytes", "digest", "stream", "envelope"),
             "features": ("detached", "attached"),
+            "notes": ("Implementation pending",),
         }
         if key_ref is None:
             return base_caps
@@ -42,6 +47,26 @@ class JWSSigner(SigningBase):
     ) -> Sequence[Signature]:
         raise NotImplementedError("JWSSigner.sign_bytes is not implemented yet")
 
+    async def sign_digest(
+        self,
+        key: KeyRef,
+        digest: bytes,
+        *,
+        alg: Optional[Alg] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> Sequence[Signature]:
+        raise NotImplementedError("JWSSigner.sign_digest is not implemented yet")
+
+    async def sign_stream(
+        self,
+        key: KeyRef,
+        stream: ByteStream,
+        *,
+        alg: Optional[Alg] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> Sequence[Signature]:
+        raise NotImplementedError("JWSSigner.sign_stream is not implemented yet")
+
     async def verify_bytes(
         self,
         payload: bytes,
@@ -51,6 +76,26 @@ class JWSSigner(SigningBase):
         opts: Optional[Mapping[str, object]] = None,
     ) -> bool:
         raise NotImplementedError("JWSSigner.verify_bytes is not implemented yet")
+
+    async def verify_digest(
+        self,
+        digest: bytes,
+        signatures: Sequence[Signature],
+        *,
+        require: Optional[Mapping[str, object]] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bool:
+        raise NotImplementedError("JWSSigner.verify_digest is not implemented yet")
+
+    async def verify_stream(
+        self,
+        stream: ByteStream,
+        signatures: Sequence[Signature],
+        *,
+        require: Optional[Mapping[str, object]] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bool:
+        raise NotImplementedError("JWSSigner.verify_stream is not implemented yet")
 
     async def canonicalize_envelope(
         self,

--- a/pkgs/standards/swarmauri_signer_openpgp/swarmauri_signer_openpgp/openpgp_signer.py
+++ b/pkgs/standards/swarmauri_signer_openpgp/swarmauri_signer_openpgp/openpgp_signer.py
@@ -8,11 +8,11 @@ from swarmauri_base import register_type
 from swarmauri_base.signing.SigningBase import SigningBase
 from swarmauri_core.crypto.types import Alg, KeyRef
 from swarmauri_core.keys.IKeyProvider import IKeyProvider
-from swarmauri_core.signing.ISigning import Canon, Envelope
+from swarmauri_core.signing.ISigning import ByteStream, Canon, Envelope
 from swarmauri_core.signing.types import Signature
 
 
-@register_type(resource_type=SigningBase, type_name="openpgp")
+@register_type(resource_type=SigningBase)
 class OpenPGPSigner(SigningBase):
     """Placeholder OpenPGP signer exposing registry metadata."""
 
@@ -26,7 +26,12 @@ class OpenPGPSigner(SigningBase):
         base_caps: Mapping[str, Iterable[str]] = {
             "algs": ("openpgp",),
             "canons": ("rfc4880",),
+            "formats": ("openpgp", "pgp", self.__class__.__name__),
+            "envelopes": ("openpgp",),
+            "signs": ("bytes", "digest", "stream", "envelope"),
+            "verifies": ("bytes", "digest", "stream", "envelope"),
             "features": ("detached", "attached"),
+            "notes": ("Implementation pending",),
         }
         if key_ref is None:
             return base_caps
@@ -42,6 +47,26 @@ class OpenPGPSigner(SigningBase):
     ) -> Sequence[Signature]:
         raise NotImplementedError("OpenPGPSigner.sign_bytes is not implemented yet")
 
+    async def sign_digest(
+        self,
+        key: KeyRef,
+        digest: bytes,
+        *,
+        alg: Optional[Alg] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> Sequence[Signature]:
+        raise NotImplementedError("OpenPGPSigner.sign_digest is not implemented yet")
+
+    async def sign_stream(
+        self,
+        key: KeyRef,
+        stream: ByteStream,
+        *,
+        alg: Optional[Alg] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> Sequence[Signature]:
+        raise NotImplementedError("OpenPGPSigner.sign_stream is not implemented yet")
+
     async def verify_bytes(
         self,
         payload: bytes,
@@ -51,6 +76,26 @@ class OpenPGPSigner(SigningBase):
         opts: Optional[Mapping[str, object]] = None,
     ) -> bool:
         raise NotImplementedError("OpenPGPSigner.verify_bytes is not implemented yet")
+
+    async def verify_digest(
+        self,
+        digest: bytes,
+        signatures: Sequence[Signature],
+        *,
+        require: Optional[Mapping[str, object]] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bool:
+        raise NotImplementedError("OpenPGPSigner.verify_digest is not implemented yet")
+
+    async def verify_stream(
+        self,
+        stream: ByteStream,
+        signatures: Sequence[Signature],
+        *,
+        require: Optional[Mapping[str, object]] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bool:
+        raise NotImplementedError("OpenPGPSigner.verify_stream is not implemented yet")
 
     async def canonicalize_envelope(
         self,

--- a/pkgs/standards/swarmauri_signer_pades/swarmauri_signer_pades/pades_signer.py
+++ b/pkgs/standards/swarmauri_signer_pades/swarmauri_signer_pades/pades_signer.py
@@ -8,11 +8,11 @@ from swarmauri_base import register_type
 from swarmauri_base.signing.SigningBase import SigningBase
 from swarmauri_core.crypto.types import Alg, KeyRef
 from swarmauri_core.keys.IKeyProvider import IKeyProvider
-from swarmauri_core.signing.ISigning import Canon, Envelope
+from swarmauri_core.signing.ISigning import ByteStream, Canon, Envelope
 from swarmauri_core.signing.types import Signature
 
 
-@register_type(resource_type=SigningBase, type_name="pades")
+@register_type(resource_type=SigningBase)
 class PadesSigner(SigningBase):
     """Placeholder PAdES signer that advertises attached PDF signature support."""
 
@@ -26,7 +26,12 @@ class PadesSigner(SigningBase):
         base_caps: Mapping[str, Iterable[str]] = {
             "algs": ("ecdsa", "rsa-pss"),
             "canons": ("pdf",),
+            "formats": ("pades", "pdf-signature", self.__class__.__name__),
+            "envelopes": ("pades",),
+            "signs": ("bytes", "digest", "stream", "envelope"),
+            "verifies": ("bytes", "digest", "stream", "envelope"),
             "features": ("attached",),
+            "notes": ("Implementation pending",),
         }
         if key_ref is None:
             return base_caps
@@ -42,6 +47,26 @@ class PadesSigner(SigningBase):
     ) -> Sequence[Signature]:
         raise NotImplementedError("PadesSigner.sign_bytes is not implemented yet")
 
+    async def sign_digest(
+        self,
+        key: KeyRef,
+        digest: bytes,
+        *,
+        alg: Optional[Alg] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> Sequence[Signature]:
+        raise NotImplementedError("PadesSigner.sign_digest is not implemented yet")
+
+    async def sign_stream(
+        self,
+        key: KeyRef,
+        stream: ByteStream,
+        *,
+        alg: Optional[Alg] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> Sequence[Signature]:
+        raise NotImplementedError("PadesSigner.sign_stream is not implemented yet")
+
     async def verify_bytes(
         self,
         payload: bytes,
@@ -51,6 +76,26 @@ class PadesSigner(SigningBase):
         opts: Optional[Mapping[str, object]] = None,
     ) -> bool:
         raise NotImplementedError("PadesSigner.verify_bytes is not implemented yet")
+
+    async def verify_digest(
+        self,
+        digest: bytes,
+        signatures: Sequence[Signature],
+        *,
+        require: Optional[Mapping[str, object]] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bool:
+        raise NotImplementedError("PadesSigner.verify_digest is not implemented yet")
+
+    async def verify_stream(
+        self,
+        stream: ByteStream,
+        signatures: Sequence[Signature],
+        *,
+        require: Optional[Mapping[str, object]] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bool:
+        raise NotImplementedError("PadesSigner.verify_stream is not implemented yet")
 
     async def canonicalize_envelope(
         self,

--- a/pkgs/swarmauri_standard/pyproject.toml
+++ b/pkgs/swarmauri_standard/pyproject.toml
@@ -32,9 +32,25 @@ dependencies = [
 
 ]
 
+[project.optional-dependencies]
+signer-cms = ["swarmauri_signer_cms"]
+signer-jws = ["swarmauri_signer_jws"]
+signer-openpgp = ["swarmauri_signer_openpgp"]
+signer-pades = ["swarmauri_signer_pades"]
+signers-all = [
+    "swarmauri_signer_cms",
+    "swarmauri_signer_jws",
+    "swarmauri_signer_openpgp",
+    "swarmauri_signer_pades",
+]
+
 [tool.uv.sources]
 swarmauri_core = { workspace = true }
 swarmauri_base = { workspace = true }
+swarmauri_signer_cms = { workspace = true }
+swarmauri_signer_jws = { workspace = true }
+swarmauri_signer_openpgp = { workspace = true }
+swarmauri_signer_pades = { workspace = true }
 
 
 

--- a/pkgs/swarmauri_standard/swarmauri_standard/signing/__init__.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/signing/__init__.py
@@ -2,6 +2,21 @@
 
 from __future__ import annotations
 
-from .signer import Signer
+import importlib
+import sys
+from pathlib import Path
+
+
+def _load_signer() -> type:
+    try:
+        return importlib.import_module("SignerNameTBD.Signer").Signer
+    except ModuleNotFoundError:  # pragma: no cover - dev fallback
+        plugin_root = Path(__file__).resolve().parents[3] / "plugins" / "SignerNameTBD"
+        if str(plugin_root) not in sys.path:
+            sys.path.append(str(plugin_root))
+        return importlib.import_module("SignerNameTBD.Signer").Signer
+
+
+Signer = _load_signer()
 
 __all__ = ["Signer"]


### PR DESCRIPTION
## Summary
- move the `Signer` facade into the new `plugins/SignerNameTBD` package with alias discovery and digest/stream APIs
- expand `ISigning`/`SigningBase` plus the CMS, JWS, OpenPGP, and PAdES signers to advertise richer capability metadata without custom `type_name` overrides
- add signer extras to `swarmauri_standard` and document the plugin with a README

## Testing
- uv run --directory pkgs/core --package swarmauri-core ruff format .
- uv run --directory pkgs/core --package swarmauri-core ruff check . --fix
- uv run --directory pkgs/base --package swarmauri-base ruff format .
- uv run --directory pkgs/base --package swarmauri-base ruff check . --fix
- uv run --directory pkgs/swarmauri_standard --package swarmauri-standard ruff format .
- uv run --directory pkgs/swarmauri_standard --package swarmauri-standard ruff check . --fix
- uv run --directory pkgs/standards/swarmauri_signer_cms --package swarmauri_signer_cms ruff format .
- uv run --directory pkgs/standards/swarmauri_signer_cms --package swarmauri_signer_cms ruff check . --fix
- uv run --directory pkgs/standards/swarmauri_signer_jws --package swarmauri_signer_jws ruff format .
- uv run --directory pkgs/standards/swarmauri_signer_jws --package swarmauri_signer_jws ruff check . --fix
- uv run --directory pkgs/standards/swarmauri_signer_openpgp --package swarmauri_signer_openpgp ruff format .
- uv run --directory pkgs/standards/swarmauri_signer_openpgp --package swarmauri_signer_openpgp ruff check . --fix
- uv run --directory pkgs/standards/swarmauri_signer_pades --package swarmauri_signer_pades ruff format .
- uv run --directory pkgs/standards/swarmauri_signer_pades --package swarmauri_signer_pades ruff check . --fix
- uv run --directory pkgs/plugins/SignerNameTBD --package signer-name-tbd ruff format .
- uv run --directory pkgs/plugins/SignerNameTBD --package signer-name-tbd ruff check . --fix

------
https://chatgpt.com/codex/tasks/task_e_68db0033b1b483269eb9d7798b8861e7