### PR TITLE
Fix zdx manifest installs outside virtual environments

### DIFF
--- a/pkgs/community/zdx/zdx/cli.py
+++ b/pkgs/community/zdx/zdx/cli.py
@@ -74,10 +74,8 @@ def install_manifest_packages(manifest: str) -> None:
             "--directory",
             pkg_dir,
         ]
-        # if os.environ.get("VIRTUAL_ENV") or sys.prefix != sys.base_prefix:
-        #     cmd.append("--system")
-        # else:
-        #     cmd.append("--user")
+        if not (os.environ.get("VIRTUAL_ENV") or sys.prefix != sys.base_prefix):
+            cmd.append("--system")
         cmd.append(".")
         subprocess.run(cmd, check=True)
 


### PR DESCRIPTION
## Summary
- detect when zdx is running without an active virtual environment and pass --system to uv pip install
- allow Docker builds (and other system-level invocations) to install manifest packages successfully

## Testing
- uv run --directory . --package zdx ruff format .
- uv run --directory . --package zdx ruff check . --fix
- PYTHONPATH=$(pwd) python -m zdx.cli install --manifest /tmp/test_manifest.yaml

------
https://chatgpt.com/codex/tasks/task_e_68dc6c5bd5e08326ac1569fd79737a10