### PR TITLE
feat(zdx): add configurable failure handling

### DIFF
--- a/infra/docs/docker-compose.yaml
+++ b/infra/docs/docker-compose.yaml
@@ -3,6 +3,7 @@ x-as-user: &as_user
   user: "${RUN_UID}:${RUN_GID}"
   environment:
     HOME: "/tmp"
+    ZDX_FAILURE_MODE: "${ZDX_FAILURE_MODE:-warn}"
   init: true
 
 services:

--- a/pkgs/community/zdx/Dockerfile
+++ b/pkgs/community/zdx/Dockerfile
@@ -1,6 +1,8 @@
 # ───────────────────────── base image ──────────────────────────────
 FROM python:3.12-slim
 
+ARG ZDX_FAILURE_MODE=warn
+
 # ─────────────────── system deps + uv package manager ──────────────
 RUN apt-get update && \
     apt-get install --yes --no-install-recommends build-essential git python3-venv && \
@@ -13,6 +15,7 @@ RUN apt-get update && \
 
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ENV ZDX_FAILURE_MODE=${ZDX_FAILURE_MODE}
 
 # Ensure non-root users can install additional dependencies at runtime.
 RUN chmod -R a+rwX /opt/venv
@@ -24,7 +27,7 @@ WORKDIR /app
 COPY ./pkgs/ /pkgs
 
 RUN uv pip install --directory /pkgs/community/zdx . && \
-    zdx install --manifest /pkgs/community/zdx/api_manifest.yaml
+    zdx install --manifest /pkgs/community/zdx/api_manifest.yaml --on-error ${ZDX_FAILURE_MODE}
 
 EXPOSE 8000
 

--- a/pkgs/community/zdx/README.md
+++ b/pkgs/community/zdx/README.md
@@ -62,6 +62,25 @@ zdx serve --docs-dir /path/to/docs
 zdx serve --generate --docs-dir /path/to/docs --manifest api_manifest.yaml
 ```
 
+### Control failure handling
+
+Use the `--on-error` flag with any command that installs packages or generates
+documentation to decide how strictly `zdx` reacts to subprocess failures:
+
+```bash
+zdx generate --on-error warn
+```
+
+Valid values are:
+
+* `fail` – stop immediately if a package installation or API build fails
+* `warn` – print a warning but keep going
+* `ignore` – suppress warnings and continue
+
+You can also define the `ZDX_FAILURE_MODE` environment variable to set the
+default for every invocation. For example, the provided Docker assets default to
+`warn` so that optional packages do not abort a deployment.
+
 ## API Manifest
 
 `zdx` uses a YAML manifest to decide which Python packages to document and how

--- a/pkgs/community/zdx/tests/test_cli.py
+++ b/pkgs/community/zdx/tests/test_cli.py
@@ -1,0 +1,78 @@
+import subprocess
+
+import pytest
+import yaml
+
+from zdx.cli import FailureMode, install_manifest_packages, run_gen_api
+
+
+def _write_manifest(tmp_path, targets):
+    manifest = tmp_path / "api_manifest.yaml"
+    manifest.write_text(yaml.safe_dump({"targets": targets}))
+    return manifest
+
+
+def test_install_packages_warn_continues(monkeypatch, tmp_path, capsys):
+    pkg_one = tmp_path / "pkg_one"
+    pkg_two = tmp_path / "pkg_two"
+    pkg_one.mkdir()
+    pkg_two.mkdir()
+    (pkg_one / "pyproject.toml").write_text("")
+    (pkg_two / "pyproject.toml").write_text("")
+
+    manifest = _write_manifest(
+        tmp_path,
+        [
+            {"name": "One", "search_path": str(pkg_one), "package": "pkg_one"},
+            {"name": "Two", "search_path": str(pkg_two), "package": "pkg_two"},
+        ],
+    )
+
+    calls = []
+
+    def fake_run(cmd, cwd=None, check=False):
+        returncode = 1 if len(calls) == 0 else 0
+        calls.append((cmd, cwd, check, returncode))
+        return subprocess.CompletedProcess(cmd, returncode)
+
+    monkeypatch.setattr("zdx.cli.subprocess.run", fake_run)
+
+    install_manifest_packages(str(manifest), failure_mode=FailureMode.WARN)
+
+    assert len(calls) == 2
+    output = capsys.readouterr().out
+    assert "WARNING" in output
+
+
+def test_install_packages_fail_raises(monkeypatch, tmp_path):
+    pkg_dir = tmp_path / "pkg_fail"
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text("")
+
+    manifest = _write_manifest(
+        tmp_path, [{"name": "One", "search_path": str(pkg_dir), "package": "pkg_fail"}]
+    )
+
+    def always_fail(cmd, cwd=None, check=False):
+        return subprocess.CompletedProcess(cmd, 1)
+
+    monkeypatch.setattr("zdx.cli.subprocess.run", always_fail)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        install_manifest_packages(str(manifest), failure_mode=FailureMode.FAIL)
+
+
+def test_run_gen_api_ignore_suppresses_warning(monkeypatch, capsys):
+    calls = []
+
+    def fake_run(cmd, cwd=None, check=False):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 1)
+
+    monkeypatch.setattr("zdx.cli.subprocess.run", fake_run)
+
+    run_gen_api(failure_mode=FailureMode.IGNORE)
+
+    assert len(calls) == 1
+    output = capsys.readouterr().out
+    assert "WARNING" not in output


### PR DESCRIPTION
## Summary
- add a configurable failure mode to zdx CLI commands, including a new --on-error flag and ZDX_FAILURE_MODE environment default
- update the zdx documentation Docker assets to default to warning-only behaviour when installs fail
- extend the README and add unit tests covering the new failure handling options

## Testing
- uv run --directory community/zdx --package zdx ruff format .
- uv run --directory community/zdx --package zdx ruff check . --fix
- uv run --package zdx --directory community/zdx pytest


------
https://chatgpt.com/codex/tasks/task_e_68dcbffd8b448326abb997587f8f3ff4