### PR TITLE
Add swarmauri_tests_griffe pytest plugin for Griffe warnings

### DIFF
--- a/pkgs/community/swarmauri_tests_griffe/LICENSE
+++ b/pkgs/community/swarmauri_tests_griffe/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/community/swarmauri_tests_griffe/README.md
+++ b/pkgs/community/swarmauri_tests_griffe/README.md
@@ -1,0 +1,19 @@
+# swarmauri_tests_griffe
+
+`swarmauri_tests_griffe` is a pytest plugin that loads project packages with
+[Griffe](https://github.com/mkdocstrings/griffe) and fails the test session if
+any warnings are emitted during inspection. The plugin is automatically
+integrated into the Swarmauri test suite via the shared `pkgs/conftest.py` file.
+
+## Usage
+
+Once installed, the plugin adds a dynamic test for each configured package. By
+default the current package defined in `pyproject.toml` is inspected, but you
+can target additional packages with:
+
+```bash
+pytest --griffe-package other_package
+```
+
+If Griffe produces warnings while processing the package, the generated test
+fails and reports the warning details.

--- a/pkgs/community/swarmauri_tests_griffe/pyproject.toml
+++ b/pkgs/community/swarmauri_tests_griffe/pyproject.toml
@@ -1,0 +1,26 @@
+[project]
+name = "swarmauri_tests_griffe"
+version = "0.1.0"
+description = "Pytest plugin to ensure Griffe inspections do not emit warnings."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "Apache-2.0" }
+authors = [{ name = "Swarmauri" }]
+dependencies = [
+    "pytest>=8.0",
+    "griffe>=0.48",
+    "tomli; python_version < '3.11'",
+]
+
+[project.entry-points."pytest11"]
+swarmauri_tests_griffe = "swarmauri_tests_griffe"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "ruff>=0.9.9",
+]

--- a/pkgs/community/swarmauri_tests_griffe/swarmauri_tests_griffe/__init__.py
+++ b/pkgs/community/swarmauri_tests_griffe/swarmauri_tests_griffe/__init__.py
@@ -1,0 +1,202 @@
+"""Pytest plugin for detecting Griffe warnings."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import importlib
+import warnings
+
+import pytest
+
+try:  # pragma: no cover - optional dependency resolution
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib  # type: ignore
+
+import griffe
+
+PLUGIN_NAME = "swarmauri_tests_griffe"
+
+
+@dataclass(frozen=True)
+class GriffeTarget:
+    """Representation of a package that should be inspected by Griffe."""
+
+    name: str
+    path: Path
+
+    @property
+    def search_path(self) -> Path:
+        return self.path.parent
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Expose configuration options for the plugin."""
+
+    group = parser.getgroup("griffe")
+    group.addoption(
+        "--griffe-package",
+        action="append",
+        dest="griffe_packages",
+        default=None,
+        help=(
+            "Package name to inspect with Griffe. "
+            "Can be provided multiple times. Defaults to the package defined in pyproject.toml."
+        ),
+    )
+    group.addoption(
+        "--griffe-root",
+        action="store",
+        dest="griffe_root",
+        default=None,
+        help="Root directory for resolving packages (defaults to pytest's rootpath).",
+    )
+
+
+def _normalized(name: str) -> str:
+    return name.replace("-", "_")
+
+
+def _candidate_paths(root: Path, name: str) -> list[Path]:
+    candidates = [root / name, root / "src" / name]
+    return [path for path in candidates if path.exists()]
+
+
+def _discover_from_pyproject(root: Path) -> list[str]:
+    pyproject = root / "pyproject.toml"
+    if not pyproject.exists():
+        return []
+    try:
+        data = tomllib.loads(pyproject.read_text())
+    except (
+        Exception
+    ):  # pragma: no cover - toml parsing errors should not crash test runs
+        return []
+    project = data.get("project", {})
+    name = project.get("name")
+    if not name:
+        return []
+    return [_normalized(name)]
+
+
+def _discover_packages(config: pytest.Config) -> list[GriffeTarget]:
+    root_option = config.getoption("griffe_root")
+    root = Path(root_option).resolve() if root_option else Path(config.rootpath)
+    packages = config.getoption("griffe_packages")
+    explicit = bool(packages)
+    package_names: list[str]
+    if packages:
+        package_names = [_normalized(name) for name in packages]
+    else:
+        package_names = _discover_from_pyproject(root)
+        if not package_names:
+            package_names = sorted(
+                path.name
+                for path in root.iterdir()
+                if path.is_dir()
+                and not path.name.startswith(".")
+                and path.name not in {"tests", "__pycache__"}
+                and (path / "__init__.py").exists()
+            )
+    targets: list[GriffeTarget] = []
+    seen: set[str] = set()
+    for package in package_names:
+        if package in seen:
+            continue
+        for candidate in _candidate_paths(root, package):
+            if (candidate / "__init__.py").exists():
+                targets.append(GriffeTarget(name=package, path=candidate))
+                seen.add(package)
+                break
+        else:
+            # Fall back to importing the module to resolve its path.
+            try:
+                module = importlib.import_module(package)
+            except (
+                Exception
+            ):  # pragma: no cover - import failure should surface during test discovery
+                if explicit:
+                    raise pytest.UsageError(
+                        f"Unable to resolve package '{package}' for Griffe inspection."
+                    ) from None
+                continue
+            module_file = getattr(module, "__file__", None)
+            if not module_file:
+                if explicit:
+                    raise pytest.UsageError(
+                        f"Unable to resolve package '{package}' for Griffe inspection."
+                    )
+                continue
+            targets.append(
+                GriffeTarget(name=package, path=Path(module_file).resolve().parent)
+            )
+            seen.add(package)
+    return targets
+
+
+class GriffeWarningsItem(pytest.Item):
+    """Pytest item responsible for executing the Griffe warning checks."""
+
+    def __init__(
+        self,
+        name: str,
+        parent: pytest.Collector,
+        target: GriffeTarget,
+    ) -> None:
+        super().__init__(name, parent)
+        self.target = target
+        self.add_marker("griffe")
+
+    def runtest(self) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            griffe.load(self.target.name, search_paths=[str(self.target.search_path)])
+        griffe_warnings = [
+            warning
+            for warning in caught
+            if "griffe" in (warning.filename or "")
+            or warning.category.__module__.startswith("griffe")
+        ]
+        # If we didn't detect explicit Griffe warnings but still captured warnings,
+        # treat them as relevant—Griffe ran and triggered them during inspection.
+        relevant = griffe_warnings or caught
+        if relevant:
+            formatted = "\n".join(
+                f"{warning.category.__name__}: {warning.message} ({warning.filename}:{warning.lineno})"
+                for warning in relevant
+            )
+            raise AssertionError(
+                f"Griffe emitted warnings while loading {self.target.name}:\n{formatted}"
+            )
+
+    def reportinfo(self) -> tuple[Path, int | None, str]:
+        return self.target.path, None, f"griffe warnings for {self.target.name}"
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line("markers", "griffe: validate packages with griffe")
+    targets = _discover_packages(config)
+    config._swarmauri_griffe_targets = targets
+
+
+def pytest_collection_modifyitems(
+    session: pytest.Session, config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    targets: list[GriffeTarget] = getattr(config, "_swarmauri_griffe_targets", [])
+    if not targets:
+        return
+    for target in targets:
+        item = GriffeWarningsItem.from_parent(
+            session,
+            name=f"{PLUGIN_NAME}::{target.name}",
+            target=target,
+        )
+        items.append(item)
+
+
+__all__ = [
+    "GriffeWarningsItem",
+    "GriffeTarget",
+    "PLUGIN_NAME",
+]

--- a/pkgs/community/swarmauri_tests_griffe/tests/test_plugin.py
+++ b/pkgs/community/swarmauri_tests_griffe/tests/test_plugin.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from textwrap import dedent
+
+pytest_plugins = ["pytester"]
+
+
+def _write_pyproject(pytester, name: str = "demo_package") -> None:
+    pytester.makefile(
+        ".toml",
+        pyproject=dedent(
+            f"""
+            [project]
+            name = "{name}"
+            version = "0.0.1"
+            description = "demo"
+            requires-python = ">=3.10"
+            authors = [{{ name = "Tester" }}]
+            readme = "README.md"
+            license = {{ text = "Apache-2.0" }}
+            """
+        ),
+    )
+
+
+def _write_package(pytester, name: str = "demo_package") -> None:
+    package_dir = pytester.path / name
+    package_dir.mkdir()
+    (package_dir / "__init__.py").write_text("value = 42\n")
+
+
+def test_plugin_passes_without_warnings(pytester):
+    _write_pyproject(pytester)
+    _write_package(pytester)
+    pytester.makeconftest(
+        """
+import swarmauri_tests_griffe
+
+
+def pytest_configure(config):
+    def silent_load(name, *, search_paths=None):
+        return name
+
+    swarmauri_tests_griffe.griffe.load = silent_load
+"""
+    )
+
+    result = pytester.runpytest("-p", "swarmauri_tests_griffe", "-q")
+    result.assert_outcomes(passed=1)
+
+
+def test_plugin_fails_on_griffe_warning(pytester):
+    _write_pyproject(pytester, name="warning_package")
+    _write_package(pytester, name="warning_package")
+    pytester.makeconftest(
+        """
+import warnings
+import swarmauri_tests_griffe
+
+
+def pytest_configure(config):
+    def noisy_load(name, *, search_paths=None):
+        warnings.warn("issued from griffe", UserWarning)
+        return name
+
+    swarmauri_tests_griffe.griffe.load = noisy_load
+"""
+    )
+
+    result = pytester.runpytest("-p", "swarmauri_tests_griffe", "-q")
+    result.assert_outcomes(failed=1)
+    result.stdout.fnmatch_lines(
+        [
+            "*Griffe emitted warnings while loading warning_package*",
+        ]
+    )

--- a/pkgs/conftest.py
+++ b/pkgs/conftest.py
@@ -1,3 +1,5 @@
+pytest_plugins = ["swarmauri_tests_griffe"]
+
 import pytest
 
 

--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -223,6 +223,7 @@ members = [
     "community/swarmauri_measurement_mutualinformation",
     "community/swarmauri_measurement_tokencountestimator",
     "community/swarmauri_ocr_pytesseract",
+    "community/swarmauri_tests_griffe",
     "community/swarmauri_embedding_mlm",
     "community/swarmauri_tool_entityrecognition",
     "community/swarmauri_llm_leptonai",
@@ -415,6 +416,7 @@ swarmauri_parser_pypdftk = { workspace = true }
 swarmauri_measurement_mutualinformation = { workspace = true }
 swarmauri_measurement_tokencountestimator = { workspace = true }
 swarmauri_ocr_pytesseract = { workspace = true }
+swarmauri_tests_griffe = { workspace = true }
 swarmauri_embedding_mlm = { workspace = true }
 swarmauri_tool_entityrecognition = { workspace = true }
 swarmauri_certservice_ms_adcs = { workspace = true }


### PR DESCRIPTION
## Summary
- add the new `swarmauri_tests_griffe` pytest plugin package to detect Griffe warnings and fail the session when they appear
- wire the plugin into the shared `pkgs/conftest.py` so every package run gains the Griffe warning check and register the package with the workspace metadata
- cover the plugin with pytester-based unit tests to validate both passing and failing scenarios

## Testing
- uv run --package swarmauri_tests_griffe --directory community/swarmauri_tests_griffe pytest
- uv run --package swarmauri_ocr_pytesseract --directory community/swarmauri_ocr_pytesseract pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcf10b8a088326b46f7cf45564e99a