### PR TITLE
Install docs workspace via monorepo pyproject

### DIFF
--- a/infra/docs/swarmauri-sdk/api_manifest.yaml
+++ b/infra/docs/swarmauri-sdk/api_manifest.yaml
@@ -1,3 +1,6 @@
+workspace:
+  pyproject: /pkgs/pyproject.toml
+
 targets:
   # Main SDK packages
   - name: Core


### PR DESCRIPTION
## Summary
- add workspace-aware installation support to zdx manifests and reuse it during package setup
- configure the swarmauri-sdk docs manifest to install from the monorepo pyproject.toml
- cover the new workspace install path and warn fallback logic in unit tests

## Testing
- `uv run --directory community/zdx --package zdx pytest`


------
https://chatgpt.com/codex/tasks/task_e_68dcf2f98c5c8326968cc071654e22bf