### PR TITLE
Avoid running griffe plugin when testing itself

### DIFF
--- a/pkgs/conftest.py
+++ b/pkgs/conftest.py
@@ -1,6 +1,21 @@
-pytest_plugins = ["swarmauri_tests_griffe"]
+from __future__ import annotations
+
+from pathlib import Path
 
 import pytest
+
+
+def _should_load_griffe_plugin() -> bool:
+    plugin_root = (Path(__file__).resolve().parent / "community" / "swarmauri_tests_griffe").resolve()
+    try:
+        cwd = Path.cwd().resolve()
+    except FileNotFoundError:
+        # Fall back to loading the plugin if the current working directory was removed.
+        return True
+    return plugin_root not in {cwd, *cwd.parents}
+
+
+pytest_plugins = ["swarmauri_tests_griffe"] if _should_load_griffe_plugin() else []
 
 
 def pytest_configure(config):


### PR DESCRIPTION
## Summary
- guard the shared pytest configuration so the swarmauri_tests_griffe plugin is skipped when running inside its own package

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd01fde63883269525eaf4ca3da3b1