### PR TITLE
Document workspace install option for zdx docs

### DIFF
--- a/pkgs/community/zdx/api_manifest.yaml
+++ b/pkgs/community/zdx/api_manifest.yaml
@@ -3,6 +3,14 @@
 # Configure a list of `targets` to control which Python packages are documented.
 # Each target becomes a section under `docs/api/<name>/` and is added to the
 # MkDocs navigation.
+#
+# If your documentation pulls code from a uv workspace (such as this monorepo),
+# add a ``workspace`` entry so ``zdx install`` performs a single ``uv pip
+# install`` against the workspace root instead of installing each package
+# individually. Example:
+#
+# workspace:
+#   pyproject: ../../pyproject.toml
 
 targets:
   - name: Example  # Navigation label and output folder name


### PR DESCRIPTION
## Summary
- document how to configure the zdx API manifest to install an entire uv workspace in one command
- explain that adding the workspace block prevents per-package installs when building docs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd038ec9a883268c69cab5f7d7a4e9