### PR TITLE
Add integration tests for MediaSigner optional signers

### DIFF
--- a/pkgs/plugins/media_signer/tests/_helpers.py
+++ b/pkgs/plugins/media_signer/tests/_helpers.py
@@ -1,0 +1,214 @@
+"""Shared helpers for MediaSigner optional signer integration tests."""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as _dt
+import hashlib
+from typing import AsyncIterator, Callable, Tuple
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import Encoding, NoEncryption
+from cryptography.x509.oid import NameOID
+
+from MediaSigner import MediaSigner
+from swarmauri_core.crypto.types import ExportPolicy, KeyRef, KeyUse
+from swarmauri_core.keys.types import KeyAlg, KeyClass, KeySpec
+from swarmauri_keyprovider_inmemory import InMemoryKeyProvider
+
+try:  # optional dependency used by OpenPGP helpers
+    import pgpy
+    from pgpy.constants import (
+        CompressionAlgorithm,
+        HashAlgorithm,
+        KeyFlags,
+        PubKeyAlgorithm,
+        SymmetricKeyAlgorithm,
+    )
+
+    _PGPY_AVAILABLE = True
+except Exception:  # pragma: no cover - runtime guard
+    _PGPY_AVAILABLE = False
+
+
+def _require_material(value: bytes | str | None) -> bytes:
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, str):
+        return value.encode("utf-8")
+    raise ValueError("KeyRef did not expose the required material bytes")
+
+
+def generate_self_signed_rsa(common_name: str) -> Tuple[bytes, bytes]:
+    """Produce a private key and certificate pair for RSA-based signers."""
+
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = issuer = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, common_name)])
+    now = _dt.datetime.utcnow()
+    certificate = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(private_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - _dt.timedelta(days=1))
+        .not_valid_after(now + _dt.timedelta(days=365))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(private_key, hashes.SHA256())
+    )
+    private_pem = private_key.private_bytes(
+        Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        NoEncryption(),
+    )
+    cert_pem = certificate.public_bytes(Encoding.PEM)
+    return private_pem, cert_pem
+
+
+async def build_media_signer_with_rsa(
+    label: str,
+) -> tuple[MediaSigner, InMemoryKeyProvider, KeyRef]:
+    """Instantiate a ``MediaSigner`` backed by an RSA key pair."""
+
+    provider = InMemoryKeyProvider()
+    private_pem, cert_pem = generate_self_signed_rsa(label)
+    spec = KeySpec(
+        klass=KeyClass.asymmetric,
+        alg=KeyAlg.RSA_PSS_SHA256,
+        uses=(KeyUse.SIGN, KeyUse.VERIFY),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+        label=label,
+    )
+    key_ref = await provider.import_key(spec, private_pem, public=cert_pem)
+    signer = MediaSigner(key_provider=provider)
+    return signer, provider, key_ref
+
+
+async def build_media_signer_with_hmac(
+    label: str,
+) -> tuple[MediaSigner, InMemoryKeyProvider, KeyRef]:
+    """Instantiate a ``MediaSigner`` with a symmetric HMAC key."""
+
+    provider = InMemoryKeyProvider()
+    spec = KeySpec(
+        klass=KeyClass.symmetric,
+        alg=KeyAlg.HMAC_SHA256,
+        uses=(KeyUse.SIGN, KeyUse.VERIFY),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+        label=label,
+    )
+    key_ref = await provider.create_key(spec)
+    signer = MediaSigner(key_provider=provider)
+    return signer, provider, key_ref
+
+
+def cms_key_entry(key_ref: KeyRef) -> dict[str, object]:
+    """Translate an RSA ``KeyRef`` into CMS signer key parameters."""
+
+    return {
+        "kind": "pem",
+        "private_key": _require_material(key_ref.material),
+        "certificate": _require_material(key_ref.public),
+    }
+
+
+def cms_trust_opts(key_ref: KeyRef) -> dict[str, object]:
+    return {"trusted_certs": [_require_material(key_ref.public)]}
+
+
+def pdf_sign_opts(attached: bool) -> dict[str, object]:
+    return {"attached": attached, "pdf": {}}
+
+
+def pdf_trust_opts(key_ref: KeyRef) -> dict[str, object]:
+    return cms_trust_opts(key_ref)
+
+
+def xml_key_entry(key_ref: KeyRef) -> dict[str, object]:
+    return {
+        "kind": "pem",
+        "private_key": _require_material(key_ref.material),
+        "certificate": _require_material(key_ref.public),
+    }
+
+
+def xml_verify_opts(key_ref: KeyRef) -> dict[str, object]:
+    return {"pubkeys": [_require_material(key_ref.public)]}
+
+
+def jws_hmac_key(key_ref: KeyRef) -> dict[str, object]:
+    secret = _require_material(key_ref.material)
+    return {"kind": "raw", "key": secret, "kid": key_ref.kid}
+
+
+def jws_verify_opts(key_ref: KeyRef) -> dict[str, object]:
+    secret = _require_material(key_ref.material)
+    return {"hmac_keys": [{"kind": "raw", "key": secret, "kid": key_ref.kid}]}
+
+
+def digest(payload: bytes) -> bytes:
+    return hashlib.sha256(payload).digest()
+
+
+def async_chunks(data: bytes, *, size: int = 5) -> Callable[[], AsyncIterator[bytes]]:
+    async def _iterator() -> AsyncIterator[bytes]:
+        for idx in range(0, len(data), size):
+            await asyncio.sleep(0)
+            yield data[idx : idx + size]
+
+    return _iterator
+
+
+def ensure_pgpy_available() -> None:
+    if not _PGPY_AVAILABLE:
+        raise RuntimeError("pgpy is required for OpenPGP integration tests")
+
+
+def generate_openpgp_keypair(common_name: str) -> tuple[str, str]:
+    ensure_pgpy_available()
+    key = pgpy.PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 2048)
+    uid = pgpy.PGPUID.new(common_name)
+    key.add_uid(
+        uid,
+        usage={KeyFlags.Sign},
+        hashes=[HashAlgorithm.SHA256],
+        ciphers=[SymmetricKeyAlgorithm.AES256],
+        compression=[CompressionAlgorithm.ZLIB],
+    )
+    return str(key), str(key.pubkey)
+
+
+async def build_media_signer_with_openpgp(
+    label: str,
+) -> tuple[MediaSigner, InMemoryKeyProvider, KeyRef]:
+    """Instantiate ``MediaSigner`` with an OpenPGP key pair."""
+
+    ensure_pgpy_available()
+    provider = InMemoryKeyProvider()
+    private_armored, public_armored = generate_openpgp_keypair(label)
+    spec = KeySpec(
+        klass=KeyClass.asymmetric,
+        alg=KeyAlg.RSA_PSS_SHA256,
+        uses=(KeyUse.SIGN, KeyUse.VERIFY),
+        export_policy=ExportPolicy.SECRET_WHEN_ALLOWED,
+        label=label,
+    )
+    key_ref = await provider.import_key(
+        spec,
+        private_armored.encode("utf-8"),
+        public=public_armored.encode("utf-8"),
+    )
+    signer = MediaSigner(key_provider=provider)
+    return signer, provider, key_ref
+
+
+def openpgp_private_entry(key_ref: KeyRef) -> dict[str, object]:
+    return {"kind": "pgpy-key", "data": _require_material(key_ref.material)}
+
+
+def openpgp_verify_opts(key_ref: KeyRef) -> dict[str, object]:
+    return {
+        "pubkeys": [{"kind": "pgpy-key", "data": _require_material(key_ref.public)}]
+    }

--- a/pkgs/plugins/media_signer/tests/test_media_signer_cms.py
+++ b/pkgs/plugins/media_signer/tests/test_media_signer_cms.py
@@ -1,0 +1,94 @@
+import pytest
+
+from ._helpers import (
+    async_chunks,
+    build_media_signer_with_rsa,
+    cms_key_entry,
+    cms_trust_opts,
+    digest,
+)
+
+
+@pytest.fixture
+async def cms_context():
+    signer, _provider, key_ref = await build_media_signer_with_rsa("cms-test")
+    return signer, cms_key_entry(key_ref), cms_trust_opts(key_ref)
+
+
+@pytest.mark.asyncio
+async def test_media_signer_cms_attached_bytes(cms_context):
+    signer, key_entry, trust_opts = cms_context
+    payload = b"cms attached payload"
+
+    signatures = await signer.sign_bytes(
+        "cms", key_entry, payload, opts={"attached": True}
+    )
+
+    assert signatures and signatures[0].mode == "attached"
+    assert await signer.verify_bytes("cms", payload, signatures, opts=trust_opts)
+
+
+@pytest.mark.asyncio
+async def test_media_signer_cms_detached_bytes(cms_context):
+    signer, key_entry, trust_opts = cms_context
+    payload = b"cms detached payload"
+
+    signatures = await signer.sign_bytes(
+        "cms", key_entry, payload, opts={"attached": False}
+    )
+
+    assert signatures and signatures[0].mode == "detached"
+    assert await signer.verify_bytes("cms", payload, signatures, opts=trust_opts)
+
+
+@pytest.mark.asyncio
+async def test_media_signer_cms_detached_digest(cms_context):
+    signer, key_entry, trust_opts = cms_context
+    payload = b"cms digest payload"
+    sha = digest(payload)
+
+    signatures = await signer.sign_digest(
+        "cms", key_entry, sha, opts={"attached": False}
+    )
+
+    assert signatures and signatures[0].mode == "detached"
+    assert await signer.verify_digest("cms", sha, signatures, opts=trust_opts)
+
+
+@pytest.mark.asyncio
+async def test_media_signer_cms_attached_stream(cms_context):
+    signer, key_entry, trust_opts = cms_context
+    payload = b"cms stream payload for media signer"
+    stream_factory = async_chunks(payload, size=7)
+
+    signatures = await signer.sign_stream(
+        "cms", key_entry, stream_factory(), opts={"attached": True}
+    )
+
+    assert signatures and signatures[0].mode == "attached"
+    assert await signer.verify_stream(
+        "cms", stream_factory(), signatures, opts=trust_opts
+    )
+
+
+@pytest.mark.asyncio
+async def test_media_signer_cms_detached_envelope(cms_context):
+    signer, key_entry, trust_opts = cms_context
+    envelope = {"event": "cms-envelope", "value": 42}
+
+    signatures = await signer.sign_envelope(
+        "cms",
+        key_entry,
+        envelope,
+        canon="json",
+        opts={"attached": False},
+    )
+
+    assert signatures and signatures[0].mode == "detached"
+    assert await signer.verify_envelope(
+        "cms",
+        envelope,
+        signatures,
+        canon="json",
+        opts=trust_opts,
+    )

--- a/pkgs/plugins/media_signer/tests/test_media_signer_jws.py
+++ b/pkgs/plugins/media_signer/tests/test_media_signer_jws.py
@@ -1,0 +1,71 @@
+import pytest
+
+from ._helpers import (
+    async_chunks,
+    build_media_signer_with_hmac,
+    digest,
+    jws_hmac_key,
+    jws_verify_opts,
+)
+
+
+@pytest.fixture
+async def jws_context():
+    signer, _provider, key_ref = await build_media_signer_with_hmac("jws-test")
+    return signer, jws_hmac_key(key_ref), jws_verify_opts(key_ref)
+
+
+@pytest.mark.asyncio
+async def test_media_signer_jws_attached_bytes(jws_context):
+    signer, key_entry, verify_opts = jws_context
+    payload = b"jws attached payload"
+
+    signatures = await signer.sign_bytes(
+        "jws", key_entry, payload, opts={"alg": "HS256"}
+    )
+
+    assert signatures and signatures[0].mode == "attached"
+    assert await signer.verify_bytes("jws", payload, signatures, opts=verify_opts)
+
+
+@pytest.mark.asyncio
+async def test_media_signer_jws_digest_round_trip(jws_context):
+    signer, key_entry, verify_opts = jws_context
+    payload = b"jws digest payload"
+    sha = digest(payload)
+
+    signatures = await signer.sign_digest("jws", key_entry, sha, opts={"alg": "HS256"})
+
+    assert signatures and signatures[0].meta.get("payload_kind") == "digest"
+    assert await signer.verify_digest("jws", sha, signatures, opts=verify_opts)
+
+
+@pytest.mark.asyncio
+async def test_media_signer_jws_stream_round_trip(jws_context):
+    signer, key_entry, verify_opts = jws_context
+    payload = b"jws stream payload"
+    stream_factory = async_chunks(payload, size=6)
+
+    signatures = await signer.sign_stream(
+        "jws", key_entry, stream_factory(), opts={"alg": "HS256"}
+    )
+
+    assert signatures and signatures[0].meta.get("payload_kind") == "stream"
+    assert await signer.verify_stream(
+        "jws", stream_factory(), signatures, opts=verify_opts
+    )
+
+
+@pytest.mark.asyncio
+async def test_media_signer_jws_envelope_round_trip(jws_context):
+    signer, key_entry, verify_opts = jws_context
+    envelope = {"type": "jws-envelope", "version": 1}
+
+    signatures = await signer.sign_envelope(
+        "jws", key_entry, envelope, canon="json", opts={"alg": "HS256"}
+    )
+
+    assert signatures and signatures[0].meta.get("payload_kind") == "envelope"
+    assert await signer.verify_envelope(
+        "jws", envelope, signatures, canon="json", opts=verify_opts
+    )

--- a/pkgs/plugins/media_signer/tests/test_media_signer_openpgp.py
+++ b/pkgs/plugins/media_signer/tests/test_media_signer_openpgp.py
@@ -1,0 +1,69 @@
+import pytest
+
+pytest.importorskip("pgpy")
+
+from ._helpers import (
+    async_chunks,
+    build_media_signer_with_openpgp,
+    digest,
+    openpgp_private_entry,
+    openpgp_verify_opts,
+)
+
+
+@pytest.fixture
+async def openpgp_context():
+    signer, _provider, key_ref = await build_media_signer_with_openpgp("openpgp-test")
+    return signer, openpgp_private_entry(key_ref), openpgp_verify_opts(key_ref)
+
+
+@pytest.mark.asyncio
+async def test_media_signer_openpgp_detached_bytes(openpgp_context):
+    signer, key_entry, verify_opts = openpgp_context
+    payload = b"openpgp bytes payload"
+
+    signatures = await signer.sign_bytes("openpgp", key_entry, payload)
+
+    assert signatures and signatures[0].mode == "detached"
+    assert await signer.verify_bytes("openpgp", payload, signatures, opts=verify_opts)
+
+
+@pytest.mark.asyncio
+async def test_media_signer_openpgp_detached_digest(openpgp_context):
+    signer, key_entry, verify_opts = openpgp_context
+    payload = b"openpgp digest payload"
+    sha = digest(payload)
+
+    signatures = await signer.sign_digest("openpgp", key_entry, sha)
+
+    assert signatures and signatures[0].mode == "detached"
+    assert await signer.verify_digest("openpgp", sha, signatures, opts=verify_opts)
+
+
+@pytest.mark.asyncio
+async def test_media_signer_openpgp_detached_stream(openpgp_context):
+    signer, key_entry, verify_opts = openpgp_context
+    payload = b"openpgp stream payload"
+    stream_factory = async_chunks(payload, size=8)
+
+    signatures = await signer.sign_stream("openpgp", key_entry, stream_factory())
+
+    assert signatures and signatures[0].mode == "detached"
+    assert await signer.verify_stream(
+        "openpgp", stream_factory(), signatures, opts=verify_opts
+    )
+
+
+@pytest.mark.asyncio
+async def test_media_signer_openpgp_detached_envelope(openpgp_context):
+    signer, key_entry, verify_opts = openpgp_context
+    envelope = {"event": "openpgp", "status": "ok"}
+
+    signatures = await signer.sign_envelope(
+        "openpgp", key_entry, envelope, canon="json"
+    )
+
+    assert signatures and signatures[0].mode == "detached"
+    assert await signer.verify_envelope(
+        "openpgp", envelope, signatures, canon="json", opts=verify_opts
+    )

--- a/pkgs/plugins/media_signer/tests/test_media_signer_pdf.py
+++ b/pkgs/plugins/media_signer/tests/test_media_signer_pdf.py
@@ -1,0 +1,89 @@
+import pytest
+
+from ._helpers import (
+    async_chunks,
+    build_media_signer_with_rsa,
+    cms_key_entry,
+    digest,
+    pdf_sign_opts,
+    pdf_trust_opts,
+)
+
+
+@pytest.fixture
+async def pdf_context():
+    signer, _provider, key_ref = await build_media_signer_with_rsa("pdf-test")
+    return signer, cms_key_entry(key_ref), pdf_trust_opts(key_ref)
+
+
+@pytest.mark.asyncio
+async def test_media_signer_pdf_attached_bytes(pdf_context):
+    signer, key_entry, trust_opts = pdf_context
+    payload = b"pdf attached payload"
+
+    signatures = await signer.sign_bytes(
+        "pdf", key_entry, payload, opts=pdf_sign_opts(True)
+    )
+
+    assert signatures and signatures[0].mode == "attached"
+    assert signatures[0].meta.get("attached") is True
+    assert await signer.verify_bytes("pdf", payload, signatures, opts=trust_opts)
+
+
+@pytest.mark.asyncio
+async def test_media_signer_pdf_detached_bytes(pdf_context):
+    signer, key_entry, trust_opts = pdf_context
+    payload = b"pdf detached payload"
+
+    signatures = await signer.sign_bytes(
+        "pdf", key_entry, payload, opts=pdf_sign_opts(False)
+    )
+
+    assert signatures and signatures[0].mode == "detached"
+    assert signatures[0].meta.get("attached") is False
+    assert await signer.verify_bytes("pdf", payload, signatures, opts=trust_opts)
+
+
+@pytest.mark.asyncio
+async def test_media_signer_pdf_detached_digest(pdf_context):
+    signer, key_entry, trust_opts = pdf_context
+    payload = b"pdf digest payload"
+    sha = digest(payload)
+
+    signatures = await signer.sign_digest(
+        "pdf", key_entry, sha, opts=pdf_sign_opts(False)
+    )
+
+    assert signatures and signatures[0].meta.get("payload_kind") == "digest"
+    assert await signer.verify_digest("pdf", sha, signatures, opts=trust_opts)
+
+
+@pytest.mark.asyncio
+async def test_media_signer_pdf_attached_stream(pdf_context):
+    signer, key_entry, trust_opts = pdf_context
+    payload = b"pdf stream payload"
+    stream_factory = async_chunks(payload, size=9)
+
+    signatures = await signer.sign_stream(
+        "pdf", key_entry, stream_factory(), opts=pdf_sign_opts(True)
+    )
+
+    assert signatures and signatures[0].meta.get("payload_kind") == "stream"
+    assert await signer.verify_stream(
+        "pdf", stream_factory(), signatures, opts=trust_opts
+    )
+
+
+@pytest.mark.asyncio
+async def test_media_signer_pdf_detached_envelope(pdf_context):
+    signer, key_entry, trust_opts = pdf_context
+    envelope = {"pdf": {"title": "MediaSigner"}, "data": "payload"}
+
+    signatures = await signer.sign_envelope(
+        "pdf", key_entry, envelope, canon="json", opts=pdf_sign_opts(False)
+    )
+
+    assert signatures and signatures[0].meta.get("attached") is False
+    assert await signer.verify_envelope(
+        "pdf", envelope, signatures, canon="json", opts=trust_opts
+    )

--- a/pkgs/plugins/media_signer/tests/test_media_signer_xmld.py
+++ b/pkgs/plugins/media_signer/tests/test_media_signer_xmld.py
@@ -1,0 +1,65 @@
+import pytest
+
+from ._helpers import (
+    async_chunks,
+    build_media_signer_with_rsa,
+    digest,
+    xml_key_entry,
+    xml_verify_opts,
+)
+
+
+@pytest.fixture
+async def xmld_context():
+    signer, _provider, key_ref = await build_media_signer_with_rsa("xmld-test")
+    return signer, xml_key_entry(key_ref), xml_verify_opts(key_ref)
+
+
+@pytest.mark.asyncio
+async def test_media_signer_xmld_detached_bytes(xmld_context):
+    signer, key_entry, verify_opts = xmld_context
+    payload = b"<root>bytes</root>"
+
+    signatures = await signer.sign_bytes("xmld", key_entry, payload)
+
+    assert signatures and signatures[0].mode == "detached"
+    assert await signer.verify_bytes("xmld", payload, signatures, opts=verify_opts)
+
+
+@pytest.mark.asyncio
+async def test_media_signer_xmld_detached_digest(xmld_context):
+    signer, key_entry, verify_opts = xmld_context
+    payload = b"<root>digest</root>"
+    sha = digest(payload)
+
+    signatures = await signer.sign_digest("xmld", key_entry, sha)
+
+    assert signatures and signatures[0].mode == "detached"
+    assert await signer.verify_digest("xmld", sha, signatures, opts=verify_opts)
+
+
+@pytest.mark.asyncio
+async def test_media_signer_xmld_detached_stream(xmld_context):
+    signer, key_entry, verify_opts = xmld_context
+    payload = b"<root>stream</root>"
+    stream_factory = async_chunks(payload, size=5)
+
+    signatures = await signer.sign_stream("xmld", key_entry, stream_factory())
+
+    assert signatures and signatures[0].mode == "detached"
+    assert await signer.verify_stream(
+        "xmld", stream_factory(), signatures, opts=verify_opts
+    )
+
+
+@pytest.mark.asyncio
+async def test_media_signer_xmld_detached_envelope(xmld_context):
+    signer, key_entry, verify_opts = xmld_context
+    envelope = "<root><value>envelope</value></root>"
+
+    signatures = await signer.sign_envelope("xmld", key_entry, envelope, canon="c14n")
+
+    assert signatures and signatures[0].mode == "detached"
+    assert await signer.verify_envelope(
+        "xmld", envelope, signatures, canon="c14n", opts=verify_opts
+    )


### PR DESCRIPTION
## Summary
- add shared helpers that generate signing materials through Swarmauri key provider plugins
- create comprehensive MediaSigner tests for CMS, JWS, OpenPGP, PDF, and XMLD signers covering bytes, digests, streams, and envelopes
- assert attached and detached signature handling where applicable for every optional signer facade entry

## Testing
- uv run --directory plugins/media_signer --package MediaSigner ruff format .
- uv run --directory plugins/media_signer --package MediaSigner ruff check . --fix

------
https://chatgpt.com/codex/tasks/task_e_68dea0e110708326b61845358011a452