### PR TITLE
Standardize signing package metadata

### DIFF
--- a/pkgs/community/swarmauri_signing_dsse/pyproject.toml
+++ b/pkgs/community/swarmauri_signing_dsse/pyproject.toml
@@ -8,13 +8,14 @@ requires-python = ">=3.10,<3.13"
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 keywords = ["swarmauri", "signing", "dsse", "sigstore", "supply-chain", "pae"]
 classifiers = [
+    "Development Status :: 1 - Planning",
     "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "Development Status :: 1 - Planning",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
 ]

--- a/pkgs/standards/swarmauri_signing_ca/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_ca/pyproject.toml
@@ -1,19 +1,27 @@
 [project]
 name = "swarmauri_signing_ca"
 version = "0.3.0.dev5"
-description = "CA-capable signer for Swarmauri"
+description = "Certificate authority style signer for Swarmauri envelopes"
 license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
+keywords = [
+    "swarmauri",
+    "signing",
+    "certificate-authority",
+    "pki",
+    "x509",
+]
 classifiers = [
+    "Development Status :: 1 - Planning",
     "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
 ]
@@ -22,6 +30,11 @@ dependencies = [
     "swarmauri_base",
     "cryptography",
 ]
+
+[project.urls]
+Homepage = "https://github.com/swarmauri/swarmauri-sdk"
+Source = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/standards/swarmauri_signing_ca"
+Documentation = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/standards/swarmauri_signing_ca#readme"
 
 [project.optional-dependencies]
 cbor = ["cbor2"]

--- a/pkgs/standards/swarmauri_signing_cms/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_cms/pyproject.toml
@@ -6,14 +6,68 @@ license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
+keywords = [
+    "swarmauri",
+    "signing",
+    "cms",
+    "pkcs7",
+    "envelope",
+]
+classifiers = [
+    "Development Status :: 1 - Planning",
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Security :: Cryptography",
+    "Intended Audience :: Developers",
+]
 dependencies = [
     "swarmauri_base",
     "swarmauri_core",
 ]
 
+[project.urls]
+Homepage = "https://github.com/swarmauri/swarmauri-sdk"
+Source = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/standards/swarmauri_signing_cms"
+Documentation = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/standards/swarmauri_signing_cms#readme"
+
 [tool.uv.sources]
 swarmauri_base = { workspace = true }
 swarmauri_core = { workspace = true }
+
+[tool.pytest.ini_options]
+norecursedirs = ["combined", "scripts"]
+markers = [
+    "test: standard test",
+    "unit: Unit tests",
+    "i9n: Integration tests",
+    "r8n: Regression tests",
+    "acceptance: Acceptance tests",
+    "perf: Performance tests",
+    "example: README-backed usage examples",
+]
+timeout = 300
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "pytest-timeout>=2.3.1",
+    "pytest-benchmark>=4.0.0",
+    "flake8>=7.0",
+    "ruff>=0.9.9",
+]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pkgs/standards/swarmauri_signing_dpop/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_dpop/pyproject.toml
@@ -6,14 +6,22 @@ license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
+keywords = [
+    "swarmauri",
+    "signing",
+    "dpop",
+    "oauth",
+    "proof-of-possession",
+]
 classifiers = [
+    "Development Status :: 1 - Planning",
     "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
 ]
@@ -23,6 +31,11 @@ dependencies = [
     "swarmauri_signing_jws",
     "cryptography",
 ]
+
+[project.urls]
+Homepage = "https://github.com/swarmauri/swarmauri-sdk"
+Source = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/standards/swarmauri_signing_dpop"
+Documentation = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/standards/swarmauri_signing_dpop#readme"
 
 [tool.uv.sources]
 swarmauri_core = { workspace = true }

--- a/pkgs/standards/swarmauri_signing_ecdsa/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_ecdsa/pyproject.toml
@@ -6,14 +6,22 @@ license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
+keywords = [
+    "swarmauri",
+    "signing",
+    "ecdsa",
+    "elliptic-curve",
+    "cryptography",
+]
 classifiers = [
+    "Development Status :: 1 - Planning",
     "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
 ]
@@ -22,6 +30,11 @@ dependencies = [
     "swarmauri_base",
     "cryptography",
 ]
+
+[project.urls]
+Homepage = "https://github.com/swarmauri/swarmauri-sdk"
+Source = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/standards/swarmauri_signing_ecdsa"
+Documentation = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/standards/swarmauri_signing_ecdsa#readme"
 
 [project.optional-dependencies]
 cbor = ["cbor2"]

--- a/pkgs/standards/swarmauri_signing_ed25519/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_ed25519/pyproject.toml
@@ -6,14 +6,22 @@ license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
+keywords = [
+    "swarmauri",
+    "signing",
+    "ed25519",
+    "elliptic-curve",
+    "cryptography",
+]
 classifiers = [
+    "Development Status :: 1 - Planning",
     "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
 ]
@@ -22,6 +30,11 @@ dependencies = [
     "swarmauri_base",
     "cryptography",
 ]
+
+[project.urls]
+Homepage = "https://github.com/swarmauri/swarmauri-sdk"
+Source = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/standards/swarmauri_signing_ed25519"
+Documentation = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/standards/swarmauri_signing_ed25519#readme"
 
 [project.optional-dependencies]
 cbor = ["cbor2"]

--- a/pkgs/standards/swarmauri_signing_hmac/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_hmac/pyproject.toml
@@ -6,14 +6,22 @@ license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
+keywords = [
+    "swarmauri",
+    "signing",
+    "hmac",
+    "symmetric",
+    "message-authentication",
+]
 classifiers = [
+    "Development Status :: 1 - Planning",
     "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
 ]
@@ -21,6 +29,11 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
 ]
+
+[project.urls]
+Homepage = "https://github.com/swarmauri/swarmauri-sdk"
+Source = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/standards/swarmauri_signing_hmac"
+Documentation = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/standards/swarmauri_signing_hmac#readme"
 
 [project.optional-dependencies]
 cbor = ["cbor2"]

--- a/pkgs/standards/swarmauri_signing_jws/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_jws/pyproject.toml
@@ -6,14 +6,22 @@ license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
+keywords = [
+    "swarmauri",
+    "signing",
+    "jws",
+    "jwt",
+    "json-web-signature",
+]
 classifiers = [
+    "Development Status :: 1 - Planning",
     "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
 ]
@@ -25,6 +33,11 @@ dependencies = [
     "swarmauri_signing_ecdsa",
     "swarmauri_signing_ed25519",
 ]
+
+[project.urls]
+Homepage = "https://github.com/swarmauri/swarmauri-sdk"
+Source = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/standards/swarmauri_signing_jws"
+Documentation = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/standards/swarmauri_signing_jws#readme"
 
 [project.optional-dependencies]
 cbor = ["cbor2"]

--- a/pkgs/standards/swarmauri_signing_openpgp/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_openpgp/pyproject.toml
@@ -6,15 +6,69 @@ license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
+keywords = [
+    "swarmauri",
+    "signing",
+    "openpgp",
+    "pgp",
+    "encryption",
+]
+classifiers = [
+    "Development Status :: 1 - Planning",
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Security :: Cryptography",
+    "Intended Audience :: Developers",
+]
 dependencies = [
     "swarmauri_base",
     "swarmauri_core",
     "pgpy>=0.6.0",
 ]
 
+[project.urls]
+Homepage = "https://github.com/swarmauri/swarmauri-sdk"
+Source = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/standards/swarmauri_signing_openpgp"
+Documentation = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/standards/swarmauri_signing_openpgp#readme"
+
 [tool.uv.sources]
 swarmauri_base = { workspace = true }
 swarmauri_core = { workspace = true }
+
+[tool.pytest.ini_options]
+norecursedirs = ["combined", "scripts"]
+markers = [
+    "test: standard test",
+    "unit: Unit tests",
+    "i9n: Integration tests",
+    "r8n: Regression tests",
+    "acceptance: Acceptance tests",
+    "perf: Performance tests",
+    "example: README-backed usage examples",
+]
+timeout = 300
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "pytest-timeout>=2.3.1",
+    "pytest-benchmark>=4.0.0",
+    "flake8>=7.0",
+    "ruff>=0.9.9",
+]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pkgs/standards/swarmauri_signing_pdf/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_pdf/pyproject.toml
@@ -6,16 +6,70 @@ license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
+keywords = [
+    "swarmauri",
+    "signing",
+    "pdf",
+    "document-signing",
+    "cms",
+]
+classifiers = [
+    "Development Status :: 1 - Planning",
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Security :: Cryptography",
+    "Intended Audience :: Developers",
+]
 dependencies = [
     "swarmauri_base",
     "swarmauri_core",
     "swarmauri_signing_cms",
 ]
 
+[project.urls]
+Homepage = "https://github.com/swarmauri/swarmauri-sdk"
+Source = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/standards/swarmauri_signing_pdf"
+Documentation = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/standards/swarmauri_signing_pdf#readme"
+
 [tool.uv.sources]
 swarmauri_base = { workspace = true }
 swarmauri_core = { workspace = true }
 swarmauri_signing_cms = { workspace = true }
+
+[tool.pytest.ini_options]
+norecursedirs = ["combined", "scripts"]
+markers = [
+    "test: standard test",
+    "unit: Unit tests",
+    "i9n: Integration tests",
+    "r8n: Regression tests",
+    "acceptance: Acceptance tests",
+    "perf: Performance tests",
+    "example: README-backed usage examples",
+]
+timeout = 300
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "pytest-timeout>=2.3.1",
+    "pytest-benchmark>=4.0.0",
+    "flake8>=7.0",
+    "ruff>=0.9.9",
+]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pkgs/standards/swarmauri_signing_pep458/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_pep458/pyproject.toml
@@ -34,9 +34,9 @@ dependencies = [
 ]
 
 [project.urls]
-"Homepage" = "https://github.com/swarmauri/swarmauri-sdk"
-"Source" = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/standards/swarmauri_signing_pep458"
-"Documentation" = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/standards/swarmauri_signing_pep458#readme"
+Homepage = "https://github.com/swarmauri/swarmauri-sdk"
+Source = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/standards/swarmauri_signing_pep458"
+Documentation = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/standards/swarmauri_signing_pep458#readme"
 
 [tool.uv.sources]
 swarmauri_core = { workspace = true }

--- a/pkgs/standards/swarmauri_signing_pgp/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_pgp/pyproject.toml
@@ -4,26 +4,38 @@ version = "0.3.0.dev5"
 description = "OpenPGP envelope signer for Swarmauri"
 license = "Apache-2.0"
 readme = "README.md"
-repository = "http://github.com/swarmauri/swarmauri-sdk"
 requires-python = ">=3.10,<3.13"
+authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
+keywords = [
+    "swarmauri",
+    "signing",
+    "pgp",
+    "openpgp",
+    "envelope",
+]
 classifiers = [
+    "Development Status :: 1 - Planning",
     "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
 ]
-authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
     "pgpy>=0.6.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/swarmauri/swarmauri-sdk"
+Source = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/standards/swarmauri_signing_pgp"
+Documentation = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/standards/swarmauri_signing_pgp#readme"
 
 [project.optional-dependencies]
 cbor = ["cbor2>=5.4.6"]

--- a/pkgs/standards/swarmauri_signing_rsa/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_rsa/pyproject.toml
@@ -6,14 +6,22 @@ license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
+keywords = [
+    "swarmauri",
+    "signing",
+    "rsa",
+    "public-key",
+    "cryptography",
+]
 classifiers = [
+    "Development Status :: 1 - Planning",
     "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
 ]
@@ -22,6 +30,11 @@ dependencies = [
     "swarmauri_base",
     "cryptography",
 ]
+
+[project.urls]
+Homepage = "https://github.com/swarmauri/swarmauri-sdk"
+Source = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/standards/swarmauri_signing_rsa"
+Documentation = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/standards/swarmauri_signing_rsa#readme"
 
 [project.optional-dependencies]
 cbor = ["cbor2"]

--- a/pkgs/standards/swarmauri_signing_secp256k1/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_secp256k1/pyproject.toml
@@ -6,14 +6,22 @@ license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
+keywords = [
+    "swarmauri",
+    "signing",
+    "secp256k1",
+    "elliptic-curve",
+    "blockchain",
+]
 classifiers = [
+    "Development Status :: 1 - Planning",
     "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
 ]
@@ -22,6 +30,11 @@ dependencies = [
     "swarmauri_base",
     "cryptography",
 ]
+
+[project.urls]
+Homepage = "https://github.com/swarmauri/swarmauri-sdk"
+Source = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/standards/swarmauri_signing_secp256k1"
+Documentation = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/standards/swarmauri_signing_secp256k1#readme"
 
 [project.optional-dependencies]
 cbor = ["cbor2"]

--- a/pkgs/standards/swarmauri_signing_ssh/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_ssh/pyproject.toml
@@ -6,14 +6,22 @@ license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
+keywords = [
+    "swarmauri",
+    "signing",
+    "ssh",
+    "public-key",
+    "secure-shell",
+]
 classifiers = [
+    "Development Status :: 1 - Planning",
     "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
 ]
@@ -21,6 +29,11 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
 ]
+
+[project.urls]
+Homepage = "https://github.com/swarmauri/swarmauri-sdk"
+Source = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/standards/swarmauri_signing_ssh"
+Documentation = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/standards/swarmauri_signing_ssh#readme"
 
 [project.optional-dependencies]
 cbor = ["cbor2"]

--- a/pkgs/standards/swarmauri_signing_xmld/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_xmld/pyproject.toml
@@ -5,7 +5,26 @@ description = "XML Digital Signature implementation for the Swarmauri SigningBas
 license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
-authors = [{ name = "Swarmauri", email = "hello@swarmauri.com" }]
+authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
+keywords = [
+    "swarmauri",
+    "signing",
+    "xml",
+    "xml-dsig",
+    "digital-signature",
+]
+classifiers = [
+    "Development Status :: 1 - Planning",
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Security :: Cryptography",
+    "Intended Audience :: Developers",
+]
 dependencies = [
     "swarmauri_base",
     "swarmauri_core",
@@ -13,14 +32,42 @@ dependencies = [
     "lxml>=4.9",
 ]
 
+[project.urls]
+Homepage = "https://github.com/swarmauri/swarmauri-sdk"
+Source = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/standards/swarmauri_signing_xmld"
+Documentation = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/standards/swarmauri_signing_xmld#readme"
+
 [tool.uv.sources]
 swarmauri_base = { workspace = true }
 swarmauri_core = { workspace = true }
 
+[tool.pytest.ini_options]
+norecursedirs = ["combined", "scripts"]
+markers = [
+    "test: standard test",
+    "unit: Unit tests",
+    "i9n: Integration tests",
+    "r8n: Regression tests",
+    "acceptance: Acceptance tests",
+    "perf: Performance tests",
+    "example: README-backed usage examples",
+]
+timeout = 300
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
+
 [dependency-groups]
 dev = [
     "pytest>=8.0",
-    "pytest-asyncio>=0.24",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "pytest-timeout>=2.3.1",
+    "pytest-benchmark>=4.0.0",
+    "flake8>=7.0",
     "ruff>=0.9.9",
 ]
 


### PR DESCRIPTION
## Summary
- align all `swarmauri_signing_*` package `pyproject.toml` files with Swarmauri metadata guidance (keywords, planning classifier, Python classifiers, and package URLs)
- add or normalize pytest markers and development dependency groups where they were missing or incomplete for the signing packages
- refresh the community DSSE signer metadata to match the same classifier expectations

## Testing
- Ran `uv run --directory pkgs/<member>/<package> --package <package> ruff format .` followed by `ruff check . --fix` for each updated signing package


------
https://chatgpt.com/codex/tasks/task_e_68debd2955fc8326bca848c0e851ca8c