### PR TITLE
Expand EmbeddedSigner extras for media handlers and signers

### DIFF
--- a/pkgs/plugins/embedded_signer/EmbeddedSigner/__init__.py
+++ b/pkgs/plugins/embedded_signer/EmbeddedSigner/__init__.py
@@ -1,0 +1,5 @@
+"""Expose the :class:`EmbedSigner` orchestrator."""
+
+from ._embed_signer import EmbedSigner
+
+__all__ = ["EmbedSigner"]

--- a/pkgs/plugins/embedded_signer/EmbeddedSigner/_embed_signer.py
+++ b/pkgs/plugins/embedded_signer/EmbeddedSigner/_embed_signer.py
@@ -1,0 +1,341 @@
+"""Embed XMP metadata and sign media payloads with Swarmauri plugins."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from importlib import metadata
+from pathlib import Path
+from typing import Any, MutableMapping, Optional
+from urllib.parse import parse_qs, urlparse
+
+from EmbedXMP import EmbedXMP
+from MediaSigner import MediaSigner
+from swarmauri_core.crypto.types import KeyRef
+from swarmauri_core.keys.IKeyProvider import IKeyProvider
+from swarmauri_core.signing.types import Signature
+
+
+@dataclass(frozen=True)
+class _ParsedKeyRef:
+    provider: Optional[str]
+    kid: str
+    version: Optional[int]
+
+
+class EmbedSigner:
+    """High-level helper that embeds XMP metadata and produces signatures."""
+
+    def __init__(
+        self,
+        *,
+        embedder: Optional[EmbedXMP] = None,
+        signer: Optional[MediaSigner] = None,
+        key_provider: Optional[IKeyProvider] = None,
+        key_provider_name: Optional[str] = None,
+        provider_plugins: Optional[
+            Mapping[str, Callable[[], IKeyProvider] | type[IKeyProvider]]
+        ] = None,
+        eager_import: bool = True,
+    ) -> None:
+        self._embedder = embedder or EmbedXMP(eager_import=eager_import)
+        self._provider_factories: MutableMapping[
+            str, Callable[[], IKeyProvider] | type[IKeyProvider]
+        ] = self._discover_provider_factories()
+        if provider_plugins:
+            self._provider_factories.update(dict(provider_plugins))
+        self._providers: MutableMapping[str, IKeyProvider] = {}
+        self._default_provider: Optional[IKeyProvider] = None
+        self._default_provider_name: Optional[str] = None
+
+        if key_provider is not None:
+            self._default_provider = key_provider
+            self._default_provider_name = key_provider.__class__.__name__
+        elif key_provider_name is not None:
+            self._default_provider = self._instantiate_provider(key_provider_name)
+            self._default_provider_name = key_provider_name
+
+        provider_for_signer = self._default_provider
+        self._signer = signer or MediaSigner(key_provider=provider_for_signer)
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _discover_provider_factories() -> MutableMapping[
+        str, Callable[[], IKeyProvider] | type[IKeyProvider]
+    ]:
+        factories: MutableMapping[
+            str, Callable[[], IKeyProvider] | type[IKeyProvider]
+        ] = {}
+        try:
+            entries = metadata.entry_points(group="swarmauri.key_providers")
+        except TypeError:  # pragma: no cover - Python <3.10 fallback
+            entries = metadata.entry_points()["swarmauri.key_providers"]
+        for entry in entries:
+            try:
+                provider_cls = entry.load()
+            except (
+                Exception
+            ):  # pragma: no cover - defensive against broken entry points
+                continue
+            if not inspect.isclass(provider_cls) and not callable(provider_cls):
+                continue
+            factories[entry.name] = provider_cls
+        return factories
+
+    def _instantiate_provider(self, name: str) -> IKeyProvider:
+        if name in self._providers:
+            return self._providers[name]
+        factory = self._provider_factories.get(name)
+        if factory is None:
+            raise ValueError(f"Unknown key provider '{name}'")
+        provider: IKeyProvider
+        if inspect.isclass(factory):
+            provider = factory()  # type: ignore[call-arg]
+        else:
+            provider = factory()
+        self._providers[name] = provider
+        return provider
+
+    def _get_provider(self, name: Optional[str]) -> IKeyProvider:
+        if name is None:
+            if self._default_provider is not None:
+                return self._default_provider
+            if self._default_provider_name is not None:
+                return self._instantiate_provider(self._default_provider_name)
+            raise ValueError(
+                "No default key provider configured; include a provider name in the key reference."
+            )
+        if name == self._default_provider_name and self._default_provider is not None:
+            return self._default_provider
+        return self._instantiate_provider(name)
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _parse_key_reference(value: str) -> _ParsedKeyRef:
+        parsed = urlparse(value)
+        if parsed.scheme:
+            provider = parsed.scheme
+            kid = (parsed.netloc + parsed.path).lstrip("/")
+            query = parse_qs(parsed.query, keep_blank_values=False)
+            version = None
+            if "version" in query and query["version"]:
+                try:
+                    version = int(query["version"][0])
+                except (TypeError, ValueError) as exc:
+                    raise ValueError(
+                        f"Invalid version component in key reference '{value}'"
+                    ) from exc
+            return _ParsedKeyRef(provider=provider, kid=kid, version=version)
+        token = value
+        provider_name = None
+        if ":" in token and not token.startswith("{"):
+            provider_name, _, token = token.partition(":")
+        kid, sep, version_token = token.partition("@")
+        version_number = None
+        if sep:
+            try:
+                version_number = int(version_token)
+            except ValueError as exc:
+                raise ValueError(
+                    f"Invalid version component in key reference '{value}'"
+                ) from exc
+        if not kid:
+            raise ValueError("Key reference must include a key identifier")
+        return _ParsedKeyRef(provider=provider_name, kid=kid, version=version_number)
+
+    async def _resolve_key(
+        self, key: KeyRef | Mapping[str, Any] | str
+    ) -> KeyRef | Mapping[str, Any]:
+        if isinstance(key, Mapping):
+            return key
+        if isinstance(key, KeyRef):
+            return key
+        if isinstance(key, str):
+            ref = self._parse_key_reference(key)
+            provider = self._get_provider(ref.provider)
+            try:
+                resolved = await provider.get_key_by_ref(ref.kid, include_secret=True)
+            except NotImplementedError:
+                resolved = None
+            except AttributeError:  # pragma: no cover - provider without method
+                resolved = None
+            if resolved is None:
+                resolved = await provider.get_key(
+                    ref.kid, version=ref.version, include_secret=True
+                )
+            return resolved
+        raise TypeError(
+            "key must be a Mapping, KeyRef, or string reference understood by EmbedSigner"
+        )
+
+    # ------------------------------------------------------------------
+    def embed_bytes(
+        self, data: bytes, xmp_xml: str, *, path: str | Path | None = None
+    ) -> bytes:
+        """Embed XMP metadata into *data* using the configured handlers."""
+
+        ref = str(path) if path is not None else None
+        return self._embedder.embed(data, xmp_xml, ref)
+
+    def read_xmp(self, data: bytes, *, path: str | Path | None = None) -> str | None:
+        """Read XMP metadata from *data* using the configured handlers."""
+
+        ref = str(path) if path is not None else None
+        return self._embedder.read(data, ref)
+
+    def remove_xmp(self, data: bytes, *, path: str | Path | None = None) -> bytes:
+        """Remove XMP metadata from *data* using the configured handlers."""
+
+        ref = str(path) if path is not None else None
+        return self._embedder.remove(data, ref)
+
+    def embed_file(
+        self,
+        path: str | Path,
+        xmp_xml: str,
+        *,
+        write_back: bool = True,
+        output: str | Path | None = None,
+    ) -> bytes:
+        """Embed XMP metadata directly into a file on disk."""
+
+        file_path = Path(path)
+        updated = self.embed_bytes(file_path.read_bytes(), xmp_xml, path=file_path)
+        target = Path(output) if output is not None else file_path
+        if write_back:
+            target.write_bytes(updated)
+        return updated
+
+    def read_xmp_file(self, path: str | Path) -> str | None:
+        """Read XMP metadata from the file located at *path*."""
+
+        file_path = Path(path)
+        return self.read_xmp(file_path.read_bytes(), path=file_path)
+
+    def remove_xmp_file(
+        self,
+        path: str | Path,
+        *,
+        write_back: bool = False,
+        output: str | Path | None = None,
+    ) -> bytes:
+        """Remove XMP metadata from a file, optionally persisting the result."""
+
+        file_path = Path(path)
+        updated = self.remove_xmp(file_path.read_bytes(), path=file_path)
+        target = Path(output) if output is not None else file_path
+        if write_back:
+            target.write_bytes(updated)
+        return updated
+
+    # ------------------------------------------------------------------
+    async def sign_bytes(
+        self,
+        fmt: str,
+        key: KeyRef | Mapping[str, Any] | str,
+        payload: bytes,
+        *,
+        attached: bool = True,
+        alg: Optional[str] = None,
+        signer_opts: Optional[Mapping[str, Any]] = None,
+    ) -> Sequence[Signature]:
+        """Produce signatures for *payload* using the requested signer format."""
+
+        resolved_key = await self._resolve_key(key)
+        opts: dict[str, Any] = dict(signer_opts or {})
+        opts.setdefault("attached", attached)
+        return await self._signer.sign_bytes(
+            fmt, resolved_key, payload, alg=alg, opts=opts
+        )
+
+    async def embed_and_sign_bytes(
+        self,
+        data: bytes,
+        *,
+        fmt: str,
+        xmp_xml: str,
+        key: KeyRef | Mapping[str, Any] | str,
+        path: str | Path | None = None,
+        attached: bool = True,
+        alg: Optional[str] = None,
+        signer_opts: Optional[Mapping[str, Any]] = None,
+    ) -> tuple[bytes, Sequence[Signature]]:
+        """Embed metadata into *data* and sign the updated payload."""
+
+        embedded = self.embed_bytes(data, xmp_xml, path=path)
+        signatures = await self.sign_bytes(
+            fmt,
+            key,
+            embedded,
+            attached=attached,
+            alg=alg,
+            signer_opts=signer_opts,
+        )
+        return embedded, signatures
+
+    async def embed_and_sign_file(
+        self,
+        path: str | Path,
+        *,
+        fmt: str,
+        xmp_xml: str,
+        key: KeyRef | Mapping[str, Any] | str,
+        attached: bool = True,
+        alg: Optional[str] = None,
+        signer_opts: Optional[Mapping[str, Any]] = None,
+        write_back: bool = False,
+    ) -> tuple[bytes, Sequence[Signature]]:
+        """Embed metadata into *path* and optionally persist the signed bytes."""
+
+        file_path = Path(path)
+        embedded, signatures = await self.embed_and_sign_bytes(
+            file_path.read_bytes(),
+            fmt=fmt,
+            xmp_xml=xmp_xml,
+            key=key,
+            path=file_path,
+            attached=attached,
+            alg=alg,
+            signer_opts=signer_opts,
+        )
+        if write_back:
+            file_path.write_bytes(embedded)
+        return embedded, signatures
+
+    async def sign_file(
+        self,
+        path: str | Path,
+        *,
+        fmt: str,
+        key: KeyRef | Mapping[str, Any] | str,
+        attached: bool = True,
+        alg: Optional[str] = None,
+        signer_opts: Optional[Mapping[str, Any]] = None,
+    ) -> Sequence[Signature]:
+        """Sign the contents of *path* and return the generated signatures."""
+
+        file_path = Path(path)
+        payload = file_path.read_bytes()
+        return await self.sign_bytes(
+            fmt,
+            key,
+            payload,
+            attached=attached,
+            alg=alg,
+            signer_opts=signer_opts,
+        )
+
+    # ------------------------------------------------------------------
+    def supported_embed_handlers(self) -> Sequence[str]:
+        """Return the names of registered XMP handlers."""
+
+        return tuple(
+            handler.__class__.__name__
+            for handler in getattr(self._embedder, "_handlers", [])
+        )
+
+    def supported_signers(self) -> Sequence[str]:
+        """Expose signer formats advertised by the underlying :class:`MediaSigner`."""
+
+        return tuple(self._signer.supported_formats())

--- a/pkgs/plugins/embedded_signer/EmbeddedSigner/cli.py
+++ b/pkgs/plugins/embedded_signer/EmbeddedSigner/cli.py
@@ -1,0 +1,325 @@
+"""Command line interface for the :mod:`EmbeddedSigner` plugin."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import json
+import sys
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from ._embed_signer import EmbedSigner
+
+
+def _load_xmp_from_args(args: argparse.Namespace) -> str:
+    if args.xmp is not None and args.xmp_file is not None:
+        raise SystemExit("Specify either --xmp or --xmp-file, not both.")
+    if args.xmp is not None:
+        return args.xmp
+    if args.xmp_file is not None:
+        return Path(args.xmp_file).read_text(encoding="utf-8")
+    raise SystemExit("An XMP payload is required for this command.")
+
+
+def _resolve_key_argument(args: argparse.Namespace) -> Any:
+    provided = [
+        value
+        for value in (args.key_ref, args.key_json, args.key_file)
+        if value is not None
+    ]
+    if len(provided) != 1:
+        raise SystemExit("Provide exactly one of --key-ref, --key-json, or --key-file.")
+    if args.key_ref:
+        return args.key_ref
+    if args.key_json:
+        try:
+            return json.loads(args.key_json)
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+            raise SystemExit(f"Invalid JSON passed to --key-json: {exc}") from exc
+    if args.key_file:
+        return json.loads(Path(args.key_file).read_text(encoding="utf-8"))
+    raise SystemExit("A key reference or JSON description must be supplied.")
+
+
+def _serialise_signature(signature: Mapping[str, Any]) -> Mapping[str, Any]:
+    payload: dict[str, Any] = dict(signature)
+    artifact = payload.get("artifact")
+    if isinstance(artifact, (bytes, bytearray)):
+        payload["artifact"] = base64.b64encode(artifact).decode("ascii")
+        payload.setdefault("artifact_encoding", "base64")
+    return payload
+
+
+def _create_signer(args: argparse.Namespace) -> EmbedSigner:
+    provider_name = getattr(args, "key_provider", None)
+    return EmbedSigner(key_provider_name=provider_name)
+
+
+def _command_embed(args: argparse.Namespace) -> int:
+    signer = _create_signer(args)
+    xmp_xml = _load_xmp_from_args(args)
+    src = Path(args.input)
+    payload = src.read_bytes()
+    updated = signer.embed_bytes(payload, xmp_xml, path=src)
+    target = Path(args.output) if args.output else src
+    target.write_bytes(updated)
+    return 0
+
+
+def _command_read(args: argparse.Namespace) -> int:
+    signer = _create_signer(args)
+    src = Path(args.input)
+    metadata = signer.read_xmp_file(src)
+    if metadata is None:
+        return 1
+    sys.stdout.write(metadata)
+    if not metadata.endswith("\n"):
+        sys.stdout.write("\n")
+    return 0
+
+
+def _command_remove(args: argparse.Namespace) -> int:
+    signer = _create_signer(args)
+    src = Path(args.input)
+    updated = signer.remove_xmp_file(src)
+    target = Path(args.output) if args.output else src
+    target.write_bytes(updated)
+    return 0
+
+
+async def _async_sign(
+    signer: EmbedSigner,
+    *,
+    src: Path,
+    fmt: str,
+    key: Any,
+    attached: bool,
+    alg: str | None,
+    opts: Mapping[str, Any] | None,
+) -> Sequence[Mapping[str, Any]]:
+    signatures = await signer.sign_file(
+        src,
+        fmt=fmt,
+        key=key,
+        attached=attached,
+        alg=alg,
+        signer_opts=opts,
+    )
+    return [_serialise_signature(sig) for sig in signatures]
+
+
+def _command_sign(args: argparse.Namespace) -> int:
+    signer = _create_signer(args)
+    src = Path(args.input)
+    key = _resolve_key_argument(args)
+    opts: dict[str, Any] | None = None
+    if args.option:
+        opts = {}
+        for token in args.option:
+            name, _, value = token.partition("=")
+            if not name:
+                raise SystemExit("Signer options must use the form name=value.")
+            opts[name] = value
+    signatures = asyncio.run(
+        _async_sign(
+            signer,
+            src=src,
+            fmt=args.format,
+            key=key,
+            attached=not args.detached,
+            alg=args.alg,
+            opts=opts,
+        )
+    )
+    output = json.dumps(signatures, indent=2)
+    if args.output:
+        Path(args.output).write_text(output, encoding="utf-8")
+    else:
+        sys.stdout.write(output + "\n")
+    return 0
+
+
+async def _async_embed_sign(
+    signer: EmbedSigner,
+    *,
+    src: Path,
+    fmt: str,
+    xmp_xml: str,
+    key: Any,
+    attached: bool,
+    alg: str | None,
+    opts: Mapping[str, Any] | None,
+    write_back: bool,
+    output: Path | None,
+) -> Sequence[Mapping[str, Any]]:
+    embedded, signatures = await signer.embed_and_sign_file(
+        src,
+        fmt=fmt,
+        xmp_xml=xmp_xml,
+        key=key,
+        attached=attached,
+        alg=alg,
+        signer_opts=opts,
+        write_back=write_back and output is None,
+    )
+    if output is not None:
+        output.write_bytes(embedded)
+    return [_serialise_signature(sig) for sig in signatures]
+
+
+def _command_embed_sign(args: argparse.Namespace) -> int:
+    signer = _create_signer(args)
+    src = Path(args.input)
+    xmp_xml = _load_xmp_from_args(args)
+    key = _resolve_key_argument(args)
+    opts: dict[str, Any] | None = None
+    if args.option:
+        opts = {}
+        for token in args.option:
+            name, _, value = token.partition("=")
+            if not name:
+                raise SystemExit("Signer options must use the form name=value.")
+            opts[name] = value
+    output_path = Path(args.output) if args.output else None
+    signatures = asyncio.run(
+        _async_embed_sign(
+            signer,
+            src=src,
+            fmt=args.format,
+            xmp_xml=xmp_xml,
+            key=key,
+            attached=not args.detached,
+            alg=args.alg,
+            opts=opts,
+            write_back=args.write_back,
+            output=output_path,
+        )
+    )
+    output = json.dumps(signatures, indent=2)
+    if args.signature_output:
+        Path(args.signature_output).write_text(output, encoding="utf-8")
+    else:
+        sys.stdout.write(output + "\n")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Embed XMP metadata and sign media.")
+    parser.add_argument(
+        "--key-provider",
+        dest="key_provider",
+        help="Default key provider to use when resolving key references.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    embed_parser = subparsers.add_parser("embed", help="Embed XMP into a file")
+    embed_parser.add_argument("input", help="Path to the media file")
+    embed_parser.add_argument("--xmp", help="Inline XMP XML payload")
+    embed_parser.add_argument("--xmp-file", help="Read the XMP payload from a file")
+    embed_parser.add_argument("--output", help="Write the embedded media to this path")
+    embed_parser.set_defaults(func=_command_embed)
+
+    read_parser = subparsers.add_parser("read", help="Read XMP metadata from a file")
+    read_parser.add_argument("input", help="Path to the media file")
+    read_parser.set_defaults(func=_command_read)
+
+    remove_parser = subparsers.add_parser(
+        "remove", help="Strip XMP metadata from a file"
+    )
+    remove_parser.add_argument("input", help="Path to the media file")
+    remove_parser.add_argument("--output", help="Write the stripped media to this path")
+    remove_parser.set_defaults(func=_command_remove)
+
+    sign_parser = subparsers.add_parser("sign", help="Generate signatures for a file")
+    sign_parser.add_argument("input", help="Path to the media file")
+    sign_parser.add_argument("--format", required=True, help="MediaSigner format name")
+    sign_parser.add_argument("--key-ref", dest="key_ref", help="Key reference string")
+    sign_parser.add_argument(
+        "--key-json",
+        dest="key_json",
+        help="Inline JSON description of the signing key",
+    )
+    sign_parser.add_argument(
+        "--key-file",
+        dest="key_file",
+        help="Path to a JSON file describing the signing key",
+    )
+    sign_parser.add_argument(
+        "--option",
+        action="append",
+        help="Additional signer option in the form name=value",
+    )
+    sign_parser.add_argument("--alg", help="Explicit algorithm identifier")
+    sign_parser.add_argument(
+        "--detached",
+        action="store_true",
+        help="Produce detached signatures when supported",
+    )
+    sign_parser.add_argument(
+        "--output", help="Write the generated signatures to a file"
+    )
+    sign_parser.set_defaults(func=_command_sign)
+
+    embed_sign_parser = subparsers.add_parser(
+        "embed-sign", help="Embed metadata and sign the updated file"
+    )
+    embed_sign_parser.add_argument("input", help="Path to the media file")
+    embed_sign_parser.add_argument("--xmp", help="Inline XMP XML payload")
+    embed_sign_parser.add_argument(
+        "--xmp-file", help="Read the XMP payload from a file"
+    )
+    embed_sign_parser.add_argument(
+        "--format", required=True, help="MediaSigner format name"
+    )
+    embed_sign_parser.add_argument(
+        "--key-ref", dest="key_ref", help="Key reference string"
+    )
+    embed_sign_parser.add_argument(
+        "--key-json",
+        dest="key_json",
+        help="Inline JSON description of the signing key",
+    )
+    embed_sign_parser.add_argument(
+        "--key-file",
+        dest="key_file",
+        help="Path to a JSON file describing the signing key",
+    )
+    embed_sign_parser.add_argument(
+        "--option",
+        action="append",
+        help="Additional signer option in the form name=value",
+    )
+    embed_sign_parser.add_argument("--alg", help="Explicit algorithm identifier")
+    embed_sign_parser.add_argument(
+        "--detached",
+        action="store_true",
+        help="Produce detached signatures when supported",
+    )
+    embed_sign_parser.add_argument(
+        "--write-back",
+        action="store_true",
+        help="Persist embedded bytes back to the original input file",
+    )
+    embed_sign_parser.add_argument(
+        "--output",
+        help="Write embedded bytes to this path instead of the input file",
+    )
+    embed_sign_parser.add_argument(
+        "--signature-output",
+        help="Write generated signatures to this JSON file",
+    )
+    embed_sign_parser.set_defaults(func=_command_embed_sign)
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())

--- a/pkgs/plugins/embedded_signer/LICENSE
+++ b/pkgs/plugins/embedded_signer/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/plugins/embedded_signer/README.md
+++ b/pkgs/plugins/embedded_signer/README.md
@@ -1,0 +1,226 @@
+<p align="center">
+  <img src="../../../assets/swarmauri.brand.theme.svg" alt="Swarmauri logotype" width="420" />
+</p>
+
+<h1 align="center">EmbeddedSigner</h1>
+
+<p align="center">
+  <a href="https://img.shields.io/pypi/dm/EmbeddedSigner?style=for-the-badge"><img src="https://img.shields.io/pypi/dm/EmbeddedSigner?style=for-the-badge" alt="PyPI - Downloads" /></a>
+  <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/plugins/embedded_signer/"><img src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/plugins/embedded_signer.svg?style=for-the-badge" alt="Repo views" /></a>
+  <a href="https://img.shields.io/pypi/pyversions/EmbeddedSigner?style=for-the-badge"><img src="https://img.shields.io/pypi/pyversions/EmbeddedSigner?style=for-the-badge" alt="Supported Python versions" /></a>
+  <a href="https://img.shields.io/pypi/l/EmbeddedSigner?style=for-the-badge"><img src="https://img.shields.io/pypi/l/EmbeddedSigner?style=for-the-badge" alt="License" /></a>
+  <a href="https://img.shields.io/pypi/v/EmbeddedSigner?style=for-the-badge"><img src="https://img.shields.io/pypi/v/EmbeddedSigner?style=for-the-badge" alt="Latest release" /></a>
+</p>
+
+EmbeddedSigner composes the dynamic XMP embedding utilities from
+[`EmbedXMP`](../EmbedXMP) with the signing facade exposed by
+[`MediaSigner`](../media_signer). It embeds metadata into media assets and then
+routes signing requests to the appropriate media-aware signer in either
+attached or detached mode. The class orchestrates key provider plugins so that
+opaque key references can be resolved automatically before signatures are
+produced.
+
+## Features
+
+- **One-shot embed & sign** – inject XMP metadata and produce signatures with a
+  single call.
+- **Media-aware detection** – delegates to all registered `EmbedXmpBase`
+  handlers so PNG, GIF, JPEG, SVG, WEBP, TIFF, PDF, and MP4 assets are
+  processed consistently.
+- **Pluggable signers** – forwards signing requests to every
+  `SigningBase` registered with `MediaSigner`, including CMS, JWS, OpenPGP, PDF,
+  and XMLDSig providers.
+- **Key provider integration** – loads providers from the
+  `swarmauri.key_providers` entry point group and resolves opaque key reference
+  strings (e.g. `local://kid@2`) before invoking a signer.
+- **Attached or detached output** – toggle between embedded signatures or
+  detached artifacts via a simple flag.
+- **File and byte workflows** – operate on in-memory payloads or update files
+  on disk with helpers for embedding, reading, removing, and signing.
+- **Command line tooling** – bundle a ready-to-use `embedded-signer` CLI for
+  ad-hoc embedding, signing, and combined workflows.
+
+## Installation
+
+### Using `uv`
+
+```bash
+uv pip install EmbeddedSigner
+```
+
+Optional dependencies align with the available key providers, EmbedXMP handlers,
+and MediaSigner backends:
+
+```bash
+uv pip install "EmbeddedSigner[local]"      # enable LocalKeyProvider resolution
+uv pip install "EmbeddedSigner[memory]"     # enable InMemoryKeyProvider resolution
+uv pip install "EmbeddedSigner[xmp_png]"    # add PNG embedding support
+uv pip install "EmbeddedSigner[xmp_all]"    # install every EmbedXMP handler
+uv pip install "EmbeddedSigner[signing_pdf]"  # enable PDF signer backend
+uv pip install "EmbeddedSigner[signing_all]"  # install every MediaSigner backend
+uv pip install "EmbeddedSigner[full]"       # bring in all extras and key providers
+```
+
+### Using `pip`
+
+```bash
+pip install EmbeddedSigner
+```
+
+Extras mirror the `uv` workflow:
+
+```bash
+pip install "EmbeddedSigner[local]"
+pip install "EmbeddedSigner[memory]"
+pip install "EmbeddedSigner[xmp_png]"
+pip install "EmbeddedSigner[xmp_all]"
+pip install "EmbeddedSigner[signing_pdf]"
+pip install "EmbeddedSigner[signing_all]"
+pip install "EmbeddedSigner[full]"
+```
+
+### Extras overview
+
+| Extra name | Purpose |
+| --- | --- |
+| `local` / `memory` | Enable Swarmauri key provider resolution for local filesystem and in-memory secrets. |
+| `xmp_gif`, `xmp_jpeg`, `xmp_png`, `xmp_svg`, `xmp_webp`, `xmp_tiff`, `xmp_pdf`, `xmp_mp4` | Pull in the corresponding `swarmauri_xmp_*` handler so EmbedXMP can embed metadata for that media format. |
+| `xmp_all` | Install every EmbedXMP media handler dependency at once. |
+| `signing_cms`, `signing_jws`, `signing_openpgp`, `signing_pdf`, `signing_xmld` | Add the matching MediaSigner backend plugin for CMS, JWS, OpenPGP, PDF, or XMLDSig signing. |
+| `signing_all` | Install all MediaSigner backends together. |
+| `full` | Bring in every key provider, EmbedXMP handler, and MediaSigner backend for maximum coverage. |
+
+## Usage
+
+```python
+import asyncio
+from pathlib import Path
+
+from EmbeddedSigner import EmbedSigner
+
+xmp_xml = """
+<x:xmpmeta xmlns:x="adobe:ns:meta/">
+  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description rdf:about=""/>
+  </rdf:RDF>
+</x:xmpmeta>
+""".strip()
+
+async def embed_and_sign() -> None:
+    signer = EmbedSigner()
+    media_bytes = Path("image.png").read_bytes()
+    embedded, signatures = await signer.embed_and_sign_bytes(
+        media_bytes,
+        fmt="JWSSigner",
+        xmp_xml=xmp_xml,
+        key={"kind": "raw", "key": b"\x00" * 32},
+        path="image.png",
+        attached=True,
+        signer_opts={"alg": "HS256"},
+    )
+    Path("image.signed.png").write_bytes(embedded)
+    print(signatures[0].mode)  # "attached"
+
+asyncio.run(embed_and_sign())
+```
+
+### Key provider integration
+
+When you install a key provider plugin such as
+`swarmauri_keyprovider_local`, EmbeddedSigner can resolve string key references
+on the fly:
+
+```python
+signer = EmbedSigner(key_provider_name="LocalKeyProvider")
+embedded, signatures = await signer.embed_and_sign_file(
+    Path("report.pdf"),
+    fmt="PDFSigner",
+    xmp_xml=xmp_xml,
+    key="LocalKeyProvider://a1b2c3@1",
+    attached=False,
+    signer_opts={"alg": "SHA256"},
+)
+```
+
+EmbeddedSigner parses the opaque reference, looks up the provider by name, and
+retrieves the specified key version using the provider's asynchronous API.
+
+### File helpers
+
+`EmbedSigner` offers mirrored helpers that operate on file paths when you need
+to persist updates directly on disk:
+
+```python
+signer = EmbedSigner()
+
+# Embed metadata into a file and write it back in place.
+signer.embed_file("image.png", xmp_xml)
+
+# Read embedded metadata without materialising the bytes in memory.
+print(signer.read_xmp_file("image.png"))
+
+# Remove metadata and persist the stripped bytes to a new path.
+signer.remove_xmp_file("image.png", write_back=True)
+
+# Sign file contents without manual IO boilerplate.
+signatures = asyncio.run(
+    signer.sign_file(
+        "image.png",
+        fmt="JWSSigner",
+        key="LocalKeyProvider://img-key",
+        attached=True,
+    )
+)
+```
+
+### Command line interface
+
+Installing the package exposes an `embedded-signer` executable that wraps the
+most common workflows:
+
+```bash
+# Embed metadata from a file into an image in place.
+embedded-signer embed example.png --xmp-file metadata.xmp
+
+# Read metadata to stdout (non-zero exit if none is embedded).
+embedded-signer read example.png
+
+# Remove metadata and write the result to a new file.
+embedded-signer remove example.png --output clean.png
+
+# Sign using a key reference exposed by a provider plugin.
+embedded-signer sign example.png --format JWSSigner --key-ref local://img-key
+
+# Embed and sign in one step, writing signatures to JSON.
+embedded-signer embed-sign example.png \
+  --xmp-file metadata.xmp \
+  --format JWSSigner \
+  --key-ref local://img-key \
+  --signature-output signatures.json
+```
+
+## Development
+
+1. Install development dependencies:
+
+   ```bash
+   uv pip install -e ".[dev]"
+   ```
+
+2. Format and lint code with `ruff`:
+
+   ```bash
+   uv run ruff format .
+   uv run ruff check . --fix
+   ```
+
+3. Run the unit tests in isolation:
+
+   ```bash
+   uv run --package EmbeddedSigner --directory plugins/embedded_signer pytest
+   ```
+
+## License
+
+EmbeddedSigner is released under the Apache 2.0 License. See the
+[LICENSE](LICENSE) file for details.

--- a/pkgs/plugins/embedded_signer/pyproject.toml
+++ b/pkgs/plugins/embedded_signer/pyproject.toml
@@ -1,0 +1,151 @@
+[project]
+name = "EmbeddedSigner"
+version = "0.1.0"
+description = "Embed XMP metadata and sign media assets using Swarmauri plugins."
+license = "Apache-2.0"
+readme = "README.md"
+requires-python = ">=3.10,<3.13"
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Development Status :: 3 - Alpha",
+    "Topic :: Security :: Cryptography",
+    "Intended Audience :: Developers",
+]
+authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
+dependencies = [
+    "EmbedXMP",
+    "MediaSigner",
+    "swarmauri_core",
+    "swarmauri_base",
+]
+keywords = [
+    "xmp",
+    "signing",
+    "swarmauri",
+    "metadata",
+    "security",
+    "digital-rights-management",
+    "drm",
+    "license-rights",
+    "embedded-licensing",
+    "tamper-proofing",
+    "tamper-evidence",
+    "content-protection",
+    "png",
+    "gif",
+    "jpeg",
+    "svg",
+    "webp",
+    "tiff",
+    "pdf",
+    "mp4",
+]
+
+[project.urls]
+Homepage = "https://github.com/swarmauri/swarmauri-sdk"
+
+[project.scripts]
+embedded-signer = "EmbeddedSigner.cli:main"
+
+[project.optional-dependencies]
+local = ["swarmauri_keyprovider_local"]
+memory = ["swarmauri_keyprovider_inmemory"]
+xmp_gif = ["swarmauri_xmp_gif"]
+xmp_jpeg = ["swarmauri_xmp_jpeg"]
+xmp_mp4 = ["swarmauri_xmp_mp4"]
+xmp_pdf = ["swarmauri_xmp_pdf"]
+xmp_png = ["swarmauri_xmp_png"]
+xmp_svg = ["swarmauri_xmp_svg"]
+xmp_tiff = ["swarmauri_xmp_tiff"]
+xmp_webp = ["swarmauri_xmp_webp"]
+xmp_all = [
+    "swarmauri_xmp_gif",
+    "swarmauri_xmp_jpeg",
+    "swarmauri_xmp_mp4",
+    "swarmauri_xmp_pdf",
+    "swarmauri_xmp_png",
+    "swarmauri_xmp_svg",
+    "swarmauri_xmp_tiff",
+    "swarmauri_xmp_webp",
+]
+signing_cms = ["swarmauri_signing_cms"]
+signing_jws = ["swarmauri_signing_jws"]
+signing_openpgp = ["swarmauri_signing_openpgp"]
+signing_pdf = ["swarmauri_signing_pdf"]
+signing_xmld = ["swarmauri_signing_xmld"]
+signing_all = [
+    "swarmauri_signing_cms",
+    "swarmauri_signing_jws",
+    "swarmauri_signing_openpgp",
+    "swarmauri_signing_pdf",
+    "swarmauri_signing_xmld",
+]
+full = [
+    "swarmauri_keyprovider_local",
+    "swarmauri_keyprovider_inmemory",
+    "swarmauri_xmp_gif",
+    "swarmauri_xmp_jpeg",
+    "swarmauri_xmp_mp4",
+    "swarmauri_xmp_pdf",
+    "swarmauri_xmp_png",
+    "swarmauri_xmp_svg",
+    "swarmauri_xmp_tiff",
+    "swarmauri_xmp_webp",
+    "swarmauri_signing_cms",
+    "swarmauri_signing_jws",
+    "swarmauri_signing_openpgp",
+    "swarmauri_signing_pdf",
+    "swarmauri_signing_xmld",
+]
+
+[tool.uv.sources]
+embedxmp = { workspace = true }
+mediasigner = { workspace = true }
+swarmauri_core = { workspace = true }
+swarmauri_base = { workspace = true }
+swarmauri_keyprovider_local = { workspace = true }
+swarmauri_keyprovider_inmemory = { workspace = true }
+swarmauri_tests_griffe = { workspace = true }
+swarmauri_xmp_gif = { workspace = true }
+swarmauri_xmp_jpeg = { workspace = true }
+swarmauri_xmp_mp4 = { workspace = true }
+swarmauri_xmp_pdf = { workspace = true }
+swarmauri_xmp_png = { workspace = true }
+swarmauri_xmp_svg = { workspace = true }
+swarmauri_xmp_tiff = { workspace = true }
+swarmauri_xmp_webp = { workspace = true }
+swarmauri_signing_cms = { workspace = true }
+swarmauri_signing_jws = { workspace = true }
+swarmauri_signing_openpgp = { workspace = true }
+swarmauri_signing_pdf = { workspace = true }
+swarmauri_signing_xmld = { workspace = true }
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "swarmauri_tests_griffe",
+    "swarmauri_xmp_gif",
+    "swarmauri_xmp_jpeg",
+    "swarmauri_xmp_mp4",
+    "swarmauri_xmp_pdf",
+    "swarmauri_xmp_png",
+    "swarmauri_xmp_svg",
+    "swarmauri_xmp_tiff",
+    "swarmauri_xmp_webp",
+    "ruff>=0.9",
+]
+
+[tool.poetry]
+packages = [
+    { include = "EmbeddedSigner" },
+]

--- a/pkgs/plugins/embedded_signer/tests/test_cli.py
+++ b/pkgs/plugins/embedded_signer/tests/test_cli.py
@@ -1,0 +1,122 @@
+"""CLI tests for the EmbeddedSigner utility."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from EmbeddedSigner import cli
+from swarmauri_core.signing.types import Signature
+
+
+class _StubSigner:
+    instances: list["_StubSigner"] = []
+
+    def __init__(self, *args, **kwargs) -> None:
+        self.embed_calls: list[tuple[bytes, str, str | None]] = []
+        self.remove_calls: list[Path] = []
+        self.sign_calls: list[tuple[str, object, bool, str | None, dict | None]] = []
+        self.read_responses: dict[Path, str | None] = {}
+        _StubSigner.instances.append(self)
+
+    def embed_bytes(
+        self, data: bytes, xmp_xml: str, *, path: Path | None = None
+    ) -> bytes:
+        self.embed_calls.append((data, xmp_xml, None if path is None else str(path)))
+        return b"embedded"
+
+    def read_xmp_file(self, path: Path) -> str | None:
+        return self.read_responses.get(path, "<x/>")
+
+    def remove_xmp_file(self, path: Path) -> bytes:
+        self.remove_calls.append(path)
+        return b"stripped"
+
+    async def sign_file(
+        self,
+        path: Path,
+        *,
+        fmt: str,
+        key,
+        attached: bool,
+        alg: str | None,
+        signer_opts: dict | None = None,
+    ):
+        self.sign_calls.append((fmt, key, attached, alg, signer_opts))
+        return [
+            Signature(
+                kid="k",
+                version=1,
+                format=fmt,
+                mode="attached" if attached else "detached",
+                alg=alg or "none",
+                artifact=b"sig",
+            )
+        ]
+
+
+@pytest.fixture(autouse=True)
+def _reset_stub(monkeypatch):
+    _StubSigner.instances.clear()
+    monkeypatch.setattr(cli, "EmbedSigner", _StubSigner)
+    yield
+    _StubSigner.instances.clear()
+
+
+def test_embed_command_writes_output(tmp_path: Path) -> None:
+    src = tmp_path / "image.png"
+    src.write_bytes(b"payload")
+    out = tmp_path / "out.png"
+
+    rc = cli.main(["embed", str(src), "--xmp", "<x/>", "--output", str(out)])
+
+    assert rc == 0
+    assert out.read_bytes() == b"embedded"
+    stub = _StubSigner.instances[0]
+    assert stub.embed_calls[0][0] == b"payload"
+    assert stub.embed_calls[0][1] == "<x/>"
+
+
+def test_read_command_prints_metadata(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    src = tmp_path / "image.png"
+    src.write_bytes(b"payload")
+
+    rc = cli.main(["read", str(src)])
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "<x/>" in captured.out
+
+
+def test_sign_command_outputs_json(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    src = tmp_path / "asset.bin"
+    src.write_bytes(b"payload")
+
+    rc = cli.main(
+        [
+            "sign",
+            str(src),
+            "--format",
+            "JWSSigner",
+            "--key-ref",
+            "provider:key",
+        ]
+    )
+
+    assert rc == 0
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload[0]["format"] == "JWSSigner"
+    assert payload[0]["artifact"]
+    stub = _StubSigner.instances[0]
+    fmt, key, attached, alg, _ = stub.sign_calls[0]
+    assert fmt == "JWSSigner"
+    assert key == "provider:key"
+    assert attached is True
+    assert alg is None

--- a/pkgs/plugins/embedded_signer/tests/test_embed_signer_embedding.py
+++ b/pkgs/plugins/embedded_signer/tests/test_embed_signer_embedding.py
@@ -1,0 +1,144 @@
+"""Integration tests for XMP embedding via :class:`EmbeddedSigner`."""
+
+from __future__ import annotations
+
+import pytest
+
+from EmbedXMP import EmbedXMP
+from EmbeddedSigner import EmbedSigner
+from swarmauri_xmp_gif import GIFXMP
+from swarmauri_xmp_jpeg import JPEGXMP
+from swarmauri_xmp_mp4 import MP4XMP
+from swarmauri_xmp_pdf import PDFXMP
+from swarmauri_xmp_png import PNGXMP
+from swarmauri_xmp_svg import SVGXMP
+from swarmauri_xmp_tiff import TIFFXMP
+from swarmauri_xmp_webp import WebPXMP
+
+
+@pytest.fixture()
+def embed_signer_all() -> EmbedSigner:
+    embedder = EmbedXMP(
+        handlers=[GIFXMP, JPEGXMP, PNGXMP, SVGXMP, WebPXMP],
+        eager_import=False,
+    )
+    return EmbedSigner(embedder=embedder)
+
+
+def _minimal_png() -> bytes:
+    import binascii
+    import zlib
+
+    def chunk(ctype: bytes, payload: bytes) -> bytes:
+        length = len(payload).to_bytes(4, "big")
+        crc = (binascii.crc32(ctype + payload) & 0xFFFFFFFF).to_bytes(4, "big")
+        return length + ctype + payload + crc
+
+    ihdr = (
+        b"\x00\x00\x00\x01"
+        + b"\x00\x00\x00\x01"
+        + b"\x08"
+        + b"\x02"
+        + b"\x00"
+        + b"\x00"
+        + b"\x00"
+    )
+    idat = zlib.compress(b"\x00\x00\x00\x00")
+    return (
+        PNGXMP.PNG_SIG
+        + chunk(b"IHDR", ihdr)
+        + chunk(b"IDAT", idat)
+        + chunk(b"IEND", b"")
+    )
+
+
+def _minimal_gif() -> bytes:
+    return b"GIF89a" + b"\x01\x00\x01\x00" + b"\x00" + b"\x00" + b"\x00" + b"\x3b"
+
+
+def _minimal_jpeg() -> bytes:
+    return (
+        b"\xff\xd8"
+        + b"\xff\xe0\x00\x10JFIF\x00\x01\x02\x00\x00\x01\x00\x01\x00\x00"
+        + b"\xff\xd9"
+    )
+
+
+def _minimal_svg() -> bytes:
+    return (
+        "<svg xmlns='http://www.w3.org/2000/svg' xmlns:x='adobe:ns:meta/'>"
+        "<rect width='1' height='1'/></svg>"
+    ).encode("utf-8")
+
+
+def _minimal_webp() -> bytes:
+    chunk_type = b"VP8 "
+    payload = b""
+    chunk = chunk_type + len(payload).to_bytes(4, "little") + payload
+    body = chunk
+    size = len(body) + 4
+    return b"RIFF" + size.to_bytes(4, "little") + b"WEBP" + body
+
+
+@pytest.mark.parametrize(
+    "name, payload_factory",
+    [
+        ("PNGXMP", _minimal_png),
+        ("GIFXMP", _minimal_gif),
+        ("JPEGXMP", _minimal_jpeg),
+        ("SVGXMP", _minimal_svg),
+        ("WebPXMP", _minimal_webp),
+    ],
+)
+def test_embed_and_read_round_trip(
+    embed_signer_all: EmbedSigner,
+    name: str,
+    payload_factory,
+) -> None:
+    payload = payload_factory()
+    xmp = "<x:xmpmeta><rdf:RDF/></x:xmpmeta>"
+
+    updated = embed_signer_all.embed_bytes(payload, xmp)
+    assert xmp == embed_signer_all.read_xmp(updated)
+    stripped = embed_signer_all.remove_xmp(updated)
+    assert embed_signer_all.read_xmp(stripped) is None
+
+
+@pytest.mark.parametrize(
+    "handler_cls, payload",
+    [
+        (MP4XMP, b"\x00\x00\x00\x18ftypmp42"),
+        (PDFXMP, b"%PDF-1.4\n%\xe2\xe3\xcf\xd3"),
+        (TIFFXMP, b"II*\x00" + b"\x00" * 8),
+    ],
+)
+def test_unimplemented_handlers_raise(handler_cls, payload: bytes) -> None:
+    embedder = EmbedXMP(handlers=[handler_cls], eager_import=False)
+    signer = EmbedSigner(embedder=embedder)
+    path_hint = None
+    if handler_cls is MP4XMP:
+        path_hint = "example.mp4"
+    with pytest.raises(NotImplementedError):
+        signer.embed_bytes(
+            payload,
+            "<x:xmpmeta><rdf:RDF/></x:xmpmeta>",
+            path=path_hint,
+        )
+
+
+def test_supported_handler_names(embed_signer_all: EmbedSigner) -> None:
+    names = embed_signer_all.supported_embed_handlers()
+    assert set(names) == {"GIFXMP", "JPEGXMP", "PNGXMP", "SVGXMP", "WebPXMP"}
+
+
+def test_file_round_trip(tmp_path, embed_signer_all: EmbedSigner) -> None:
+    payload = _minimal_png()
+    file_path = tmp_path / "image.png"
+    file_path.write_bytes(payload)
+    xmp = "<x:xmpmeta><rdf:RDF/></x:xmpmeta>"
+
+    embed_signer_all.embed_file(file_path, xmp)
+    assert embed_signer_all.read_xmp_file(file_path) == xmp
+
+    embed_signer_all.remove_xmp_file(file_path, write_back=True)
+    assert embed_signer_all.read_xmp_file(file_path) is None

--- a/pkgs/plugins/embedded_signer/tests/test_embed_signer_signing.py
+++ b/pkgs/plugins/embedded_signer/tests/test_embed_signer_signing.py
@@ -1,0 +1,274 @@
+"""Tests covering signing orchestration performed by :class:`EmbedSigner`."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from EmbeddedSigner import EmbedSigner
+from swarmauri_core.keys.IKeyProvider import IKeyProvider
+from swarmauri_core.signing.types import Signature
+
+
+@dataclass
+class _RecordedCall:
+    fmt: str
+    key: Any
+    payload: bytes
+    alg: Any
+    opts: Mapping[str, Any] | None
+
+
+class _FakeEmbedder:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, bytes, str, str | None]] = []
+
+    def embed(self, data: bytes, xmp_xml: str, path: str | None) -> bytes:
+        self.calls.append(("embed", data, xmp_xml, path))
+        return data + xmp_xml.encode("utf-8")
+
+    def read(
+        self, data: bytes, path: str | None
+    ) -> str | None:  # pragma: no cover - unused in signing tests
+        return None
+
+    def remove(
+        self, data: bytes, path: str | None
+    ) -> bytes:  # pragma: no cover - unused in signing tests
+        return data
+
+
+class _FakeMediaSigner:
+    def __init__(self) -> None:
+        self.calls: list[_RecordedCall] = []
+        self._formats = (
+            "JWSSigner",
+            "CMSSigner",
+            "OpenPGPSigner",
+            "PDFSigner",
+            "XMLDSigner",
+        )
+
+    async def sign_bytes(
+        self,
+        fmt: str,
+        key: Any,
+        payload: bytes,
+        *,
+        alg: str | None = None,
+        opts: Mapping[str, Any] | None = None,
+    ) -> Sequence[Signature]:
+        self.calls.append(_RecordedCall(fmt, key, payload, alg, opts))
+        attached = True if opts is None else bool(opts.get("attached", True))
+        mode = "attached" if attached else "detached"
+        return [
+            Signature(
+                kid=None,
+                version=None,
+                format=fmt,
+                mode=mode,
+                alg=str(alg or "unspecified"),
+                artifact=payload,
+            )
+        ]
+
+    def supported_formats(self) -> Sequence[str]:
+        return self._formats
+
+
+class _StubKeyProvider(IKeyProvider):
+    def __init__(self, mapping: Mapping[tuple[str, int], Any]) -> None:
+        self._mapping = dict(mapping)
+        self.requests: list[tuple[str, tuple[Any, ...]]] = []
+
+    def supports(
+        self,
+    ) -> Mapping[str, Sequence[str]]:  # pragma: no cover - capability unused
+        return {}
+
+    async def create_key(self, spec):  # pragma: no cover - unused in tests
+        raise NotImplementedError
+
+    async def import_key(
+        self, spec, material: bytes, *, public: bytes | None = None
+    ):  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def rotate_key(
+        self, kid: str, *, spec_overrides: dict | None = None
+    ):  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def destroy_key(
+        self, kid: str, version: int | None = None
+    ) -> bool:  # pragma: no cover - unused
+        return False
+
+    async def get_key(
+        self,
+        kid: str,
+        version: int | None = None,
+        *,
+        include_secret: bool = False,
+    ) -> Any:
+        self.requests.append(("get_key", (kid, version, include_secret)))
+        key_version = version or 1
+        return self._mapping[(kid, key_version)]
+
+    async def get_key_by_ref(
+        self,
+        key_ref: str,
+        *,
+        include_secret: bool = False,
+    ) -> Any:
+        self.requests.append(("get_key_by_ref", (key_ref, include_secret)))
+        if key_ref == "ref-token":
+            return self._mapping[(key_ref, 1)]
+        raise NotImplementedError
+
+    async def list_versions(
+        self, kid: str
+    ) -> tuple[int, ...]:  # pragma: no cover - unused
+        return (1,)
+
+    async def get_public_jwk(
+        self, kid: str, version: int | None = None
+    ) -> dict:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def jwks(
+        self, *, prefix_kids: str | None = None
+    ) -> dict:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def random_bytes(self, n: int) -> bytes:  # pragma: no cover - unused
+        return b"\x00" * n
+
+    async def hkdf(
+        self,
+        ikm: bytes,
+        *,
+        salt: bytes,
+        info: bytes,
+        length: int,
+    ) -> bytes:  # pragma: no cover - unused
+        return b"\x00" * length
+
+
+@pytest.mark.asyncio()
+@pytest.mark.parametrize(
+    "fmt, attached",
+    [
+        ("JWSSigner", True),
+        ("JWSSigner", False),
+        ("CMSSigner", True),
+        ("CMSSigner", False),
+        ("OpenPGPSigner", True),
+        ("OpenPGPSigner", False),
+        ("PDFSigner", True),
+        ("PDFSigner", False),
+        ("XMLDSigner", True),
+        ("XMLDSigner", False),
+    ],
+)
+async def test_sign_bytes_propagates_attached_flag(fmt: str, attached: bool) -> None:
+    embedder = _FakeEmbedder()
+    media = _FakeMediaSigner()
+    signer = EmbedSigner(embedder=embedder, signer=media)
+    payload = b"payload"
+    xmp = "<x:xmpmeta><rdf:RDF/></x:xmpmeta>"
+    embedded, signatures = await signer.embed_and_sign_bytes(
+        payload,
+        fmt=fmt,
+        xmp_xml=xmp,
+        key={"kind": "raw", "key": b"x" * 32},
+        attached=attached,
+    )
+    assert embedded.endswith(xmp.encode("utf-8"))
+    assert signatures[0].mode == ("attached" if attached else "detached")
+    call = media.calls[-1]
+    assert call.fmt == fmt
+    assert call.opts is not None
+    assert call.opts.get("attached", True) is attached
+
+
+@pytest.mark.asyncio()
+async def test_embed_and_sign_file_writes_back(tmp_path: Path) -> None:
+    embedder = _FakeEmbedder()
+    media = _FakeMediaSigner()
+    signer = EmbedSigner(embedder=embedder, signer=media)
+    file_path = tmp_path / "asset.bin"
+    file_path.write_bytes(b"abc")
+
+    await signer.embed_and_sign_file(
+        file_path,
+        fmt="JWSSigner",
+        xmp_xml="<x/>",
+        key={"kind": "raw", "key": b"y" * 32},
+        write_back=True,
+    )
+
+    assert file_path.read_bytes().endswith(b"<x/>")
+    assert embedder.calls
+
+
+@pytest.mark.asyncio()
+async def test_key_provider_resolution_via_reference() -> None:
+    provider = _StubKeyProvider(
+        {
+            ("abc", 1): {"kid": "abc", "version": 1},
+            ("ref-token", 1): {"kid": "from-ref", "version": 1},
+        }
+    )
+    embedder = _FakeEmbedder()
+    media = _FakeMediaSigner()
+    signer = EmbedSigner(
+        embedder=embedder,
+        signer=media,
+        provider_plugins={"custom": lambda: provider},
+    )
+
+    await signer.sign_bytes(
+        "JWSSigner",
+        key="custom://abc",
+        payload=b"data",
+        attached=False,
+    )
+    await signer.sign_bytes(
+        "JWSSigner",
+        key="custom:ref-token",
+        payload=b"data2",
+        attached=True,
+    )
+
+    assert [req[0] for req in provider.requests] == [
+        "get_key_by_ref",
+        "get_key",
+        "get_key_by_ref",
+    ]
+
+
+@pytest.mark.asyncio()
+async def test_sign_file_uses_media_signer(tmp_path: Path) -> None:
+    embedder = _FakeEmbedder()
+    media = _FakeMediaSigner()
+    signer = EmbedSigner(embedder=embedder, signer=media)
+    file_path = tmp_path / "payload.bin"
+    file_path.write_bytes(b"payload")
+
+    await signer.sign_file(
+        file_path,
+        fmt="JWSSigner",
+        key={"kid": "k", "kind": "raw", "key": b"\x00" * 32},
+        attached=False,
+        alg="HS256",
+    )
+
+    call = media.calls[-1]
+    assert call.payload == b"payload"
+    assert call.alg == "HS256"
+    assert call.opts is not None and call.opts.get("attached") is False

--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -172,6 +172,7 @@ members = [
     "standards/swarmauri_xmp_svg",
     "standards/swarmauri_xmp_tiff",
     "standards/swarmauri_xmp_webp",
+    "plugins/embedded_signer",
 
     "standards/swarmauri_tokens_introspection",
     "standards/swarmauri_tokens_paseto_v4",


### PR DESCRIPTION
## Summary
- expand project keywords to cover media extensions, digital rights topics, and tamper-proofing terminology
- add optional dependencies for each EmbedXMP media handler, each MediaSigner backend, and bundled extras for complete installs
- document the new extras in the README with updated installation guidance and an overview table

## Testing
- uv run --package EmbeddedSigner --directory plugins/embedded_signer ruff format .
- uv run --package EmbeddedSigner --directory plugins/embedded_signer ruff check . --fix

------
https://chatgpt.com/codex/tasks/task_e_68e0e11e29e88326b96cb1e8310ed191