### PR TITLE
Refactor KeyProviderBase serialization hooks

### DIFF
--- a/pkgs/base/swarmauri_base/keys/KeyProviderBase.py
+++ b/pkgs/base/swarmauri_base/keys/KeyProviderBase.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, Optional, Tuple, Literal
+from typing import Callable, Dict, Iterable, Optional, Tuple, Literal
 import base64
 import hashlib
 import json
@@ -8,8 +8,6 @@ import os
 from pathlib import Path
 from urllib.parse import parse_qs
 
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import ec, ed25519, ed448, rsa
 from pydantic import Field
 
 from swarmauri_base.ComponentBase import ComponentBase, ResourceTypes
@@ -80,40 +78,74 @@ class KeyProviderBase(IKeyProvider, ComponentBase):
     def _build_keyref_from_private(
         self,
         private_key,
-        chain,
+        chain: Iterable[object] | None,
         *,
         include_secret: bool,
         tags: Optional[Dict[str, str]] = None,
+        key_type: KeyType | None = None,
+        export_public: Callable[[object], Optional[bytes]] | None = None,
+        export_private: Callable[[object], Optional[bytes]] | None = None,
+        export_chain: Callable[[object], Optional[bytes]] | None = None,
     ) -> KeyRef:
-        public_bytes = private_key.public_key().public_bytes(
-            serialization.Encoding.DER,
-            serialization.PublicFormat.SubjectPublicKeyInfo,
+        """Construct a :class:`KeyRef` from provider-specific key material.
+
+        Parameters
+        ----------
+        private_key:
+            Provider-specific handle to the private key. Downstream providers
+            SHOULD supply ``export_public``/``export_private`` callables when the
+            object cannot be expressed without third-party dependencies.
+        chain:
+            Optional iterable describing the certificate chain or related
+            metadata. Items are expected to already be ``bytes`` objects unless
+            ``export_chain`` is provided.
+        include_secret:
+            When ``True`` the resulting :class:`KeyRef` will contain private key
+            material. Providers MUST supply ``export_private`` if the private
+            material is not directly representable without additional
+            dependencies.
+        tags:
+            Additional tags to merge into the returned :class:`KeyRef`.
+        key_type:
+            Explicit key type override. When omitted ``_infer_key_type`` is used
+            which defaults to :class:`KeyType.OPAQUE` for unknown structures.
+        export_public / export_private / export_chain:
+            Optional callables responsible for turning provider specific objects
+            into ``bytes``. They allow downstream implementations to keep the
+            serialization logic (and any third-party imports) out of the base
+            class.
+        """
+
+        public_bytes = self._resolve_public_bytes(
+            private_key, export_public=export_public
         )
         material: Optional[bytes] = None
         if include_secret:
-            material = private_key.private_bytes(
-                serialization.Encoding.PEM,
-                serialization.PrivateFormat.PKCS8,
-                serialization.NoEncryption(),
+            material = self._resolve_private_bytes(
+                private_key, export_private=export_private
             )
-        kid = self._fingerprint(public=public_bytes)
-        chain_der = [cert.public_bytes(serialization.Encoding.DER) for cert in chain]
-        key_type = self._infer_key_type(private_key)
+        chain_bytes = self._resolve_chain_bytes(chain, export_chain=export_chain)
+
+        kid = self._fingerprint(public=public_bytes, material=material)
+        resolved_key_type = key_type or self._infer_key_type(private_key)
+        export_policy = (
+            ExportPolicy.SECRET_WHEN_ALLOWED
+            if include_secret and material is not None
+            else ExportPolicy.PUBLIC_ONLY
+        )
+        merged_tags = {"chain_len": str(len(chain_bytes))}
+        if tags:
+            merged_tags.update(tags)
+
         return KeyRef(
             kid=kid,
             version=1,
-            type=key_type,
+            type=resolved_key_type,
             uses=(KeyUse.SIGN, KeyUse.VERIFY),
-            export_policy=(
-                ExportPolicy.SECRET_WHEN_ALLOWED
-                if include_secret
-                else ExportPolicy.PUBLIC_ONLY
-            ),
+            export_policy=export_policy,
             material=material,
             public=public_bytes,
-            tags={**(tags or {}), "chain_len": str(len(chain_der))}
-            if tags
-            else {"chain_len": str(len(chain_der))},
+            tags=merged_tags,
         )
 
     def _build_keyref_from_jwk(
@@ -148,15 +180,101 @@ class KeyProviderBase(IKeyProvider, ComponentBase):
         )
 
     def _infer_key_type(self, private_key) -> KeyType:
-        if isinstance(private_key, rsa.RSAPrivateKey):
-            return KeyType.RSA
-        if isinstance(private_key, ec.EllipticCurvePrivateKey):
-            return KeyType.EC
-        if isinstance(private_key, ed25519.Ed25519PrivateKey):
-            return KeyType.ED25519
-        if isinstance(private_key, ed448.Ed448PrivateKey):
-            return KeyType.ED25519
+        if isinstance(private_key, dict):
+            hint = private_key.get("kty") or private_key.get("type")
+            if isinstance(hint, str):
+                normalized = hint.upper()
+                if normalized == "RSA":
+                    return KeyType.RSA
+                if normalized in {"EC", "ECDSA", "ELLIPTIC"}:
+                    return KeyType.EC
+                if normalized in {"ED25519", "OKP", "OKP-ED25519"}:
+                    return KeyType.ED25519
+                if normalized == "OCT":
+                    return KeyType.SYMMETRIC
         return KeyType.OPAQUE
+
+    # ------------------------------------------------------------------
+    def _resolve_public_bytes(
+        self,
+        private_key,
+        *,
+        export_public: Callable[[object], Optional[bytes]] | None = None,
+    ) -> Optional[bytes]:
+        if export_public is not None:
+            result = export_public(private_key)
+            return self._coerce_to_bytes(result, allow_none=True)
+        if isinstance(private_key, dict):
+            if "public" in private_key:
+                return self._coerce_to_bytes(private_key["public"], allow_none=True)
+            if "pub" in private_key:
+                return self._coerce_to_bytes(private_key["pub"], allow_none=True)
+        if isinstance(private_key, (bytes, bytearray, memoryview)):
+            return None
+        raise NotImplementedError(
+            "Provide export_public to serialize provider-specific key objects"
+        )
+
+    def _resolve_private_bytes(
+        self,
+        private_key,
+        *,
+        export_private: Callable[[object], Optional[bytes]] | None = None,
+    ) -> Optional[bytes]:
+        if export_private is not None:
+            result = export_private(private_key)
+            return self._coerce_to_bytes(result, allow_none=True)
+        if isinstance(private_key, dict):
+            if "private" in private_key:
+                return self._coerce_to_bytes(private_key["private"], allow_none=True)
+            if "secret" in private_key:
+                return self._coerce_to_bytes(private_key["secret"], allow_none=True)
+        if isinstance(private_key, (bytes, bytearray, memoryview)):
+            return bytes(private_key)
+        raise NotImplementedError(
+            "Provide export_private to serialize provider-specific key objects"
+        )
+
+    def _resolve_chain_bytes(
+        self,
+        chain: Iterable[object] | None,
+        *,
+        export_chain: Callable[[object], Optional[bytes]] | None = None,
+    ) -> Tuple[bytes, ...]:
+        if not chain:
+            return ()
+        resolved: list[bytes] = []
+        for item in chain:
+            value = None
+            if export_chain is not None:
+                value = export_chain(item)
+            else:
+                try:
+                    value = self._coerce_to_bytes(item, allow_none=True)
+                except TypeError as exc:  # pragma: no cover - defensive
+                    raise NotImplementedError(
+                        "Provide export_chain to serialize chain entries"
+                    ) from exc
+            if value is not None:
+                resolved.append(value)
+        return tuple(resolved)
+
+    def _coerce_to_bytes(
+        self, value: object, *, allow_none: bool = False
+    ) -> Optional[bytes]:
+        if value is None:
+            if allow_none:
+                return None
+            raise TypeError("Cannot coerce None to bytes without allow_none")
+        if isinstance(value, (bytes, bytearray, memoryview)):
+            return bytes(value)
+        if isinstance(value, str):
+            return value.encode("utf-8")
+        if isinstance(value, dict):
+            return json.dumps(value, sort_keys=True).encode("utf-8")
+        raise TypeError(
+            "Unable to coerce value to bytes; supply an explicit export callable"
+        )
 
     def _infer_key_type_from_jwk(self, jwk: Dict[str, object]) -> KeyType:
         kty = jwk.get("kty")


### PR DESCRIPTION
## Summary
- remove the hard dependency on `cryptography` from `KeyProviderBase`
- add provider-supplied export hooks and lightweight byte coercion helpers for assembling `KeyRef` objects
- fall back to simple heuristics for key type inference when no explicit type hint is provided

## Testing
- uv run --package swarmauri-base --directory base pytest *(fails: circular import between swarmauri_base.transports and swarmauri_core.transports while collecting tests)*
- uv run --package swarmauri --directory swarmauri pytest *(fails: swarmauri_tests_pylicense reports non-standard licenses for sniffio and joblib)*

------
https://chatgpt.com/codex/tasks/task_e_68e12da797d083268babf429c7eefb17