### PR TITLE
Fix Matplotlib tool test fixture usage

### DIFF
--- a/pkgs/standards/swarmauri_tool_matplotlib/tests/unit/MatplotlibTool_unit_test.py
+++ b/pkgs/standards/swarmauri_tool_matplotlib/tests/unit/MatplotlibTool_unit_test.py
@@ -4,7 +4,7 @@ import pytest
 from swarmauri_tool_matplotlib.MatplotlibTool import MatplotlibTool as Tool
 
 
-@pytest.fixture
+@pytest.fixture(name="tool")
 def matplotlib_tool():
     return Tool()
 


### PR DESCRIPTION
## Summary
- expose the MatplotlibTool pytest fixture under the expected `tool` name to satisfy unit tests

## Testing
- uv run --directory standards/swarmauri_tool_matplotlib --package swarmauri_tool_matplotlib pytest

------
https://chatgpt.com/codex/tasks/task_e_68e12ddc95b483269517177b739edc0c