### PR TITLE
Fix MatplotlibTool test fixture naming

### DIFF
--- a/pkgs/standards/swarmauri_tool_matplotlib/tests/unit/MatplotlibTool_unit_test.py
+++ b/pkgs/standards/swarmauri_tool_matplotlib/tests/unit/MatplotlibTool_unit_test.py
@@ -4,8 +4,10 @@ import pytest
 from swarmauri_tool_matplotlib.MatplotlibTool import MatplotlibTool as Tool
 
 
-@pytest.fixture
+@pytest.fixture(name="tool")
 def matplotlib_tool():
+    """Provide a MatplotlibTool instance for the unit tests."""
+
     return Tool()
 
 


### PR DESCRIPTION
## Summary
- ensure MatplotlibTool unit tests use the expected `tool` fixture name
- add a short fixture docstring for clarity

## Testing
- uv run --package swarmauri_tool_matplotlib --directory swarmauri_tool_matplotlib pytest

------
https://chatgpt.com/codex/tasks/task_e_68e1359aad288326b5ed282542227f72