### PR TITLE
Align dev dependency groups for swarmauri PoP packages

### DIFF
--- a/pkgs/standards/swarmauri_pop_cwt/pyproject.toml
+++ b/pkgs/standards/swarmauri_pop_cwt/pyproject.toml
@@ -29,3 +29,17 @@ swarmauri-base = { workspace = true }
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "python-dotenv",
+    "requests>=2.32.3",
+    "flake8>=7.0",
+    "pytest-timeout>=2.3.1",
+    "ruff>=0.9.9",
+    "pytest-benchmark>=4.0.0",
+]

--- a/pkgs/standards/swarmauri_pop_dpop/pyproject.toml
+++ b/pkgs/standards/swarmauri_pop_dpop/pyproject.toml
@@ -29,3 +29,17 @@ swarmauri-base = { workspace = true }
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "python-dotenv",
+    "requests>=2.32.3",
+    "flake8>=7.0",
+    "pytest-timeout>=2.3.1",
+    "ruff>=0.9.9",
+    "pytest-benchmark>=4.0.0",
+]

--- a/pkgs/standards/swarmauri_pop_x509/pyproject.toml
+++ b/pkgs/standards/swarmauri_pop_x509/pyproject.toml
@@ -27,3 +27,17 @@ swarmauri-base = { workspace = true }
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "python-dotenv",
+    "requests>=2.32.3",
+    "flake8>=7.0",
+    "pytest-timeout>=2.3.1",
+    "ruff>=0.9.9",
+    "pytest-benchmark>=4.0.0",
+]


### PR DESCRIPTION
## Summary
- add the standard development dependency group to each swarmauri_pop package so they align with the rest of the workspace

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e141d769ac832689816e06fcfacc48