### PR TITLE
Polish swarmauri PoP package docs and licensing

### DIFF
--- a/pkgs/standards/swarmauri_pop_cwt/LICENSE
+++ b/pkgs/standards/swarmauri_pop_cwt/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [2025] [Jacob Stewart @ Swarmauri]
+   Copyright 2025 Jacob Stewart @ Swarmauri
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/pkgs/standards/swarmauri_pop_cwt/README.md
+++ b/pkgs/standards/swarmauri_pop_cwt/README.md
@@ -116,6 +116,17 @@ asyncio.run(verify_request(cwp_header, signer.cnf_binding(), "opaque-access-toke
 The verifier enforces COSE key thumbprints against the `cnf` binding and applies
 the same replay and nonce strategies shared across Swarmauri PoP strategies.
 
+## Compatibility
+
+- Supports Python 3.10, 3.11, and 3.12
+- Depends on `swarmauri_core` and `swarmauri-base` from the Swarmauri SDK
+- Uses `cose>=0.9.dev8` and `cbor2>=5.5.0` for COSE Sign1 handling
+
+## Related Packages
+
+- [swarmauri_pop_dpop](https://pypi.org/project/swarmauri_pop_dpop/) for RFC 9449 DPoP proofs
+- [swarmauri_pop_x509](https://pypi.org/project/swarmauri_pop_x509/) for mutual TLS PoP verification
+
 ## License
 
 Apache License 2.0. See the [LICENSE](./LICENSE) file for details.

--- a/pkgs/standards/swarmauri_pop_dpop/LICENSE
+++ b/pkgs/standards/swarmauri_pop_dpop/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [2025] [Jacob Stewart @ Swarmauri]
+   Copyright 2025 Jacob Stewart @ Swarmauri
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/pkgs/standards/swarmauri_pop_dpop/README.md
+++ b/pkgs/standards/swarmauri_pop_dpop/README.md
@@ -117,6 +117,17 @@ asyncio.run(verify_request({"DPoP": dpop_header}, signer.cnf_binding(), "opaque-
 The verifier enforces thumbprints for the provided JWK, checks nonce and replay
 constraints, and validates `ath` hashes when bearer tokens are provided.
 
+## Compatibility
+
+- Supports Python 3.10, 3.11, and 3.12
+- Depends on `swarmauri_core` and `swarmauri-base` from the Swarmauri SDK
+- Uses `pyjwt>=2.8` and `cryptography>=41` for JOSE processing
+
+## Related Packages
+
+- [swarmauri_pop_cwt](https://pypi.org/project/swarmauri_pop_cwt/) for COSE/CBOR PoP tokens
+- [swarmauri_pop_x509](https://pypi.org/project/swarmauri_pop_x509/) for mutual TLS confirmation
+
 ## License
 
 Apache License 2.0. See the [LICENSE](./LICENSE) file for details.

--- a/pkgs/standards/swarmauri_pop_x509/LICENSE
+++ b/pkgs/standards/swarmauri_pop_x509/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [2025] [Jacob Stewart @ Swarmauri]
+   Copyright 2025 Jacob Stewart @ Swarmauri
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/pkgs/standards/swarmauri_pop_x509/README.md
+++ b/pkgs/standards/swarmauri_pop_x509/README.md
@@ -77,6 +77,17 @@ asyncio.run(main())
 supplies the evidence. Only the certificate thumbprint comparison is performed,
 mirroring the behaviour of OAuth 2.0 mutual TLS confirmation.
 
+## Compatibility
+
+- Supports Python 3.10, 3.11, and 3.12
+- Depends on `swarmauri_core` and `swarmauri-base` from the Swarmauri SDK
+- Designed for deployments where mutual TLS is already enforced by the network perimeter
+
+## Related Packages
+
+- [swarmauri_pop_cwt](https://pypi.org/project/swarmauri_pop_cwt/) for COSE/CBOR PoP bindings
+- [swarmauri_pop_dpop](https://pypi.org/project/swarmauri_pop_dpop/) for HTTP proof-of-possession headers
+
 ## License
 
 Apache License 2.0. See the [LICENSE](./LICENSE) file for details.


### PR DESCRIPTION
## Summary
- add compatibility and related package cross-links to each swarmauri_pop_* README so users know runtime expectations and adjacent tooling
- normalize the Apache 2.0 license boilerplate across the swarmauri_pop_* packages by removing placeholder markers

## Testing
- uv run --directory pkgs/standards/swarmauri_pop_cwt --package swarmauri_pop_cwt ruff format .
- uv run --directory pkgs/standards/swarmauri_pop_cwt --package swarmauri_pop_cwt ruff check . --fix
- uv run --directory pkgs/standards/swarmauri_pop_dpop --package swarmauri_pop_dpop ruff format .
- uv run --directory pkgs/standards/swarmauri_pop_dpop --package swarmauri_pop_dpop ruff check . --fix
- uv run --directory pkgs/standards/swarmauri_pop_x509 --package swarmauri_pop_x509 ruff format .
- uv run --directory pkgs/standards/swarmauri_pop_x509 --package swarmauri_pop_x509 ruff check . --fix


------
https://chatgpt.com/codex/tasks/task_e_68e1448ffdb483268bc4709e20756260