### PR TITLE
Add pylicense checks to plugin packages

### DIFF
--- a/pkgs/experimental/swarmauri_tests_pylicense/README.md
+++ b/pkgs/experimental/swarmauri_tests_pylicense/README.md
@@ -85,6 +85,21 @@ If both are provided, any license not in the allow list or explicitly present
 in the disallow list will cause a test failure. By default, all licenses are
 allowed and none are disallowed.
 
+### Accepting Specific Dependencies
+
+Some transitive dependencies may ship with unusual or proprietary licenses that
+are acceptable for your project. Use `--pylicense-accept-deps` (or the
+`PYLICENSE_ACCEPT_DEPS` environment variable) with a comma-separated list to
+explicitly bypass those packages. For example:
+
+```bash
+pytest --pylicense-package=<your-package> --pylicense-accept-deps=cffi
+```
+
+This tells the plugin to treat `cffi` as pre-approved. Any license issues for
+`cffi`—including unknown or non-standard licenses—are ignored while other
+dependencies continue to be validated normally.
+
 ## License
 
 Licensed under the [Apache 2.0 License](LICENSE).

--- a/pkgs/plugins/EmbedXMP/pyproject.toml
+++ b/pkgs/plugins/EmbedXMP/pyproject.toml
@@ -26,6 +26,7 @@ Homepage = "https://github.com/swarmauri/swarmauri-sdk"
 [tool.uv.sources]
 swarmauri_core = { workspace = true }
 swarmauri_base = { workspace = true }
+swarmauri_tests_pylicense = { workspace = true }
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
@@ -35,7 +36,11 @@ build-backend = "poetry.core.masonry.api"
 dev = [
     "pytest>=8.0",
     "ruff>=0.9",
+    "swarmauri_tests_pylicense",
 ]
+
+[tool.pytest.ini_options]
+addopts = "--pylicense-package=EmbedXMP --pylicense-mode=parameterized"
 
 [tool.poetry]
 packages = [

--- a/pkgs/plugins/embedded_signer/pyproject.toml
+++ b/pkgs/plugins/embedded_signer/pyproject.toml
@@ -124,6 +124,7 @@ swarmauri_signing_jws = { workspace = true }
 swarmauri_signing_openpgp = { workspace = true }
 swarmauri_signing_pdf = { workspace = true }
 swarmauri_signing_xmld = { workspace = true }
+swarmauri_tests_pylicense = { workspace = true }
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
@@ -143,7 +144,11 @@ dev = [
     "swarmauri_xmp_tiff",
     "swarmauri_xmp_webp",
     "ruff>=0.9",
+    "swarmauri_tests_pylicense",
 ]
+
+[tool.pytest.ini_options]
+addopts = "--pylicense-package=EmbeddedSigner --pylicense-mode=parameterized --pylicense-accept-deps=cffi"
 
 [tool.poetry]
 packages = [

--- a/pkgs/plugins/example_plugin/pyproject.toml
+++ b/pkgs/plugins/example_plugin/pyproject.toml
@@ -15,6 +15,9 @@ classifiers = [
 requires-python = ">=3.10,<3.13"
 dependencies = []
 
+[tool.uv.sources]
+swarmauri_tests_pylicense = { workspace = true }
+
 [project.entry-points."swarmauri.plugins"]
 example_agent = "swm_example_plugin.agents:ExampleAgent"
 
@@ -27,6 +30,7 @@ dev = [
     "python-dotenv>=1.0.0",
     "requests>=2.32.3",
     "ruff>=0.9.9",
+    "swarmauri_tests_pylicense",
 ]
 
 [tool.pytest.ini_options]
@@ -43,6 +47,7 @@ log_cli_level = "INFO"
 log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
 log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 asyncio_default_fixture_loop_scope = "function"
+addopts = "--pylicense-package=swm-example-plugin --pylicense-mode=parameterized"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pkgs/plugins/media_signer/pyproject.toml
+++ b/pkgs/plugins/media_signer/pyproject.toml
@@ -48,6 +48,7 @@ swarmauri_signing_jws = { workspace = true }
 swarmauri_signing_openpgp = { workspace = true }
 swarmauri_signing_pdf = { workspace = true }
 swarmauri_signing_xmld = { workspace = true }
+swarmauri_tests_pylicense = { workspace = true }
 
 [dependency-groups]
 dev = [
@@ -57,6 +58,7 @@ dev = [
     "pytest-json-report>=1.5.0",
     "python-dotenv>=1.0.0",
     "ruff>=0.9.9",
+    "swarmauri_tests_pylicense",
 ]
 
 [tool.pytest.ini_options]
@@ -65,6 +67,7 @@ log_cli_level = "INFO"
 log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
 log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 asyncio_default_fixture_loop_scope = "function"
+addopts = "--pylicense-package=MediaSigner --pylicense-mode=parameterized --pylicense-accept-deps=cffi"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -164,6 +164,7 @@ members = [
     "standards/swarmauri_signing_ssh",
     "standards/swarmauri_certs_x509verify",
     "plugins/EmbedXMP",
+    "plugins/example_plugin",
     "standards/swarmauri_xmp_gif",
     "standards/swarmauri_xmp_jpeg",
     "standards/swarmauri_xmp_mp4",


### PR DESCRIPTION
## Summary
- wire swarmauri_tests_pylicense into every plugin package via dev dependencies, workspace sources, and pytest addopts
- allow the EmbeddedSigner and MediaSigner suites to accept cffi licenses and document how accept-deps works in the plugin README
- include the example plugin in the workspace membership list so shared tooling (ruff/pytest) can resolve workspace sources

## Testing
- uv run --package EmbedXMP --directory plugins/EmbedXMP pytest
- uv run --package EmbeddedSigner --directory plugins/embedded_signer pytest
- uv run --package swm-example-plugin --directory plugins/example_plugin pytest
- uv run --package MediaSigner --directory plugins/media_signer pytest -k pylicense

------
https://chatgpt.com/codex/tasks/task_e_68e1466bde408326ae9ba8068a96f94b