### PR TITLE
Update default branch references to master

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ Follow these high-level steps when updating this repository:
 - **Tests** – execute tests in isolation from `pkgs/` with `uv run --package <name> --directory <member> pytest`.
 - **Documentation and Style** – keep code consistent with [STYLE_GUIDE.md](STYLE_GUIDE.md).
 - **Pull Requests** – ensure commits are well described and reference related issues if applicable.
+- **Default Branch** – the repository's default branch is `master`.
 
 Changes to the **peagen** package require additional validation steps detailed in
 `pkgs/standards/peagen/AGENTS.md`. Plugins should be instantiated directly;

--- a/pkgs/community/swarmauri_toolkit_github/README.md
+++ b/pkgs/community/swarmauri_toolkit_github/README.md
@@ -95,7 +95,7 @@ toolkit.github_branch_tool(
     action="create_branch",
     repo_name="owner/service",
     new_branch="release/v1.4.0",
-    source_branch="main"
+    source_branch="master"
 )
 
 # Cut a changelog commit
@@ -123,7 +123,7 @@ registry.register(toolkit.github_issue_tool)
 registry.register(toolkit.github_pr_tool)
 
 agent = Agent(tool_registry=registry)
-response = agent.run(HumanMessage(content="Open a PR from feature/auth to main"))
+response = agent.run(HumanMessage(content="Open a PR from feature/auth to master"))
 print(response)
 ```
 

--- a/pkgs/community/swarmauri_toolkit_github/swarmauri_toolkit_github/GithubBranchTool.py
+++ b/pkgs/community/swarmauri_toolkit_github/swarmauri_toolkit_github/GithubBranchTool.py
@@ -71,7 +71,7 @@ class GithubBranchTool(ToolBase):
 
     # Branch Management Methods
     def create_branch(
-        self, repo_name: str, branch_name: str, source: str = "main"
+        self, repo_name: str, branch_name: str, source: str = "master"
     ) -> str:
         try:
             repo = self._github.get_repo(repo_name)

--- a/pkgs/community/swarmauri_toolkit_github/swarmauri_toolkit_github/GithubCommitTool.py
+++ b/pkgs/community/swarmauri_toolkit_github/swarmauri_toolkit_github/GithubCommitTool.py
@@ -106,7 +106,7 @@ class GithubCommitTool(ToolBase):
         file_path: str,
         message: str,
         content: str,
-        branch: str = "main",
+        branch: str = "master",
     ) -> str:
         try:
             repo = self._github.get_repo(repo_name)

--- a/pkgs/community/swarmauri_toolkit_github/tests/unit/GithubBranchTool_test.py
+++ b/pkgs/community/swarmauri_toolkit_github/tests/unit/GithubBranchTool_test.py
@@ -56,7 +56,7 @@ def test_serialization(github_branch_tool):
             {
                 "repo_name": "test-repo",
                 "branch_name": "new-branch",
-                "source_branch": "main",
+                "source_branch": "master",
             },
             "create_branch",
         ),
@@ -66,7 +66,7 @@ def test_serialization(github_branch_tool):
             "delete_branch",
         ),
         ("list_branches", {"repo_name": "test-repo"}, "list_branches"),
-        ("get_branch", {"repo_name": "test-repo", "branch_name": "main"}, "get_branch"),
+        ("get_branch", {"repo_name": "test-repo", "branch_name": "master"}, "get_branch"),
         # Invalid action
         ("invalid_action", {}, None),
     ],

--- a/pkgs/community/swarmauri_toolkit_github/tests/unit/GithubCommitTool_test.py
+++ b/pkgs/community/swarmauri_toolkit_github/tests/unit/GithubCommitTool_test.py
@@ -59,7 +59,7 @@ def test_serialization(github_commit_tool):
                 "file_path": "path/to/file.txt",
                 "message": "Test Commit",
                 "content": "File content",
-                "branch": "main",
+                "branch": "master",
             },
             "create_commit",
         ),
@@ -67,7 +67,7 @@ def test_serialization(github_commit_tool):
         ("get_commit", {"repo_name": "test-repo", "sha": "abcdef"}, "get_commit"),
         (
             "compare_commits",
-            {"repo_name": "test-repo", "base": "main", "head": "feature"},
+            {"repo_name": "test-repo", "base": "master", "head": "feature"},
             "compare_commits",
         ),
         # Invalid action

--- a/pkgs/experimental/jaml/tests/r8n/test_git_methods.py
+++ b/pkgs/experimental/jaml/tests/r8n/test_git_methods.py
@@ -8,7 +8,7 @@ def test_git_embed_method():
     # Test using the .embed() method to include raw content
     jml = """
 [scripts]
-deploy = git(url = "https://github.com/user/scripts", branch = "main").embed("deploy.sh")
+deploy = git(url = "https://github.com/user/scripts", branch = "master").embed("deploy.sh")
 readme = git(url = "https://github.com/user/docs", tag = "v1.0").embed("README.md")
     """.strip()
 

--- a/pkgs/experimental/jaml/tests/r8n/test_git_named_parameters.py
+++ b/pkgs/experimental/jaml/tests/r8n/test_git_named_parameters.py
@@ -8,7 +8,7 @@ def test_git_named_parameters_basic():
     # Test basic usage with named parameters
     jml = """
 [config]
-repo = git(url = "https://github.com/user/project", branch = "main")
+repo = git(url = "https://github.com/user/project", branch = "master")
 release = git(url = "https://github.com/user/release", tag = "v1.0")
 fixed = git(url = "https://github.com/user/fix", commit = "abc123")
     """.strip()
@@ -19,7 +19,7 @@ fixed = git(url = "https://github.com/user/fix", commit = "abc123")
 
     # Validate structured git references
     assert data["config"]["repo"]["url"] == "https://github.com/user/project"
-    assert data["config"]["repo"]["branch"] == "main"
+    assert data["config"]["repo"]["branch"] == "master"
     assert data["config"]["release"]["tag"] == "v1.0"
     assert data["config"]["fixed"]["commit"] == "abc123"
 
@@ -30,7 +30,7 @@ def test_git_named_parameters_with_embed():
     # Test embedding raw content from a git repository
     jml = """
 [script]
-deploy = git(url = "https://github.com/user/scripts", branch = "main").embed("deploy.sh")
+deploy = git(url = "https://github.com/user/scripts", branch = "master").embed("deploy.sh")
     """.strip()
 
     ast = round_trip_loads(jml)

--- a/pkgs/standards/peagen/peagen/cli/commands/init.py
+++ b/pkgs/standards/peagen/peagen/cli/commands/init.py
@@ -331,7 +331,7 @@ def remote_init_repo(
     repo: str = typer.Argument(..., help="owner/name"),
     pat: str = typer.Option(..., envvar="GITHUB_PAT"),
     path: str = typer.Option(".", "--path", help="Local repository path"),
-    default_branch: str = typer.Option("main", "--default-branch"),
+    default_branch: str = typer.Option("master", "--default-branch"),
 ) -> None:
     """
     Register *repo* with the gateway (provisions origin on git-shadow and mirror on GitHub),

--- a/pkgs/standards/peagen/peagen/handlers/fetch_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/fetch_handler.py
@@ -8,7 +8,7 @@ Async entry-point for the *fetch* pipeline.
 
     {
         "repos":   [ "<git-url>", … ],   # required – list of clone URLs
-        "ref":     "main",               # optional – branch/tag/SHA (default "HEAD")
+        "ref":     "master",             # optional – branch/tag/SHA (default "HEAD")
         "out_dir": "<path>"              # optional – base directory for work-trees
     }
 

--- a/pkgs/standards/peagen/peagen/handlers/mutate_handler.py
+++ b/pkgs/standards/peagen/peagen/handlers/mutate_handler.py
@@ -37,7 +37,7 @@ async def mutate_handler(task: TaskRead) -> Dict[str, Any]:
 
         {
             "repo":         "<git-url>",          # required
-            "ref":          "main",               # optional (default HEAD)
+            "ref":          "master",             # optional (default HEAD)
             "target_file":  "src/foo.py",         # required – relative to repo root
             "import_path":  "pkg.module",         # required
             "entry_fn":     "benchmark",          # required

--- a/pkgs/standards/peagen/peagen/orm/mixins.py
+++ b/pkgs/standards/peagen/peagen/orm/mixins.py
@@ -41,7 +41,7 @@ class RepositoryRefMixin:
     )  # e.g. "github.com/acme/app"
     ref: Mapped[str] = acol(
         storage=S(String, nullable=False)
-    )  # e.g. "main" / SHA / tag
+    )  # e.g. "master" / SHA / tag
 
     @declared_attr
     def repository(cls):

--- a/pkgs/standards/peagen/peagen/orm/repositories.py
+++ b/pkgs/standards/peagen/peagen/orm/repositories.py
@@ -42,7 +42,7 @@ class Repository(Base, GUIDPk, Timestamped, Ownable, TenantBound, StatusColumn):
 
     name: Mapped[str] = acol(storage=S(String, nullable=False))
     url: Mapped[str] = acol(storage=S(String, unique=True, nullable=False))
-    default_branch: Mapped[str] = acol(storage=S(String, default="main"))
+    default_branch: Mapped[str] = acol(storage=S(String, default="master"))
     commit_sha: Mapped[str | None] = acol(storage=S(String(length=40), nullable=True))
     github_pat: str | None = vcol(
         field=F(

--- a/pkgs/standards/peagen/tests/unit/test_extras_cli.py
+++ b/pkgs/standards/peagen/tests/unit/test_extras_cli.py
@@ -30,7 +30,7 @@ def test_extras_cli_generates_schemas(monkeypatch, tmp_path):
             "--repo",
             "repo",
             "--ref",
-            "main",
+            "master",
             "--templates-root",
             str(templates),
             "--schemas-dir",
@@ -44,7 +44,7 @@ def test_extras_cli_generates_schemas(monkeypatch, tmp_path):
     assert called["args"]["templates_root"] == str(templates)
     assert called["args"]["schemas_dir"] == str(schemas)
     assert called["args"]["repo"] == "repo"
-    assert called["args"]["ref"] == "main"
+    assert called["args"]["ref"] == "master"
     assert called["pool"] == "default"
     assert called["task"] == "TASK"
     assert "\u2705 Wrote" in result.stdout

--- a/pkgs/standards/peagen/tests/unit/test_fetch_handler.py
+++ b/pkgs/standards/peagen/tests/unit/test_fetch_handler.py
@@ -21,7 +21,7 @@ async def test_fetch_handler_passes_args(monkeypatch):
     args = {
         "repos": ["git+repo1", "git+repo2"],
         "out_dir": "~/out",
-        "ref": "main",
+        "ref": "master",
     }
 
     task = build_task(
@@ -29,11 +29,11 @@ async def test_fetch_handler_passes_args(monkeypatch):
         args=args,
         pool_id="p",
         repo="repo",
-        ref="main",
+        ref="master",
     )
     result = await handler.fetch_handler(task)
 
     assert result == {"count": 2}
     assert captured["repos"] == ["git+repo1", "git+repo2"]
-    assert captured["ref"] == "main"
+    assert captured["ref"] == "master"
     assert captured["out_dir"] == Path("~/out").expanduser()

--- a/pkgs/standards/peagen/tests/unit/test_validate_cli.py
+++ b/pkgs/standards/peagen/tests/unit/test_validate_cli.py
@@ -42,7 +42,7 @@ def test_local_validate_cli_invokes_handler(monkeypatch, tmp_path):
             "--repo",
             "repo",
             "--ref",
-            "main",
+            "master",
         ],
     )
     assert result.exit_code == 0
@@ -69,7 +69,7 @@ def test_remote_validate_cli_submits_task(monkeypatch):
             "--repo",
             "repo",
             "--ref",
-            "main",
+            "master",
         ],
         obj={"rpc": object(), "pool": "default"},
     )

--- a/pkgs/standards/swarmauri_tool_githubloader/README.md
+++ b/pkgs/standards/swarmauri_tool_githubloader/README.md
@@ -45,7 +45,7 @@ result = tool(x=1, y=2)
 
 Customize how the loader fetches your component:
 
-- **branch** – Branch to read from (defaults to `"main"`).
+- **branch** – Branch to read from (defaults to `"master"`).
 - **commit_ref** – Specific commit SHA; overrides `branch` when provided.
 - **token** – GitHub token for private repositories.
 - **use_cache** – Set to `False` to reload the component on every call.

--- a/pkgs/standards/swarmauri_tool_githubloader/swarmauri_tool_githubloader/GithubLoadedTool.py
+++ b/pkgs/standards/swarmauri_tool_githubloader/swarmauri_tool_githubloader/GithubLoadedTool.py
@@ -20,7 +20,7 @@ class GithubLoadedTool(ToolBase):
     owner: str
     repo: str
     path: str
-    branch: str = "main"
+    branch: str = "master"
     commit_ref: Optional[str] = None
     token: Optional[str] = None
     use_cache: bool = True

--- a/scripts/update_pyproject_version.py
+++ b/scripts/update_pyproject_version.py
@@ -3,7 +3,7 @@ from tomlkit import parse, dumps, inline_table
 from urllib.parse import urljoin
 
 
-def fetch_remote_pyproject_version(git_url, branch="main", subdirectory=""):
+def fetch_remote_pyproject_version(git_url, branch="master", subdirectory=""):
     """
     Fetch the version from a remote pyproject.toml file in a GitHub repository.
 
@@ -63,7 +63,7 @@ def update_pyproject_with_versions(file_path):
             # Check if the dependency is a table (dict-like) with a 'git' key.
             if isinstance(details, dict) and "git" in details:
                 git_url = details["git"]
-                branch = details.get("branch", "main")
+                branch = details.get("branch", "master")
                 subdirectory = details.get("subdirectory", "")
 
                 print(f"Updating dependency: {dep_name}")


### PR DESCRIPTION
## Summary
- update documentation and tooling defaults to reflect the repository's master default branch
- adjust GitHub-related utilities, tests, and scripts to use master as the default branch
- document the master default branch in the contributor guidance

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e149a65ac8832697e36f1d46978cf6