### PR TITLE
chore(plugins): enrich metadata and documentation

### DIFF
--- a/pkgs/plugins/EmbedXMP/README.md
+++ b/pkgs/plugins/EmbedXMP/README.md
@@ -1,30 +1,28 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+<p align="center">
+  <img src="https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg" alt="Swarmauri logotype" width="420" />
+</p>
 
+<h1 align="center">EmbedXMP</h1>
 
 <p align="center">
-    <a href="https://pypi.org/project/EmbedXMP/">
-        <img src="https://img.shields.io/pypi/dm/EmbedXMP" alt="PyPI - Downloads"/></a>
-    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/plugins/EmbedXMP/">
-        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/plugins/EmbedXMP.svg"/></a>
-    <a href="https://pypi.org/project/EmbedXMP/">
-        <img src="https://img.shields.io/pypi/pyversions/EmbedXMP" alt="PyPI - Python Version"/></a>
-    <a href="https://pypi.org/project/EmbedXMP/">
-        <img src="https://img.shields.io/pypi/l/EmbedXMP" alt="PyPI - License"/></a>
-    <a href="https://pypi.org/project/EmbedXMP/">
-        <img src="https://img.shields.io/pypi/v/EmbedXMP?label=EmbedXMP&color=green" alt="PyPI - EmbedXMP"/></a>
+  <a href="https://pypi.org/project/EmbedXMP/"><img src="https://img.shields.io/pypi/dm/EmbedXMP?style=for-the-badge" alt="PyPI - Downloads" /></a>
+  <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/plugins/EmbedXMP/"><img src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/plugins/EmbedXMP.svg?style=for-the-badge" alt="Repository views" /></a>
+  <a href="https://pypi.org/project/EmbedXMP/"><img src="https://img.shields.io/pypi/pyversions/EmbedXMP?style=for-the-badge" alt="Supported Python versions" /></a>
+  <a href="https://pypi.org/project/EmbedXMP/"><img src="https://img.shields.io/pypi/l/EmbedXMP?style=for-the-badge" alt="License" /></a>
+  <a href="https://pypi.org/project/EmbedXMP/"><img src="https://img.shields.io/pypi/v/EmbedXMP?style=for-the-badge&label=EmbedXMP" alt="Latest release" /></a>
 </p>
 
 ---
 
-# EmbedXMP
-
-`EmbedXMP` collects every installed `EmbedXmpBase` implementation, discovers them via Swarmauri's dynamic registry, and exposes a single manager that can embed, read, or remove XMP packets without worrying about container formats.
+EmbedXMP collects every installed `EmbedXmpBase` implementation, discovers them via Swarmauri's dynamic registry, and exposes a unified manager that can embed, read, or remove XMP packets without worrying about container formats.
 
 ## Features
 
 - **Dynamic discovery** – lazily imports modules named `swarmauri_xmp_*` and collects subclasses registered under `EmbedXmpBase`.
 - **Unified interface** – delegates to the first handler whose `supports` method confirms compatibility with the payload.
 - **Convenience wrappers** – module-level helpers (`embed`, `read`, `remove`) keep high-level workflows succinct.
+- **Async-friendly APIs** – integrate inside event loops without blocking when calling out to plugin hooks.
+- **Media-format coverage** – load handlers for PNG, GIF, JPEG, SVG, WEBP, TIFF, PDF, and MP4 assets through extras.
 
 ## Installation
 
@@ -51,19 +49,37 @@ manager = EmbedXMP()
 image = Path("example.png")
 packet = """<x:xmpmeta xmlns:x='adobe:ns:meta/'><rdf:RDF>...</rdf:RDF></x:xmpmeta>"""
 
-# Embed into the file in-place
+# Embed into the file in place.
 embed_file(image, packet)
 
-# Inspect metadata via the manager API
+# Inspect metadata via the manager API.
 xmp_text = manager.read(image.read_bytes(), str(image))
 print(xmp_text)
+
+# Remove metadata from the file when it is no longer required.
+manager.remove(image.read_bytes(), str(image))
 ```
 
-### How it works
+### Async orchestration
 
-- **Dynamic discovery** – lazily imports modules named `swarmauri_xmp_*` and collects subclasses registered under `EmbedXmpBase`.
-- **Unified interface** – delegates to the first handler whose `supports` method confirms compatibility with the payload.
-- **Convenience wrappers** – module-level helpers (`embed`, `read`, `remove`) keep high-level workflows succinct.
+EmbedXMP's manager can be shared inside asynchronous workflows by deferring media-aware work to plugin hooks:
+
+```python
+import asyncio
+from pathlib import Path
+
+from EmbedXMP import EmbedXMP, embed
+
+
+async def embed_all(paths: list[str], packet: str) -> None:
+    manager = EmbedXMP()
+    for path in paths:
+        data = Path(path).read_bytes()
+        await asyncio.to_thread(embed, data, packet, hint=path)
+
+
+asyncio.run(embed_all(["one.png", "two.svg"], "<x:xmpmeta>...</x:xmpmeta>"))
+```
 
 ## Project Resources
 
@@ -71,3 +87,4 @@ print(xmp_text)
 - Documentation: <https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/plugins/EmbedXMP#readme>
 - Issues: <https://github.com/swarmauri/swarmauri-sdk/issues>
 - Releases: <https://github.com/swarmauri/swarmauri-sdk/releases>
+- Discussions: <https://github.com/orgs/swarmauri/discussions>

--- a/pkgs/plugins/EmbedXMP/pyproject.toml
+++ b/pkgs/plugins/EmbedXMP/pyproject.toml
@@ -11,10 +11,12 @@ classifiers = [
     "Natural Language :: English",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Intended Audience :: Developers",
+    "Framework :: AsyncIO",
     "Topic :: Multimedia :: Graphics",
     "Topic :: Software Development :: Libraries",
 ]
@@ -30,9 +32,14 @@ keywords = [
     "metadata",
     "embedding",
     "digital-asset-management",
+    "digital-asset-workflows",
+    "metadata-pipelines",
     "media-workflows",
     "metadata-extraction",
+    "metadata-synchronization",
     "python-library",
+    "async-discovery",
+    "plugin-discovery",
 ]
 
 [project.urls]
@@ -41,6 +48,7 @@ Source = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/plugins/Embe
 Documentation = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/plugins/EmbedXMP#readme"
 Issues = "https://github.com/swarmauri/swarmauri-sdk/issues"
 Changelog = "https://github.com/swarmauri/swarmauri-sdk/releases"
+Discussions = "https://github.com/orgs/swarmauri/discussions"
 
 [tool.uv.sources]
 swarmauri_core = { workspace = true }

--- a/pkgs/plugins/embedded_signer/README.md
+++ b/pkgs/plugins/embedded_signer/README.md
@@ -45,20 +45,20 @@ produced.
 ### Using `uv`
 
 ```bash
-uv pip install EmbeddedSigner
+uv add EmbeddedSigner
 ```
 
 Optional dependencies align with the available key providers, EmbedXMP handlers,
 and MediaSigner backends:
 
 ```bash
-uv pip install "EmbeddedSigner[local]"      # enable LocalKeyProvider resolution
-uv pip install "EmbeddedSigner[memory]"     # enable InMemoryKeyProvider resolution
-uv pip install "EmbeddedSigner[xmp_png]"    # add PNG embedding support
-uv pip install "EmbeddedSigner[xmp_all]"    # install every EmbedXMP handler
-uv pip install "EmbeddedSigner[signing_pdf]"  # enable PDF signer backend
-uv pip install "EmbeddedSigner[signing_all]"  # install every MediaSigner backend
-uv pip install "EmbeddedSigner[full]"       # bring in all extras and key providers
+uv add "EmbeddedSigner[local]"      # enable LocalKeyProvider resolution
+uv add "EmbeddedSigner[memory]"     # enable InMemoryKeyProvider resolution
+uv add "EmbeddedSigner[xmp_png]"    # add PNG embedding support
+uv add "EmbeddedSigner[xmp_all]"    # install every EmbedXMP handler
+uv add "EmbeddedSigner[signing_pdf]"  # enable PDF signer backend
+uv add "EmbeddedSigner[signing_all]"  # install every MediaSigner backend
+uv add "EmbeddedSigner[full]"       # bring in all extras and key providers
 ```
 
 ### Using `pip`
@@ -219,6 +219,14 @@ embedded-signer embed-sign example.png \
    ```bash
    uv run --package EmbeddedSigner --directory plugins/embedded_signer pytest
    ```
+
+## Project Resources
+
+- Source: <https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/plugins/embedded_signer>
+- Documentation: <https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/plugins/embedded_signer#readme>
+- Issues: <https://github.com/swarmauri/swarmauri-sdk/issues>
+- Releases: <https://github.com/swarmauri/swarmauri-sdk/releases>
+- Discussions: <https://github.com/orgs/swarmauri/discussions>
 
 ## License
 

--- a/pkgs/plugins/embedded_signer/pyproject.toml
+++ b/pkgs/plugins/embedded_signer/pyproject.toml
@@ -11,9 +11,11 @@ classifiers = [
     "Natural Language :: English",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Framework :: AsyncIO",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
 ]
@@ -45,6 +47,10 @@ keywords = [
     "tiff",
     "pdf",
     "mp4",
+    "digital-asset-security",
+    "metadata-signing",
+    "workflow-automation",
+    "plugin-orchestration",
 ]
 
 [project.urls]
@@ -53,6 +59,7 @@ Source = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/plugins/embe
 Documentation = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/plugins/embedded_signer#readme"
 Issues = "https://github.com/swarmauri/swarmauri-sdk/issues"
 Changelog = "https://github.com/swarmauri/swarmauri-sdk/releases"
+Discussions = "https://github.com/orgs/swarmauri/discussions"
 
 [project.scripts]
 embedded-signer = "EmbeddedSigner.cli:main"

--- a/pkgs/plugins/example_plugin/README.md
+++ b/pkgs/plugins/example_plugin/README.md
@@ -76,3 +76,4 @@ custom functionality into the Swarmauri plugin registry.
 - Documentation: <https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/plugins/example_plugin#readme>
 - Issues: <https://github.com/swarmauri/swarmauri-sdk/issues>
 - Releases: <https://github.com/swarmauri/swarmauri-sdk/releases>
+- Discussions: <https://github.com/orgs/swarmauri/discussions>

--- a/pkgs/plugins/example_plugin/pyproject.toml
+++ b/pkgs/plugins/example_plugin/pyproject.toml
@@ -12,11 +12,13 @@ classifiers = [
     "Natural Language :: English",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Libraries",
+    "Topic :: Education",
 ]
 requires-python = ">=3.10,<3.13"
 dependencies = []
@@ -28,6 +30,10 @@ keywords = [
     "agents",
     "entry-points",
     "sdk",
+    "scaffolding",
+    "template",
+    "tutorial",
+    "packaging",
 ]
 
 [project.urls]
@@ -36,6 +42,7 @@ Source = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/plugins/exam
 Documentation = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/plugins/example_plugin#readme"
 Issues = "https://github.com/swarmauri/swarmauri-sdk/issues"
 Changelog = "https://github.com/swarmauri/swarmauri-sdk/releases"
+Discussions = "https://github.com/orgs/swarmauri/discussions"
 
 [tool.uv.sources]
 swarmauri_tests_pylicense = { workspace = true }

--- a/pkgs/plugins/media_signer/README.md
+++ b/pkgs/plugins/media_signer/README.md
@@ -154,3 +154,4 @@ materials matching the selected plugin.
 - Documentation: <https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/plugins/media_signer#readme>
 - Issues: <https://github.com/swarmauri/swarmauri-sdk/issues>
 - Releases: <https://github.com/swarmauri/swarmauri-sdk/releases>
+- Discussions: <https://github.com/orgs/swarmauri/discussions>

--- a/pkgs/plugins/media_signer/pyproject.toml
+++ b/pkgs/plugins/media_signer/pyproject.toml
@@ -12,11 +12,14 @@ classifiers = [
     "Natural Language :: English",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Intended Audience :: Developers",
+    "Framework :: AsyncIO",
     "Topic :: Security :: Cryptography",
+    "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
     "swarmauri_core",
@@ -38,6 +41,10 @@ keywords = [
     "plugin",
     "orchestration",
     "asyncio",
+    "signature-aggregation",
+    "workflow-automation",
+    "key-management",
+    "verification",
 ]
 
 [project.urls]
@@ -46,6 +53,7 @@ Source = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/plugins/medi
 Documentation = "https://github.com/swarmauri/swarmauri-sdk/tree/main/pkgs/plugins/media_signer#readme"
 Issues = "https://github.com/swarmauri/swarmauri-sdk/issues"
 Changelog = "https://github.com/swarmauri/swarmauri-sdk/releases"
+Discussions = "https://github.com/orgs/swarmauri/discussions"
 
 [project.scripts]
 media-signer = "MediaSigner.cli:main"


### PR DESCRIPTION
## Summary
- expand classifiers, keywords, and project URLs across plugin pyproject.toml files to better describe distribution metadata
- refresh plugin README files with standardized branding, installation guidance, and resource links consistent with monorepo standards

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e14e0491708326b3062f84dd5cda02