### PR TITLE
Standardize community package metadata

### DIFF
--- a/pkgs/community/swarmauri_certs_acme/pyproject.toml
+++ b/pkgs/community/swarmauri_certs_acme/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -19,6 +23,13 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "certs",
+    "acme",
+    "certificate",
+    "service",
 ]
 
 [project.optional-dependencies]

--- a/pkgs/community/swarmauri_certs_azure/pyproject.toml
+++ b/pkgs/community/swarmauri_certs_azure/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -20,6 +24,16 @@ dependencies = [
     "azure-keyvault-keys",
     "cryptography",
     "asn1crypto",
+]
+keywords = [
+    "swarmauri",
+    "certs",
+    "azure",
+    "key",
+    "vault",
+    "certificate",
+    "utilities",
+    "ecosystem",
 ]
 
 [project.optional-dependencies]

--- a/pkgs/community/swarmauri_certs_cfssl/pyproject.toml
+++ b/pkgs/community/swarmauri_certs_cfssl/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -20,6 +24,14 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "certs",
+    "cfssl",
+    "backed",
+    "certificate",
+    "service",
 ]
 
 [project.optional-dependencies]

--- a/pkgs/community/swarmauri_certs_crlverifyservice/pyproject.toml
+++ b/pkgs/community/swarmauri_certs_crlverifyservice/pyproject.toml
@@ -11,11 +11,24 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
     "cryptography>=41.0.0",
     "swarmauri-base",
+]
+keywords = [
+    "swarmauri",
+    "certs",
+    "crlverifyservice",
+    "certificate",
+    "verification",
+    "against",
+    "crls",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_certs_csronly/pyproject.toml
+++ b/pkgs/community/swarmauri_certs_csronly/pyproject.toml
@@ -11,9 +11,23 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = ["swarmauri_core", "swarmauri_base", "cryptography>=41"]
+keywords = [
+    "swarmauri",
+    "certs",
+    "csronly",
+    "community",
+    "service",
+    "generating",
+    "pkcs",
+    "csrs",
+]
 
 [project.optional-dependencies]
 tests = [

--- a/pkgs/community/swarmauri_certs_ocspverify/pyproject.toml
+++ b/pkgs/community/swarmauri_certs_ocspverify/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -19,6 +23,15 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "certs",
+    "ocspverify",
+    "ocsp",
+    "certificate",
+    "verification",
+    "service",
 ]
 
 [project.optional-dependencies]

--- a/pkgs/community/swarmauri_certservice_aws_kms/pyproject.toml
+++ b/pkgs/community/swarmauri_certservice_aws_kms/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -20,6 +24,13 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "certservice",
+    "aws",
+    "kms",
+    "backed",
 ]
 
 [project.optional-dependencies]

--- a/pkgs/community/swarmauri_certservice_gcpkms/pyproject.toml
+++ b/pkgs/community/swarmauri_certservice_gcpkms/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -18,6 +22,16 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "certservice",
+    "gcpkms",
+    "google",
+    "cloud",
+    "kms",
+    "certificate",
+    "service",
 ]
 
 [project.optional-dependencies]

--- a/pkgs/community/swarmauri_certservice_ms_adcs/pyproject.toml
+++ b/pkgs/community/swarmauri_certservice_ms_adcs/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -19,6 +23,16 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "certservice",
+    "ms",
+    "adcs",
+    "microsoft",
+    "certificate",
+    "service",
+    "client",
 ]
 
 [project.optional-dependencies]

--- a/pkgs/community/swarmauri_certservice_scep/pyproject.toml
+++ b/pkgs/community/swarmauri_certservice_scep/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -18,6 +22,13 @@ dependencies = [
     "cryptography>=41.0.0",
     "swarmauri_core",
     "swarmauri_base",
+]
+keywords = [
+    "swarmauri",
+    "certservice",
+    "scep",
+    "certificate",
+    "service",
 ]
 
 [project.optional-dependencies]

--- a/pkgs/community/swarmauri_certservice_stepca/pyproject.toml
+++ b/pkgs/community/swarmauri_certservice_stepca/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -19,6 +23,15 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "certservice",
+    "stepca",
+    "step",
+    "backed",
+    "certificate",
+    "service",
 ]
 
 [project.optional-dependencies]

--- a/pkgs/community/swarmauri_embedding_mlm/pyproject.toml
+++ b/pkgs/community/swarmauri_embedding_mlm/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -19,6 +23,14 @@ dependencies = [
     "swarmauri_standard",
     "torch>=2.6.0",
     "transformers>=4.49.0",
+]
+keywords = [
+    "swarmauri",
+    "embedding",
+    "mlm",
+    "example",
+    "community",
+    "package",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_keyprovider_aws_kms/pyproject.toml
+++ b/pkgs/community/swarmauri_keyprovider_aws_kms/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -19,6 +23,12 @@ dependencies = [
     "swarmauri_base",
     "swarmauri_standard",
     "cryptography",
+]
+keywords = [
+    "swarmauri",
+    "keyprovider",
+    "aws",
+    "kms",
 ]
 
 [project.optional-dependencies]

--- a/pkgs/community/swarmauri_keyprovider_gcpkms/pyproject.toml
+++ b/pkgs/community/swarmauri_keyprovider_gcpkms/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -20,6 +24,16 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "keyprovider",
+    "gcpkms",
+    "google",
+    "cloud",
+    "kms",
+    "key",
+    "provider",
 ]
 
 [project.optional-dependencies]

--- a/pkgs/community/swarmauri_keyprovider_vaulttransit/pyproject.toml
+++ b/pkgs/community/swarmauri_keyprovider_vaulttransit/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -19,6 +23,15 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "keyprovider",
+    "vaulttransit",
+    "vault",
+    "transit",
+    "key",
+    "provider",
 ]
 
 [project.optional-dependencies]

--- a/pkgs/community/swarmauri_llm_leptonai/pyproject.toml
+++ b/pkgs/community/swarmauri_llm_leptonai/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -18,6 +22,13 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "llm",
+    "leptonai",
+    "lepton",
+    "model",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_measurement_mutualinformation/pyproject.toml
+++ b/pkgs/community/swarmauri_measurement_mutualinformation/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -18,6 +22,15 @@ dependencies = [
     "pandas>=2.2.3",
     "swarmauri_core",
     "swarmauri_base",
+]
+keywords = [
+    "swarmauri",
+    "measurement",
+    "mutualinformation",
+    "mutual",
+    "information",
+    "community",
+    "package",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_measurement_tokencountestimator/pyproject.toml
+++ b/pkgs/community/swarmauri_measurement_tokencountestimator/pyproject.toml
@@ -11,9 +11,23 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = ["tiktoken>=0.8.0", "swarmauri_core", "swarmauri_base"]
+keywords = [
+    "swarmauri",
+    "measurement",
+    "tokencountestimator",
+    "repository",
+    "includes",
+    "example",
+    "first",
+    "class",
+]
 
 [tool.uv.sources]
 swarmauri_core = { workspace = true }

--- a/pkgs/community/swarmauri_middleware_circuitbreaker/pyproject.toml
+++ b/pkgs/community/swarmauri_middleware_circuitbreaker/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "Topic :: Software Development :: Libraries :: Application Frameworks"
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 dependencies = [
     "fastapi",
@@ -23,6 +23,13 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard"
+]
+keywords = [
+    "swarmauri",
+    "middleware",
+    "circuitbreaker",
+    "circuit",
+    "breaker",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_middleware_ratepolicy/pyproject.toml
+++ b/pkgs/community/swarmauri_middleware_ratepolicy/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "Topic :: Software Development :: Libraries :: Application Frameworks"
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -32,7 +32,11 @@ keywords = [
     "tenacity",
     "async",
     "api",
-    "framework"
+    "framework",
+    "implementing",
+    "rate",
+    "policy",
+    "logic",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_ocr_pytesseract/pyproject.toml
+++ b/pkgs/community/swarmauri_ocr_pytesseract/pyproject.toml
@@ -11,9 +11,22 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = ["pytesseract>=0.3.13", "swarmauri_core", "swarmauri_base", "swarmauri_standard"]
+keywords = [
+    "swarmauri",
+    "ocr",
+    "pytesseract",
+    "tesseract",
+    "image",
+    "text",
+    "model",
+]
 
 [tool.uv.sources]
 swarmauri_core = { workspace = true }

--- a/pkgs/community/swarmauri_parser_bertembedding/pyproject.toml
+++ b/pkgs/community/swarmauri_parser_bertembedding/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -19,6 +23,13 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "parser",
+    "bertembedding",
+    "bert",
+    "embedding",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_parser_entityrecognition/pyproject.toml
+++ b/pkgs/community/swarmauri_parser_entityrecognition/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -19,6 +23,13 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "parser",
+    "entityrecognition",
+    "entity",
+    "recognition",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_parser_fitzpdf/pyproject.toml
+++ b/pkgs/community/swarmauri_parser_fitzpdf/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -18,6 +22,13 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "parser",
+    "fitzpdf",
+    "fitz",
+    "pdf",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_parser_pypdf2/pyproject.toml
+++ b/pkgs/community/swarmauri_parser_pypdf2/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -18,6 +22,11 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "parser",
+    "pypdf2",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_parser_pypdftk/pyproject.toml
+++ b/pkgs/community/swarmauri_parser_pypdftk/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -18,6 +22,14 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "parser",
+    "pypdftk",
+    "extracting",
+    "text",
+    "pdfs",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_parser_slate/pyproject.toml
+++ b/pkgs/community/swarmauri_parser_slate/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -18,6 +22,14 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "parser",
+    "slate",
+    "extracting",
+    "text",
+    "pdfs",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_parser_textblob/pyproject.toml
+++ b/pkgs/community/swarmauri_parser_textblob/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -19,6 +23,11 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "parser",
+    "textblob",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_signing_dsse/pyproject.toml
+++ b/pkgs/community/swarmauri_signing_dsse/pyproject.toml
@@ -6,7 +6,23 @@ readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.10,<3.13"
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
-keywords = ["swarmauri", "signing", "dsse", "sigstore", "supply-chain", "pae"]
+keywords = [
+    "swarmauri",
+    "signing",
+    "dsse",
+    "sigstore",
+    "supply-chain",
+    "pae",
+    "composable",
+    "envelope",
+    "adapter",
+    "layers",
+    "pre",
+    "authentication",
+    "encoding",
+    "onto",
+    "providers",
+]
 classifiers = [
     "Development Status :: 1 - Planning",
     "License :: OSI Approved :: Apache Software License",
@@ -18,6 +34,8 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Development Status :: 3 - Alpha",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 dependencies = [
     "swarmauri_core",

--- a/pkgs/community/swarmauri_state_clipboard/pyproject.toml
+++ b/pkgs/community/swarmauri_state_clipboard/pyproject.toml
@@ -11,9 +11,19 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = ["swarmauri_core", "swarmauri_base"]
+keywords = [
+    "swarmauri",
+    "state",
+    "clipboard",
+    "community",
+]
 
 [tool.uv.sources]
 swarmauri_core = { workspace = true }

--- a/pkgs/community/swarmauri_tests_griffe/pyproject.toml
+++ b/pkgs/community/swarmauri_tests_griffe/pyproject.toml
@@ -17,6 +17,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 keywords = [
     "swarmauri",
@@ -25,6 +29,15 @@ keywords = [
     "static analysis",
     "developer experience",
     "quality gates",
+    "tests",
+    "plugin",
+    "turns",
+    "inspection",
+    "warnings",
+    "failing",
+    "quality",
+    "gates",
+    "packages",
 ]
 dependencies = [
     "pytest>=8.0",

--- a/pkgs/community/swarmauri_tool_captchagenerator/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_captchagenerator/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -18,6 +22,14 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "tool",
+    "captchagenerator",
+    "community",
+    "captcha",
+    "generator",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_tool_dalechallreadability/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_dalechallreadability/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -18,6 +22,15 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "tool",
+    "dalechallreadability",
+    "community",
+    "dale",
+    "chall",
+    "readability",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_tool_downloadpdf/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_downloadpdf/pyproject.toml
@@ -11,9 +11,21 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = ["swarmauri_core", "swarmauri_base", "swarmauri_standard"]
+keywords = [
+    "swarmauri",
+    "tool",
+    "downloadpdf",
+    "community",
+    "download",
+    "pdf",
+]
 
 [tool.uv.sources]
 swarmauri_core = { workspace = true }

--- a/pkgs/community/swarmauri_tool_entityrecognition/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_entityrecognition/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -20,6 +24,14 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "tool",
+    "entityrecognition",
+    "community",
+    "entity",
+    "recognition",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_tool_folium/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_folium/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -18,6 +22,16 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "tool",
+    "folium",
+    "repository",
+    "includes",
+    "example",
+    "first",
+    "class",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_tool_gmail/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_gmail/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -18,6 +22,14 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "tool",
+    "gmail",
+    "example",
+    "community",
+    "package",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_tool_jupyterclearoutput/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_jupyterclearoutput/pyproject.toml
@@ -12,6 +12,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -19,6 +23,23 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "tool",
+    "jupyterclearoutput",
+    "designed",
+    "clear",
+    "all",
+    "outputs",
+    "jupyter",
+    "notebook",
+    "nbconvert",
+    "clearoutputpreprocessor",
+    "preparing",
+    "sharing",
+    "version",
+    "control",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_tool_jupyterdisplay/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_jupyterdisplay/pyproject.toml
@@ -12,6 +12,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -19,6 +23,21 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "tool",
+    "jupyterdisplay",
+    "designed",
+    "display",
+    "rich",
+    "media",
+    "object",
+    "representations",
+    "jupyter",
+    "notebook",
+    "ipython",
+    "functionality",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_tool_jupyterdisplayhtml/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_jupyterdisplayhtml/pyproject.toml
@@ -12,6 +12,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -19,6 +23,21 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "tool",
+    "jupyterdisplayhtml",
+    "designed",
+    "render",
+    "html",
+    "content",
+    "within",
+    "jupyter",
+    "notebook",
+    "ipython",
+    "display",
+    "method",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_tool_jupyterexecuteandconvert/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_jupyterexecuteandconvert/pyproject.toml
@@ -12,6 +12,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -19,6 +23,24 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "tool",
+    "jupyterexecuteandconvert",
+    "programmatically",
+    "executes",
+    "converts",
+    "jupyter",
+    "notebook",
+    "nbconvert",
+    "cli",
+    "functionality",
+    "enabling",
+    "automated",
+    "execution",
+    "format",
+    "conversion",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_tool_jupyterexecutecell/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_jupyterexecutecell/pyproject.toml
@@ -12,6 +12,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -21,6 +25,24 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "tool",
+    "jupyterexecutecell",
+    "designed",
+    "execute",
+    "single",
+    "code",
+    "cell",
+    "running",
+    "jupyter",
+    "kernel",
+    "client",
+    "capturing",
+    "its",
+    "output",
+    "errors",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_tool_jupyterexecutenotebook/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_jupyterexecutenotebook/pyproject.toml
@@ -12,6 +12,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -21,6 +25,23 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "tool",
+    "jupyterexecutenotebook",
+    "designed",
+    "execute",
+    "all",
+    "cells",
+    "jupyter",
+    "notebook",
+    "nbconvert",
+    "executepreprocessor",
+    "capturing",
+    "outputs",
+    "testing",
+    "reporting",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_tool_jupyterexecutenotebookwithparameters/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_jupyterexecutenotebookwithparameters/pyproject.toml
@@ -12,6 +12,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -19,6 +23,23 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "tool",
+    "jupyterexecutenotebookwithparameters",
+    "designed",
+    "execute",
+    "parameterized",
+    "notebooks",
+    "papermill",
+    "allowing",
+    "dynamic",
+    "input",
+    "output",
+    "capture",
+    "automated",
+    "workflows",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_tool_jupyterexporthtml/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_jupyterexporthtml/pyproject.toml
@@ -12,6 +12,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -19,6 +23,23 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "tool",
+    "jupyterexporthtml",
+    "exports",
+    "jupyter",
+    "notebook",
+    "html",
+    "format",
+    "nbconvert",
+    "htmlexporter",
+    "enabling",
+    "web",
+    "based",
+    "presentation",
+    "notebooks",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_tool_jupyterexportlatex/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_jupyterexportlatex/pyproject.toml
@@ -12,6 +12,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -19,6 +23,22 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "tool",
+    "jupyterexportlatex",
+    "exports",
+    "jupyter",
+    "notebook",
+    "latex",
+    "format",
+    "nbconvert",
+    "latexexporter",
+    "enabling",
+    "further",
+    "conversion",
+    "pdf",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_tool_jupyterexportmarkdown/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_jupyterexportmarkdown/pyproject.toml
@@ -12,6 +12,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -19,6 +23,16 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "tool",
+    "jupyterexportmarkdown",
+    "designed",
+    "export",
+    "jupyter",
+    "notebooks",
+    "markdown",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_tool_jupyterexportpython/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_jupyterexportpython/pyproject.toml
@@ -12,6 +12,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -19,6 +23,21 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "tool",
+    "jupyterexportpython",
+    "exports",
+    "jupyter",
+    "notebook",
+    "script",
+    "nbconvert",
+    "pythonexporter",
+    "facilitating",
+    "code",
+    "extraction",
+    "python",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_tool_jupyterfromdict/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_jupyterfromdict/pyproject.toml
@@ -12,6 +12,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -19,6 +23,21 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "tool",
+    "jupyterfromdict",
+    "converts",
+    "plain",
+    "dictionary",
+    "notebooknode",
+    "object",
+    "nbformat",
+    "facilitating",
+    "programmatic",
+    "notebook",
+    "creation",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_tool_jupytergetiopubmessage/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_jupytergetiopubmessage/pyproject.toml
@@ -12,6 +12,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -20,6 +24,23 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "tool",
+    "jupytergetiopubmessage",
+    "designed",
+    "retrieve",
+    "messages",
+    "iopub",
+    "channel",
+    "jupyter",
+    "kernel",
+    "client",
+    "capturing",
+    "cell",
+    "outputs",
+    "logs",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_tool_jupytergetshellmessage/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_jupytergetshellmessage/pyproject.toml
@@ -12,6 +12,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -20,6 +24,23 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "tool",
+    "jupytergetshellmessage",
+    "designed",
+    "retrieve",
+    "shell",
+    "messages",
+    "running",
+    "jupyter",
+    "kernel",
+    "client",
+    "useful",
+    "debugging",
+    "execution",
+    "responses",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_tool_jupyterreadnotebook/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_jupyterreadnotebook/pyproject.toml
@@ -12,6 +12,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -19,6 +23,20 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "tool",
+    "jupyterreadnotebook",
+    "reads",
+    "jupyter",
+    "notebook",
+    "file",
+    "nbformat",
+    "converting",
+    "json",
+    "notebooknode",
+    "object",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_tool_jupyterruncell/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_jupyterruncell/pyproject.toml
@@ -12,6 +12,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -19,6 +23,22 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "tool",
+    "jupyterruncell",
+    "designed",
+    "execute",
+    "single",
+    "code",
+    "cell",
+    "ipython",
+    "interactive",
+    "shell",
+    "mimicking",
+    "notebook",
+    "execution",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_tool_jupytershutdownkernel/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_jupytershutdownkernel/pyproject.toml
@@ -12,6 +12,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -19,6 +23,23 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "tool",
+    "jupytershutdownkernel",
+    "designed",
+    "shut",
+    "down",
+    "running",
+    "jupyter",
+    "kernel",
+    "programmatically",
+    "client",
+    "releasing",
+    "all",
+    "associated",
+    "resources",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_tool_jupyterstartkernel/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_jupyterstartkernel/pyproject.toml
@@ -12,6 +12,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -20,6 +24,22 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "tool",
+    "jupyterstartkernel",
+    "designed",
+    "start",
+    "new",
+    "jupyter",
+    "kernel",
+    "programmatically",
+    "client",
+    "enabling",
+    "execution",
+    "notebook",
+    "cells",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_tool_jupytervalidatenotebook/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_jupytervalidatenotebook/pyproject.toml
@@ -12,6 +12,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -21,6 +25,22 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "tool",
+    "jupytervalidatenotebook",
+    "validates",
+    "notebooknode",
+    "object",
+    "against",
+    "jupyter",
+    "notebook",
+    "schema",
+    "nbformat",
+    "ensuring",
+    "structural",
+    "correctness",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_tool_jupyterwritenotebook/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_jupyterwritenotebook/pyproject.toml
@@ -12,6 +12,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -19,6 +23,20 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "tool",
+    "jupyterwritenotebook",
+    "writes",
+    "notebooknode",
+    "object",
+    "file",
+    "json",
+    "format",
+    "preserving",
+    "notebook",
+    "structure",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_tool_lexicaldensity/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_lexicaldensity/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -19,6 +23,13 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "tool",
+    "lexicaldensity",
+    "lexical",
+    "density",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_tool_psutil/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_psutil/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -18,6 +22,11 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "tool",
+    "psutil",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_tool_qrcodegenerator/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_qrcodegenerator/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -18,6 +22,13 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "tool",
+    "qrcodegenerator",
+    "code",
+    "generator",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_tool_searchword/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_searchword/pyproject.toml
@@ -12,9 +12,23 @@ classifiers = [
     "Natural Language :: English",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    "Development Status :: 3 - Alpha"
+    "Development Status :: 3 - Alpha",
+    "Programming Language :: Python :: 3.12",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
-keywords = ["search", "tool", "word", "phrase", "file", "highlight", "swarmauri"]
+keywords = [
+    "search",
+    "tool",
+    "word",
+    "phrase",
+    "file",
+    "highlight",
+    "swarmauri",
+    "searchword",
+    "searching",
+    "specific",
+]
 
 # Dependencies
 dependencies = [

--- a/pkgs/community/swarmauri_tool_sentencecomplexity/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_sentencecomplexity/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -18,6 +22,16 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "tool",
+    "sentencecomplexity",
+    "repository",
+    "includes",
+    "example",
+    "first",
+    "class",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_tool_sentimentanalysis/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_sentimentanalysis/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -20,6 +24,13 @@ dependencies = [
     "transformers>=4.49.0",
     "tensorflow>=2.16.2",
     "tf-keras"
+]
+keywords = [
+    "swarmauri",
+    "tool",
+    "sentimentanalysis",
+    "sentiment",
+    "analysis",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_tool_smogindex/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_smogindex/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -19,6 +23,13 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "tool",
+    "smogindex",
+    "smog",
+    "index",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_tool_textlength/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_textlength/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -18,6 +22,13 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "tool",
+    "textlength",
+    "text",
+    "length",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_tool_webscraping/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_webscraping/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -18,6 +22,13 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "tool",
+    "webscraping",
+    "web",
+    "scraping",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_tool_zapierhook/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_zapierhook/pyproject.toml
@@ -11,9 +11,20 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = ["swarmauri_core", "swarmauri_base", "swarmauri_standard"]
+keywords = [
+    "swarmauri",
+    "tool",
+    "zapierhook",
+    "zapier",
+    "hook",
+]
 
 [tool.uv.sources]
 swarmauri_core = { workspace = true }

--- a/pkgs/community/swarmauri_toolkit_github/pyproject.toml
+++ b/pkgs/community/swarmauri_toolkit_github/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -18,6 +22,11 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "toolkit",
+    "github",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_toolkit_jupytertoolkit/pyproject.toml
+++ b/pkgs/community/swarmauri_toolkit_jupytertoolkit/pyproject.toml
@@ -12,6 +12,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -39,6 +43,17 @@ dependencies = [
     "swarmauri_tool_jupyterstartkernel",
     "swarmauri_tool_jupytervalidatenotebook",
     "swarmauri_tool_jupyterwritenotebook",
+]
+keywords = [
+    "swarmauri",
+    "toolkit",
+    "jupytertoolkit",
+    "unified",
+    "aggregating",
+    "standalone",
+    "jupyter",
+    "notebook",
+    "tools",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_vectorstore_annoy/pyproject.toml
+++ b/pkgs/community/swarmauri_vectorstore_annoy/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -19,6 +23,13 @@ dependencies = [
     "swarmauri_base",
     "swarmauri_standard",
     "swarmauri_embedding_doc2vec",
+]
+keywords = [
+    "swarmauri",
+    "vectorstore",
+    "annoy",
+    "vector",
+    "store",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_vectorstore_cloudweaviate/pyproject.toml
+++ b/pkgs/community/swarmauri_vectorstore_cloudweaviate/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -19,6 +23,14 @@ dependencies = [
     "swarmauri_base",
     "swarmauri_standard",
     "swarmauri_embedding_doc2vec",
+]
+keywords = [
+    "swarmauri",
+    "vectorstore",
+    "cloudweaviate",
+    "weaviate",
+    "vector",
+    "store",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_vectorstore_duckdb/pyproject.toml
+++ b/pkgs/community/swarmauri_vectorstore_duckdb/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -19,6 +23,14 @@ dependencies = [
     "swarmauri_base",
     "swarmauri_standard",
     "swarmauri_embedding_doc2vec",
+]
+keywords = [
+    "swarmauri",
+    "vectorstore",
+    "duckdb",
+    "based",
+    "vector",
+    "store",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_vectorstore_mlm/pyproject.toml
+++ b/pkgs/community/swarmauri_vectorstore_mlm/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -20,6 +24,13 @@ dependencies = [
     "swarmauri_base",
     "swarmauri_standard",
     "swarmauri_embedding_mlm",
+]
+keywords = [
+    "swarmauri",
+    "vectorstore",
+    "mlm",
+    "vector",
+    "store",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_vectorstore_neo4j/pyproject.toml
+++ b/pkgs/community/swarmauri_vectorstore_neo4j/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -18,6 +22,13 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "vectorstore",
+    "neo4j",
+    "vector",
+    "store",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_vectorstore_persistentchromadb/pyproject.toml
+++ b/pkgs/community/swarmauri_vectorstore_persistentchromadb/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -19,6 +23,16 @@ dependencies = [
     "swarmauri_base",
     "swarmauri_standard",
     "swarmauri_embedding_doc2vec",
+]
+keywords = [
+    "swarmauri",
+    "vectorstore",
+    "persistentchromadb",
+    "persistent",
+    "chromadb",
+    "based",
+    "vector",
+    "store",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_vectorstore_pinecone/pyproject.toml
+++ b/pkgs/community/swarmauri_vectorstore_pinecone/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -19,6 +23,13 @@ dependencies = [
     "swarmauri_base",
     "swarmauri_standard",
     "swarmauri_embedding_doc2vec",
+]
+keywords = [
+    "swarmauri",
+    "vectorstore",
+    "pinecone",
+    "vector",
+    "store",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_vectorstore_qdrant/pyproject.toml
+++ b/pkgs/community/swarmauri_vectorstore_qdrant/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -19,6 +23,14 @@ dependencies = [
     "swarmauri_base",
     "swarmauri_standard",
     "swarmauri_embedding_doc2vec",
+]
+keywords = [
+    "swarmauri",
+    "vectorstore",
+    "qdrant",
+    "persistent",
+    "vector",
+    "store",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swarmauri_vectorstore_redis/pyproject.toml
+++ b/pkgs/community/swarmauri_vectorstore_redis/pyproject.toml
@@ -11,6 +11,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -20,6 +24,13 @@ dependencies = [
     "swarmauri_base",
     "swarmauri_standard",
     "swarmauri_embedding_doc2vec"
+]
+keywords = [
+    "swarmauri",
+    "vectorstore",
+    "redis",
+    "vector",
+    "store",
 ]
 
 [tool.uv.sources]

--- a/pkgs/community/swm_example_community_package/pyproject.toml
+++ b/pkgs/community/swm_example_community_package/pyproject.toml
@@ -10,10 +10,21 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12"
+    "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 authors = [{name = "Jacob Stewart", email = "jacob@swarmauri.com"}]
 dependencies = ["swarmauri_core", "swarmauri_base"]
+keywords = [
+    "swarmauri",
+    "swm",
+    "example",
+    "community",
+    "package",
+]
 
 [tool.uv.sources]
 swarmauri_core = { workspace = true }

--- a/pkgs/community/zdx/pyproject.toml
+++ b/pkgs/community/zdx/pyproject.toml
@@ -6,7 +6,17 @@ readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.12,<3.13"
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
-keywords = ["mkdocs", "documentation", "swarmauri", "docs", "doc builder"]
+keywords = [
+    "mkdocs",
+    "documentation",
+    "swarmauri",
+    "docs",
+    "doc builder",
+    "zdx",
+    "doc",
+    "builder",
+    "experience",
+]
 dependencies = [
     "mkdocs",
     "mkdocs-gen-files",
@@ -17,6 +27,16 @@ dependencies = [
     "griffe-typingdoc",
     "pyyaml>=6.0",
     "ruff>=0.5",
+]
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- ensure each community package advertises consistent license, audience, and Python version classifiers
- add descriptive keyword lists so community packages are searchable on PyPI

## Testing
- not run (metadata-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e14fc1705483268ff12fe0ef6ce6e1