### PR TITLE
Add PyPI metadata keywords and classifiers to standards packages

### DIFF
--- a/pkgs/standards/peagen/pyproject.toml
+++ b/pkgs/standards/peagen/pyproject.toml
@@ -13,6 +13,9 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
 
@@ -92,6 +95,11 @@ dependencies = [
     "tigrbl_client",
     "tigrbl_auth",
 
+]
+keywords = [
+    'sdk',
+    'standards',
+    'peagen',
 ]
 
 

--- a/pkgs/standards/peagen_templset_vue/pyproject.toml
+++ b/pkgs/standards/peagen_templset_vue/pyproject.toml
@@ -12,6 +12,16 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+]
+keywords = [
+    'sdk',
+    'standards',
+    'peagen',
+    'templset',
+    'vue',
 ]
 
 [tool.poetry]

--- a/pkgs/standards/swarmauri_certs_composite/pyproject.toml
+++ b/pkgs/standards/swarmauri_certs_composite/pyproject.toml
@@ -16,10 +16,21 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'certs',
+    'composite',
+    'certificates',
 ]
 
 [project.optional-dependencies]

--- a/pkgs/standards/swarmauri_certs_local_ca/pyproject.toml
+++ b/pkgs/standards/swarmauri_certs_local_ca/pyproject.toml
@@ -16,11 +16,23 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "cryptography",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'certs',
+    'local',
+    'ca',
+    'certificates',
 ]
 
 [project.optional-dependencies]

--- a/pkgs/standards/swarmauri_certs_remote_ca/pyproject.toml
+++ b/pkgs/standards/swarmauri_certs_remote_ca/pyproject.toml
@@ -16,11 +16,23 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "httpx",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'certs',
+    'remote',
+    'ca',
+    'certificates',
 ]
 
 [project.optional-dependencies]

--- a/pkgs/standards/swarmauri_certs_self_signed/pyproject.toml
+++ b/pkgs/standards/swarmauri_certs_self_signed/pyproject.toml
@@ -16,10 +16,22 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "cryptography",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'certs',
+    'self',
+    'signed',
+    'certificates',
 ]
 
 [project.optional-dependencies]

--- a/pkgs/standards/swarmauri_certs_x509/pyproject.toml
+++ b/pkgs/standards/swarmauri_certs_x509/pyproject.toml
@@ -16,6 +16,9 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "Topic :: Security :: Cryptography",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
@@ -23,6 +26,14 @@ dependencies = [
     "swarmauri_keyprovider_local",
     "swarmauri_keyprovider_inmemory",
     "cryptography",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'certs',
+    'x509',
+    'certificates',
 ]
 
 [project.optional-dependencies]

--- a/pkgs/standards/swarmauri_certs_x509verify/pyproject.toml
+++ b/pkgs/standards/swarmauri_certs_x509verify/pyproject.toml
@@ -16,11 +16,22 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "cryptography",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'certs',
+    'x509verify',
+    'certificates',
 ]
 
 [project.optional-dependencies]

--- a/pkgs/standards/swarmauri_cipher_suite_cades/pyproject.toml
+++ b/pkgs/standards/swarmauri_cipher_suite_cades/pyproject.toml
@@ -16,10 +16,22 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'cipher',
+    'suite',
+    'cades',
+    'cryptography',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_cipher_suite_cnsa20/pyproject.toml
+++ b/pkgs/standards/swarmauri_cipher_suite_cnsa20/pyproject.toml
@@ -16,10 +16,22 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'cipher',
+    'suite',
+    'cnsa20',
+    'cryptography',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_cipher_suite_cose/pyproject.toml
+++ b/pkgs/standards/swarmauri_cipher_suite_cose/pyproject.toml
@@ -16,10 +16,22 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'cipher',
+    'suite',
+    'cose',
+    'cryptography',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_cipher_suite_fips1403/pyproject.toml
+++ b/pkgs/standards/swarmauri_cipher_suite_fips1403/pyproject.toml
@@ -16,10 +16,22 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'cipher',
+    'suite',
+    'fips1403',
+    'cryptography',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_cipher_suite_ipsec/pyproject.toml
+++ b/pkgs/standards/swarmauri_cipher_suite_ipsec/pyproject.toml
@@ -16,10 +16,22 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'cipher',
+    'suite',
+    'ipsec',
+    'cryptography',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_cipher_suite_jwa/pyproject.toml
+++ b/pkgs/standards/swarmauri_cipher_suite_jwa/pyproject.toml
@@ -16,10 +16,22 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'cipher',
+    'suite',
+    'jwa',
+    'cryptography',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_cipher_suite_pades/pyproject.toml
+++ b/pkgs/standards/swarmauri_cipher_suite_pades/pyproject.toml
@@ -16,10 +16,22 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'cipher',
+    'suite',
+    'pades',
+    'cryptography',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_cipher_suite_pep458/pyproject.toml
+++ b/pkgs/standards/swarmauri_cipher_suite_pep458/pyproject.toml
@@ -12,6 +12,11 @@ keywords = [
     "policy",
     "cipher-suite",
     "swarmauri",
+    "sdk",
+    "standards",
+    "cipher",
+    "suite",
+    "cryptography",
 ]
 authors = [
     { name = "Jacob Stewart", email = "jacob@swarmauri.com" },
@@ -27,6 +32,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",

--- a/pkgs/standards/swarmauri_cipher_suite_sigstore/pyproject.toml
+++ b/pkgs/standards/swarmauri_cipher_suite_sigstore/pyproject.toml
@@ -16,10 +16,22 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'cipher',
+    'suite',
+    'sigstore',
+    'cryptography',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_cipher_suite_ssh/pyproject.toml
+++ b/pkgs/standards/swarmauri_cipher_suite_ssh/pyproject.toml
@@ -16,10 +16,22 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'cipher',
+    'suite',
+    'ssh',
+    'cryptography',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_cipher_suite_tls13/pyproject.toml
+++ b/pkgs/standards/swarmauri_cipher_suite_tls13/pyproject.toml
@@ -16,10 +16,22 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'cipher',
+    'suite',
+    'tls13',
+    'cryptography',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_cipher_suite_webauthn/pyproject.toml
+++ b/pkgs/standards/swarmauri_cipher_suite_webauthn/pyproject.toml
@@ -16,10 +16,22 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'cipher',
+    'suite',
+    'webauthn',
+    'cryptography',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_cipher_suite_xades/pyproject.toml
+++ b/pkgs/standards/swarmauri_cipher_suite_xades/pyproject.toml
@@ -16,10 +16,22 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'cipher',
+    'suite',
+    'xades',
+    'cryptography',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_cipher_suite_yubikey/pyproject.toml
+++ b/pkgs/standards/swarmauri_cipher_suite_yubikey/pyproject.toml
@@ -2,7 +2,7 @@
 name = "swarmauri_cipher_suite_yubikey"
 version = "0.1.0.dev1"
 description = "YubiKey-backed cipher suite for Swarmauri PIV signing and key transport"
-keywords = ["yubikey", "piv", "cipher-suite", "rsa-pss", "ecdsa", "attestation"]
+keywords = ["yubikey", "piv", "cipher-suite", "rsa-pss", "ecdsa", "attestation", "swarmauri", "sdk", "standards", "cipher", "suite", "cryptography"]
 license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
@@ -17,6 +17,9 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Intended Audience :: Developers",
     "Topic :: Security :: Cryptography",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",

--- a/pkgs/standards/swarmauri_cipher_suite_yubikey_fips/pyproject.toml
+++ b/pkgs/standards/swarmauri_cipher_suite_yubikey_fips/pyproject.toml
@@ -2,7 +2,7 @@
 name = "swarmauri_cipher_suite_yubikey_fips"
 version = "0.1.0.dev1"
 description = "FIPS-constrained YubiKey cipher suite for Swarmauri PIV operations"
-keywords = ["yubikey", "piv", "cipher-suite", "fips", "rsa-pss", "ecdsa"]
+keywords = ["yubikey", "piv", "cipher-suite", "fips", "rsa-pss", "ecdsa", "swarmauri", "sdk", "standards", "cipher", "suite", "cryptography"]
 license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
@@ -17,6 +17,9 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Intended Audience :: Developers",
     "Topic :: Security :: Cryptography",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",

--- a/pkgs/standards/swarmauri_crypto_composite/pyproject.toml
+++ b/pkgs/standards/swarmauri_crypto_composite/pyproject.toml
@@ -16,10 +16,21 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'crypto',
+    'composite',
+    'cryptography',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_crypto_ecdh_es_a128kw/pyproject.toml
+++ b/pkgs/standards/swarmauri_crypto_ecdh_es_a128kw/pyproject.toml
@@ -16,11 +16,24 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "cryptography",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'crypto',
+    'ecdh',
+    'es',
+    'a128kw',
+    'cryptography',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_crypto_jwe/pyproject.toml
+++ b/pkgs/standards/swarmauri_crypto_jwe/pyproject.toml
@@ -16,11 +16,22 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "cryptography>=41",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'crypto',
+    'jwe',
+    'cryptography',
 ]
 
 [project.optional-dependencies]

--- a/pkgs/standards/swarmauri_crypto_nacl_pkcs11/pyproject.toml
+++ b/pkgs/standards/swarmauri_crypto_nacl_pkcs11/pyproject.toml
@@ -16,6 +16,9 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
@@ -23,6 +26,15 @@ dependencies = [
     "PyNaCl>=1.5",
     "cryptography>=41",
     "python-pkcs11>=0.7.0",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'crypto',
+    'nacl',
+    'pkcs11',
+    'cryptography',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_crypto_paramiko/pyproject.toml
+++ b/pkgs/standards/swarmauri_crypto_paramiko/pyproject.toml
@@ -16,12 +16,23 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "cryptography>=41",
     "paramiko>=3.4",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'crypto',
+    'paramiko',
+    'cryptography',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_crypto_pgp/pyproject.toml
+++ b/pkgs/standards/swarmauri_crypto_pgp/pyproject.toml
@@ -16,12 +16,23 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "cryptography>=41",
     "python-gnupg>=0.5.0",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'crypto',
+    'pgp',
+    'cryptography',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_crypto_rust/pyproject.toml
+++ b/pkgs/standards/swarmauri_crypto_rust/pyproject.toml
@@ -15,10 +15,21 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'crypto',
+    'rust',
+    'cryptography',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_distance_minkowski/pyproject.toml
+++ b/pkgs/standards/swarmauri_distance_minkowski/pyproject.toml
@@ -11,6 +11,9 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -18,6 +21,13 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'distance',
+    'minkowski',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_embedding_doc2vec/pyproject.toml
+++ b/pkgs/standards/swarmauri_embedding_doc2vec/pyproject.toml
@@ -11,6 +11,9 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -18,6 +21,14 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'embedding',
+    'doc2vec',
+    'machine-learning',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_embedding_nmf/pyproject.toml
+++ b/pkgs/standards/swarmauri_embedding_nmf/pyproject.toml
@@ -11,6 +11,9 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -18,6 +21,14 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'embedding',
+    'nmf',
+    'machine-learning',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_evaluator_abstractmethods/pyproject.toml
+++ b/pkgs/standards/swarmauri_evaluator_abstractmethods/pyproject.toml
@@ -12,7 +12,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Development Status :: 3 - Alpha"
+    "Development Status :: 3 - Alpha",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only"
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 keywords = [
@@ -25,7 +28,11 @@ keywords = [
     "interface design",
     "code standards",
     "code evaluation",
-    "swarmauri"
+    "swarmauri",
+    "sdk",
+    "standards",
+    "abstractmethods",
+    "evaluation"
 ]
 dependencies = [
     "swarmauri_core",

--- a/pkgs/standards/swarmauri_evaluator_anyusage/pyproject.toml
+++ b/pkgs/standards/swarmauri_evaluator_anyusage/pyproject.toml
@@ -20,6 +20,8 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Software Development :: Quality Assurance",
     "Topic :: Software Development :: Testing",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 keywords = [
     "swarmauri",
@@ -31,7 +33,11 @@ keywords = [
     "type checking",
     "type hints",
     "code evaluation",
-    "python"
+    "python",
+    "sdk",
+    "standards",
+    "anyusage",
+    "evaluation"
 ]
 dependencies = [
     "swarmauri_core",

--- a/pkgs/standards/swarmauri_evaluator_constanttime/pyproject.toml
+++ b/pkgs/standards/swarmauri_evaluator_constanttime/pyproject.toml
@@ -13,6 +13,9 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Development Status :: 3 - Alpha",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 keywords = [
@@ -21,6 +24,10 @@ keywords = [
     "constant time",
     "side channel",
     "timing",
+    "sdk",
+    "standards",
+    "constanttime",
+    "evaluation",
 ]
 dependencies = [
     "swarmauri_core",

--- a/pkgs/standards/swarmauri_evaluator_externalimports/pyproject.toml
+++ b/pkgs/standards/swarmauri_evaluator_externalimports/pyproject.toml
@@ -12,7 +12,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Development Status :: 3 - Alpha"
+    "Development Status :: 3 - Alpha",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only"
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 keywords = [
@@ -23,7 +26,11 @@ keywords = [
     "static analysis",
     "code quality",
     "external modules",
-    "standard library"
+    "standard library",
+    "sdk",
+    "standards",
+    "externalimports",
+    "evaluation"
 ]
 dependencies = [
     "swarmauri_core",

--- a/pkgs/standards/swarmauri_evaluator_subprocess/pyproject.toml
+++ b/pkgs/standards/swarmauri_evaluator_subprocess/pyproject.toml
@@ -17,6 +17,9 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
     "Topic :: Software Development :: Testing",
     "Topic :: System :: Monitoring",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 keywords = [
@@ -31,6 +34,9 @@ keywords = [
     "swarm",
     "ai",
     "swarmauri",
+    "sdk",
+    "standards",
+    "evaluator",
 ]
 dependencies = ["swarmauri_core", "swarmauri_base"]
 

--- a/pkgs/standards/swarmauri_evaluatorpool_accessibility/pyproject.toml
+++ b/pkgs/standards/swarmauri_evaluatorpool_accessibility/pyproject.toml
@@ -15,7 +15,10 @@ classifiers = [
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Text Processing :: Linguistic",
-    "Topic :: Software Development :: Quality Assurance"
+    "Topic :: Software Development :: Quality Assurance",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only"
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 keywords = [
@@ -29,7 +32,11 @@ keywords = [
     "automated-readability-index",
     "flesch-reading-ease",
     "text-analysis",
-    "nlp"
+    "nlp",
+    "sdk",
+    "standards",
+    "evaluatorpool",
+    "evaluation"
 ]
 dependencies = [
     "swarmauri_core",

--- a/pkgs/standards/swarmauri_gitfilter_file/pyproject.toml
+++ b/pkgs/standards/swarmauri_gitfilter_file/pyproject.toml
@@ -16,6 +16,8 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "peagen",
@@ -23,6 +25,13 @@ dependencies = [
     "swarmauri_base",
     "swarmauri_standard",
     "swarmauri_storage_file",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'gitfilter',
+    'file',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_gitfilter_gh_release/pyproject.toml
+++ b/pkgs/standards/swarmauri_gitfilter_gh_release/pyproject.toml
@@ -16,6 +16,8 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "peagen",
@@ -23,6 +25,14 @@ dependencies = [
     "swarmauri_base",
     "swarmauri_standard",
     "PyGithub",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'gitfilter',
+    'gh',
+    'release',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_gitfilter_minio/pyproject.toml
+++ b/pkgs/standards/swarmauri_gitfilter_minio/pyproject.toml
@@ -16,6 +16,8 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "peagen",
@@ -23,6 +25,13 @@ dependencies = [
     "swarmauri_base",
     "swarmauri_standard",
     "minio",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'gitfilter',
+    'minio',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_gitfilter_s3fs/pyproject.toml
+++ b/pkgs/standards/swarmauri_gitfilter_s3fs/pyproject.toml
@@ -16,6 +16,8 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "peagen",
@@ -23,6 +25,13 @@ dependencies = [
     "swarmauri_base",
     "swarmauri_standard",
     "s3fs",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'gitfilter',
+    's3fs',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_keyprovider_file/pyproject.toml
+++ b/pkgs/standards/swarmauri_keyprovider_file/pyproject.toml
@@ -16,11 +16,22 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "cryptography",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'keyprovider',
+    'file',
+    'key-management',
 ]
 
 [project.optional-dependencies]

--- a/pkgs/standards/swarmauri_keyprovider_hierarchical/pyproject.toml
+++ b/pkgs/standards/swarmauri_keyprovider_hierarchical/pyproject.toml
@@ -16,11 +16,22 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_keyprovider_local",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'keyprovider',
+    'hierarchical',
+    'key-management',
 ]
 
 [project.optional-dependencies]

--- a/pkgs/standards/swarmauri_keyprovider_inmemory/pyproject.toml
+++ b/pkgs/standards/swarmauri_keyprovider_inmemory/pyproject.toml
@@ -16,10 +16,21 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'keyprovider',
+    'inmemory',
+    'key-management',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_keyprovider_local/pyproject.toml
+++ b/pkgs/standards/swarmauri_keyprovider_local/pyproject.toml
@@ -16,11 +16,22 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "cryptography",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'keyprovider',
+    'local',
+    'key-management',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_keyprovider_remote_jwks/pyproject.toml
+++ b/pkgs/standards/swarmauri_keyprovider_remote_jwks/pyproject.toml
@@ -16,6 +16,9 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
@@ -23,6 +26,15 @@ dependencies = [
     "swarmauri_keyprovider_local",
     "cryptography",
     "pydantic",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'keyprovider',
+    'remote',
+    'jwks',
+    'key-management',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_keyprovider_ssh/pyproject.toml
+++ b/pkgs/standards/swarmauri_keyprovider_ssh/pyproject.toml
@@ -16,11 +16,22 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "cryptography",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'keyprovider',
+    'ssh',
+    'key-management',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_keyproviders_mirrored/pyproject.toml
+++ b/pkgs/standards/swarmauri_keyproviders_mirrored/pyproject.toml
@@ -16,11 +16,22 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_keyprovider_local",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'keyproviders',
+    'mirrored',
+    'key-management',
 ]
 
 [project.optional-dependencies]

--- a/pkgs/standards/swarmauri_middleware_auth/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_auth/pyproject.toml
@@ -18,6 +18,9 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP :: HTTP Servers",
     "Topic :: Internet :: WWW/HTTP :: Middleware",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
@@ -25,6 +28,13 @@ dependencies = [
     "swarmauri_standard",
     "fastapi",
     "swarmauri_signing_jws",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'middleware',
+    'auth',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_middleware_bulkhead/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_bulkhead/pyproject.toml
@@ -13,7 +13,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Development Status :: 3 - Alpha"
+    "Development Status :: 3 - Alpha",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only"
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -21,6 +24,13 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'middleware',
+    'bulkhead',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_middleware_cachecontrol/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_cachecontrol/pyproject.toml
@@ -14,7 +14,10 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Development Status :: 3 - Alpha",
-    "Typing :: Typed"
+    "Typing :: Typed",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only"
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -23,6 +26,13 @@ dependencies = [
     "swarmauri_standard",
     "fastapi",
     "python-dotenv>=0.19.0"
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'middleware',
+    'cachecontrol',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_middleware_cors/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_cors/pyproject.toml
@@ -13,7 +13,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Development Status :: 3 - Alpha"
+    "Development Status :: 3 - Alpha",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only"
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -21,6 +24,13 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'middleware',
+    'cors',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_middleware_exceptionhandling/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_exceptionhandling/pyproject.toml
@@ -13,7 +13,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Development Status :: 3 - Alpha"
+    "Development Status :: 3 - Alpha",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only"
 ]
 authors = [{name = "Jacob Stewart", email = "jacob@swarmauri.com"}]
 dependencies = [
@@ -21,6 +24,13 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'middleware',
+    'exceptionhandling',
 ]
 [tool.uv.sources]
 swarmauri_core = {workspace = true}

--- a/pkgs/standards/swarmauri_middleware_gzipcompression/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_gzipcompression/pyproject.toml
@@ -13,7 +13,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Development Status :: 3 - Alpha"
+    "Development Status :: 3 - Alpha",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only"
 ]
 authors = [
 {name = "Jacob Stewart", email = "jacob@swarmauri.com"},
@@ -24,6 +27,13 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'middleware',
+    'gzipcompression',
 ]
 [tool.uv.sources]
 swarmauri_core = {workspace = true}

--- a/pkgs/standards/swarmauri_middleware_httpsig/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_httpsig/pyproject.toml
@@ -14,6 +14,9 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Development Status :: 3 - Alpha",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -21,6 +24,13 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'middleware',
+    'httpsig',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_middleware_jsonrpc/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_jsonrpc/pyproject.toml
@@ -14,6 +14,9 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Development Status :: 3 - Alpha",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -21,6 +24,13 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'middleware',
+    'jsonrpc',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_middleware_jwksverifier/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_jwksverifier/pyproject.toml
@@ -16,6 +16,9 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
@@ -23,6 +26,13 @@ dependencies = [
     "swarmauri_standard",
     "PyJWT>=2.8",
     "cryptography",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'middleware',
+    'jwksverifier',
 ]
 
 [project.optional-dependencies]

--- a/pkgs/standards/swarmauri_middleware_jwt/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_jwt/pyproject.toml
@@ -14,6 +14,9 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Development Status :: 3 - Alpha",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "fastapi",
@@ -21,6 +24,13 @@ dependencies = [
     "swarmauri_base",
     "swarmauri_standard",
     "PyJWT",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'middleware',
+    'jwt',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_middleware_llamaguard/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_llamaguard/pyproject.toml
@@ -13,7 +13,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Development Status :: 3 - Alpha"
+    "Development Status :: 3 - Alpha",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only"
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -22,6 +25,13 @@ dependencies = [
     "swarmauri_standard",
     "fastapi",
     "python-dotenv>=1.0.0"
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'middleware',
+    'llamaguard',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_middleware_logging/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_logging/pyproject.toml
@@ -13,7 +13,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Development Status :: 3 - Alpha"
+    "Development Status :: 3 - Alpha",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only"
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -21,6 +24,13 @@ dependencies = [
     "swarmauri_base",
     "swarmauri_standard",
     "fastapi"
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'middleware',
+    'logging',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_middleware_ratelimit/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_ratelimit/pyproject.toml
@@ -13,7 +13,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Development Status :: 3 - Alpha"
+    "Development Status :: 3 - Alpha",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only"
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -21,6 +24,13 @@ dependencies = [
     "swarmauri_base",
     "swarmauri_standard",
     "fastapi"
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'middleware',
+    'ratelimit',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_middleware_securityheaders/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_securityheaders/pyproject.toml
@@ -14,6 +14,9 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Development Status :: 3 - Alpha",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -21,6 +24,14 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'middleware',
+    'securityheaders',
+    'security',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_middleware_session/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_session/pyproject.toml
@@ -13,7 +13,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Development Status :: 3 - Alpha"
+    "Development Status :: 3 - Alpha",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only"
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -21,6 +24,13 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'middleware',
+    'session',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_middleware_stdio/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_stdio/pyproject.toml
@@ -14,6 +14,9 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Development Status :: 3 - Alpha",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -21,6 +24,13 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'middleware',
+    'stdio',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_middleware_time/pyproject.toml
+++ b/pkgs/standards/swarmauri_middleware_time/pyproject.toml
@@ -14,6 +14,9 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Development Status :: 3 - Alpha",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -21,6 +24,13 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'middleware',
+    'time',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_mre_crypto_age/pyproject.toml
+++ b/pkgs/standards/swarmauri_mre_crypto_age/pyproject.toml
@@ -16,11 +16,23 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "cryptography>=41",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'mre',
+    'crypto',
+    'age',
+    'cryptography',
 ]
 
 [project.optional-dependencies]

--- a/pkgs/standards/swarmauri_mre_crypto_ecdh_es_kw/pyproject.toml
+++ b/pkgs/standards/swarmauri_mre_crypto_ecdh_es_kw/pyproject.toml
@@ -16,11 +16,25 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "cryptography>=41",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'mre',
+    'crypto',
+    'ecdh',
+    'es',
+    'kw',
+    'cryptography',
 ]
 
 [project.optional-dependencies]

--- a/pkgs/standards/swarmauri_mre_crypto_keyring/pyproject.toml
+++ b/pkgs/standards/swarmauri_mre_crypto_keyring/pyproject.toml
@@ -16,11 +16,23 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "cryptography>=41",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'mre',
+    'crypto',
+    'keyring',
+    'cryptography',
 ]
 
 [project.optional-dependencies]

--- a/pkgs/standards/swarmauri_mre_crypto_pgp/pyproject.toml
+++ b/pkgs/standards/swarmauri_mre_crypto_pgp/pyproject.toml
@@ -16,11 +16,23 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "pgpy>=0.6.0",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'mre',
+    'crypto',
+    'pgp',
+    'cryptography',
 ]
 
 [project.optional-dependencies]

--- a/pkgs/standards/swarmauri_mre_crypto_shamir/pyproject.toml
+++ b/pkgs/standards/swarmauri_mre_crypto_shamir/pyproject.toml
@@ -16,11 +16,23 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "cryptography",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'mre',
+    'crypto',
+    'shamir',
+    'cryptography',
 ]
 
 [project.optional-dependencies]

--- a/pkgs/standards/swarmauri_parser_beautifulsoupelement/pyproject.toml
+++ b/pkgs/standards/swarmauri_parser_beautifulsoupelement/pyproject.toml
@@ -11,6 +11,9 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -18,6 +21,13 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'parser',
+    'beautifulsoupelement',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_parser_keywordextractor/pyproject.toml
+++ b/pkgs/standards/swarmauri_parser_keywordextractor/pyproject.toml
@@ -11,6 +11,9 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -18,6 +21,13 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'parser',
+    'keywordextractor',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_pop_cwt/pyproject.toml
+++ b/pkgs/standards/swarmauri_pop_cwt/pyproject.toml
@@ -17,6 +17,10 @@ keywords = [
     "token-binding",
     "confirmation-method",
     "http",
+    "sdk",
+    "standards",
+    "pop",
+    "authentication",
 ]
 classifiers = [
     "Development Status :: 1 - Planning",
@@ -35,6 +39,7 @@ classifiers = [
     "Topic :: Security :: Cryptography",
     "Topic :: Software Development :: Libraries :: Application Frameworks",
     "Typing :: Typed",
+    "Programming Language :: Python",
 ]
 dependencies = [
     "swarmauri_core",

--- a/pkgs/standards/swarmauri_pop_dpop/pyproject.toml
+++ b/pkgs/standards/swarmauri_pop_dpop/pyproject.toml
@@ -17,6 +17,10 @@ keywords = [
     "token-binding",
     "cnf",
     "access-token",
+    "sdk",
+    "standards",
+    "pop",
+    "authentication",
 ]
 classifiers = [
     "Development Status :: 1 - Planning",
@@ -35,6 +39,7 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP :: HTTP Headers",
     "Topic :: Software Development :: Libraries :: Application Frameworks",
     "Typing :: Typed",
+    "Programming Language :: Python",
 ]
 dependencies = [
     "swarmauri_core",

--- a/pkgs/standards/swarmauri_pop_x509/pyproject.toml
+++ b/pkgs/standards/swarmauri_pop_x509/pyproject.toml
@@ -17,6 +17,10 @@ keywords = [
     "cnf",
     "mutual-tls",
     "http",
+    "sdk",
+    "standards",
+    "pop",
+    "authentication",
 ]
 classifiers = [
     "Development Status :: 1 - Planning",
@@ -35,6 +39,7 @@ classifiers = [
     "Topic :: Security :: Cryptography",
     "Topic :: Software Development :: Libraries :: Application Frameworks",
     "Typing :: Typed",
+    "Programming Language :: Python",
 ]
 dependencies = [
     "swarmauri_core",

--- a/pkgs/standards/swarmauri_prompt_j2prompttemplate/pyproject.toml
+++ b/pkgs/standards/swarmauri_prompt_j2prompttemplate/pyproject.toml
@@ -11,6 +11,9 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -19,6 +22,13 @@ dependencies = [
     "pydantic>=1.8.2",
     "swarmauri_core",
     "swarmauri_base",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'prompt',
+    'j2prompttemplate',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_publisher_rabbitmq/pyproject.toml
+++ b/pkgs/standards/swarmauri_publisher_rabbitmq/pyproject.toml
@@ -16,12 +16,21 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "pika>=1.3.1",
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'publisher',
+    'rabbitmq',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_publisher_redis/pyproject.toml
+++ b/pkgs/standards/swarmauri_publisher_redis/pyproject.toml
@@ -15,12 +15,21 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "redis>=4.6.0",
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'publisher',
+    'redis',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_publisher_webhook/pyproject.toml
+++ b/pkgs/standards/swarmauri_publisher_webhook/pyproject.toml
@@ -16,12 +16,21 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'publisher',
+    'webhook',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_signing_ca/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_ca/pyproject.toml
@@ -12,6 +12,10 @@ keywords = [
     "certificate-authority",
     "pki",
     "x509",
+    "sdk",
+    "standards",
+    "ca",
+    "cryptography",
 ]
 classifiers = [
     "Development Status :: 1 - Planning",
@@ -24,6 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",

--- a/pkgs/standards/swarmauri_signing_cms/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_cms/pyproject.toml
@@ -12,6 +12,9 @@ keywords = [
     "cms",
     "pkcs7",
     "envelope",
+    "sdk",
+    "standards",
+    "cryptography",
 ]
 classifiers = [
     "Development Status :: 1 - Planning",
@@ -24,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_base",

--- a/pkgs/standards/swarmauri_signing_dpop/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_dpop/pyproject.toml
@@ -12,6 +12,9 @@ keywords = [
     "dpop",
     "oauth",
     "proof-of-possession",
+    "sdk",
+    "standards",
+    "cryptography",
 ]
 classifiers = [
     "Development Status :: 1 - Planning",
@@ -24,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",

--- a/pkgs/standards/swarmauri_signing_ecdsa/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_ecdsa/pyproject.toml
@@ -12,6 +12,8 @@ keywords = [
     "ecdsa",
     "elliptic-curve",
     "cryptography",
+    "sdk",
+    "standards",
 ]
 classifiers = [
     "Development Status :: 1 - Planning",
@@ -24,6 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",

--- a/pkgs/standards/swarmauri_signing_ed25519/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_ed25519/pyproject.toml
@@ -12,6 +12,8 @@ keywords = [
     "ed25519",
     "elliptic-curve",
     "cryptography",
+    "sdk",
+    "standards",
 ]
 classifiers = [
     "Development Status :: 1 - Planning",
@@ -24,6 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",

--- a/pkgs/standards/swarmauri_signing_hmac/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_hmac/pyproject.toml
@@ -12,6 +12,9 @@ keywords = [
     "hmac",
     "symmetric",
     "message-authentication",
+    "sdk",
+    "standards",
+    "cryptography",
 ]
 classifiers = [
     "Development Status :: 1 - Planning",
@@ -24,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",

--- a/pkgs/standards/swarmauri_signing_jws/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_jws/pyproject.toml
@@ -12,6 +12,9 @@ keywords = [
     "jws",
     "jwt",
     "json-web-signature",
+    "sdk",
+    "standards",
+    "cryptography",
 ]
 classifiers = [
     "Development Status :: 1 - Planning",
@@ -24,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",

--- a/pkgs/standards/swarmauri_signing_openpgp/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_openpgp/pyproject.toml
@@ -12,6 +12,9 @@ keywords = [
     "openpgp",
     "pgp",
     "encryption",
+    "sdk",
+    "standards",
+    "cryptography",
 ]
 classifiers = [
     "Development Status :: 1 - Planning",
@@ -24,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_base",

--- a/pkgs/standards/swarmauri_signing_pdf/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_pdf/pyproject.toml
@@ -12,6 +12,9 @@ keywords = [
     "pdf",
     "document-signing",
     "cms",
+    "sdk",
+    "standards",
+    "cryptography",
 ]
 classifiers = [
     "Development Status :: 1 - Planning",
@@ -24,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_base",

--- a/pkgs/standards/swarmauri_signing_pep458/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_pep458/pyproject.toml
@@ -11,6 +11,9 @@ keywords = [
     "pep458",
     "signing",
     "swarmauri",
+    "sdk",
+    "standards",
+    "cryptography",
 ]
 authors = [
     { name = "Jacob Stewart", email = "jacob@swarmauri.com" },
@@ -26,6 +29,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",

--- a/pkgs/standards/swarmauri_signing_pgp/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_pgp/pyproject.toml
@@ -12,6 +12,9 @@ keywords = [
     "pgp",
     "openpgp",
     "envelope",
+    "sdk",
+    "standards",
+    "cryptography",
 ]
 classifiers = [
     "Development Status :: 1 - Planning",
@@ -24,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",

--- a/pkgs/standards/swarmauri_signing_rsa/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_rsa/pyproject.toml
@@ -12,6 +12,8 @@ keywords = [
     "rsa",
     "public-key",
     "cryptography",
+    "sdk",
+    "standards",
 ]
 classifiers = [
     "Development Status :: 1 - Planning",
@@ -24,6 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",

--- a/pkgs/standards/swarmauri_signing_secp256k1/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_secp256k1/pyproject.toml
@@ -12,6 +12,9 @@ keywords = [
     "secp256k1",
     "elliptic-curve",
     "blockchain",
+    "sdk",
+    "standards",
+    "cryptography",
 ]
 classifiers = [
     "Development Status :: 1 - Planning",
@@ -24,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",

--- a/pkgs/standards/swarmauri_signing_ssh/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_ssh/pyproject.toml
@@ -12,6 +12,9 @@ keywords = [
     "ssh",
     "public-key",
     "secure-shell",
+    "sdk",
+    "standards",
+    "cryptography",
 ]
 classifiers = [
     "Development Status :: 1 - Planning",
@@ -24,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",

--- a/pkgs/standards/swarmauri_signing_xmld/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_xmld/pyproject.toml
@@ -12,6 +12,10 @@ keywords = [
     "xml",
     "xml-dsig",
     "digital-signature",
+    "sdk",
+    "standards",
+    "xmld",
+    "cryptography",
 ]
 classifiers = [
     "Development Status :: 1 - Planning",
@@ -24,6 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_base",

--- a/pkgs/standards/swarmauri_storage_file/pyproject.toml
+++ b/pkgs/standards/swarmauri_storage_file/pyproject.toml
@@ -16,12 +16,21 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "peagen",
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'storage',
+    'file',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_storage_github/pyproject.toml
+++ b/pkgs/standards/swarmauri_storage_github/pyproject.toml
@@ -16,12 +16,21 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "peagen",
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'storage',
+    'github',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_storage_github_release/pyproject.toml
+++ b/pkgs/standards/swarmauri_storage_github_release/pyproject.toml
@@ -16,6 +16,8 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "peagen",
@@ -23,6 +25,14 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'storage',
+    'github',
+    'release',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_storage_minio/pyproject.toml
+++ b/pkgs/standards/swarmauri_storage_minio/pyproject.toml
@@ -16,6 +16,8 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "peagen",
@@ -23,6 +25,13 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'storage',
+    'minio',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_tokens_composite/pyproject.toml
+++ b/pkgs/standards/swarmauri_tokens_composite/pyproject.toml
@@ -16,10 +16,20 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'tokens',
+    'composite',
 ]
 
 [project.optional-dependencies]

--- a/pkgs/standards/swarmauri_tokens_dpopboundjwt/pyproject.toml
+++ b/pkgs/standards/swarmauri_tokens_dpopboundjwt/pyproject.toml
@@ -16,11 +16,21 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "pyjwt[crypto]>=2.8.0",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'tokens',
+    'dpopboundjwt',
 ]
 
 [project.optional-dependencies]

--- a/pkgs/standards/swarmauri_tokens_introspection/pyproject.toml
+++ b/pkgs/standards/swarmauri_tokens_introspection/pyproject.toml
@@ -16,11 +16,22 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Internet :: WWW/HTTP",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "httpx",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'tokens',
+    'introspection',
+    'authentication',
 ]
 
 [project.optional-dependencies]

--- a/pkgs/standards/swarmauri_tokens_jwt/pyproject.toml
+++ b/pkgs/standards/swarmauri_tokens_jwt/pyproject.toml
@@ -11,12 +11,22 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_signing_jws",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'tokens',
+    'jwt',
 ]
 
 [project.optional-dependencies]

--- a/pkgs/standards/swarmauri_tokens_paseto_v4/pyproject.toml
+++ b/pkgs/standards/swarmauri_tokens_paseto_v4/pyproject.toml
@@ -16,12 +16,23 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "pyseto",
     "cryptography",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'tokens',
+    'paseto',
+    'v4',
 ]
 
 [project.optional-dependencies]

--- a/pkgs/standards/swarmauri_tokens_remoteoidc/pyproject.toml
+++ b/pkgs/standards/swarmauri_tokens_remoteoidc/pyproject.toml
@@ -16,12 +16,23 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "pyjwt>=2.8.0",
     "cryptography",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'tokens',
+    'remoteoidc',
+    'authentication',
 ]
 
 [project.optional-dependencies]

--- a/pkgs/standards/swarmauri_tokens_rotatingjwt/pyproject.toml
+++ b/pkgs/standards/swarmauri_tokens_rotatingjwt/pyproject.toml
@@ -16,11 +16,21 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Topic :: Security :: Cryptography",
     "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "PyJWT>=2.9.0",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'tokens',
+    'rotatingjwt',
 ]
 
 [project.optional-dependencies]

--- a/pkgs/standards/swarmauri_tokens_sshcert/pyproject.toml
+++ b/pkgs/standards/swarmauri_tokens_sshcert/pyproject.toml
@@ -11,11 +11,21 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'tokens',
+    'sshcert',
 ]
 
 [project.optional-dependencies]

--- a/pkgs/standards/swarmauri_tokens_sshsig/pyproject.toml
+++ b/pkgs/standards/swarmauri_tokens_sshsig/pyproject.toml
@@ -11,12 +11,22 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "cryptography>=41.0.3",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'tokens',
+    'sshsig',
 ]
 
 [project.optional-dependencies]

--- a/pkgs/standards/swarmauri_tokens_tlsboundjwt/pyproject.toml
+++ b/pkgs/standards/swarmauri_tokens_tlsboundjwt/pyproject.toml
@@ -16,10 +16,20 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "Topic :: Security :: Cryptography",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'tokens',
+    'tlsboundjwt',
 ]
 
 [project.optional-dependencies]

--- a/pkgs/standards/swarmauri_tool_containerfeedchars/pyproject.toml
+++ b/pkgs/standards/swarmauri_tool_containerfeedchars/pyproject.toml
@@ -11,12 +11,23 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'tool',
+    'containerfeedchars',
+    'tooling',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_tool_containermakepr/pyproject.toml
+++ b/pkgs/standards/swarmauri_tool_containermakepr/pyproject.toml
@@ -11,12 +11,23 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'tool',
+    'containermakepr',
+    'tooling',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_tool_containernewsession/pyproject.toml
+++ b/pkgs/standards/swarmauri_tool_containernewsession/pyproject.toml
@@ -11,12 +11,23 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'tool',
+    'containernewsession',
+    'tooling',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_tool_githubloader/pyproject.toml
+++ b/pkgs/standards/swarmauri_tool_githubloader/pyproject.toml
@@ -11,6 +11,9 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -18,6 +21,14 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'tool',
+    'githubloader',
+    'tooling',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_tool_httploaded/pyproject.toml
+++ b/pkgs/standards/swarmauri_tool_httploaded/pyproject.toml
@@ -11,6 +11,9 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -19,6 +22,14 @@ dependencies = [
     "swarmauri_standard",
     "httpx>=0.27.0",
     "pyyaml>=6.0",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'tool',
+    'httploaded',
+    'tooling',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_tool_matplotlib/pyproject.toml
+++ b/pkgs/standards/swarmauri_tool_matplotlib/pyproject.toml
@@ -11,6 +11,9 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -18,6 +21,14 @@ dependencies = [
     "swarmauri_core",
     "swarmauri_base",
     "swarmauri_standard",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'tool',
+    'matplotlib',
+    'tooling',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_toolkit_containertoolkit/pyproject.toml
+++ b/pkgs/standards/swarmauri_toolkit_containertoolkit/pyproject.toml
@@ -11,6 +11,9 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -20,6 +23,14 @@ dependencies = [
     "swarmauri_tool_containernewsession",
     "swarmauri_tool_containerfeedchars",
     "swarmauri_tool_containermakepr",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'toolkit',
+    'containertoolkit',
+    'tooling',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_transport_asgi/pyproject.toml
+++ b/pkgs/standards/swarmauri_transport_asgi/pyproject.toml
@@ -22,6 +22,7 @@ keywords = [
     "asyncio",
     "sdk",
     "microservices",
+    "standards",
 ]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",

--- a/pkgs/standards/swarmauri_transport_h2/pyproject.toml
+++ b/pkgs/standards/swarmauri_transport_h2/pyproject.toml
@@ -21,6 +21,7 @@ keywords = [
     "server",
     "sdk",
     "microservices",
+    "standards",
 ]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",

--- a/pkgs/standards/swarmauri_transport_h2mux/pyproject.toml
+++ b/pkgs/standards/swarmauri_transport_h2mux/pyproject.toml
@@ -20,6 +20,8 @@ keywords = [
     "h2",
     "sdk",
     "networking",
+    "standards",
+    "h2mux",
 ]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",

--- a/pkgs/standards/swarmauri_transport_meshsidecarhttp2/pyproject.toml
+++ b/pkgs/standards/swarmauri_transport_meshsidecarhttp2/pyproject.toml
@@ -21,6 +21,8 @@ keywords = [
     "proxy",
     "sdk",
     "networking",
+    "standards",
+    "meshsidecarhttp2",
 ]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",

--- a/pkgs/standards/swarmauri_transport_mtlsunicast/pyproject.toml
+++ b/pkgs/standards/swarmauri_transport_mtlsunicast/pyproject.toml
@@ -21,6 +21,8 @@ keywords = [
     "sdk",
     "authentication",
     "encryption",
+    "standards",
+    "mtlsunicast",
 ]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",

--- a/pkgs/standards/swarmauri_transport_quic/pyproject.toml
+++ b/pkgs/standards/swarmauri_transport_quic/pyproject.toml
@@ -16,9 +16,18 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'transport',
+    'quic',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_transport_sseoutbound/pyproject.toml
+++ b/pkgs/standards/swarmauri_transport_sseoutbound/pyproject.toml
@@ -20,6 +20,9 @@ keywords = [
     "http",
     "asyncio",
     "realtime",
+    "sdk",
+    "standards",
+    "sseoutbound",
 ]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",

--- a/pkgs/standards/swarmauri_transport_sshtunnel/pyproject.toml
+++ b/pkgs/standards/swarmauri_transport_sshtunnel/pyproject.toml
@@ -19,6 +19,9 @@ keywords = [
     "proxy",
     "asyncio",
     "networking",
+    "sdk",
+    "standards",
+    "sshtunnel",
 ]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",

--- a/pkgs/standards/swarmauri_transport_stdio/pyproject.toml
+++ b/pkgs/standards/swarmauri_transport_stdio/pyproject.toml
@@ -19,6 +19,7 @@ keywords = [
     "asyncio",
     "bridge",
     "sdk",
+    "standards",
 ]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",

--- a/pkgs/standards/swarmauri_transport_tcpunicast/pyproject.toml
+++ b/pkgs/standards/swarmauri_transport_tcpunicast/pyproject.toml
@@ -21,6 +21,8 @@ keywords = [
     "unicast",
     "agents",
     "microservices",
+    "standards",
+    "tcpunicast",
 ]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",

--- a/pkgs/standards/swarmauri_transport_tls_unicast/pyproject.toml
+++ b/pkgs/standards/swarmauri_transport_tls_unicast/pyproject.toml
@@ -16,9 +16,19 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'transport',
+    'tls',
+    'unicast',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_transport_udp/pyproject.toml
+++ b/pkgs/standards/swarmauri_transport_udp/pyproject.toml
@@ -16,9 +16,18 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri_core",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'transport',
+    'udp',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_transport_uds_unicast/pyproject.toml
+++ b/pkgs/standards/swarmauri_transport_uds_unicast/pyproject.toml
@@ -16,10 +16,20 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
     "swarmauri-base",
     "swarmauri_core",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'transport',
+    'uds',
+    'unicast',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_transport_wsjsonrpcmux/pyproject.toml
+++ b/pkgs/standards/swarmauri_transport_wsjsonrpcmux/pyproject.toml
@@ -19,6 +19,9 @@ keywords = [
     "asyncio",
     "realtime",
     "browser",
+    "sdk",
+    "standards",
+    "wsjsonrpcmux",
 ]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",

--- a/pkgs/standards/swarmauri_vectorstore_doc2vec/pyproject.toml
+++ b/pkgs/standards/swarmauri_vectorstore_doc2vec/pyproject.toml
@@ -11,6 +11,9 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -18,6 +21,14 @@ dependencies = [
     "swarmauri_base",
     "swarmauri_embedding_doc2vec",
     "swarmauri_standard",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'vectorstore',
+    'doc2vec',
+    'machine-learning',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/swarmauri_xmp_gif/pyproject.toml
+++ b/pkgs/standards/swarmauri_xmp_gif/pyproject.toml
@@ -13,11 +13,21 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Development Status :: 3 - Alpha",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'xmp',
+    'gif',
 ]
 
 [project.urls]

--- a/pkgs/standards/swarmauri_xmp_jpeg/pyproject.toml
+++ b/pkgs/standards/swarmauri_xmp_jpeg/pyproject.toml
@@ -13,11 +13,21 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Development Status :: 3 - Alpha",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'xmp',
+    'jpeg',
 ]
 
 [project.urls]

--- a/pkgs/standards/swarmauri_xmp_mp4/pyproject.toml
+++ b/pkgs/standards/swarmauri_xmp_mp4/pyproject.toml
@@ -13,11 +13,21 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Development Status :: 2 - Pre-Alpha",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'xmp',
+    'mp4',
 ]
 
 [project.urls]

--- a/pkgs/standards/swarmauri_xmp_pdf/pyproject.toml
+++ b/pkgs/standards/swarmauri_xmp_pdf/pyproject.toml
@@ -13,11 +13,21 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Development Status :: 2 - Pre-Alpha",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'xmp',
+    'pdf',
 ]
 
 [project.urls]

--- a/pkgs/standards/swarmauri_xmp_png/pyproject.toml
+++ b/pkgs/standards/swarmauri_xmp_png/pyproject.toml
@@ -13,11 +13,21 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Development Status :: 3 - Alpha",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'xmp',
+    'png',
 ]
 
 [project.urls]

--- a/pkgs/standards/swarmauri_xmp_svg/pyproject.toml
+++ b/pkgs/standards/swarmauri_xmp_svg/pyproject.toml
@@ -13,11 +13,21 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Development Status :: 3 - Alpha",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'xmp',
+    'svg',
 ]
 
 [project.urls]

--- a/pkgs/standards/swarmauri_xmp_tiff/pyproject.toml
+++ b/pkgs/standards/swarmauri_xmp_tiff/pyproject.toml
@@ -13,11 +13,21 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Development Status :: 2 - Pre-Alpha",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'xmp',
+    'tiff',
 ]
 
 [project.urls]

--- a/pkgs/standards/swarmauri_xmp_webp/pyproject.toml
+++ b/pkgs/standards/swarmauri_xmp_webp/pyproject.toml
@@ -13,11 +13,21 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Development Status :: 2 - Pre-Alpha",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
     "swarmauri_core",
     "swarmauri_base",
+]
+keywords = [
+    'swarmauri',
+    'sdk',
+    'standards',
+    'xmp',
+    'webp',
 ]
 
 [project.urls]

--- a/pkgs/standards/swm_example_package/pyproject.toml
+++ b/pkgs/standards/swm_example_package/pyproject.toml
@@ -10,10 +10,20 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12"
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only"
 ]
 authors = [{name = "Jacob Stewart", email = "jacob@swarmauri.com"}]
 dependencies = ["swarmauri_core", "swarmauri_base"]
+keywords = [
+    'swm',
+    'sdk',
+    'standards',
+    'example',
+    'package',
+]
 
 [tool.uv.sources]
 swarmauri_core = { workspace = true }

--- a/pkgs/standards/tigrbl/pyproject.toml
+++ b/pkgs/standards/tigrbl/pyproject.toml
@@ -12,6 +12,9 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 authors = [{ name = "Swarmauri Team", email = "team@swarmauri.com" }]
 dependencies = [
@@ -25,6 +28,11 @@ dependencies = [
     "httpx>=0.27.0",
     "greenlet>=3.2.3",
     "uvicorn", 
+]
+keywords = [
+    'tigrbl',
+    'sdk',
+    'standards',
 ]
 
 [project.optional-dependencies]

--- a/pkgs/standards/tigrbl_auth/pyproject.toml
+++ b/pkgs/standards/tigrbl_auth/pyproject.toml
@@ -12,6 +12,9 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -39,7 +42,7 @@ dependencies = [
     "httpx>=0.27",
     "tigrbl",
 ]
-keywords = ["oidc", "oauth2", "fastapi", "identity-provider", "jwks", "jwt"]
+keywords = ["oidc", "oauth2", "fastapi", "identity-provider", "jwks", "jwt", "tigrbl", "sdk", "standards", "auth", "authentication"]
 
 [tool.uv.sources]
 swarmauri_core = { workspace = true }

--- a/pkgs/standards/tigrbl_client/pyproject.toml
+++ b/pkgs/standards/tigrbl_client/pyproject.toml
@@ -12,6 +12,9 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -20,6 +23,12 @@ dependencies = [
     "swarmauri_standard",
     "fastapi>=0.100.0",
     "pydantic>=2.0.0",
+]
+keywords = [
+    'tigrbl',
+    'sdk',
+    'standards',
+    'client',
 ]
 
 [tool.uv.sources]

--- a/pkgs/standards/tigrbl_kms/pyproject.toml
+++ b/pkgs/standards/tigrbl_kms/pyproject.toml
@@ -12,6 +12,9 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
 dependencies = [
@@ -26,6 +29,12 @@ dependencies = [
     "sqlalchemy[asyncio]>=2.0.0",
     "asyncpg>=0.29,<1.0",
     "swarmauri_crypto_paramiko"
+]
+keywords = [
+    'tigrbl',
+    'sdk',
+    'standards',
+    'kms',
 ]
 
 [tool.uv.sources]


### PR DESCRIPTION
## Summary
- ensure every standards package under `pkgs/standards` declares the core Python 3.10–3.12 classifiers
- add consistent keyword metadata across the standards packages to improve package discovery on PyPI

## Testing
- not run (metadata-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e14fbc7150832680cb40c097d4690c