### PR TITLE
chore(plugins): expand keywords for media and signing formats

### DIFF
--- a/pkgs/plugins/EmbedXMP/pyproject.toml
+++ b/pkgs/plugins/EmbedXMP/pyproject.toml
@@ -45,6 +45,14 @@ keywords = [
     "python-library",
     "async-discovery",
     "plugin-discovery",
+    "png",
+    "gif",
+    "jpeg",
+    "svg",
+    "webp",
+    "tiff",
+    "pdf",
+    "mp4",
 ]
 
 [project.urls]

--- a/pkgs/plugins/embedded_signer/pyproject.toml
+++ b/pkgs/plugins/embedded_signer/pyproject.toml
@@ -57,6 +57,13 @@ keywords = [
     "asyncio",
     "plugin",
     "digital-asset-workflows",
+    "cms",
+    "pkcs7",
+    "cades",
+    "jws",
+    "openpgp",
+    "pdf-signatures",
+    "xmldsig",
 ]
 
 [project.urls]

--- a/pkgs/plugins/media_signer/pyproject.toml
+++ b/pkgs/plugins/media_signer/pyproject.toml
@@ -50,6 +50,13 @@ keywords = [
     "verification",
     "digital-asset-security",
     "media-compliance",
+    "cms",
+    "pkcs7",
+    "cades",
+    "jws",
+    "openpgp",
+    "pdf-signatures",
+    "xmldsig",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
- add explicit media format keywords to the EmbedXMP plugin metadata
- list signing format keywords across EmbeddedSigner and MediaSigner packages for discoverability

## Testing
- uv run --directory pkgs/plugins/EmbedXMP --package EmbedXMP ruff format .
- uv run --directory pkgs/plugins/EmbedXMP --package EmbedXMP ruff check . --fix
- uv run --directory pkgs/plugins/embedded_signer --package EmbeddedSigner ruff format .
- uv run --directory pkgs/plugins/embedded_signer --package EmbeddedSigner ruff check . --fix
- uv run --directory pkgs/plugins/media_signer --package MediaSigner ruff format .
- uv run --directory pkgs/plugins/media_signer --package MediaSigner ruff check . --fix

------
https://chatgpt.com/codex/tasks/task_e_68e15270e84083268708deca9096d3e3