### PR TITLE
feat: add Hamming metric and matrix packages

### DIFF
--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -64,6 +64,8 @@ members = [
     "standards/swarmauri_transport_quic",
     #"standards/swarmauri_vectorstore_tfidf",
     "standards/swarmauri_distance_minkowski",
+    "standards/swarmauri_metric_hamming",
+    "standards/swarmauri_matrix_hamming74",
     "standards/swarmauri_middleware_auth",
     "standards/swarmauri_middleware_bulkhead",
     "standards/swarmauri_middleware_cachecontrol",
@@ -292,6 +294,8 @@ swarmauri_evaluator_subprocess = { workspace = true }
 swarmauri_evaluatorpool_accessibility = { workspace = true }
 #swarmauri_vectorstore_tfidf = { workspace = true } # We have a tfidf with built-in formula now, this can move to community support with minor rename
 swarmauri_distance_minkowski = { workspace = true }
+swarmauri_metric_hamming = { workspace = true }
+swarmauri_matrix_hamming74 = { workspace = true }
 swarmauri_middleware_auth = { workspace = true }
 swarmauri_middleware_bulkhead = { workspace = true }
 swarmauri_middleware_cachecontrol = { workspace = true }

--- a/pkgs/standards/swarmauri_matrix_hamming74/LICENSE
+++ b/pkgs/standards/swarmauri_matrix_hamming74/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/standards/swarmauri_matrix_hamming74/README.md
+++ b/pkgs/standards/swarmauri_matrix_hamming74/README.md
@@ -1,0 +1,73 @@
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_matrix_hamming74/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_matrix_hamming74" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_matrix_hamming74/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_matrix_hamming74.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_matrix_hamming74/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_matrix_hamming74" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_matrix_hamming74/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_matrix_hamming74" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_matrix_hamming74/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_matrix_hamming74?label=swarmauri_matrix_hamming74&color=green" alt="PyPI - swarmauri_matrix_hamming74"/></a>
+</p>
+
+---
+
+# Swarmauri Hamming (7, 4) Matrix
+
+`swarmauri_matrix_hamming74` delivers a production-ready generator matrix for
+the binary `(7, 4)` Hamming code.  The component extends `MatrixBase` and uses
+the companion `swarmauri_metric_hamming` package to reason about codeword
+distances and minimum distance properties.
+
+## Features
+
+- Canonical `(7, 4)` generator and parity-check matrices with validation.
+- Message encoding, syndrome computation, and single-bit error correction
+  helpers.
+- Integration with the Swarmauri Hamming metric for distance measurements.
+- Utilities to enumerate all codewords and compute the minimum distance of the
+  code.
+
+## Installation
+
+Install the package with your preferred Python tooling:
+
+```bash
+pip install swarmauri_matrix_hamming74 swarmauri_metric_hamming
+```
+
+```bash
+uv pip install swarmauri_matrix_hamming74 swarmauri_metric_hamming
+```
+
+## Usage
+
+```python
+from swarmauri_matrix_hamming74 import Hamming74Matrix
+
+matrix = Hamming74Matrix()
+message = [1, 0, 1, 1]
+codeword = matrix.encode(message)
+print("Codeword:", codeword)
+
+received = codeword.copy()
+received[3] ^= 1  # introduce a single-bit error
+corrected = matrix.correct(received)
+print("Corrected:", corrected)
+
+print("Syndrome:", matrix.syndrome(received))
+print("Minimum distance:", matrix.minimum_distance())
+```
+
+The matrix exposes convenience helpers for error detection while preserving the
+`MatrixBase` contract so it can interoperate with the rest of the Swarmauri
+SDK.
+
+## Want to help?
+
+If you want to contribute to swarmauri-sdk, read up on our
+[guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/CONTRIBUTING.md)
+that will help you get started.

--- a/pkgs/standards/swarmauri_matrix_hamming74/pyproject.toml
+++ b/pkgs/standards/swarmauri_matrix_hamming74/pyproject.toml
@@ -1,0 +1,54 @@
+[project]
+name = "swarmauri_matrix_hamming74"
+version = "0.1.0.dev0"
+description = "Hamming (7, 4) generator matrix implementation for the Swarmauri SDK."
+license = "Apache-2.0"
+readme = "README.md"
+repository = "http://github.com/swarmauri/swarmauri-sdk"
+requires-python = ">=3.10,<3.13"
+classifiers = [
+    "Development Status :: 1 - Planning",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
+dependencies = [
+    "numpy>=1.26,<3",
+    "swarmauri_core",
+    "swarmauri_base",
+    "swarmauri_metric_hamming",
+]
+keywords = [
+    "swarmauri",
+    "sdk",
+    "matrix",
+    "hamming",
+    "error-correcting-code",
+]
+
+[tool.uv.sources]
+swarmauri_core = { workspace = true }
+swarmauri_base = { workspace = true }
+swarmauri_metric_hamming = { workspace = true }
+
+[project.entry-points.'swarmauri.matrices']
+Hamming74Matrix = "swarmauri_matrix_hamming74:Hamming74Matrix"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "python-dotenv",
+    "requests>=2.32.3",
+    "pytest-timeout>=2.3.1",
+    "ruff>=0.9.9",
+    "pytest-benchmark>=4.0.0",
+]

--- a/pkgs/standards/swarmauri_matrix_hamming74/swarmauri_matrix_hamming74/Hamming74Matrix.py
+++ b/pkgs/standards/swarmauri_matrix_hamming74/swarmauri_matrix_hamming74/Hamming74Matrix.py
@@ -1,0 +1,259 @@
+"""Hamming (7, 4) generator matrix packaged as a Swarmauri component."""
+
+from __future__ import annotations
+
+import itertools
+import logging
+from typing import Iterator, List, Literal, Sequence, Tuple, Union
+
+import numpy as np
+
+from swarmauri_base.ComponentBase import ComponentBase
+from swarmauri_base.matrices.MatrixBase import MatrixBase
+from swarmauri_metric_hamming import HammingMetric
+
+logger = logging.getLogger(__name__)
+
+
+@ComponentBase.register_type(MatrixBase, "Hamming74Matrix")
+class Hamming74Matrix(MatrixBase):
+    """Concrete generator matrix for the binary ``(7, 4)`` Hamming code."""
+
+    type: Literal["Hamming74Matrix"] = "Hamming74Matrix"
+
+    _DEFAULT_GENERATOR = np.array(
+        [
+            [1, 0, 0, 0, 1, 1, 0],
+            [0, 1, 0, 0, 1, 0, 1],
+            [0, 0, 1, 0, 0, 1, 1],
+            [0, 0, 0, 1, 1, 1, 1],
+        ],
+        dtype=int,
+    )
+
+    _DEFAULT_PARITY_CHECK = np.array(
+        [
+            [1, 1, 0, 1, 1, 0, 0],
+            [1, 0, 1, 1, 0, 1, 0],
+            [0, 1, 1, 1, 0, 0, 1],
+        ],
+        dtype=int,
+    )
+
+    def __init__(self, data: Sequence[Sequence[int]] | None = None) -> None:
+        matrix = (
+            np.array(data, dtype=int)
+            if data is not None
+            else self._DEFAULT_GENERATOR.copy()
+        )
+        self._matrix = self._validate_matrix(matrix)
+        self._metric = HammingMetric()
+
+    # ------------------------------------------------------------------
+    # MatrixBase interface
+    # ------------------------------------------------------------------
+    def __getitem__(self, key: Union[int, slice, Tuple[Union[int, slice], ...]]):
+        value = self._matrix[key]
+        if isinstance(value, np.ndarray):
+            return value.tolist()
+        return int(value)
+
+    def __setitem__(self, key, value) -> None:  # type: ignore[override]
+        updated = self._matrix.copy()
+        updated[key] = value
+        self._matrix = self._validate_matrix(updated)
+
+    @property
+    def shape(self) -> Tuple[int, int]:
+        return tuple(self._matrix.shape)  # type: ignore[return-value]
+
+    def reshape(self, shape: Tuple[int, int]) -> "Hamming74Matrix":
+        if shape != self._matrix.shape:
+            raise ValueError("Hamming74Matrix is fixed at shape (4, 7)")
+        return Hamming74Matrix(self.tolist())
+
+    @property
+    def dtype(self) -> type:
+        return int
+
+    def tolist(self) -> List[List[int]]:
+        return self._matrix.astype(int).tolist()
+
+    def row(self, index: int) -> List[int]:
+        return self._matrix[index, :].astype(int).tolist()
+
+    def column(self, index: int) -> List[int]:
+        return self._matrix[:, index].astype(int).tolist()
+
+    def __add__(
+        self, other: Union["Hamming74Matrix", Sequence[Sequence[int]], int]
+    ) -> "Hamming74Matrix":
+        other_matrix = self._coerce_other(other)
+        result = (self._matrix + other_matrix) % 2
+        return Hamming74Matrix(result.tolist())
+
+    def __sub__(
+        self, other: Union["Hamming74Matrix", Sequence[Sequence[int]], int]
+    ) -> "Hamming74Matrix":
+        other_matrix = self._coerce_other(other)
+        result = (self._matrix - other_matrix) % 2
+        return Hamming74Matrix(result.tolist())
+
+    def __mul__(
+        self, other: Union["Hamming74Matrix", Sequence[Sequence[int]], int]
+    ) -> "Hamming74Matrix":
+        other_matrix = self._coerce_other(other)
+        result = (self._matrix * other_matrix) % 2
+        return Hamming74Matrix(result.tolist())
+
+    def __matmul__(self, other: Union[Sequence[int], Sequence[Sequence[int]]]):
+        other_array = np.array(other, dtype=int)
+        if other_array.ndim == 1:
+            if other_array.shape[0] != self._matrix.shape[1]:
+                raise ValueError("Vector length must match matrix columns (7)")
+            result = self._matrix.dot(other_array) % 2
+            return result.astype(int).tolist()
+        if other_array.ndim == 2:
+            if other_array.shape[0] != self._matrix.shape[1]:
+                raise ValueError("Matrix row count must match matrix columns (7)")
+            result = (self._matrix @ other_array) % 2
+            return result.astype(int).tolist()
+        raise TypeError("Unsupported operand for matrix multiplication")
+
+    def __truediv__(self, other: int) -> "Hamming74Matrix":
+        if other != 1:
+            raise NotImplementedError("Hamming74Matrix only supports division by 1")
+        return Hamming74Matrix(self.tolist())
+
+    def __neg__(self) -> "Hamming74Matrix":
+        return Hamming74Matrix(((-self._matrix) % 2).astype(int).tolist())
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Hamming74Matrix):
+            return False
+        return bool(np.array_equal(self._matrix, other._matrix))
+
+    def __iter__(self) -> Iterator[List[int]]:
+        for row in self._matrix:
+            yield row.astype(int).tolist()
+
+    def transpose(self):  # type: ignore[override]
+        raise NotImplementedError(
+            "Transpose is not defined for the fixed Hamming74Matrix shape"
+        )
+
+    def __array__(self) -> np.ndarray:  # type: ignore[override]
+        return self._matrix.copy()
+
+    # ------------------------------------------------------------------
+    # Hamming-code specific helpers
+    # ------------------------------------------------------------------
+    @property
+    def parity_check_matrix(self) -> List[List[int]]:
+        return self._DEFAULT_PARITY_CHECK.astype(int).tolist()
+
+    def encode(self, message: Sequence[int]) -> List[int]:
+        if len(message) != 4:
+            raise ValueError("Message length must be 4 for Hamming(7,4)")
+        message_array = np.array(message, dtype=int)
+        if not self._is_binary(message_array):
+            raise ValueError("Message symbols must be binary (0 or 1)")
+        codeword = message_array.dot(self._matrix) % 2
+        return codeword.astype(int).tolist()
+
+    def syndrome(self, codeword: Sequence[int]) -> List[int]:
+        code_array = np.array(codeword, dtype=int)
+        if code_array.shape != (7,):
+            raise ValueError("Codeword must contain exactly 7 bits")
+        if not self._is_binary(code_array):
+            raise ValueError("Codeword symbols must be binary (0 or 1)")
+        syndrome = self._DEFAULT_PARITY_CHECK.dot(code_array) % 2
+        return syndrome.astype(int).tolist()
+
+    def correct(self, received: Sequence[int]) -> List[int]:
+        code_array = np.array(received, dtype=int)
+        if code_array.shape != (7,):
+            raise ValueError("Received vector must contain exactly 7 bits")
+        if not self._is_binary(code_array):
+            raise ValueError("Received vector must be binary (0 or 1)")
+        syndrome = self.syndrome(code_array)
+        if not any(syndrome):
+            return code_array.astype(int).tolist()
+        syndrome_vector = np.array(syndrome, dtype=int)
+        for index in range(self._matrix.shape[1]):
+            column = self._DEFAULT_PARITY_CHECK[:, index]
+            if np.array_equal(column, syndrome_vector):
+                code_array[index] ^= 1
+                logger.debug("Corrected error at position %s", index)
+                return code_array.astype(int).tolist()
+        logger.debug("Syndrome %s did not match a single-bit error", syndrome)
+        return code_array.astype(int).tolist()
+
+    def distance(self, a: Sequence[int], b: Sequence[int]) -> float:
+        return self._metric.distance(a, b)
+
+    def minimum_distance(self) -> int:
+        codewords = self._all_codewords()
+        min_distance = min(
+            self._metric.distance(x, y)
+            for i, x in enumerate(codewords)
+            for y in codewords[i + 1 :]
+            if x != y
+        )
+        return int(min_distance)
+
+    def nearest_codeword(self, received: Sequence[int]) -> List[int]:
+        received_array = np.array(received, dtype=int)
+        if received_array.shape != (7,):
+            raise ValueError("Received vector must contain exactly 7 bits")
+        if not self._is_binary(received_array):
+            raise ValueError("Received vector must be binary (0 or 1)")
+        best_codeword: List[int] | None = None
+        best_distance: float | None = None
+        for codeword in self._all_codewords():
+            distance = self._metric.distance(received_array.tolist(), codeword)
+            if best_distance is None or distance < best_distance:
+                best_distance = distance
+                best_codeword = codeword
+        return (
+            best_codeword
+            if best_codeword is not None
+            else received_array.astype(int).tolist()
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _validate_matrix(self, matrix: np.ndarray) -> np.ndarray:
+        if matrix.shape != (4, 7):
+            raise ValueError("Hamming74Matrix must be 4x7")
+        if not self._is_binary(matrix):
+            raise ValueError("Matrix entries must be binary (0 or 1)")
+        return matrix.astype(int)
+
+    def _coerce_other(
+        self, other: Union["Hamming74Matrix", Sequence[Sequence[int]], int]
+    ) -> np.ndarray:
+        if isinstance(other, Hamming74Matrix):
+            return other._matrix
+        if isinstance(other, Sequence) and not isinstance(other, (str, bytes)):
+            arr = np.array(other, dtype=int)
+            if arr.shape != self._matrix.shape:
+                raise ValueError("Operand must match matrix shape (4, 7)")
+            if not self._is_binary(arr):
+                raise ValueError("Operand entries must be binary (0 or 1)")
+            return arr
+        if isinstance(other, int):
+            if other not in (0, 1):
+                raise ValueError("Scalar operands must be binary (0 or 1)")
+            return np.full(self._matrix.shape, other, dtype=int)
+        raise TypeError("Unsupported operand type")
+
+    def _is_binary(self, array: np.ndarray) -> bool:
+        return np.isin(array, [0, 1]).all()
+
+    def _all_codewords(self) -> List[List[int]]:
+        codewords: List[List[int]] = []
+        for message in itertools.product([0, 1], repeat=4):
+            codewords.append(self.encode(message))
+        return codewords

--- a/pkgs/standards/swarmauri_matrix_hamming74/swarmauri_matrix_hamming74/__init__.py
+++ b/pkgs/standards/swarmauri_matrix_hamming74/swarmauri_matrix_hamming74/__init__.py
@@ -1,0 +1,5 @@
+"""Hamming (7, 4) matrix utilities for the Swarmauri SDK."""
+
+from .Hamming74Matrix import Hamming74Matrix
+
+__all__ = ["Hamming74Matrix"]

--- a/pkgs/standards/swarmauri_matrix_hamming74/tests/test_hamming74_matrix.py
+++ b/pkgs/standards/swarmauri_matrix_hamming74/tests/test_hamming74_matrix.py
@@ -1,0 +1,61 @@
+import pytest
+
+from swarmauri_matrix_hamming74 import Hamming74Matrix
+
+
+def test_shape_is_fixed():
+    matrix = Hamming74Matrix()
+    assert matrix.shape == (4, 7)
+
+
+def test_encode_known_message():
+    matrix = Hamming74Matrix()
+    message = [1, 0, 1, 1]
+    assert matrix.encode(message) == [1, 0, 1, 1, 0, 1, 0]
+
+
+def test_syndrome_detects_single_bit_error():
+    matrix = Hamming74Matrix()
+    codeword = matrix.encode([1, 1, 0, 1])
+    corrupted = codeword.copy()
+    corrupted[2] ^= 1
+    syndrome = matrix.syndrome(corrupted)
+    parity_columns = list(zip(*matrix.parity_check_matrix))
+    assert syndrome in [list(column) for column in parity_columns]
+
+
+def test_correct_recovers_single_bit_error():
+    matrix = Hamming74Matrix()
+    codeword = matrix.encode([0, 1, 1, 0])
+    corrupted = codeword.copy()
+    corrupted[5] ^= 1
+    corrected = matrix.correct(corrupted)
+    assert corrected == codeword
+
+
+def test_distance_matches_metric():
+    matrix = Hamming74Matrix()
+    a = matrix.encode([1, 0, 0, 0])
+    b = matrix.encode([0, 1, 0, 0])
+    assert matrix.distance(a, b) == pytest.approx(4.0)
+
+
+def test_minimum_distance_is_three():
+    matrix = Hamming74Matrix()
+    assert matrix.minimum_distance() == 3
+
+
+def test_nearest_codeword_returns_closest_match():
+    matrix = Hamming74Matrix()
+    codeword = matrix.encode([1, 1, 1, 0])
+    received = codeword.copy()
+    received[0] ^= 1
+    received[6] ^= 1
+    nearest = matrix.nearest_codeword(received)
+    assert nearest == matrix.correct(received)
+
+
+def test_invalid_message_raises():
+    matrix = Hamming74Matrix()
+    with pytest.raises(ValueError):
+        matrix.encode([1, 0, 1])

--- a/pkgs/standards/swarmauri_metric_hamming/LICENSE
+++ b/pkgs/standards/swarmauri_metric_hamming/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/standards/swarmauri_metric_hamming/README.md
+++ b/pkgs/standards/swarmauri_metric_hamming/README.md
@@ -1,0 +1,63 @@
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_metric_hamming/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_metric_hamming" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_metric_hamming/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_metric_hamming.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_metric_hamming/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_metric_hamming" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_metric_hamming/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_metric_hamming" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_metric_hamming/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_metric_hamming?label=swarmauri_metric_hamming&color=green" alt="PyPI - swarmauri_metric_hamming"/></a>
+</p>
+
+---
+
+# Swarmauri Hamming Metric
+
+`swarmauri_metric_hamming` packages a reusable implementation of the Hamming
+metric for the Swarmauri ecosystem.  The component extends the
+`MetricBase` abstraction so it can be composed with other SDK primitives like
+matrices, vectors, and error-correcting codes.
+
+## Features
+
+- Drop-in `MetricBase` implementation that validates metric axioms.
+- Distance, collection-wise distance and normalised distance helpers.
+- Convenience utilities for computing Hamming weight.
+- Forms the foundation for error-correcting code utilities such as the
+  `(7, 4)` Hamming matrix package.
+
+## Installation
+
+Install the package with your preferred Python tooling:
+
+```bash
+pip install swarmauri_metric_hamming
+```
+
+```bash
+uv pip install swarmauri_metric_hamming
+```
+
+## Usage
+
+```python
+from swarmauri_metric_hamming import HammingMetric
+
+metric = HammingMetric()
+print(metric.distance([1, 0, 1, 1], [1, 1, 0, 1]))      # -> 2.0
+print(metric.normalized_distance("abcd", "abcf"))      # -> 0.25
+print(metric.weight([0, 0, 1, 0, 1, 1, 0]))             # -> 3.0
+```
+
+The metric integrates seamlessly with any Swarmauri component expecting a
+`MetricBase` implementation.
+
+## Want to help?
+
+If you want to contribute to swarmauri-sdk, read up on our
+[guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/CONTRIBUTING.md)
+that will help you get started.

--- a/pkgs/standards/swarmauri_metric_hamming/pyproject.toml
+++ b/pkgs/standards/swarmauri_metric_hamming/pyproject.toml
@@ -1,0 +1,51 @@
+[project]
+name = "swarmauri_metric_hamming"
+version = "0.1.0.dev0"
+description = "Hamming metric implementation for the Swarmauri SDK."
+license = "Apache-2.0"
+readme = "README.md"
+repository = "http://github.com/swarmauri/swarmauri-sdk"
+requires-python = ">=3.10,<3.13"
+classifiers = [
+    "Development Status :: 1 - Planning",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
+dependencies = [
+    "swarmauri_core",
+    "swarmauri_base",
+]
+keywords = [
+    "swarmauri",
+    "sdk",
+    "metric",
+    "hamming",
+    "error-correcting-code",
+]
+
+[tool.uv.sources]
+swarmauri_core = { workspace = true }
+swarmauri_base = { workspace = true }
+
+[project.entry-points.'swarmauri.metrics']
+HammingMetric = "swarmauri_metric_hamming:HammingMetric"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "python-dotenv",
+    "requests>=2.32.3",
+    "pytest-timeout>=2.3.1",
+    "ruff>=0.9.9",
+    "pytest-benchmark>=4.0.0",
+]

--- a/pkgs/standards/swarmauri_metric_hamming/swarmauri_metric_hamming/HammingMetric.py
+++ b/pkgs/standards/swarmauri_metric_hamming/swarmauri_metric_hamming/HammingMetric.py
@@ -1,0 +1,121 @@
+"""Hamming distance metric packaged for the Swarmauri SDK."""
+
+from __future__ import annotations
+
+import logging
+from typing import List, Literal, Sequence, Union
+
+from swarmauri_base.ComponentBase import ComponentBase
+from swarmauri_base.metrics.MetricBase import MetricBase
+from swarmauri_core.matrices.IMatrix import IMatrix
+from swarmauri_core.metrics.IMetric import MetricInput, MetricInputCollection
+from swarmauri_core.vectors.IVector import IVector
+
+logger = logging.getLogger(__name__)
+
+
+@ComponentBase.register_type(MetricBase, "HammingMetric")
+class HammingMetric(MetricBase):
+    """Concrete implementation of :class:`~swarmauri_core.metrics.IMetric`.
+
+    The metric measures the Hamming distance between two equally-sized
+    sequences.  Only the number of positions with unequal entries matters,
+    making the metric especially convenient for binary codes such as the
+    ``(7, 4)`` Hamming code implemented in :mod:`swarmauri_matrix_hamming74`.
+    """
+
+    type: Literal["HammingMetric"] = "HammingMetric"
+
+    @staticmethod
+    def _validate_sequences(x: Sequence[object], y: Sequence[object]) -> None:
+        """Validate the provided sequences.
+
+        Parameters
+        ----------
+        x, y:
+            The sequences to compare.  Both must be indexable and have equal
+            length.
+        """
+
+        if not isinstance(x, Sequence) or not isinstance(y, Sequence):
+            raise TypeError("Inputs must be sequences")
+
+        if len(x) != len(y):
+            raise ValueError(f"Sequences must have equal length: {len(x)} != {len(y)}")
+
+    def distance(self, x: MetricInput, y: MetricInput) -> float:
+        """Return the Hamming distance between two sequences."""
+
+        if not isinstance(x, Sequence) or not isinstance(y, Sequence):
+            raise TypeError("Inputs must be sequences")
+
+        self._validate_sequences(x, y)
+        distance = sum(1 for xi, yi in zip(x, y) if xi != yi)
+        logger.debug("Hamming distance between %s and %s: %s", x, y, distance)
+        return float(distance)
+
+    def distances(
+        self,
+        x: Union[MetricInput, MetricInputCollection],
+        y: Union[MetricInput, MetricInputCollection],
+    ) -> Union[List[float], IVector, IMatrix]:
+        """Return Hamming distances for the provided collections."""
+
+        if isinstance(x, Sequence) and isinstance(y, Sequence):
+            if x and isinstance(x[0], Sequence):
+                if y and isinstance(y[0], Sequence):
+                    return [
+                        [self.distance(xi, yi) for yi in y]  # type: ignore[arg-type]
+                        for xi in x  # type: ignore[arg-type]
+                    ]
+                return [self.distance(xi, y) for xi in x]  # type: ignore[arg-type]
+
+            if y and isinstance(y[0], Sequence):
+                return [self.distance(x, yi) for yi in y]  # type: ignore[arg-type]
+
+            return [self.distance(x, y)]
+
+        raise TypeError("Inputs must be sequences or collections of sequences")
+
+    def check_non_negativity(self, x: MetricInput, y: MetricInput) -> bool:
+        """The Hamming metric is always non-negative."""
+
+        return self.distance(x, y) >= 0
+
+    def check_identity_of_indiscernibles(self, x: MetricInput, y: MetricInput) -> bool:
+        """The distance is zero if and only if the sequences are identical."""
+
+        return self.distance(x, y) == 0 if x == y else self.distance(x, y) > 0
+
+    def check_symmetry(self, x: MetricInput, y: MetricInput) -> bool:
+        """Return ``True`` if the symmetry axiom holds."""
+
+        return self.distance(x, y) == self.distance(y, x)
+
+    def check_triangle_inequality(
+        self,
+        x: MetricInput,
+        y: MetricInput,
+        z: MetricInput,
+    ) -> bool:
+        """Return ``True`` if the triangle inequality holds."""
+
+        return self.distance(x, z) <= self.distance(x, y) + self.distance(y, z)
+
+    def normalized_distance(self, x: MetricInput, y: MetricInput) -> float:
+        """Return the Hamming distance normalised by the sequence length."""
+
+        if not isinstance(x, Sequence) or not isinstance(y, Sequence):
+            raise TypeError("Inputs must be sequences")
+
+        self._validate_sequences(x, y)
+        if not x:
+            return 0.0
+        return self.distance(x, y) / len(x)
+
+    def weight(self, x: MetricInput) -> float:
+        """Return the Hamming weight of a single sequence."""
+
+        if not isinstance(x, Sequence):
+            raise TypeError("Input must be a sequence")
+        return float(sum(1 for xi in x if xi))

--- a/pkgs/standards/swarmauri_metric_hamming/swarmauri_metric_hamming/__init__.py
+++ b/pkgs/standards/swarmauri_metric_hamming/swarmauri_metric_hamming/__init__.py
@@ -1,0 +1,5 @@
+"""Top-level package for the Swarmauri Hamming metric implementation."""
+
+from .HammingMetric import HammingMetric
+
+__all__ = ["HammingMetric"]

--- a/pkgs/standards/swarmauri_metric_hamming/tests/test_hamming_metric.py
+++ b/pkgs/standards/swarmauri_metric_hamming/tests/test_hamming_metric.py
@@ -1,0 +1,43 @@
+import pytest
+
+from swarmauri_metric_hamming import HammingMetric
+
+
+def test_distance_zero_for_identical_sequences():
+    metric = HammingMetric()
+    assert metric.distance([0, 1, 1, 0], [0, 1, 1, 0]) == 0.0
+
+
+def test_distance_counts_differences():
+    metric = HammingMetric()
+    assert metric.distance([1, 0, 1, 0], [0, 1, 1, 0]) == 2.0
+
+
+def test_normalized_distance():
+    metric = HammingMetric()
+    assert metric.normalized_distance("abcd", "abcf") == pytest.approx(0.25)
+
+
+def test_weight_counts_non_zero_symbols():
+    metric = HammingMetric()
+    assert metric.weight([0, 1, 0, 0, 1, 1, 0]) == 3.0
+
+
+def test_distances_pairwise_matrix():
+    metric = HammingMetric()
+    x = [[0, 0, 0], [1, 1, 1]]
+    y = [[0, 0, 0], [1, 0, 1]]
+    assert metric.distances(x, y) == [[0.0, 2.0], [3.0, 1.0]]
+
+
+def test_invalid_lengths_raise_value_error():
+    metric = HammingMetric()
+    with pytest.raises(ValueError):
+        metric.distance([0, 1, 0], [0, 1])
+
+
+@pytest.mark.parametrize("data", [42, "abc", None])
+def test_invalid_inputs_raise_type_error(data):
+    metric = HammingMetric()
+    with pytest.raises(TypeError):
+        metric.distance(data, [0, 1, 0])


### PR DESCRIPTION
## Summary
- create the `swarmauri_metric_hamming` package with a reusable MetricBase Hamming implementation
- add the `swarmauri_matrix_hamming74` package that offers encoding, syndrome, and correction helpers backed by the Hamming metric
- document, test, and register both packages in the workspace configuration

## Testing
- Not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e27c54a5488326bbfa010a9959d5cf