### PR TITLE
Add Hamming metric and matrix community packages

### DIFF
--- a/pkgs/community/swarmauri_matrix_hamming74/LICENSE
+++ b/pkgs/community/swarmauri_matrix_hamming74/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/community/swarmauri_matrix_hamming74/README.md
+++ b/pkgs/community/swarmauri_matrix_hamming74/README.md
@@ -1,0 +1,68 @@
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_matrix_hamming74/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_matrix_hamming74" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/community/swarmauri_matrix_hamming74/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/community/swarmauri_matrix_hamming74.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_matrix_hamming74/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_matrix_hamming74" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_matrix_hamming74/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_matrix_hamming74" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_matrix_hamming74/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_matrix_hamming74?label=swarmauri_matrix_hamming74&color=green" alt="PyPI - swarmauri_matrix_hamming74"/></a>
+</p>
+
+---
+
+# Swarmauri Matrix Hamming(7,4)
+
+The `swarmauri_matrix_hamming74` package provides a binary Hamming (7,4) code matrix that extends `MatrixBase`. It includes generator and parity-check representations, encoding and decoding helpers, and tight integration with the `swarmauri_metric_hamming` package for error detection and correction workflows.
+
+## Features
+
+- 🧮 Binary matrix implementation built on `MatrixBase` with full indexing and arithmetic support.
+- 🧷 Generator and parity-check matrix accessors for classic Hamming (7,4) coding schemes.
+- 📨 Encoding, syndrome calculation, and nearest-codeword decoding helpers powered by the Hamming metric.
+- 🔁 Binary-safe matrix operations (addition, subtraction, multiplication, and matrix multiplication modulo 2).
+
+## Installation
+
+### Using `uv`
+
+```bash
+uv pip install swarmauri_matrix_hamming74
+```
+
+### Using `pip`
+
+```bash
+pip install swarmauri_matrix_hamming74
+```
+
+## Usage
+
+```python
+from swarmauri_matrix_hamming74 import Hamming74Matrix
+
+matrix = Hamming74Matrix()
+message = [1, 0, 1, 1]
+codeword = matrix.encode(message)
+
+# Introduce a single-bit error
+received = codeword.copy()
+received[3] ^= 1
+
+# Decode using syndrome lookup and Hamming distance search
+nearest = matrix.nearest_codeword(received)
+print(nearest)  # Recovers the original codeword
+```
+
+## Support
+
+- Python 3.10, 3.11, and 3.12
+- Licensed under the Apache-2.0 license
+
+## Contributing
+
+We welcome contributions! Please submit issues and pull requests through the [Swarmauri SDK GitHub repository](https://github.com/swarmauri/swarmauri-sdk).

--- a/pkgs/community/swarmauri_matrix_hamming74/pyproject.toml
+++ b/pkgs/community/swarmauri_matrix_hamming74/pyproject.toml
@@ -1,0 +1,79 @@
+[project]
+name = "swarmauri_matrix_hamming74"
+version = "0.9.0.dev8"
+description = "Swarmauri Hamming (7,4) matrix community package."
+license = "Apache-2.0"
+readme = "README.md"
+repository = "http://github.com/swarmauri/swarmauri-sdk"
+requires-python = ">=3.10,<3.13"
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
+]
+authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
+dependencies = [
+    "numpy>=1.26",
+    "swarmauri_metric_hamming",
+    "swarmauri_core",
+    "swarmauri_base",
+]
+keywords = [
+    "swarmauri",
+    "matrix",
+    "hamming",
+    "error-correcting",
+    "community",
+    "package",
+]
+
+[tool.uv.sources]
+swarmauri_metric_hamming = { workspace = true }
+swarmauri_core = { workspace = true }
+swarmauri_base = { workspace = true }
+
+[tool.pytest.ini_options]
+norecursedirs = ["combined", "scripts"]
+markers = [
+    "test: standard test",
+    "unit: Unit tests",
+    "i9n: Integration tests",
+    "r8n: Regression tests",
+    "timeout: mark test to timeout after X seconds",
+    "xpass: Expected passes",
+    "xfail: Expected failures",
+    "acceptance: Acceptance tests",
+    "perf: Performance tests that measure execution time and resource usage",
+]
+timeout = 300
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
+
+[project.entry-points.'swarmauri.matrices']
+Hamming74Matrix = "swarmauri_matrix_hamming74.Hamming74Matrix:Hamming74Matrix"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "python-dotenv",
+    "requests>=2.32.3",
+    "flake8>=7.0",
+    "pytest-timeout>=2.3.1",
+    "ruff>=0.9.9",
+    "pytest-benchmark>=4.0.0",
+]

--- a/pkgs/community/swarmauri_matrix_hamming74/swarmauri_matrix_hamming74/Hamming74Matrix.py
+++ b/pkgs/community/swarmauri_matrix_hamming74/swarmauri_matrix_hamming74/Hamming74Matrix.py
@@ -1,0 +1,191 @@
+"""MatrixBase implementation for the binary Hamming (7,4) code."""
+
+from __future__ import annotations
+
+from itertools import product
+from typing import Iterator, List, Literal, Optional, Sequence, Tuple, Union
+
+import numpy as np
+from swarmauri_base.ComponentBase import ComponentBase
+from swarmauri_base.matrices.MatrixBase import MatrixBase
+from swarmauri_core.matrices.IMatrix import IMatrix
+from swarmauri_core.metrics.IMetric import MetricInput
+
+from swarmauri_metric_hamming import HammingMetric
+
+BinaryLike = Union[
+    "Hamming74Matrix",
+    IMatrix,
+    Sequence[Sequence[int]],
+    Sequence[int],
+    np.ndarray,
+    int,
+]
+
+_DEFAULT_MATRIX = np.array(
+    [
+        [1, 0, 0, 0, 1, 1, 0],
+        [0, 1, 0, 0, 1, 0, 1],
+        [0, 0, 1, 0, 0, 1, 1],
+        [0, 0, 0, 1, 1, 1, 1],
+    ],
+    dtype=int,
+)
+
+_PARITY_CHECK = np.array(
+    [
+        [1, 1, 0, 1, 1, 0, 0],
+        [1, 0, 1, 1, 0, 1, 0],
+        [0, 1, 1, 1, 0, 0, 1],
+    ],
+    dtype=int,
+)
+
+
+@ComponentBase.register_type(MatrixBase, "Hamming74Matrix")
+class Hamming74Matrix(MatrixBase):
+    """Concrete matrix that models the Hamming (7,4) linear block code."""
+
+    type: Literal["Hamming74Matrix"] = "Hamming74Matrix"
+
+    def __init__(self, data: Optional[Sequence[Sequence[int]]] = None) -> None:
+        source = _DEFAULT_MATRIX if data is None else np.array(data, dtype=int)
+        if source.ndim != 2:
+            raise ValueError("Hamming74Matrix requires a 2D array of integers")
+        self._data = np.mod(source, 2)
+        self._metric = HammingMetric()
+
+    # ------------------------------------------------------------------
+    # MatrixBase protocol implementation
+    # ------------------------------------------------------------------
+    def __getitem__(self, key):
+        return self._data[key]
+
+    def __setitem__(self, key, value):
+        self._data[key] = np.mod(value, 2)
+
+    @property
+    def shape(self) -> Tuple[int, int]:
+        return tuple(self._data.shape)
+
+    def reshape(self, shape: Tuple[int, int]) -> "Hamming74Matrix":
+        return Hamming74Matrix(self._data.reshape(shape))
+
+    @property
+    def dtype(self) -> type:
+        return self._data.dtype.type
+
+    def tolist(self) -> List[List[int]]:
+        return self._data.tolist()
+
+    def row(self, index: int) -> np.ndarray:
+        return self._data[index, :].copy()
+
+    def column(self, index: int) -> np.ndarray:
+        return self._data[:, index].copy()
+
+    def _coerce(self, other: BinaryLike) -> np.ndarray:
+        if isinstance(other, Hamming74Matrix):
+            return other._data
+        if isinstance(other, np.ndarray):
+            return np.mod(other, 2)
+        if isinstance(other, IMatrix):
+            return np.mod(np.array(other.tolist(), dtype=int), 2)
+        if isinstance(other, Sequence):
+            return np.mod(np.array(other, dtype=int), 2)
+        if isinstance(other, int):
+            return np.mod(np.full(self.shape, other, dtype=int), 2)
+        raise TypeError(f"Unsupported operand type: {type(other)!r}")
+
+    def __add__(self, other: BinaryLike) -> "Hamming74Matrix":
+        return Hamming74Matrix((self._data + self._coerce(other)) % 2)
+
+    def __sub__(self, other: BinaryLike) -> "Hamming74Matrix":
+        return Hamming74Matrix((self._data - self._coerce(other)) % 2)
+
+    def __mul__(self, other: BinaryLike) -> "Hamming74Matrix":
+        return Hamming74Matrix((self._data * self._coerce(other)) % 2)
+
+    def __matmul__(self, other: Union[BinaryLike, np.ndarray]) -> "Hamming74Matrix":
+        matrix = self._coerce(other)
+        if self.shape[1] != matrix.shape[0]:
+            raise ValueError("Matrix dimensions do not align for multiplication")
+        return Hamming74Matrix(np.mod(self._data @ matrix, 2))
+
+    def __truediv__(self, other: BinaryLike) -> "Hamming74Matrix":
+        raise NotImplementedError("Division is undefined in GF(2)")
+
+    def __neg__(self) -> "Hamming74Matrix":
+        return Hamming74Matrix(self._data.copy())
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, (Hamming74Matrix, np.ndarray, Sequence)):
+            return False
+        return np.array_equal(self._data, self._coerce(other))
+
+    def __iter__(self) -> Iterator[np.ndarray]:
+        for row in self._data:
+            yield row.copy()
+
+    def transpose(self) -> "Hamming74Matrix":
+        return Hamming74Matrix(self._data.T)
+
+    def __array__(self) -> np.ndarray:  # pragma: no cover - numpy protocol helper
+        return np.array(self._data, copy=True)
+
+    # ------------------------------------------------------------------
+    # Hamming code helpers
+    # ------------------------------------------------------------------
+    @property
+    def generator_matrix(self) -> np.ndarray:
+        """Return the 4x7 generator matrix G."""
+
+        return self._data.copy()
+
+    @property
+    def parity_check_matrix(self) -> np.ndarray:
+        """Return the 3x7 parity-check matrix H."""
+
+        return _PARITY_CHECK.copy()
+
+    def encode(self, message: Sequence[int]) -> List[int]:
+        bits = np.mod(np.array(message, dtype=int), 2)
+        if bits.size != 4:
+            raise ValueError("Hamming (7,4) encoding expects exactly 4 message bits")
+        codeword = np.mod(bits @ self._data, 2)
+        return codeword.astype(int).tolist()
+
+    def syndrome(self, word: Sequence[int]) -> List[int]:
+        bits = np.mod(np.array(word, dtype=int), 2)
+        if bits.size != 7:
+            raise ValueError("Syndrome calculation expects a 7-bit codeword")
+        result = np.mod(self.parity_check_matrix @ bits, 2)
+        return result.astype(int).tolist()
+
+    def codewords(self) -> List[List[int]]:
+        return [self.encode(message) for message in product([0, 1], repeat=4)]
+
+    def _normalise_vector(self, word: MetricInput) -> np.ndarray:
+        normalised = np.array(self._metric.normalise(word), dtype=int)
+        return np.mod(normalised, 2)
+
+    def nearest_codeword(self, word: MetricInput) -> List[int]:
+        candidate = self._normalise_vector(word)
+        if candidate.size != 7:
+            raise ValueError("Nearest codeword search expects 7-bit inputs")
+        codebook = self.codewords()
+        distances = [
+            self._metric.distance(candidate.tolist(), codeword) for codeword in codebook
+        ]
+        index = int(np.argmin(distances))
+        return codebook[index]
+
+    def decode(self, word: MetricInput) -> Tuple[List[int], List[int]]:
+        """Decode a noisy 7-bit sequence into ``(message, codeword)``."""
+
+        nearest = self.nearest_codeword(word)
+        message = nearest[:4]
+        return message, nearest
+
+
+__all__ = ["Hamming74Matrix"]

--- a/pkgs/community/swarmauri_matrix_hamming74/swarmauri_matrix_hamming74/__init__.py
+++ b/pkgs/community/swarmauri_matrix_hamming74/swarmauri_matrix_hamming74/__init__.py
@@ -1,0 +1,5 @@
+"""Community package exposing a Hamming (7,4) matrix implementation."""
+
+from .Hamming74Matrix import Hamming74Matrix
+
+__all__ = ["Hamming74Matrix"]

--- a/pkgs/community/swarmauri_matrix_hamming74/tests/test_hamming74_matrix.py
+++ b/pkgs/community/swarmauri_matrix_hamming74/tests/test_hamming74_matrix.py
@@ -1,0 +1,66 @@
+import numpy as np
+import pytest
+
+from swarmauri_matrix_hamming74 import Hamming74Matrix
+
+
+def test_default_shape_and_generator_matrix():
+    matrix = Hamming74Matrix()
+    assert matrix.shape == (4, 7)
+    expected_generator = np.array(
+        [
+            [1, 0, 0, 0, 1, 1, 0],
+            [0, 1, 0, 0, 1, 0, 1],
+            [0, 0, 1, 0, 0, 1, 1],
+            [0, 0, 0, 1, 1, 1, 1],
+        ],
+        dtype=int,
+    )
+    np.testing.assert_array_equal(matrix.generator_matrix, expected_generator)
+
+
+def test_encode_and_syndrome_detection():
+    matrix = Hamming74Matrix()
+    message = [1, 0, 1, 1]
+    codeword = matrix.encode(message)
+    assert codeword == [1, 0, 1, 1, 0, 1, 0]
+
+    errored = codeword.copy()
+    errored[4] ^= 1
+    assert matrix.syndrome(errored) == [1, 0, 0]
+
+
+def test_nearest_codeword_corrects_single_error():
+    matrix = Hamming74Matrix()
+    codeword = matrix.encode([0, 1, 1, 0])
+    errored = codeword.copy()
+    errored[2] ^= 1
+    assert matrix.nearest_codeword(errored) == codeword
+
+
+def test_decode_returns_message_and_codeword():
+    matrix = Hamming74Matrix()
+    codeword = matrix.encode([1, 1, 0, 0])
+    errored = codeword.copy()
+    errored[6] ^= 1
+    message, corrected = matrix.decode(errored)
+    assert message == [1, 1, 0, 0]
+    assert corrected == codeword
+
+
+def test_matrix_arithmetic_respects_binary_field():
+    matrix = Hamming74Matrix()
+    ones = np.ones_like(matrix.generator_matrix)
+    complemented = matrix + 1
+    np.testing.assert_array_equal(
+        np.mod(matrix.generator_matrix + ones, 2), complemented.generator_matrix
+    )
+
+    product = matrix @ matrix.transpose()
+    assert product.shape == (4, 4)
+
+
+def test_nearest_codeword_requires_seven_bits():
+    matrix = Hamming74Matrix()
+    with pytest.raises(ValueError):
+        matrix.nearest_codeword([1, 0, 1])

--- a/pkgs/community/swarmauri_metric_hamming/LICENSE
+++ b/pkgs/community/swarmauri_metric_hamming/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/community/swarmauri_metric_hamming/README.md
+++ b/pkgs/community/swarmauri_metric_hamming/README.md
@@ -1,0 +1,68 @@
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_metric_hamming/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_metric_hamming" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/community/swarmauri_metric_hamming/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/community/swarmauri_metric_hamming.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_metric_hamming/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_metric_hamming" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_metric_hamming/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_metric_hamming" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_metric_hamming/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_metric_hamming?label=swarmauri_metric_hamming&color=green" alt="PyPI - swarmauri_metric_hamming"/></a>
+</p>
+
+---
+
+# Swarmauri Metric Hamming
+
+The `swarmauri_metric_hamming` package delivers a production-ready implementation of the Hamming distance that integrates seamlessly with the Swarmauri metric ecosystem. It extends `MetricBase` with binary vector validation, pairwise distance calculations, and axiom verification utilities designed for error-correcting code workflows.
+
+## Features
+
+- ✅ Fully compliant `MetricBase` implementation for binary sequences.
+- 🔁 Pairwise and batched distance calculations for matrices, vectors, and iterables.
+- 🧪 Built-in validation helpers for metric axioms and input compatibility checks.
+- 🧰 Utility conversion helpers for strings, dictionaries, NumPy arrays, and Swarmauri matrices/vectors.
+
+## Installation
+
+### Using `uv`
+
+```bash
+uv pip install swarmauri_metric_hamming
+```
+
+### Using `pip`
+
+```bash
+pip install swarmauri_metric_hamming
+```
+
+## Usage
+
+```python
+from swarmauri_metric_hamming import HammingMetric
+
+metric = HammingMetric()
+
+codeword = [1, 0, 1, 1, 0, 0, 1]
+received = [1, 1, 1, 1, 0, 0, 1]
+
+# Compute the Hamming distance between two binary vectors
+print(metric.distance(codeword, received))  # 1.0
+
+# Verify the metric axioms for the provided inputs
+assert metric.check_symmetry(codeword, received)
+assert metric.check_triangle_inequality(codeword, received, codeword)
+```
+
+## Support
+
+- Python 3.10, 3.11, and 3.12
+- Licensed under the Apache-2.0 license
+
+## Contributing
+
+We welcome contributions! Please submit issues and pull requests through the [Swarmauri SDK GitHub repository](https://github.com/swarmauri/swarmauri-sdk).

--- a/pkgs/community/swarmauri_metric_hamming/pyproject.toml
+++ b/pkgs/community/swarmauri_metric_hamming/pyproject.toml
@@ -1,0 +1,77 @@
+[project]
+name = "swarmauri_metric_hamming"
+version = "0.9.0.dev8"
+description = "Swarmauri Hamming distance metric community package."
+license = "Apache-2.0"
+readme = "README.md"
+repository = "http://github.com/swarmauri/swarmauri-sdk"
+requires-python = ">=3.10,<3.13"
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
+]
+authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
+dependencies = [
+    "numpy>=1.26",
+    "swarmauri_core",
+    "swarmauri_base",
+]
+keywords = [
+    "swarmauri",
+    "metric",
+    "hamming",
+    "distance",
+    "community",
+    "package",
+]
+
+[tool.uv.sources]
+swarmauri_core = { workspace = true }
+swarmauri_base = { workspace = true }
+
+[tool.pytest.ini_options]
+norecursedirs = ["combined", "scripts"]
+markers = [
+    "test: standard test",
+    "unit: Unit tests",
+    "i9n: Integration tests",
+    "r8n: Regression tests",
+    "timeout: mark test to timeout after X seconds",
+    "xpass: Expected passes",
+    "xfail: Expected failures",
+    "acceptance: Acceptance tests",
+    "perf: Performance tests that measure execution time and resource usage",
+]
+timeout = 300
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
+
+[project.entry-points.'swarmauri.metrics']
+HammingMetric = "swarmauri_metric_hamming.HammingMetric:HammingMetric"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "python-dotenv",
+    "requests>=2.32.3",
+    "flake8>=7.0",
+    "pytest-timeout>=2.3.1",
+    "ruff>=0.9.9",
+    "pytest-benchmark>=4.0.0",
+]

--- a/pkgs/community/swarmauri_metric_hamming/swarmauri_metric_hamming/HammingMetric.py
+++ b/pkgs/community/swarmauri_metric_hamming/swarmauri_metric_hamming/HammingMetric.py
@@ -1,0 +1,157 @@
+"""Implementation of the classic Hamming distance for Swarmauri metrics."""
+
+from __future__ import annotations
+
+from typing import List, Literal, Sequence, Tuple, Union, cast
+
+import numpy as np
+from swarmauri_base.ComponentBase import ComponentBase
+from swarmauri_base.metrics.MetricBase import MetricBase
+from swarmauri_core.matrices.IMatrix import IMatrix
+from swarmauri_core.metrics.IMetric import MetricInput, MetricInputCollection
+from swarmauri_core.vectors.IVector import IVector
+
+
+def _is_scalar_sequence(value: Sequence[object]) -> bool:
+    """Return ``True`` if *value* behaves like a single metric input."""
+
+    if isinstance(value, (str, bytes)):
+        return True
+
+    if not value:
+        return True
+
+    first = value[0]
+    return not isinstance(first, (Sequence, dict, np.ndarray)) or isinstance(
+        first, (str, bytes)
+    )
+
+
+def _flatten_once(value: Sequence[object]) -> List[object]:
+    """Flatten a sequence by one dimension."""
+
+    flattened: List[object] = []
+    for item in value:
+        if isinstance(item, Sequence) and not isinstance(item, (str, bytes)):
+            flattened.extend(list(item))
+        else:
+            flattened.append(item)
+    return flattened
+
+
+@ComponentBase.register_type(MetricBase, "HammingMetric")
+class HammingMetric(MetricBase):
+    """Concrete implementation of the Hamming distance."""
+
+    type: Literal["HammingMetric"] = "HammingMetric"
+
+    def _normalise_single(self, value: MetricInput) -> List[object]:
+        """Convert a ``MetricInput`` into a one-dimensional Python list."""
+
+        if isinstance(value, (int, float)):
+            return [value]
+
+        if isinstance(value, (str, bytes)):
+            return list(value.decode() if isinstance(value, bytes) else value)
+
+        if isinstance(value, dict):
+            return list(value.values())
+
+        if isinstance(value, np.ndarray):
+            return value.flatten().tolist()
+
+        if isinstance(value, IMatrix):
+            return _flatten_once(cast(Sequence[object], value.tolist()))
+
+        if isinstance(value, IVector):
+            if hasattr(value, "tolist"):
+                result = cast(Sequence[object], value.tolist())
+                return (
+                    list(result)
+                    if _is_scalar_sequence(result)
+                    else _flatten_once(result)
+                )
+            return list(value)  # type: ignore[arg-type]
+
+        if hasattr(value, "tolist"):
+            as_list = cast(Sequence[object], value.tolist())
+            return (
+                list(as_list)
+                if _is_scalar_sequence(as_list)
+                else _flatten_once(as_list)
+            )
+
+        if isinstance(value, Sequence):
+            return list(value) if _is_scalar_sequence(value) else _flatten_once(value)
+
+        raise TypeError(f"Unsupported metric input type: {type(value)!r}")
+
+    def _normalise_collection(
+        self, values: Union[MetricInput, MetricInputCollection]
+    ) -> List[List[object]]:
+        """Normalise a metric input or collection into a list of vectors."""
+
+        if isinstance(values, np.ndarray) and values.ndim > 1:
+            return [row.flatten().tolist() for row in values]
+
+        if isinstance(values, Sequence) and not isinstance(values, (str, bytes)):
+            if values and not _is_scalar_sequence(values):
+                return [self._normalise_single(item) for item in values]  # type: ignore[arg-type]
+
+        return [self._normalise_single(cast(MetricInput, values))]
+
+    def normalise(self, value: MetricInput) -> List[object]:
+        """Expose the internal normalisation logic for downstream components."""
+
+        return self._normalise_single(value)
+
+    def _validate_pair(
+        self, x: List[object], y: List[object]
+    ) -> Tuple[List[object], List[object]]:
+        if len(x) != len(y):
+            raise ValueError("Hamming distance requires inputs of equal length")
+        return x, y
+
+    def distance(self, x: MetricInput, y: MetricInput) -> float:
+        left, right = self._validate_pair(
+            self._normalise_single(x), self._normalise_single(y)
+        )
+        return float(sum(1 for a, b in zip(left, right) if a != b))
+
+    def distances(
+        self,
+        x: Union[MetricInput, MetricInputCollection],
+        y: Union[MetricInput, MetricInputCollection],
+    ) -> Union[List[float], List[List[float]]]:
+        left_vectors = self._normalise_collection(x)
+        right_vectors = self._normalise_collection(y)
+
+        if len(left_vectors) == 1 and len(right_vectors) == 1:
+            return [self.distance(left_vectors[0], right_vectors[0])]  # type: ignore[arg-type]
+
+        results: List[List[float]] = []
+        for left in left_vectors:
+            row: List[float] = []
+            for right in right_vectors:
+                row.append(self.distance(left, right))  # type: ignore[arg-type]
+            results.append(row)
+        return results
+
+    def check_non_negativity(self, x: MetricInput, y: MetricInput) -> bool:
+        return self.distance(x, y) >= 0
+
+    def check_identity_of_indiscernibles(self, x: MetricInput, y: MetricInput) -> bool:
+        left, right = self._normalise_single(x), self._normalise_single(y)
+        distance = self.distance(left, right)
+        return distance == 0 if left == right else distance > 0
+
+    def check_symmetry(self, x: MetricInput, y: MetricInput) -> bool:
+        return self.distance(x, y) == self.distance(y, x)
+
+    def check_triangle_inequality(
+        self, x: MetricInput, y: MetricInput, z: MetricInput
+    ) -> bool:
+        return self.distance(x, z) <= self.distance(x, y) + self.distance(y, z)
+
+
+__all__ = ["HammingMetric"]

--- a/pkgs/community/swarmauri_metric_hamming/swarmauri_metric_hamming/__init__.py
+++ b/pkgs/community/swarmauri_metric_hamming/swarmauri_metric_hamming/__init__.py
@@ -1,0 +1,5 @@
+"""Community package providing a Hamming distance metric for Swarmauri."""
+
+from .HammingMetric import HammingMetric
+
+__all__ = ["HammingMetric"]

--- a/pkgs/community/swarmauri_metric_hamming/tests/test_hamming_metric.py
+++ b/pkgs/community/swarmauri_metric_hamming/tests/test_hamming_metric.py
@@ -1,0 +1,41 @@
+import numpy as np
+import pytest
+
+from swarmauri_metric_hamming import HammingMetric
+
+
+def test_distance_between_binary_vectors():
+    metric = HammingMetric()
+    assert metric.distance([1, 0, 1, 1], [1, 1, 0, 1]) == pytest.approx(2.0)
+
+
+def test_distance_with_strings_and_numpy_arrays():
+    metric = HammingMetric()
+    left = "1011001"
+    right = np.array([1, 0, 1, 0, 0, 0, 1])
+    assert metric.distance(left, right) == pytest.approx(2.0)
+
+
+def test_distances_supports_collections():
+    metric = HammingMetric()
+    left = [[0, 0, 0], [1, 1, 1]]
+    right = [[0, 0, 1], [1, 0, 1]]
+    distances = metric.distances(left, right)
+    assert distances == [[1.0, 2.0], [2.0, 1.0]]
+
+
+def test_metric_axioms_hold_for_valid_inputs():
+    metric = HammingMetric()
+    x = [0, 1, 0, 1]
+    y = [0, 0, 1, 1]
+    z = [1, 0, 1, 0]
+
+    assert metric.check_non_negativity(x, y)
+    assert metric.check_symmetry(x, y)
+    assert metric.check_triangle_inequality(x, y, z)
+
+
+def test_distance_requires_equal_length_inputs():
+    metric = HammingMetric()
+    with pytest.raises(ValueError):
+        metric.distance([1, 0, 1], [1, 0])

--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -224,6 +224,8 @@ members = [
     "community/swarmauri_parser_pypdftk",
     "community/swarmauri_measurement_mutualinformation",
     "community/swarmauri_measurement_tokencountestimator",
+    "community/swarmauri_metric_hamming",
+    "community/swarmauri_matrix_hamming74",
     "community/swarmauri_ocr_pytesseract",
     "community/swarmauri_tests_griffe",
     "community/swarmauri_embedding_mlm",
@@ -413,6 +415,8 @@ swarmauri_parser_pypdf2 = { workspace = true }
 swarmauri_parser_pypdftk = { workspace = true }
 swarmauri_measurement_mutualinformation = { workspace = true }
 swarmauri_measurement_tokencountestimator = { workspace = true }
+swarmauri_metric_hamming = { workspace = true }
+swarmauri_matrix_hamming74 = { workspace = true }
 swarmauri_ocr_pytesseract = { workspace = true }
 swarmauri_tests_griffe = { workspace = true }
 swarmauri_embedding_mlm = { workspace = true }


### PR DESCRIPTION
## Summary
- add the `swarmauri_metric_hamming` package that implements a MetricBase-compliant Hamming distance with documentation and unit tests
- add the `swarmauri_matrix_hamming74` package providing a MatrixBase implementation with encoding/decoding helpers backed by the Hamming metric plus tests and docs
- register both packages in the workspace configuration so they participate in uv workflows

## Testing
- `uv run --directory pkgs/community/swarmauri_metric_hamming --package swarmauri_metric_hamming ruff format .`
- `uv run --directory pkgs/community/swarmauri_metric_hamming --package swarmauri_metric_hamming ruff check . --fix`
- `uv run --directory pkgs/community/swarmauri_matrix_hamming74 --package swarmauri_matrix_hamming74 ruff format .`
- `uv run --directory pkgs/community/swarmauri_matrix_hamming74 --package swarmauri_matrix_hamming74 ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68e27e90115c8326bab44b494c49be2d