### PR TITLE
Align wcag_pdf_pytest metadata and docs with monorepo standards

### DIFF
--- a/pkgs/experimental/wcag_pdf_pytest/LICENSE
+++ b/pkgs/experimental/wcag_pdf_pytest/LICENSE
@@ -1,5 +1,201 @@
-Apache License
-Version 2.0, January 2004
-http://www.apache.org/licenses/LICENSE-2.0
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-This project is licensed under Apache-2.0. See the URL above for the full license text.
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/experimental/wcag_pdf_pytest/README.md
+++ b/pkgs/experimental/wcag_pdf_pytest/README.md
@@ -1,55 +1,94 @@
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+
+<p align="center">
+    <a href="https://pypi.org/project/wcag-pdf-pytest/">
+        <img src="https://img.shields.io/pypi/dm/wcag-pdf-pytest" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/experimental/wcag_pdf_pytest/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/experimental/wcag_pdf_pytest.svg"/></a>
+    <a href="https://pypi.org/project/wcag-pdf-pytest/">
+        <img src="https://img.shields.io/pypi/pyversions/wcag-pdf-pytest" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/wcag-pdf-pytest/">
+        <img src="https://img.shields.io/pypi/l/wcag-pdf-pytest" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/wcag-pdf-pytest/">
+        <img src="https://img.shields.io/pypi/v/wcag-pdf-pytest?label=wcag-pdf-pytest&color=green" alt="PyPI - wcag-pdf-pytest"/></a>
+</p>
+
+---
+
 # wcag-pdf-pytest
 
-**Pytest plugin** for structuring WCAG 2.1 **A / AA / AAA** compliance checks against **PDF** documents.
+`wcag-pdf-pytest` is a [pytest](https://docs.pytest.org/) plugin that scaffolds WCAG 2.1
+compliance testing for PDF documents. The plugin auto-generates one test per WCAG 2.1
+Success Criterion (SC) that applies to PDFs, organizes them by conformance level, and
+exposes CLI switches for narrowing execution to the criteria relevant to your review.
 
-> Ships **one test file per WCAG 2.1 Success Criterion** relevant to PDFs (the "PDF_Rules_Filtered" set). Each test is pre-marked with its **Level** and includes metadata in a docstring.
+## Features
+- **SC-aware test generation** &mdash; each applicable WCAG 2.1 SC ships as an individual pytest
+  module with structured docstrings that document the requirement.
+- **Level-based selection** &mdash; mark sets (`A`, `AA`, `AAA`) and CLI flags allow you to focus on
+  the conformance tier under audit.
+- **Context-aware filtering** &mdash; opt-in inclusion of "Depends" criteria lets you decide when
+  to execute context-sensitive checks.
+- **Extensible PDF inspection** &mdash; centralize heavy lifting in `pdf_inspector.py` so new
+  assertions or document parsers can be layered in without touching the generated tests.
 
-## Install (uv + Poetry backend)
+## Installation
 
-This project uses a **uv-based pyproject.toml** with a **Poetry build backend**. There is **no uv.toml**; uv reads configuration and dev-dependencies from `pyproject.toml`.
+### pip
 
 ```bash
-uv venv -p 3.11
-source .venv/bin/activate
-uv pip install -e .[pdf]
+pip install wcag-pdf-pytest[pdf]
 ```
 
-Or with Poetry:
+### uv
 
 ```bash
-poetry install -E pdf
-poetry run pytest -m "AA" --wcag-pdf path/to/file.pdf
+uv add wcag-pdf-pytest[pdf]
 ```
+
+Install the optional `pdf` extra when you need the bundled `pypdf` helpers.
 
 ## Usage
 
-Run all generated WCAG 2.1 tests:
+Run the full WCAG 2.1 test suite against a PDF document:
 
 ```bash
 pytest --wcag-pdf path/to/file.pdf
 ```
 
-Run only **AA** criteria:
+Execute only Level AA criteria using pytest markers:
 
 ```bash
 pytest -m "AA" --wcag-pdf path/to/file.pdf
-# or
-pytest --wcag-pdf-level AA --wcag-pdf path/to/file.pdf
 ```
 
-Include context-dependent criteria (**Depends**):
+The plugin also exposes explicit CLI options:
 
 ```bash
+pytest --wcag-pdf-level AA --wcag-pdf path/to/file.pdf
 pytest --wcag-pdf-include-depends --wcag-pdf path/to/file.pdf
 ```
 
-### CLI namespace
-The plugin's options are prefixed with `--wcag-pdf-*` to avoid collisions with other pytest plugins.
+Tests are namespaced under the `wcag21` marker to keep discovery isolated from other pytest
+plugins. Each test is seeded with an `xfail` placeholder so you can progressively
+replace the stub assertion with a concrete PDF accessibility check.
 
-### Notes
-- Tests currently `xfail` as **"Implementation pending"**; next steps will add real PDF checks.
-- Centralize real checks in `wcag_pdf_pytest/pdf_inspector.py`.
+## CLI reference
+
+| Option | Description |
+| --- | --- |
+| `--wcag-pdf` | Path to one or more PDF files to validate. |
+| `--wcag-pdf-level {A,AA,AAA}` | Restrict execution to a specific WCAG level. |
+| `--wcag-pdf-include-depends` | Execute context-dependent criteria flagged as "Depends". |
+
+Combine CLI switches with pytest marker expressions for granular selection during CI runs.
+
+## Extending PDF checks
+
+Extend `wcag_pdf_pytest/pdf_inspector.py` with reusable utilities that evaluate
+individual criteria. Generated tests should stay declarative &mdash; import helpers from the
+inspector module to keep assertions maintainable and consistent across the suite.
 
 ## License
 
-Apache-2.0. See [LICENSE](LICENSE).
+Apache License 2.0. See [LICENSE](LICENSE) for details.

--- a/pkgs/experimental/wcag_pdf_pytest/pyproject.toml
+++ b/pkgs/experimental/wcag_pdf_pytest/pyproject.toml
@@ -2,49 +2,67 @@
 requires = ["poetry-core>=1.9.0"]
 build-backend = "poetry.core.masonry.api"
 
-[tool.poetry]
+[project]
 name = "wcag-pdf-pytest"
 version = "0.2.0"
-description = "Pytest plugin for WCAG 2.1 A/AA/AAA compliance checks on PDFs; ships one test per SC applicable to PDFs."
-authors = ["Example Org <dev@example.org>"]
-license = "Apache-2.0"
+description = "Pytest plugin for WCAG 2.1 A/AA/AAA compliance checks on PDFs."
 readme = "README.md"
-packages = [{ include = "wcag_pdf_pytest", from = "src" }]
-keywords = ["pytest", "wcag", "accessibility", "pdf", "wcag2.1"]
+license = "Apache-2.0"
+authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
+requires-python = ">=3.10,<3.13"
+keywords = [
+    "pytest",
+    "wcag",
+    "accessibility",
+    "pdf",
+    "wcag2.1",
+    "pdf-accessibility",
+    "compliance",
+    "testing",
+]
 classifiers = [
-  "Framework :: Pytest",
-  "License :: OSI Approved :: Apache Software License",
-  "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3 :: Only",
-  "Operating System :: OS Independent"
+    "Development Status :: 1 - Planning",
+    "Framework :: Pytest",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Operating System :: OS Independent",
+    "Topic :: Software Development :: Testing",
+]
+dependencies = [
+    "pytest>=8.2",
 ]
 
-[tool.poetry.dependencies]
-python = ">=3.9,<3.13"
-pytest = ">=8.2"
-pypdf = {version = ">=3.17", optional = true}
+[project.optional-dependencies]
+pdf = ["pypdf>=3.17"]
 
-[tool.poetry.extras]
-pdf = ["pypdf"]
-
-[tool.poetry.plugins."pytest11"]
+[project.entry-points."pytest11"]
 wcag_pdf = "wcag_pdf_pytest.plugin"
 
-[tool.pytest.ini_options]
-testpaths = ["src/wcag_pdf_pytest/criteria"]
-addopts = "-q"
-markers = [
-  "A: WCAG 2.1 Level A criteria.",
-  "AA: WCAG 2.1 Level AA criteria.",
-  "AAA: WCAG 2.1 Level AAA criteria.",
-  "wcag21: All WCAG 2.1 criteria generated from the spreadsheet."
+[project.urls]
+Homepage = "https://github.com/swarmauri/swarmauri-sdk"
+Source = "https://github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/experimental/wcag_pdf_pytest"
+Documentation = "https://github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/experimental/wcag_pdf_pytest#readme"
+Issues = "https://github.com/swarmauri/swarmauri-sdk/issues"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.2",
+    "ruff>=0.6.0",
 ]
 
-# uv reads configuration from pyproject.toml (no uv.toml used)
-[tool.uv]
-dev-dependencies = [
-  "pytest>=8.2",
-  "ruff>=0.6.0"
+[tool.pytest.ini_options]
+testpaths = ["wcag_pdf_pytest/criteria"]
+addopts = "-q"
+markers = [
+    "A: WCAG 2.1 Level A criteria.",
+    "AA: WCAG 2.1 Level AA criteria.",
+    "AAA: WCAG 2.1 Level AAA criteria.",
+    "wcag21: All WCAG 2.1 criteria generated from the spreadsheet.",
 ]
 
 [tool.ruff]
@@ -53,4 +71,8 @@ line-length = 100
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B"]
-fix = true
+
+[tool.poetry]
+packages = [
+    { include = "wcag_pdf_pytest" },
+]


### PR DESCRIPTION
## Summary
- update the wcag_pdf_pytest pyproject to use the repository-standard metadata, classifiers, optional dependencies, and pytest configuration
- refresh the README with Swarmauri branding, badges, feature overview, installation, usage, and extension guidance
- replace the abbreviated license stub with the full Apache 2.0 license text

## Testing
- ✅ `uv run --directory experimental/wcag_pdf_pytest --package wcag-pdf-pytest ruff format .`
- ❌ `uv run --directory experimental/wcag_pdf_pytest --package wcag-pdf-pytest ruff check . --fix` *(fails because of pre-existing lint violations in wcag_pdf_pytest/pdf_inspector.py)*

------
https://chatgpt.com/codex/tasks/task_e_68e288b97d6c832683f943ef79ab7412