### PR TITLE
Restore UDP transport mixin inheritance

### DIFF
--- a/pkgs/standards/swarmauri_transport_udp/pyproject.toml
+++ b/pkgs/standards/swarmauri_transport_udp/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
+    "swarmauri_base",
     "swarmauri_core",
 ]
 keywords = [
@@ -31,6 +32,7 @@ keywords = [
 ]
 
 [tool.uv.sources]
+swarmauri_base = { workspace = true }
 swarmauri_core = { workspace = true }
 
 [build-system]

--- a/pkgs/standards/swarmauri_transport_udp/swarmauri_transport_udp/udp_transport.py
+++ b/pkgs/standards/swarmauri_transport_udp/swarmauri_transport_udp/udp_transport.py
@@ -6,18 +6,20 @@ import asyncio
 import socket
 from typing import Optional, Sequence
 
-from swarmauri_core.transports import (
-    AddressScheme,
+from swarmauri_base.transports import (
     AnycastTransportMixin,
     BroadcastTransportMixin,
+    MulticastTransportMixin,
+    TransportBase,
+    UnicastTransportMixin,
+)
+from swarmauri_core.transports.capabilities import TransportCapabilities
+from swarmauri_core.transports.enums import (
+    AddressScheme,
     Cast,
     IOModel,
-    MulticastTransportMixin,
     Protocol,
     SecurityMode,
-    TransportBase,
-    TransportCapabilities,
-    UnicastTransportMixin,
 )
 
 


### PR DESCRIPTION
## Summary
- update the UDP transport to inherit the Swarmauri mixins instead of the interfaces
- refresh the transport imports to use swarmauri_base mixins alongside the existing capability and enum definitions

## Testing
- uv run --package swarmauri_transport_udp --directory standards/swarmauri_transport_udp ruff format .
- uv run --package swarmauri_transport_udp --directory standards/swarmauri_transport_udp ruff check . --fix

------
https://chatgpt.com/codex/tasks/task_e_68e2add2e9308326baa1975c9d9025b4