### PR TITLE
Fix CSR challenge password test for cryptography API change

### DIFF
--- a/pkgs/community/swarmauri_certservice_scep/tests/unit/test_scepcertservice_rfc2986.py
+++ b/pkgs/community/swarmauri_certservice_scep/tests/unit/test_scepcertservice_rfc2986.py
@@ -32,5 +32,10 @@ async def test_create_csr_rfc2986() -> None:
     csr = x509.load_pem_x509_csr(csr_bytes)
     cn = csr.subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value
     assert cn == "example.com"
-    attr = csr.get_attribute_for_oid(x509.oid.AttributeOID.CHALLENGE_PASSWORD)
-    assert attr == b"pass"
+    challenge_attrs = [
+        attr.value
+        for attr in csr.attributes
+        if attr.oid == x509.oid.AttributeOID.CHALLENGE_PASSWORD
+    ]
+    assert challenge_attrs, "challenge password attribute should be present"
+    assert challenge_attrs[0] == b"pass"


### PR DESCRIPTION
## Summary
- update the RFC2986 unit test to look up the challenge password via the attributes API used by recent cryptography releases
- add a guard assertion so the test reports a missing challenge password more clearly

## Testing
- uv run --package swarmauri_certservice_scep --directory community/swarmauri_certservice_scep pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2aec7b9d48326be60ac98ff58fee4