### PR TITLE
Adopt mixin inheritance for TLS unicast transport

### DIFF
--- a/pkgs/standards/swarmauri_transport_tls_unicast/pyproject.toml
+++ b/pkgs/standards/swarmauri_transport_tls_unicast/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
+    "swarmauri-base",
     "swarmauri_core",
 ]
 keywords = [
@@ -32,6 +33,7 @@ keywords = [
 ]
 
 [tool.uv.sources]
+swarmauri-base = { workspace = true }
 swarmauri_core = { workspace = true }
 
 [build-system]


### PR DESCRIPTION
## Summary
- update `TlsUnicastTransport` to inherit the peer and unicast mixins instead of the raw interfaces

## Testing
- `uv run --package swarmauri_transport_tls_unicast --directory standards/swarmauri_transport_tls_unicast ruff format .`
- `uv run --package swarmauri_transport_tls_unicast --directory standards/swarmauri_transport_tls_unicast ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68e2adc7548083268323cc38b7d49ab7