### PR TITLE
Fix QUIC transport initialization without pydantic

### DIFF
--- a/pkgs/standards/swarmauri_transport_quic/pyproject.toml
+++ b/pkgs/standards/swarmauri_transport_quic/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
+    "swarmauri_base",
     "swarmauri_core",
 ]
 keywords = [
@@ -31,6 +32,7 @@ keywords = [
 ]
 
 [tool.uv.sources]
+swarmauri_base = { workspace = true }
 swarmauri_core = { workspace = true }
 
 [build-system]


### PR DESCRIPTION
## Summary
- replace the QUIC transport's pydantic PrivateAttr fields with native attribute initialization
- realign imports and declare the swarmauri_base dependency required for the transport implementation

## Testing
- uv run --package swarmauri_transport_quic --directory standards/swarmauri_transport_quic pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2c01beea883269ac9486126a21d05