### PR TITLE
Add AWS SigV4 signing package

### DIFF
--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -142,6 +142,7 @@ members = [
     "standards/swarmauri_signing_ed25519",
     "standards/swarmauri_signing_secp256k1",
     "standards/swarmauri_signing_hmac",
+    "standards/swarmauri_signing_sigv4",
     "standards/swarmauri_signing_ecdsa",
     "standards/swarmauri_signing_ca",
     "standards/swarmauri_signing_jws",
@@ -355,6 +356,7 @@ swarmauri_keyproviders_mirrored = { workspace = true }
 swarmauri_keyprovider_hierarchical = { workspace = true }
 swarmauri_keyprovider_inmemory = { workspace = true }
 swarmauri_signing_hmac = { workspace = true }
+swarmauri_signing_sigv4 = { workspace = true }
 swarmauri_signing_ecdsa = { workspace = true }
 swarmauri_signing_ca = { workspace = true }
 swarmauri_certs_remote_ca = { workspace = true }

--- a/pkgs/standards/swarmauri_signing_sigv4/LICENSE
+++ b/pkgs/standards/swarmauri_signing_sigv4/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/standards/swarmauri_signing_sigv4/README.md
+++ b/pkgs/standards/swarmauri_signing_sigv4/README.md
@@ -1,0 +1,103 @@
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+
+<p align="center">
+    <a href="https://pypi.org/project/swarmauri_signing_sigv4/">
+        <img src="https://img.shields.io/pypi/dm/swarmauri_signing_sigv4" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_signing_sigv4/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_signing_sigv4.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_signing_sigv4/">
+        <img src="https://img.shields.io/pypi/pyversions/swarmauri_signing_sigv4" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_signing_sigv4/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_signing_sigv4" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_signing_sigv4/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_signing_sigv4?label=swarmauri_signing_sigv4&color=green" alt="PyPI - swarmauri_signing_sigv4"/></a>
+</p>
+
+---
+
+# Swarmauri Signing SigV4
+
+AWS Signature Version 4 (SigV4) signer and verifier that implements the `ISigning` interface for HTTP requests and raw byte payloads.
+
+## Features
+
+- Canonicalizes HTTP request envelopes according to AWS SigV4 rules
+- Derives SigV4 signing keys from AWS credentials and scope information
+- Supports both request signing and raw payload HMAC generation/verification
+- Returns structured signature metadata (scope, signed headers, canonical hash) for downstream Authorization headers
+
+## Security Notes
+
+- Requires valid AWS-style credentials (`access_key`, `secret_key`, optional `session_token`)
+- Verification requires access to the shared secret material; compare signatures externally when AWS performs verification
+- Payload canonicalization expects callers to supply the appropriate SHA-256 hash or the `UNSIGNED-PAYLOAD` marker
+
+## Installation
+
+Install the package with your preferred Python packaging tool:
+
+```bash
+pip install swarmauri_signing_sigv4
+```
+
+```bash
+uv pip install swarmauri_signing_sigv4
+```
+
+```bash
+poetry add swarmauri_signing_sigv4
+```
+
+## Usage
+
+```python
+import asyncio
+from swarmauri_signing_sigv4 import SigV4Signing
+
+
+envelope = {
+    "method": "GET",
+    "uri": "/",
+    "query": {"Action": ["ListUsers"], "Version": ["2010-05-08"]},
+    "headers": {
+        "host": "iam.amazonaws.com",
+        "x-amz-date": "20150830T123600Z",
+        "content-type": "application/x-www-form-urlencoded; charset=utf-8",
+    },
+    "payload_hash": "UNSIGNED-PAYLOAD",
+    "amz_date": "20150830T123600Z",
+    "scope": {"date": "20150830", "region": "us-east-1", "service": "iam"},
+}
+
+key = {"access_key": "AKIDEXAMPLE", "secret_key": "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"}
+
+
+async def main() -> None:
+    signer = SigV4Signing()
+    signatures = await signer.sign_envelope(key, envelope)
+    print(signatures[0]["signature"])
+
+
+asyncio.run(main())
+```
+
+When verifying signatures you must provide the shared secret via `opts["secret_key"]` or `require["secret_key"]`.
+
+### Byte payload signing
+
+Use `sign_bytes` / `verify_bytes` when you only need a SigV4-derived HMAC:
+
+```python
+payload = b"example"
+opts = {"date": "20150830", "region": "us-east-1", "service": "iam"}
+signatures = await signer.sign_bytes(key, payload, opts=opts)
+assert await signer.verify_bytes(payload, signatures, opts={**opts, "secret_key": key["secret_key"]})
+```
+
+## Entry Point
+
+The signer registers under the `swarmauri.signings` entry point as `SigV4Signing`.
+
+## Want to help?
+
+If you want to contribute to swarmauri-sdk, read up on our [guidelines for contributing](https://github.com/swarmauri/swarmauri-sdk/blob/master/CONTRIBUTING.md) that will help you get started.

--- a/pkgs/standards/swarmauri_signing_sigv4/pyproject.toml
+++ b/pkgs/standards/swarmauri_signing_sigv4/pyproject.toml
@@ -1,0 +1,88 @@
+[project]
+name = "swarmauri_signing_sigv4"
+version = "0.1.0"
+description = "AWS Signature Version 4 signer for Swarmauri"
+license = "Apache-2.0"
+readme = "README.md"
+requires-python = ">=3.10,<3.13"
+authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
+keywords = [
+    "swarmauri",
+    "signing",
+    "aws",
+    "sigv4",
+    "http",
+    "hmac",
+    "sdk",
+    "standards",
+    "cryptography",
+    "message-integrity",
+    "request-signing",
+    "authorization",
+]
+classifiers = [
+    "Development Status :: 1 - Planning",
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3 :: Only",
+    "Topic :: Security :: Cryptography",
+    "Intended Audience :: Developers",
+]
+dependencies = [
+    "swarmauri_core",
+    "swarmauri_base",
+]
+
+[project.urls]
+Homepage = "https://github.com/swarmauri/swarmauri-sdk"
+Source = "https://github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_signing_sigv4"
+Documentation = "https://github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_signing_sigv4#readme"
+
+[tool.uv.sources]
+swarmauri_core = { workspace = true }
+swarmauri_base = { workspace = true }
+
+[tool.pytest.ini_options]
+norecursedirs = ["combined", "scripts"]
+markers = [
+    "test: standard test",
+    "unit: Unit tests",
+    "i9n: Integration tests",
+    "r8n: Regression tests",
+    "acceptance: Acceptance tests",
+    "perf: Performance tests",
+    "example: Documentation-backed usage examples",
+]
+timeout = 300
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "pytest-timeout>=2.3.1",
+    "pytest-benchmark>=4.0.0",
+    "flake8>=7.0",
+    "ruff>=0.9.9",
+]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[project.entry-points.'swarmauri.signings']
+SigV4Signing = "swarmauri_signing_sigv4:SigV4Signing"
+
+[project.entry-points."peagen.plugins.signings"]
+sigv4 = "swarmauri_signing_sigv4:SigV4Signing"

--- a/pkgs/standards/swarmauri_signing_sigv4/swarmauri_signing_sigv4/SigV4Signing.py
+++ b/pkgs/standards/swarmauri_signing_sigv4/swarmauri_signing_sigv4/SigV4Signing.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+import datetime
+import hashlib
+import hmac
+import urllib.parse
+from typing import Any, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+from pydantic import Field
+
+from swarmauri_base.signing.SigningBase import SigningBase
+from swarmauri_base.ComponentBase import ResourceTypes
+from swarmauri_core.crypto.types import Alg, KeyRef
+from swarmauri_core.signing.ISigning import Canon, Envelope
+from swarmauri_core.signing.types import Signature
+
+
+class SigV4Signing(SigningBase):
+    """AWS Signature Version 4 (SigV4) signer/verifier."""
+
+    resource: Optional[str] = Field(default=ResourceTypes.CRYPTO.value, frozen=True)
+    type: str = "SigV4Signing"
+
+    # ---------- capabilities ----------
+    def supports(self) -> Mapping[str, Iterable[str]]:
+        return {
+            "alg": ("AWS4-HMAC-SHA256",),
+            "envelope": ("http-request-v1",),
+            "payload": ("bytes-hmac-v1",),
+        }
+
+    # ---------- helpers ----------
+    @staticmethod
+    def _get_key_fields(key: KeyRef) -> Tuple[str, str, Optional[str]]:
+        """Extract key fields from a flexible :class:`KeyRef`."""
+
+        def get_first(data: Any, *names: str) -> Optional[str]:
+            for name in names:
+                if isinstance(data, Mapping) and name in data:
+                    return data[name]  # type: ignore[index]
+                if hasattr(data, name):
+                    return getattr(data, name)
+            return None
+
+        akid = get_first(key, "access_key", "akid", "accessKeyId", "AccessKeyId")
+        secret = get_first(
+            key, "secret_key", "sk", "secretAccessKey", "SecretAccessKey"
+        )
+        token = get_first(key, "session_token", "token", "SessionToken")
+        if not akid or not secret:
+            raise ValueError("KeyRef must contain access key id and secret key")
+        return akid, secret, token
+
+    @staticmethod
+    def _hmac(key_bytes: bytes, msg: str) -> bytes:
+        return hmac.new(key_bytes, msg.encode("utf-8"), hashlib.sha256).digest()
+
+    @staticmethod
+    def _sha256_hex(data: bytes) -> str:
+        return hashlib.sha256(data).hexdigest()
+
+    @staticmethod
+    def _canonical_uri(uri: str) -> str:
+        # RFC3986 path normalization; AWS allows '/-_.~' unescaped
+        return urllib.parse.quote(uri if uri else "/", safe="/-_.~")
+
+    @staticmethod
+    def _canonical_query(qs: Mapping[str, Iterable[str]] | None) -> str:
+        if not qs:
+            return ""
+        items: List[Tuple[str, str]] = []
+        for key, values in qs.items():
+            if values is None:
+                items.append((key, ""))
+                continue
+            for value in values:
+                items.append((key, "" if value is None else str(value)))
+        items.sort(key=lambda pair: (pair[0], pair[1]))
+
+        def encode(value: str) -> str:
+            return urllib.parse.quote(str(value), safe="-_.~")
+
+        return "&".join(f"{encode(k)}={encode(v)}" for k, v in items)
+
+    @staticmethod
+    def _canonical_headers(headers: Mapping[str, str]) -> Tuple[str, str]:
+        """Return canonical header block and the signed headers list."""
+
+        canonical_lines: List[str] = []
+        signed: List[str] = []
+        for key, value in headers.items():
+            key_lower = key.strip().lower()
+            value_clean = " ".join(value.strip().split())
+            canonical_lines.append(f"{key_lower}:{value_clean}\n")
+            signed.append(key_lower)
+        canonical_lines.sort()
+        signed.sort()
+        return "".join(canonical_lines), ";".join(signed)
+
+    @classmethod
+    def _string_to_sign(cls, amz_date: str, scope: str, canonical_request: str) -> str:
+        request_hash = hashlib.sha256(canonical_request.encode("utf-8")).hexdigest()
+        return "AWS4-HMAC-SHA256\n" + amz_date + "\n" + scope + "\n" + request_hash
+
+    @classmethod
+    def _derive_signing_key(
+        cls, secret_key: str, date: str, region: str, service: str
+    ) -> bytes:
+        k_date = hmac.new(
+            ("AWS4" + secret_key).encode("utf-8"), date.encode("utf-8"), hashlib.sha256
+        ).digest()
+        k_region = hmac.new(k_date, region.encode("utf-8"), hashlib.sha256).digest()
+        k_service = hmac.new(k_region, service.encode("utf-8"), hashlib.sha256).digest()
+        return hmac.new(k_service, b"aws4_request", hashlib.sha256).digest()
+
+    @classmethod
+    def _ensure_scope(cls, scope: Mapping[str, str]) -> Tuple[str, str, str, str]:
+        date = scope.get("date") or ""
+        region = scope.get("region") or ""
+        service = scope.get("service") or ""
+        if not (date and region and service):
+            raise ValueError("scope must contain {date, region, service}")
+        return date, region, service, f"{date}/{region}/{service}/aws4_request"
+
+    # ---------- core (HTTP request) ----------
+    async def canonicalize_envelope(
+        self,
+        env: Envelope,
+        *,
+        canon: Optional[Canon] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bytes:
+        """Build the canonical request bytes for a SigV4 HTTP request envelope."""
+
+        method = str(env["method"]).upper()
+        uri = str(env.get("uri", "/"))
+        query = env.get("query") or {}
+        headers = env.get("headers") or {}
+        payload_hash = str(env.get("payload_hash", ""))
+        header_lookup = {k.lower(): v for k, v in headers.items()}
+        if "host" not in header_lookup:
+            raise ValueError("envelope.headers must include 'Host'")
+
+        canonical_uri = self._canonical_uri(uri)
+        canonical_query = self._canonical_query(query)  # type: ignore[arg-type]
+        canonical_headers, signed_headers = self._canonical_headers(headers)
+
+        canonical_request = "\n".join(
+            [
+                method,
+                canonical_uri,
+                canonical_query,
+                canonical_headers,
+                signed_headers,
+                payload_hash,
+            ]
+        )
+        return canonical_request.encode("utf-8")
+
+    async def sign_envelope(
+        self,
+        key: KeyRef,
+        env: Envelope,
+        *,
+        alg: Optional[Alg] = None,
+        canon: Optional[Canon] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> Sequence[Signature]:
+        """Compute SigV4 Authorization over an HTTP request envelope."""
+
+        akid, secret_key, _ = self._get_key_fields(key)
+        amz_date = str(env.get("amz_date") or "")
+        if not amz_date:
+            amz_date = datetime.datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+
+        date, region, service, scope = self._ensure_scope(env["scope"])
+        canonical_request = (await self.canonicalize_envelope(env)).decode("utf-8")
+
+        string_to_sign = self._string_to_sign(amz_date, scope, canonical_request)
+        signing_key = self._derive_signing_key(secret_key, date, region, service)
+        signature_hex = hmac.new(
+            signing_key, string_to_sign.encode("utf-8"), hashlib.sha256
+        ).hexdigest()
+
+        _, signed_headers = self._canonical_headers(env.get("headers") or {})
+
+        signature: Signature = {
+            "alg": "AWS4-HMAC-SHA256",
+            "kid": akid,
+            "amz_date": amz_date,
+            "scope": scope,
+            "signed_headers": signed_headers,
+            "signature": signature_hex,
+            "canonical_request_sha256": hashlib.sha256(
+                canonical_request.encode("utf-8")
+            ).hexdigest(),
+        }
+        return [signature]
+
+    async def verify_envelope(
+        self,
+        env: Envelope,
+        signatures: Sequence[Signature],
+        *,
+        canon: Optional[Canon] = None,
+        require: Optional[Mapping[str, object]] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bool:
+        """Recompute SigV4 and compare with provided signature(s)."""
+
+        if not signatures:
+            return False
+        signature = signatures[0]
+        amz_date = signature.get("amz_date") or env.get("amz_date")
+        scope_str = signature.get("scope")
+        if not amz_date or not scope_str:
+            return False
+
+        try:
+            parts = scope_str.split("/")
+            scope = {"date": parts[0], "region": parts[1], "service": parts[2]}
+            date, region, service, _ = self._ensure_scope(scope)
+        except Exception:
+            return False
+
+        secret = None
+        if opts and "secret_key" in opts:
+            secret = str(opts["secret_key"])
+        elif require and "secret_key" in require:
+            secret = str(require["secret_key"])
+        if not secret:
+            return False
+
+        canonical_request = (await self.canonicalize_envelope(env)).decode("utf-8")
+        string_to_sign = self._string_to_sign(
+            str(amz_date), scope_str, canonical_request
+        )
+        signing_key = self._derive_signing_key(secret, date, region, service)
+        calculated = hmac.new(
+            signing_key, string_to_sign.encode("utf-8"), hashlib.sha256
+        ).hexdigest()
+        return hmac.compare_digest(calculated, str(signature.get("signature", "")))
+
+    # ---------- payload-only (bytes) ----------
+    async def sign_bytes(
+        self,
+        key: KeyRef,
+        payload: bytes,
+        *,
+        alg: Optional[Alg] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> Sequence[Signature]:
+        """HMAC over raw bytes using a SigV4-derived signing key."""
+
+        akid, secret_key, _ = self._get_key_fields(key)
+        if not opts:
+            raise ValueError("opts must include {date, region, service}")
+        date = str(opts.get("date") or "")
+        region = str(opts.get("region") or "")
+        service = str(opts.get("service") or "")
+        if not (date and region and service):
+            raise ValueError("opts must include {date, region, service}")
+
+        signing_key = self._derive_signing_key(secret_key, date, region, service)
+        signature_hex = hmac.new(signing_key, payload, hashlib.sha256).hexdigest()
+        signature: Signature = {
+            "alg": "AWS4-HMAC-SHA256",
+            "kid": akid,
+            "scope": f"{date}/{region}/{service}/aws4_request",
+            "signature": signature_hex,
+        }
+        return [signature]
+
+    async def verify_bytes(
+        self,
+        payload: bytes,
+        signatures: Sequence[Signature],
+        *,
+        require: Optional[Mapping[str, object]] = None,
+        opts: Optional[Mapping[str, object]] = None,
+    ) -> bool:
+        """Verify bytes HMAC using SigV4-derived key."""
+
+        if not signatures:
+            return False
+        signature = signatures[0]
+        scope_str = signature.get("scope") or ""
+        parts = scope_str.split("/") if scope_str else []
+        if len(parts) >= 4:
+            date, region, service = parts[0], parts[1], parts[2]
+        else:
+            if not opts:
+                return False
+            date = str(opts.get("date") or "")
+            region = str(opts.get("region") or "")
+            service = str(opts.get("service") or "")
+            if not (date and region and service):
+                return False
+
+        secret = None
+        if require and "secret_key" in require:
+            secret = str(require["secret_key"])
+        elif opts and "secret_key" in opts:
+            secret = str(opts["secret_key"])
+        if not secret:
+            return False
+
+        signing_key = self._derive_signing_key(secret, date, region, service)
+        calculated = hmac.new(signing_key, payload, hashlib.sha256).hexdigest()
+        return hmac.compare_digest(calculated, str(signature.get("signature", "")))

--- a/pkgs/standards/swarmauri_signing_sigv4/swarmauri_signing_sigv4/__init__.py
+++ b/pkgs/standards/swarmauri_signing_sigv4/swarmauri_signing_sigv4/__init__.py
@@ -1,0 +1,5 @@
+"""AWS Signature Version 4 signer for the Swarmauri SDK."""
+
+from .SigV4Signing import SigV4Signing
+
+__all__ = ["SigV4Signing"]

--- a/pkgs/standards/swarmauri_signing_sigv4/tests/test_sigv4_signing.py
+++ b/pkgs/standards/swarmauri_signing_sigv4/tests/test_sigv4_signing.py
@@ -1,0 +1,94 @@
+from typing import Mapping
+
+import pytest
+
+from swarmauri_signing_sigv4 import SigV4Signing
+
+
+@pytest.fixture()
+def sigv4_envelope() -> Mapping[str, object]:
+    return {
+        "method": "GET",
+        "uri": "/",
+        "query": {"Action": ["ListUsers"], "Version": ["2010-05-08"]},
+        "headers": {
+            "host": "iam.amazonaws.com",
+            "x-amz-date": "20150830T123600Z",
+            "content-type": "application/x-www-form-urlencoded; charset=utf-8",
+        },
+        "payload_hash": "UNSIGNED-PAYLOAD",
+        "amz_date": "20150830T123600Z",
+        "scope": {"date": "20150830", "region": "us-east-1", "service": "iam"},
+    }
+
+
+@pytest.fixture()
+def sigv4_key() -> Mapping[str, str]:
+    return {
+        "access_key": "AKIDEXAMPLE",
+        "secret_key": "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+    }
+
+
+@pytest.mark.asyncio
+async def test_canonical_request_matches_reference(sigv4_envelope):
+    signer = SigV4Signing()
+    canonical = (await signer.canonicalize_envelope(sigv4_envelope)).decode()
+    assert canonical == (
+        "GET\n"
+        "/\n"
+        "Action=ListUsers&Version=2010-05-08\n"
+        "content-type:application/x-www-form-urlencoded; charset=utf-8\n"
+        "host:iam.amazonaws.com\n"
+        "x-amz-date:20150830T123600Z\n\n"
+        "content-type;host;x-amz-date\n"
+        "UNSIGNED-PAYLOAD"
+    )
+
+
+@pytest.mark.asyncio
+async def test_sign_envelope_produces_expected_signature(sigv4_key, sigv4_envelope):
+    signer = SigV4Signing()
+    signatures = await signer.sign_envelope(sigv4_key, sigv4_envelope)
+    signature = signatures[0]
+    assert (
+        signature["signature"]
+        == "86116edbb7e0e8c675dc9cfa9fcfcd0115a98ee9cc1196e4623cd2673a806766"
+    )
+    assert signature["scope"] == "20150830/us-east-1/iam/aws4_request"
+    assert signature["signed_headers"] == "content-type;host;x-amz-date"
+    assert (
+        signature["canonical_request_sha256"]
+        == "2714b15fec5795e21b0fa0c48f6944f639224b42fd8e71d16f57ed58265f9c7d"
+    )
+
+
+@pytest.mark.asyncio
+async def test_verify_envelope_with_secret(sigv4_key, sigv4_envelope):
+    signer = SigV4Signing()
+    signatures = await signer.sign_envelope(sigv4_key, sigv4_envelope)
+    assert await signer.verify_envelope(
+        sigv4_envelope,
+        signatures,
+        opts={"secret_key": sigv4_key["secret_key"]},
+    )
+
+
+@pytest.mark.asyncio
+async def test_sign_and_verify_bytes(sigv4_key):
+    signer = SigV4Signing()
+    payload = b"example-payload"
+    opts = {"date": "20150830", "region": "us-east-1", "service": "iam"}
+    signatures = await signer.sign_bytes(sigv4_key, payload, opts=opts)
+    assert await signer.verify_bytes(
+        payload,
+        signatures,
+        opts={**opts, "secret_key": sigv4_key["secret_key"]},
+    )
+
+
+@pytest.mark.asyncio
+async def test_verify_envelope_without_secret_fails(sigv4_key, sigv4_envelope):
+    signer = SigV4Signing()
+    signatures = await signer.sign_envelope(sigv4_key, sigv4_envelope)
+    assert not await signer.verify_envelope(sigv4_envelope, signatures)


### PR DESCRIPTION
## Summary
- add the new `swarmauri_signing_sigv4` package that provides an AWS Signature Version 4 signer implementation and automated tests
- document installation and usage details while registering project metadata and exposing entry points
- include the package in the workspace configuration so tooling can format and lint it

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e377aef2e48326b45ccd415205483b