### PR TITLE
Add runnable dashboard example for layout engine

### DIFF
--- a/pkgs/experimental/layout_engine/examples/dashboard.py
+++ b/pkgs/experimental/layout_engine/examples/dashboard.py
@@ -1,0 +1,165 @@
+"""Minimal end-to-end example for layout_engine.
+
+Run with:
+    uv run --directory experimental/layout_engine --package layout-engine python examples/dashboard.py
+
+The script builds a component registry, declares a table-based layout, compiles it
+into a manifest, and exports an HTML preview.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from layout_engine import (
+    ComponentRegistry,
+    ComponentSpec,
+    SizeToken,
+    TileSpec,
+    Viewport,
+    block,
+    col,
+    quick_manifest_from_table,
+    row,
+    table,
+)
+from layout_engine.targets.media import HtmlExporter
+
+OUTPUT_HTML = Path(__file__).with_suffix(".html")
+
+
+def build_components() -> ComponentRegistry:
+    """Register semantic roles with front-end modules and defaults."""
+    registry = ComponentRegistry()
+    registry.register_many(
+        [
+            ComponentSpec(
+                role="hero",
+                module="@demo/hero-card",
+                defaults={
+                    "heading": "Realtime fleet telemetry",
+                    "cta": "Open dashboard",
+                },
+            ),
+            ComponentSpec(
+                role="stat",
+                module="@demo/metric-tile",
+                defaults={
+                    "format": "compact",
+                    "trend": "stable",
+                },
+            ),
+            ComponentSpec(
+                role="activity",
+                module="@demo/activity-feed",
+                defaults={
+                    "limit": 5,
+                },
+            ),
+        ]
+    )
+    return registry
+
+
+def build_tiles() -> list[TileSpec]:
+    """Declare tile constraints and authoring-time props."""
+    return [
+        TileSpec(
+            id="hero",
+            role="hero",
+            min_w=600,
+            min_h=320,
+            props={
+                "heading": "Autonomous ops overview",
+                "cta": "View incidents",
+            },
+        ),
+        TileSpec(
+            id="stat_revenue",
+            role="stat",
+            min_w=260,
+            min_h=180,
+            props={
+                "label": "Monthly revenue",
+                "value": "$1.2M",
+                "trend": "up",
+            },
+        ),
+        TileSpec(
+            id="stat_nps",
+            role="stat",
+            min_w=260,
+            min_h=180,
+            props={
+                "label": "Support CSAT",
+                "value": "93",
+                "format": "percent",
+            },
+        ),
+        TileSpec(
+            id="activity",
+            role="activity",
+            min_w=640,
+            min_h=360,
+            props={
+                "title": "Recent activity",
+            },
+        ),
+    ]
+
+
+def build_structure():
+    """Author a table layout with rows, columns, and tile placements."""
+    return table(
+        row(
+            col(block("hero"), size=SizeToken.xl),
+            col(block("stat_revenue"), block("stat_nps"), size=SizeToken.s),
+            height_rows=2,
+        ),
+        row(
+            col(block("activity"), size=SizeToken.l),
+        ),
+        gap_x=24,
+        gap_y=24,
+    )
+
+
+def main() -> int:
+    viewport = Viewport(width=1280, height=720)
+    components = build_components()
+    tiles = build_tiles()
+    layout = build_structure()
+
+    manifest = quick_manifest_from_table(
+        layout,
+        viewport,
+        tiles,
+        row_height=200,
+        components_registry=components,
+    )
+
+    print("Manifest version:", manifest.version)
+    for tile in manifest.tiles:
+        frame = tile["frame"]
+        props = tile.get("props", {})
+        print(
+            f"- {tile['id']}: role={tile['role']} frame=({frame['x']}, {frame['y']}, {frame['w']}x{frame['h']}) props={props}"
+        )
+
+    exporter = HtmlExporter(
+        title="Layout Engine Dashboard",
+        inline_css="""
+        body{margin:0;font-family:system-ui,sans-serif;background:#0f172a;color:#f8fafc;}
+        .page{background:linear-gradient(135deg,#1e293b,#0f172a);}
+        .tile{border-radius:18px;padding:24px;background:rgba(15,118,110,0.2);border:1px solid rgba(45,212,191,0.35);}
+        .tile::after{content:attr(data-tile);position:absolute;top:16px;left:20px;font-size:14px;color:#a5f3fc;}
+        .tile[data-tile^='stat']{background:rgba(14,116,144,0.2);border-color:rgba(56,189,248,0.45);}
+        """,
+    )
+    exporter.export(manifest, out=str(OUTPUT_HTML))
+    print("Exported HTML preview →", OUTPUT_HTML)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pkgs/experimental/layout_engine/src/layout_engine/__init__.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/__init__.py
@@ -1,4 +1,3 @@
-
 """layout_engine — Grid-first, framework-agnostic layout & manifest toolkit.
 
 This package provides:
@@ -29,70 +28,129 @@ from .tiles import TileSpec, Tile, tile_spec, make_tile
 
 # ---- Components ----
 from .components import (
-    ComponentSpec, ComponentRegistry, define_component, use_component, apply_defaults
+    ComponentSpec,
+    ComponentRegistry,
+    define_component,
+    use_component,
+    apply_defaults,
 )
 
 # ---- Grid ----
 from .grid import (
-    GridTrack, GridSpec, GridTile,
+    GridTrack,
+    GridSpec,
+    GridTile,
     ExplicitGridResolver,
-    make_gridspec, place, gridspec_from_tokens, breakpoint, breakpoints,
+    make_gridspec,
+    place,
+    gridspec_from_tokens,
+    breakpoint,
+    breakpoints,
 )
 
 # ---- Structure (authoring DSL) ----
 from .structure import (
-    Block, Column, Row, Table,
-    GridBuilder, validate_table,
-    block, col, row, table, build_grid, gridify,
+    Block,
+    Column,
+    Row,
+    Table,
+    GridBuilder,
+    validate_table,
+    block,
+    col,
+    row,
+    table,
+    build_grid,
+    gridify,
 )
 
 # ---- Compile ----
 from .compile import (
     LayoutCompiler,
-    frame_map_from_placements, frame_diff, frames_almost_equal,
-    ordering_by_topleft, ordering_diff,
+    frame_map_from_placements,
+    frame_diff,
+    frames_almost_equal,
+    ordering_by_topleft,
+    ordering_diff,
 )
 
 # ---- Manifest ----
 from .manifest import (
-    Manifest, TileEntry, ManifestBuilder, build_manifest,
-    manifest_to_json, manifest_from_json,
-    compute_etag, validate_manifest, sort_tiles, to_plain_dict, from_plain_dict,
-    diff_manifests, make_patch, apply_patch,
+    Manifest,
+    ManifestBuilder,
+    build_manifest,
+    manifest_to_json,
+    manifest_from_json,
+    compute_etag,
+    validate_manifest,
+    sort_tiles,
+    to_plain_dict,
+    from_plain_dict,
+    diff_manifests,
+    make_patch,
+    apply_patch,
 )
 
 # ---- Events ----
 from .events import (
-    EventEnvelope, ValidationError,
-    validate_envelope, is_allowed, allowed_types_for, route_topic,
-    InProcEventBus, EventRouter,
-    utc_now_iso, make_ack, make_error,
+    EventEnvelope,
+    ValidationError,
+    validate_envelope,
+    is_allowed,
+    allowed_types_for,
+    route_topic,
+    InProcEventBus,
+    EventRouter,
+    utc_now_iso,
+    make_ack,
+    make_error,
 )
 
 # ---- Site (routing) ----
 from .site import (
-    SlotSpec, PageSpec, SiteSpec, RouteMatch,
-    compile_route_pattern, normalize_base_path,
-    SiteIndex, resolve_path, validate_site, build_page_context, bind_page_builder,
+    SlotSpec,
+    PageSpec,
+    SiteSpec,
+    RouteMatch,
+    compile_route_pattern,
+    normalize_base_path,
+    SiteIndex,
+    resolve_path,
+    validate_site,
+    build_page_context,
+    bind_page_builder,
 )
 
 # ---- MFE (remote registry & import-map) ----
 from .mfe import (
-    Remote, Framework, RemoteRegistry, ImportMapBuilder,
-    remote, remotes, build_import_map, compose_import_maps,
+    Remote,
+    Framework,
+    RemoteRegistry,
+    ImportMapBuilder,
+    remote,
+    remotes,
+    build_import_map,
+    compose_import_maps,
     import_map_json,
 )
 
 # ---- Targets ----
 from .targets import (
-    RenderResult,
-    HtmlShell, SiteRouter, import_map_json as webgui_import_map_json,
-    HtmlExporter, SvgExporter, PdfExporter, CodeExporter,
+    HtmlShell,
+    SiteRouter,
+    import_map_json as webgui_import_map_json,
+    HtmlExporter,
+    SvgExporter,
+    PdfExporter,
+    CodeExporter,
 )
 
 # ---------------- Convenience helpers ----------------
 
-def quick_view_model_from_table(tbl, vp: Viewport, tiles, *, row_height: int = 180, components_registry=None) -> dict:
+
+def quick_view_model_from_table(
+    tbl, vp: Viewport, tiles, *, row_height: int = 180, components_registry=None
+) -> dict:
     """Authoring DSL → (Frames →) view-model suitable for manifest building.
 
     Args:
@@ -107,46 +165,132 @@ def quick_view_model_from_table(tbl, vp: Viewport, tiles, *, row_height: int = 1
     """
     compiler = LayoutCompiler()
     return compiler.view_model_from_structure(
-        tbl, vp, tiles,
-        row_height=row_height,
-        components_registry=components_registry
+        tbl, vp, tiles, row_height=row_height, components_registry=components_registry
     )
 
-def quick_manifest_from_table(tbl, vp: Viewport, tiles, *, row_height: int = 180, components_registry=None, version: str = "2025.10") -> Manifest:
+
+def quick_manifest_from_table(
+    tbl,
+    vp: Viewport,
+    tiles,
+    *,
+    row_height: int = 180,
+    components_registry=None,
+    version: str = "2025.10",
+) -> Manifest:
     """Authoring DSL → manifest (one call convenience)."""
     vm = quick_view_model_from_table(
-        tbl, vp, tiles,
-        row_height=row_height,
-        components_registry=components_registry
+        tbl, vp, tiles, row_height=row_height, components_registry=components_registry
     )
     return build_manifest(vm, version=version)
+
 
 __all__ = [
     "__version__",
     # core
-    "Size","SizeToken","DEFAULT_TOKEN_WEIGHTS","Viewport","Frame",
+    "Size",
+    "SizeToken",
+    "DEFAULT_TOKEN_WEIGHTS",
+    "Viewport",
+    "Frame",
     # tiles
-    "TileSpec","Tile","tile_spec","make_tile",
+    "TileSpec",
+    "Tile",
+    "tile_spec",
+    "make_tile",
     # components
-    "ComponentSpec","ComponentRegistry","define_component","use_component","apply_defaults",
+    "ComponentSpec",
+    "ComponentRegistry",
+    "define_component",
+    "use_component",
+    "apply_defaults",
     # grid
-    "GridTrack","GridSpec","GridTile","ExplicitGridResolver",
-    "make_gridspec","place","gridspec_from_tokens","breakpoint","breakpoints",
+    "GridTrack",
+    "GridSpec",
+    "GridTile",
+    "ExplicitGridResolver",
+    "make_gridspec",
+    "place",
+    "gridspec_from_tokens",
+    "breakpoint",
+    "breakpoints",
     # structure
-    "Block","Column","Row","Table","GridBuilder","validate_table","block","col","row","table","build_grid","gridify",
+    "Block",
+    "Column",
+    "Row",
+    "Table",
+    "GridBuilder",
+    "validate_table",
+    "block",
+    "col",
+    "row",
+    "table",
+    "build_grid",
+    "gridify",
     # compile
-    "LayoutCompiler","frame_map_from_placements","frame_diff","frames_almost_equal","ordering_by_topleft","ordering_diff",
+    "LayoutCompiler",
+    "frame_map_from_placements",
+    "frame_diff",
+    "frames_almost_equal",
+    "ordering_by_topleft",
+    "ordering_diff",
     # manifest
-    "Manifest","TileEntry","ManifestBuilder","build_manifest","manifest_to_json","manifest_from_json",
-    "compute_etag","validate_manifest","sort_tiles","to_plain_dict","from_plain_dict","diff_manifests","make_patch","apply_patch",
+    "Manifest",
+    "ManifestBuilder",
+    "build_manifest",
+    "manifest_to_json",
+    "manifest_from_json",
+    "compute_etag",
+    "validate_manifest",
+    "sort_tiles",
+    "to_plain_dict",
+    "from_plain_dict",
+    "diff_manifests",
+    "make_patch",
+    "apply_patch",
     # events
-    "EventEnvelope","ValidationError","validate_envelope","is_allowed","allowed_types_for","route_topic","InProcEventBus","EventRouter","utc_now_iso","make_ack","make_error",
+    "EventEnvelope",
+    "ValidationError",
+    "validate_envelope",
+    "is_allowed",
+    "allowed_types_for",
+    "route_topic",
+    "InProcEventBus",
+    "EventRouter",
+    "utc_now_iso",
+    "make_ack",
+    "make_error",
     # site
-    "SlotSpec","PageSpec","SiteSpec","RouteMatch","compile_route_pattern","normalize_base_path","SiteIndex","resolve_path","validate_site","build_page_context","bind_page_builder",
+    "SlotSpec",
+    "PageSpec",
+    "SiteSpec",
+    "RouteMatch",
+    "compile_route_pattern",
+    "normalize_base_path",
+    "SiteIndex",
+    "resolve_path",
+    "validate_site",
+    "build_page_context",
+    "bind_page_builder",
     # mfe
-    "Remote","Framework","RemoteRegistry","ImportMapBuilder","remote","remotes","build_import_map","compose_import_maps","import_map_json",
+    "Remote",
+    "Framework",
+    "RemoteRegistry",
+    "ImportMapBuilder",
+    "remote",
+    "remotes",
+    "build_import_map",
+    "compose_import_maps",
+    "import_map_json",
     # targets
-    "RenderResult","HtmlShell","SiteRouter","webgui_import_map_json","HtmlExporter","SvgExporter","PdfExporter","CodeExporter",
+    "HtmlShell",
+    "SiteRouter",
+    "webgui_import_map_json",
+    "HtmlExporter",
+    "SvgExporter",
+    "PdfExporter",
+    "CodeExporter",
     # helpers
-    "quick_view_model_from_table","quick_manifest_from_table",
+    "quick_view_model_from_table",
+    "quick_manifest_from_table",
 ]

--- a/pkgs/experimental/layout_engine/src/layout_engine/authoring/ctx/__init__.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/authoring/ctx/__init__.py
@@ -14,10 +14,16 @@ Usage:
 
   html = render_table(t)  # SSR page HTML
 """
+
 from .builder import TableCtx, RowCtx, ColCtx
 from .runtime import compile_table, render_table, export_table, serve_table
 
 __all__ = [
-    "TableCtx","RowCtx","ColCtx",
-    "compile_table","render_table","export_table","serve_table",
+    "TableCtx",
+    "RowCtx",
+    "ColCtx",
+    "compile_table",
+    "render_table",
+    "export_table",
+    "serve_table",
 ]

--- a/pkgs/experimental/layout_engine/src/layout_engine/authoring/ctx/builder.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/authoring/ctx/builder.py
@@ -2,31 +2,53 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, List
 
+
 @dataclass
 class ColCtx:
     size: str
     items: List[Any] = field(default_factory=list)
-    def __enter__(self): return self
-    def __exit__(self, *exc): return False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
     def add(self, *components: Any) -> "ColCtx":
         self.items.extend(components)
         return self
+
 
 @dataclass
 class RowCtx:
     height_rows: int = 1
     cols: List[ColCtx] = field(default_factory=list)
-    def __enter__(self): return self
-    def __exit__(self, *exc): return False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
     def col(self, size: str) -> ColCtx:
-        c = ColCtx(size=size); self.cols.append(c); return c
+        c = ColCtx(size=size)
+        self.cols.append(c)
+        return c
+
 
 @dataclass
 class TableCtx:
     rows: List[RowCtx] = field(default_factory=list)
     gap_x: int = 12
     gap_y: int = 12
-    def __enter__(self): return self
-    def __exit__(self, *exc): return False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
     def row(self, *, height_rows: int = 1) -> RowCtx:
-        r = RowCtx(height_rows=height_rows); self.rows.append(r); return r
+        r = RowCtx(height_rows=height_rows)
+        self.rows.append(r)
+        return r

--- a/pkgs/experimental/layout_engine/src/layout_engine/authoring/ctx/runtime.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/authoring/ctx/runtime.py
@@ -7,15 +7,26 @@ from ...core.size import SizeToken
 from ...tiles import tile_spec as _tile_spec
 from ... import (
     # structure/compile/manifest
-    block as d_block, col as d_col, row as d_row, table as d_table,
-    LayoutCompiler, Viewport, build_manifest,
+    block as d_block,
+    col as d_col,
+    row as d_row,
+    table as d_table,
+    LayoutCompiler,
+    Viewport,
+    build_manifest,
     # components + targets
-    ComponentRegistry, define_component,
-    HtmlShell, HtmlExporter, SvgExporter, PdfExporter, CodeExporter,
+    ComponentRegistry,
+    define_component,
+    HtmlShell,
+    HtmlExporter,
+    SvgExporter,
+    PdfExporter,
+    CodeExporter,
 )
 from ..widgets import _Base as _WidgetBase
 from ...contrib.presets import DEFAULT_ATOMS
 from .builder import TableCtx
+
 
 def _to_token(size: str) -> SizeToken:
     try:
@@ -23,17 +34,33 @@ def _to_token(size: str) -> SizeToken:
     except Exception:
         raise ValueError(f"Invalid column size token: {size!r}")
 
-def _build_registry(roles: Iterable[str], *, presets: Dict[str, Dict[str, Any]] | None = None) -> ComponentRegistry:
+
+def _build_registry(
+    roles: Iterable[str], *, presets: Dict[str, Dict[str, Any]] | None = None
+) -> ComponentRegistry:
     reg = ComponentRegistry()
     mapping = presets or DEFAULT_ATOMS
     for role in sorted(set(roles)):
         atom = mapping.get(role)
         if not atom:
             raise KeyError(f"No preset mapping for role {role!r}")
-        define_component(reg, role=role, module=atom["module"], export=atom["export"], defaults=atom["defaults"])
+        define_component(
+            reg,
+            role=role,
+            module=atom["module"],
+            export=atom["export"],
+            defaults=atom["defaults"],
+        )
     return reg
 
-def compile_table(table: TableCtx, *, width: int = 1280, height: int = 800, presets: Dict[str, Dict[str, Any]] | None = None):
+
+def compile_table(
+    table: TableCtx,
+    *,
+    width: int = 1280,
+    height: int = 800,
+    presets: Dict[str, Dict[str, Any]] | None = None,
+):
     roles = []
     specs_by_id: Dict[str, Any] = {}
     d_rows = []
@@ -46,7 +73,9 @@ def compile_table(table: TableCtx, *, width: int = 1280, height: int = 800, pres
                 if not isinstance(w, _WidgetBase):
                     raise TypeError(f"Unsupported item in column: {w!r}")
                 roles.append(w.role)
-                specs_by_id.setdefault(w.id, _tile_spec(id=w.id, role=w.role, min_w=160, min_h=120))
+                specs_by_id.setdefault(
+                    w.id, _tile_spec(id=w.id, role=w.role, min_w=160, min_h=120)
+                )
                 d_blocks.append(d_block(w.id))
             d_cols.append(d_col(*d_blocks, size=token))
         d_rows.append(d_row(*d_cols, height_rows=r.height_rows))
@@ -56,31 +85,72 @@ def compile_table(table: TableCtx, *, width: int = 1280, height: int = 800, pres
     compiler = LayoutCompiler()
     gs, placements, frames = compiler.frames_from_structure(tbl, vp)
     reg = _build_registry(roles, presets=presets)
-    vm = compiler.view_model(gs, vp, frames, list(specs_by_id.values()), components_registry=reg)
+    vm = compiler.view_model(
+        gs, vp, frames, list(specs_by_id.values()), components_registry=reg
+    )
     return build_manifest(vm)
 
-def render_table(table: TableCtx, *, width: int = 1280, height: int = 800, presets: Dict[str, Dict[str, Any]] | None = None) -> str:
+
+def render_table(
+    table: TableCtx,
+    *,
+    width: int = 1280,
+    height: int = 800,
+    presets: Dict[str, Dict[str, Any]] | None = None,
+) -> str:
     m = compile_table(table, width=width, height=height, presets=presets)
     return HtmlShell().render(m)
 
-def export_table(table: TableCtx, *, out: str, format: str = "html", width: int = 1280, height: int = 800, presets: Dict[str, Dict[str, Any]] | None = None) -> str:
+
+def export_table(
+    table: TableCtx,
+    *,
+    out: str,
+    format: str = "html",
+    width: int = 1280,
+    height: int = 800,
+    presets: Dict[str, Dict[str, Any]] | None = None,
+) -> str:
     m = compile_table(table, width=width, height=height, presets=presets)
     match format:
-        case "html": return HtmlExporter().export(m, out=out)
-        case "svg":  return SvgExporter().export(m, out=out)
-        case "pdf":  return PdfExporter().export(m, out=out)
-        case "code": return CodeExporter().export(m, out=out)
-        case _:      raise ValueError("unsupported format")
+        case "html":
+            return HtmlExporter().export(m, out=out)
+        case "svg":
+            return SvgExporter().export(m, out=out)
+        case "pdf":
+            return PdfExporter().export(m, out=out)
+        case "code":
+            return CodeExporter().export(m, out=out)
+        case _:
+            raise ValueError("unsupported format")
 
-def serve_table(table: TableCtx, *, host: str = "127.0.0.1", port: int = 8789, width: int = 1280, height: int = 800, presets: Dict[str, Dict[str, Any]] | None = None):
+
+def serve_table(
+    table: TableCtx,
+    *,
+    host: str = "127.0.0.1",
+    port: int = 8789,
+    width: int = 1280,
+    height: int = 800,
+    presets: Dict[str, Dict[str, Any]] | None = None,
+):
     m = compile_table(table, width=width, height=height, presets=presets)
     html = HtmlShell().render(m)
+
     def app(environ, start_response):
-        path = environ.get("PATH_INFO","/")
+        path = environ.get("PATH_INFO", "/")
         if path == "/":
-            start_response("200 OK",[("Content-Type","text/html; charset=utf-8")]); return [html.encode("utf-8")]
+            start_response("200 OK", [("Content-Type", "text/html; charset=utf-8")])
+            return [html.encode("utf-8")]
         if path == "/manifest.json":
-            start_response("200 OK",[("Content-Type","application/json")]); return [json.dumps(m.to_dict(), separators=(",",":"), sort_keys=True).encode("utf-8")]
-        start_response("404 Not Found",[("Content-Type","text/plain")]); return [b"not found"]
+            start_response("200 OK", [("Content-Type", "application/json")])
+            return [
+                json.dumps(m.to_dict(), separators=(",", ":"), sort_keys=True).encode(
+                    "utf-8"
+                )
+            ]
+        start_response("404 Not Found", [("Content-Type", "text/plain")])
+        return [b"not found"]
+
     print(f"Serving table at http://{host}:{port}/")
     make_server(host, port, app).serve_forever()

--- a/pkgs/experimental/layout_engine/src/layout_engine/authoring/declarative.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/authoring/declarative.py
@@ -1,51 +1,117 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Tuple, Dict, Any, Iterable
+from typing import Any, Dict, Iterable, Tuple
 
 from ..authoring.widgets import _Base as _WidgetBase
+from ..components import ComponentRegistry, ComponentSpec
 from ..contrib.presets import DEFAULT_ATOMS
 from ..core.size import SizeToken
 from ..tiles import tile_spec as _tile_spec
 from .. import (
-    block as d_block, col as d_col, row as d_row, table as d_table,
-    LayoutCompiler, Viewport, build_manifest,
-    ComponentRegistry, define_component, HtmlShell
+    block as d_block,
+    col as d_col,
+    row as d_row,
+    table as d_table,
+    LayoutCompiler,
+    Viewport,
+    build_manifest,
+    HtmlShell,
 )
 
-@dataclass(frozen=True)  class ColD:  size: str; items: Tuple[_WidgetBase, ...]
-@dataclass(frozen=True)  class RowD:  height_rows: int; cols: Tuple[ColD, ...]
-@dataclass(frozen=True)  class TableD: rows: Tuple[RowD, ...]; gap_x: int = 12; gap_y: int = 12
-@dataclass(frozen=True)  class PageD:  route: str; title: str; table: TableD
-@dataclass(frozen=True)  class SiteD:  base_path: str = "/"; pages: Tuple[PageD, ...] = ()
 
-def _build_registry(roles: Iterable[str], presets: Dict[str, Dict[str, Any]] | None = None) -> ComponentRegistry:
-    from .. import define_component, ComponentRegistry
-    reg = ComponentRegistry()
+@dataclass(frozen=True)
+class ColD:
+    size: str
+    items: Tuple[_WidgetBase, ...]
+
+
+@dataclass(frozen=True)
+class RowD:
+    height_rows: int
+    cols: Tuple[ColD, ...]
+
+
+@dataclass(frozen=True)
+class TableD:
+    rows: Tuple[RowD, ...]
+    gap_x: int = 12
+    gap_y: int = 12
+
+
+@dataclass(frozen=True)
+class PageD:
+    route: str
+    title: str
+    table: TableD
+
+
+@dataclass(frozen=True)
+class SiteD:
+    base_path: str = "/"
+    pages: Tuple[PageD, ...] = ()
+
+
+def _build_registry(
+    roles: Iterable[str],
+    presets: Dict[str, Dict[str, Any]] | None = None,
+) -> ComponentRegistry:
+    registry = ComponentRegistry()
     mapping = presets or DEFAULT_ATOMS
     for role in sorted(set(roles)):
         atom = mapping.get(role)
         if not atom:
             raise KeyError(f"No preset mapping for role {role!r}")
-        define_component(reg, role=role, module=atom["module"], export=atom["export"], defaults=atom["defaults"])
-    return reg
+        spec = ComponentSpec(
+            role=role,
+            module=atom["module"],
+            export=atom.get("export", "default"),
+            defaults=atom.get("defaults", {}),
+        )
+        registry.register(spec)
+    return registry
 
-def render(site: SiteD, route: str, *, width: int = 1280, height: int = 800, presets: Dict[str, Dict[str, Any]] | None = None) -> str:
+
+def render(
+    site: SiteD,
+    route: str,
+    *,
+    width: int = 1280,
+    height: int = 800,
+    presets: Dict[str, Dict[str, Any]] | None = None,
+) -> str:
     page = next(p for p in site.pages if p.route == route)
-    roles = []; specs_by_id: Dict[str, Any] = {}; d_rows = []
-    for r in page.table.rows:
+    roles: list[str] = []
+    specs_by_id: Dict[str, Any] = {}
+    d_rows = []
+
+    for row in page.table.rows:
         d_cols = []
-        for c in r.cols:
-            token = SizeToken(c.size); d_blocks = []
-            for w in c.items:
-                roles.append(w.role)
-                specs_by_id.setdefault(w.id, _tile_spec(id=w.id, role=w.role, min_w=160, min_h=120))
-                d_blocks.append(d_block(w.id))
+        for col in row.cols:
+            token = SizeToken(col.size)
+            d_blocks = []
+            for widget in col.items:
+                roles.append(widget.role)
+                specs_by_id.setdefault(
+                    widget.id,
+                    _tile_spec(id=widget.id, role=widget.role, min_w=160, min_h=120),
+                )
+                d_blocks.append(d_block(widget.id))
             d_cols.append(d_col(*d_blocks, size=token))
-        d_rows.append(d_row(*d_cols, height_rows=r.height_rows))
+        d_rows.append(d_row(*d_cols, height_rows=row.height_rows))
+
     tbl = d_table(*d_rows, gap_x=page.table.gap_x, gap_y=page.table.gap_y)
-    vp = Viewport(width, height)
-    comp = LayoutCompiler()
-    gs, placements, frames = comp.frames_from_structure(tbl, vp)
-    reg = _build_registry(roles, presets=presets)
-    vm = comp.view_model(gs, vp, frames, list(specs_by_id.values()), components_registry=reg)
-    return HtmlShell().render(build_manifest(vm))
+    viewport = Viewport(width, height)
+
+    compiler = LayoutCompiler()
+    grid_spec, placements, frames_map = compiler.frames_from_structure(tbl, viewport)
+    registry = _build_registry(roles, presets=presets)
+    view_model = compiler.view_model(
+        grid_spec,
+        viewport,
+        frames_map,
+        list(specs_by_id.values()),
+        components_registry=registry,
+    )
+    manifest = build_manifest(view_model)
+    return HtmlShell().render(manifest)

--- a/pkgs/experimental/layout_engine/src/layout_engine/authoring/widgets.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/authoring/widgets.py
@@ -2,23 +2,29 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Dict
 
+
 @dataclass
 class _Base:
     id: str
     role: str
     props: Dict[str, Any] = field(default_factory=dict)
 
+
 @dataclass
 class Text(_Base):
     def __init__(self, id: str, value: str = "", **props):
         super().__init__(id=id, role="text", props={"value": value, **props})
+
 
 @dataclass
 class Button(_Base):
     def __init__(self, id: str, label: str = "Run", **props):
         super().__init__(id=id, role="button", props={"label": label, **props})
 
+
 @dataclass
 class Timeseries(_Base):
     def __init__(self, id: str, series: list[dict] | None = None, **props):
-        super().__init__(id=id, role="timeseries", props={"series": series or [], **props})
+        super().__init__(
+            id=id, role="timeseries", props={"series": series or [], **props}
+        )

--- a/pkgs/experimental/layout_engine/src/layout_engine/compile/__init__.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/compile/__init__.py
@@ -1,8 +1,14 @@
-
 """Compile package: explicit grid → frames, diffs, and view-model helpers."""
+
 from .base import ILayoutCompiler
 from .default import LayoutCompiler
-from .utils import frame_map_from_placements, frame_diff, frames_almost_equal, ordering_by_topleft, ordering_diff
+from .utils import (
+    frame_map_from_placements,
+    frame_diff,
+    frames_almost_equal,
+    ordering_by_topleft,
+    ordering_diff,
+)
 
 __all__ = [
     "ILayoutCompiler",

--- a/pkgs/experimental/layout_engine/src/layout_engine/compile/base.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/compile/base.py
@@ -4,11 +4,15 @@ from ..core.viewport import Viewport
 from ..core.frame import Frame
 from ..grid.spec import GridSpec, GridTile
 
+
 class ILayoutCompiler(ABC):
     """Contract for turning explicit grids into pixel frames.
 
     Minimal required method keeps the engine decoupled from authoring and manifests.
     """
+
     @abstractmethod
-    def frames(self, gs: GridSpec, vp: Viewport, placements: list[GridTile]) -> dict[str, Frame]:
+    def frames(
+        self, gs: GridSpec, vp: Viewport, placements: list[GridTile]
+    ) -> dict[str, Frame]:
         raise NotImplementedError

--- a/pkgs/experimental/layout_engine/src/layout_engine/compile/default.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/compile/default.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from dataclasses import dataclass
 from typing import Iterable, Literal
 
 from ..core.viewport import Viewport
@@ -8,8 +7,10 @@ from ..grid.default import ExplicitGridResolver
 from ..grid.base import IGridResolver
 from ..grid.spec import GridSpec, GridTile
 from ..tiles.spec import TileSpec
+from ..components.base import IComponentRegistry
 
 # --------- Core compiler ---------
+
 
 class LayoutCompiler:
     """High-level compiler utilities around the explicit grid runtime.
@@ -19,11 +20,14 @@ class LayoutCompiler:
     - (Optional) Compile from the authoring DSL (Table/Row/Col/Block) to explicit grid, then to Frames.
     - (Optional) Assemble a framework-agnostic view-model consumable by the manifest builder.
     """
+
     def __init__(self, resolver: IGridResolver | None = None) -> None:
         self._resolver: IGridResolver = resolver or ExplicitGridResolver()
 
     # ---- Core API ----
-    def frames(self, gs: GridSpec, vp: Viewport, placements: list[GridTile]) -> dict[str, Frame]:
+    def frames(
+        self, gs: GridSpec, vp: Viewport, placements: list[GridTile]
+    ) -> dict[str, Frame]:
         """Compile placements to pixel frames using the configured grid resolver."""
         return self._resolver.frames(gs, vp, placements)
 
@@ -33,50 +37,61 @@ class LayoutCompiler:
 
         Notes: We import structure lazily to avoid import cycles for users who don't use the DSL.
         """
-        from ..structure.default import GridBuilder  # local import to avoid hard dep if unused
+        from ..structure.default import (
+            GridBuilder,
+        )  # local import to avoid hard dep if unused
+
         gb = GridBuilder(row_height=row_height)
         gs, placements = gb.to_grid(tbl, vp)
         return gs, placements, self.frames(gs, vp, placements)
 
     # ---- View-model helpers (for manifest building) ----
-    def view_model(self,
-                   gs: GridSpec,
-                   vp: Viewport,
-                   frames_map: dict[str, Frame],
-                   tiles: Iterable[TileSpec],
-                   components_registry: "IComponentRegistry|None" = None) -> dict:
+    def view_model(
+        self,
+        gs: GridSpec,
+        vp: Viewport,
+        frames_map: dict[str, Frame],
+        tiles: Iterable[TileSpec],
+        components_registry: IComponentRegistry | None = None,
+    ) -> dict:
         """Build a minimal view-model dict expected by `manifest.build_manifest`.
 
         - Adds viewport, serialized grid, and a tile list with frames.
         - Optionally includes component mapping (module/export/version/defaults) from a registry.
         """
         from ..grid.bindings import gridspec_to_dict
+
         tiles_payload: list[dict] = []
         for t in tiles:
             if t.id not in frames_map:
                 # skip tiles that have no placement/frame
                 continue
             frame = frames_map[t.id].to_dict()
+            base_props = dict(getattr(t, "props", {}))
             entry = {
                 "id": t.id,
                 "role": t.role,
-                "props": {},   # caller can merge defaults downstream if desired
+                "props": base_props,
                 "frame": frame,
             }
             if components_registry is not None:
                 try:
                     comp = components_registry.get(t.role)  # type: ignore[attr-defined]
+                except Exception:
+                    # unknown role; leave component mapping absent
+                    pass
+                else:
+                    defaults = dict(getattr(comp, "defaults", {}))
+                    merged_props = dict(defaults)
+                    merged_props.update(base_props)
                     entry["component"] = {
                         "module": comp.module,
                         "export": comp.export,
                         "version": comp.version,
-                        "defaults": dict(comp.defaults),
+                        "defaults": defaults,
                     }
-                    # By default, adopt defaults as props (can be overridden later)
-                    entry["props"] = dict(comp.defaults)
-                except Exception:
-                    # unknown role; leave component mapping absent
-                    pass
+                    # Defaults merge underneath author-specified props
+                    entry["props"] = merged_props
             tiles_payload.append(entry)
 
         vm = {
@@ -86,41 +101,54 @@ class LayoutCompiler:
         }
         return vm
 
-    def view_model_from_structure(self,
-                                  tbl,
-                                  vp: Viewport,
-                                  tiles: Iterable[TileSpec],
-                                  *,
-                                  row_height: int = 180,
-                                  components_registry: "IComponentRegistry|None" = None) -> dict:
+    def view_model_from_structure(
+        self,
+        tbl,
+        vp: Viewport,
+        tiles: Iterable[TileSpec],
+        *,
+        row_height: int = 180,
+        components_registry: IComponentRegistry | None = None,
+    ) -> dict:
         """End-to-end convenience: Table/Row/Col/Block → Frames → view-model dict."""
-        gs, placements, frames_map = self.frames_from_structure(tbl, vp, row_height=row_height)
-        return self.view_model(gs, vp, frames_map, tiles, components_registry=components_registry)
+        gs, placements, frames_map = self.frames_from_structure(
+            tbl, vp, row_height=row_height
+        )
+        return self.view_model(
+            gs, vp, frames_map, tiles, components_registry=components_registry
+        )
 
-# --------- Standalone helpers (pure functions) ---------
+    # --------- Standalone helpers (pure functions) ---------
 
     # --- context manager support ---
     def __enter__(self):
         return self
+
     def __exit__(self, exc_type, exc, tb):
         return False
+
     async def __aenter__(self):
         return self
+
     async def __aexit__(self, exc_type, exc, tb):
         return False
+
 
 class FrameChange:
     tile_id: str
     before: Frame | None
     after: Frame | None
-    kind: Literal["added","removed","changed","unchanged"]
+    kind: Literal["added", "removed", "changed", "unchanged"]
 
     # --- context manager support ---
     def __enter__(self):
         return self
+
     def __exit__(self, exc_type, exc, tb):
         return False
+
     async def __aenter__(self):
         return self
+
     async def __aexit__(self, exc_type, exc, tb):
         return False

--- a/pkgs/experimental/layout_engine/src/layout_engine/compile/utils.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/compile/utils.py
@@ -1,39 +1,47 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Iterable, Literal
+from typing import Literal
+
 from ..core.frame import Frame
 from ..grid.spec import GridSpec, GridTile
-from ..tiles.spec import TileSpec
 from ..core.viewport import Viewport
 from ..grid.base import IGridResolver
 from ..grid.default import ExplicitGridResolver
 
-def frame_map_from_placements(gs: GridSpec, vp: Viewport, placements: list[GridTile], resolver: IGridResolver | None = None) -> dict[str, Frame]:
-    """Convenience: compute frames map for given placements with optional resolver injection."""
+
+def frame_map_from_placements(
+    gs: GridSpec,
+    vp: Viewport,
+    placements: list[GridTile],
+    resolver: IGridResolver | None = None,
+) -> dict[str, Frame]:
+    """Compute a frames map for given placements with optional resolver injection."""
     r = resolver or ExplicitGridResolver()
     return r.frames(gs, vp, placements)
 
+
 @dataclass(frozen=True)
+class FrameChange:
+    tile_id: str
+    before: Frame | None
+    after: Frame | None
+    kind: Literal["added", "removed", "changed", "unchanged"]
+
 
 def frames_almost_equal(a: Frame, b: Frame, epsilon: int = 0) -> bool:
     return (
-        abs(a.x - b.x) <= epsilon and
-        abs(a.y - b.y) <= epsilon and
-        abs(a.w - b.w) <= epsilon and
-        abs(a.h - b.h) <= epsilon
+        abs(a.x - b.x) <= epsilon
+        and abs(a.y - b.y) <= epsilon
+        and abs(a.w - b.w) <= epsilon
+        and abs(a.h - b.h) <= epsilon
     )
 
 
-def frame_diff(old: dict[str, Frame], new: dict[str, Frame], *, epsilon: int = 0) -> dict:
-    """Compute a diff between two frame maps.
-
-    Returns a dict with:
-      - added:   [tile_id]
-      - removed: [tile_id]
-      - changed: [tile_id]
-      - unchanged: [tile_id]
-      - changes: [FrameChange]
-    """
+def frame_diff(
+    old: dict[str, Frame], new: dict[str, Frame], *, epsilon: int = 0
+) -> dict:
+    """Compute a diff between two frame maps."""
     old_keys = set(old.keys())
     new_keys = set(new.keys())
     added = sorted(new_keys - old_keys)
@@ -44,18 +52,25 @@ def frame_diff(old: dict[str, Frame], new: dict[str, Frame], *, epsilon: int = 0
     changes: list[FrameChange] = []
 
     for tid in sorted(old_keys & new_keys):
-        a = old[tid]; b = new[tid]
+        a = old[tid]
+        b = new[tid]
         if frames_almost_equal(a, b, epsilon=epsilon):
             unchanged.append(tid)
-            changes.append(FrameChange(tile_id=tid, before=a, after=b, kind="unchanged"))
+            changes.append(
+                FrameChange(tile_id=tid, before=a, after=b, kind="unchanged")
+            )
         else:
             changed.append(tid)
             changes.append(FrameChange(tile_id=tid, before=a, after=b, kind="changed"))
 
     for tid in added:
-        changes.append(FrameChange(tile_id=tid, before=None, after=new[tid], kind="added"))
+        changes.append(
+            FrameChange(tile_id=tid, before=None, after=new[tid], kind="added")
+        )
     for tid in removed:
-        changes.append(FrameChange(tile_id=tid, before=old[tid], after=None, kind="removed"))
+        changes.append(
+            FrameChange(tile_id=tid, before=old[tid], after=None, kind="removed")
+        )
 
     return {
         "added": added,
@@ -68,16 +83,17 @@ def frame_diff(old: dict[str, Frame], new: dict[str, Frame], *, epsilon: int = 0
 
 def ordering_by_topleft(frames_map: dict[str, Frame]) -> list[str]:
     """Return tile ids sorted by (y, x, id) to provide a stable, visual ordering."""
-    return sorted(frames_map.keys(), key=lambda k: (frames_map[k].y, frames_map[k].x, k))
+    return sorted(
+        frames_map.keys(), key=lambda k: (frames_map[k].y, frames_map[k].x, k)
+    )
 
 
-def ordering_diff(before_ids: list[str], after_ids: list[str]) -> list[tuple[str, int, int]]:
-    """Compute simple positional index moves between two orderings.
-
-    Returns a list of (tile_id, old_index, new_index) for ids present in both lists where index changed.
-    """
+def ordering_diff(
+    before_ids: list[str], after_ids: list[str]
+) -> list[tuple[str, int, int]]:
+    """Compute simple positional index moves between two orderings."""
     before_pos = {tid: i for i, tid in enumerate(before_ids)}
-    moves: list[tuple[str,int,int]] = []
+    moves: list[tuple[str, int, int]] = []
     for j, tid in enumerate(after_ids):
         if tid in before_pos:
             i = before_pos[tid]

--- a/pkgs/experimental/layout_engine/src/layout_engine/components/__init__.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/components/__init__.py
@@ -4,27 +4,65 @@
 - ComponentRegistry stores ComponentSpec entries and can resolve merged props.
 - bindings provides JSON (de)serialization and optional server-side render bindings (html/svg).
 """
+
 from .spec import ComponentSpec, merge_props, validate_role, validate_module
 from .base import IComponentRegistry
 from .default import ComponentRegistry, Component
 from .shortcuts import define_component, use_component, apply_defaults
 from .decorators import component, validate_props
 from .bindings import (
-    to_dict, from_dict,
-    registry_to_dict, registry_from_dict,
-    ServerBindings, Renderer, HTMLRenderer, SVGRenderer
+    to_dict,
+    from_dict,
+    registry_to_dict,
+    registry_from_dict,
+    ServerBindings,
+    Renderer,
+    HTMLRenderer,
+    SVGRenderer,
 )
 
 __all__ = [
-    "ComponentSpec", "merge_props", "validate_role", "validate_module",
-    "IComponentRegistry", "Component","ComponentRegistry",
-    "define_component", "use_component", "apply_defaults",
-    "component", "validate_props",
-    "to_dict", "from_dict", "registry_to_dict", "registry_from_dict",
-    "ServerBindings", "Renderer", "HTMLRenderer", "SVGRenderer",
+    "ComponentSpec",
+    "merge_props",
+    "validate_role",
+    "validate_module",
+    "IComponentRegistry",
+    "Component",
+    "ComponentRegistry",
+    "define_component",
+    "use_component",
+    "apply_defaults",
+    "component",
+    "validate_props",
+    "to_dict",
+    "from_dict",
+    "registry_to_dict",
+    "registry_from_dict",
+    "ServerBindings",
+    "Renderer",
+    "HTMLRenderer",
+    "SVGRenderer",
 ]
 
-from .default import Component
-from .shortcuts import define_component, derive_component, make_component
-from .decorators import component_ctx
-__all__ = list(set([*(globals().get("__all__", [])), "Component", "define_component", "derive_component", "make_component", "component_ctx"]))
+from .shortcuts import (
+    derive_component as _derive_component,
+    make_component as _make_component,
+)
+from .decorators import component_ctx as _component_ctx
+
+derive_component = _derive_component
+make_component = _make_component
+component_ctx = _component_ctx
+
+__all__ = list(
+    set(
+        [
+            *(globals().get("__all__", [])),
+            "Component",
+            "define_component",
+            "derive_component",
+            "make_component",
+            "component_ctx",
+        ]
+    )
+)

--- a/pkgs/experimental/layout_engine/src/layout_engine/components/base.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/components/base.py
@@ -1,36 +1,53 @@
 from __future__ import annotations
-from abc import ABC, abstractmethod, Iterable, Mapping, Any, Optional
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Iterable, Mapping, Optional
+
 from .spec import ComponentSpec
+
 
 class IComponentRegistry(ABC):
     """ABC for storing and resolving ComponentSpec entries by role."""
+
     @abstractmethod
     def register(self, spec: ComponentSpec) -> None:
         raise NotImplementedError
+
     @abstractmethod
     def register_many(self, specs: Iterable[ComponentSpec]) -> None:
         raise NotImplementedError
+
     @abstractmethod
     def override(self, role: str, **fields: Any) -> ComponentSpec:
         raise NotImplementedError
+
     @abstractmethod
     def get(self, role: str) -> ComponentSpec:
         raise NotImplementedError
+
     @abstractmethod
     def try_get(self, role: str) -> Optional[ComponentSpec]:
         raise NotImplementedError
+
     @abstractmethod
     def has(self, role: str) -> bool:
         raise NotImplementedError
+
     @abstractmethod
     def list(self) -> Iterable[ComponentSpec]:
         raise NotImplementedError
+
     @abstractmethod
-    def resolve_props(self, role: str, overrides: Mapping[str, Any] | None = None) -> dict:
+    def resolve_props(
+        self, role: str, overrides: Mapping[str, Any] | None = None
+    ) -> dict:
         raise NotImplementedError
+
     @abstractmethod
     def to_dict(self) -> dict[str, dict]:
         raise NotImplementedError
+
     @abstractmethod
     def update_from_dict(self, data: Mapping[str, Mapping[str, Any]]) -> None:
         raise NotImplementedError

--- a/pkgs/experimental/layout_engine/src/layout_engine/components/bindings.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/components/bindings.py
@@ -4,6 +4,7 @@ from .spec import ComponentSpec
 
 # -------- JSON (de)serialization --------
 
+
 def to_dict(spec: ComponentSpec) -> dict:
     return {
         "role": spec.role,
@@ -12,6 +13,7 @@ def to_dict(spec: ComponentSpec) -> dict:
         "version": spec.version,
         "defaults": dict(spec.defaults),
     }
+
 
 def from_dict(obj: Mapping[str, Any]) -> ComponentSpec:
     return ComponentSpec(
@@ -22,17 +24,21 @@ def from_dict(obj: Mapping[str, Any]) -> ComponentSpec:
         defaults=dict(obj.get("defaults", {})),
     )
 
+
 def registry_to_dict(registry) -> dict[str, dict]:
     return registry.dict()
 
+
 def registry_from_dict(registry, data: Mapping[str, Mapping[str, Any]]) -> None:
     registry.update_from_dict(data)
+
 
 # -------- Optional server render bindings (SSR partials) --------
 
 Renderer = Callable[[Mapping[str, Any]], str]
 HTMLRenderer = Renderer
 SVGRenderer = Renderer
+
 
 class ServerBindings:
     """Container for server-side renderers by (role, target).
@@ -42,6 +48,7 @@ class ServerBindings:
         bindings.register("kpi", "html", lambda props: f"<div>{props['value']}</div>")
         html = bindings.render("kpi", "html", {"value": 123})
     """
+
     def __init__(self):
         self._map: Dict[str, Dict[str, Renderer]] = {}
 

--- a/pkgs/experimental/layout_engine/src/layout_engine/components/decorators.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/components/decorators.py
@@ -4,17 +4,31 @@ from typing import Mapping, Any
 from .default import ComponentRegistry
 from .spec import ComponentSpec
 
-def component_ctx(*, role: str, module: str, export: str = "default",
-              version: str = "1.0.0", defaults: Mapping[str, Any] | None = None,
-              registry: ComponentRegistry | None = None):
+
+def component_ctx(
+    *,
+    role: str,
+    module: str,
+    export: str = "default",
+    version: str = "1.0.0",
+    defaults: Mapping[str, Any] | None = None,
+    registry: ComponentRegistry | None = None,
+):
     """Decorator to declare and optionally register a component_ctx specification.
 
     Example:
         @component_ctx(role="kpi", module="@app/widgets/Kpi.svelte", defaults={"format":"currency"}, registry=REG)
         def kpi(): pass
     """
+
     def deco(fn):
-        spec = ComponentSpec(role=role, module=module, export=export, version=version, defaults=defaults or {})
+        spec = ComponentSpec(
+            role=role,
+            module=module,
+            export=export,
+            version=version,
+            defaults=defaults or {},
+        )
         setattr(fn, "__component_spec__", spec)
         if registry is not None:
             registry.register(spec)
@@ -22,8 +36,31 @@ def component_ctx(*, role: str, module: str, export: str = "default",
         @wraps(fn)
         def wrapper(*a, **kw):
             return fn(*a, **kw)
+
         return wrapper
+
     return deco
+
+
+def component(
+    *,
+    role: str,
+    module: str,
+    export: str = "default",
+    version: str = "1.0.0",
+    defaults: Mapping[str, Any] | None = None,
+    registry: ComponentRegistry | None = None,
+):
+    """Backward compatible alias for :func:`component_ctx`."""
+    return component_ctx(
+        role=role,
+        module=module,
+        export=export,
+        version=version,
+        defaults=defaults,
+        registry=registry,
+    )
+
 
 def validate_props(schema: Mapping[str, Any] | None = None):
     """No-op validation decorator placeholder.
@@ -31,10 +68,13 @@ def validate_props(schema: Mapping[str, Any] | None = None):
     Hook point for adding runtime schema validation (pydantic/jsonschema) in apps that need it,
     while keeping core package free of heavy deps.
     """
+
     def deco(fn):
         @wraps(fn)
         def wrapper(*a, **kw):
             # place to validate kw against schema if provided
             return fn(*a, **kw)
+
         return wrapper
+
     return deco

--- a/pkgs/experimental/layout_engine/src/layout_engine/components/default.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/components/default.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 from typing import Iterable, Mapping, Any, Optional
 from .spec import ComponentSpec, merge_props
 
+
 class ComponentRegistry:
     """In-memory registry keyed by role (case-sensitive)."""
+
     def __init__(self):
         self._by_role: dict[str, ComponentSpec] = {}
 
@@ -15,7 +17,8 @@ class ComponentRegistry:
         self._by_role[role] = spec
 
     def register_many(self, specs: Iterable[ComponentSpec]) -> None:
-        for s in specs: self.register(s)
+        for s in specs:
+            self.register(s)
 
     def override(self, role: str, **fields: Any) -> ComponentSpec:
         try:
@@ -43,17 +46,21 @@ class ComponentRegistry:
         return list(self._by_role.values())
 
     # --- Resolution ---
-    def resolve_props(self, role: str, overrides: Mapping[str, Any] | None = None) -> dict:
+    def resolve_props(
+        self, role: str, overrides: Mapping[str, Any] | None = None
+    ) -> dict:
         spec = self.get(role)
         return merge_props(spec.defaults, overrides)
 
     # --- (De)serialization ---
     def to_dict(self) -> dict[str, dict]:
         from .bindings import to_dict as _to
+
         return {role: _to(spec) for role, spec in self._by_role.items()}
 
     def update_from_dict(self, data: Mapping[str, Mapping[str, Any]]) -> None:
         from .bindings import from_dict as _from
+
         for role, specd in data.items():
             spec = _from(specd)
             if role != spec.role:
@@ -62,22 +69,26 @@ class ComponentRegistry:
             # upsert semantics
             self._by_role[role] = spec
 
-
     # --- context manager support ---
     def __enter__(self):
         return self
+
     def __exit__(self, exc_type, exc, tb):
         return False
+
     async def __aenter__(self):
         return self
+
     async def __aexit__(self, exc_type, exc, tb):
         return False
+
 
 class Component:
     """Default runtime wrapper around ComponentSpec.
 
     Provides ergonomic accessors and merged props resolution.
     """
+
     def __init__(self, spec: ComponentSpec):
         self.spec = spec
 
@@ -104,9 +115,12 @@ class Component:
     # --- context manager support ---
     def __enter__(self):
         return self
+
     def __exit__(self, exc_type, exc, tb):
         return False
+
     async def __aenter__(self):
         return self
+
     async def __aexit__(self, exc_type, exc, tb):
         return False

--- a/pkgs/experimental/layout_engine/src/layout_engine/components/shortcuts.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/components/shortcuts.py
@@ -1,20 +1,51 @@
 from __future__ import annotations
 from typing import Mapping, Any
 from .spec import ComponentSpec
-from .default import Component
-from .registry import ComponentRegistry  # if present; otherwise import from __init__
+from .default import Component, ComponentRegistry
 
-def define_component(*, role: str, module: str, export: str = "default",
-                     version: str | None = None, defaults: Mapping[str, Any] | None = None) -> ComponentSpec:
+
+def define_component(
+    *,
+    role: str,
+    module: str,
+    export: str = "default",
+    version: str | None = None,
+    defaults: Mapping[str, Any] | None = None,
+) -> ComponentSpec:
     """Return a ComponentSpec (no registration side-effects)."""
-    return ComponentSpec(role=role, module=module, export=export, version=version, defaults=defaults or {})
+    return ComponentSpec(
+        role=role,
+        module=module,
+        export=export,
+        version=version,
+        defaults=defaults or {},
+    )
+
 
 def derive_component(base: ComponentSpec, **overrides) -> ComponentSpec:
     """Immutable copy of a ComponentSpec with field overrides."""
-    data = base.dict()
+    if hasattr(base, "model_dump"):
+        data = base.model_dump()
+    else:
+        data = base.dict()
     data.update(overrides)
     return ComponentSpec(**data)
+
 
 def make_component(spec: ComponentSpec) -> Component:
     """Instantiate a default Component from a spec."""
     return Component(spec=spec)
+
+
+def use_component(registry: ComponentRegistry, role: str) -> Component:
+    """Convenience accessor that wraps a registry lookup in a Component."""
+    spec = registry.get(role)
+    return Component(spec=spec)
+
+
+def apply_defaults(
+    registry: ComponentRegistry, role: str, overrides: Mapping[str, Any] | None = None
+) -> dict:
+    """Resolve component props by merging defaults with optional overrides."""
+    component = use_component(registry, role)
+    return component.resolve_props(overrides)

--- a/pkgs/experimental/layout_engine/src/layout_engine/components/spec.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/components/spec.py
@@ -1,29 +1,38 @@
-from pydantic import BaseModel, Field, validator
 from __future__ import annotations
-from pydantic import BaseModel, Field, validator, field, replace
-from typing import Any, Mapping
+
 import re
+from typing import Any, Mapping
+
+from pydantic import BaseModel, Field
 
 _ROLE_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9_:-]{1,63}$")
 # Approximate ESM specifier sanity check (package or path, may include '@scope/', '.', '/', '-', digits)
 _MODULE_RE = re.compile(r"^[a-zA-Z0-9@_./\-][a-zA-Z0-9@_./\-]*$")
 
+
 def validate_role(role: str) -> str:
     if not _ROLE_RE.match(role):
-        raise ValueError(f"invalid component role '{role}' (allowed: [A-Za-z][A-Za-z0-9_:-] 2..64)")
+        raise ValueError(
+            f"invalid component role '{role}' (allowed: [A-Za-z][A-Za-z0-9_:-] 2..64)"
+        )
     return role
+
 
 def validate_module(module: str) -> str:
     if not _MODULE_RE.match(module):
         raise ValueError(f"invalid module specifier '{module}'")
     return module
 
-def merge_props(defaults: Mapping[str, Any], overrides: Mapping[str, Any] | None) -> dict:
+
+def merge_props(
+    defaults: Mapping[str, Any], overrides: Mapping[str, Any] | None
+) -> dict:
     """Shallow-merge defaults with overrides (overrides win)."""
     out = dict(defaults or {})
     if overrides:
         out.update(overrides)
     return out
+
 
 class ComponentSpec(BaseModel):
     """Declarative mapping for a tile role to a client module/export.
@@ -34,9 +43,9 @@ class ComponentSpec(BaseModel):
     - version: component version tag for cache-busting/telemetry
     - defaults: default props merged at compile/manifest time
     """
+
     role: str
     module: str
     export: str = "default"
     version: str = "1.0.0"
-    defaults: Mapping[str, Any] = field(default_factory=dict)
-
+    defaults: Mapping[str, Any] = Field(default_factory=dict)

--- a/pkgs/experimental/layout_engine/src/layout_engine/contrib/presets.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/contrib/presets.py
@@ -1,7 +1,20 @@
 from __future__ import annotations
+
 # Default atoms (role -> ESM module/export/defaults). Consumers can override at call-sites.
 DEFAULT_ATOMS = {
-    "text":   {"module": "@le/atoms/Text.svelte",   "export": "default", "defaults": {"variant": "body"}},
-    "button": {"module": "@le/atoms/Button.svelte", "export": "default", "defaults": {"kind": "primary"}},
-    "timeseries": {"module": "@le/atoms/Timeseries.svelte", "export":"default", "defaults":{"legend": True}},
+    "text": {
+        "module": "@le/atoms/Text.svelte",
+        "export": "default",
+        "defaults": {"variant": "body"},
+    },
+    "button": {
+        "module": "@le/atoms/Button.svelte",
+        "export": "default",
+        "defaults": {"kind": "primary"},
+    },
+    "timeseries": {
+        "module": "@le/atoms/Timeseries.svelte",
+        "export": "default",
+        "defaults": {"legend": True},
+    },
 }

--- a/pkgs/experimental/layout_engine/src/layout_engine/core/__init__.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/core/__init__.py
@@ -2,4 +2,4 @@ from .size import Size, SizeToken, DEFAULT_TOKEN_WEIGHTS
 from .viewport import Viewport
 from .frame import Frame
 
-__all__ = ["Size","SizeToken","DEFAULT_TOKEN_WEIGHTS","Viewport","Frame"]
+__all__ = ["Size", "SizeToken", "DEFAULT_TOKEN_WEIGHTS", "Viewport", "Frame"]

--- a/pkgs/experimental/layout_engine/src/layout_engine/core/frame.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/core/frame.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 from dataclasses import dataclass
 
+
 @dataclass(frozen=True)
 class Frame:
-    x: int; y: int; w: int; h: int
+    x: int
+    y: int
+    w: int
+    h: int
+
+    def to_dict(self) -> dict[str, int]:
+        return {"x": self.x, "y": self.y, "w": self.w, "h": self.h}

--- a/pkgs/experimental/layout_engine/src/layout_engine/core/size.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/core/size.py
@@ -1,22 +1,32 @@
 from __future__ import annotations
-from dataclasses import dataclass
-from typing import Literal, Optional
-from enum import Enum
 
-Unit = Literal["px","fr","%"]
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Iterable, Literal, Mapping, Optional
+
+Unit = Literal["px", "fr", "%"]
+
 
 class SizeToken(str, Enum):
-    xxs = "xxs"; xs = "xs"; s = "s"; m = "m"; l = "l"; xl = "xl"; xxl = "xxl"
+    xxs = "xxs"
+    xs = "xs"
+    s = "s"
+    m = "m"
+    l = "l"  # noqa: E741 - short token name retained for backwards compat
+    xl = "xl"
+    xxl = "xxl"
+
 
 DEFAULT_TOKEN_WEIGHTS: dict[SizeToken, float] = {
     SizeToken.xxs: 0.5,
-    SizeToken.xs:  0.75,
-    SizeToken.s:   1.0,
-    SizeToken.m:   1.5,
-    SizeToken.l:   2.0,
-    SizeToken.xl:  3.0,
+    SizeToken.xs: 0.75,
+    SizeToken.s: 1.0,
+    SizeToken.m: 1.5,
+    SizeToken.l: 2.0,
+    SizeToken.xl: 3.0,
     SizeToken.xxl: 4.0,
 }
+
 
 @dataclass(frozen=True)
 class Size:
@@ -24,3 +34,104 @@ class Size:
     unit: Unit = "px"
     min_px: int = 0
     max_px: Optional[int] = None
+
+
+def tokens_to_fr_sizes(tokens: Iterable[SizeToken], *, min_px: int = 200) -> list[Size]:
+    """Convert size tokens to FR-based Size descriptors."""
+    sizes: list[Size] = []
+    for token in tokens:
+        tok = SizeToken(token)
+        sizes.append(Size(value=DEFAULT_TOKEN_WEIGHTS[tok], unit="fr", min_px=min_px))
+    return sizes
+
+
+def resolve_column_widths(
+    tracks: list[Size], viewport_width: int, gap: int
+) -> list[int]:
+    """Resolve a sequence of Size tracks into concrete pixel widths."""
+    n = len(tracks)
+    if n == 0:
+        return []
+
+    total_gap = max(0, n - 1) * max(0, gap)
+    available = max(0, int(viewport_width) - total_gap)
+
+    resolved = [0.0] * n
+    fixed_total = 0.0
+    fr_indices: list[int] = []
+    total_fr = 0.0
+
+    for idx, size in enumerate(tracks):
+        unit = size.unit
+        if unit == "px":
+            resolved[idx] = float(size.value)
+            fixed_total += resolved[idx]
+        elif unit == "%":
+            width = available * float(size.value) / 100.0
+            resolved[idx] = width
+            fixed_total += width
+        elif unit == "fr":
+            fr_indices.append(idx)
+            total_fr += float(size.value)
+        else:
+            raise ValueError(f"Unknown size unit '{unit}'")
+
+    remaining = max(0.0, available - fixed_total)
+    if fr_indices:
+        share = remaining / total_fr if total_fr > 0 else 0.0
+        for idx in fr_indices:
+            resolved[idx] = share * float(tracks[idx].value)
+
+    widths: list[int] = []
+    for idx, size in enumerate(tracks):
+        w = int(round(resolved[idx]))
+        w = max(w, size.min_px)
+        if size.max_px is not None:
+            w = min(w, size.max_px)
+        widths.append(max(w, 0))
+
+    drift = available - sum(widths)
+    i = 0
+    while drift != 0 and widths:
+        step = 1 if drift > 0 else -1
+        idx = i % n
+        candidate = widths[idx] + step
+        if candidate >= tracks[idx].min_px and (
+            tracks[idx].max_px is None or candidate <= tracks[idx].max_px
+        ):
+            widths[idx] = candidate
+            drift -= step
+        i += 1
+
+    return widths
+
+
+def parse_size(value: Any) -> Size:
+    """Parse common representations into a :class:`Size` instance."""
+    if isinstance(value, Size):
+        return value
+    if isinstance(value, Mapping):
+        return Size(
+            value=float(value.get("value", 0)),
+            unit=str(value.get("unit", "px")),
+            min_px=int(value.get("min_px", 0)),
+            max_px=(int(value["max_px"]) if value.get("max_px") is not None else None),
+        )
+    if isinstance(value, (tuple, list)) and len(value) >= 2:
+        val, unit = value[0], value[1]
+        return Size(value=float(val), unit=str(unit))
+    if isinstance(value, (int, float)):
+        return Size(value=float(value), unit="px")
+    if isinstance(value, str):
+        text = value.strip().lower()
+        if text.endswith("fr"):
+            num = text[:-2] or "1"
+            return Size(value=float(num), unit="fr")
+        if text.endswith("px"):
+            num = text[:-2] or "0"
+            return Size(value=float(num), unit="px")
+        if text.endswith("%"):
+            num = text[:-1] or "0"
+            return Size(value=float(num), unit="%")
+        raise ValueError(f"Unrecognized size string '{value}'")
+    raise TypeError(f"Cannot parse size from value of type {type(value)!r}")

--- a/pkgs/experimental/layout_engine/src/layout_engine/core/viewport.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/core/viewport.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 
+
 @dataclass(frozen=True)
 class Viewport:
     width: int

--- a/pkgs/experimental/layout_engine/src/layout_engine/events/__init__.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/events/__init__.py
@@ -9,17 +9,41 @@ Use:
       route_topic, InProcEventBus, EventRouter, utc_now_iso, make_ack, make_error
   )
 """
+
 from .spec import EventEnvelope, utc_now_iso, make_ack, make_error
 from .validators import (
-    ValidationError, validate_envelope, route_topic, is_allowed, allowed_types_for,
-    ALLOW, SITE, SLOT, PAGE, GRID, TILE, COMPONENT
+    ValidationError,
+    validate_envelope,
+    route_topic,
+    is_allowed,
+    allowed_types_for,
+    ALLOW,
+    SITE,
+    SLOT,
+    PAGE,
+    GRID,
+    TILE,
+    COMPONENT,
 )
 from .ws import InProcEventBus, EventRouter
 
 __all__ = [
-    "EventEnvelope", "ValidationError",
-    "validate_envelope", "route_topic", "is_allowed", "allowed_types_for",
-    "ALLOW", "SITE", "SLOT", "PAGE", "GRID", "TILE", "COMPONENT",
-    "InProcEventBus", "EventRouter",
-    "utc_now_iso", "make_ack", "make_error",
+    "EventEnvelope",
+    "ValidationError",
+    "validate_envelope",
+    "route_topic",
+    "is_allowed",
+    "allowed_types_for",
+    "ALLOW",
+    "SITE",
+    "SLOT",
+    "PAGE",
+    "GRID",
+    "TILE",
+    "COMPONENT",
+    "InProcEventBus",
+    "EventRouter",
+    "utc_now_iso",
+    "make_ack",
+    "make_error",
 ]

--- a/pkgs/experimental/layout_engine/src/layout_engine/events/spec.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/events/spec.py
@@ -1,14 +1,17 @@
-from pydantic import BaseModel, Field, validator
 from __future__ import annotations
-from pydantic import BaseModel, Field, validator
-from typing import Literal, Any, Mapping
-from datetime import datetime, timezone
 
-Scope = Literal["site","slot","page","grid","tile","component"]
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+Scope = Literal["site", "slot", "page", "grid", "tile", "component"]
+
 
 def utc_now_iso() -> str:
     """UTC timestamp in RFC3339/ISO8601 with 'Z'."""
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
 
 class EventEnvelope(BaseModel):
     scope: Scope
@@ -21,7 +24,9 @@ class EventEnvelope(BaseModel):
     target: dict[str, Any] | None
     payload: dict[str, Any] | None
 
+
 # Optional server responses
+
 
 class Ack(BaseModel):
     ok: bool
@@ -29,14 +34,17 @@ class Ack(BaseModel):
     code: str = "ok"
     message: str = ""
 
+
 def make_ack(request_id: str, message: str = "") -> Ack:
     return Ack(ok=True, request_id=request_id, code="ok", message=message)
+
 
 class ErrorAck(BaseModel):
     ok: bool
     request_id: str
     code: str
     message: str
+
 
 def make_error(request_id: str, code: str, message: str) -> ErrorAck:
     return ErrorAck(ok=False, request_id=request_id, code=code, message=message)

--- a/pkgs/experimental/layout_engine/src/layout_engine/events/validators.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/events/validators.py
@@ -1,51 +1,140 @@
 from __future__ import annotations
-from typing import Any, Iterable, Set
+from typing import Any, Set
 from .spec import EventEnvelope
 
 # ----- Allow lists (expanded) -----
 
 SITE: Set[str] = {
-  "site:load","site:ready","site:error","site:navigate",
-  "site:theme:change","site:locale:change",
-  "ws_open","ws_message","ws_close","ws_error",
+    "site:load",
+    "site:ready",
+    "site:error",
+    "site:navigate",
+    "site:theme:change",
+    "site:locale:change",
+    "ws_open",
+    "ws_message",
+    "ws_close",
+    "ws_error",
 }
-SLOT: Set[str] = {"slot:mount","slot:unmount","slot:visibilitychange","slot:resize"}
-PAGE: Set[str] = {"page:load","page:unload","page:params:change","page:resize","page:refresh","page:patch-applied","page:export","page:scroll"}
+SLOT: Set[str] = {"slot:mount", "slot:unmount", "slot:visibilitychange", "slot:resize"}
+PAGE: Set[str] = {
+    "page:load",
+    "page:unload",
+    "page:params:change",
+    "page:resize",
+    "page:refresh",
+    "page:patch-applied",
+    "page:export",
+    "page:scroll",
+}
 GRID: Set[str] = {
-    "grid:layout:compute-start","grid:layout:computed","grid:breakpoint:change",
-    "grid:reflow","grid:resize","grid:scroll",
+    "grid:layout:compute-start",
+    "grid:layout:computed",
+    "grid:breakpoint:change",
+    "grid:reflow",
+    "grid:resize",
+    "grid:scroll",
     # rearrange variants covered via wildcard matcher too
-    "grid:tile:rearrange:start","grid:tile:rearrange:over","grid:tile:rearrange:commit","grid:tile:rearrange:cancel"
+    "grid:tile:rearrange:start",
+    "grid:tile:rearrange:over",
+    "grid:tile:rearrange:commit",
+    "grid:tile:rearrange:cancel",
 }
 TILE: Set[str] = {
-    "tile:focus","tile:blur","tile:hover","tile:contextmenu","tile:visibilitychange","tile:resize",
-    "tile:maximize","tile:minimize","tile:refresh","tile:export",
-    "tile:dragstart","tile:dragover","tile:drop","tile:dragend"
+    "tile:focus",
+    "tile:blur",
+    "tile:hover",
+    "tile:contextmenu",
+    "tile:visibilitychange",
+    "tile:resize",
+    "tile:maximize",
+    "tile:minimize",
+    "tile:refresh",
+    "tile:export",
+    "tile:dragstart",
+    "tile:dragover",
+    "tile:drop",
+    "tile:dragend",
 }
 COMPONENT: Set[str] = {
-  # pointer*
-  "pointerdown","pointerup","pointermove","pointerenter","pointerleave","pointerover","pointerout","pointercancel",
-  "gotpointercapture","lostpointercapture",
-  # basic mouse/wheel/context for parity
-  "click","dblclick","contextmenu","wheel",
-  # keys & composition*
-  "keydown","keyup","compositionstart","compositionupdate","compositionend",
-  # forms
-  "beforeinput","input","change","submit","reset",
-  # focus/blur
-  "focus","blur",
-  # selection
-  "select","selectionchange",
-  # clipboard
-  "copy","cut","paste",
-  # drag*
-  "dragstart","drag","dragenter","dragover","dragleave","dragend","drop",
-  # media*
-  "play","pause","seeking","seeked","timeupdate","volumechange","ratechange","ended","loadeddata","loadedmetadata",
-  "canplay","canplaythrough","stalled","suspend","waiting","error","progress","durationchange","emptied","abort",
+    # pointer*
+    "pointerdown",
+    "pointerup",
+    "pointermove",
+    "pointerenter",
+    "pointerleave",
+    "pointerover",
+    "pointerout",
+    "pointercancel",
+    "gotpointercapture",
+    "lostpointercapture",
+    # basic mouse/wheel/context for parity
+    "click",
+    "dblclick",
+    "contextmenu",
+    "wheel",
+    # keys & composition*
+    "keydown",
+    "keyup",
+    "compositionstart",
+    "compositionupdate",
+    "compositionend",
+    # forms
+    "beforeinput",
+    "input",
+    "change",
+    "submit",
+    "reset",
+    # focus/blur
+    "focus",
+    "blur",
+    # selection
+    "select",
+    "selectionchange",
+    # clipboard
+    "copy",
+    "cut",
+    "paste",
+    # drag*
+    "dragstart",
+    "drag",
+    "dragenter",
+    "dragover",
+    "dragleave",
+    "dragend",
+    "drop",
+    # media*
+    "play",
+    "pause",
+    "seeking",
+    "seeked",
+    "timeupdate",
+    "volumechange",
+    "ratechange",
+    "ended",
+    "loadeddata",
+    "loadedmetadata",
+    "canplay",
+    "canplaythrough",
+    "stalled",
+    "suspend",
+    "waiting",
+    "error",
+    "progress",
+    "durationchange",
+    "emptied",
+    "abort",
 }
 
-ALLOW = {"site": SITE, "slot": SLOT, "page": PAGE, "grid": GRID, "tile": TILE, "component": COMPONENT}
+ALLOW = {
+    "site": SITE,
+    "slot": SLOT,
+    "page": PAGE,
+    "grid": GRID,
+    "tile": TILE,
+    "component": COMPONENT,
+}
+
 
 # Wildcard families per scope
 def _wildcards(scope: str) -> list[str]:
@@ -59,16 +148,19 @@ def _wildcards(scope: str) -> list[str]:
         return ["tile:drag"]
     if scope == "component":
         return [
-            "pointer",            # pointer*
-            "composition",        # composition*
-            "drag",               # drag*
+            "pointer",  # pointer*
+            "composition",  # composition*
+            "drag",  # drag*
             # media* covered by explicit list above; keep here for completeness
         ]
     return []
 
+
 class ValidationError(Exception):
     """Raised when an event envelope fails validation."""
+
     pass
+
 
 def is_allowed(scope: str, etype: str) -> bool:
     # Exact
@@ -83,6 +175,7 @@ def is_allowed(scope: str, etype: str) -> bool:
         return True
     return False
 
+
 def allowed_types_for(scope: str) -> set[str]:
     base = set(ALLOW.get(scope, set()))
     # Add documented wildcard hints (not exhaustive enumeration)
@@ -91,28 +184,42 @@ def allowed_types_for(scope: str) -> set[str]:
         base.add("ws:*")
     return base
 
+
 def validate_envelope(e: dict[str, Any]) -> EventEnvelope:
-    for k in ("scope","type","ts","request_id"):
-        if k not in e: raise ValidationError(f"missing field: {k}")
-    scope = e["scope"]; etype = e["type"]
+    for k in ("scope", "type", "ts", "request_id"):
+        if k not in e:
+            raise ValidationError(f"missing field: {k}")
+    scope = e["scope"]
+    etype = e["type"]
     if scope not in ALLOW:
         raise ValidationError(f"unknown scope: {scope}")
     if not is_allowed(scope, etype):
         raise ValidationError(f"event '{etype}' not allowed for scope '{scope}'")
     return EventEnvelope(
-        scope=scope, type=etype,
-        page_id=e.get("page_id"), slot=e.get("slot"), tile_id=e.get("tile_id"),
-        ts=e["ts"], request_id=e["request_id"],
-        target=e.get("target") or {}, payload=e.get("payload") or {}
+        scope=scope,
+        type=etype,
+        page_id=e.get("page_id"),
+        slot=e.get("slot"),
+        tile_id=e.get("tile_id"),
+        ts=e["ts"],
+        request_id=e["request_id"],
+        target=e.get("target") or {},
+        payload=e.get("payload") or {},
     )
 
+
 def route_topic(ev: EventEnvelope) -> str:
-    if ev.scope == "site": return "site"
-    if ev.scope == "page": return f"page:{ev.page_id}"
-    if ev.scope == "slot": return f"slot:{ev.page_id}:{ev.slot}"
-    if ev.scope == "grid": return f"grid:{ev.page_id}"
-    if ev.scope == "tile": return f"tile:{ev.page_id}:{ev.tile_id}"
+    if ev.scope == "site":
+        return "site"
+    if ev.scope == "page":
+        return f"page:{ev.page_id}"
+    if ev.scope == "slot":
+        return f"slot:{ev.page_id}:{ev.slot}"
+    if ev.scope == "grid":
+        return f"grid:{ev.page_id}"
+    if ev.scope == "tile":
+        return f"tile:{ev.page_id}:{ev.tile_id}"
     if ev.scope == "component":
-        key = (ev.target or {}).get("key","_")
+        key = (ev.target or {}).get("key", "_")
         return f"component:{ev.page_id}:{ev.tile_id}:{key}"
     raise ValidationError("unroutable")

--- a/pkgs/experimental/layout_engine/src/layout_engine/events/ws.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/events/ws.py
@@ -1,36 +1,44 @@
 from __future__ import annotations
 from collections import defaultdict
-from typing import Callable, Dict, List, Any, Tuple
+from typing import Callable, Dict, List, Tuple
 
-from .validators import validate_envelope, route_topic, ValidationError
+from .validators import validate_envelope, route_topic
 
 Subscriber = Callable[[dict], None]
+
 
 class InProcEventBus:
     """A tiny in-process pub/sub with optional retained last message per topic.
 
     This is intended for tests and lightweight servers; swap with a real broker in production.
     """
+
     def __init__(self):
         self._subs: Dict[str, List[Subscriber]] = defaultdict(list)
         self._retained: Dict[str, dict] = {}
 
     # ---- Subscription API ----
-    def subscribe(self, topic: str, fn: Subscriber, *, replay_last: bool = False) -> Callable[[], None]:
+    def subscribe(
+        self, topic: str, fn: Subscriber, *, replay_last: bool = False
+    ) -> Callable[[], None]:
         self._subs[topic].append(fn)
         if replay_last and topic in self._retained:
             try:
                 fn(self._retained[topic])
             except Exception:
                 pass
+
         def _unsub():
             lst = self._subs.get(topic, [])
-            if fn in lst: lst.remove(fn)
+            if fn in lst:
+                lst.remove(fn)
+
         return _unsub
 
     def unsubscribe(self, topic: str, fn: Subscriber) -> None:
         lst = self._subs.get(topic, [])
-        if fn in lst: lst.remove(fn)
+        if fn in lst:
+            lst.remove(fn)
 
     # ---- Publish API ----
     def publish(self, topic: str, message: dict, *, retain: bool = False) -> int:
@@ -39,7 +47,8 @@ class InProcEventBus:
         count = 0
         for fn in list(self._subs.get(topic, [])):
             try:
-                fn(message); count += 1
+                fn(message)
+                count += 1
             except Exception:
                 # best-effort: swallow subscriber errors
                 pass
@@ -48,10 +57,13 @@ class InProcEventBus:
     def last(self, topic: str) -> dict | None:
         return self._retained.get(topic)
 
+
 # -------- Router that validates + publishes --------
+
 
 class EventRouter:
     """Validate envelopes and publish to topic derived from scope/page/slot/tile."""
+
     def __init__(self, bus: InProcEventBus):
         self.bus = bus
 

--- a/pkgs/experimental/layout_engine/src/layout_engine/grid/__init__.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/grid/__init__.py
@@ -6,28 +6,75 @@ Public API:
 - Utilities: tracks helpers, make_gridspec, place
 - Bindings: to/from dict
 """
+
 from .spec import GridTrack, GridSpec, GridTile
 from .default import ExplicitGridResolver
 from .shortcuts import (
-    make_gridspec, place, tracks_fr, tracks_px, tracks_pct,
-    make_gridspec_from_tokens
+    make_gridspec,
+    place,
+    tracks_fr,
+    tracks_px,
+    tracks_pct,
+    make_gridspec_from_tokens,
+    gridspec_from_tokens,
+    breakpoint,
+    breakpoints,
 )
 from .bindings import (
-    gridspec_to_dict, gridspec_from_dict,
-    gridtrack_to_dict, gridtrack_from_dict,
-    gridtile_to_dict, gridtile_from_dict
+    gridspec_to_dict,
+    gridspec_from_dict,
+    gridtrack_to_dict,
+    gridtrack_from_dict,
+    gridtile_to_dict,
+    gridtile_from_dict,
 )
 
 __all__ = [
-    "GridTrack","GridSpec","GridTile","ExplicitGridResolver",
-    "make_gridspec","place","tracks_fr","tracks_px","tracks_pct","make_gridspec_from_tokens",
-    "gridspec_to_dict","gridspec_from_dict","gridtrack_to_dict","gridtrack_from_dict",
-    "gridtile_to_dict","gridtile_from_dict",
+    "GridTrack",
+    "GridSpec",
+    "GridTile",
+    "ExplicitGridResolver",
+    "make_gridspec",
+    "place",
+    "tracks_fr",
+    "tracks_px",
+    "tracks_pct",
+    "make_gridspec_from_tokens",
+    "gridspec_from_tokens",
+    "breakpoint",
+    "breakpoints",
+    "gridspec_to_dict",
+    "gridspec_from_dict",
+    "gridtrack_to_dict",
+    "gridtrack_from_dict",
+    "gridtile_to_dict",
+    "gridtile_from_dict",
 ]
 
 from .default import Grid
-__all__ = [*(globals().get('__all__', [])), 'Grid']
 
-from .shortcuts import define_gridspec, derive_gridspec, make_grid
-from .decorators import with_breakpoints_ctx
-__all__ = list(set([*(globals().get("__all__", [])), "define_gridspec", "derive_gridspec", "make_grid", "with_breakpoints_ctx"]))
+__all__ = [*(globals().get("__all__", [])), "Grid"]
+
+from .shortcuts import (
+    define_gridspec as _define_gridspec,
+    derive_gridspec as _derive_gridspec,
+    make_grid as _make_grid,
+)
+from .decorators import with_breakpoints_ctx as _with_breakpoints_ctx
+
+define_gridspec = _define_gridspec
+derive_gridspec = _derive_gridspec
+make_grid = _make_grid
+with_breakpoints_ctx = _with_breakpoints_ctx
+
+__all__ = list(
+    set(
+        [
+            *(globals().get("__all__", [])),
+            "define_gridspec",
+            "derive_gridspec",
+            "make_grid",
+            "with_breakpoints_ctx",
+        ]
+    )
+)

--- a/pkgs/experimental/layout_engine/src/layout_engine/grid/base.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/grid/base.py
@@ -4,8 +4,11 @@ from ..core.viewport import Viewport
 from ..core.frame import Frame
 from .spec import GridSpec, GridTile
 
+
 class IGridResolver(ABC):
     @abstractmethod
-    def frames(self, spec: GridSpec, vp: Viewport, tiles: list[GridTile]) -> dict[str, Frame]:
+    def frames(
+        self, spec: GridSpec, vp: Viewport, tiles: list[GridTile]
+    ) -> dict[str, Frame]:
         """Compute absolute frames for tiles from a grid specification."""
         raise NotImplementedError

--- a/pkgs/experimental/layout_engine/src/layout_engine/grid/bindings.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/grid/bindings.py
@@ -1,29 +1,53 @@
 from __future__ import annotations
 from typing import Mapping, Any, List, Tuple
 from .spec import GridSpec, GridTrack, GridTile
-from ..core.size import Size, parse_size
+from ..core.size import Size
+
 
 # ----------- GridTrack -----------
 def gridtrack_to_dict(gt: GridTrack) -> dict:
     s = gt.size
-    return {"size": {"value": s.value, "unit": s.unit, "min_px": s.min_px, "max_px": s.max_px}}
+    return {
+        "size": {
+            "value": s.value,
+            "unit": s.unit,
+            "min_px": s.min_px,
+            "max_px": s.max_px,
+        }
+    }
+
 
 def gridtrack_from_dict(d: Mapping[str, Any]) -> GridTrack:
     s = d.get("size", {})
-    size = Size(float(s.get("value", 0)), unit=s.get("unit", "px"), min_px=int(s.get("min_px", 0)), max_px=s.get("max_px"))
+    size = Size(
+        float(s.get("value", 0)),
+        unit=s.get("unit", "px"),
+        min_px=int(s.get("min_px", 0)),
+        max_px=s.get("max_px"),
+    )
     return GridTrack(size)
+
 
 # ----------- GridTile -----------
 def gridtile_to_dict(gt: GridTile) -> dict:
-    return {"tile_id": gt.tile_id, "col": gt.col, "row": gt.row, "col_span": gt.col_span, "row_span": gt.row_span}
+    return {
+        "tile_id": gt.tile_id,
+        "col": gt.col,
+        "row": gt.row,
+        "col_span": gt.col_span,
+        "row_span": gt.row_span,
+    }
+
 
 def gridtile_from_dict(d: Mapping[str, Any]) -> GridTile:
     return GridTile(
         tile_id=str(d["tile_id"]),
-        col=int(d["col"]), row=int(d["row"]),
+        col=int(d["col"]),
+        row=int(d["row"]),
         col_span=int(d.get("col_span", 1)),
-        row_span=int(d.get("row_span", 1))
+        row_span=int(d.get("row_span", 1)),
     )
+
 
 # ----------- GridSpec -----------
 def gridspec_to_dict(gs: GridSpec) -> dict:
@@ -38,9 +62,15 @@ def gridspec_to_dict(gs: GridSpec) -> dict:
         ],
     }
 
+
 def gridspec_from_dict(d: Mapping[str, Any]) -> GridSpec:
     cols = [gridtrack_from_dict(x) for x in d.get("columns", [])]
-    gs = GridSpec(columns=cols, row_height=int(d.get("row_height", 180)), gap_x=int(d.get("gap_x", 12)), gap_y=int(d.get("gap_y", 12)))
+    gs = GridSpec(
+        columns=cols,
+        row_height=int(d.get("row_height", 180)),
+        gap_x=int(d.get("gap_x", 12)),
+        gap_y=int(d.get("gap_y", 12)),
+    )
     bps: List[Tuple[int, list[GridTrack]]] = []
     for entry in d.get("breakpoints", []):
         max_w, cols_entry = entry

--- a/pkgs/experimental/layout_engine/src/layout_engine/grid/decorators.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/grid/decorators.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 from functools import wraps
-from typing import Iterable
 from .spec import GridSpec, GridTrack
 from ..core.size import Size, parse_size
 
-def with_breakpoints_ctx(*breakpoints: tuple[int, list[str | float | int | Size | GridTrack]]):  # (max_w, columns)
+
+def with_breakpoints_ctx(
+    *breakpoints: tuple[int, list[str | float | int | Size | GridTrack]],
+):  # (max_w, columns)
     """Decorator to attach breakpoints to a GridSpec factory.
 
     Each breakpoint is a tuple: (max_width_px, columns), where `columns` is a list of
@@ -20,6 +22,7 @@ def with_breakpoints_ctx(*breakpoints: tuple[int, list[str | float | int | Size 
         def build_spec() -> GridSpec:
             return make_gridspec([1,1,1,1])  # default (>=1280px): 4 cols
     """
+
     def deco(fn):
         @wraps(fn)
         def wrapper(*a, **kw) -> GridSpec:
@@ -41,8 +44,11 @@ def with_breakpoints_ctx(*breakpoints: tuple[int, list[str | float | int | Size 
             # attach (replace/extend) breakpoints
             gs.breakpoints = tuple(sorted(bps, key=lambda x: x[0]))  # type: ignore[attr-defined]
             return gs
+
         return wrapper
+
     return deco
+
 
 def stable(fn):
     """No-op decorator placeholder to mark stable grid factories (policy hook)."""

--- a/pkgs/experimental/layout_engine/src/layout_engine/grid/default.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/grid/default.py
@@ -4,7 +4,8 @@ from .base import IGridResolver
 from .spec import GridSpec, GridTile, GridTrack
 from ..core.viewport import Viewport
 from ..core.frame import Frame
-from ..core.size import Size, resolve_column_widths
+from ..core.size import resolve_column_widths
+
 
 class ExplicitGridResolver(IGridResolver):
     """Deterministic resolver for explicit grids.
@@ -21,7 +22,10 @@ class ExplicitGridResolver(IGridResolver):
       3) Compute column x-offsets.
       4) For each GridTile, create a Frame; validate bounds.
     """
-    def frames(self, spec: GridSpec, vp: Viewport, tiles: list[GridTile]) -> dict[str, Frame]:
+
+    def frames(
+        self, spec: GridSpec, vp: Viewport, tiles: list[GridTile]
+    ) -> dict[str, Frame]:
         cols = self._columns_for_viewport(spec, vp)
         n = len(cols)
         if n == 0:
@@ -33,14 +37,22 @@ class ExplicitGridResolver(IGridResolver):
         frames: dict[str, Frame] = {}
         for gt in tiles:
             if gt.col < 0 or gt.col >= n:
-                raise ValueError(f"tile '{gt.tile_id}' col out of range: {gt.col} in [0,{n-1}]")
+                raise ValueError(
+                    f"tile '{gt.tile_id}' col out of range: {gt.col} in [0,{n - 1}]"
+                )
             if gt.col_span < 1 or gt.col + gt.col_span > n:
-                raise ValueError(f"tile '{gt.tile_id}' col_span invalid: start={gt.col} span={gt.col_span} with {n} columns")
+                raise ValueError(
+                    f"tile '{gt.tile_id}' col_span invalid: start={gt.col} span={gt.col_span} with {n} columns"
+                )
             if gt.row < 0 or gt.row_span < 1:
-                raise ValueError(f"tile '{gt.tile_id}' row/row_span invalid: row={gt.row} row_span={gt.row_span}")
+                raise ValueError(
+                    f"tile '{gt.tile_id}' row/row_span invalid: row={gt.row} row_span={gt.row_span}"
+                )
 
             x = xoffs[gt.col]
-            w = sum(widths[gt.col : gt.col + gt.col_span]) + spec.gap_x * (gt.col_span - 1)
+            w = sum(widths[gt.col : gt.col + gt.col_span]) + spec.gap_x * (
+                gt.col_span - 1
+            )
             y = gt.row * (spec.row_height + spec.gap_y)
             h = gt.row_span * spec.row_height + spec.gap_y * (gt.row_span - 1)
             frames[gt.tile_id] = Frame(x=x, y=y, w=w, h=h)
@@ -70,6 +82,7 @@ class ExplicitGridResolver(IGridResolver):
 
 class Grid:
     """Default grid runtime wrapper that pairs a GridSpec with a resolver."""
+
     def __init__(self, spec: GridSpec, resolver: IGridResolver | None = None):
         self.spec = spec
         self.resolver = resolver or ExplicitGridResolver()
@@ -80,9 +93,12 @@ class Grid:
     # --- context manager support ---
     def __enter__(self):
         return self
+
     def __exit__(self, exc_type, exc, tb):
         return False
+
     async def __aenter__(self):
         return self
+
     async def __aexit__(self, exc_type, exc, tb):
         return False

--- a/pkgs/experimental/layout_engine/src/layout_engine/grid/shortcuts.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/grid/shortcuts.py
@@ -1,35 +1,82 @@
 from __future__ import annotations
 from typing import Iterable
+
+from .default import Grid
 from .spec import GridSpec, GridTrack, GridTile
 from ..core.size import Size, SizeToken, tokens_to_fr_sizes
+
 
 def tracks_fr(fr_values: Iterable[float], *, min_px: int = 200) -> list[GridTrack]:
     return [GridTrack(Size(float(v), unit="fr", min_px=min_px)) for v in fr_values]
 
+
 def tracks_px(px_values: Iterable[float]) -> list[GridTrack]:
     return [GridTrack(Size(float(v), unit="px")) for v in px_values]
+
 
 def tracks_pct(percent_values: Iterable[float], *, min_px: int = 0) -> list[GridTrack]:
     return [GridTrack(Size(float(v), unit="%", min_px=min_px)) for v in percent_values]
 
-def make_gridspec(fr_values: list[float], *, row_height: int = 180, gap_x: int = 12, gap_y: int = 12) -> GridSpec:
+
+def make_gridspec(
+    fr_values: list[float], *, row_height: int = 180, gap_x: int = 12, gap_y: int = 12
+) -> GridSpec:
     columns = tracks_fr(fr_values)
     return GridSpec(columns=columns, row_height=row_height, gap_x=gap_x, gap_y=gap_y)
 
-def make_gridspec_from_tokens(tokens: list[SizeToken], *, row_height: int = 180, gap_x: int = 12, gap_y: int = 12, min_px: int = 200) -> GridSpec:
+
+def make_gridspec_from_tokens(
+    tokens: list[SizeToken],
+    *,
+    row_height: int = 180,
+    gap_x: int = 12,
+    gap_y: int = 12,
+    min_px: int = 200,
+) -> GridSpec:
     sizes = tokens_to_fr_sizes(tokens, min_px=min_px)
     columns = [GridTrack(s) for s in sizes]
     return GridSpec(columns=columns, row_height=row_height, gap_x=gap_x, gap_y=gap_y)
 
-def place(tile_id: str, col: int, row: int, *, col_span: int = 1, row_span: int = 1) -> GridTile:
+
+def gridspec_from_tokens(tokens: list[SizeToken], **kwargs) -> GridSpec:
+    """Backward compatible alias for :func:`make_gridspec_from_tokens`."""
+    return make_gridspec_from_tokens(tokens, **kwargs)
+
+
+def breakpoint(max_width: int, columns: list[GridTrack]) -> tuple[int, list[GridTrack]]:
+    """Helper to define a breakpoint entry."""
+    return (max_width, columns)
+
+
+def breakpoints(
+    *entries: tuple[int, list[GridTrack]],
+) -> list[tuple[int, list[GridTrack]]]:
+    """Collect breakpoint tuples into a list."""
+    return list(entries)
+
+
+def place(
+    tile_id: str, col: int, row: int, *, col_span: int = 1, row_span: int = 1
+) -> GridTile:
     return GridTile(tile_id, col, row, col_span, row_span)
 
-# -- define/derive/make for Grid --
-from .default import Grid
-from .spec import GridSpec
 
-def define_gridspec(*, columns: list[GridTrack] | None = None, row_height: int = 180, gap_x: int = 12, gap_y: int = 12, breakpoints=None) -> GridSpec:
-    return GridSpec(columns=columns or [], row_height=row_height, gap_x=gap_x, gap_y=gap_y, breakpoints=breakpoints or ())
+def define_gridspec(
+    *,
+    columns: list[GridTrack] | None = None,
+    row_height: int = 180,
+    gap_x: int = 12,
+    gap_y: int = 12,
+    breakpoints=None,
+) -> GridSpec:
+    return GridSpec(
+        columns=columns or [],
+        row_height=row_height,
+        gap_x=gap_x,
+        gap_y=gap_y,
+        breakpoints=breakpoints or (),
+    )
+
 
 def derive_gridspec(base: GridSpec, **overrides) -> GridSpec:
     return GridSpec(
@@ -39,6 +86,7 @@ def derive_gridspec(base: GridSpec, **overrides) -> GridSpec:
         gap_y=overrides.get("gap_y", base.gap_y),
         breakpoints=overrides.get("breakpoints", base.breakpoints),
     )
+
 
 def make_grid(spec: GridSpec) -> Grid:
     return Grid(spec=spec)

--- a/pkgs/experimental/layout_engine/src/layout_engine/grid/spec.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/grid/spec.py
@@ -1,12 +1,15 @@
-from pydantic import BaseModel, Field, validator
 from __future__ import annotations
-from pydantic import BaseModel, Field, validator
-from typing import Optional
+
+from pydantic import BaseModel
+
 from ..core.size import Size
+
 
 class GridTrack(BaseModel):
     """A single grid column track with a Size (px|%|fr)."""
+
     size: Size
+
 
 class GridSpec(BaseModel):
     """Explicit grid container description.
@@ -17,15 +20,17 @@ class GridSpec(BaseModel):
     - breakpoints: optional list of (max_width_px, columns_for_that_break)
       The first entry whose max_width >= viewport.width wins.
     """
+
     columns: list[GridTrack]
     row_height: int = 180
     gap_x: int = 12
     gap_y: int = 12
     breakpoints: list[tuple[int, list[GridTrack]]] = ()
 
+
 class GridTile(BaseModel):
-    """A tile placement within the grid."
-    """
+    """A tile placement within the grid." """
+
     tile_id: str
     col: int
     row: int

--- a/pkgs/experimental/layout_engine/src/layout_engine/manifest/__init__.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/manifest/__init__.py
@@ -1,4 +1,3 @@
-
 """Manifest: canonical, framework-agnostic description of a rendered page.
 
 Exports:
@@ -8,15 +7,47 @@ Exports:
 - Validation & schema: `validate(manifest)`, `schema()`
 - Patching: `diff(old, new)`, `apply_patch(base, patch)`
 """
+
 from .spec import Manifest
 from .default import ManifestBuilder
 from .utils import (
-    build_manifest, etag_of, to_dict, from_dict, validate, schema, diff, apply_patch
+    build_manifest,
+    etag_of,
+    to_dict,
+    from_dict,
+    validate,
+    schema,
+    diff,
+    apply_patch,
+    manifest_to_json,
+    manifest_from_json,
+    compute_etag,
+    validate_manifest,
+    sort_tiles,
+    to_plain_dict,
+    from_plain_dict,
+    diff_manifests,
+    make_patch,
 )
 
 __all__ = [
     "Manifest",
     "ManifestBuilder",
-    "build_manifest", "etag_of", "to_dict", "from_dict",
-    "validate", "schema", "diff", "apply_patch",
+    "build_manifest",
+    "etag_of",
+    "to_dict",
+    "from_dict",
+    "validate",
+    "schema",
+    "diff",
+    "apply_patch",
+    "manifest_to_json",
+    "manifest_from_json",
+    "compute_etag",
+    "validate_manifest",
+    "sort_tiles",
+    "to_plain_dict",
+    "from_plain_dict",
+    "diff_manifests",
+    "make_patch",
 ]

--- a/pkgs/experimental/layout_engine/src/layout_engine/manifest/base.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/manifest/base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod, Mapping, Any
 from .spec import Manifest
 
+
 class IManifestBuilder(ABC):
     @abstractmethod
     def build(self, view_model: Mapping[str, Any]) -> Manifest:

--- a/pkgs/experimental/layout_engine/src/layout_engine/manifest/default.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/manifest/default.py
@@ -1,19 +1,38 @@
 from __future__ import annotations
 from typing import Mapping, Any
 from .spec import Manifest
-from .utils import build_manifest
+from .utils import (
+    build_manifest,
+    manifest_to_json as _manifest_to_json,
+    manifest_from_json as _manifest_from_json,
+)
+
 
 class ManifestBuilder:
     """Default manifest builder; thin class wrapper over utils.build_manifest()."""
-    def build(self, view_model: Mapping[str, Any], *, version: str = "2025.10") -> Manifest:
+
+    def build(
+        self, view_model: Mapping[str, Any], *, version: str = "2025.10"
+    ) -> Manifest:
         return build_manifest(view_model, version=version)
 
     # --- context manager support ---
     def __enter__(self):
         return self
+
     def __exit__(self, exc_type, exc, tb):
         return False
+
     async def __aenter__(self):
         return self
+
     async def __aexit__(self, exc_type, exc, tb):
         return False
+
+
+def manifest_to_json(manifest: Manifest, *, indent: int | None = None) -> str:
+    return _manifest_to_json(manifest, indent=indent)
+
+
+def manifest_from_json(data: str | Mapping[str, Any]) -> Manifest:
+    return _manifest_from_json(data)

--- a/pkgs/experimental/layout_engine/src/layout_engine/manifest/shortcuts.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/manifest/shortcuts.py
@@ -1,23 +1,36 @@
 from __future__ import annotations
 import json
 from typing import Mapping, Any
-from .default import build_manifest as _build, to_dict as _to_dict, from_dict as _from_dict, diff as _diff, apply_patch as _apply, schema as _schema
+from .default import (
+    build_manifest as _build,
+    to_dict as _to_dict,
+    from_dict as _from_dict,
+    diff as _diff,
+    apply_patch as _apply,
+    schema as _schema,
+)
 from .spec import Manifest
+
 
 def build(view_model: Mapping[str, Any]) -> Manifest:
     return _build(view_model)
 
+
 def to_json(manifest: Manifest) -> str:
     return json.dumps(_to_dict(manifest), separators=(",", ":"), sort_keys=True)
+
 
 def from_json(data: str) -> Manifest:
     return _from_dict(json.loads(data))
 
+
 def patch(old: Manifest, new: Manifest) -> dict:
     return _diff(old, new)
 
+
 def apply(manifest: Manifest, patch: Mapping[str, Any]) -> Manifest:
     return _apply(manifest, patch)
+
 
 def schema() -> dict:
     return _schema()

--- a/pkgs/experimental/layout_engine/src/layout_engine/manifest/spec.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/manifest/spec.py
@@ -1,7 +1,9 @@
-from pydantic import BaseModel, Field, validator
 from __future__ import annotations
-from pydantic import BaseModel, Field, validator
-from typing import Any, Mapping, Sequence
+
+from typing import Any, Mapping
+
+from pydantic import BaseModel
+
 
 class Manifest(BaseModel):
     """Canonical page manifest.
@@ -15,6 +17,7 @@ class Manifest(BaseModel):
                          { id: str, role: str, frame: {x,y,w,h}, props: {...}, component?: {...} }
       - etag:            content hash for cache/patch validation
     """
+
     kind: str
     version: str
     viewport: Mapping[str, Any]

--- a/pkgs/experimental/layout_engine/src/layout_engine/manifest/utils.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/manifest/utils.py
@@ -1,23 +1,22 @@
 from __future__ import annotations
-import json, hashlib
+
+import json
+import hashlib
 from typing import Any, Mapping
+
 from .spec import Manifest
 from ..compile.utils import frame_diff
+from ..core.frame import Frame
+
 
 def etag_of(obj: Mapping[str, Any]) -> str:
     """Stable content hash (sha256 over canonical JSON)."""
-    return hashlib.sha256(json.dumps(obj, sort_keys=True, separators=(",", ":"), default=str).encode()).hexdigest()
+    return hashlib.sha256(
+        json.dumps(obj, sort_keys=True, separators=(",", ":"), default=str).encode()
+    ).hexdigest()
 
 
 def _normalize_tile(tile: Mapping[str, Any]) -> dict:
-    """Normalize a tile payload to a canonical structure & field order.
-
-    Required keys:
-      - id (str), role (str), frame (mapping x,y,w,h), props (mapping)
-    Optional:
-      - component (mapping: module/export/version/defaults)
-    Unknown keys are preserved for forward-compat but serialized at the end.
-    """
     t = dict(tile)
     tid = str(t.get("id"))
     role = str(t.get("role"))
@@ -27,8 +26,12 @@ def _normalize_tile(tile: Mapping[str, Any]) -> dict:
     base = {
         "id": tid,
         "role": role,
-        "frame": {"x": int(frame.get("x", 0)), "y": int(frame.get("y", 0)),
-                  "w": int(frame.get("w", 0)), "h": int(frame.get("h", 0))},
+        "frame": {
+            "x": int(frame.get("x", 0)),
+            "y": int(frame.get("y", 0)),
+            "w": int(frame.get("w", 0)),
+            "h": int(frame.get("h", 0)),
+        },
         "props": props,
     }
     if component is not None:
@@ -39,14 +42,33 @@ def _normalize_tile(tile: Mapping[str, Any]) -> dict:
             "version": str(c.get("version", "1.0.0")),
             "defaults": dict(c.get("defaults", {})),
         }
-    # Append any extra keys deterministically
     for k in sorted(t.keys()):
         if k not in base:
             base[k] = t[k]
     return base
 
 
-def build_manifest(view_model: Mapping[str, Any], *, version: str | None = None) -> Manifest:
+def _normalize_view_model(data: Mapping[str, Any]) -> dict:
+    kind = str(data.get("kind") or "layout_manifest")
+    version = str(data.get("version") or "2025.10")
+    viewport = dict(data.get("viewport") or {})
+    grid = data.get("grid") or {}
+    tiles = [_normalize_tile(t) for t in data.get("tiles", [])]
+    return {
+        "kind": kind,
+        "version": version,
+        "viewport": {
+            "width": int(viewport.get("width", 0)),
+            "height": int(viewport.get("height", 0)),
+        },
+        "grid": dict(grid),
+        "tiles": tiles,
+    }
+
+
+def build_manifest(
+    view_model: Mapping[str, Any], *, version: str | None = None
+) -> Manifest:
     payload = _normalize_view_model(view_model)
     if version is not None:
         payload["version"] = version
@@ -65,22 +87,28 @@ def to_dict(manifest: Manifest) -> dict:
 
 
 def from_dict(data: Mapping[str, Any]) -> Manifest:
-    # Normalize again to ensure field ordering and computed types are clean
     payload = _normalize_view_model(data)
     etag = str(data.get("etag") or etag_of(payload))
     return Manifest(**payload, etag=etag)
 
-# --------- Validation & schema ---------
+
+def manifest_to_json(manifest: Manifest, *, indent: int | None = None) -> str:
+    return json.dumps(to_dict(manifest), indent=indent, sort_keys=True)
+
+
+def manifest_from_json(data: str | Mapping[str, Any]) -> Manifest:
+    if isinstance(data, str):
+        return from_dict(json.loads(data))
+    return from_dict(data)
 
 
 def validate(manifest: Manifest) -> None:
     if manifest.kind != "layout_manifest":
         raise ValueError("manifest.kind must be 'layout_manifest'")
     vp = manifest.viewport
-    for k in ("width","height"):
+    for k in ("width", "height"):
         if k not in vp or not isinstance(vp[k], int) or vp[k] < 0:
             raise ValueError(f"viewport.{k} must be a non-negative int")
-    # basic tile checks
     seen = set()
     for t in manifest.tiles:
         if "id" not in t or "frame" not in t:
@@ -89,45 +117,46 @@ def validate(manifest: Manifest) -> None:
             raise ValueError(f"duplicate tile id: {t['id']}")
         seen.add(t["id"])
         f = t["frame"]
-        for k in ("x","y","w","h"):
+        for k in ("x", "y", "w", "h"):
             if k not in f or not isinstance(f[k], int):
                 raise ValueError(f"tile {t['id']} frame.{k} must be int")
 
 
 def schema() -> dict:
-    """Minimal JSON schema for interoperability and validation in adapters."""
     return {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "Layout Manifest",
         "type": "object",
-        "required": ["kind","version","viewport","grid","tiles","etag"],
+        "required": ["kind", "version", "viewport", "grid", "tiles", "etag"],
         "properties": {
             "kind": {"const": "layout_manifest"},
             "version": {"type": "string"},
             "viewport": {
                 "type": "object",
-                "required": ["width","height"],
+                "required": ["width", "height"],
                 "properties": {
                     "width": {"type": "integer", "minimum": 0},
-                    "height": {"type": "integer", "minimum": 0}
-                }
+                    "height": {"type": "integer", "minimum": 0},
+                },
             },
             "grid": {"type": "object"},
             "tiles": {
                 "type": "array",
                 "items": {
                     "type": "object",
-                    "required": ["id","role","frame","props"],
+                    "required": ["id", "role", "frame", "props"],
                     "properties": {
                         "id": {"type": "string"},
                         "role": {"type": "string"},
                         "frame": {
                             "type": "object",
-                            "required": ["x","y","w","h"],
+                            "required": ["x", "y", "w", "h"],
                             "properties": {
-                                "x": {"type": "integer"}, "y": {"type": "integer"},
-                                "w": {"type": "integer"}, "h": {"type": "integer"},
-                            }
+                                "x": {"type": "integer"},
+                                "y": {"type": "integer"},
+                                "w": {"type": "integer"},
+                                "h": {"type": "integer"},
+                            },
                         },
                         "props": {"type": "object"},
                         "component": {
@@ -137,71 +166,95 @@ def schema() -> dict:
                                 "export": {"type": "string"},
                                 "version": {"type": "string"},
                                 "defaults": {"type": "object"},
-                            }
-                        }
-                    }
-                }
+                            },
+                        },
+                    },
+                },
             },
-            "etag": {"type": "string"}
+            "etag": {"type": "string"},
         },
-        "additionalProperties": False
+        "additionalProperties": False,
     }
 
-# --------- Diff / Patch ---------
+
+def _frame_map(manifest: Manifest) -> dict[str, Frame]:
+    frames: dict[str, Frame] = {}
+    for tile in manifest.tiles:
+        tile_dict = dict(tile)
+        frame = tile_dict.get("frame", {})
+        frames[tile_dict["id"]] = Frame(
+            x=int(frame.get("x", 0)),
+            y=int(frame.get("y", 0)),
+            w=int(frame.get("w", 0)),
+            h=int(frame.get("h", 0)),
+        )
+    return frames
 
 
 def diff(old: Manifest, new: Manifest, *, epsilon: int = 0) -> dict:
-    """Compute a simple manifest patch focused on geometry and tile set.
-    Returns:
-      {
-        "base_etag": str,
-        "etag": str,
-        "added": [ids], "removed": [ids], "changed": [ids], "unchanged": [ids],
-        "frames": { id: {x,y,w,h} }   # for added+changed
-      }
-    """
-    a = _frame_map(old); b = _frame_map(new)
-    old_keys = set(a); new_keys = set(b)
-    added = sorted(new_keys - old_keys)
-    removed = sorted(old_keys - new_keys)
-    changed = []
-    unchanged = []
-    frames = {}
-
-    for tid in sorted(old_keys & new_keys):
-        fa = a[tid]; fb = b[tid]
-        if abs(fa["x"]-fb["x"])<=epsilon and abs(fa["y"]-fb["y"])<=epsilon and abs(fa["w"]-fb["w"])<=epsilon and abs(fa["h"]-fb["h"])<=epsilon:
-            unchanged.append(tid)
-        else:
-            changed.append(tid); frames[tid] = fb
-    for tid in added:
-        frames[tid] = b[tid]
-
+    old_frames = _frame_map(old)
+    new_frames = _frame_map(new)
+    geom = frame_diff(old_frames, new_frames, epsilon=epsilon)
+    added = geom["added"]
+    removed = geom["removed"]
+    changed = geom["changed"]
+    unchanged = geom["unchanged"]
+    frames = {tid: new_frames[tid].__dict__ for tid in changed + added}
     return {
         "base_etag": old.etag,
         "etag": new.etag,
-        "added": added, "removed": removed, "changed": changed, "unchanged": unchanged,
-        "frames": frames
+        "added": added,
+        "removed": removed,
+        "changed": changed,
+        "unchanged": unchanged,
+        "frames": frames,
     }
 
 
 def apply_patch(base: Manifest, patch: Mapping[str, Any]) -> Manifest:
-    """Apply a geometry-only patch produced by `diff`.
-
-    If `patch['base_etag']` doesn't match `base.etag`, the caller is responsible
-    for reconciling; we still apply to allow last-wins behavior in clients.
-    """
     base_d = to_dict(base)
     tiles = {t["id"]: dict(t) for t in base_d["tiles"]}
-    # Remove tiles
     for tid in patch.get("removed", []):
         tiles.pop(tid, None)
-    # Add/update frames
     for tid, fr in (patch.get("frames") or {}).items():
         if tid not in tiles:
-            tiles[tid] = {"id": tid, "role": "", "props": {}, "frame": {"x":0,"y":0,"w":0,"h":0}}
-        tiles[tid]["frame"] = {k:int(fr[k]) for k in ("x","y","w","h")}
-
+            tiles[tid] = {
+                "id": tid,
+                "role": "",
+                "props": {},
+                "frame": {"x": 0, "y": 0, "w": 0, "h": 0},
+            }
+        tiles[tid]["frame"] = {k: int(fr[k]) for k in ("x", "y", "w", "h")}
     base_d["tiles"] = sorted(tiles.values(), key=lambda t: t["id"])
     base_d["etag"] = patch.get("etag", base.etag)
     return from_dict(base_d)
+
+
+def compute_etag(obj: Mapping[str, Any]) -> str:
+    return etag_of(obj)
+
+
+def validate_manifest(manifest: Manifest) -> None:
+    validate(manifest)
+
+
+def sort_tiles(manifest: Manifest) -> Manifest:
+    data = to_dict(manifest)
+    data["tiles"] = sorted(data["tiles"], key=lambda t: t.get("id", ""))
+    return from_dict(data)
+
+
+def to_plain_dict(manifest: Manifest) -> dict:
+    return to_dict(manifest)
+
+
+def from_plain_dict(data: Mapping[str, Any]) -> Manifest:
+    return from_dict(data)
+
+
+def diff_manifests(old: Manifest, new: Manifest, *, epsilon: int = 0) -> dict:
+    return diff(old, new, epsilon=epsilon)
+
+
+def make_patch(old: Manifest, new: Manifest, *, epsilon: int = 0) -> dict:
+    return diff(old, new, epsilon=epsilon)

--- a/pkgs/experimental/layout_engine/src/layout_engine/mfe/__init__.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/mfe/__init__.py
@@ -1,25 +1,73 @@
-'''Micro-frontend (MFE) registry and import-map utilities.
+"""Micro-frontend (MFE) registry and import-map utilities.
 
 This module is framework-agnostic. It describes **remotes** (composite apps)
 and produces an **import map** the host (Svelte/Vue/React/HTML) can consume.
-'''
-from .spec import Remote, Framework, validate_id, validate_framework, validate_entry, validate_exposed
+"""
+
+from .spec import (
+    Remote,
+    Framework,
+    validate_id,
+    validate_framework,
+    validate_entry,
+    validate_exposed,
+)
 from .base import IRemoteRegistry, IImportMapBuilder
 from .default import RemoteRegistry, ImportMapBuilder
-from .shortcuts import remote, remotes, build_import_map, import_map_script, modulepreload_links
-from .decorators import remote as remote_deco, stable_entry, require_integrity
-from .bindings import to_dict, from_dict, registry_to_dict, registry_from_dict, to_import_map, to_import_map_json, script_tag, modulepreload_html
+from .shortcuts import (
+    remote,
+    remotes,
+    build_import_map,
+    import_map_script,
+    modulepreload_links,
+    import_map_json,
+    compose_import_maps,
+)
+from .decorators import (
+    remote as remote_deco,
+    remote_ctx,
+    require_integrity,
+    stable_entry,
+)
+from .bindings import (
+    to_dict,
+    from_dict,
+    registry_to_dict,
+    registry_from_dict,
+    to_import_map,
+    to_import_map_json,
+    script_tag,
+    modulepreload_html,
+)
 
 __all__ = [
-    "Remote", "Framework",
-    "validate_id", "validate_framework", "validate_entry", "validate_exposed",
-    "IRemoteRegistry", "IImportMapBuilder",
-    "RemoteRegistry", "ImportMapBuilder",
-    "remote", "remotes", "build_import_map", "import_map_script", "modulepreload_links",
-    "remote_deco", "stable_entry", "require_integrity",
-    "to_dict", "from_dict", "registry_to_dict", "registry_from_dict", "to_import_map", "to_import_map_json",
-    "script_tag", "modulepreload_html",
+    "Remote",
+    "Framework",
+    "validate_id",
+    "validate_framework",
+    "validate_entry",
+    "validate_exposed",
+    "IRemoteRegistry",
+    "IImportMapBuilder",
+    "RemoteRegistry",
+    "ImportMapBuilder",
+    "remote",
+    "remotes",
+    "build_import_map",
+    "import_map_script",
+    "modulepreload_links",
+    "import_map_json",
+    "compose_import_maps",
+    "remote_deco",
+    "remote_ctx",
+    "stable_entry",
+    "require_integrity",
+    "to_dict",
+    "from_dict",
+    "registry_to_dict",
+    "registry_from_dict",
+    "to_import_map",
+    "to_import_map_json",
+    "script_tag",
+    "modulepreload_html",
 ]
-
-from .decorators import remote_ctx
-__all__ = list(set([*(globals().get("__all__", [])), "remote_ctx"]))

--- a/pkgs/experimental/layout_engine/src/layout_engine/mfe/base.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/mfe/base.py
@@ -1,21 +1,52 @@
 from __future__ import annotations
-from abc import ABC, abstractmethod, Iterable, Mapping
+
+from abc import ABC, abstractmethod
+from typing import Any, Iterable, Mapping
+
 from .spec import Remote
+
 
 class IRemoteRegistry(ABC):
     @abstractmethod
-    def register(self, remote: Remote) -> None: raise NotImplementedError
+    def register(self, remote: Remote) -> None:
+        raise NotImplementedError
+
     @abstractmethod
-    def register_many(self, remotes: Iterable[Remote]) -> None: raise NotImplementedError
+    def register_many(self, remotes: Iterable[Remote]) -> None:
+        raise NotImplementedError
+
     @abstractmethod
-    def get(self, id: str) -> Remote: raise NotImplementedError
+    def get(self, id: str) -> Remote:
+        raise NotImplementedError
+
     @abstractmethod
-    def try_get(self, id: str) -> Remote | None: raise NotImplementedError
+    def try_get(self, id: str) -> Remote | None:
+        raise NotImplementedError
+
     @abstractmethod
-    def remove(self, id: str) -> None: raise NotImplementedError
+    def remove(self, id: str) -> None:
+        raise NotImplementedError
+
     @abstractmethod
-    def all(self) -> Iterable[Remote]: raise NotImplementedError
+    def all(self) -> Iterable[Remote]:
+        raise NotImplementedError
+
     @abstractmethod
-    def to_dict(self) -> dict[str, dict]: raise NotImplementedError
+    def to_dict(self) -> dict[str, dict]:
+        raise NotImplementedError
+
     @abstractmethod
-    def update_from_dict(self, data: Mapping[str, Mapping]) -> None: raise NotImplementedError
+    def update_from_dict(self, data: Mapping[str, Mapping]) -> None:
+        raise NotImplementedError
+
+
+class IImportMapBuilder(ABC):
+    @abstractmethod
+    def build(
+        self,
+        registry: "IRemoteRegistry",
+        *,
+        extra_imports: Mapping[str, str] | None = None,
+        scopes: Mapping[str, Mapping[str, str]] | None = None,
+    ) -> Mapping[str, Any]:
+        raise NotImplementedError

--- a/pkgs/experimental/layout_engine/src/layout_engine/mfe/decorators.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/mfe/decorators.py
@@ -1,25 +1,43 @@
 from __future__ import annotations
 from functools import wraps
 
+
 def remote_ctx(id: str):
     """Decorator to tag a function/factory with a remote_ctx id for discovery."""
+
     def deco(fn):
         @wraps(fn)
-        def wrapper(*a, **kw): return fn(*a, **kw)
+        def wrapper(*a, **kw):
+            return fn(*a, **kw)
+
         setattr(wrapper, "__remote_id__", id)
         return wrapper
+
     return deco
+
 
 def stable_entry(fn):
     """Marker that the remote_ctx entry URL must be immutable (e.g., contains a version)."""
+
     @wraps(fn)
-    def wrapper(*a, **kw): return fn(*a, **kw)
+    def wrapper(*a, **kw):
+        return fn(*a, **kw)
+
     setattr(wrapper, "__remote_stable_entry__", True)
     return wrapper
 
+
 def require_integrity(fn):
     """Marker that the remote_ctx should provide SRI integrity."""
+
     @wraps(fn)
-    def wrapper(*a, **kw): return fn(*a, **kw)
+    def wrapper(*a, **kw):
+        return fn(*a, **kw)
+
     setattr(wrapper, "__remote_require_integrity__", True)
     return wrapper
+
+
+def remote(id: str):
+    """Backward compatible alias for :func:`remote_ctx`."""
+    return remote_ctx(id)

--- a/pkgs/experimental/layout_engine/src/layout_engine/mfe/default.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/mfe/default.py
@@ -4,6 +4,7 @@ from typing import Iterable
 from .spec import Remote
 from .base import IRemoteRegistry, IImportMapBuilder
 
+
 class RemoteRegistry(IRemoteRegistry):
     def __init__(self, remotes: Iterable[Remote] = ()):
         self._r: dict[str, Remote] = {}
@@ -16,7 +17,8 @@ class RemoteRegistry(IRemoteRegistry):
         self._r[remote.id] = remote
 
     def register_many(self, remotes: Iterable[Remote]) -> None:
-        for r in remotes: self.register(r)
+        for r in remotes:
+            self.register(r)
 
     def get(self, id: str) -> Remote:
         try:
@@ -35,21 +37,35 @@ class RemoteRegistry(IRemoteRegistry):
 
     def to_dict(self) -> dict[str, dict]:
         from .bindings import to_dict as _to
+
         return {rid: _to(r) for rid, r in self._r.items()}
 
     def update_from_dict(self, data: dict[str, dict]) -> None:
         from .bindings import from_dict as _from
+
         for rid, obj in data.items():
             r = _from(obj)
             # ensure key and dataclass id aligned (use dict key as authority)
             if rid != r.id:
-                r = Remote(id=rid, framework=r.framework, entry=r.entry, exposed=r.exposed, integrity=r.integrity)
+                r = Remote(
+                    id=rid,
+                    framework=r.framework,
+                    entry=r.entry,
+                    exposed=r.exposed,
+                    integrity=r.integrity,
+                )
             # upsert
             self._r[rid] = r
 
+
 class ImportMapBuilder(IImportMapBuilder):
-    def build(self, registry: IRemoteRegistry, *, extra_imports: dict[str,str] | None = None,
-              scopes: dict[str, dict[str,str]] | None = None) -> dict:
+    def build(
+        self,
+        registry: IRemoteRegistry,
+        *,
+        extra_imports: dict[str, str] | None = None,
+        scopes: dict[str, dict[str, str]] | None = None,
+    ) -> dict:
         imports = {rid: r.entry for rid, r in registry.to_dict().items()}
         if extra_imports:
             imports.update(extra_imports)

--- a/pkgs/experimental/layout_engine/src/layout_engine/mfe/shortcuts.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/mfe/shortcuts.py
@@ -1,25 +1,71 @@
 from __future__ import annotations
-from typing import Iterable
+from typing import Any
 from .spec import Remote
 from .default import RemoteRegistry, ImportMapBuilder
 from .bindings import to_import_map_json, script_tag, modulepreload_html
 
+
 def remote(**kwargs) -> Remote:
     return Remote(**kwargs)
+
 
 def remotes(*r: Remote) -> RemoteRegistry:
     return RemoteRegistry(r)
 
-def build_import_map(registry: RemoteRegistry, *, extra_imports: dict[str,str] | None = None,
-                     scopes: dict[str, dict[str,str]] | None = None) -> dict:
-    return ImportMapBuilder().build(registry, extra_imports=extra_imports, scopes=scopes)
 
-def import_map_script(registry: RemoteRegistry, *, extra_imports: dict[str,str] | None = None,
-                      scopes: dict[str, dict[str,str]] | None = None, indent: int | None = None) -> str:
+def build_import_map(
+    registry: RemoteRegistry,
+    *,
+    extra_imports: dict[str, str] | None = None,
+    scopes: dict[str, dict[str, str]] | None = None,
+) -> dict:
+    return ImportMapBuilder().build(
+        registry, extra_imports=extra_imports, scopes=scopes
+    )
+
+
+def import_map_script(
+    registry: RemoteRegistry,
+    *,
+    extra_imports: dict[str, str] | None = None,
+    scopes: dict[str, dict[str, str]] | None = None,
+    indent: int | None = None,
+) -> str:
     imap = build_import_map(registry, extra_imports=extra_imports, scopes=scopes)
     return script_tag(imap, indent=indent)
 
-def modulepreload_links(registry: RemoteRegistry, *, extra_imports: dict[str,str] | None = None,
-                        scopes: dict[str, dict[str,str]] | None = None) -> str:
+
+def modulepreload_links(
+    registry: RemoteRegistry,
+    *,
+    extra_imports: dict[str, str] | None = None,
+    scopes: dict[str, dict[str, str]] | None = None,
+) -> str:
     imap = build_import_map(registry, extra_imports=extra_imports, scopes=scopes)
     return modulepreload_html(imap)
+
+
+def import_map_json(
+    registry: RemoteRegistry,
+    *,
+    extra_imports: dict[str, str] | None = None,
+    scopes: dict[str, dict[str, str]] | None = None,
+    indent: int | None = None,
+) -> str:
+    return to_import_map_json(
+        registry, extra_imports=extra_imports, scopes=scopes, indent=indent
+    )
+
+
+def compose_import_maps(*maps: dict[str, Any]) -> dict:
+    merged_imports: dict[str, str] = {}
+    merged_scopes: dict[str, dict[str, str]] = {}
+    for imap in maps:
+        imports = imap.get("imports", {})
+        merged_imports.update(imports)
+        for scope, entries in imap.get("scopes", {}).items():
+            merged_scopes.setdefault(scope, {}).update(entries)
+    result: dict[str, Any] = {"imports": merged_imports}
+    if merged_scopes:
+        result["scopes"] = merged_scopes
+    return result

--- a/pkgs/experimental/layout_engine/src/layout_engine/mfe/spec.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/mfe/spec.py
@@ -1,30 +1,43 @@
-from pydantic import BaseModel, Field, validator
 from __future__ import annotations
-from pydantic import BaseModel, Field, validator
-from typing import Literal
-import re
 
-Framework = Literal["svelte","vue","react"]
+import re
+from typing import Literal
+
+from pydantic import BaseModel
+
+Framework = Literal["svelte", "vue", "react"]
 
 _ID_RE = re.compile(r"^[a-z][a-z0-9\-]{1,63}$")  # simple, CDN/cache-friendly ids
-_EXPOSED_RE = re.compile(r"^(\./)?[A-Za-z0-9_./\-]+$")  # "./App" or "App" or "./lib/App.js"
+_EXPOSED_RE = re.compile(
+    r"^(\./)?[A-Za-z0-9_./\-]+$"
+)  # "./App" or "App" or "./lib/App.js"
+
 
 def validate_id(id: str) -> str:
     if not _ID_RE.match(id):
         raise ValueError(f"invalid remote id '{id}' (lowercase alnum-dash, 2..64)")
     return id
 
+
 def validate_framework(framework: str) -> Framework:
-    if framework not in ("svelte","vue","react"):
+    if framework not in ("svelte", "vue", "react"):
         raise ValueError(f"invalid framework '{framework}' (expected svelte|vue|react)")
     return framework  # type: ignore
+
 
 def validate_entry(entry: str) -> str:
     # allow absolute https/http, root-relative, or relative paths
     s = entry.strip()
-    if not (s.startswith("https://") or s.startswith("http://") or s.startswith("/") or s.startswith("./") or s.startswith("../")):
+    if not (
+        s.startswith("https://")
+        or s.startswith("http://")
+        or s.startswith("/")
+        or s.startswith("./")
+        or s.startswith("../")
+    ):
         raise ValueError(f"invalid entry '{entry}' (must be http(s) URL or path)")
     return s
+
 
 def validate_exposed(exposed: str) -> str:
     if not _EXPOSED_RE.match(exposed):
@@ -34,10 +47,10 @@ def validate_exposed(exposed: str) -> str:
         exposed = "./" + exposed
     return exposed
 
+
 class Remote(BaseModel):
     id: str
     framework: Framework
-    entry: str            # ESM URL or MF remote entry
-    exposed: str          # exposed module (e.g., "./App")
+    entry: str  # ESM URL or MF remote entry
+    exposed: str  # exposed module (e.g., "./App")
     integrity: str | None = None
-

--- a/pkgs/experimental/layout_engine/src/layout_engine/site/__init__.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/site/__init__.py
@@ -6,13 +6,37 @@ This module defines:
   - SiteIndex for fast resolution
   - Helpers for building per-page contexts
 """
-from .spec import SlotSpec, PageSpec, SiteSpec, RouteMatch, compile_route_pattern, normalize_base_path
+
+from .spec import (
+    SlotSpec,
+    PageSpec,
+    SiteSpec,
+    RouteMatch,
+    compile_route_pattern,
+    normalize_base_path,
+)
 from .shortcuts import slot, page, site
-from .default import SiteIndex, resolve_path, validate_site, build_page_context, bind_page_builder
+from .default import (
+    SiteIndex,
+    resolve_path,
+    validate_site,
+    build_page_context,
+    bind_page_builder,
+)
 
 __all__ = [
-    "SlotSpec","PageSpec","SiteSpec","RouteMatch",
-    "compile_route_pattern","normalize_base_path",
-    "slot","page","site",
-    "SiteIndex","resolve_path","validate_site","build_page_context","bind_page_builder",
+    "SlotSpec",
+    "PageSpec",
+    "SiteSpec",
+    "RouteMatch",
+    "compile_route_pattern",
+    "normalize_base_path",
+    "slot",
+    "page",
+    "site",
+    "SiteIndex",
+    "resolve_path",
+    "validate_site",
+    "build_page_context",
+    "bind_page_builder",
 ]

--- a/pkgs/experimental/layout_engine/src/layout_engine/site/default.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/site/default.py
@@ -1,24 +1,36 @@
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import Callable, Mapping, Any, Iterable, Dict, Tuple, Optional
+from typing import Callable, Mapping, Any, Tuple
 
-from .spec import SiteSpec, PageSpec, RouteMatch, compile_route_pattern, normalize_base_path
+from .spec import (
+    SiteSpec,
+    PageSpec,
+    RouteMatch,
+    compile_route_pattern,
+    normalize_base_path,
+)
 from ..manifest.spec import Manifest
 
 # ---- DI: Manifest builder binding ----
 
-def bind_page_builder(build_fn: Callable[[PageSpec, Mapping[str, Any]], Manifest]) -> Callable[[PageSpec, Mapping[str, Any]], Manifest]:
+
+def bind_page_builder(
+    build_fn: Callable[[PageSpec, Mapping[str, Any]], Manifest],
+) -> Callable[[PageSpec, Mapping[str, Any]], Manifest]:
     """Return the given function; placeholder for dependency injection hooks."""
     return build_fn
 
+
 # ---- Site index / resolver ----
+
 
 @dataclass(slots=True)
 class _Entry:
     page: PageSpec
-    regex: Any     # compiled Pattern[str]
+    regex: Any  # compiled Pattern[str]
     params: Tuple[str, ...]
     route: str
+
 
 class SiteIndex:
     """Pre-compiled resolver for SiteSpec.
@@ -26,6 +38,7 @@ class SiteIndex:
     - Compiles each PageSpec.route to a regex.
     - Resolves absolute paths by stripping SiteSpec.base_path, then matching.
     """
+
     def __init__(self, site: SiteSpec):
         self.base = normalize_base_path(site.base_path)
         entries: list[_Entry] = []
@@ -37,18 +50,26 @@ class SiteIndex:
     def resolve(self, absolute_path: str) -> RouteMatch | None:
         rel = absolute_path
         if self.base != "/" and absolute_path.startswith(self.base):
-            rel = absolute_path[len(self.base):] or "/"
+            rel = absolute_path[len(self.base) :] or "/"
         for e in self._entries:
             m = e.regex.match(rel)
             if m:
                 params = {k: v for k, v in m.groupdict().items() if v is not None}
-                return RouteMatch(page=e.page, params=params, absolute_path=absolute_path, relative_path=rel)
+                return RouteMatch(
+                    page=e.page,
+                    params=params,
+                    absolute_path=absolute_path,
+                    relative_path=rel,
+                )
         return None
+
 
 def resolve_path(site: SiteSpec, absolute_path: str) -> RouteMatch | None:
     return SiteIndex(site).resolve(absolute_path)
 
+
 # ---- Validation ----
+
 
 def validate_site(site: SiteSpec) -> None:
     seen_ids: set[str] = set()
@@ -71,9 +92,16 @@ def validate_site(site: SiteSpec) -> None:
             if not s.name:
                 raise ValueError(f"slot name must be non-empty on page {p.id}")
 
+
 # ---- Context assembly ----
 
-def build_page_context(match: RouteMatch, *, query: Mapping[str, Any] | None = None, extras: Mapping[str, Any] | None = None) -> dict:
+
+def build_page_context(
+    match: RouteMatch,
+    *,
+    query: Mapping[str, Any] | None = None,
+    extras: Mapping[str, Any] | None = None,
+) -> dict:
     """Assemble a minimal context dict for manifest/page rendering.
 
     Contains:
@@ -91,7 +119,10 @@ def build_page_context(match: RouteMatch, *, query: Mapping[str, Any] | None = N
             "params": dict(match.params),
             "query": q,
         },
-        "slots": [{"name": s.name, "role": s.role, "remote": s.remote} for s in match.page.slots],
+        "slots": [
+            {"name": s.name, "role": s.role, "remote": s.remote}
+            for s in match.page.slots
+        ],
         "meta": dict(match.page.meta),
     }
     if extras:

--- a/pkgs/experimental/layout_engine/src/layout_engine/site/shortcuts.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/site/shortcuts.py
@@ -1,11 +1,29 @@
 from __future__ import annotations
 from .spec import SiteSpec, PageSpec, SlotSpec, normalize_base_path
 
+
 def slot(name: str, role: str, remote: str | None = None) -> SlotSpec:
     return SlotSpec(name=name, role=role, remote=remote)
 
-def page(id: str, route: str, title: str, *, slots: tuple[SlotSpec, ...] = (), page_vm: dict | None = None, meta: dict | None = None) -> PageSpec:
-    return PageSpec(id=id, route=route, title=title, slots=slots, page_vm=page_vm or {}, meta=meta or {})
+
+def page(
+    id: str,
+    route: str,
+    title: str,
+    *,
+    slots: tuple[SlotSpec, ...] = (),
+    page_vm: dict | None = None,
+    meta: dict | None = None,
+) -> PageSpec:
+    return PageSpec(
+        id=id,
+        route=route,
+        title=title,
+        slots=slots,
+        page_vm=page_vm or {},
+        meta=meta or {},
+    )
+
 
 def site(*pages: PageSpec, base_path: str = "/") -> SiteSpec:
     return SiteSpec(base_path=normalize_base_path(base_path), pages=tuple(pages))

--- a/pkgs/experimental/layout_engine/src/layout_engine/site/spec.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/site/spec.py
@@ -1,16 +1,23 @@
-from pydantic import BaseModel, Field, validator
 from __future__ import annotations
-from pydantic import BaseModel, Field, validator, field
-from typing import Mapping, Any, Tuple, Pattern, Dict, Optional
+
 import re
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping, Pattern, Tuple
+
+from pydantic import BaseModel, Field
 
 # ---- utilities ----
 
+
 def normalize_base_path(p: str) -> str:
-    if not p: return "/"
-    if not p.startswith("/"): p = "/" + p
-    if len(p) > 1 and p.endswith("/"): p = p[:-1]
+    if not p:
+        return "/"
+    if not p.startswith("/"):
+        p = "/" + p
+    if len(p) > 1 and p.endswith("/"):
+        p = p[:-1]
     return p
+
 
 def compile_route_pattern(route: str) -> tuple[Pattern[str], tuple[str, ...]]:
     """Compile a route like '/reports/:id' to a regex with named groups.
@@ -31,7 +38,9 @@ def compile_route_pattern(route: str) -> tuple[Pattern[str], tuple[str, ...]]:
             continue
         if seg == "*":
             if idx != len(segs) - 1 or wildcard_used:
-                raise ValueError("Wildcard '*' is only allowed once at the end of the route")
+                raise ValueError(
+                    "Wildcard '*' is only allowed once at the end of the route"
+                )
             regex_parts.append("(?P<rest>.*)")
             param_names.append("rest")
             wildcard_used = True
@@ -40,36 +49,47 @@ def compile_route_pattern(route: str) -> tuple[Pattern[str], tuple[str, ...]]:
             name = seg[1:]
             if not name or not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", name):
                 raise ValueError(f"Invalid route param name: {seg}")
-            regex_parts.append(fr"(?P<{name}>[^/]+)")
+            regex_parts.append(rf"(?P<{name}>[^/]+)")
             param_names.append(name)
         else:
             regex_parts.append(re.escape(seg))
     regex = "^/" + "/".join(regex_parts) + "/?$"
     return re.compile(regex), tuple(param_names)
 
+
 # ---- specs ----
+
 
 class SlotSpec(BaseModel):
     name: str
     role: str
     remote: str | None = None
 
+
 class PageSpec(BaseModel):
     id: str
     route: str
     title: str
     slots: Tuple[SlotSpec, ...] = ()
-    page_vm: Mapping[str, Any] = field(default_factory=dict)
-    meta: Mapping[str, Any] = field(default_factory=dict)
+    page_vm: Mapping[str, Any] = Field(default_factory=dict)
+    meta: Mapping[str, Any] = Field(default_factory=dict)
 
     # derived (lazy): compiled pattern and params
     def match(self, path: str) -> dict[str, str] | None:
         pat, _ = compile_route_pattern(self.route)
         m = pat.match(path)
-        if not m: return None
+        if not m:
+            return None
         return {k: v for k, v in m.groupdict().items() if v is not None}
+
 
 class SiteSpec(BaseModel):
     base_path: str = "/"
     pages: Tuple[PageSpec, ...] = ()
 
+
+@dataclass(frozen=True)
+class RouteMatch:
+    page: "PageSpec"
+    params: Dict[str, str]
+    path: str

--- a/pkgs/experimental/layout_engine/src/layout_engine/structure/__init__.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/structure/__init__.py
@@ -1,7 +1,39 @@
+"""Structure authoring DSL for layout tables."""
+
+from __future__ import annotations
+
 from .spec import Block, Column, Row, Table
-from .shortcuts import block, col, row, table, build_grid
+from .base import IGridBuilder
+from .default import GridBuilder, validate_table
+from .shortcuts import (
+    block,
+    col,
+    row,
+    table,
+    stack,
+    hstack,
+    build_grid,
+    gridify,
+)
+from .decorators import table_ctx, table_defaults, derive_policy
 
-__all__ = ["Block","Column","Row","Table","block","col","row","table","build_grid"]
-
-from .decorators import table_ctx
-__all__ = list(set([*(globals().get("__all__", [])), "table_ctx"]))
+__all__ = [
+    "Block",
+    "Column",
+    "Row",
+    "Table",
+    "IGridBuilder",
+    "GridBuilder",
+    "validate_table",
+    "block",
+    "col",
+    "row",
+    "table",
+    "stack",
+    "hstack",
+    "build_grid",
+    "gridify",
+    "table_ctx",
+    "table_defaults",
+    "derive_policy",
+]

--- a/pkgs/experimental/layout_engine/src/layout_engine/structure/base.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/structure/base.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
-from abc import ABC, abstractmethod
+from abc import ABC
 from ..core.viewport import Viewport
 from ..grid.spec import GridSpec, GridTile
 from .spec import Table
 
+
 class IGridBuilder(ABC):
     """Convert an authoring Table into an explicit GridSpec and placements."""
+
     def to_grid(self, t: Table, vp: Viewport) -> tuple[GridSpec, list[GridTile]]: ...

--- a/pkgs/experimental/layout_engine/src/layout_engine/structure/bindings.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/structure/bindings.py
@@ -3,6 +3,7 @@ from typing import Mapping, Any
 from .spec import Table, Row, Column, Block
 from ..core.size import SizeToken
 
+
 def to_dict(tbl: Table) -> dict:
     """Serialize Table → plain dict (JSON-friendly)."""
     return {
@@ -14,7 +15,14 @@ def to_dict(tbl: Table) -> dict:
                 "columns": [
                     {
                         "size": c.size.value,
-                        "blocks": [{"tile_id": b.tile_id, "col_span": b.col_span, "row_span": b.row_span} for b in c.blocks],
+                        "blocks": [
+                            {
+                                "tile_id": b.tile_id,
+                                "col_span": b.col_span,
+                                "row_span": b.row_span,
+                            }
+                            for b in c.blocks
+                        ],
                     }
                     for c in r.columns
                 ],
@@ -23,14 +31,25 @@ def to_dict(tbl: Table) -> dict:
         ],
     }
 
+
 def from_dict(obj: Mapping[str, Any]) -> Table:
     """Deserialize Table from a plain dict produced by to_dict."""
     rows = []
     for r in obj.get("rows", []):
         cols = []
         for c in r.get("columns", []):
-            blocks = [Block(tile_id=str(b["tile_id"]), col_span=int(b.get("col_span",1)), row_span=int(b.get("row_span",1)))
-                      for b in c.get("blocks", [])]
+            blocks = [
+                Block(
+                    tile_id=str(b["tile_id"]),
+                    col_span=int(b.get("col_span", 1)),
+                    row_span=int(b.get("row_span", 1)),
+                )
+                for b in c.get("blocks", [])
+            ]
             cols.append(Column(size=SizeToken(str(c["size"])), blocks=tuple(blocks)))
         rows.append(Row(columns=tuple(cols), height_rows=int(r.get("height_rows", 1))))
-    return Table(rows=tuple(rows), gap_x=int(obj.get("gap_x", 12)), gap_y=int(obj.get("gap_y", 12)))
+    return Table(
+        rows=tuple(rows),
+        gap_x=int(obj.get("gap_x", 12)),
+        gap_y=int(obj.get("gap_y", 12)),
+    )

--- a/pkgs/experimental/layout_engine/src/layout_engine/structure/decorators.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/structure/decorators.py
@@ -3,6 +3,7 @@ from functools import wraps
 from typing import Callable
 from .spec import Table
 
+
 def table_defaults(*, gap_x: int | None = None, gap_y: int | None = None):
     """Decorator to enforce/override default gaps on a Table factory.
 
@@ -10,6 +11,7 @@ def table_defaults(*, gap_x: int | None = None, gap_y: int | None = None):
         @table_defaults(gap_x=16, gap_y=12)
         def dashboard() -> Table: ...
     """
+
     def deco(fn: Callable[..., Table]):
         @wraps(fn)
         def wrapper(*a, **kw) -> Table:
@@ -20,12 +22,22 @@ def table_defaults(*, gap_x: int | None = None, gap_y: int | None = None):
                 return t
             # return a new table with same rows but overridden gaps
             return Table(rows=t.rows, gap_x=gx, gap_y=gy)
+
         return wrapper
+
     return deco
+
 
 def derive_policy(fn: Callable[..., Table]):
     """Placeholder policy decorator retained for backward compatibility."""
+
     @wraps(fn)
     def wrapper(*a, **kw) -> Table:
         return fn(*a, **kw)
+
     return wrapper
+
+
+def table_ctx(*, gap_x: int | None = None, gap_y: int | None = None):
+    """Backward compatible alias mirroring :func:`table_defaults`."""
+    return table_defaults(gap_x=gap_x, gap_y=gap_y)

--- a/pkgs/experimental/layout_engine/src/layout_engine/structure/default.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/structure/default.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
-from typing import List, Iterable
+from typing import List
 from .base import IGridBuilder
-from .spec import Table, Row, Column, Block
+from .spec import Table, Row, Block
 from ..core.viewport import Viewport
-from ..core.size import Size, SizeToken, DEFAULT_TOKEN_WEIGHTS
+from ..core.size import Size, DEFAULT_TOKEN_WEIGHTS
 from ..grid.spec import GridSpec, GridTrack, GridTile
+
 
 class GridBuilder(IGridBuilder):
     """Deterministic compiler from authoring DSL → explicit grid.
@@ -18,6 +19,7 @@ class GridBuilder(IGridBuilder):
       - The row's effective height (in logical rows) is:
             max(Row.height_rows, max_stacked_row_span_across_columns)
     """
+
     def __init__(self, row_height: int = 180, min_track_px: int = 200):
         self.row_height = row_height
         self.min_track_px = min_track_px
@@ -32,8 +34,13 @@ class GridBuilder(IGridBuilder):
         ref_row = next(r for r in t.rows if len(r.columns) == max_cols)
         weights = [DEFAULT_TOKEN_WEIGHTS[c.size] for c in ref_row.columns]
         total = sum(weights) or 1.0
-        tracks = [GridTrack(Size(value=w/total, unit="fr", min_px=self.min_track_px)) for w in weights]
-        gs = GridSpec(columns=tracks, row_height=self.row_height, gap_x=t.gap_x, gap_y=t.gap_y)
+        tracks = [
+            GridTrack(size=Size(value=w / total, unit="fr", min_px=self.min_track_px))
+            for w in weights
+        ]
+        gs = GridSpec(
+            columns=tracks, row_height=self.row_height, gap_x=t.gap_x, gap_y=t.gap_y
+        )
 
         # placements
         placements: List[GridTile] = []
@@ -46,7 +53,7 @@ class GridBuilder(IGridBuilder):
             base_floor = max(1, r.height_rows)
             tallest = 0
 
-            for (idx, col) in enumerate(r.columns):
+            for idx, col in enumerate(r.columns):
                 start_col, span_cols = col_map[idx]
                 # stack blocks within this (start_col .. span)
                 local_rows_used = 0
@@ -55,13 +62,15 @@ class GridBuilder(IGridBuilder):
                     # effective spans
                     eff_col_span = max(1, span_cols * max(1, blk.col_span))
                     eff_row_span = max(1, blk.row_span)
-                    placements.append(GridTile(
-                        tile_id=blk.tile_id,
-                        col=start_col,
-                        row=cur_grid_row + local_rows_used,
-                        col_span=eff_col_span,
-                        row_span=eff_row_span
-                    ))
+                    placements.append(
+                        GridTile(
+                            tile_id=blk.tile_id,
+                            col=start_col,
+                            row=cur_grid_row + local_rows_used,
+                            col_span=eff_col_span,
+                            row_span=eff_row_span,
+                        )
+                    )
                     local_rows_used += eff_row_span
                 tallest = max(tallest, local_rows_used)
 
@@ -70,20 +79,21 @@ class GridBuilder(IGridBuilder):
         return gs, placements
 
     # --- internals ---
-    def _column_map(self, r: Row, max_cols: int) -> list[tuple[int,int]]:
+    def _column_map(self, r: Row, max_cols: int) -> list[tuple[int, int]]:
         """Map the row's columns to starting index + span so that total == max_cols.
 
         The distribution is proportional to the row's SizeToken weights; rounding is corrected
         by distributing the drift ±1 across columns from left to right.
         """
         n = len(r.columns)
-        if n <= 0: return []
+        if n <= 0:
+            return []
         if n == max_cols:
-            return [(i,1) for i in range(n)]
+            return [(i, 1) for i in range(n)]
 
         weights = [DEFAULT_TOKEN_WEIGHTS[c.size] for c in r.columns]
         s = sum(weights) or 1.0
-        raw = [w/s * max_cols for w in weights]
+        raw = [w / s * max_cols for w in weights]
         spans = [max(1, round(x)) for x in raw]
 
         drift = max_cols - sum(spans)
@@ -92,12 +102,14 @@ class GridBuilder(IGridBuilder):
             step = 1 if drift > 0 else -1
             j = i % len(spans)
             spans[j] = max(1, spans[j] + step)
-            drift -= step; i += 1
+            drift -= step
+            i += 1
 
         starts = []
         run = 0
         for sp in spans:
-            starts.append(run); run += sp
+            starts.append(run)
+            run += sp
         return list(zip(starts, spans))
 
     @staticmethod
@@ -107,3 +119,19 @@ class GridBuilder(IGridBuilder):
         if blk.tile_id in seen:
             raise ValueError(f"Duplicate tile_id in structure: {blk.tile_id}")
         seen.add(blk.tile_id)
+
+
+def validate_table(table: Table) -> Table:
+    """Basic validation for authoring tables."""
+    seen: set[str] = set()
+    for row in table.rows:
+        if not row.columns:
+            raise ValueError("Each row must contain at least one column")
+        for col in row.columns:
+            for block in col.blocks:
+                if not block.tile_id:
+                    raise ValueError("Each block must have a tile_id")
+                if block.tile_id in seen:
+                    raise ValueError(f"Duplicate tile_id '{block.tile_id}' detected")
+                seen.add(block.tile_id)
+    return table

--- a/pkgs/experimental/layout_engine/src/layout_engine/structure/shortcuts.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/structure/shortcuts.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from typing import Iterable
 from .spec import Block, Column, Row, Table
 from ..core.size import SizeToken
 from ..core.viewport import Viewport
@@ -8,33 +7,52 @@ from .default import GridBuilder
 
 # ---- atomic constructors ----
 
+
 def block(tile_id: str, *, col_span: int = 1, row_span: int = 1) -> Block:
     """Create a Block (atomic tile placeholder)."""
     return Block(tile_id=tile_id, col_span=col_span, row_span=row_span)
+
 
 def col(*blocks: Block, size: SizeToken = SizeToken.m) -> Column:
     """Create a Column with a size token and a sequence of blocks."""
     return Column(size=size, blocks=tuple(blocks))
 
+
 def row(*columns: Column, height_rows: int = 1) -> Row:
     """Create a Row from columns, with an optional row-height floor in logical units."""
     return Row(columns=tuple(columns), height_rows=height_rows)
+
 
 def table(*rows: Row, gap_x: int = 12, gap_y: int = 12) -> Table:
     """Create a Table with gaps between columns and rows (in pixels)."""
     return Table(rows=tuple(rows), gap_x=gap_x, gap_y=gap_y)
 
+
 # ---- higher-level helpers ----
+
 
 def stack(*blocks: Block, size: SizeToken = SizeToken.m, height_rows: int = 1) -> Row:
     """Create a single-column row with blocks stacked vertically."""
     return row(col(*blocks, size=size), height_rows=height_rows)
+
 
 def hstack(*blocks: Block, size: SizeToken = SizeToken.m, height_rows: int = 1) -> Row:
     """Create a row placing each block into its own column (uniform size)."""
     columns = tuple(col(b, size=size) for b in blocks)
     return row(*columns, height_rows=height_rows)
 
-def build_grid(tbl: Table, vp: Viewport, *, row_height: int = 180, min_track_px: int = 200) -> tuple[GridSpec, list[GridTile]]:
+
+def build_grid(
+    tbl: Table, vp: Viewport, *, row_height: int = 180, min_track_px: int = 200
+) -> tuple[GridSpec, list[GridTile]]:
     """Compile the authoring Table into a GridSpec + placements using GridBuilder."""
-    return GridBuilder(row_height=row_height, min_track_px=min_track_px).to_grid(tbl, vp)
+    return GridBuilder(row_height=row_height, min_track_px=min_track_px).to_grid(
+        tbl, vp
+    )
+
+
+def gridify(
+    tbl: Table, vp: Viewport, *, row_height: int = 180, min_track_px: int = 200
+) -> tuple[GridSpec, list[GridTile]]:
+    """Alias for :func:`build_grid` maintained for compatibility."""
+    return build_grid(tbl, vp, row_height=row_height, min_track_px=min_track_px)

--- a/pkgs/experimental/layout_engine/src/layout_engine/structure/spec.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/structure/spec.py
@@ -1,8 +1,11 @@
-from pydantic import BaseModel, Field, validator
 from __future__ import annotations
-from pydantic import BaseModel, Field, validator
+
 from typing import Tuple
+
+from pydantic import BaseModel
+
 from ..core.size import SizeToken
+
 
 class Block(BaseModel):
     """Atomic content unit to be placed in a column.
@@ -10,17 +13,21 @@ class Block(BaseModel):
     - tile_id: unique identifier of the tile to render
     - col_span / row_span: logical spans within the derived grid
     """
+
     tile_id: str
     col_span: int = 1
     row_span: int = 1
 
+
 class Column(BaseModel):
     """Column within a Row with a semantic size token (xxs..xxl)."""
+
     size: SizeToken
     blocks: Tuple[Block, ...] = ()
 
     def is_empty(self) -> bool:
         return len(self.blocks) == 0
+
 
 class Row(BaseModel):
     """Row contains one or more Columns.
@@ -28,17 +35,20 @@ class Row(BaseModel):
     - height_rows: minimal row-span the row should occupy (used as a floor
       when no blocks force a taller span).
     """
+
     columns: Tuple[Column, ...]
     height_rows: int = 1
 
     def column_count(self) -> int:
         return len(self.columns)
 
+
 class Table(BaseModel):
     """High-level authoring artifact composed of Rows → Columns → Blocks.
 
     The GridBuilder compiles this into an explicit GridSpec + GridTile placements.
     """
+
     rows: Tuple[Row, ...]
     gap_x: int = 12
     gap_y: int = 12

--- a/pkgs/experimental/layout_engine/src/layout_engine/targets/__init__.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/targets/__init__.py
@@ -1,4 +1,5 @@
 """Targets: WebGUI SSR shell + Media exporters (HTML/SVG/PDF/Code)."""
+
 from .base import ITarget, IWebGuiTarget, IMediaTarget
 from .webgui.router import SiteRouter
 from .webgui.html import HtmlShell
@@ -10,7 +11,15 @@ from .media.pdf import PdfExporter
 from .media.code import CodeExporter
 
 __all__ = [
-    "ITarget","IWebGuiTarget","IMediaTarget",
-    "SiteRouter","HtmlShell","import_map_json","InProcWSBridge",
-    "HtmlExporter","SvgExporter","PdfExporter","CodeExporter",
+    "ITarget",
+    "IWebGuiTarget",
+    "IMediaTarget",
+    "SiteRouter",
+    "HtmlShell",
+    "import_map_json",
+    "InProcWSBridge",
+    "HtmlExporter",
+    "SvgExporter",
+    "PdfExporter",
+    "CodeExporter",
 ]

--- a/pkgs/experimental/layout_engine/src/layout_engine/targets/base.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/targets/base.py
@@ -1,21 +1,34 @@
 from __future__ import annotations
-from abc import ABC, abstractmethod, Any
+from abc import ABC, abstractmethod
+from typing import Any
+
 from ..manifest.spec import Manifest
+
 
 class ITarget(ABC):
     """Abstract rendering/export target."""
+
     @abstractmethod
     def render(self, manifest: Manifest, *, out: str | None = None) -> Any:
         raise NotImplementedError
 
+
 class IWebGuiTarget(ITarget, ABC):
     """Web GUI page shells (SSR HTML) for hosts to hydrate."""
+
     @abstractmethod
     def render(self, manifest: Manifest, *, out: str | None = None) -> str:
         raise NotImplementedError
 
+
 class IMediaTarget(ITarget, ABC):
     """Offline artifact exporters (PDF/SVG/HTML/Code)."""
+
     @abstractmethod
     def export(self, manifest: Manifest, *, out: str) -> str:
         raise NotImplementedError
+
+    def render(self, manifest: Manifest, *, out: str | None = None) -> str:
+        if out is None:
+            raise ValueError("IMediaTarget.render requires 'out' path")
+        return self.export(manifest, out=out)

--- a/pkgs/experimental/layout_engine/src/layout_engine/targets/media/__init__.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/targets/media/__init__.py
@@ -1,1 +1,13 @@
-"""Media exporters: HTML, SVG, PDF (placeholder), and code emission."""
+"""Media exporters: HTML, SVG, PDF, and code emission."""
+
+from .html import HtmlExporter
+from .svg import SvgExporter
+from .pdf import PdfExporter
+from .code import CodeExporter
+
+__all__ = [
+    "HtmlExporter",
+    "SvgExporter",
+    "PdfExporter",
+    "CodeExporter",
+]

--- a/pkgs/experimental/layout_engine/src/layout_engine/targets/media/code.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/targets/media/code.py
@@ -4,6 +4,7 @@ from ..base import IMediaTarget
 from ...manifest.spec import Manifest
 import json
 
+
 class CodeExporter(IMediaTarget):
     def export(self, manifest: Manifest, *, out: str) -> str:
         """Emit a portable page description (JSON) suitable for generating Svelte/Vue/React pages."""
@@ -16,5 +17,7 @@ class CodeExporter(IMediaTarget):
             "etag": manifest.etag,
         }
         Path(out).parent.mkdir(parents=True, exist_ok=True)
-        Path(out).write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+        Path(out).write_text(
+            json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8"
+        )
         return out

--- a/pkgs/experimental/layout_engine/src/layout_engine/targets/media/svg.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/targets/media/svg.py
@@ -3,17 +3,22 @@ from pathlib import Path
 from ..base import IMediaTarget
 from ...manifest.spec import Manifest
 
+
 class SvgExporter(IMediaTarget):
     def export(self, manifest: Manifest, *, out: str) -> str:
         vw = int(manifest.viewport.get("width", 1280))
         vh = int(manifest.viewport.get("height", 800))
-        parts = [f"<svg xmlns='http://www.w3.org/2000/svg' width='{vw}' height='{vh}' viewBox='0 0 {vw} {vh}'>"]
+        parts = [
+            f"<svg xmlns='http://www.w3.org/2000/svg' width='{vw}' height='{vh}' viewBox='0 0 {vw} {vh}'>"
+        ]
         parts.append(f"<rect width='{vw}' height='{vh}' fill='white' stroke='none' />")
         for t in manifest.tiles:
             f = t.frame
-            x,y,w,h = int(f['x']), int(f['y']), int(f['w']), int(f['h'])
+            x, y, w, h = int(f["x"]), int(f["y"]), int(f["w"]), int(f["h"])
             parts.append(f"<g data-tile='{t.id}' transform='translate({x},{y})'>")
-            parts.append(f"<rect width='{w}' height='{h}' fill='none' stroke='#cccccc' />")
+            parts.append(
+                f"<rect width='{w}' height='{h}' fill='none' stroke='#cccccc' />"
+            )
             parts.append("</g>")
         parts.append("</svg>")
         Path(out).parent.mkdir(parents=True, exist_ok=True)

--- a/pkgs/experimental/layout_engine/src/layout_engine/targets/webgui/html.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/targets/webgui/html.py
@@ -2,17 +2,27 @@ from __future__ import annotations
 from ...manifest.spec import Manifest
 from ..base import IWebGuiTarget
 
+
 class HtmlShell(IWebGuiTarget):
     """Render a minimal SSR HTML snippet for a single page manifest.
 
     This does not emit <html>/<head>; it returns a <div class='page'> block intended to be
     embedded into a larger shell (e.g., SiteRouter.render_shell).
     """
+
     def render(self, manifest: Manifest, *, out: str | None = None) -> str:
         tiles_html = []
         for t in manifest.tiles:
             f = t.frame
             style = f"position:absolute;left:{int(f['x'])}px;top:{int(f['y'])}px;width:{int(f['w'])}px;height:{int(f['h'])}px;"
-            tiles_html.append(f"<div class='tile' data-tile='{t.id}' style='{style}'></div>")
+            tiles_html.append(
+                f"<div class='tile' data-tile='{t.id}' style='{style}'></div>"
+            )
         page_style = "position:relative;min-height:100vh;"
-        return "<div class='page' style='" + page_style + "'>" + "".join(tiles_html) + "</div>"
+        return (
+            "<div class='page' style='"
+            + page_style
+            + "'>"
+            + "".join(tiles_html)
+            + "</div>"
+        )

--- a/pkgs/experimental/layout_engine/src/layout_engine/targets/webgui/importmap.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/targets/webgui/importmap.py
@@ -2,8 +2,21 @@ from __future__ import annotations
 import json
 from ...mfe.default import ImportMapBuilder, RemoteRegistry
 
-def import_map_json(registry: RemoteRegistry, *, include_integrity: bool = True) -> dict:
+
+def import_map_json(
+    registry: RemoteRegistry, *, include_integrity: bool = True
+) -> dict:
     return ImportMapBuilder().build(registry, include_integrity=include_integrity)
 
-def import_map_text(registry: RemoteRegistry, *, include_integrity: bool = True, indent: int | None = None) -> str:
-    return json.dumps(import_map_json(registry, include_integrity=include_integrity), indent=indent, sort_keys=True)
+
+def import_map_text(
+    registry: RemoteRegistry,
+    *,
+    include_integrity: bool = True,
+    indent: int | None = None,
+) -> str:
+    return json.dumps(
+        import_map_json(registry, include_integrity=include_integrity),
+        indent=indent,
+        sort_keys=True,
+    )

--- a/pkgs/experimental/layout_engine/src/layout_engine/targets/webgui/router.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/targets/webgui/router.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Callable, Mapping, Any, Optional
+from typing import Callable, Mapping, Any
 
 from ...site.spec import SiteSpec, PageSpec
 from ...site.default import SiteIndex, build_page_context
@@ -10,20 +10,32 @@ from .importmap import import_map_json
 
 Html = str
 
+
 class SiteRouter:
     """Site-aware utilities to generate SSR HTML shells and manifest JSON.
 
     This class does not depend on any web framework; bind its methods to your routes.
     """
-    def __init__(self, site: SiteSpec, page_manifest_fn: Callable[[PageSpec, Mapping[str, Any]], Manifest]):
+
+    def __init__(
+        self,
+        site: SiteSpec,
+        page_manifest_fn: Callable[[PageSpec, Mapping[str, Any]], Manifest],
+    ):
         self.site = site
         self.page_manifest_fn = page_manifest_fn
         self._index = SiteIndex(site)
 
     # ---- Shells ----
-    def render_shell(self, page: PageSpec, params: Mapping[str, Any] | None = None,
-                     *, lang: str = "en", dir: str = "ltr",
-                     slots_attrs: Mapping[str, Mapping[str, str]] | None = None) -> Html:
+    def render_shell(
+        self,
+        page: PageSpec,
+        params: Mapping[str, Any] | None = None,
+        *,
+        lang: str = "en",
+        dir: str = "ltr",
+        slots_attrs: Mapping[str, Mapping[str, str]] | None = None,
+    ) -> Html:
         """Return a minimal SSR HTML containing slot containers.
         Slots are sized/positioned by hydrating clients using the manifest.
         """
@@ -38,16 +50,27 @@ class SiteRouter:
 </style>"""
         slots_html = []
         for s in page.slots:
-            attrs = " ".join(f"{k}='{v}'" for k,v in (slots_attrs.get(s.name, {}) or {}).items())
+            attrs = " ".join(
+                f"{k}='{v}'" for k, v in (slots_attrs.get(s.name, {}) or {}).items()
+            )
             slots_html.append(f"<div class='slot' data-slot='{s.name}' {attrs}></div>")
         body = f"<div id='app'>{''.join(slots_html)}</div>"
         return f"<!doctype html><html lang='{lang}' dir='{dir}'><head>{head}</head><body>{body}</body></html>"
 
     # ---- Manifest ----
-    def manifest_for(self, page: PageSpec, *, query: Mapping[str, Any] | None = None, extras: Mapping[str, Any] | None = None) -> Manifest:
+    def manifest_for(
+        self,
+        page: PageSpec,
+        *,
+        query: Mapping[str, Any] | None = None,
+        extras: Mapping[str, Any] | None = None,
+    ) -> Manifest:
         ctx = build_page_context(
-            match=self.site.resolve(page.route) or self._index.resolve(page.route) or  # local self route
-                  self._index.resolve(page.route if page.route.startswith('/') else ('/' + page.route)),
+            match=self.site.resolve(page.route)
+            or self._index.resolve(page.route)  # local self route
+            or self._index.resolve(
+                page.route if page.route.startswith("/") else ("/" + page.route)
+            ),
             query=query or {},
             extras=extras or {},
         )
@@ -56,12 +79,25 @@ class SiteRouter:
         cm.update(page.page_vm or {})
         return self.page_manifest_fn(page, cm)
 
-    def manifest_json(self, page: PageSpec, *, query: Mapping[str, Any] | None = None, extras: Mapping[str, Any] | None = None, indent: int | None = None) -> str:
+    def manifest_json(
+        self,
+        page: PageSpec,
+        *,
+        query: Mapping[str, Any] | None = None,
+        extras: Mapping[str, Any] | None = None,
+        indent: int | None = None,
+    ) -> str:
         m = self.manifest_for(page, query=query, extras=extras)
         return manifest_to_json(m, indent=indent)
 
     # ---- Path-driven helpers (MPA) ----
-    def manifest_for_path(self, absolute_path: str, *, query: Mapping[str, Any] | None = None, extras: Mapping[str, Any] | None = None) -> Manifest:
+    def manifest_for_path(
+        self,
+        absolute_path: str,
+        *,
+        query: Mapping[str, Any] | None = None,
+        extras: Mapping[str, Any] | None = None,
+    ) -> Manifest:
         match = self._index.resolve(absolute_path)
         if not match:
             raise KeyError(f"No page matches path: {absolute_path}")
@@ -71,10 +107,19 @@ class SiteRouter:
         cm.update(page.page_vm or {})
         return self.page_manifest_fn(page, cm)
 
-    def manifest_json_for_path(self, absolute_path: str, *, query: Mapping[str, Any] | None = None, extras: Mapping[str, Any] | None = None, indent: int | None = None) -> str:
+    def manifest_json_for_path(
+        self,
+        absolute_path: str,
+        *,
+        query: Mapping[str, Any] | None = None,
+        extras: Mapping[str, Any] | None = None,
+        indent: int | None = None,
+    ) -> str:
         m = self.manifest_for_path(absolute_path, query=query, extras=extras)
         return manifest_to_json(m, indent=indent)
 
     # ---- Import map ----
-    def import_map(self, registry: RemoteRegistry, *, include_integrity: bool = True) -> dict:
+    def import_map(
+        self, registry: RemoteRegistry, *, include_integrity: bool = True
+    ) -> dict:
         return import_map_json(registry, include_integrity=include_integrity)

--- a/pkgs/experimental/layout_engine/src/layout_engine/targets/webgui/ws_endpoints.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/targets/webgui/ws_endpoints.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
-from typing import Callable, Any, Tuple
-import json
+from typing import Callable, Tuple
 
 from ...events.ws import InProcEventBus
-from ...events.validators import validate_envelope, route_topic, ValidationError
+from ...events.validators import validate_envelope, route_topic
+
 
 class InProcWSBridge:
     """A minimal WS-like bridge you can use in tests or simple apps.
@@ -14,6 +14,7 @@ class InProcWSBridge:
         ws.on_receive_json({...event...})  # validates; publishes to derived topic
         unsub = ws.subscribe("page:dash", lambda msg: print(msg))
     """
+
     def __init__(self, bus: InProcEventBus):
         self.bus = bus
 
@@ -25,7 +26,9 @@ class InProcWSBridge:
         return topic, delivered
 
     # -- server -> client (send) --
-    def subscribe(self, topic: str, callback: Callable[[dict], None]) -> Callable[[], None]:
+    def subscribe(
+        self, topic: str, callback: Callable[[dict], None]
+    ) -> Callable[[], None]:
         return self.bus.subscribe(topic, callback)
 
     def send_json(self, topic: str, payload: dict) -> int:

--- a/pkgs/experimental/layout_engine/src/layout_engine/tiles/__init__.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/tiles/__init__.py
@@ -9,21 +9,30 @@ Exports
 - Bindings: to_dict()/from_dict() (spec), tile_to_dict()/tile_from_dict()
 - Decorators: @tile(...), @validate_spec
 """
+
 from .spec import TileSpec, validate_tile_id, validate_role
 from .base import ITile, ITileFactory
 from .default import Tile
 from .shortcuts import tile_spec, make_tile, define_tile, derive_tile
-from .decorators import tile, validate_spec
+from .decorators import tile, tile_ctx, validate_spec
 from .bindings import to_dict, from_dict, tile_to_dict, tile_from_dict
 
 __all__ = [
-    "TileSpec","validate_tile_id","validate_role",
-    "ITile","ITileFactory","Tile",
-    "tile_spec","make_tile","define_tile","derive_tile",
-    "tile","validate_spec",
-    "to_dict","from_dict","tile_to_dict","tile_from_dict",
+    "TileSpec",
+    "validate_tile_id",
+    "validate_role",
+    "ITile",
+    "ITileFactory",
+    "Tile",
+    "tile_spec",
+    "make_tile",
+    "define_tile",
+    "derive_tile",
+    "tile",
+    "tile_ctx",
+    "validate_spec",
+    "to_dict",
+    "from_dict",
+    "tile_to_dict",
+    "tile_from_dict",
 ]
-
-from .shortcuts import define_tile, derive_tile, make_tile
-from .decorators import tile_ctx
-__all__ = list(set([*(globals().get("__all__", [])), "define_tile", "derive_tile", "make_tile", "tile_ctx"]))

--- a/pkgs/experimental/layout_engine/src/layout_engine/tiles/base.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/tiles/base.py
@@ -3,18 +3,22 @@ from abc import ABC, abstractmethod
 from typing import Mapping, Any
 from .spec import TileSpec
 
+
 class ITile(ABC):
     """Runtime tile object (thin wrapper around TileSpec)."""
+
     @property
     @property
     @abstractmethod
     def spec(self) -> TileSpec:
         """Bound TileSpec for this runtime Tile."""
         raise NotImplementedError
+
     @abstractmethod
     def to_dict(self) -> Mapping[str, Any]:
         """Serialize tile to a JSON-safe dict."""
         raise NotImplementedError
+
 
 class ITileFactory(ABC):
     @abstractmethod

--- a/pkgs/experimental/layout_engine/src/layout_engine/tiles/bindings.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/tiles/bindings.py
@@ -5,8 +5,16 @@ from .default import Tile
 
 # ---- Spec JSON (de)serialization ----
 
+
 def to_dict(spec: TileSpec) -> dict:
-    return obj.dict() if hasattr(obj, 'dict') else dict(obj)def from_dict(obj: Mapping[str, Any]) -> TileSpec:
+    if hasattr(spec, "model_dump"):
+        return spec.model_dump()
+    if hasattr(spec, "dict"):
+        return spec.dict()
+    return dict(spec)
+
+
+def from_dict(obj: Mapping[str, Any]) -> TileSpec:
     return TileSpec(
         id=str(obj["id"]),
         role=str(obj.get("role", "generic")),
@@ -19,10 +27,13 @@ def to_dict(spec: TileSpec) -> dict:
         meta=dict(obj.get("meta", {})),
     )
 
+
 # ---- Tile JSON (de)serialization ----
+
 
 def tile_to_dict(t: Tile) -> dict:
     return {"spec": to_dict(t.spec)}
 
+
 def tile_from_dict(d: Mapping[str, Any]) -> Tile:
-    return Tile(from_dict(d["spec"]))
+    return Tile(spec=from_dict(d["spec"]))

--- a/pkgs/experimental/layout_engine/src/layout_engine/tiles/decorators.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/tiles/decorators.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from functools import wraps
-from typing import Mapping, Any
 from .spec import TileSpec
+
 
 def tile_ctx(*, id: str, role: str = "generic", **kwargs):
     """Decorator to attach a TileSpec to a factory function.
@@ -11,13 +11,23 @@ def tile_ctx(*, id: str, role: str = "generic", **kwargs):
         def revenue_tile(): return {"source": "metrics.revenue"}
     """
     spec = TileSpec(id=id, role=role, **kwargs)
+
     def deco(fn):
         setattr(fn, "__tile_spec__", spec)
+
         @wraps(fn)
         def wrapper(*a, **kw):
             return fn(*a, **kw)
+
         return wrapper
+
     return deco
+
+
+def tile(*, id: str, role: str = "generic", **kwargs):
+    """Backward compatible alias for :func:`tile_ctx`."""
+    return tile_ctx(id=id, role=role, **kwargs)
+
 
 def validate_spec(fn):
     """Placeholder decorator to validate function-provided specs at call-time.
@@ -25,6 +35,7 @@ def validate_spec(fn):
     If the function returns a dict with 'id'/'role', attempt to build a TileSpec for validation.
     Otherwise, pass-through.
     """
+
     @wraps(fn)
     def wrapper(*a, **kw):
         out = fn(*a, **kw)
@@ -33,4 +44,5 @@ def validate_spec(fn):
             if "id" in out and "role" in out:
                 TileSpec(**out)  # will raise on invalid
         return out
+
     return wrapper

--- a/pkgs/experimental/layout_engine/src/layout_engine/tiles/default.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/tiles/default.py
@@ -3,15 +3,19 @@ from dataclasses import dataclass
 from typing import Mapping, Any
 from .spec import TileSpec
 
+
 @dataclass(frozen=True)
 class Tile:
     spec: TileSpec
 
     # convenience property passthroughs
     @property
-    def id(self) -> str: return self.spec.id
+    def id(self) -> str:
+        return self.spec.id
+
     @property
-    def role(self) -> str: return self.spec.role
+    def role(self) -> str:
+        return self.spec.role
 
     def to_dict(self) -> Mapping[str, Any]:
         s = self.spec
@@ -19,8 +23,10 @@ class Tile:
             "id": s.id,
             "role": s.role,
             "constraints": {
-                "min_w": s.min_w, "min_h": s.min_h,
-                "max_w": s.max_w, "max_h": s.max_h,
+                "min_w": s.min_w,
+                "min_h": s.min_h,
+                "max_w": s.max_w,
+                "max_h": s.max_h,
                 "aspect": s.aspect,
             },
             "props": dict(s.props),

--- a/pkgs/experimental/layout_engine/src/layout_engine/tiles/shortcuts.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/tiles/shortcuts.py
@@ -3,15 +3,23 @@ from typing import Any
 from .spec import TileSpec
 from .default import Tile
 
+
+def tile_spec(**kwargs) -> TileSpec:
+    """Construct a :class:`TileSpec` (backward compatible helper)."""
+    return TileSpec(**kwargs)
+
+
 def define_tile(**kwargs) -> TileSpec:
     """Return a TileSpec from kwargs."""
     return TileSpec(**kwargs)
+
 
 def derive_tile(base: TileSpec, **overrides: Any) -> TileSpec:
     """Immutable copy of a TileSpec with overrides."""
     data = base.__dict__.copy()
     data.update(overrides)
     return TileSpec(**data)
+
 
 def make_tile(spec: TileSpec | None = None, **kwargs) -> Tile:
     """Return a Tile instance from a spec or kwargs."""

--- a/pkgs/experimental/layout_engine/src/layout_engine/tiles/spec.py
+++ b/pkgs/experimental/layout_engine/src/layout_engine/tiles/spec.py
@@ -1,21 +1,29 @@
-from pydantic import BaseModel, Field, validator
 from __future__ import annotations
-from pydantic import BaseModel, Field, validator, field, replace
-from typing import Optional, Mapping, Any
+
 import re
+from typing import Any, Mapping, Optional
+
+from pydantic import BaseModel, Field
 
 _ID_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_:-]{1,63}$")
 _ROLE_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_:-]{1,63}$")
 
+
 def validate_tile_id(tile_id: str) -> str:
     if not _ID_RE.match(tile_id):
-        raise ValueError(f"invalid tile id '{tile_id}' (allowed: [A-Za-z][A-Za-z0-9_:-] 2..64)")
+        raise ValueError(
+            f"invalid tile id '{tile_id}' (allowed: [A-Za-z][A-Za-z0-9_:-] 2..64)"
+        )
     return tile_id
+
 
 def validate_role(role: str) -> str:
     if not _ROLE_RE.match(role):
-        raise ValueError(f"invalid role '{role}' (allowed: [A-Za-z][A-Za-z0-9_:-] 2..64)")
+        raise ValueError(
+            f"invalid role '{role}' (allowed: [A-Za-z][A-Za-z0-9_:-] 2..64)"
+        )
     return role
+
 
 class TileSpec(BaseModel):
     """Declarative spec for a tile's identity, role, and constraints.
@@ -30,6 +38,7 @@ class TileSpec(BaseModel):
     props:     authoring-time properties (merged later with component defaults)
     meta:      free-form metadata (owner, tags, testids, etc.)
     """
+
     id: str
     role: str = "generic"
     min_w: int = 160
@@ -37,6 +46,5 @@ class TileSpec(BaseModel):
     max_w: Optional[int] = None
     max_h: Optional[int] = None
     aspect: Optional[float] = None
-    props: Mapping[str, Any] = field(default_factory=dict)
-    meta: Mapping[str, Any] = field(default_factory=dict)
-
+    props: Mapping[str, Any] = Field(default_factory=dict)
+    meta: Mapping[str, Any] = Field(default_factory=dict)

--- a/pkgs/experimental/layout_engine/uv.lock
+++ b/pkgs/experimental/layout_engine/uv.lock
@@ -1,0 +1,660 @@
+version = 1
+revision = 3
+requires-python = ">=3.10, <3.13"
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/78/7d432127c41b50bccba979505f272c16cbcadcc33645d5fa3a738110ae75/anyio-4.11.0.tar.gz", hash = "sha256:82a8d0b81e318cc5ce71a5f1f8b5c4e63619620b63141ef8c995fa0db95a57c4", size = 219094, upload-time = "2025-09-23T09:19:12.58Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/b3/9b1a8074496371342ec1e796a96f99c82c945a339cd81a8e73de28b4cf9e/anyio-4.11.0-py3-none-any.whl", hash = "sha256:0287e96f4d26d4149305414d4e3bc32f0dcd0862365a4bddea19d7a1ec38c4fc", size = 109097, upload-time = "2025-09-23T09:19:10.601Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/61/de6cd827efad202d7057d93e0fed9294b96952e188f7384832791c7b2254/click-8.3.0.tar.gz", hash = "sha256:e7b8232224eba16f4ebe410c25ced9f7875cb5f3263ffc93cc3e8da705e229c4", size = 276943, upload-time = "2025-09-18T17:32:23.696Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/d3/9dcc0f5797f070ec8edf30fbadfb200e71d9db6b84d211e3b2085a7589a0/click-8.3.0-py3-none-any.whl", hash = "sha256:9b9f285302c6e3064f4330c05f05b81945b2a39544279343e6e7c5f27a9baddc", size = 107295, upload-time = "2025-09-18T17:32:22.42Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/f4/c6e662dade71f56cd2f3735141b265c3c79293c109549c1e6933b0651ffc/exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10", size = 16674, upload-time = "2025-05-10T17:42:49.33Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.118.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/3c/2b9345a6504e4055eaa490e0b41c10e338ad61d9aeaae41d97807873cdf2/fastapi-0.118.0.tar.gz", hash = "sha256:5e81654d98c4d2f53790a7d32d25a7353b30c81441be7d0958a26b5d761fa1c8", size = 310536, upload-time = "2025-09-29T03:37:23.126Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/54e2bdaad22ca91a59455251998d43094d5c3d3567c52c7c04774b3f43f2/fastapi-0.118.0-py3-none-any.whl", hash = "sha256:705137a61e2ef71019d2445b123aa8845bd97273c395b744d5a7dfe559056855", size = 97694, upload-time = "2025-09-29T03:37:21.338Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.2.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/b8/704d753a5a45507a7aab61f18db9509302ed3d0a27ac7e0359ec2905b1a6/greenlet-3.2.4.tar.gz", hash = "sha256:0dca0d95ff849f9a364385f36ab49f50065d76964944638be9691e1832e9f86d", size = 188260, upload-time = "2025-08-07T13:24:33.51Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/ed/6bfa4109fcb23a58819600392564fea69cdc6551ffd5e69ccf1d52a40cbc/greenlet-3.2.4-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:8c68325b0d0acf8d91dde4e6f930967dd52a5302cd4062932a6b2e7c2969f47c", size = 271061, upload-time = "2025-08-07T13:17:15.373Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fc/102ec1a2fc015b3a7652abab7acf3541d58c04d3d17a8d3d6a44adae1eb1/greenlet-3.2.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:94385f101946790ae13da500603491f04a76b6e4c059dab271b3ce2e283b2590", size = 629475, upload-time = "2025-08-07T13:42:54.009Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/26/80383131d55a4ac0fb08d71660fd77e7660b9db6bdb4e8884f46d9f2cc04/greenlet-3.2.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f10fd42b5ee276335863712fa3da6608e93f70629c631bf77145021600abc23c", size = 640802, upload-time = "2025-08-07T13:45:25.52Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/7c/e7833dbcd8f376f3326bd728c845d31dcde4c84268d3921afcae77d90d08/greenlet-3.2.4-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c8c9e331e58180d0d83c5b7999255721b725913ff6bc6cf39fa2a45841a4fd4b", size = 636703, upload-time = "2025-08-07T13:53:12.622Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/49/547b93b7c0428ede7b3f309bc965986874759f7d89e4e04aeddbc9699acb/greenlet-3.2.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:58b97143c9cc7b86fc458f215bd0932f1757ce649e05b640fea2e79b54cedb31", size = 635417, upload-time = "2025-08-07T13:18:25.189Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/91/ae2eb6b7979e2f9b035a9f612cf70f1bf54aad4e1d125129bef1eae96f19/greenlet-3.2.4-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c2ca18a03a8cfb5b25bc1cbe20f3d9a4c80d8c3b13ba3df49ac3961af0b1018d", size = 584358, upload-time = "2025-08-07T13:18:23.708Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/85/433de0c9c0252b22b16d413c9407e6cb3b41df7389afc366ca204dbc1393/greenlet-3.2.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:9fe0a28a7b952a21e2c062cd5756d34354117796c6d9215a87f55e38d15402c5", size = 1113550, upload-time = "2025-08-07T13:42:37.467Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/8d/88f3ebd2bc96bf7747093696f4335a0a8a4c5acfcf1b757717c0d2474ba3/greenlet-3.2.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8854167e06950ca75b898b104b63cc646573aa5fef1353d4508ecdd1ee76254f", size = 1137126, upload-time = "2025-08-07T13:18:20.239Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/6f/b60b0291d9623c496638c582297ead61f43c4b72eef5e9c926ef4565ec13/greenlet-3.2.4-cp310-cp310-win_amd64.whl", hash = "sha256:73f49b5368b5359d04e18d15828eecc1806033db5233397748f4ca813ff1056c", size = 298654, upload-time = "2025-08-07T13:50:00.469Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/de/f28ced0a67749cac23fecb02b694f6473f47686dff6afaa211d186e2ef9c/greenlet-3.2.4-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:96378df1de302bc38e99c3a9aa311967b7dc80ced1dcc6f171e99842987882a2", size = 272305, upload-time = "2025-08-07T13:15:41.288Z" },
+    { url = "https://files.pythonhosted.org/packages/09/16/2c3792cba130000bf2a31c5272999113f4764fd9d874fb257ff588ac779a/greenlet-3.2.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1ee8fae0519a337f2329cb78bd7a8e128ec0f881073d43f023c7b8d4831d5246", size = 632472, upload-time = "2025-08-07T13:42:55.044Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/95d48d7e3d433e6dae5b1682e4292242a53f22df82e6d3dda81b1701a960/greenlet-3.2.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94abf90142c2a18151632371140b3dba4dee031633fe614cb592dbb6c9e17bc3", size = 644646, upload-time = "2025-08-07T13:45:26.523Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/5e/405965351aef8c76b8ef7ad370e5da58d57ef6068df197548b015464001a/greenlet-3.2.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:4d1378601b85e2e5171b99be8d2dc85f594c79967599328f95c1dc1a40f1c633", size = 640519, upload-time = "2025-08-07T13:53:13.928Z" },
+    { url = "https://files.pythonhosted.org/packages/25/5d/382753b52006ce0218297ec1b628e048c4e64b155379331f25a7316eb749/greenlet-3.2.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0db5594dce18db94f7d1650d7489909b57afde4c580806b8d9203b6e79cdc079", size = 639707, upload-time = "2025-08-07T13:18:27.146Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/8e/abdd3f14d735b2929290a018ecf133c901be4874b858dd1c604b9319f064/greenlet-3.2.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2523e5246274f54fdadbce8494458a2ebdcdbc7b802318466ac5606d3cded1f8", size = 587684, upload-time = "2025-08-07T13:18:25.164Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/65/deb2a69c3e5996439b0176f6651e0052542bb6c8f8ec2e3fba97c9768805/greenlet-3.2.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1987de92fec508535687fb807a5cea1560f6196285a4cde35c100b8cd632cc52", size = 1116647, upload-time = "2025-08-07T13:42:38.655Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/cc/b07000438a29ac5cfb2194bfc128151d52f333cee74dd7dfe3fb733fc16c/greenlet-3.2.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:55e9c5affaa6775e2c6b67659f3a71684de4c549b3dd9afca3bc773533d284fa", size = 1142073, upload-time = "2025-08-07T13:18:21.737Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/0f/30aef242fcab550b0b3520b8e3561156857c94288f0332a79928c31a52cf/greenlet-3.2.4-cp311-cp311-win_amd64.whl", hash = "sha256:9c40adce87eaa9ddb593ccb0fa6a07caf34015a29bf8d344811665b573138db9", size = 299100, upload-time = "2025-08-07T13:44:12.287Z" },
+    { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
+    { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
+    { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/c7/12381b18e21aef2c6bd3a636da1088b888b97b7a0362fac2e4de92405f97/greenlet-3.2.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:20fb936b4652b6e307b8f347665e2c615540d4b42b3b4c8a321d8286da7e520f", size = 1151142, upload-time = "2025-08-07T13:18:22.981Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/08/b0814846b79399e585f974bbeebf5580fbe59e258ea7be64d9dfb253c84f/greenlet-3.2.4-cp312-cp312-win_amd64.whl", hash = "sha256:a7d4e128405eea3814a12cc2605e0e6aedb4035bf32697f72deca74de4105e02", size = 299899, upload-time = "2025-08-07T13:38:53.448Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "layout-engine"
+version = "0.1.1"
+source = { editable = "." }
+dependencies = [
+    { name = "jinja2" },
+    { name = "pydantic" },
+]
+
+[package.optional-dependencies]
+pdf = [
+    { name = "playwright" },
+]
+server = [
+    { name = "fastapi" },
+    { name = "orjson" },
+    { name = "uvicorn" },
+    { name = "websockets" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "ruff" },
+    { name = "typing-extensions" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.115" },
+    { name = "jinja2", specifier = ">=3.1" },
+    { name = "orjson", marker = "extra == 'server'", specifier = ">=3.9" },
+    { name = "playwright", marker = "extra == 'pdf'", specifier = ">=1.46" },
+    { name = "pydantic", specifier = ">=2.6" },
+    { name = "uvicorn", marker = "extra == 'server'", specifier = ">=0.30" },
+    { name = "websockets", marker = "extra == 'server'", specifier = ">=12.0" },
+]
+provides-extras = ["pdf", "server"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=1.10" },
+    { name = "pytest", specifier = ">=8.2" },
+    { name = "ruff", specifier = ">=0.6" },
+    { name = "typing-extensions", specifier = ">=4.12" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/4b/3541d44f3937ba468b75da9eebcae497dcf67adb65caa16760b0a6807ebb/markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559", size = 11631, upload-time = "2025-09-27T18:36:05.558Z" },
+    { url = "https://files.pythonhosted.org/packages/98/1b/fbd8eed11021cabd9226c37342fa6ca4e8a98d8188a8d9b66740494960e4/markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419", size = 12057, upload-time = "2025-09-27T18:36:07.165Z" },
+    { url = "https://files.pythonhosted.org/packages/40/01/e560d658dc0bb8ab762670ece35281dec7b6c1b33f5fbc09ebb57a185519/markupsafe-3.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ba88449deb3de88bd40044603fafffb7bc2b055d626a330323a9ed736661695", size = 22050, upload-time = "2025-09-27T18:36:08.005Z" },
+    { url = "https://files.pythonhosted.org/packages/af/cd/ce6e848bbf2c32314c9b237839119c5a564a59725b53157c856e90937b7a/markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f42d0984e947b8adf7dd6dde396e720934d12c506ce84eea8476409563607591", size = 20681, upload-time = "2025-09-27T18:36:08.881Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2a/b5c12c809f1c3045c4d580b035a743d12fcde53cf685dbc44660826308da/markupsafe-3.0.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0c0b3ade1c0b13b936d7970b1d37a57acde9199dc2aecc4c336773e1d86049c", size = 20705, upload-time = "2025-09-27T18:36:10.131Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e3/9427a68c82728d0a88c50f890d0fc072a1484de2f3ac1ad0bfc1a7214fd5/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f", size = 21524, upload-time = "2025-09-27T18:36:11.324Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/36/23578f29e9e582a4d0278e009b38081dbe363c5e7165113fad546918a232/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:d2ee202e79d8ed691ceebae8e0486bd9a2cd4794cec4824e1c99b6f5009502f6", size = 20282, upload-time = "2025-09-27T18:36:12.573Z" },
+    { url = "https://files.pythonhosted.org/packages/56/21/dca11354e756ebd03e036bd8ad58d6d7168c80ce1fe5e75218e4945cbab7/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:177b5253b2834fe3678cb4a5f0059808258584c559193998be2601324fdeafb1", size = 20745, upload-time = "2025-09-27T18:36:13.504Z" },
+    { url = "https://files.pythonhosted.org/packages/87/99/faba9369a7ad6e4d10b6a5fbf71fa2a188fe4a593b15f0963b73859a1bbd/markupsafe-3.0.3-cp310-cp310-win32.whl", hash = "sha256:2a15a08b17dd94c53a1da0438822d70ebcd13f8c3a95abe3a9ef9f11a94830aa", size = 14571, upload-time = "2025-09-27T18:36:14.779Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/25/55dc3ab959917602c96985cb1253efaa4ff42f71194bddeb61eb7278b8be/markupsafe-3.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:c4ffb7ebf07cfe8931028e3e4c85f0357459a3f9f9490886198848f4fa002ec8", size = 15056, upload-time = "2025-09-27T18:36:16.125Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9e/0a02226640c255d1da0b8d12e24ac2aa6734da68bff14c05dd53b94a0fc3/markupsafe-3.0.3-cp310-cp310-win_arm64.whl", hash = "sha256:e2103a929dfa2fcaf9bb4e7c091983a49c9ac3b19c9061b6d5427dd7d14d81a1", size = 13932, upload-time = "2025-09-27T18:36:17.311Z" },
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "1.18.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/77/8f0d0001ffad290cef2f7f216f96c814866248a0b92a722365ed54648e7e/mypy-1.18.2.tar.gz", hash = "sha256:06a398102a5f203d7477b2923dda3634c36727fa5c237d8f859ef90c42a9924b", size = 3448846, upload-time = "2025-09-19T00:11:10.519Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/6f/657961a0743cff32e6c0611b63ff1c1970a0b482ace35b069203bf705187/mypy-1.18.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c1eab0cf6294dafe397c261a75f96dc2c31bffe3b944faa24db5def4e2b0f77c", size = 12807973, upload-time = "2025-09-19T00:10:35.282Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e9/420822d4f661f13ca8900f5fa239b40ee3be8b62b32f3357df9a3045a08b/mypy-1.18.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7a780ca61fc239e4865968ebc5240bb3bf610ef59ac398de9a7421b54e4a207e", size = 11896527, upload-time = "2025-09-19T00:10:55.791Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/73/a05b2bbaa7005f4642fcfe40fb73f2b4fb6bb44229bd585b5878e9a87ef8/mypy-1.18.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:448acd386266989ef11662ce3c8011fd2a7b632e0ec7d61a98edd8e27472225b", size = 12507004, upload-time = "2025-09-19T00:11:05.411Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/f6e4b9f0d031c11ccbd6f17da26564f3a0f3c4155af344006434b0a05a9d/mypy-1.18.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f9e171c465ad3901dc652643ee4bffa8e9fef4d7d0eece23b428908c77a76a66", size = 13245947, upload-time = "2025-09-19T00:10:46.923Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/97/19727e7499bfa1ae0773d06afd30ac66a58ed7437d940c70548634b24185/mypy-1.18.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:592ec214750bc00741af1f80cbf96b5013d81486b7bb24cb052382c19e40b428", size = 13499217, upload-time = "2025-09-19T00:09:39.472Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/4f/90dc8c15c1441bf31cf0f9918bb077e452618708199e530f4cbd5cede6ff/mypy-1.18.2-cp310-cp310-win_amd64.whl", hash = "sha256:7fb95f97199ea11769ebe3638c29b550b5221e997c63b14ef93d2e971606ebed", size = 9766753, upload-time = "2025-09-19T00:10:49.161Z" },
+    { url = "https://files.pythonhosted.org/packages/88/87/cafd3ae563f88f94eec33f35ff722d043e09832ea8530ef149ec1efbaf08/mypy-1.18.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:807d9315ab9d464125aa9fcf6d84fde6e1dc67da0b6f80e7405506b8ac72bc7f", size = 12731198, upload-time = "2025-09-19T00:09:44.857Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e0/1e96c3d4266a06d4b0197ace5356d67d937d8358e2ee3ffac71faa843724/mypy-1.18.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:776bb00de1778caf4db739c6e83919c1d85a448f71979b6a0edd774ea8399341", size = 11817879, upload-time = "2025-09-19T00:09:47.131Z" },
+    { url = "https://files.pythonhosted.org/packages/72/ef/0c9ba89eb03453e76bdac5a78b08260a848c7bfc5d6603634774d9cd9525/mypy-1.18.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1379451880512ffce14505493bd9fe469e0697543717298242574882cf8cdb8d", size = 12427292, upload-time = "2025-09-19T00:10:22.472Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/52/ec4a061dd599eb8179d5411d99775bec2a20542505988f40fc2fee781068/mypy-1.18.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1331eb7fd110d60c24999893320967594ff84c38ac6d19e0a76c5fd809a84c86", size = 13163750, upload-time = "2025-09-19T00:09:51.472Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/5f/2cf2ceb3b36372d51568f2208c021870fe7834cf3186b653ac6446511839/mypy-1.18.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3ca30b50a51e7ba93b00422e486cbb124f1c56a535e20eff7b2d6ab72b3b2e37", size = 13351827, upload-time = "2025-09-19T00:09:58.311Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/7d/2697b930179e7277529eaaec1513f8de622818696857f689e4a5432e5e27/mypy-1.18.2-cp311-cp311-win_amd64.whl", hash = "sha256:664dc726e67fa54e14536f6e1224bcfce1d9e5ac02426d2326e2bb4e081d1ce8", size = 9757983, upload-time = "2025-09-19T00:10:09.071Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/dfdd2bc60c66611dd8335f463818514733bc763e4760dee289dcc33df709/mypy-1.18.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:33eca32dd124b29400c31d7cf784e795b050ace0e1f91b8dc035672725617e34", size = 12908273, upload-time = "2025-09-19T00:10:58.321Z" },
+    { url = "https://files.pythonhosted.org/packages/81/14/6a9de6d13a122d5608e1a04130724caf9170333ac5a924e10f670687d3eb/mypy-1.18.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a3c47adf30d65e89b2dcd2fa32f3aeb5e94ca970d2c15fcb25e297871c8e4764", size = 11920910, upload-time = "2025-09-19T00:10:20.043Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/a9/b29de53e42f18e8cc547e38daa9dfa132ffdc64f7250e353f5c8cdd44bee/mypy-1.18.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5d6c838e831a062f5f29d11c9057c6009f60cb294fea33a98422688181fe2893", size = 12465585, upload-time = "2025-09-19T00:10:33.005Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ae/6c3d2c7c61ff21f2bee938c917616c92ebf852f015fb55917fd6e2811db2/mypy-1.18.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01199871b6110a2ce984bde85acd481232d17413868c9807e95c1b0739a58914", size = 13348562, upload-time = "2025-09-19T00:10:11.51Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/31/aec68ab3b4aebdf8f36d191b0685d99faa899ab990753ca0fee60fb99511/mypy-1.18.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a2afc0fa0b0e91b4599ddfe0f91e2c26c2b5a5ab263737e998d6817874c5f7c8", size = 13533296, upload-time = "2025-09-19T00:10:06.568Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/83/abcb3ad9478fca3ebeb6a5358bb0b22c95ea42b43b7789c7fb1297ca44f4/mypy-1.18.2-cp312-cp312-win_amd64.whl", hash = "sha256:d8068d0afe682c7c4897c0f7ce84ea77f6de953262b12d07038f4d296d547074", size = 9828828, upload-time = "2025-09-19T00:10:28.203Z" },
+    { url = "https://files.pythonhosted.org/packages/87/e3/be76d87158ebafa0309946c4a73831974d4d6ab4f4ef40c3b53a385a66fd/mypy-1.18.2-py3-none-any.whl", hash = "sha256:22a1748707dd62b58d2ae53562ffc4d7f8bcc727e8ac7cbc69c053ddc874d47e", size = 2352367, upload-time = "2025-09-19T00:10:15.489Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "orjson"
+version = "3.11.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/4d/8df5f83256a809c22c4d6792ce8d43bb503be0fb7a8e4da9025754b09658/orjson-3.11.3.tar.gz", hash = "sha256:1c0603b1d2ffcd43a411d64797a19556ef76958aef1c182f22dc30860152a98a", size = 5482394, upload-time = "2025-08-26T17:46:43.171Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/64/4a3cef001c6cd9c64256348d4c13a7b09b857e3e1cbb5185917df67d8ced/orjson-3.11.3-cp310-cp310-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:29cb1f1b008d936803e2da3d7cba726fc47232c45df531b29edf0b232dd737e7", size = 238600, upload-time = "2025-08-26T17:44:36.875Z" },
+    { url = "https://files.pythonhosted.org/packages/10/ce/0c8c87f54f79d051485903dc46226c4d3220b691a151769156054df4562b/orjson-3.11.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:97dceed87ed9139884a55db8722428e27bd8452817fbf1869c58b49fecab1120", size = 123526, upload-time = "2025-08-26T17:44:39.574Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/d0/249497e861f2d438f45b3ab7b7b361484237414945169aa285608f9f7019/orjson-3.11.3-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:58533f9e8266cb0ac298e259ed7b4d42ed3fa0b78ce76860626164de49e0d467", size = 128075, upload-time = "2025-08-26T17:44:40.672Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/64/00485702f640a0fd56144042a1ea196469f4a3ae93681871564bf74fa996/orjson-3.11.3-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0c212cfdd90512fe722fa9bd620de4d46cda691415be86b2e02243242ae81873", size = 130483, upload-time = "2025-08-26T17:44:41.788Z" },
+    { url = "https://files.pythonhosted.org/packages/64/81/110d68dba3909171bf3f05619ad0cf187b430e64045ae4e0aa7ccfe25b15/orjson-3.11.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5ff835b5d3e67d9207343effb03760c00335f8b5285bfceefd4dc967b0e48f6a", size = 132539, upload-time = "2025-08-26T17:44:43.12Z" },
+    { url = "https://files.pythonhosted.org/packages/79/92/dba25c22b0ddfafa1e6516a780a00abac28d49f49e7202eb433a53c3e94e/orjson-3.11.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f5aa4682912a450c2db89cbd92d356fef47e115dffba07992555542f344d301b", size = 135390, upload-time = "2025-08-26T17:44:44.199Z" },
+    { url = "https://files.pythonhosted.org/packages/44/1d/ca2230fd55edbd87b58a43a19032d63a4b180389a97520cc62c535b726f9/orjson-3.11.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d7d18dd34ea2e860553a579df02041845dee0af8985dff7f8661306f95504ddf", size = 132966, upload-time = "2025-08-26T17:44:45.719Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/b9/96bbc8ed3e47e52b487d504bd6861798977445fbc410da6e87e302dc632d/orjson-3.11.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d8b11701bc43be92ea42bd454910437b355dfb63696c06fe953ffb40b5f763b4", size = 131349, upload-time = "2025-08-26T17:44:46.862Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/3c/418fbd93d94b0df71cddf96b7fe5894d64a5d890b453ac365120daec30f7/orjson-3.11.3-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:90368277087d4af32d38bd55f9da2ff466d25325bf6167c8f382d8ee40cb2bbc", size = 404087, upload-time = "2025-08-26T17:44:48.079Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/a9/2bfd58817d736c2f63608dec0c34857339d423eeed30099b126562822191/orjson-3.11.3-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:fd7ff459fb393358d3a155d25b275c60b07a2c83dcd7ea962b1923f5a1134569", size = 146067, upload-time = "2025-08-26T17:44:49.302Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ba/29023771f334096f564e48d82ed855a0ed3320389d6748a9c949e25be734/orjson-3.11.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f8d902867b699bcd09c176a280b1acdab57f924489033e53d0afe79817da37e6", size = 135506, upload-time = "2025-08-26T17:44:50.558Z" },
+    { url = "https://files.pythonhosted.org/packages/39/62/b5a1eca83f54cb3aa11a9645b8a22f08d97dbd13f27f83aae7c6666a0a05/orjson-3.11.3-cp310-cp310-win32.whl", hash = "sha256:bb93562146120bb51e6b154962d3dadc678ed0fce96513fa6bc06599bb6f6edc", size = 136352, upload-time = "2025-08-26T17:44:51.698Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/c0/7ebfaa327d9a9ed982adc0d9420dbce9a3fec45b60ab32c6308f731333fa/orjson-3.11.3-cp310-cp310-win_amd64.whl", hash = "sha256:976c6f1975032cc327161c65d4194c549f2589d88b105a5e3499429a54479770", size = 131539, upload-time = "2025-08-26T17:44:52.974Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8b/360674cd817faef32e49276187922a946468579fcaf37afdfb6c07046e92/orjson-3.11.3-cp311-cp311-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:9d2ae0cc6aeb669633e0124531f342a17d8e97ea999e42f12a5ad4adaa304c5f", size = 238238, upload-time = "2025-08-26T17:44:54.214Z" },
+    { url = "https://files.pythonhosted.org/packages/05/3d/5fa9ea4b34c1a13be7d9046ba98d06e6feb1d8853718992954ab59d16625/orjson-3.11.3-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:ba21dbb2493e9c653eaffdc38819b004b7b1b246fb77bfc93dc016fe664eac91", size = 127713, upload-time = "2025-08-26T17:44:55.596Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/5f/e18367823925e00b1feec867ff5f040055892fc474bf5f7875649ecfa586/orjson-3.11.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:00f1a271e56d511d1569937c0447d7dce5a99a33ea0dec76673706360a051904", size = 123241, upload-time = "2025-08-26T17:44:57.185Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/bd/3c66b91c4564759cf9f473251ac1650e446c7ba92a7c0f9f56ed54f9f0e6/orjson-3.11.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b67e71e47caa6680d1b6f075a396d04fa6ca8ca09aafb428731da9b3ea32a5a6", size = 127895, upload-time = "2025-08-26T17:44:58.349Z" },
+    { url = "https://files.pythonhosted.org/packages/82/b5/dc8dcd609db4766e2967a85f63296c59d4722b39503e5b0bf7fd340d387f/orjson-3.11.3-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d7d012ebddffcce8c85734a6d9e5f08180cd3857c5f5a3ac70185b43775d043d", size = 130303, upload-time = "2025-08-26T17:44:59.491Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c2/d58ec5fd1270b2aa44c862171891adc2e1241bd7dab26c8f46eb97c6c6f1/orjson-3.11.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dd759f75d6b8d1b62012b7f5ef9461d03c804f94d539a5515b454ba3a6588038", size = 132366, upload-time = "2025-08-26T17:45:00.654Z" },
+    { url = "https://files.pythonhosted.org/packages/73/87/0ef7e22eb8dd1ef940bfe3b9e441db519e692d62ed1aae365406a16d23d0/orjson-3.11.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6890ace0809627b0dff19cfad92d69d0fa3f089d3e359a2a532507bb6ba34efb", size = 135180, upload-time = "2025-08-26T17:45:02.424Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/6a/e5bf7b70883f374710ad74faf99bacfc4b5b5a7797c1d5e130350e0e28a3/orjson-3.11.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9d4a5e041ae435b815e568537755773d05dac031fee6a57b4ba70897a44d9d2", size = 132741, upload-time = "2025-08-26T17:45:03.663Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/0c/4577fd860b6386ffaa56440e792af01c7882b56d2766f55384b5b0e9d39b/orjson-3.11.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2d68bf97a771836687107abfca089743885fb664b90138d8761cce61d5625d55", size = 131104, upload-time = "2025-08-26T17:45:04.939Z" },
+    { url = "https://files.pythonhosted.org/packages/66/4b/83e92b2d67e86d1c33f2ea9411742a714a26de63641b082bdbf3d8e481af/orjson-3.11.3-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:bfc27516ec46f4520b18ef645864cee168d2a027dbf32c5537cb1f3e3c22dac1", size = 403887, upload-time = "2025-08-26T17:45:06.228Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e5/9eea6a14e9b5ceb4a271a1fd2e1dec5f2f686755c0fab6673dc6ff3433f4/orjson-3.11.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:f66b001332a017d7945e177e282a40b6997056394e3ed7ddb41fb1813b83e824", size = 145855, upload-time = "2025-08-26T17:45:08.338Z" },
+    { url = "https://files.pythonhosted.org/packages/45/78/8d4f5ad0c80ba9bf8ac4d0fc71f93a7d0dc0844989e645e2074af376c307/orjson-3.11.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:212e67806525d2561efbfe9e799633b17eb668b8964abed6b5319b2f1cfbae1f", size = 135361, upload-time = "2025-08-26T17:45:09.625Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5f/16386970370178d7a9b438517ea3d704efcf163d286422bae3b37b88dbb5/orjson-3.11.3-cp311-cp311-win32.whl", hash = "sha256:6e8e0c3b85575a32f2ffa59de455f85ce002b8bdc0662d6b9c2ed6d80ab5d204", size = 136190, upload-time = "2025-08-26T17:45:10.962Z" },
+    { url = "https://files.pythonhosted.org/packages/09/60/db16c6f7a41dd8ac9fb651f66701ff2aeb499ad9ebc15853a26c7c152448/orjson-3.11.3-cp311-cp311-win_amd64.whl", hash = "sha256:6be2f1b5d3dc99a5ce5ce162fc741c22ba9f3443d3dd586e6a1211b7bc87bc7b", size = 131389, upload-time = "2025-08-26T17:45:12.285Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/2a/bb811ad336667041dea9b8565c7c9faf2f59b47eb5ab680315eea612ef2e/orjson-3.11.3-cp311-cp311-win_arm64.whl", hash = "sha256:fafb1a99d740523d964b15c8db4eabbfc86ff29f84898262bf6e3e4c9e97e43e", size = 126120, upload-time = "2025-08-26T17:45:13.515Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b0/a7edab2a00cdcb2688e1c943401cb3236323e7bfd2839815c6131a3742f4/orjson-3.11.3-cp312-cp312-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:8c752089db84333e36d754c4baf19c0e1437012242048439c7e80eb0e6426e3b", size = 238259, upload-time = "2025-08-26T17:45:15.093Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/c6/ff4865a9cc398a07a83342713b5932e4dc3cb4bf4bc04e8f83dedfc0d736/orjson-3.11.3-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:9b8761b6cf04a856eb544acdd82fc594b978f12ac3602d6374a7edb9d86fd2c2", size = 127633, upload-time = "2025-08-26T17:45:16.417Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/e6/e00bea2d9472f44fe8794f523e548ce0ad51eb9693cf538a753a27b8bda4/orjson-3.11.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b13974dc8ac6ba22feaa867fc19135a3e01a134b4f7c9c28162fed4d615008a", size = 123061, upload-time = "2025-08-26T17:45:17.673Z" },
+    { url = "https://files.pythonhosted.org/packages/54/31/9fbb78b8e1eb3ac605467cb846e1c08d0588506028b37f4ee21f978a51d4/orjson-3.11.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f83abab5bacb76d9c821fd5c07728ff224ed0e52d7a71b7b3de822f3df04e15c", size = 127956, upload-time = "2025-08-26T17:45:19.172Z" },
+    { url = "https://files.pythonhosted.org/packages/36/88/b0604c22af1eed9f98d709a96302006915cfd724a7ebd27d6dd11c22d80b/orjson-3.11.3-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e6fbaf48a744b94091a56c62897b27c31ee2da93d826aa5b207131a1e13d4064", size = 130790, upload-time = "2025-08-26T17:45:20.586Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/9d/1c1238ae9fffbfed51ba1e507731b3faaf6b846126a47e9649222b0fd06f/orjson-3.11.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bc779b4f4bba2847d0d2940081a7b6f7b5877e05408ffbb74fa1faf4a136c424", size = 132385, upload-time = "2025-08-26T17:45:22.036Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/b5/c06f1b090a1c875f337e21dd71943bc9d84087f7cdf8c6e9086902c34e42/orjson-3.11.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd4b909ce4c50faa2192da6bb684d9848d4510b736b0611b6ab4020ea6fd2d23", size = 135305, upload-time = "2025-08-26T17:45:23.4Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/26/5f028c7d81ad2ebbf84414ba6d6c9cac03f22f5cd0d01eb40fb2d6a06b07/orjson-3.11.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:524b765ad888dc5518bbce12c77c2e83dee1ed6b0992c1790cc5fb49bb4b6667", size = 132875, upload-time = "2025-08-26T17:45:25.182Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/d4/b8df70d9cfb56e385bf39b4e915298f9ae6c61454c8154a0f5fd7efcd42e/orjson-3.11.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:84fd82870b97ae3cdcea9d8746e592b6d40e1e4d4527835fc520c588d2ded04f", size = 130940, upload-time = "2025-08-26T17:45:27.209Z" },
+    { url = "https://files.pythonhosted.org/packages/da/5e/afe6a052ebc1a4741c792dd96e9f65bf3939d2094e8b356503b68d48f9f5/orjson-3.11.3-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:fbecb9709111be913ae6879b07bafd4b0785b44c1eb5cac8ac76da048b3885a1", size = 403852, upload-time = "2025-08-26T17:45:28.478Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/90/7bbabafeb2ce65915e9247f14a56b29c9334003536009ef5b122783fe67e/orjson-3.11.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:9dba358d55aee552bd868de348f4736ca5a4086d9a62e2bfbbeeb5629fe8b0cc", size = 146293, upload-time = "2025-08-26T17:45:29.86Z" },
+    { url = "https://files.pythonhosted.org/packages/27/b3/2d703946447da8b093350570644a663df69448c9d9330e5f1d9cce997f20/orjson-3.11.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:eabcf2e84f1d7105f84580e03012270c7e97ecb1fb1618bda395061b2a84a049", size = 135470, upload-time = "2025-08-26T17:45:31.243Z" },
+    { url = "https://files.pythonhosted.org/packages/38/70/b14dcfae7aff0e379b0119c8a812f8396678919c431efccc8e8a0263e4d9/orjson-3.11.3-cp312-cp312-win32.whl", hash = "sha256:3782d2c60b8116772aea8d9b7905221437fdf53e7277282e8d8b07c220f96cca", size = 136248, upload-time = "2025-08-26T17:45:32.567Z" },
+    { url = "https://files.pythonhosted.org/packages/35/b8/9e3127d65de7fff243f7f3e53f59a531bf6bb295ebe5db024c2503cc0726/orjson-3.11.3-cp312-cp312-win_amd64.whl", hash = "sha256:79b44319268af2eaa3e315b92298de9a0067ade6e6003ddaef72f8e0bedb94f1", size = 131437, upload-time = "2025-08-26T17:45:34.949Z" },
+    { url = "https://files.pythonhosted.org/packages/51/92/a946e737d4d8a7fd84a606aba96220043dcc7d6988b9e7551f7f6d5ba5ad/orjson-3.11.3-cp312-cp312-win_arm64.whl", hash = "sha256:0e92a4e83341ef79d835ca21b8bd13e27c859e4e9e4d7b63defc6e58462a3710", size = 125978, upload-time = "2025-08-26T17:45:36.422Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
+]
+
+[[package]]
+name = "playwright"
+version = "1.55.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/3a/c81ff76df266c62e24f19718df9c168f49af93cabdbc4608ae29656a9986/playwright-1.55.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:d7da108a95001e412effca4f7610de79da1637ccdf670b1ae3fdc08b9694c034", size = 40428109, upload-time = "2025-08-28T15:46:20.357Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/f5/bdb61553b20e907196a38d864602a9b4a461660c3a111c67a35179b636fa/playwright-1.55.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:8290cf27a5d542e2682ac274da423941f879d07b001f6575a5a3a257b1d4ba1c", size = 38687254, upload-time = "2025-08-28T15:46:23.925Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/64/48b2837ef396487807e5ab53c76465747e34c7143fac4a084ef349c293a8/playwright-1.55.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:25b0d6b3fd991c315cca33c802cf617d52980108ab8431e3e1d37b5de755c10e", size = 40428108, upload-time = "2025-08-28T15:46:27.119Z" },
+    { url = "https://files.pythonhosted.org/packages/08/33/858312628aa16a6de97839adc2ca28031ebc5391f96b6fb8fdf1fcb15d6c/playwright-1.55.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:c6d4d8f6f8c66c483b0835569c7f0caa03230820af8e500c181c93509c92d831", size = 45905643, upload-time = "2025-08-28T15:46:30.312Z" },
+    { url = "https://files.pythonhosted.org/packages/83/83/b8d06a5b5721931aa6d5916b83168e28bd891f38ff56fe92af7bdee9860f/playwright-1.55.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29a0777c4ce1273acf90c87e4ae2fe0130182100d99bcd2ae5bf486093044838", size = 45296647, upload-time = "2025-08-28T15:46:33.221Z" },
+    { url = "https://files.pythonhosted.org/packages/06/2e/9db64518aebcb3d6ef6cd6d4d01da741aff912c3f0314dadb61226c6a96a/playwright-1.55.0-py3-none-win32.whl", hash = "sha256:29e6d1558ad9d5b5c19cbec0a72f6a2e35e6353cd9f262e22148685b86759f90", size = 35476046, upload-time = "2025-08-28T15:46:36.184Z" },
+    { url = "https://files.pythonhosted.org/packages/46/4f/9ba607fa94bb9cee3d4beb1c7b32c16efbfc9d69d5037fa85d10cafc618b/playwright-1.55.0-py3-none-win_amd64.whl", hash = "sha256:7eb5956473ca1951abb51537e6a0da55257bb2e25fc37c2b75af094a5c93736c", size = 35476048, upload-time = "2025-08-28T15:46:38.867Z" },
+    { url = "https://files.pythonhosted.org/packages/21/98/5ca173c8ec906abde26c28e1ecb34887343fd71cc4136261b90036841323/playwright-1.55.0-py3-none-win_arm64.whl", hash = "sha256:012dc89ccdcbd774cdde8aeee14c08e0dd52ddb9135bf10e9db040527386bd76", size = 31225543, upload-time = "2025-08-28T15:46:41.613Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.11.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/54/ecab642b3bed45f7d5f59b38443dcb36ef50f85af192e6ece103dbfe9587/pydantic-2.11.10.tar.gz", hash = "sha256:dc280f0982fbda6c38fada4e476dc0a4f3aeaf9c6ad4c28df68a666ec3c61423", size = 788494, upload-time = "2025-10-04T10:40:41.338Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/1f/73c53fcbfb0b5a78f91176df41945ca466e71e9d9d836e5c522abda39ee7/pydantic-2.11.10-py3-none-any.whl", hash = "sha256:802a655709d49bd004c31e865ef37da30b540786a46bfce02333e0e24b5fe29a", size = 444823, upload-time = "2025-10-04T10:40:39.055Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.33.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/88/5f2260bdfae97aabf98f1778d43f69574390ad787afb646292a638c923d4/pydantic_core-2.33.2.tar.gz", hash = "sha256:7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc", size = 435195, upload-time = "2025-04-23T18:33:52.104Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/92/b31726561b5dae176c2d2c2dc43a9c5bfba5d32f96f8b4c0a600dd492447/pydantic_core-2.33.2-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2b3d326aaef0c0399d9afffeb6367d5e26ddc24d351dbc9c636840ac355dc5d8", size = 2028817, upload-time = "2025-04-23T18:30:43.919Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/44/3f0b95fafdaca04a483c4e685fe437c6891001bf3ce8b2fded82b9ea3aa1/pydantic_core-2.33.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0e5b2671f05ba48b94cb90ce55d8bdcaaedb8ba00cc5359f6810fc918713983d", size = 1861357, upload-time = "2025-04-23T18:30:46.372Z" },
+    { url = "https://files.pythonhosted.org/packages/30/97/e8f13b55766234caae05372826e8e4b3b96e7b248be3157f53237682e43c/pydantic_core-2.33.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0069c9acc3f3981b9ff4cdfaf088e98d83440a4c7ea1bc07460af3d4dc22e72d", size = 1898011, upload-time = "2025-04-23T18:30:47.591Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/a3/99c48cf7bafc991cc3ee66fd544c0aae8dc907b752f1dad2d79b1b5a471f/pydantic_core-2.33.2-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d53b22f2032c42eaaf025f7c40c2e3b94568ae077a606f006d206a463bc69572", size = 1982730, upload-time = "2025-04-23T18:30:49.328Z" },
+    { url = "https://files.pythonhosted.org/packages/de/8e/a5b882ec4307010a840fb8b58bd9bf65d1840c92eae7534c7441709bf54b/pydantic_core-2.33.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0405262705a123b7ce9f0b92f123334d67b70fd1f20a9372b907ce1080c7ba02", size = 2136178, upload-time = "2025-04-23T18:30:50.907Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/bb/71e35fc3ed05af6834e890edb75968e2802fe98778971ab5cba20a162315/pydantic_core-2.33.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4b25d91e288e2c4e0662b8038a28c6a07eaac3e196cfc4ff69de4ea3db992a1b", size = 2736462, upload-time = "2025-04-23T18:30:52.083Z" },
+    { url = "https://files.pythonhosted.org/packages/31/0d/c8f7593e6bc7066289bbc366f2235701dcbebcd1ff0ef8e64f6f239fb47d/pydantic_core-2.33.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6bdfe4b3789761f3bcb4b1ddf33355a71079858958e3a552f16d5af19768fef2", size = 2005652, upload-time = "2025-04-23T18:30:53.389Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/7a/996d8bd75f3eda405e3dd219ff5ff0a283cd8e34add39d8ef9157e722867/pydantic_core-2.33.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:efec8db3266b76ef9607c2c4c419bdb06bf335ae433b80816089ea7585816f6a", size = 2113306, upload-time = "2025-04-23T18:30:54.661Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/84/daf2a6fb2db40ffda6578a7e8c5a6e9c8affb251a05c233ae37098118788/pydantic_core-2.33.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:031c57d67ca86902726e0fae2214ce6770bbe2f710dc33063187a68744a5ecac", size = 2073720, upload-time = "2025-04-23T18:30:56.11Z" },
+    { url = "https://files.pythonhosted.org/packages/77/fb/2258da019f4825128445ae79456a5499c032b55849dbd5bed78c95ccf163/pydantic_core-2.33.2-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:f8de619080e944347f5f20de29a975c2d815d9ddd8be9b9b7268e2e3ef68605a", size = 2244915, upload-time = "2025-04-23T18:30:57.501Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/7a/925ff73756031289468326e355b6fa8316960d0d65f8b5d6b3a3e7866de7/pydantic_core-2.33.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:73662edf539e72a9440129f231ed3757faab89630d291b784ca99237fb94db2b", size = 2241884, upload-time = "2025-04-23T18:30:58.867Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b0/249ee6d2646f1cdadcb813805fe76265745c4010cf20a8eba7b0e639d9b2/pydantic_core-2.33.2-cp310-cp310-win32.whl", hash = "sha256:0a39979dcbb70998b0e505fb1556a1d550a0781463ce84ebf915ba293ccb7e22", size = 1910496, upload-time = "2025-04-23T18:31:00.078Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ff/172ba8f12a42d4b552917aa65d1f2328990d3ccfc01d5b7c943ec084299f/pydantic_core-2.33.2-cp310-cp310-win_amd64.whl", hash = "sha256:b0379a2b24882fef529ec3b4987cb5d003b9cda32256024e6fe1586ac45fc640", size = 1955019, upload-time = "2025-04-23T18:31:01.335Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/8d/71db63483d518cbbf290261a1fc2839d17ff89fce7089e08cad07ccfce67/pydantic_core-2.33.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:4c5b0a576fb381edd6d27f0a85915c6daf2f8138dc5c267a57c08a62900758c7", size = 2028584, upload-time = "2025-04-23T18:31:03.106Z" },
+    { url = "https://files.pythonhosted.org/packages/24/2f/3cfa7244ae292dd850989f328722d2aef313f74ffc471184dc509e1e4e5a/pydantic_core-2.33.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e799c050df38a639db758c617ec771fd8fb7a5f8eaaa4b27b101f266b216a246", size = 1855071, upload-time = "2025-04-23T18:31:04.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/d3/4ae42d33f5e3f50dd467761304be2fa0a9417fbf09735bc2cce003480f2a/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dc46a01bf8d62f227d5ecee74178ffc448ff4e5197c756331f71efcc66dc980f", size = 1897823, upload-time = "2025-04-23T18:31:06.377Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f3/aa5976e8352b7695ff808599794b1fba2a9ae2ee954a3426855935799488/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a144d4f717285c6d9234a66778059f33a89096dfb9b39117663fd8413d582dcc", size = 1983792, upload-time = "2025-04-23T18:31:07.93Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/7a/cda9b5a23c552037717f2b2a5257e9b2bfe45e687386df9591eff7b46d28/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:73cf6373c21bc80b2e0dc88444f41ae60b2f070ed02095754eb5a01df12256de", size = 2136338, upload-time = "2025-04-23T18:31:09.283Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/b8f9ec8dd1417eb9da784e91e1667d58a2a4a7b7b34cf4af765ef663a7e5/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3dc625f4aa79713512d1976fe9f0bc99f706a9dee21dfd1810b4bbbf228d0e8a", size = 2730998, upload-time = "2025-04-23T18:31:11.7Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bc/cd720e078576bdb8255d5032c5d63ee5c0bf4b7173dd955185a1d658c456/pydantic_core-2.33.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:881b21b5549499972441da4758d662aeea93f1923f953e9cbaff14b8b9565aef", size = 2003200, upload-time = "2025-04-23T18:31:13.536Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/22/3602b895ee2cd29d11a2b349372446ae9727c32e78a94b3d588a40fdf187/pydantic_core-2.33.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:bdc25f3681f7b78572699569514036afe3c243bc3059d3942624e936ec93450e", size = 2113890, upload-time = "2025-04-23T18:31:15.011Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/e6/e3c5908c03cf00d629eb38393a98fccc38ee0ce8ecce32f69fc7d7b558a7/pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:fe5b32187cbc0c862ee201ad66c30cf218e5ed468ec8dc1cf49dec66e160cc4d", size = 2073359, upload-time = "2025-04-23T18:31:16.393Z" },
+    { url = "https://files.pythonhosted.org/packages/12/e7/6a36a07c59ebefc8777d1ffdaf5ae71b06b21952582e4b07eba88a421c79/pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:bc7aee6f634a6f4a95676fcb5d6559a2c2a390330098dba5e5a5f28a2e4ada30", size = 2245883, upload-time = "2025-04-23T18:31:17.892Z" },
+    { url = "https://files.pythonhosted.org/packages/16/3f/59b3187aaa6cc0c1e6616e8045b284de2b6a87b027cce2ffcea073adf1d2/pydantic_core-2.33.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:235f45e5dbcccf6bd99f9f472858849f73d11120d76ea8707115415f8e5ebebf", size = 2241074, upload-time = "2025-04-23T18:31:19.205Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ed/55532bb88f674d5d8f67ab121a2a13c385df382de2a1677f30ad385f7438/pydantic_core-2.33.2-cp311-cp311-win32.whl", hash = "sha256:6368900c2d3ef09b69cb0b913f9f8263b03786e5b2a387706c5afb66800efd51", size = 1910538, upload-time = "2025-04-23T18:31:20.541Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/1b/25b7cccd4519c0b23c2dd636ad39d381abf113085ce4f7bec2b0dc755eb1/pydantic_core-2.33.2-cp311-cp311-win_amd64.whl", hash = "sha256:1e063337ef9e9820c77acc768546325ebe04ee38b08703244c1309cccc4f1bab", size = 1952909, upload-time = "2025-04-23T18:31:22.371Z" },
+    { url = "https://files.pythonhosted.org/packages/49/a9/d809358e49126438055884c4366a1f6227f0f84f635a9014e2deb9b9de54/pydantic_core-2.33.2-cp311-cp311-win_arm64.whl", hash = "sha256:6b99022f1d19bc32a4c2a0d544fc9a76e3be90f0b3f4af413f87d38749300e65", size = 1897786, upload-time = "2025-04-23T18:31:24.161Z" },
+    { url = "https://files.pythonhosted.org/packages/18/8a/2b41c97f554ec8c71f2a8a5f85cb56a8b0956addfe8b0efb5b3d77e8bdc3/pydantic_core-2.33.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a7ec89dc587667f22b6a0b6579c249fca9026ce7c333fc142ba42411fa243cdc", size = 2009000, upload-time = "2025-04-23T18:31:25.863Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/02/6224312aacb3c8ecbaa959897af57181fb6cf3a3d7917fd44d0f2917e6f2/pydantic_core-2.33.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3c6db6e52c6d70aa0d00d45cdb9b40f0433b96380071ea80b09277dba021ddf7", size = 1847996, upload-time = "2025-04-23T18:31:27.341Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/46/6dcdf084a523dbe0a0be59d054734b86a981726f221f4562aed313dbcb49/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e61206137cbc65e6d5256e1166f88331d3b6238e082d9f74613b9b765fb9025", size = 1880957, upload-time = "2025-04-23T18:31:28.956Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/6b/1ec2c03837ac00886ba8160ce041ce4e325b41d06a034adbef11339ae422/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eb8c529b2819c37140eb51b914153063d27ed88e3bdc31b71198a198e921e011", size = 1964199, upload-time = "2025-04-23T18:31:31.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/1d/6bf34d6adb9debd9136bd197ca72642203ce9aaaa85cfcbfcf20f9696e83/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c52b02ad8b4e2cf14ca7b3d918f3eb0ee91e63b3167c32591e57c4317e134f8f", size = 2120296, upload-time = "2025-04-23T18:31:32.514Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/94/2bd0aaf5a591e974b32a9f7123f16637776c304471a0ab33cf263cf5591a/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:96081f1605125ba0855dfda83f6f3df5ec90c61195421ba72223de35ccfb2f88", size = 2676109, upload-time = "2025-04-23T18:31:33.958Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/41/4b043778cf9c4285d59742281a769eac371b9e47e35f98ad321349cc5d61/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f57a69461af2a5fa6e6bbd7a5f60d3b7e6cebb687f55106933188e79ad155c1", size = 2002028, upload-time = "2025-04-23T18:31:39.095Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/d5/7bb781bf2748ce3d03af04d5c969fa1308880e1dca35a9bd94e1a96a922e/pydantic_core-2.33.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:572c7e6c8bb4774d2ac88929e3d1f12bc45714ae5ee6d9a788a9fb35e60bb04b", size = 2100044, upload-time = "2025-04-23T18:31:41.034Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/36/def5e53e1eb0ad896785702a5bbfd25eed546cdcf4087ad285021a90ed53/pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:db4b41f9bd95fbe5acd76d89920336ba96f03e149097365afe1cb092fceb89a1", size = 2058881, upload-time = "2025-04-23T18:31:42.757Z" },
+    { url = "https://files.pythonhosted.org/packages/01/6c/57f8d70b2ee57fc3dc8b9610315949837fa8c11d86927b9bb044f8705419/pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:fa854f5cf7e33842a892e5c73f45327760bc7bc516339fda888c75ae60edaeb6", size = 2227034, upload-time = "2025-04-23T18:31:44.304Z" },
+    { url = "https://files.pythonhosted.org/packages/27/b9/9c17f0396a82b3d5cbea4c24d742083422639e7bb1d5bf600e12cb176a13/pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:5f483cfb75ff703095c59e365360cb73e00185e01aaea067cd19acffd2ab20ea", size = 2234187, upload-time = "2025-04-23T18:31:45.891Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/6a/adf5734ffd52bf86d865093ad70b2ce543415e0e356f6cacabbc0d9ad910/pydantic_core-2.33.2-cp312-cp312-win32.whl", hash = "sha256:9cb1da0f5a471435a7bc7e439b8a728e8b61e59784b2af70d7c169f8dd8ae290", size = 1892628, upload-time = "2025-04-23T18:31:47.819Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e4/5479fecb3606c1368d496a825d8411e126133c41224c1e7238be58b87d7e/pydantic_core-2.33.2-cp312-cp312-win_amd64.whl", hash = "sha256:f941635f2a3d96b2973e867144fde513665c87f13fe0e193c158ac51bfaaa7b2", size = 1955866, upload-time = "2025-04-23T18:31:49.635Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/24/8b11e8b3e2be9dd82df4b11408a67c61bb4dc4f8e11b5b0fc888b38118b5/pydantic_core-2.33.2-cp312-cp312-win_arm64.whl", hash = "sha256:cca3868ddfaccfbc4bfb1d608e2ccaaebe0ae628e1416aeb9c4d88c001bb45ab", size = 1888894, upload-time = "2025-04-23T18:31:51.609Z" },
+    { url = "https://files.pythonhosted.org/packages/30/68/373d55e58b7e83ce371691f6eaa7175e3a24b956c44628eb25d7da007917/pydantic_core-2.33.2-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:5c4aa4e82353f65e548c476b37e64189783aa5384903bfea4f41580f255fddfa", size = 2023982, upload-time = "2025-04-23T18:32:53.14Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/16/145f54ac08c96a63d8ed6442f9dec17b2773d19920b627b18d4f10a061ea/pydantic_core-2.33.2-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:d946c8bf0d5c24bf4fe333af284c59a19358aa3ec18cb3dc4370080da1e8ad29", size = 1858412, upload-time = "2025-04-23T18:32:55.52Z" },
+    { url = "https://files.pythonhosted.org/packages/41/b1/c6dc6c3e2de4516c0bb2c46f6a373b91b5660312342a0cf5826e38ad82fa/pydantic_core-2.33.2-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:87b31b6846e361ef83fedb187bb5b4372d0da3f7e28d85415efa92d6125d6e6d", size = 1892749, upload-time = "2025-04-23T18:32:57.546Z" },
+    { url = "https://files.pythonhosted.org/packages/12/73/8cd57e20afba760b21b742106f9dbdfa6697f1570b189c7457a1af4cd8a0/pydantic_core-2.33.2-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aa9d91b338f2df0508606f7009fde642391425189bba6d8c653afd80fd6bb64e", size = 2067527, upload-time = "2025-04-23T18:32:59.771Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/d5/0bb5d988cc019b3cba4a78f2d4b3854427fc47ee8ec8e9eaabf787da239c/pydantic_core-2.33.2-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2058a32994f1fde4ca0480ab9d1e75a0e8c87c22b53a3ae66554f9af78f2fe8c", size = 2108225, upload-time = "2025-04-23T18:33:04.51Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/c5/00c02d1571913d496aabf146106ad8239dc132485ee22efe08085084ff7c/pydantic_core-2.33.2-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:0e03262ab796d986f978f79c943fc5f620381be7287148b8010b4097f79a39ec", size = 2069490, upload-time = "2025-04-23T18:33:06.391Z" },
+    { url = "https://files.pythonhosted.org/packages/22/a8/dccc38768274d3ed3a59b5d06f59ccb845778687652daa71df0cab4040d7/pydantic_core-2.33.2-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:1a8695a8d00c73e50bff9dfda4d540b7dee29ff9b8053e38380426a85ef10052", size = 2237525, upload-time = "2025-04-23T18:33:08.44Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/e7/4f98c0b125dda7cf7ccd14ba936218397b44f50a56dd8c16a3091df116c3/pydantic_core-2.33.2-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:fa754d1850735a0b0e03bcffd9d4b4343eb417e47196e4485d9cca326073a42c", size = 2238446, upload-time = "2025-04-23T18:33:10.313Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/91/2ec36480fdb0b783cd9ef6795753c1dea13882f2e68e73bce76ae8c21e6a/pydantic_core-2.33.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:a11c8d26a50bfab49002947d3d237abe4d9e4b5bdc8846a63537b6488e197808", size = 2066678, upload-time = "2025-04-23T18:33:12.224Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/27/d4ae6487d73948d6f20dddcd94be4ea43e74349b56eba82e9bdee2d7494c/pydantic_core-2.33.2-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:dd14041875d09cc0f9308e37a6f8b65f5585cf2598a53aa0123df8b129d481f8", size = 2025200, upload-time = "2025-04-23T18:33:14.199Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b8/b3cb95375f05d33801024079b9392a5ab45267a63400bf1866e7ce0f0de4/pydantic_core-2.33.2-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d87c561733f66531dced0da6e864f44ebf89a8fba55f31407b00c2f7f9449593", size = 1859123, upload-time = "2025-04-23T18:33:16.555Z" },
+    { url = "https://files.pythonhosted.org/packages/05/bc/0d0b5adeda59a261cd30a1235a445bf55c7e46ae44aea28f7bd6ed46e091/pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2f82865531efd18d6e07a04a17331af02cb7a651583c418df8266f17a63c6612", size = 1892852, upload-time = "2025-04-23T18:33:18.513Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/11/d37bdebbda2e449cb3f519f6ce950927b56d62f0b84fd9cb9e372a26a3d5/pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bfb5112df54209d820d7bf9317c7a6c9025ea52e49f46b6a2060104bba37de7", size = 2067484, upload-time = "2025-04-23T18:33:20.475Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/55/1f95f0a05ce72ecb02a8a8a1c3be0579bbc29b1d5ab68f1378b7bebc5057/pydantic_core-2.33.2-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:64632ff9d614e5eecfb495796ad51b0ed98c453e447a76bcbeeb69615079fc7e", size = 2108896, upload-time = "2025-04-23T18:33:22.501Z" },
+    { url = "https://files.pythonhosted.org/packages/53/89/2b2de6c81fa131f423246a9109d7b2a375e83968ad0800d6e57d0574629b/pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:f889f7a40498cc077332c7ab6b4608d296d852182211787d4f3ee377aaae66e8", size = 2069475, upload-time = "2025-04-23T18:33:24.528Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/e9/1f7efbe20d0b2b10f6718944b5d8ece9152390904f29a78e68d4e7961159/pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:de4b83bb311557e439b9e186f733f6c645b9417c84e2eb8203f3f820a4b988bf", size = 2239013, upload-time = "2025-04-23T18:33:26.621Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/b2/5309c905a93811524a49b4e031e9851a6b00ff0fb668794472ea7746b448/pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:82f68293f055f51b51ea42fafc74b6aad03e70e191799430b90c13d643059ebb", size = 2238715, upload-time = "2025-04-23T18:33:28.656Z" },
+    { url = "https://files.pythonhosted.org/packages/32/56/8a7ca5d2cd2cda1d245d34b1c9a942920a718082ae8e54e5f3e5a58b7add/pydantic_core-2.33.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:329467cecfb529c925cf2bbd4d60d2c509bc2fb52a20c1045bf09bb70971a9c1", size = 2066757, upload-time = "2025-04-23T18:33:30.645Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/03/1fd98d5841cd7964a27d729ccf2199602fe05eb7a405c1462eb7277945ed/pyee-13.0.0.tar.gz", hash = "sha256:b391e3c5a434d1f5118a25615001dbc8f669cf410ab67d04c4d4e07c55481c37", size = 31250, upload-time = "2025-03-17T18:53:15.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/4d/b9add7c84060d4c1906abe9a7e5359f2a60f7a9a4f67268b2766673427d8/pyee-13.0.0-py3-none-any.whl", hash = "sha256:48195a3cddb3b1515ce0695ed76036b5ccc2ef3a9f963ff9f77aec0139845498", size = 15730, upload-time = "2025-03-17T18:53:14.532Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.13.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/8e/f9f9ca747fea8e3ac954e3690d4698c9737c23b51731d02df999c150b1c9/ruff-0.13.3.tar.gz", hash = "sha256:5b0ba0db740eefdfbcce4299f49e9eaefc643d4d007749d77d047c2bab19908e", size = 5438533, upload-time = "2025-10-02T19:29:31.582Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/33/8f7163553481466a92656d35dea9331095122bb84cf98210bef597dd2ecd/ruff-0.13.3-py3-none-linux_armv6l.whl", hash = "sha256:311860a4c5e19189c89d035638f500c1e191d283d0cc2f1600c8c80d6dcd430c", size = 12484040, upload-time = "2025-10-02T19:28:49.199Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/b5/4a21a4922e5dd6845e91896b0d9ef493574cbe061ef7d00a73c61db531af/ruff-0.13.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:2bdad6512fb666b40fcadb65e33add2b040fc18a24997d2e47fee7d66f7fcae2", size = 13122975, upload-time = "2025-10-02T19:28:52.446Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/15649af836d88c9f154e5be87e64ae7d2b1baa5a3ef317cb0c8fafcd882d/ruff-0.13.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fc6fa4637284708d6ed4e5e970d52fc3b76a557d7b4e85a53013d9d201d93286", size = 12346621, upload-time = "2025-10-02T19:28:54.712Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/42/bcbccb8141305f9a6d3f72549dd82d1134299177cc7eaf832599700f95a7/ruff-0.13.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1c9e6469864f94a98f412f20ea143d547e4c652f45e44f369d7b74ee78185838", size = 12574408, upload-time = "2025-10-02T19:28:56.679Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/19/0f3681c941cdcfa2d110ce4515624c07a964dc315d3100d889fcad3bfc9e/ruff-0.13.3-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5bf62b705f319476c78891e0e97e965b21db468b3c999086de8ffb0d40fd2822", size = 12285330, upload-time = "2025-10-02T19:28:58.79Z" },
+    { url = "https://files.pythonhosted.org/packages/10/f8/387976bf00d126b907bbd7725219257feea58650e6b055b29b224d8cb731/ruff-0.13.3-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:78cc1abed87ce40cb07ee0667ce99dbc766c9f519eabfd948ed87295d8737c60", size = 13980815, upload-time = "2025-10-02T19:29:01.577Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/a6/7c8ec09d62d5a406e2b17d159e4817b63c945a8b9188a771193b7e1cc0b5/ruff-0.13.3-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:4fb75e7c402d504f7a9a259e0442b96403fa4a7310ffe3588d11d7e170d2b1e3", size = 14987733, upload-time = "2025-10-02T19:29:04.036Z" },
+    { url = "https://files.pythonhosted.org/packages/97/e5/f403a60a12258e0fd0c2195341cfa170726f254c788673495d86ab5a9a9d/ruff-0.13.3-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:17b951f9d9afb39330b2bdd2dd144ce1c1335881c277837ac1b50bfd99985ed3", size = 14439848, upload-time = "2025-10-02T19:29:06.684Z" },
+    { url = "https://files.pythonhosted.org/packages/39/49/3de381343e89364c2334c9f3268b0349dc734fc18b2d99a302d0935c8345/ruff-0.13.3-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6052f8088728898e0a449f0dde8fafc7ed47e4d878168b211977e3e7e854f662", size = 13421890, upload-time = "2025-10-02T19:29:08.767Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/b5/c0feca27d45ae74185a6bacc399f5d8920ab82df2d732a17213fb86a2c4c/ruff-0.13.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc742c50f4ba72ce2a3be362bd359aef7d0d302bf7637a6f942eaa763bd292af", size = 13444870, upload-time = "2025-10-02T19:29:11.234Z" },
+    { url = "https://files.pythonhosted.org/packages/50/a1/b655298a1f3fda4fdc7340c3f671a4b260b009068fbeb3e4e151e9e3e1bf/ruff-0.13.3-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:8e5640349493b378431637019366bbd73c927e515c9c1babfea3e932f5e68e1d", size = 13691599, upload-time = "2025-10-02T19:29:13.353Z" },
+    { url = "https://files.pythonhosted.org/packages/32/b0/a8705065b2dafae007bcae21354e6e2e832e03eb077bb6c8e523c2becb92/ruff-0.13.3-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:6b139f638a80eae7073c691a5dd8d581e0ba319540be97c343d60fb12949c8d0", size = 12421893, upload-time = "2025-10-02T19:29:15.668Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/1e/cbe7082588d025cddbb2f23e6dfef08b1a2ef6d6f8328584ad3015b5cebd/ruff-0.13.3-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:6b547def0a40054825de7cfa341039ebdfa51f3d4bfa6a0772940ed351d2746c", size = 12267220, upload-time = "2025-10-02T19:29:17.583Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/99/4086f9c43f85e0755996d09bdcb334b6fee9b1eabdf34e7d8b877fadf964/ruff-0.13.3-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9cc48a3564423915c93573f1981d57d101e617839bef38504f85f3677b3a0a3e", size = 13177818, upload-time = "2025-10-02T19:29:19.943Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/de/7b5db7e39947d9dc1c5f9f17b838ad6e680527d45288eeb568e860467010/ruff-0.13.3-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1a993b17ec03719c502881cb2d5f91771e8742f2ca6de740034433a97c561989", size = 13618715, upload-time = "2025-10-02T19:29:22.527Z" },
+    { url = "https://files.pythonhosted.org/packages/28/d3/bb25ee567ce2f61ac52430cf99f446b0e6d49bdfa4188699ad005fdd16aa/ruff-0.13.3-py3-none-win32.whl", hash = "sha256:f14e0d1fe6460f07814d03c6e32e815bff411505178a1f539a38f6097d3e8ee3", size = 12334488, upload-time = "2025-10-02T19:29:24.782Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/49/12f5955818a1139eed288753479ba9d996f6ea0b101784bb1fe6977ec128/ruff-0.13.3-py3-none-win_amd64.whl", hash = "sha256:621e2e5812b691d4f244638d693e640f188bacbb9bc793ddd46837cea0503dd2", size = 13455262, upload-time = "2025-10-02T19:29:26.882Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/72/7b83242b26627a00e3af70d0394d68f8f02750d642567af12983031777fc/ruff-0.13.3-py3-none-win_arm64.whl", hash = "sha256:9e9e9d699841eaf4c2c798fa783df2fabc680b72059a02ca0ed81c460bc58330", size = 12538484, upload-time = "2025-10-02T19:29:28.951Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "0.48.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/a5/d6f429d43394057b67a6b5bbe6eae2f77a6bf7459d961fdb224bf206eee6/starlette-0.48.0.tar.gz", hash = "sha256:7e8cee469a8ab2352911528110ce9088fdc6a37d9876926e73da7ce4aa4c7a46", size = 2652949, upload-time = "2025-09-13T08:41:05.699Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/72/2db2f49247d0a18b4f1bb9a5a39a0162869acf235f3a96418363947b3d46/starlette-0.48.0-py3-none-any.whl", hash = "sha256:0764ca97b097582558ecb498132ed0c7d942f233f365b86ba37770e026510659", size = 73736, upload-time = "2025-09-13T08:41:03.869Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/87/302344fed471e44a87289cf4967697d07e532f2421fdaf868a303cbae4ff/tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff", size = 17175, upload-time = "2024-11-27T22:38:36.873Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/ca/75707e6efa2b37c77dadb324ae7d9571cb424e61ea73fad7c56c2d14527f/tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249", size = 131077, upload-time = "2024-11-27T22:37:54.956Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/16/51ae563a8615d472fdbffc43a3f3d46588c264ac4f024f63f01283becfbb/tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6", size = 123429, upload-time = "2024-11-27T22:37:56.698Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/dd/4f6cd1e7b160041db83c694abc78e100473c15d54620083dbd5aae7b990e/tomli-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a", size = 226067, upload-time = "2024-11-27T22:37:57.63Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/6b/c54ede5dc70d648cc6361eaf429304b02f2871a345bbdd51e993d6cdf550/tomli-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6972ca9c9cc9f0acaa56a8ca1ff51e7af152a9f87fb64623e31d5c83700080ee", size = 236030, upload-time = "2024-11-27T22:37:59.344Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/47/999514fa49cfaf7a92c805a86c3c43f4215621855d151b61c602abb38091/tomli-2.2.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c954d2250168d28797dd4e3ac5cf812a406cd5a92674ee4c8f123c889786aa8e", size = 240898, upload-time = "2024-11-27T22:38:00.429Z" },
+    { url = "https://files.pythonhosted.org/packages/73/41/0a01279a7ae09ee1573b423318e7934674ce06eb33f50936655071d81a24/tomli-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8dd28b3e155b80f4d54beb40a441d366adcfe740969820caf156c019fb5c7ec4", size = 229894, upload-time = "2024-11-27T22:38:02.094Z" },
+    { url = "https://files.pythonhosted.org/packages/55/18/5d8bc5b0a0362311ce4d18830a5d28943667599a60d20118074ea1b01bb7/tomli-2.2.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e59e304978767a54663af13c07b3d1af22ddee3bb2fb0618ca1593e4f593a106", size = 245319, upload-time = "2024-11-27T22:38:03.206Z" },
+    { url = "https://files.pythonhosted.org/packages/92/a3/7ade0576d17f3cdf5ff44d61390d4b3febb8a9fc2b480c75c47ea048c646/tomli-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:33580bccab0338d00994d7f16f4c4ec25b776af3ffaac1ed74e0b3fc95e885a8", size = 238273, upload-time = "2024-11-27T22:38:04.217Z" },
+    { url = "https://files.pythonhosted.org/packages/72/6f/fa64ef058ac1446a1e51110c375339b3ec6be245af9d14c87c4a6412dd32/tomli-2.2.1-cp311-cp311-win32.whl", hash = "sha256:465af0e0875402f1d226519c9904f37254b3045fc5084697cefb9bdde1ff99ff", size = 98310, upload-time = "2024-11-27T22:38:05.908Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1c/4a2dcde4a51b81be3530565e92eda625d94dafb46dbeb15069df4caffc34/tomli-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2d0f2fdd22b02c6d81637a3c95f8cd77f995846af7414c5c4b8d0545afa1bc4b", size = 108309, upload-time = "2024-11-27T22:38:06.812Z" },
+    { url = "https://files.pythonhosted.org/packages/52/e1/f8af4c2fcde17500422858155aeb0d7e93477a0d59a98e56cbfe75070fd0/tomli-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea", size = 132762, upload-time = "2024-11-27T22:38:07.731Z" },
+    { url = "https://files.pythonhosted.org/packages/03/b8/152c68bb84fc00396b83e7bbddd5ec0bd3dd409db4195e2a9b3e398ad2e3/tomli-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8", size = 123453, upload-time = "2024-11-27T22:38:09.384Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/d6/fc9267af9166f79ac528ff7e8c55c8181ded34eb4b0e93daa767b8841573/tomli-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192", size = 233486, upload-time = "2024-11-27T22:38:10.329Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/51c3f2884d7bab89af25f678447ea7d297b53b5a3b5730a7cb2ef6069f07/tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222", size = 242349, upload-time = "2024-11-27T22:38:11.443Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/df/bfa89627d13a5cc22402e441e8a931ef2108403db390ff3345c05253935e/tomli-2.2.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40741994320b232529c802f8bc86da4e1aa9f413db394617b9a256ae0f9a7f77", size = 252159, upload-time = "2024-11-27T22:38:13.099Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/6e/fa2b916dced65763a5168c6ccb91066f7639bdc88b48adda990db10c8c0b/tomli-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:400e720fe168c0f8521520190686ef8ef033fb19fc493da09779e592861b78c6", size = 237243, upload-time = "2024-11-27T22:38:14.766Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/04/885d3b1f650e1153cbb93a6a9782c58a972b94ea4483ae4ac5cedd5e4a09/tomli-2.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd", size = 259645, upload-time = "2024-11-27T22:38:15.843Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/de/6b432d66e986e501586da298e28ebeefd3edc2c780f3ad73d22566034239/tomli-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b82ebccc8c8a36f2094e969560a1b836758481f3dc360ce9a3277c65f374285e", size = 244584, upload-time = "2024-11-27T22:38:17.645Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/9a/47c0449b98e6e7d1be6cbac02f93dd79003234ddc4aaab6ba07a9a7482e2/tomli-2.2.1-cp312-cp312-win32.whl", hash = "sha256:889f80ef92701b9dbb224e49ec87c645ce5df3fa2cc548664eb8a25e03127a98", size = 98875, upload-time = "2024-11-27T22:38:19.159Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/60/9b9638f081c6f1261e2688bd487625cd1e660d0a85bd469e91d8db969734/tomli-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:7fc04e92e1d624a4a63c76474610238576942d6b8950a2d7f908a340494e67e4", size = 109418, upload-time = "2024-11-27T22:38:20.064Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257, upload-time = "2024-11-27T22:38:35.385Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/57/1616c8274c3442d802621abf5deb230771c7a0fec9414cb6763900eb3868/uvicorn-0.37.0.tar.gz", hash = "sha256:4115c8add6d3fd536c8ee77f0e14a7fd2ebba939fed9b02583a97f80648f9e13", size = 80367, upload-time = "2025-09-23T13:33:47.486Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/cd/584a2ceb5532af99dd09e50919e3615ba99aa127e9850eafe5f31ddfdb9a/uvicorn-0.37.0-py3-none-any.whl", hash = "sha256:913b2b88672343739927ce381ff9e2ad62541f9f8289664fa1d1d3803fa2ce6c", size = 67976, upload-time = "2025-09-23T13:33:45.842Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016, upload-time = "2025-03-05T20:03:41.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/da/6462a9f510c0c49837bbc9345aca92d767a56c1fb2939e1579df1e1cdcf7/websockets-15.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d63efaa0cd96cf0c5fe4d581521d9fa87744540d4bc999ae6e08595a1014b45b", size = 175423, upload-time = "2025-03-05T20:01:35.363Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/9f/9d11c1a4eb046a9e106483b9ff69bce7ac880443f00e5ce64261b47b07e7/websockets-15.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ac60e3b188ec7574cb761b08d50fcedf9d77f1530352db4eef1707fe9dee7205", size = 173080, upload-time = "2025-03-05T20:01:37.304Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/4f/b462242432d93ea45f297b6179c7333dd0402b855a912a04e7fc61c0d71f/websockets-15.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5756779642579d902eed757b21b0164cd6fe338506a8083eb58af5c372e39d9a", size = 173329, upload-time = "2025-03-05T20:01:39.668Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0c/6afa1f4644d7ed50284ac59cc70ef8abd44ccf7d45850d989ea7310538d0/websockets-15.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fdfe3e2a29e4db3659dbd5bbf04560cea53dd9610273917799f1cde46aa725e", size = 182312, upload-time = "2025-03-05T20:01:41.815Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d4/ffc8bd1350b229ca7a4db2a3e1c482cf87cea1baccd0ef3e72bc720caeec/websockets-15.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c2529b320eb9e35af0fa3016c187dffb84a3ecc572bcee7c3ce302bfeba52bf", size = 181319, upload-time = "2025-03-05T20:01:43.967Z" },
+    { url = "https://files.pythonhosted.org/packages/97/3a/5323a6bb94917af13bbb34009fac01e55c51dfde354f63692bf2533ffbc2/websockets-15.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac1e5c9054fe23226fb11e05a6e630837f074174c4c2f0fe442996112a6de4fb", size = 181631, upload-time = "2025-03-05T20:01:46.104Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/cc/1aeb0f7cee59ef065724041bb7ed667b6ab1eeffe5141696cccec2687b66/websockets-15.0.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5df592cd503496351d6dc14f7cdad49f268d8e618f80dce0cd5a36b93c3fc08d", size = 182016, upload-time = "2025-03-05T20:01:47.603Z" },
+    { url = "https://files.pythonhosted.org/packages/79/f9/c86f8f7af208e4161a7f7e02774e9d0a81c632ae76db2ff22549e1718a51/websockets-15.0.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:0a34631031a8f05657e8e90903e656959234f3a04552259458aac0b0f9ae6fd9", size = 181426, upload-time = "2025-03-05T20:01:48.949Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/b9/828b0bc6753db905b91df6ae477c0b14a141090df64fb17f8a9d7e3516cf/websockets-15.0.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3d00075aa65772e7ce9e990cab3ff1de702aa09be3940d1dc88d5abf1ab8a09c", size = 181360, upload-time = "2025-03-05T20:01:50.938Z" },
+    { url = "https://files.pythonhosted.org/packages/89/fb/250f5533ec468ba6327055b7d98b9df056fb1ce623b8b6aaafb30b55d02e/websockets-15.0.1-cp310-cp310-win32.whl", hash = "sha256:1234d4ef35db82f5446dca8e35a7da7964d02c127b095e172e54397fb6a6c256", size = 176388, upload-time = "2025-03-05T20:01:52.213Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/46/aca7082012768bb98e5608f01658ff3ac8437e563eca41cf068bd5849a5e/websockets-15.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:39c1fec2c11dc8d89bba6b2bf1556af381611a173ac2b511cf7231622058af41", size = 176830, upload-time = "2025-03-05T20:01:53.922Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/32/18fcd5919c293a398db67443acd33fde142f283853076049824fc58e6f75/websockets-15.0.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:823c248b690b2fd9303ba00c4f66cd5e2d8c3ba4aa968b2779be9532a4dad431", size = 175423, upload-time = "2025-03-05T20:01:56.276Z" },
+    { url = "https://files.pythonhosted.org/packages/76/70/ba1ad96b07869275ef42e2ce21f07a5b0148936688c2baf7e4a1f60d5058/websockets-15.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678999709e68425ae2593acf2e3ebcbcf2e69885a5ee78f9eb80e6e371f1bf57", size = 173082, upload-time = "2025-03-05T20:01:57.563Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f2/10b55821dd40eb696ce4704a87d57774696f9451108cff0d2824c97e0f97/websockets-15.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d50fd1ee42388dcfb2b3676132c78116490976f1300da28eb629272d5d93e905", size = 173330, upload-time = "2025-03-05T20:01:59.063Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/90/1c37ae8b8a113d3daf1065222b6af61cc44102da95388ac0018fcb7d93d9/websockets-15.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d99e5546bf73dbad5bf3547174cd6cb8ba7273062a23808ffea025ecb1cf8562", size = 182878, upload-time = "2025-03-05T20:02:00.305Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/8d/96e8e288b2a41dffafb78e8904ea7367ee4f891dafc2ab8d87e2124cb3d3/websockets-15.0.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:66dd88c918e3287efc22409d426c8f729688d89a0c587c88971a0faa2c2f3792", size = 181883, upload-time = "2025-03-05T20:02:03.148Z" },
+    { url = "https://files.pythonhosted.org/packages/93/1f/5d6dbf551766308f6f50f8baf8e9860be6182911e8106da7a7f73785f4c4/websockets-15.0.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8dd8327c795b3e3f219760fa603dcae1dcc148172290a8ab15158cf85a953413", size = 182252, upload-time = "2025-03-05T20:02:05.29Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/78/2d4fed9123e6620cbf1706c0de8a1632e1a28e7774d94346d7de1bba2ca3/websockets-15.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8fdc51055e6ff4adeb88d58a11042ec9a5eae317a0a53d12c062c8a8865909e8", size = 182521, upload-time = "2025-03-05T20:02:07.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/3b/66d4c1b444dd1a9823c4a81f50231b921bab54eee2f69e70319b4e21f1ca/websockets-15.0.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:693f0192126df6c2327cce3baa7c06f2a117575e32ab2308f7f8216c29d9e2e3", size = 181958, upload-time = "2025-03-05T20:02:09.842Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ff/e9eed2ee5fed6f76fdd6032ca5cd38c57ca9661430bb3d5fb2872dc8703c/websockets-15.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:54479983bd5fb469c38f2f5c7e3a24f9a4e70594cd68cd1fa6b9340dadaff7cf", size = 181918, upload-time = "2025-03-05T20:02:11.968Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/75/994634a49b7e12532be6a42103597b71098fd25900f7437d6055ed39930a/websockets-15.0.1-cp311-cp311-win32.whl", hash = "sha256:16b6c1b3e57799b9d38427dda63edcbe4926352c47cf88588c0be4ace18dac85", size = 176388, upload-time = "2025-03-05T20:02:13.32Z" },
+    { url = "https://files.pythonhosted.org/packages/98/93/e36c73f78400a65f5e236cd376713c34182e6663f6889cd45a4a04d8f203/websockets-15.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:27ccee0071a0e75d22cb35849b1db43f2ecd3e161041ac1ee9d2352ddf72f065", size = 176828, upload-time = "2025-03-05T20:02:14.585Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6b/4545a0d843594f5d0771e86463606a3988b5a09ca5123136f8a76580dd63/websockets-15.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3e90baa811a5d73f3ca0bcbf32064d663ed81318ab225ee4f427ad4e26e5aff3", size = 175437, upload-time = "2025-03-05T20:02:16.706Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/71/809a0f5f6a06522af902e0f2ea2757f71ead94610010cf570ab5c98e99ed/websockets-15.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:592f1a9fe869c778694f0aa806ba0374e97648ab57936f092fd9d87f8bc03665", size = 173096, upload-time = "2025-03-05T20:02:18.832Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/69/1a681dd6f02180916f116894181eab8b2e25b31e484c5d0eae637ec01f7c/websockets-15.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2", size = 173332, upload-time = "2025-03-05T20:02:20.187Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/02/0073b3952f5bce97eafbb35757f8d0d54812b6174ed8dd952aa08429bcc3/websockets-15.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8b56bdcdb4505c8078cb6c7157d9811a85790f2f2b3632c7d1462ab5783d215", size = 183152, upload-time = "2025-03-05T20:02:22.286Z" },
+    { url = "https://files.pythonhosted.org/packages/74/45/c205c8480eafd114b428284840da0b1be9ffd0e4f87338dc95dc6ff961a1/websockets-15.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0af68c55afbd5f07986df82831c7bff04846928ea8d1fd7f30052638788bc9b5", size = 182096, upload-time = "2025-03-05T20:02:24.368Z" },
+    { url = "https://files.pythonhosted.org/packages/14/8f/aa61f528fba38578ec553c145857a181384c72b98156f858ca5c8e82d9d3/websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64dee438fed052b52e4f98f76c5790513235efaa1ef7f3f2192c392cd7c91b65", size = 182523, upload-time = "2025-03-05T20:02:25.669Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/6d/0267396610add5bc0d0d3e77f546d4cd287200804fe02323797de77dbce9/websockets-15.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d5f6b181bb38171a8ad1d6aa58a67a6aa9d4b38d0f8c5f496b9e42561dfc62fe", size = 182790, upload-time = "2025-03-05T20:02:26.99Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/c68c5adbf679cf610ae2f74a9b871ae84564462955d991178f95a1ddb7dd/websockets-15.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5d54b09eba2bada6011aea5375542a157637b91029687eb4fdb2dab11059c1b4", size = 182165, upload-time = "2025-03-05T20:02:30.291Z" },
+    { url = "https://files.pythonhosted.org/packages/29/93/bb672df7b2f5faac89761cb5fa34f5cec45a4026c383a4b5761c6cea5c16/websockets-15.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3be571a8b5afed347da347bfcf27ba12b069d9d7f42cb8c7028b5e98bbb12597", size = 182160, upload-time = "2025-03-05T20:02:31.634Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/83/de1f7709376dc3ca9b7eeb4b9a07b4526b14876b6d372a4dc62312bebee0/websockets-15.0.1-cp312-cp312-win32.whl", hash = "sha256:c338ffa0520bdb12fbc527265235639fb76e7bc7faafbb93f6ba80d9c06578a9", size = 176395, upload-time = "2025-03-05T20:02:33.017Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/71/abf2ebc3bbfa40f391ce1428c7168fb20582d0ff57019b69ea20fa698043/websockets-15.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7", size = 176841, upload-time = "2025-03-05T20:02:34.498Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/d40f779fa16f74d3468357197af8d6ad07e7c5a27ea1ca74ceb38986f77a/websockets-15.0.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0c9e74d766f2818bb95f84c25be4dea09841ac0f734d1966f415e4edfc4ef1c3", size = 173109, upload-time = "2025-03-05T20:03:17.769Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/cd/5b887b8585a593073fd92f7c23ecd3985cd2c3175025a91b0d69b0551372/websockets-15.0.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:1009ee0c7739c08a0cd59de430d6de452a55e42d6b522de7aa15e6f67db0b8e1", size = 173343, upload-time = "2025-03-05T20:03:19.094Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ae/d34f7556890341e900a95acf4886833646306269f899d58ad62f588bf410/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76d1f20b1c7a2fa82367e04982e708723ba0e7b8d43aa643d3dcd404d74f1475", size = 174599, upload-time = "2025-03-05T20:03:21.1Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e6/5fd43993a87db364ec60fc1d608273a1a465c0caba69176dd160e197ce42/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f29d80eb9a9263b8d109135351caf568cc3f80b9928bccde535c235de55c22d9", size = 174207, upload-time = "2025-03-05T20:03:23.221Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/fb/c492d6daa5ec067c2988ac80c61359ace5c4c674c532985ac5a123436cec/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b359ed09954d7c18bbc1680f380c7301f92c60bf924171629c5db97febb12f04", size = 174155, upload-time = "2025-03-05T20:03:25.321Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a1/dcb68430b1d00b698ae7a7e0194433bce4f07ded185f0ee5fb21e2a2e91e/websockets-15.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cad21560da69f4ce7658ca2cb83138fb4cf695a2ba3e475e0559e05991aa8122", size = 176884, upload-time = "2025-03-05T20:03:27.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
+]


### PR DESCRIPTION
## Summary
- add a runnable dashboard example that compiles a manifest and exports an HTML preview
- document the example in the package README and regenerate the uv.lock file
- clean up layout engine module exports and lint issues so Ruff passes again

## Testing
- uv run --directory pkgs/experimental/layout_engine --package layout-engine ruff check . --fix
- uv run --directory pkgs/experimental/layout_engine --package layout-engine python examples/dashboard.py

------
https://chatgpt.com/codex/tasks/task_e_68e4acda1c3883269809a80a2f86c44e