### PR TITLE
Run Ruff formatting and lint fixes for Tigrbl

### DIFF
--- a/pkgs/standards/tigrbl/examples/book_api.ipynb
+++ b/pkgs/standards/tigrbl/examples/book_api.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "7fb27b941602401d91542211134fc71a",
    "metadata": {},
    "source": [
     "# Tigrbl v3 \u2014 Book Management API (Notebook)\n",
@@ -18,6 +19,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "acae54e37e7d407bbb7b55eff062a284",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -38,7 +40,7 @@
     "from fastapi import FastAPI\n",
     "\n",
     "from tigrbl.api import TigrblApi\n",
-    "from tigrbl.op import alias_ctx, op_ctx\n",
+    "from tigrbl.op import op_ctx\n",
     "from tigrbl.hook import hook_ctx\n",
     "from tigrbl.schema.decorators import schema_ctx\n",
     "from tigrbl.specs import F, IO, S, acol, vcol\n",
@@ -48,6 +50,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9a63283cbaf04dbcab1f6479b197f3a8",
    "metadata": {},
    "source": [
     "## Async SQLAlchemy Setup"
@@ -56,6 +59,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "8dd0d8092fe74a7c96281538738b07e2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -74,6 +78,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "72eea5119410473aa328ad9291626812",
    "metadata": {},
    "source": [
     "## Tigrbl Instance"
@@ -82,6 +87,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "8edb47106e1a46a883d545849b8ab81b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -90,6 +96,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "10185d26023b46108eb7d9f57d49d2b3",
    "metadata": {},
    "source": [
     "## Model \u2014 `Book` with `acol`/`vcol` and `alias_ctx`"
@@ -98,6 +105,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "8763a12b2bbd4a93a75aff182afb95dc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -155,12 +163,14 @@
     "    slug: Mapped[str] = vcol(\n",
     "        field=F(py_type=str, constraints={\"max_length\": 256}),\n",
     "        io=IO(out_verbs=(\"read\", \"list\")),\n",
-    "        read_producer=lambda obj, ctx: f\"{(obj.title or '').strip().lower().replace(' ', '-')}-{(obj.author or '').strip().lower().replace(' ', '-')}\",\n",
+    "        read_producer=lambda obj,\n",
+    "        ctx: f\"{(obj.title or '').strip().lower().replace(' ', '-')}-{(obj.author or '').strip().lower().replace(' ', '-')}\",\n",
     "    )"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "7623eae2785240b9bd12b16a66d81610",
    "metadata": {},
    "source": [
     "## Custom Request Schema \u2014 `publish.in`"
@@ -169,6 +179,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7cdc8c89c7104fffa095e18ddfef8986",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -186,6 +197,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b118ea5561624da68c537baed56e602f",
    "metadata": {},
    "source": [
     "## Custom Ops \u2014 `publish` (member) and `search` (collection)"
@@ -194,6 +206,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "938c804e27f84196a10c8828c723f798",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -236,6 +249,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "504fb2a444614c0babb325280ed9130a",
    "metadata": {},
    "source": [
     "## Hook \u2014 Normalize strings on `create`/`update` (PRE_HANDLER)"
@@ -244,6 +258,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "59bbdb311c014d738909a11f9e486628",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -258,6 +273,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b43b363d81ae4b689946ece5c682cd59",
    "metadata": {},
    "source": [
     "## API Wiring \u2014 Include model, mount REST and JSON-RPC"
@@ -266,6 +282,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "8a65eabff63a45729fe45fb5ade58bdc",
    "metadata": {},
    "outputs": [
     {
@@ -500,7 +517,7 @@
     "for alias in sorted(aliases):\n",
     "    a, in_s, out_s = schema_info(alias)\n",
     "    print(\n",
-    "        f'[{a}] in_={getattr(in_s, \"__name__\", type(in_s).__name__)} out={getattr(out_s, \"__name__\", type(out_s).__name__)}'\n",
+    "        f\"[{a}] in_={getattr(in_s, '__name__', type(in_s).__name__)} out={getattr(out_s, '__name__', type(out_s).__name__)}\"\n",
     "    )\n",
     "\n",
     "# Example: dump JSON schema for 'create.in_' and 'read.out' if present\n",
@@ -776,11 +793,14 @@
     "# Core runtime helpers\n",
     "from tigrbl.runtime import labels as L, events as E\n",
     "from tigrbl.runtime.kernel import build_phase_chains\n",
+    "\n",
     "# Hook phase list (ordering for display)\n",
     "from tigrbl.hook.types import PHASES as HOOK_PHASES\n",
     "\n",
+    "\n",
     "def _func_name(fn):\n",
     "    return getattr(fn, \"__qualname__\", getattr(fn, \"__name__\", str(fn)))\n",
+    "\n",
     "\n",
     "def _aliases_for_model(model):\n",
     "    # Try registered opspecs\n",
@@ -790,6 +810,7 @@
     "    # Fallback to common defaults if opspec registry not present\n",
     "    return [\"create\", \"read\", \"update\", \"delete\", \"list\"]\n",
     "\n",
+    "\n",
     "def _is_persistent_for_alias(model, alias):\n",
     "    \"\"\"\n",
     "    Mirror kernel._is_persistent heuristic:\n",
@@ -798,16 +819,19 @@
     "      - otherwise assume False (read-only)\n",
     "    \"\"\"\n",
     "    chains = build_phase_chains(model, alias)\n",
+    "\n",
     "    def has_named(phase, name):\n",
     "        for fn in chains.get(phase, []) or ():\n",
     "            if getattr(fn, \"__name__\", \"\") == name:\n",
     "                return True\n",
     "        return False\n",
+    "\n",
     "    if has_named(\"START_TX\", \"start_tx\"):\n",
     "        return True\n",
     "    if has_named(\"PRE_TX_BEGIN\", \"mark_skip_persist\"):\n",
     "        return False\n",
     "    return False\n",
+    "\n",
     "\n",
     "def show_runtime_legend():\n",
     "    print(\"Step kinds, domains, phases, anchors\")\n",
@@ -815,18 +839,20 @@
     "    pprint(L.legend())\n",
     "    print()\n",
     "\n",
+    "\n",
     "def show_anchor_order():\n",
     "    print(\"Canonical anchor order\")\n",
     "    print(\"======================\")\n",
     "    print(E.all_events_ordered())\n",
     "    print()\n",
     "\n",
+    "\n",
     "def show_model_overview(model):\n",
     "    print(f\"Model: {getattr(model, '__name__', model)}\")\n",
-    "    hooks_root = getattr(model, \"hooks\", SimpleNamespace())\n",
     "    alias_map = getattr(model, \"alias_map\", {})\n",
     "    print(\"Aliases (canonical \u2192 alias):\", alias_map)\n",
     "    print()\n",
+    "\n",
     "\n",
     "def show_phase_chains(model, alias):\n",
     "    chains = build_phase_chains(model, alias)\n",
@@ -835,8 +861,9 @@
     "    for phase in HOOK_PHASES:\n",
     "        steps = chains.get(phase, ()) or ()\n",
     "        if steps:\n",
-    "            print(f\"  {phase:<18} ({len(steps)}):\", [ _func_name(s) for s in steps ])\n",
+    "            print(f\"  {phase:<18} ({len(steps)}):\", [_func_name(s) for s in steps])\n",
     "    print()\n",
+    "\n",
     "\n",
     "# ---- Run the inspections ----\n",
     "\n",
@@ -851,10 +878,13 @@
     "\n",
     "# 4) Per-alias phase chains (what actually runs in each phase)\n",
     "for a in _aliases_for_model(Book):\n",
-    "\n",
     "    # 5) If you defined custom ops (e.g., 'publish' in the notebook), include them too:\n",
     "    try:\n",
-    "        if \"publish\" in _aliases_for_model(Book) or hasattr(Book, \"hooks\") and hasattr(Book.hooks, \"publish\"):\n",
+    "        if (\n",
+    "            \"publish\" in _aliases_for_model(Book)\n",
+    "            or hasattr(Book, \"hooks\")\n",
+    "            and hasattr(Book.hooks, \"publish\")\n",
+    "        ):\n",
     "            show_phase_chains(Book, \"publish\")\n",
     "    except Exception:\n",
     "        pass"

--- a/pkgs/standards/tigrbl/tigrbl/engine/capabilities.py
+++ b/pkgs/standards/tigrbl/tigrbl/engine/capabilities.py
@@ -1,20 +1,21 @@
-
 from __future__ import annotations
-from typing import Any, Dict, Set
+from typing import Any, Dict
+
 
 def sqlite_capabilities(*, async_: bool, memory: bool) -> Dict[str, Any]:
     # SQLite supports transactional semantics; isolation semantics differ from server DBs.
     # We expose a conservative set that higher layers can reason about.
     return {
         "transactional": True,
-        "async_native": async_,             # async layer is provided by aiosqlite/SQLAlchemy AsyncEngine
+        "async_native": async_,  # async layer is provided by aiosqlite/SQLAlchemy AsyncEngine
         "isolation_levels": {"read_committed", "serializable"},
-        "read_only_enforced": False,        # app layer should enforce; file-open RO may be used externally
+        "read_only_enforced": False,  # app layer should enforce; file-open RO may be used externally
         "supports_timeouts": True,
         "supports_ddl": True,
         "engine": "sqlite",
         "memory": bool(memory),
     }
+
 
 def postgres_capabilities(*, async_: bool) -> Dict[str, Any]:
     return {

--- a/pkgs/standards/tigrbl/tigrbl/engine/decorators.py
+++ b/pkgs/standards/tigrbl/tigrbl/engine/decorators.py
@@ -56,12 +56,11 @@ def _normalize(ctx: Optional[EngineCfg] = None, **kw: Any) -> EngineCfg:
             if k in kw:
                 m[k] = kw[k]
     else:
-    # Allow external engine kinds; pass mapping through unchanged.
-    # Keep provided keys as-is so external builders can interpret them.
-    m.update({k:v for k,v in kw.items() if k not in m})
-    return m
+        # Allow external engine kinds; pass mapping through unchanged.
+        # Keep provided keys as-is so external builders can interpret them.
+        m.update({k: v for k, v in kw.items() if k not in m})
 
-return m
+    return m
 
 
 def engine_ctx(ctx: Optional[EngineCfg] = None, **kw: Any):

--- a/pkgs/standards/tigrbl/tigrbl/engine/plugins.py
+++ b/pkgs/standards/tigrbl/tigrbl/engine/plugins.py
@@ -1,10 +1,8 @@
-
 from __future__ import annotations
-from typing import Any
 
-from .registry import register_engine  # re-exported for convenience
 
 _loaded = False
+
 
 def load_engine_plugins() -> None:
     """Discover and load external engine plugins via entry points.
@@ -18,14 +16,24 @@ def load_engine_plugins() -> None:
     eps = None
     try:
         from importlib.metadata import entry_points  # Python >= 3.10
+
         eps = entry_points()
         # New API: .select(group="tigrbl.engine")
-        selected = eps.select(group="tigrbl.engine") if hasattr(eps, "select") else eps.get("tigrbl.engine", [])
+        selected = (
+            eps.select(group="tigrbl.engine")
+            if hasattr(eps, "select")
+            else eps.get("tigrbl.engine", [])
+        )
     except Exception:
         try:
             from importlib_metadata import entry_points as entry_points_backport
+
             eps = entry_points_backport()
-            selected = eps.select(group="tigrbl.engine") if hasattr(eps, "select") else eps.get("tigrbl.engine", [])
+            selected = (
+                eps.select(group="tigrbl.engine")
+                if hasattr(eps, "select")
+                else eps.get("tigrbl.engine", [])
+            )
         except Exception:
             selected = []
 

--- a/pkgs/standards/tigrbl/tigrbl/engine/registry.py
+++ b/pkgs/standards/tigrbl/tigrbl/engine/registry.py
@@ -1,7 +1,7 @@
-
 from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Callable, Optional, Tuple, Dict
+
 
 # A registration for an engine kind provided by an external (or built-in) package.
 @dataclass
@@ -9,11 +9,15 @@ class EngineRegistration:
     build: Callable[..., Tuple[Any, Callable[[], Any]]]
     capabilities: Optional[Callable[[], Any]] = None
 
+
 _registry: Dict[str, EngineRegistration] = {}
 
-def register_engine(kind: str,
-                    build: Callable[..., Tuple[Any, Callable[[], Any]]],
-                    capabilities: Optional[Callable[[], Any]] = None) -> None:
+
+def register_engine(
+    kind: str,
+    build: Callable[..., Tuple[Any, Callable[[], Any]]],
+    capabilities: Optional[Callable[[], Any]] = None,
+) -> None:
     """Register an engine kind → (builder, capabilities). Idempotent."""
     k = (kind or "").strip().lower()
     if not k:
@@ -23,8 +27,10 @@ def register_engine(kind: str,
         return
     _registry[k] = EngineRegistration(build=build, capabilities=capabilities)
 
+
 def get_engine_registration(kind: str) -> Optional[EngineRegistration]:
     return _registry.get((kind or "").strip().lower())
+
 
 def known_engine_kinds() -> list[str]:
     return sorted(_registry.keys())

--- a/pkgs/standards/tigrbl/tigrbl/session/__init__.py
+++ b/pkgs/standards/tigrbl/tigrbl/session/__init__.py
@@ -1,4 +1,3 @@
-
 from .abc import SessionABC
 from .spec import SessionSpec
 from .base import TigrblSessionBase

--- a/pkgs/standards/tigrbl/tigrbl/session/abc.py
+++ b/pkgs/standards/tigrbl/tigrbl/session/abc.py
@@ -1,8 +1,8 @@
-
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from typing import Any, Callable
+
 
 class SessionABC(ABC):
     """

--- a/pkgs/standards/tigrbl/tigrbl/session/base.py
+++ b/pkgs/standards/tigrbl/tigrbl/session/base.py
@@ -1,4 +1,3 @@
-
 from __future__ import annotations
 
 import asyncio
@@ -91,7 +90,9 @@ class TigrblSessionBase(SessionABC):
 
     async def flush(self) -> None:
         if self._pending:
-            done, _ = await asyncio.wait(self._pending, return_when=asyncio.ALL_COMPLETED)
+            done, _ = await asyncio.wait(
+                self._pending, return_when=asyncio.ALL_COMPLETED
+            )
             self._pending = []
             # surface any exception
             for t in done:
@@ -138,7 +139,9 @@ class TigrblSessionBase(SessionABC):
     async def _refresh_impl(self, obj: Any) -> None:  # pragma: no cover - abstract hook
         return
 
-    async def _get_impl(self, model: type, ident: Any) -> Any | None:  # pragma: no cover
+    async def _get_impl(
+        self, model: type, ident: Any
+    ) -> Any | None:  # pragma: no cover
         raise NotImplementedError
 
     async def _execute_impl(self, stmt: Any) -> Any:  # pragma: no cover - abstract hook

--- a/pkgs/standards/tigrbl/tigrbl/session/decorators.py
+++ b/pkgs/standards/tigrbl/tigrbl/session/decorators.py
@@ -1,13 +1,14 @@
-
 from __future__ import annotations
 
 from typing import Any, Optional
 from .spec import SessionSpec, SessionCfg
 
+
 def _normalize(cfg: Optional[SessionCfg] = None, **kw: Any) -> SessionSpec:
     if cfg is not None and kw:
         raise ValueError("Pass either a mapping/spec or keyword args, not both")
-    return (SessionSpec.from_any(cfg or kw) or SessionSpec())
+    return SessionSpec.from_any(cfg or kw) or SessionSpec()
+
 
 def session_ctx(cfg: Optional[SessionCfg] = None, /, **kw: Any):
     """
@@ -18,16 +19,25 @@ def session_ctx(cfg: Optional[SessionCfg] = None, /, **kw: Any):
     (Resolver is part of the runtime/engine layer and is independent of this decorator.)
     """
     spec = _normalize(cfg, **kw)
+
     def _apply(obj: Any) -> Any:
         setattr(obj, "__tigrbl_session_ctx__", spec)
         return obj
+
     return _apply
+
 
 def read_only_session(obj: Any = None, /, *, isolation: Optional[str] = None):
     """
     Convenience decorator for read-only sessions.
     """
+
     def _wrap(o: Any) -> Any:
-        setattr(o, "__tigrbl_session_ctx__", SessionSpec(read_only=True, isolation=isolation))
+        setattr(
+            o,
+            "__tigrbl_session_ctx__",
+            SessionSpec(read_only=True, isolation=isolation),
+        )
         return o
+
     return _wrap(obj) if obj is not None else _wrap

--- a/pkgs/standards/tigrbl/tigrbl/session/default.py
+++ b/pkgs/standards/tigrbl/tigrbl/session/default.py
@@ -1,4 +1,3 @@
-
 from __future__ import annotations
 
 import inspect
@@ -72,7 +71,9 @@ class DefaultSession(TigrblSessionBase):
     async def _delete_impl(self, obj: Any) -> None:
         fn = getattr(self._u, "delete", None)
         if not callable(fn):
-            raise NotImplementedError("underlying session does not implement delete(obj)")
+            raise NotImplementedError(
+                "underlying session does not implement delete(obj)"
+            )
         rv = fn(obj)
         if inspect.isawaitable(rv):
             await rv
@@ -94,14 +95,18 @@ class DefaultSession(TigrblSessionBase):
     async def _get_impl(self, model: type, ident: Any) -> Any | None:
         fn = getattr(self._u, "get", None)
         if not callable(fn):
-            raise NotImplementedError("underlying session does not implement get(model, ident)")
+            raise NotImplementedError(
+                "underlying session does not implement get(model, ident)"
+            )
         rv = fn(model, ident)
         return await rv if inspect.isawaitable(rv) else rv
 
     async def _execute_impl(self, stmt: Any) -> Any:
         fn = getattr(self._u, "execute", None)
         if not callable(fn):
-            raise NotImplementedError("underlying session does not implement execute(stmt)")
+            raise NotImplementedError(
+                "underlying session does not implement execute(stmt)"
+            )
         rv = fn(stmt)
         return await rv if inspect.isawaitable(rv) else rv
 

--- a/pkgs/standards/tigrbl/tigrbl/session/shortcuts.py
+++ b/pkgs/standards/tigrbl/tigrbl/session/shortcuts.py
@@ -1,4 +1,3 @@
-
 from __future__ import annotations
 
 from typing import Any, Callable, Optional
@@ -15,28 +14,37 @@ def session_spec(cfg: SessionCfg = None, /, **kw: Any) -> SessionSpec:
         raise ValueError("Provide either a mapping/spec or kwargs, not both")
     return SessionSpec.from_any(cfg or kw) or SessionSpec()
 
+
 # Isolation presets
 def tx_read_committed(*, read_only: Optional[bool] = None) -> SessionSpec:
     return SessionSpec(isolation="read_committed", read_only=read_only)
 
+
 def tx_repeatable_read(*, read_only: Optional[bool] = None) -> SessionSpec:
     return SessionSpec(isolation="repeatable_read", read_only=read_only)
+
 
 def tx_serializable(*, read_only: Optional[bool] = None) -> SessionSpec:
     return SessionSpec(isolation="serializable", read_only=read_only)
 
+
 def readonly() -> SessionSpec:
     return SessionSpec(read_only=True)
 
+
 # Provider/sessionmaker wrapper
-def wrap_sessionmaker(maker: Callable[[], Any], spec: SessionSpec) -> Callable[[], DefaultSession]:
+def wrap_sessionmaker(
+    maker: Callable[[], Any], spec: SessionSpec
+) -> Callable[[], DefaultSession]:
     """
     Wrap any provider's session factory to yield DefaultSession instances that
     enforce the Tigrbl Session ABC and policy.
     """
+
     def _mk() -> DefaultSession:
         underlying = maker()
         s = DefaultSession(underlying, spec)
         s.apply_spec(spec)
         return s
+
     return _mk

--- a/pkgs/standards/tigrbl/tigrbl/session/spec.py
+++ b/pkgs/standards/tigrbl/tigrbl/session/spec.py
@@ -1,10 +1,10 @@
-
 from __future__ import annotations
 
 from dataclasses import dataclass, fields
 from typing import Any, Mapping, MutableMapping, Optional, Union
 
 SessionCfg = Union["SessionSpec", Mapping[str, Any], None]
+
 
 @dataclass(frozen=True)
 class SessionSpec:
@@ -15,8 +15,11 @@ class SessionSpec:
     validate and apply them where supported; critical ones (like isolation and
     read_only) SHOULD be validated and enforced.
     """
+
     # Transaction policy
-    isolation: Optional[str] = None            # "read_committed" | "repeatable_read" | "snapshot" | "serializable"
+    isolation: Optional[str] = (
+        None  # "read_committed" | "repeatable_read" | "snapshot" | "serializable"
+    )
     read_only: Optional[bool] = None
     autobegin: Optional[bool] = True
     expire_on_commit: Optional[bool] = None
@@ -36,7 +39,7 @@ class SessionSpec:
     # Consistency coordinates
     min_lsn: Optional[str] = None
     as_of_ts: Optional[str] = None
-    consistency: Optional[str] = None          # "strong" | "bounded_staleness" | "eventual"
+    consistency: Optional[str] = None  # "strong" | "bounded_staleness" | "eventual"
     staleness_ms: Optional[int] = None
 
     # Tenancy & security
@@ -74,7 +77,9 @@ class SessionSpec:
         h = higher if isinstance(higher, SessionSpec) else SessionSpec.from_any(higher)
         if h is None:
             return self
-        vals: MutableMapping[str, Any] = {f.name: getattr(self, f.name) for f in fields(SessionSpec)}
+        vals: MutableMapping[str, Any] = {
+            f.name: getattr(self, f.name) for f in fields(SessionSpec)
+        }
         for f in fields(SessionSpec):
             hv = getattr(h, f.name)
             if hv is not None:
@@ -83,7 +88,11 @@ class SessionSpec:
 
     def to_kwargs(self) -> dict[str, Any]:
         """Return only non-None items as a plain dict (adapters can **kwargs this)."""
-        return {f.name: getattr(self, f.name) for f in fields(SessionSpec) if getattr(self, f.name) is not None}
+        return {
+            f.name: getattr(self, f.name)
+            for f in fields(SessionSpec)
+            if getattr(self, f.name) is not None
+        }
 
     @staticmethod
     def from_any(x: SessionCfg) -> Optional["SessionSpec"]:


### PR DESCRIPTION
## Summary
- run `uv run --directory pkgs/standards/tigrbl --package tigrbl ruff format .` to apply Ruff formatting across the Tigrbl engine and session modules
- fix the `_normalize` fallback in `engine.decodators` and clean up the Book API notebook per Ruff feedback

## Testing
- `uv run --directory pkgs/standards/tigrbl --package tigrbl ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_e_68e4df0e1ce48326b2d2da65ae1c8f81