### PR TITLE
Replace py-spiffe integration with internal workload client

### DIFF
--- a/pkgs/experimental/tigrbl_spiffe/pyproject.toml
+++ b/pkgs/experimental/tigrbl_spiffe/pyproject.toml
@@ -7,7 +7,7 @@ name = "tigrbl-spiffe"
 version = "0.1.0"
 description = "SPIFFE/SPIRE plugin for Tigrbl — table/op-centric with UDS + HTTP(S) transports"
 readme = "README.md"
-license = { file = "LICENSE-APACHE" }
+license = { file = "LICENSE" }
 requires-python = ">=3.11"
 authors = [{ name = "Tigrbl Contributors" }]
 keywords = ["tigrbl", "spiffe", "spire", "mtls", "identity", "jwt", "cwt"]
@@ -22,7 +22,6 @@ classifiers = [
 
 dependencies = [
   "httpx>=0.27",
-  "py-spiffe>=0.15",
 ]
 
 [project.optional-dependencies]

--- a/pkgs/experimental/tigrbl_spiffe/src/tigrbl_spiffe/adapters/__init__.py
+++ b/pkgs/experimental/tigrbl_spiffe/src/tigrbl_spiffe/adapters/__init__.py
@@ -1,2 +1,8 @@
 from __future__ import annotations
-from .tigrbl_client_adapter import Endpoint, TigrblClientAdapter, Txn
+from .tigrbl_client_adapter import (
+    Endpoint as Endpoint,
+    TigrblClientAdapter as TigrblClientAdapter,
+    Txn as Txn,
+)
+
+__all__ = ["Endpoint", "TigrblClientAdapter", "Txn"]

--- a/pkgs/experimental/tigrbl_spiffe/src/tigrbl_spiffe/tables/workload.py
+++ b/pkgs/experimental/tigrbl_spiffe/src/tigrbl_spiffe/tables/workload.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 from typing import Tuple
 
+import httpx
+
 from tigrbl import engine_ctx, op_ctx
 from tigrbl.orm.tables import Base
 from tigrbl.specs import acol, S, F, IO
 from tigrbl.types import String, Integer, LargeBinary, HTTPException
+
+from ..workload_client import WorkloadClientError, fetch_remote_svid
 
 
 @engine_ctx(kind="sqlite", async_=True, mode="memory")
@@ -15,12 +19,36 @@ class Workload(Base):
     __resource__ = "workload"
 
     # Shape hints for response schemas (not persisted)
-    spiffe_id = acol(storage=S(type_=String(255), nullable=True), field=F(py_type=str), io=IO(out_verbs=("read",)))
-    kind = acol(storage=S(type_=String(10), nullable=True), field=F(py_type=str), io=IO(out_verbs=("read",)))
-    not_before = acol(storage=S(type_=Integer, nullable=True), field=F(py_type=int), io=IO(out_verbs=("read",)))
-    not_after = acol(storage=S(type_=Integer, nullable=True), field=F(py_type=int), io=IO(out_verbs=("read",)))
-    audiences = acol(storage=S(type_=String(255), nullable=True), field=F(py_type=Tuple[str, ...]), io=IO(out_verbs=("read",)))
-    material = acol(storage=S(type_=LargeBinary, nullable=True), field=F(py_type=bytes), io=IO(out_verbs=("read",)))
+    spiffe_id = acol(
+        storage=S(type_=String(255), nullable=True),
+        field=F(py_type=str),
+        io=IO(out_verbs=("read",)),
+    )
+    kind = acol(
+        storage=S(type_=String(10), nullable=True),
+        field=F(py_type=str),
+        io=IO(out_verbs=("read",)),
+    )
+    not_before = acol(
+        storage=S(type_=Integer, nullable=True),
+        field=F(py_type=int),
+        io=IO(out_verbs=("read",)),
+    )
+    not_after = acol(
+        storage=S(type_=Integer, nullable=True),
+        field=F(py_type=int),
+        io=IO(out_verbs=("read",)),
+    )
+    audiences = acol(
+        storage=S(type_=String(255), nullable=True),
+        field=F(py_type=Tuple[str, ...]),
+        io=IO(out_verbs=("read",)),
+    )
+    material = acol(
+        storage=S(type_=LargeBinary, nullable=True),
+        field=F(py_type=bytes),
+        io=IO(out_verbs=("read",)),
+    )
 
     @op_ctx(alias="read", persist="skip")
     async def _remote_read(cls, ctx):
@@ -30,48 +58,16 @@ class Workload(Base):
         adapter = ctx.get("spiffe_adapter")
         cfg = ctx.get("spiffe_config")
         if adapter is None or cfg is None:
-            raise HTTPException(status_code=500, detail="SPIFFE adapter/config missing for workload read")
+            raise HTTPException(
+                status_code=500,
+                detail="SPIFFE adapter/config missing for workload read",
+            )
         tx = await adapter.for_endpoint(cfg.workload_endpoint)
-
-        if kind == "x509" and tx.kind == "uds":
-            from pyspiffe.workloadapi.default_workload_api_client import DefaultWorkloadApiClient
-            client = DefaultWorkloadApiClient(socket_path=tx.uds_path)
-            try:
-                svid = client.fetch_x509_svid()
-                chain_der = b"".join(c.public_bytes() for c in svid.cert_chain)  # type: ignore[attr-defined]
-                return {
-                    "spiffe_id": str(svid.spiffe_id()),
-                    "kind": "x509",
-                    "not_before": int(svid.expires_at.timestamp()) - 3600,
-                    "not_after": int(svid.expires_at.timestamp()),
-                    "audiences": tuple(aud),
-                    "material": chain_der,
-                }
-            finally:
-                client.close()
-
-        if kind == "jwt":
-            data = (await tx.http.post("/workload/jwtsvid", json={"aud": list(aud)})).json()
-            return {
-                "spiffe_id": data["spiffe_id"],
-                "kind": "jwt",
-                "not_before": data.get("nbf", 0),
-                "not_after": data.get("exp", 0),
-                "audiences": tuple(data.get("aud", [])),
-                "material": data["jwt"].encode("utf-8"),
-                "bundle_id": data.get("bundle_id"),
-            }
-
-        if kind == "cwt":
-            data = (await tx.http.post("/workload/cwtsvid", json={"aud": list(aud)})).json()
-            return {
-                "spiffe_id": data["spiffe_id"],
-                "kind": "cwt",
-                "not_before": data.get("nbf", 0),
-                "not_after": data.get("exp", 0),
-                "audiences": tuple(data.get("aud", [])),
-                "material": data["cwt"].encode("utf-8"),
-                "bundle_id": data.get("bundle_id"),
-            }
-
-        raise HTTPException(status_code=400, detail=f"Unsupported kind: {kind}")
+        try:
+            return await fetch_remote_svid(tx, kind=kind, audiences=tuple(aud))
+        except WorkloadClientError as exc:
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+        except httpx.HTTPError as exc:
+            raise HTTPException(
+                status_code=502, detail="Workload endpoint request failed"
+            ) from exc

--- a/pkgs/experimental/tigrbl_spiffe/src/tigrbl_spiffe/workload_client.py
+++ b/pkgs/experimental/tigrbl_spiffe/src/tigrbl_spiffe/workload_client.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Iterable, Sequence, Tuple
+
+import base64
+import binascii
+
+import httpx
+
+from .adapters import Txn
+
+
+class WorkloadClientError(RuntimeError):
+    """Raised when the custom workload client cannot satisfy a request."""
+
+
+class _Certificate:
+    __slots__ = ("_der",)
+
+    def __init__(self, der: bytes) -> None:
+        self._der = der
+
+    def public_bytes(self) -> bytes:  # pragma: no cover - trivial proxy
+        return self._der
+
+
+@dataclass(slots=True)
+class X509Svid:
+    _spiffe_id: str
+    _cert_chain: Tuple[_Certificate, ...]
+    _expires_at: datetime
+
+    def spiffe_id(self) -> str:
+        return self._spiffe_id
+
+    @property
+    def cert_chain(self) -> Tuple[_Certificate, ...]:
+        return self._cert_chain
+
+    @property
+    def expires_at(self) -> datetime:
+        return self._expires_at
+
+
+class UnixWorkloadClient:
+    """Minimal HTTP-over-UDS workload client used in place of ``py-spiffe``.
+
+    The client expects a SPIFFE agent to expose REST-like endpoints that mirror
+    the Workload API semantics. This keeps the runtime self-contained while
+    providing deterministic behaviour for tests.
+    """
+
+    def __init__(self, socket_path: str, *, timeout: float = 5.0) -> None:
+        if not socket_path:
+            raise WorkloadClientError("Unix socket path is required")
+        transport = httpx.HTTPTransport(uds=socket_path)
+        self._client = httpx.Client(transport=transport, timeout=timeout)
+
+    def fetch_x509_svid(self, *, aud: Sequence[str] = ()) -> X509Svid:
+        response = self._client.post("/workload/x509svid", json={"aud": list(aud)})
+        response.raise_for_status()
+        data = response.json()
+
+        spiffe_id = data.get("spiffe_id")
+        if not spiffe_id:
+            raise WorkloadClientError("Missing spiffe_id in workload response")
+
+        chain = _coerce_cert_chain(data)
+        expires_at = _coerce_expires_at(data)
+
+        return X509Svid(spiffe_id, chain, expires_at)
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> "UnixWorkloadClient":  # pragma: no cover - context protocol
+        return self
+
+    def __exit__(
+        self, exc_type, exc, tb
+    ) -> None:  # pragma: no cover - context protocol
+        self.close()
+
+
+async def fetch_remote_svid(
+    tx: Txn, *, kind: str, audiences: Sequence[str]
+) -> dict[str, object]:
+    """Fetch a remote SVID for the given transaction and kind."""
+
+    if kind == "x509":
+        if tx.kind != "uds" or not tx.uds_path:
+            raise WorkloadClientError(
+                "Unix domain socket endpoint required for x509 SVID"
+            )
+        with UnixWorkloadClient(tx.uds_path) as client:
+            svid = client.fetch_x509_svid(aud=audiences)
+        expires_at = int(svid.expires_at.timestamp())
+        return {
+            "spiffe_id": svid.spiffe_id(),
+            "kind": "x509",
+            "not_before": max(expires_at - 3600, 0),
+            "not_after": expires_at,
+            "audiences": tuple(audiences),
+            "material": b"".join(cert.public_bytes() for cert in svid.cert_chain),
+            "bundle_id": None,
+        }
+
+    if kind in {"jwt", "cwt"}:
+        if tx.http is None:
+            raise WorkloadClientError("HTTP transport required for JWT/CWT SVID fetch")
+        path = "/workload/jwtsvid" if kind == "jwt" else "/workload/cwtsvid"
+        response = await tx.http.post(path, json={"aud": list(audiences)})
+        response.raise_for_status()
+        data = response.json()
+        token_key = "jwt" if kind == "jwt" else "cwt"
+        token = data.get(token_key)
+        if not token:
+            raise WorkloadClientError(
+                f"Missing {token_key} payload in workload response"
+            )
+        return {
+            "spiffe_id": data["spiffe_id"],
+            "kind": kind,
+            "not_before": data.get("nbf", 0),
+            "not_after": data.get("exp", data.get("expires_at", 0)),
+            "audiences": tuple(data.get("aud", audiences)),
+            "material": token.encode("utf-8"),
+            "bundle_id": data.get("bundle_id"),
+        }
+
+    raise WorkloadClientError(f"Unsupported SVID kind: {kind}")
+
+
+def _coerce_cert_chain(data: dict) -> Tuple[_Certificate, ...]:
+    raw_chain = (
+        data.get("cert_chain_der")
+        or data.get("cert_chain")
+        or data.get("chain_der")
+        or data.get("chain")
+        or data.get("cert_chain_pem")
+    )
+    if raw_chain is None:
+        raise WorkloadClientError("Certificate chain missing from workload response")
+
+    if isinstance(raw_chain, (bytes, bytearray, str)):
+        items: Iterable[bytes | str] = [raw_chain]
+    else:
+        items = raw_chain
+
+    chain: list[_Certificate] = []
+    for item in items:
+        if isinstance(item, bytes):
+            chain.append(_Certificate(bytes(item)))
+            continue
+        if not isinstance(item, str):
+            raise WorkloadClientError("Unsupported certificate payload type")
+        token = item.strip()
+        if token.startswith("-----BEGIN"):
+            chain.append(_Certificate(token.encode("utf-8")))
+            continue
+        chain.append(_Certificate(_decode_text_token(token)))
+
+    if not chain:
+        raise WorkloadClientError("Certificate chain is empty")
+
+    return tuple(chain)
+
+
+def _decode_text_token(token: str) -> bytes:
+    try:
+        return base64.b64decode(token, validate=True)
+    except (binascii.Error, ValueError):
+        try:
+            return bytes.fromhex(token)
+        except ValueError as exc:  # pragma: no cover - defensive
+            raise WorkloadClientError("Unable to decode certificate token") from exc
+
+
+def _coerce_expires_at(data: dict) -> datetime:
+    for key in ("expires_at", "exp", "not_after"):
+        if key in data:
+            raw = data[key]
+            break
+    else:
+        return datetime.fromtimestamp(0, tz=timezone.utc)
+
+    if isinstance(raw, (int, float)):
+        return datetime.fromtimestamp(float(raw), tz=timezone.utc)
+
+    if isinstance(raw, str):
+        try:
+            dt = datetime.fromisoformat(raw)
+        except ValueError:
+            return datetime.fromtimestamp(float(raw), tz=timezone.utc)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc)
+
+    raise WorkloadClientError("Unsupported expires_at payload type")

--- a/pkgs/experimental/tigrbl_spiffe/src/tigrbl_spiffe/workload_client.py
+++ b/pkgs/experimental/tigrbl_spiffe/src/tigrbl_spiffe/workload_client.py
@@ -114,6 +114,10 @@ async def fetch_remote_svid(
         response = await tx.http.post(path, json={"aud": list(audiences)})
         response.raise_for_status()
         data = response.json()
+        spiffe_id = data.get("spiffe_id")
+        if not spiffe_id:
+            raise WorkloadClientError("Missing spiffe_id in workload response")
+
         token_key = "jwt" if kind == "jwt" else "cwt"
         token = data.get(token_key)
         if not token:
@@ -121,7 +125,7 @@ async def fetch_remote_svid(
                 f"Missing {token_key} payload in workload response"
             )
         return {
-            "spiffe_id": data["spiffe_id"],
+            "spiffe_id": spiffe_id,
             "kind": kind,
             "not_before": data.get("nbf", 0),
             "not_after": data.get("exp", data.get("expires_at", 0)),

--- a/pkgs/experimental/tigrbl_spiffe/tests/conftest.py
+++ b/pkgs/experimental/tigrbl_spiffe/tests/conftest.py
@@ -1,0 +1,129 @@
+import sys
+import types
+from types import SimpleNamespace
+
+
+def _ensure_stub_modules() -> None:
+    if "tigrbl" in sys.modules:
+        return
+
+    tigrbl = types.ModuleType("tigrbl")
+
+    def engine_ctx(**_kwargs):
+        def decorator(cls):
+            handlers = SimpleNamespace()
+            for name, attr in cls.__dict__.items():
+                alias = getattr(attr, "__tigrbl_op_alias__", None)
+                if not alias:
+                    continue
+
+                async def raw(ctx, _func=attr, _cls=cls):
+                    return await _func(_cls, ctx)
+
+                setattr(handlers, alias, SimpleNamespace(raw=raw))
+            cls.handlers = handlers
+            return cls
+
+        return decorator
+
+    def op_ctx(*, alias, **_meta):
+        def decorator(func):
+            func.__tigrbl_op_alias__ = alias
+            return func
+
+        return decorator
+
+    def hook_ctx(*_args, **_kwargs):
+        def decorator(func):
+            return func
+
+        return decorator
+
+    def include_model(model):
+        return model
+
+    tigrbl.engine_ctx = engine_ctx
+    tigrbl.op_ctx = op_ctx
+    tigrbl.hook_ctx = hook_ctx
+    tigrbl.include_model = include_model
+
+    sys.modules["tigrbl"] = tigrbl
+
+    orm = types.ModuleType("tigrbl.orm")
+    tables = types.ModuleType("tigrbl.orm.tables")
+
+    class Base:
+        pass
+
+    tables.Base = Base
+    orm.tables = tables
+
+    sys.modules["tigrbl.orm"] = orm
+    sys.modules["tigrbl.orm.tables"] = tables
+
+    specs = types.ModuleType("tigrbl.specs")
+
+    class _Spec:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+    def _factory(*args, **kwargs):
+        return _Spec(*args, **kwargs)
+
+    specs.acol = _factory
+    specs.vcol = _factory
+    specs.S = _factory
+    specs.F = _factory
+    specs.IO = _factory
+
+    sys.modules["tigrbl.specs"] = specs
+
+    types_mod = types.ModuleType("tigrbl.types")
+
+    class _Type:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+    class HTTPException(Exception):
+        def __init__(self, status_code: int, detail: str):
+            super().__init__(detail)
+            self.status_code = status_code
+            self.detail = detail
+
+    for name in [
+        "String",
+        "Integer",
+        "LargeBinary",
+        "JSON",
+        "SAEnum",
+        "Text",
+    ]:
+        setattr(types_mod, name, type(name, (_Type,), {}))
+
+    types_mod.HTTPException = HTTPException
+
+    sys.modules["tigrbl.types"] = types_mod
+
+    core = types.ModuleType("tigrbl.core")
+
+    async def read(cls, ident, db=None):
+        return None
+
+    async def list(cls, db=None, filters=None, sort=None):
+        return []
+
+    async def merge(cls, ident, data, db=None):
+        result = {"id": ident}
+        result.update(data or {})
+        return result
+
+    core.read = read
+    core.list = list
+    core.merge = merge
+
+    sys.modules["tigrbl.core"] = core
+
+
+_ensure_stub_modules()

--- a/pkgs/experimental/tigrbl_spiffe/tests/test_adapters.py
+++ b/pkgs/experimental/tigrbl_spiffe/tests/test_adapters.py
@@ -1,0 +1,47 @@
+import pytest
+import httpx
+
+from tigrbl_spiffe.adapters import Endpoint, TigrblClientAdapter, Txn
+
+
+@pytest.mark.asyncio
+async def test_for_endpoint_uds_returns_transaction():
+    adapter = TigrblClientAdapter()
+    txn = await adapter.for_endpoint(
+        Endpoint(scheme="uds", address="unix:///var/run/workload.sock")
+    )
+    assert isinstance(txn, Txn)
+    assert txn.kind == "uds"
+    assert txn.uds_path == "/var/run/workload.sock"
+    assert txn.http is None
+
+
+@pytest.mark.asyncio
+async def test_for_endpoint_http_creates_async_client():
+    adapter = TigrblClientAdapter()
+    txn = await adapter.for_endpoint(
+        Endpoint(scheme="http", address="http://example.test")
+    )
+    assert txn.kind == "http"
+    assert isinstance(txn.http, httpx.AsyncClient)
+    assert str(txn.http.base_url) == "http://example.test"
+    await txn.http.aclose()
+
+
+@pytest.mark.asyncio
+async def test_for_endpoint_https_creates_async_client():
+    adapter = TigrblClientAdapter()
+    txn = await adapter.for_endpoint(
+        Endpoint(scheme="https", address="https://secure.test", timeout_s=9.5)
+    )
+    assert txn.kind == "https"
+    assert isinstance(txn.http, httpx.AsyncClient)
+    assert txn.http.timeout.read == 9.5
+    await txn.http.aclose()
+
+
+@pytest.mark.asyncio
+async def test_for_endpoint_unknown_scheme_raises():
+    adapter = TigrblClientAdapter()
+    with pytest.raises(ValueError):
+        await adapter.for_endpoint(Endpoint(scheme="smtp", address="smtp://example"))

--- a/pkgs/experimental/tigrbl_spiffe/tests/test_e2e_flow.py
+++ b/pkgs/experimental/tigrbl_spiffe/tests/test_e2e_flow.py
@@ -1,0 +1,174 @@
+import json
+from contextlib import AsyncExitStack, contextmanager
+from types import MethodType
+
+import httpx
+import pytest
+
+from tigrbl_spiffe.adapters import Endpoint, Txn
+from tigrbl_spiffe.middleware.authn import SpiffeAuthn
+from tigrbl_spiffe.plugin import TigrblSpiffePlugin
+from tigrbl_spiffe.registry import register
+from tigrbl_spiffe import registry as registry_module
+from tigrbl_spiffe.tables import bundle, registrar, svid, workload
+from tigrbl_spiffe.tables.svid import Svid
+
+
+class EchoServerASGI:
+    """Minimal ASGI echo server guarded by SpiffeAuthn."""
+
+    def __init__(self, *, plugin: TigrblSpiffePlugin) -> None:
+        self._plugin = plugin
+        self._authn = SpiffeAuthn(validator=plugin.ctx_extras()["svid_validator"])
+
+    async def __call__(
+        self, scope, receive, send
+    ):  # pragma: no cover - invoked via httpx
+        if scope["type"] != "http":
+            await send({"type": "http.response.start", "status": 500, "headers": []})
+            await send({"type": "http.response.body", "body": b"unsupported"})
+            return
+
+        # Drain request body (httpx's ASGI transport sends a single event for GET)
+        while True:
+            event = await receive()
+            if event["type"] != "http.request":
+                continue
+            if not event.get("more_body"):
+                break
+
+        headers = {
+            k.decode("latin1"): v.decode("latin1") for k, v in scope.get("headers", [])
+        }
+        ctx = self._plugin.ctx_extras()
+        ctx["http"] = {"headers": headers}
+
+        async def endpoint(local_ctx):
+            return {"ok": True, "principal": local_ctx.get("principal")}
+
+        result = await self._authn(ctx, endpoint)
+        payload = json.dumps(result).encode("utf-8")
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"application/json")],
+            }
+        )
+        await send({"type": "http.response.body", "body": payload})
+
+
+@contextmanager
+def override_attr(module, name, replacement):
+    original = getattr(module, name)
+    setattr(module, name, replacement)
+    try:
+        yield original
+    finally:
+        setattr(module, name, original)
+
+
+@pytest.mark.asyncio
+async def test_end_to_end_registration_and_jwt_authentication():
+    recorded = []
+
+    with override_attr(
+        registry_module, "include_model", lambda model: recorded.append(model)
+    ):
+        register(app=object())
+
+    assert recorded == [
+        svid.Svid,
+        registrar.Registrar,
+        bundle.Bundle,
+        workload.Workload,
+    ]
+
+    plugin = TigrblSpiffePlugin(
+        workload_endpoint=Endpoint(scheme="http", address="http://agent.test")
+    )
+
+    token = "header.payload.signature"
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        assert request.url.path == "/workload/jwtsvid"
+        payload = json.loads(request.content.decode("utf-8"))
+        assert payload["aud"] == ["echo"]
+        return httpx.Response(
+            200,
+            json={
+                "spiffe_id": "spiffe://example/client",
+                "jwt": token,
+                "aud": ["echo"],
+                "nbf": 1,
+                "exp": 2,
+            },
+        )
+
+    transport = httpx.MockTransport(responder)
+    mock_client = httpx.AsyncClient(transport=transport, base_url="http://agent.test")
+    txn = Txn(kind="http", http=mock_client)
+
+    adapter = plugin.ctx_extras()["spiffe_adapter"]
+
+    validator = plugin.ctx_extras()["svid_validator"]
+    calls = []
+
+    async def fake_for_endpoint(self, ep: Endpoint) -> Txn:
+        assert ep.scheme == "http"
+        assert ep.address == "http://agent.test"
+        return txn
+
+    async def tracking_validate(self, *, kind, material, bundle_id, ctx):
+        calls.append((kind, material, bundle_id))
+        return await original_validate(
+            kind=kind, material=material, bundle_id=bundle_id, ctx=ctx
+        )
+
+    app = EchoServerASGI(plugin=plugin)
+    client = httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://asgi.test"
+    )
+    async with AsyncExitStack() as stack:
+        stack.push_async_callback(client.aclose)
+        stack.push_async_callback(mock_client.aclose)
+        stack.enter_context(
+            override_attr(
+                adapter,
+                "for_endpoint",
+                MethodType(fake_for_endpoint, adapter),
+            )
+        )
+        original_validate = stack.enter_context(
+            override_attr(
+                validator,
+                "validate",
+                MethodType(tracking_validate, validator),
+            )
+        )
+
+        ctx_fetch = {
+            **plugin.ctx_extras(),
+            "payload": {"remote": True, "kind": "jwt", "aud": ["echo"]},
+        }
+        fetched = await Svid.handlers.read.raw(ctx_fetch)
+        assert fetched["spiffe_id"] == "spiffe://example/client"
+        assert fetched["kind"] == "jwt"
+        assert fetched["audiences"] == ("echo",)
+        assert fetched["material"].decode("utf-8") == token
+
+        response = await client.get(
+            "/echo",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["ok"] is True
+        assert body["principal"] == {
+            "spiffe_id": None,
+            "token": token,
+            "kind": "jwt",
+        }
+
+        assert calls == [("jwt", token.encode("utf-8"), None)]

--- a/pkgs/experimental/tigrbl_spiffe/tests/test_registry_install.py
+++ b/pkgs/experimental/tigrbl_spiffe/tests/test_registry_install.py
@@ -1,0 +1,82 @@
+from contextlib import contextmanager
+
+from tigrbl_spiffe import register
+from tigrbl_spiffe import plugin as plugin_module
+from tigrbl_spiffe import registry as registry_module
+from tigrbl_spiffe.tables import bundle, registrar, svid, workload
+
+
+class DummyApp:
+    def __init__(self) -> None:
+        self.middlewares = []
+
+    def use(self, middleware):
+        self.middlewares.append(middleware)
+
+
+@contextmanager
+def override_attr(module, name, replacement):
+    original = getattr(module, name)
+    setattr(module, name, replacement)
+    try:
+        yield
+    finally:
+        setattr(module, name, original)
+
+
+def test_register_includes_spiffe_tables():
+    captured: list[type] = []
+    with override_attr(
+        registry_module, "include_model", lambda model: captured.append(model)
+    ):
+        register(app=object())
+
+    assert captured == [
+        svid.Svid,
+        registrar.Registrar,
+        bundle.Bundle,
+        workload.Workload,
+    ]
+
+
+def test_plugin_install_wires_models_and_middleware():
+    from tigrbl_spiffe.adapters import Endpoint
+    from tigrbl_spiffe.middleware.identity import InjectSpiffeExtras
+    from tigrbl_spiffe.middleware.authn import SpiffeAuthn
+    from tigrbl_spiffe.middleware.tls import AttachTlsContexts
+    from tigrbl_spiffe.plugin import TigrblSpiffePlugin
+
+    captured: list[type] = []
+    with override_attr(
+        plugin_module, "include_model", lambda model: captured.append(model)
+    ):
+        plugin = TigrblSpiffePlugin(
+            workload_endpoint=Endpoint(
+                scheme="uds", address="unix:///tmp/workload.sock"
+            )
+        )
+        app = DummyApp()
+
+        plugin.install(app)
+
+    assert captured == [
+        svid.Svid,
+        registrar.Registrar,
+        bundle.Bundle,
+        workload.Workload,
+    ]
+
+    assert [type(mw) for mw in app.middlewares] == [
+        InjectSpiffeExtras,
+        SpiffeAuthn,
+        AttachTlsContexts,
+    ]
+
+    extras = plugin.ctx_extras()
+    assert extras["spiffe_adapter"] is not None
+    assert extras["rotation_policy"] is not None
+    assert extras["svid_validator"] is not None
+    assert extras["tls_helper"] is not None
+    cfg = extras["spiffe_config"]
+    assert cfg.workload_endpoint.scheme == "uds"
+    assert cfg.workload_endpoint.address == "unix:///tmp/workload.sock"

--- a/pkgs/experimental/tigrbl_spiffe/tests/test_svid_validator.py
+++ b/pkgs/experimental/tigrbl_spiffe/tests/test_svid_validator.py
@@ -1,0 +1,39 @@
+import pytest
+
+from tigrbl_spiffe.identity.svid_validator import SvidValidator
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_unknown_kind():
+    validator = SvidValidator()
+    with pytest.raises(ValueError):
+        await validator.validate(kind="otp", material=b"token", bundle_id=None, ctx={})
+
+
+@pytest.mark.asyncio
+async def test_validate_requires_bytes_material():
+    validator = SvidValidator()
+    with pytest.raises(ValueError):
+        await validator.validate(kind="jwt", material="token", bundle_id=None, ctx={})
+
+
+@pytest.mark.asyncio
+async def test_validate_enforces_minimum_x509_size():
+    validator = SvidValidator()
+    with pytest.raises(ValueError):
+        await validator.validate(
+            kind="x509", material=b"0" * 32, bundle_id=None, ctx={}
+        )
+
+    await validator.validate(kind="x509", material=b"1" * 64, bundle_id=None, ctx={})
+
+
+@pytest.mark.asyncio
+async def test_validate_accepts_jwt_token_bytes():
+    validator = SvidValidator()
+    await validator.validate(
+        kind="jwt",
+        material=b"header.payload.signature",
+        bundle_id=None,
+        ctx={},
+    )

--- a/pkgs/experimental/tigrbl_spiffe/tests/test_workload_client.py
+++ b/pkgs/experimental/tigrbl_spiffe/tests/test_workload_client.py
@@ -59,3 +59,18 @@ async def test_fetch_remote_svid_missing_token_raises():
             await fetch_remote_svid(txn, kind="jwt", audiences=())
     finally:
         await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fetch_remote_svid_missing_spiffe_id_raises():
+    def responder(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"jwt": "token-value"})
+
+    transport = httpx.MockTransport(responder)
+    client = httpx.AsyncClient(transport=transport, base_url="http://agent.test")
+    txn = Txn(kind="http", http=client)
+    try:
+        with pytest.raises(WorkloadClientError):
+            await fetch_remote_svid(txn, kind="jwt", audiences=())
+    finally:
+        await client.aclose()

--- a/pkgs/experimental/tigrbl_spiffe/tests/test_workload_client.py
+++ b/pkgs/experimental/tigrbl_spiffe/tests/test_workload_client.py
@@ -1,0 +1,61 @@
+import json
+
+import httpx
+import pytest
+
+from tigrbl_spiffe.adapters import Txn
+from tigrbl_spiffe.workload_client import WorkloadClientError, fetch_remote_svid
+
+
+@pytest.mark.asyncio
+async def test_fetch_remote_svid_jwt_via_http():
+    token = "header.payload.signature"
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        assert request.url.path == "/workload/jwtsvid"
+        payload = json.loads(request.content.decode("utf-8"))
+        assert payload["aud"] == ["demo"]
+        return httpx.Response(
+            200,
+            json={
+                "spiffe_id": "spiffe://example/client",
+                "jwt": token,
+                "aud": ["demo"],
+                "nbf": 10,
+                "exp": 20,
+            },
+        )
+
+    transport = httpx.MockTransport(responder)
+    client = httpx.AsyncClient(transport=transport, base_url="http://agent.test")
+    txn = Txn(kind="http", http=client)
+    try:
+        result = await fetch_remote_svid(txn, kind="jwt", audiences=("demo",))
+    finally:
+        await client.aclose()
+
+    assert result == {
+        "spiffe_id": "spiffe://example/client",
+        "kind": "jwt",
+        "not_before": 10,
+        "not_after": 20,
+        "audiences": ("demo",),
+        "material": token.encode("utf-8"),
+        "bundle_id": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_fetch_remote_svid_missing_token_raises():
+    def responder(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"spiffe_id": "spiffe://example/missing"})
+
+    transport = httpx.MockTransport(responder)
+    client = httpx.AsyncClient(transport=transport, base_url="http://agent.test")
+    txn = Txn(kind="http", http=client)
+    try:
+        with pytest.raises(WorkloadClientError):
+            await fetch_remote_svid(txn, kind="jwt", audiences=())
+    finally:
+        await client.aclose()


### PR DESCRIPTION
## Summary
- drop the external py-spiffe dependency in favour of a bundled workload client and update the package license path
- update the rotation policy plus workload and SVID tables to reuse the shared fetch helper with consistent error handling
- provide stubbed tigrbl modules and new tests that exercise JWT fetch behaviour for the custom client

## Testing
- `uv run --package tigrbl-spiffe --directory experimental/tigrbl_spiffe pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e5872e304c8326bc1783ca3038a97d