### PR TITLE
Add AsyncAPI and JSON Schema docs endpoints and builders

### DIFF
--- a/pkgs/standards/tigrbl_concrete/tigrbl_concrete/_concrete/tigrbl_app.py
+++ b/pkgs/standards/tigrbl_concrete/tigrbl_concrete/_concrete/tigrbl_app.py
@@ -34,9 +34,13 @@ from tigrbl_concrete._mapping.router.rpc import rpc_call as _rpc_call
 from tigrbl_concrete._mapping.model import rebind as _rebind, bind as _bind
 from tigrbl_concrete.system import mount_diagnostics as _mount_diagnostics
 from tigrbl_concrete.system import mount_lens as _mount_lens
+from tigrbl_concrete.system import mount_asyncapi as _mount_asyncapi
+from tigrbl_concrete.system import mount_json_schema as _mount_json_schema
 from tigrbl_concrete.system import mount_openapi as _mount_openapi
 from tigrbl_concrete.system import mount_openrpc as _mount_openrpc
 from tigrbl_concrete.system import mount_swagger as _mount_swagger
+from tigrbl_concrete.system import build_asyncapi_spec as _build_asyncapi_spec
+from tigrbl_concrete.system import build_json_schema_spec as _build_json_schema_spec
 from tigrbl_concrete.system import build_openrpc_spec as _build_openrpc_spec
 from tigrbl_concrete.system.docs import build_openapi as _build_openapi
 from ._op_registry import get_registry
@@ -237,6 +241,8 @@ class TigrblApp(_App):
             _mount_swagger(self, path="/docs")
             self.attach_diagnostics(prefix=self.system_prefix)
             self.mount_openrpc(path="/openrpc.json")
+            self.mount_asyncapi(path="/asyncapi.json")
+            self.mount_json_schema(path="/json-schema.json")
             self.mount_lens(path="/lens", spec_path="/openrpc.json")
         if routers:
             initial_routers.extend(list(routers))
@@ -834,9 +840,35 @@ class TigrblApp(_App):
         """Mount an OpenRPC JSON endpoint onto this instance."""
         return _mount_openrpc(self, path=path, name=name, tags=tags)
 
+    def mount_asyncapi(
+        self,
+        *,
+        path: str = "/asyncapi.json",
+        name: str = "asyncapi_json",
+    ) -> Any:
+        """Mount an AsyncAPI-styled docs endpoint onto this instance."""
+        return _mount_asyncapi(self, path=path, name=name)
+
+    def mount_json_schema(
+        self,
+        *,
+        path: str = "/json-schema.json",
+        name: str = "json_schema",
+    ) -> Any:
+        """Mount a JSON Schema-styled docs endpoint onto this instance."""
+        return _mount_json_schema(self, path=path, name=name)
+
     def openrpc(self) -> Dict[str, Any]:
         """Build and return the OpenRPC document for this app."""
         return _build_openrpc_spec(self)
+
+    def asyncapi(self) -> Dict[str, Any]:
+        """Build and return the AsyncAPI-styled document for this app."""
+        return _build_asyncapi_spec(self)
+
+    def json_schema(self) -> Dict[str, Any]:
+        """Build and return the JSON Schema-styled document for this app."""
+        return _build_json_schema_spec(self)
 
     def openapi(self) -> Dict[str, Any]:
         """Build and return the OpenAPI document for this app."""

--- a/pkgs/standards/tigrbl_concrete/tigrbl_concrete/_concrete/tigrbl_router.py
+++ b/pkgs/standards/tigrbl_concrete/tigrbl_concrete/_concrete/tigrbl_router.py
@@ -29,7 +29,11 @@ from ._op_registry import get_registry
 from tigrbl_core._spec import OpSpec
 from ._table_registry import TableRegistry
 from ._routing import include_router as _include_router_impl
+from tigrbl_concrete.system import mount_asyncapi as _mount_asyncapi
+from tigrbl_concrete.system import mount_json_schema as _mount_json_schema
 from tigrbl_concrete.system import mount_openrpc as _mount_openrpc
+from tigrbl_concrete.system import build_asyncapi_spec as _build_asyncapi_spec
+from tigrbl_concrete.system import build_json_schema_spec as _build_json_schema_spec
 from tigrbl_concrete.system import mount_diagnostics as _mount_diagnostics
 from tigrbl_concrete.system.docs import build_openapi as _build_openapi
 from tigrbl_concrete._concrete import engine_resolver as _resolver
@@ -305,6 +309,24 @@ class TigrblRouter(_Router):
         """Mount an OpenRPC JSON endpoint onto this router instance."""
         return _mount_openrpc(self, path=path, name=name, tags=tags)
 
+    def mount_asyncapi(
+        self,
+        *,
+        path: str = "/asyncapi.json",
+        name: str = "asyncapi_json",
+    ) -> Any:
+        """Mount an AsyncAPI-styled docs endpoint onto this router."""
+        return _mount_asyncapi(self, path=path, name=name)
+
+    def mount_json_schema(
+        self,
+        *,
+        path: str = "/json-schema.json",
+        name: str = "json_schema",
+    ) -> Any:
+        """Mount a JSON Schema-styled docs endpoint onto this router."""
+        return _mount_json_schema(self, path=path, name=name)
+
     def attach_diagnostics(
         self, *, prefix: str | None = None, app: Any | None = None
     ) -> Any:
@@ -333,6 +355,14 @@ class TigrblRouter(_Router):
     def openapi(self) -> Dict[str, Any]:
         """Build and return the OpenAPI document for this router."""
         return _build_openapi(self)
+
+    def asyncapi(self) -> Dict[str, Any]:
+        """Build and return the AsyncAPI-styled document for this router."""
+        return _build_asyncapi_spec(self)
+
+    def json_schema(self) -> Dict[str, Any]:
+        """Build and return the JSON Schema-styled document for this router."""
+        return _build_json_schema_spec(self)
 
     # ------------------------- registry passthroughs -------------------------
 

--- a/pkgs/standards/tigrbl_concrete/tigrbl_concrete/system/__init__.py
+++ b/pkgs/standards/tigrbl_concrete/tigrbl_concrete/system/__init__.py
@@ -39,6 +39,18 @@ def mount_openrpc(*args: Any, **kwargs: Any) -> Any:
     return _mount_openrpc(*args, **kwargs)
 
 
+def mount_asyncapi(*args: Any, **kwargs: Any) -> Any:
+    from .docs import mount_asyncapi as _mount_asyncapi
+
+    return _mount_asyncapi(*args, **kwargs)
+
+
+def mount_json_schema(*args: Any, **kwargs: Any) -> Any:
+    from .docs import mount_json_schema as _mount_json_schema
+
+    return _mount_json_schema(*args, **kwargs)
+
+
 def mount_favicon(*args: Any, **kwargs: Any) -> Any:
     from .favicon import mount_favicon as _mount_favicon
 
@@ -75,6 +87,18 @@ def build_openrpc_spec(*args: Any, **kwargs: Any) -> Any:
     return _build_openrpc_spec(*args, **kwargs)
 
 
+def build_asyncapi_spec(*args: Any, **kwargs: Any) -> Any:
+    from .docs import build_asyncapi_spec as _build_asyncapi_spec
+
+    return _build_asyncapi_spec(*args, **kwargs)
+
+
+def build_json_schema_spec(*args: Any, **kwargs: Any) -> Any:
+    from .docs import build_json_schema_spec as _build_json_schema_spec
+
+    return _build_json_schema_spec(*args, **kwargs)
+
+
 def stop_uvicorn_server(*args: Any, **kwargs: Any) -> Any:
     from .uvicorn import stop_uvicorn_server as _stop_uvicorn_server
 
@@ -85,12 +109,16 @@ __all__ = [
     "FAVICON_PATH",
     "mount_diagnostics",
     "mount_favicon",
+    "mount_asyncapi",
+    "mount_json_schema",
     "mount_lens",
     "mount_openapi",
     "mount_openrpc",
     "mount_swagger",
     "build_favicon",
     "build_lens",
+    "build_asyncapi_spec",
+    "build_json_schema_spec",
     "build_openapi",
     "build_openrpc_spec",
     "build_swagger",

--- a/pkgs/standards/tigrbl_concrete/tigrbl_concrete/system/docs/__init__.py
+++ b/pkgs/standards/tigrbl_concrete/tigrbl_concrete/system/docs/__init__.py
@@ -51,11 +51,39 @@ def build_openrpc_spec(*args: Any, **kwargs: Any) -> Any:
     return _build_openrpc_spec(*args, **kwargs)
 
 
+def build_asyncapi_spec(*args: Any, **kwargs: Any) -> Any:
+    from .asyncapi import build_asyncapi_spec as _build_asyncapi_spec
+
+    return _build_asyncapi_spec(*args, **kwargs)
+
+
+def build_json_schema_spec(*args: Any, **kwargs: Any) -> Any:
+    from .jsonschema import build_json_schema_spec as _build_json_schema_spec
+
+    return _build_json_schema_spec(*args, **kwargs)
+
+
+def mount_asyncapi(*args: Any, **kwargs: Any) -> Any:
+    from .asyncapi import mount_asyncapi as _mount_asyncapi
+
+    return _mount_asyncapi(*args, **kwargs)
+
+
+def mount_json_schema(*args: Any, **kwargs: Any) -> Any:
+    from .jsonschema import mount_json_schema as _mount_json_schema
+
+    return _mount_json_schema(*args, **kwargs)
+
+
 __all__ = [
+    "build_asyncapi_spec",
+    "build_json_schema_spec",
     "build_lens",
     "build_openapi",
     "build_openrpc_spec",
     "build_swagger",
+    "mount_asyncapi",
+    "mount_json_schema",
     "mount_lens",
     "mount_openapi",
     "mount_openrpc",

--- a/pkgs/standards/tigrbl_concrete/tigrbl_concrete/system/docs/asyncapi.py
+++ b/pkgs/standards/tigrbl_concrete/tigrbl_concrete/system/docs/asyncapi.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from pprint import pformat
+from typing import Any, Dict
+
+from tigrbl_concrete._concrete._response import Response
+from tigrbl_concrete.system.docs.runtime_ops import register_runtime_get_route
+
+from .openrpc import (
+    _iter_models,
+    _iter_ops,
+    _is_docs_only_op,
+    _schema_with_defs,
+)
+
+JsonObject = Dict[str, Any]
+
+
+def _with_leading_slash(path: str) -> str:
+    return path if path.startswith("/") else f"/{path}"
+
+
+def build_asyncapi_spec(router: Any) -> JsonObject:
+    info_title = (
+        getattr(router, "title", None) or getattr(router, "name", None) or "API"
+    )
+    info_version = getattr(router, "version", None) or "0.1.0"
+    spec: JsonObject = {
+        "asyncapi": "3.0.0",
+        "info": {"title": f"{info_title} AsyncAPI", "version": info_version},
+        "channels": {},
+        "operations": {},
+        "components": {"schemas": {}},
+    }
+
+    channels = spec["channels"]
+    operations = spec["operations"]
+    components = spec["components"]["schemas"]
+
+    for model in _iter_models(router):
+        model_key = model.__name__
+        for op in _iter_ops(model):
+            if not getattr(op, "expose_rpc", True):
+                continue
+            if _is_docs_only_op(op):
+                continue
+
+            op_name = f"{model_key}.{op.alias}"
+            channel_name = f"{model_key}/{op.alias}"
+
+            alias_ns = getattr(getattr(model, "schemas", None), op.alias, None)
+            in_schema = getattr(alias_ns, "in_", None)
+            out_schema = getattr(alias_ns, "out", None)
+
+            request_message: JsonObject | None = None
+            if in_schema is not None:
+                in_json, defs = _schema_with_defs(in_schema)
+                components.update(defs)
+                request_message = {"payload": in_json}
+
+            reply_message: JsonObject | None = None
+            if out_schema is not None:
+                out_json, defs = _schema_with_defs(out_schema)
+                components.update(defs)
+                reply_message = {"payload": out_json}
+
+            channels[channel_name] = {"address": channel_name, "messages": {}}
+            if request_message is not None:
+                channels[channel_name]["messages"]["request"] = request_message
+            if reply_message is not None:
+                channels[channel_name]["messages"]["reply"] = reply_message
+
+            operations[op_name] = {
+                "action": "send",
+                "channel": {"$ref": f"#/channels/{channel_name}"},
+                "messages": [{"$ref": f"#/channels/{channel_name}/messages/request"}],
+            }
+
+            if reply_message is not None:
+                operations[op_name]["reply"] = {
+                    "messages": [{"$ref": f"#/channels/{channel_name}/messages/reply"}]
+                }
+
+    return spec
+
+
+def mount_asyncapi(
+    router: Any,
+    *,
+    path: str = "/asyncapi.json",
+    name: str = "asyncapi_json",
+) -> Any:
+    """Mount an AsyncAPI-styled documentation endpoint onto ``router``."""
+
+    normalized_path = _with_leading_slash(path)
+    setattr(router, "asyncapi_path", normalized_path)
+
+    def _asyncapi_handler(_request: Any) -> Response:
+        spec = build_asyncapi_spec(router)
+        return Response.text(pformat(spec, indent=4, width=1, sort_dicts=False))
+
+    register_runtime_get_route(
+        router,
+        path=normalized_path,
+        alias=name,
+        endpoint=_asyncapi_handler,
+    )
+
+    router.add_route(
+        normalized_path,
+        _asyncapi_handler,
+        methods=["GET"],
+        name=name,
+        include_in_schema=False,
+    )
+    return router
+
+
+__all__ = ["build_asyncapi_spec", "mount_asyncapi"]

--- a/pkgs/standards/tigrbl_concrete/tigrbl_concrete/system/docs/jsonschema.py
+++ b/pkgs/standards/tigrbl_concrete/tigrbl_concrete/system/docs/jsonschema.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from pprint import pformat
+from typing import Any, Dict
+
+from pydantic import BaseModel
+
+from tigrbl_concrete._concrete._response import Response
+from tigrbl_concrete.system.docs.runtime_ops import register_runtime_get_route
+
+from .openrpc import _iter_models
+
+JsonObject = Dict[str, Any]
+
+
+def _with_leading_slash(path: str) -> str:
+    return path if path.startswith("/") else f"/{path}"
+
+
+def _model_schema(model: type) -> JsonObject:
+    if issubclass(model, BaseModel):
+        return model.model_json_schema()
+    return {"title": model.__name__, "type": "object"}
+
+
+def build_json_schema_spec(router: Any) -> JsonObject:
+    schemas: JsonObject = {}
+    for model in _iter_models(router):
+        schemas[model.__name__] = _model_schema(model)
+
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": getattr(router, "title", None)
+        or getattr(router, "name", None)
+        or "API",
+        "type": "object",
+        "properties": schemas,
+        "additionalProperties": False,
+    }
+
+
+def mount_json_schema(
+    router: Any,
+    *,
+    path: str = "/json-schema.json",
+    name: str = "json_schema",
+) -> Any:
+    """Mount a JSON Schema-styled documentation endpoint onto ``router``."""
+
+    normalized_path = _with_leading_slash(path)
+    setattr(router, "json_schema_path", normalized_path)
+
+    def _json_schema_handler(_request: Any) -> Response:
+        spec = build_json_schema_spec(router)
+        return Response.text(pformat(spec, indent=4, width=1, sort_dicts=False))
+
+    register_runtime_get_route(
+        router,
+        path=normalized_path,
+        alias=name,
+        endpoint=_json_schema_handler,
+    )
+
+    router.add_route(
+        normalized_path,
+        _json_schema_handler,
+        methods=["GET"],
+        name=name,
+        include_in_schema=False,
+    )
+    return router
+
+
+__all__ = ["build_json_schema_spec", "mount_json_schema"]

--- a/pkgs/standards/tigrbl_concrete/tigrbl_concrete/system/docs/openrpc.py
+++ b/pkgs/standards/tigrbl_concrete/tigrbl_concrete/system/docs/openrpc.py
@@ -138,12 +138,22 @@ def _iter_ops(model: type) -> Sequence[OpSpec]:
 
 def _is_docs_only_op(op: OpSpec) -> bool:
     alias = str(getattr(op, "alias", "")).lower()
-    if any(token in alias for token in ("docs", "lens", "openapi", "openrpc")):
+    if any(
+        token in alias
+        for token in ("docs", "lens", "openapi", "openrpc", "asyncapi", "json_schema")
+    ):
         return True
 
     for binding in tuple(getattr(op, "bindings", ()) or ()):
         path = str(getattr(binding, "path", "") or "").lower()
-        if path in {"/docs", "/lens", "/openapi.json", "/openrpc.json"}:
+        if path in {
+            "/docs",
+            "/lens",
+            "/openapi.json",
+            "/openrpc.json",
+            "/asyncapi.json",
+            "/json-schema.json",
+        }:
             return True
 
     return False

--- a/pkgs/standards/tigrbl_tests/tests/unit/test_jsonrpc_openrpc.py
+++ b/pkgs/standards/tigrbl_tests/tests/unit/test_jsonrpc_openrpc.py
@@ -133,6 +133,8 @@ def test_default_system_docs_endpoints_are_present_and_gettable() -> None:
         lens = client.get("/lens")
         openapi = client.get("/openapi.json")
         openrpc = client.get("/openrpc.json")
+        asyncapi = client.get("/asyncapi.json")
+        json_schema = client.get("/json-schema.json")
 
     assert docs.status_code == 200
     assert "text/html" in docs.headers.get("content-type", "")
@@ -148,13 +150,30 @@ def test_default_system_docs_endpoints_are_present_and_gettable() -> None:
     assert openrpc.status_code == 200
     assert openrpc.json()["openrpc"] == "1.2.6"
 
+    assert asyncapi.status_code == 200
+    assert "text/plain" in asyncapi.headers.get("content-type", "")
+    assert "'asyncapi': '3.0.0'" in asyncapi.text
+
+    assert json_schema.status_code == 200
+    assert "text/plain" in json_schema.headers.get("content-type", "")
+    assert (
+        "'$schema': 'https://json-schema.org/draft/2020-12/schema'" in json_schema.text
+    )
+
 
 def test_docs_lens_openapi_openrpc_are_rest_get_only_and_not_rpc_methods() -> None:
     app, _ = _build_app()
     transport = ASGITransport(app=app)
 
     route_map = {route.path: route for route in app.routes}
-    for path in ("/docs", "/lens", "/openapi.json", "/openrpc.json"):
+    for path in (
+        "/docs",
+        "/lens",
+        "/openapi.json",
+        "/openrpc.json",
+        "/asyncapi.json",
+        "/json-schema.json",
+    ):
         assert path in route_map
         assert set(route_map[path].methods or []) == {"GET"}
 
@@ -166,13 +185,32 @@ def test_docs_lens_openapi_openrpc_are_rest_get_only_and_not_rpc_methods() -> No
         assert client.post("/lens").status_code in {404, 405}
         assert client.post("/openapi.json").status_code in {404, 405}
         assert client.post("/openrpc.json").status_code in {404, 405}
+        assert client.post("/asyncapi.json").status_code in {404, 405}
+        assert client.post("/json-schema.json").status_code in {404, 405}
 
         method_names = {
             method["name"] for method in client.get("/openrpc.json").json()["methods"]
         }
 
-    for forbidden in ("docs", "lens", "openapi", "openrpc"):
+    for forbidden in ("docs", "lens", "openapi", "openrpc", "asyncapi", "json_schema"):
         assert all(forbidden not in name.lower() for name in method_names)
+
+
+def test_asyncapi_and_json_schema_are_pretty_printed() -> None:
+    app, _ = _build_app()
+    transport = ASGITransport(app=app)
+
+    with Client(transport=transport, base_url="http://test") as client:
+        asyncapi = client.get("/asyncapi.json")
+        json_schema = client.get("/json-schema.json")
+
+    assert asyncapi.status_code == 200
+    assert "\n    'info': {" in asyncapi.text
+    assert "'title':" in asyncapi.text
+
+    assert json_schema.status_code == 200
+    assert "\n    'properties': {" in json_schema.text
+    assert "'Widget': {" in json_schema.text
 
 
 def test_openrpc_server_url_respects_router_mount_jsonrpc_prefix_argument():

--- a/pkgs/standards/tigrbl_tests/tests/unit/test_system_docs_builders.py
+++ b/pkgs/standards/tigrbl_tests/tests/unit/test_system_docs_builders.py
@@ -1,7 +1,14 @@
 import pytest
 
 from tigrbl import TigrblApp
-from tigrbl.system import build_lens, build_openapi, build_openrpc_spec, build_swagger
+from tigrbl.system import (
+    build_asyncapi_spec,
+    build_json_schema_spec,
+    build_lens,
+    build_openapi,
+    build_openrpc_spec,
+    build_swagger,
+)
 
 
 from tigrbl import Request
@@ -16,11 +23,15 @@ def test_system_build_helpers_return_documents() -> None:
 
     openapi_doc = build_openapi(app)
     openrpc_doc = build_openrpc_spec(app)
+    asyncapi_doc = build_asyncapi_spec(app)
+    json_schema_doc = build_json_schema_spec(app)
     swagger_html = build_swagger(app, request)
     lens_html = build_lens(app, request, spec_path="/openrpc.json")
 
     assert openapi_doc["openapi"].startswith("3.")
     assert openrpc_doc["openrpc"] == "1.2.6"
+    assert asyncapi_doc["asyncapi"] == "3.0.0"
+    assert json_schema_doc["$schema"].startswith("https://json-schema.org/")
     assert openrpc_doc["servers"] == [{"name": app.title, "url": "/rpc"}]
     assert "swagger-ui" in swagger_html
     assert "tigrbl-lens" in lens_html


### PR DESCRIPTION
### Motivation
- Provide additional system documentation formats (AsyncAPI and JSON Schema) alongside existing OpenAPI/OpenRPC tooling so services can expose messaging and schema artifacts.

### Description
- Added `asyncapi.py` and `jsonschema.py` under `system/docs` to build and mount AsyncAPI-styled and JSON Schema-styled documentation endpoints, including runtime GET handlers and pretty-printed responses.
- Exposed new helpers in `system` and `system/docs` (`mount_asyncapi`, `mount_json_schema`, `build_asyncapi_spec`, `build_json_schema_spec`) and exported them via `__all__`.
- Extended `TigrblApp` and `TigrblRouter` with `mount_asyncapi`, `mount_json_schema`, `asyncapi`, and `json_schema` methods and wired default mounting when `mount_system` is enabled.
- Updated OpenRPC docs builder to ignore ops and paths related to the new async/json-schema docs so they are not listed as RPC methods.
- Added unit tests asserting the presence, content and pretty-printing of the new endpoints and builder helpers.

### Testing
- Ran unit tests with `pytest` covering `tests/unit/test_jsonrpc_openrpc.py` and `tests/unit/test_system_docs_builders.py` which verify endpoint availability, methods, payload contents, and builder outputs; these tests passed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4f4a7e5308326925b88e8f415992e)