### PR TITLE
docs(swarmauri): expand README with public operator surfaces, extension surface, and authoring guide

### DIFF
--- a/pkgs/swarmauri/README.md
+++ b/pkgs/swarmauri/README.md
@@ -30,6 +30,27 @@ in `interface_registry.py`, then mapped to plugin modules via
 `plugin_citizenship_registry.py`. For a deeper look at the import flow, see
 [`docs/callflow.md`](docs/callflow.md).
 
+## Public Operator Surfaces
+
+Swarmauri exposes three stable operator-facing surfaces:
+
+1. **Namespace imports (`swarmauri.<kind>`)**  
+   The primary runtime surface is the namespace import path. Importing concrete
+   operators through the `swarmauri` namespace triggers the microkernel
+   importer and resolves to the installed implementation.
+
+2. **Registry contracts (`interface_registry.py`)**  
+   The interface registry defines the accepted interface path for each resource
+   kind. This is the canonical public contract that implementations must satisfy.
+
+3. **Citizenship mappings (`plugin_citizenship_registry.py`)**  
+   Citizenship maps each public interface path to a concrete plugin module that
+   can be loaded. This is the public compatibility surface used to connect
+   interface contracts to implementations.
+
+Together these surfaces allow operators to use stable import paths while
+implementations evolve independently.
+
 ## Core 
 - **Core Interfaces**: Define the fundamental communication and data-sharing protocols between components in a Swarmauri-based system.
 
@@ -59,6 +80,48 @@ in `interface_registry.py`, then mapped to plugin modules via
 - **Third-Party Integrations**: Extend the system's capabilities by easily incorporating third-party tools, libraries, and services.
 - **Prototype and Experimentation**: Test cutting-edge ideas using the experimental components in the SDK, while retaining the reliability of core and standard features for production systems.
 
+## Extension Surface
+
+Swarmauri is designed to be extended by adding new resource kinds or new
+implementations for existing kinds.
+
+For extension work:
+
+- Add or update the interface contract in
+  [`swarmauri/interface_registry.py`](swarmauri/interface_registry.py).
+- Register the concrete implementation in
+  [`swarmauri/plugin_citizenship_registry.py`](swarmauri/plugin_citizenship_registry.py).
+- Ensure the implementation module can be imported and instantiated directly
+  through its public class API.
+- Validate import resolution against the call flow documented in
+  [`docs/callflow.md`](docs/callflow.md).
+
+This extension surface keeps the microkernel small while allowing packages,
+plugins, and standards modules to participate in the same runtime model.
+
+## Authoring Guide
+
+When authoring new Swarmauri components:
+
+1. **Define the interface first**  
+   Start from the interface contract and ensure your class adheres to the
+   expected methods and typing.
+
+2. **Implement concrete behavior in your package**  
+   Keep domain logic in the implementation package and keep the namespace
+   microkernel declarations focused on discovery and routing.
+
+3. **Register the implementation**  
+   Add citizenship entries so the namespace importer can resolve your class.
+
+4. **Instantiate plugins directly in usage examples**  
+   Prefer direct class imports/instantiation in examples and integrations unless
+   a manager abstraction is explicitly required.
+
+5. **Document expected workflow**  
+   Include installation, minimal usage, and extension notes so users can adopt
+   and extend the component safely.
+
 # Future Development
 
 The Swarmauri SDK is an evolving platform, and the community is encouraged to contribute to its growth. Upcoming releases will focus on enhancing the framework's modularity, providing more advanced serialization methods, and expanding the community-driven component library.
@@ -77,9 +140,6 @@ The Swarmauri SDK is an evolving platform, and the community is encouraged to co
 When introducing a new resource kind or class, remember to update both the
 `plugin_citizenship_registry.py` and `interface_registry.py` so the framework can
 discover and validate your additions.
-
-### Plugin Manager
-- [plugin_manager.py](swarmauri/plugin_manager.py): Oversees the loading, initialization, and management of plugins to extend the functionality of the Swarmauri framework.
 
 ## Contributing
 


### PR DESCRIPTION
### Motivation

- Clarify the runtime and extension model of the `swarmauri` namespace microkernel so operators and implementers can reliably discover and register implementations.
- Provide explicit guidance for extending the SDK and authoring components to reduce onboarding friction and avoid misuse of namespace imports.
- Remove a stale `plugin_manager` reference from the modules overview to keep the overview accurate.

### Description

- Add a `Public Operator Surfaces` section that documents the three stable operator-facing surfaces: namespace imports, the `interface_registry.py` contract, and the `plugin_citizenship_registry.py` mapping.
- Add an `Extension Surface` section with step-by-step instructions to add interfaces and register implementations via `swarmauri/interface_registry.py` and `swarmauri/plugin_citizenship_registry.py`.
- Add an `Authoring Guide` that lists recommended authoring steps and best practices for creating and documenting new `swarmauri` components.
- Update the `Modules Overview` to remove the `plugin_manager.py` entry and adjust wording and links throughout the README for clarity.

### Testing

- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4c740d1e88326a85a7032dc1ec84c)