### PR TITLE
docs: use light-theme PNG branding across Swarmauri package READMEs

### DIFF
--- a/pkgs/base/README.md
+++ b/pkgs/base/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri-base/">

--- a/pkgs/community/swarmauri_billing_adyen/README.md
+++ b/pkgs/community/swarmauri_billing_adyen/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_billing_adyen/">

--- a/pkgs/community/swarmauri_billing_authorize_net/README.md
+++ b/pkgs/community/swarmauri_billing_authorize_net/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_billing_authorize_net/">

--- a/pkgs/community/swarmauri_billing_braintree/README.md
+++ b/pkgs/community/swarmauri_billing_braintree/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_billing_braintree/">

--- a/pkgs/community/swarmauri_billing_paypal/README.md
+++ b/pkgs/community/swarmauri_billing_paypal/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_billing_paypal/">

--- a/pkgs/community/swarmauri_billing_paystack/README.md
+++ b/pkgs/community/swarmauri_billing_paystack/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_billing_paystack/">

--- a/pkgs/community/swarmauri_billing_razorpay/README.md
+++ b/pkgs/community/swarmauri_billing_razorpay/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_billing_razorpay/">

--- a/pkgs/community/swarmauri_billing_square/README.md
+++ b/pkgs/community/swarmauri_billing_square/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_billing_square/">

--- a/pkgs/community/swarmauri_certs_acme/README.md
+++ b/pkgs/community/swarmauri_certs_acme/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_certs_acme/">

--- a/pkgs/community/swarmauri_certs_azure/README.md
+++ b/pkgs/community/swarmauri_certs_azure/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_certs_azure/">

--- a/pkgs/community/swarmauri_certs_cfssl/README.md
+++ b/pkgs/community/swarmauri_certs_cfssl/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_certs_cfssl/">

--- a/pkgs/community/swarmauri_certs_crlverifyservice/README.md
+++ b/pkgs/community/swarmauri_certs_crlverifyservice/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_certs_crlverifyservice/">

--- a/pkgs/community/swarmauri_certs_csronly/README.md
+++ b/pkgs/community/swarmauri_certs_csronly/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_certs_csronly/">

--- a/pkgs/community/swarmauri_certs_ocspverify/README.md
+++ b/pkgs/community/swarmauri_certs_ocspverify/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_certs_ocspverify/">

--- a/pkgs/community/swarmauri_certservice_aws_kms/README.md
+++ b/pkgs/community/swarmauri_certservice_aws_kms/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_certservice_aws_kms/">

--- a/pkgs/community/swarmauri_certservice_gcpkms/README.md
+++ b/pkgs/community/swarmauri_certservice_gcpkms/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_certservice_gcpkms/">

--- a/pkgs/community/swarmauri_certservice_ms_adcs/README.md
+++ b/pkgs/community/swarmauri_certservice_ms_adcs/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_certservice_ms_adcs/">

--- a/pkgs/community/swarmauri_certservice_scep/README.md
+++ b/pkgs/community/swarmauri_certservice_scep/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_certservice_scep/">

--- a/pkgs/community/swarmauri_certservice_stepca/README.md
+++ b/pkgs/community/swarmauri_certservice_stepca/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_certservice_stepca/">

--- a/pkgs/community/swarmauri_embedding_mlm/README.md
+++ b/pkgs/community/swarmauri_embedding_mlm/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_embedding_mlm/">

--- a/pkgs/community/swarmauri_keyprovider_aws_kms/README.md
+++ b/pkgs/community/swarmauri_keyprovider_aws_kms/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_keyprovider_aws_kms/">

--- a/pkgs/community/swarmauri_keyprovider_gcpkms/README.md
+++ b/pkgs/community/swarmauri_keyprovider_gcpkms/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_keyprovider_gcpkms/">

--- a/pkgs/community/swarmauri_keyprovider_vaulttransit/README.md
+++ b/pkgs/community/swarmauri_keyprovider_vaulttransit/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_keyprovider_vaulttransit/">

--- a/pkgs/community/swarmauri_llm_ai21/README.md
+++ b/pkgs/community/swarmauri_llm_ai21/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_llm_ai21/">

--- a/pkgs/community/swarmauri_llm_anthropic/README.md
+++ b/pkgs/community/swarmauri_llm_anthropic/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_llm_anthropic/">

--- a/pkgs/community/swarmauri_llm_cerebras/README.md
+++ b/pkgs/community/swarmauri_llm_cerebras/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_llm_cerebras/">

--- a/pkgs/community/swarmauri_llm_cohere/README.md
+++ b/pkgs/community/swarmauri_llm_cohere/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_llm_cohere/">

--- a/pkgs/community/swarmauri_llm_deepinfra/README.md
+++ b/pkgs/community/swarmauri_llm_deepinfra/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_llm_deepinfra/">

--- a/pkgs/community/swarmauri_llm_deepseek/README.md
+++ b/pkgs/community/swarmauri_llm_deepseek/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_llm_deepseek/">

--- a/pkgs/community/swarmauri_llm_falai/README.md
+++ b/pkgs/community/swarmauri_llm_falai/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_llm_falai/">

--- a/pkgs/community/swarmauri_llm_gemini/README.md
+++ b/pkgs/community/swarmauri_llm_gemini/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_llm_gemini/">

--- a/pkgs/community/swarmauri_llm_groq/README.md
+++ b/pkgs/community/swarmauri_llm_groq/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_llm_groq/">

--- a/pkgs/community/swarmauri_llm_hyperbolic/README.md
+++ b/pkgs/community/swarmauri_llm_hyperbolic/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_llm_hyperbolic/">

--- a/pkgs/community/swarmauri_llm_leptonai/README.md
+++ b/pkgs/community/swarmauri_llm_leptonai/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_llm_leptonai/">

--- a/pkgs/community/swarmauri_llm_llamacpp/README.md
+++ b/pkgs/community/swarmauri_llm_llamacpp/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_llm_llamacpp/">

--- a/pkgs/community/swarmauri_llm_mistral/README.md
+++ b/pkgs/community/swarmauri_llm_mistral/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_llm_mistral/">

--- a/pkgs/community/swarmauri_llm_openai/README.md
+++ b/pkgs/community/swarmauri_llm_openai/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_llm_openai/">

--- a/pkgs/community/swarmauri_llm_perplexity/README.md
+++ b/pkgs/community/swarmauri_llm_perplexity/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_llm_perplexity/">

--- a/pkgs/community/swarmauri_llm_playht/README.md
+++ b/pkgs/community/swarmauri_llm_playht/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_llm_playht/">

--- a/pkgs/community/swarmauri_llm_whisper/README.md
+++ b/pkgs/community/swarmauri_llm_whisper/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_llm_whisper/">

--- a/pkgs/community/swarmauri_matrix_hamming74/README.md
+++ b/pkgs/community/swarmauri_matrix_hamming74/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_matrix_hamming74/">

--- a/pkgs/community/swarmauri_measurement_mutualinformation/README.md
+++ b/pkgs/community/swarmauri_measurement_mutualinformation/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_measurement_mutualinformation/">

--- a/pkgs/community/swarmauri_measurement_tokencountestimator/README.md
+++ b/pkgs/community/swarmauri_measurement_tokencountestimator/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_measurement_tokencountestimator/">

--- a/pkgs/community/swarmauri_metric_hamming/README.md
+++ b/pkgs/community/swarmauri_metric_hamming/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_metric_hamming/">

--- a/pkgs/community/swarmauri_middleware_circuitbreaker/README.md
+++ b/pkgs/community/swarmauri_middleware_circuitbreaker/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_middleware_circuitbreaker/">

--- a/pkgs/community/swarmauri_middleware_ratepolicy/README.md
+++ b/pkgs/community/swarmauri_middleware_ratepolicy/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_middleware_ratepolicy/">

--- a/pkgs/community/swarmauri_ocr_pytesseract/README.md
+++ b/pkgs/community/swarmauri_ocr_pytesseract/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_ocr_pytesseract/">

--- a/pkgs/community/swarmauri_parser_bertembedding/README.md
+++ b/pkgs/community/swarmauri_parser_bertembedding/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_parser_bertembedding/">

--- a/pkgs/community/swarmauri_parser_entityrecognition/README.md
+++ b/pkgs/community/swarmauri_parser_entityrecognition/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_parser_entityrecognition/">

--- a/pkgs/community/swarmauri_parser_fitzpdf/README.md
+++ b/pkgs/community/swarmauri_parser_fitzpdf/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_parser_fitzpdf/">

--- a/pkgs/community/swarmauri_parser_pypdf2/README.md
+++ b/pkgs/community/swarmauri_parser_pypdf2/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_parser_pypdf2/">

--- a/pkgs/community/swarmauri_parser_pypdftk/README.md
+++ b/pkgs/community/swarmauri_parser_pypdftk/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_parser_pypdftk/">

--- a/pkgs/community/swarmauri_parser_slate/README.md
+++ b/pkgs/community/swarmauri_parser_slate/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_parser_slate/">

--- a/pkgs/community/swarmauri_parser_textblob/README.md
+++ b/pkgs/community/swarmauri_parser_textblob/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_parser_textblob/">

--- a/pkgs/community/swarmauri_signing_dsse/README.md
+++ b/pkgs/community/swarmauri_signing_dsse/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_signing_dsse/">

--- a/pkgs/community/swarmauri_state_clipboard/README.md
+++ b/pkgs/community/swarmauri_state_clipboard/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_state_clipboard/">

--- a/pkgs/community/swarmauri_tests_griffe/README.md
+++ b/pkgs/community/swarmauri_tests_griffe/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri-tests-griffe/">

--- a/pkgs/community/swarmauri_tool_captchagenerator/README.md
+++ b/pkgs/community/swarmauri_tool_captchagenerator/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_captchagenerator/">

--- a/pkgs/community/swarmauri_tool_dalechallreadability/README.md
+++ b/pkgs/community/swarmauri_tool_dalechallreadability/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_dalechallreadability/">

--- a/pkgs/community/swarmauri_tool_downloadpdf/README.md
+++ b/pkgs/community/swarmauri_tool_downloadpdf/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_downloadpdf/">

--- a/pkgs/community/swarmauri_tool_entityrecognition/README.md
+++ b/pkgs/community/swarmauri_tool_entityrecognition/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_entityrecognition/">

--- a/pkgs/community/swarmauri_tool_folium/README.md
+++ b/pkgs/community/swarmauri_tool_folium/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_folium/">

--- a/pkgs/community/swarmauri_tool_gmail/README.md
+++ b/pkgs/community/swarmauri_tool_gmail/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_gmail/">

--- a/pkgs/community/swarmauri_tool_jupyterclearoutput/README.md
+++ b/pkgs/community/swarmauri_tool_jupyterclearoutput/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupyterclearoutput/">

--- a/pkgs/community/swarmauri_tool_jupyterdisplay/README.md
+++ b/pkgs/community/swarmauri_tool_jupyterdisplay/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupyterdisplay/">

--- a/pkgs/community/swarmauri_tool_jupyterdisplayhtml/README.md
+++ b/pkgs/community/swarmauri_tool_jupyterdisplayhtml/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupyterdisplayhtml/">

--- a/pkgs/community/swarmauri_tool_jupyterexecuteandconvert/README.md
+++ b/pkgs/community/swarmauri_tool_jupyterexecuteandconvert/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupyterexecuteandconvert/">

--- a/pkgs/community/swarmauri_tool_jupyterexecutecell/README.md
+++ b/pkgs/community/swarmauri_tool_jupyterexecutecell/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupyterexecutecell/">

--- a/pkgs/community/swarmauri_tool_jupyterexecutenotebook/README.md
+++ b/pkgs/community/swarmauri_tool_jupyterexecutenotebook/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupyterexecutenotebook/">

--- a/pkgs/community/swarmauri_tool_jupyterexecutenotebookwithparameters/README.md
+++ b/pkgs/community/swarmauri_tool_jupyterexecutenotebookwithparameters/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupyterexecutenotebookwithparameters/">

--- a/pkgs/community/swarmauri_tool_jupyterexporthtml/README.md
+++ b/pkgs/community/swarmauri_tool_jupyterexporthtml/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupyterexporthtml/">

--- a/pkgs/community/swarmauri_tool_jupyterexportlatex/README.md
+++ b/pkgs/community/swarmauri_tool_jupyterexportlatex/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupyterexportlatex/">

--- a/pkgs/community/swarmauri_tool_jupyterexportmarkdown/README.md
+++ b/pkgs/community/swarmauri_tool_jupyterexportmarkdown/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupyterexportmarkdown/">

--- a/pkgs/community/swarmauri_tool_jupyterexportpython/README.md
+++ b/pkgs/community/swarmauri_tool_jupyterexportpython/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupyterexportpython/">

--- a/pkgs/community/swarmauri_tool_jupyterfromdict/README.md
+++ b/pkgs/community/swarmauri_tool_jupyterfromdict/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupyterfromdict/">

--- a/pkgs/community/swarmauri_tool_jupytergetiopubmessage/README.md
+++ b/pkgs/community/swarmauri_tool_jupytergetiopubmessage/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupytergetiopubmessage/">

--- a/pkgs/community/swarmauri_tool_jupytergetshellmessage/README.md
+++ b/pkgs/community/swarmauri_tool_jupytergetshellmessage/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupytergetshellmessage/">

--- a/pkgs/community/swarmauri_tool_jupyterreadnotebook/README.md
+++ b/pkgs/community/swarmauri_tool_jupyterreadnotebook/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupyterreadnotebook/">

--- a/pkgs/community/swarmauri_tool_jupyterruncell/README.md
+++ b/pkgs/community/swarmauri_tool_jupyterruncell/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupyterruncell/">

--- a/pkgs/community/swarmauri_tool_jupytershutdownkernel/README.md
+++ b/pkgs/community/swarmauri_tool_jupytershutdownkernel/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupytershutdownkernel/">

--- a/pkgs/community/swarmauri_tool_jupyterstartkernel/README.md
+++ b/pkgs/community/swarmauri_tool_jupyterstartkernel/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupyterstartkernel/">

--- a/pkgs/community/swarmauri_tool_jupytervalidatenotebook/README.md
+++ b/pkgs/community/swarmauri_tool_jupytervalidatenotebook/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupytervalidatenotebook/">

--- a/pkgs/community/swarmauri_tool_jupyterwritenotebook/README.md
+++ b/pkgs/community/swarmauri_tool_jupyterwritenotebook/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_jupyterwritenotebook/">

--- a/pkgs/community/swarmauri_tool_lexicaldensity/README.md
+++ b/pkgs/community/swarmauri_tool_lexicaldensity/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_lexicaldensity/">

--- a/pkgs/community/swarmauri_tool_psutil/README.md
+++ b/pkgs/community/swarmauri_tool_psutil/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_psutil/">

--- a/pkgs/community/swarmauri_tool_qrcodegenerator/README.md
+++ b/pkgs/community/swarmauri_tool_qrcodegenerator/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_qrcodegenerator/">

--- a/pkgs/community/swarmauri_tool_searchword/README.md
+++ b/pkgs/community/swarmauri_tool_searchword/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_searchword/">

--- a/pkgs/community/swarmauri_tool_sentencecomplexity/README.md
+++ b/pkgs/community/swarmauri_tool_sentencecomplexity/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_sentencecomplexity/">

--- a/pkgs/community/swarmauri_tool_sentimentanalysis/README.md
+++ b/pkgs/community/swarmauri_tool_sentimentanalysis/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_sentimentanalysis/">

--- a/pkgs/community/swarmauri_tool_smogindex/README.md
+++ b/pkgs/community/swarmauri_tool_smogindex/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_smogindex/">

--- a/pkgs/community/swarmauri_tool_textlength/README.md
+++ b/pkgs/community/swarmauri_tool_textlength/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_textlength/">

--- a/pkgs/community/swarmauri_tool_webscraping/README.md
+++ b/pkgs/community/swarmauri_tool_webscraping/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_webscraping/">

--- a/pkgs/community/swarmauri_tool_zapierhook/README.md
+++ b/pkgs/community/swarmauri_tool_zapierhook/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_zapierhook/">

--- a/pkgs/community/swarmauri_toolkit_github/README.md
+++ b/pkgs/community/swarmauri_toolkit_github/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_toolkit_github/">

--- a/pkgs/community/swarmauri_toolkit_jupytertoolkit/README.md
+++ b/pkgs/community/swarmauri_toolkit_jupytertoolkit/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_toolkit_jupytertoolkit/">

--- a/pkgs/community/swarmauri_vectorstore_annoy/README.md
+++ b/pkgs/community/swarmauri_vectorstore_annoy/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_vectorstore_annoy/">

--- a/pkgs/community/swarmauri_vectorstore_cloudweaviate/README.md
+++ b/pkgs/community/swarmauri_vectorstore_cloudweaviate/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_vectorstore_cloudweaviate/">

--- a/pkgs/community/swarmauri_vectorstore_duckdb/README.md
+++ b/pkgs/community/swarmauri_vectorstore_duckdb/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_vectorstore_duckdb/">

--- a/pkgs/community/swarmauri_vectorstore_mlm/README.md
+++ b/pkgs/community/swarmauri_vectorstore_mlm/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_vectorstore_mlm/">

--- a/pkgs/community/swarmauri_vectorstore_neo4j/README.md
+++ b/pkgs/community/swarmauri_vectorstore_neo4j/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_vectorstore_neo4j/">

--- a/pkgs/community/swarmauri_vectorstore_persistentchromadb/README.md
+++ b/pkgs/community/swarmauri_vectorstore_persistentchromadb/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_vectorstore_persistentchromadb/">

--- a/pkgs/community/swarmauri_vectorstore_pinecone/README.md
+++ b/pkgs/community/swarmauri_vectorstore_pinecone/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_vectorstore_pinecone/">

--- a/pkgs/community/swarmauri_vectorstore_qdrant/README.md
+++ b/pkgs/community/swarmauri_vectorstore_qdrant/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_vectorstore_qdrant/">

--- a/pkgs/community/swarmauri_vectorstore_redis/README.md
+++ b/pkgs/community/swarmauri_vectorstore_redis/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_vectorstore_redis/">

--- a/pkgs/community/swm_example_community_package/README.md
+++ b/pkgs/community/swm_example_community_package/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swm_example_community_package/">

--- a/pkgs/core/README.md
+++ b/pkgs/core/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
 

--- a/pkgs/deprecated/swarmauri_documentstore_redis/README.md
+++ b/pkgs/deprecated/swarmauri_documentstore_redis/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_documentstore_redis/">

--- a/pkgs/deprecated/swarmauri_embedding_tfidf/README.md
+++ b/pkgs/deprecated/swarmauri_embedding_tfidf/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_embedding_tfidf/">

--- a/pkgs/deprecated/swarmauri_experimental/README.md
+++ b/pkgs/deprecated/swarmauri_experimental/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri-experimental/">

--- a/pkgs/deprecated/swarmauri_vectorstore_tfidf/README.md
+++ b/pkgs/deprecated/swarmauri_vectorstore_tfidf/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_vectorstore_tfidf/">

--- a/pkgs/experimental/6w/README.md
+++ b/pkgs/experimental/6w/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/sf/">

--- a/pkgs/experimental/6x/README.md
+++ b/pkgs/experimental/6x/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/sf/">

--- a/pkgs/experimental/6y/README.md
+++ b/pkgs/experimental/6y/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/sf/">

--- a/pkgs/experimental/6z/README.md
+++ b/pkgs/experimental/6z/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/sf/">

--- a/pkgs/experimental/77/README.md
+++ b/pkgs/experimental/77/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/sf/">

--- a/pkgs/experimental/9x/README.md
+++ b/pkgs/experimental/9x/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/sf/">

--- a/pkgs/experimental/FastTokenizer/README.md
+++ b/pkgs/experimental/FastTokenizer/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/FastTokenizer/">

--- a/pkgs/experimental/catoml/README.md
+++ b/pkgs/experimental/catoml/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/catoml/">

--- a/pkgs/experimental/cayaml/README.md
+++ b/pkgs/experimental/cayaml/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/cayaml/">

--- a/pkgs/experimental/g9/README.md
+++ b/pkgs/experimental/g9/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/sf/">

--- a/pkgs/experimental/jaml/README.md
+++ b/pkgs/experimental/jaml/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/jaml/">

--- a/pkgs/experimental/jz/README.md
+++ b/pkgs/experimental/jz/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/sf/">

--- a/pkgs/experimental/layout_engine/README.md
+++ b/pkgs/experimental/layout_engine/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/layout-engine/">

--- a/pkgs/experimental/layout_engine_atoms/README.md
+++ b/pkgs/experimental/layout_engine_atoms/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/layout-engine-atoms/">

--- a/pkgs/experimental/ptree_dag_extension_example/README.md
+++ b/pkgs/experimental/ptree_dag_extension_example/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/ptree_dag_extension_example/">

--- a/pkgs/experimental/s_f/README.md
+++ b/pkgs/experimental/s_f/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/sf/">

--- a/pkgs/experimental/sfw/README.md
+++ b/pkgs/experimental/sfw/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/sf/">

--- a/pkgs/experimental/snt/README.md
+++ b/pkgs/experimental/snt/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/sf/">

--- a/pkgs/experimental/swarmauri_canon_http/README.md
+++ b/pkgs/experimental/swarmauri_canon_http/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri-canon-http/">

--- a/pkgs/experimental/swarmauri_certs_pkcs11/README.md
+++ b/pkgs/experimental/swarmauri_certs_pkcs11/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 
 <p align="center">

--- a/pkgs/experimental/swarmauri_crypto_sodium/README.md
+++ b/pkgs/experimental/swarmauri_crypto_sodium/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_crypto_sodium/">

--- a/pkgs/experimental/swarmauri_keyprovider_pkcs11/README.md
+++ b/pkgs/experimental/swarmauri_keyprovider_pkcs11/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 
 <p align="center">

--- a/pkgs/experimental/swarmauri_tests_loc_tersity/README.md
+++ b/pkgs/experimental/swarmauri_tests_loc_tersity/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tests_loc_tersity/">

--- a/pkgs/experimental/swarmauri_tests_pylicense/README.md
+++ b/pkgs/experimental/swarmauri_tests_pylicense/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tests_pylicense/">

--- a/pkgs/experimental/swarmauri_tests_readme_examples/README.md
+++ b/pkgs/experimental/swarmauri_tests_readme_examples/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tests_readme_examples/">

--- a/pkgs/experimental/swarmauri_workflow_statedriven/README.md
+++ b/pkgs/experimental/swarmauri_workflow_statedriven/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_workflow_statedriven/">

--- a/pkgs/experimental/ye/README.md
+++ b/pkgs/experimental/ye/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/sf/">

--- a/pkgs/experimental/ymls/README.md
+++ b/pkgs/experimental/ymls/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/sf/">

--- a/pkgs/experimental/zr0/README.md
+++ b/pkgs/experimental/zr0/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/sf/">

--- a/pkgs/plugins/EmbedXMP/README.md
+++ b/pkgs/plugins/EmbedXMP/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg" alt="Swarmauri logotype" width="420" />
+  <img src="https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png" alt="Swarmauri logotype" width="420" />
 </p>
 
 <h1 align="center">EmbedXMP</h1>

--- a/pkgs/plugins/embedded_signer/README.md
+++ b/pkgs/plugins/embedded_signer/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="../../../assets/swarmauri.brand.theme.svg" alt="Swarmauri logotype" width="420" />
+  <img src="../../../assets/swarmauri_brand_frag_light.png" alt="Swarmauri logotype" width="420" />
 </p>
 
 <h1 align="center">EmbeddedSigner</h1>

--- a/pkgs/plugins/example_plugin/README.md
+++ b/pkgs/plugins/example_plugin/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg" alt="Swarmauri logotype" width="420" />
+  <img src="https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png" alt="Swarmauri logotype" width="420" />
 </p>
 
 <h1 align="center">Swarmauri Example Plugin</h1>

--- a/pkgs/plugins/media_signer/README.md
+++ b/pkgs/plugins/media_signer/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="../../../assets/swarmauri.brand.theme.svg" alt="Swarmauri logotype" width="420" />
+  <img src="../../../assets/swarmauri_brand_frag_light.png" alt="Swarmauri logotype" width="420" />
 </p>
 
 <h1 align="center">MediaSigner</h1>

--- a/pkgs/plugins/wcag_pdf_pytest/README.md
+++ b/pkgs/plugins/wcag_pdf_pytest/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/wcag-pdf-pytest/">

--- a/pkgs/plugins/zdx/README.md
+++ b/pkgs/plugins/zdx/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 
 <p align="center">

--- a/pkgs/standards/peagen_templset_vue/README.md
+++ b/pkgs/standards/peagen_templset_vue/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/peagen_templset_vue/">

--- a/pkgs/standards/swamauri_metric_wasserstein/README.md
+++ b/pkgs/standards/swamauri_metric_wasserstein/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swamauri_metric_wasserstein/">

--- a/pkgs/standards/swarmauri_auth_idp_apple/README.md
+++ b/pkgs/standards/swarmauri_auth_idp_apple/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_auth_idp_apple/">

--- a/pkgs/standards/swarmauri_auth_idp_aws/README.md
+++ b/pkgs/standards/swarmauri_auth_idp_aws/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_auth_idp_aws/">

--- a/pkgs/standards/swarmauri_auth_idp_azure/README.md
+++ b/pkgs/standards/swarmauri_auth_idp_azure/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_auth_idp_azure/">

--- a/pkgs/standards/swarmauri_auth_idp_cognito/README.md
+++ b/pkgs/standards/swarmauri_auth_idp_cognito/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_auth_idp_cognito/">

--- a/pkgs/standards/swarmauri_auth_idp_facebook/README.md
+++ b/pkgs/standards/swarmauri_auth_idp_facebook/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_auth_idp_facebook/">

--- a/pkgs/standards/swarmauri_auth_idp_gitea/README.md
+++ b/pkgs/standards/swarmauri_auth_idp_gitea/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_auth_idp_gitea/">

--- a/pkgs/standards/swarmauri_auth_idp_github/README.md
+++ b/pkgs/standards/swarmauri_auth_idp_github/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_auth_idp_github/">

--- a/pkgs/standards/swarmauri_auth_idp_gitlab/README.md
+++ b/pkgs/standards/swarmauri_auth_idp_gitlab/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_auth_idp_gitlab/">

--- a/pkgs/standards/swarmauri_auth_idp_google/README.md
+++ b/pkgs/standards/swarmauri_auth_idp_google/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_auth_idp_google/">

--- a/pkgs/standards/swarmauri_auth_idp_keycloak/README.md
+++ b/pkgs/standards/swarmauri_auth_idp_keycloak/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_auth_idp_keycloak/">

--- a/pkgs/standards/swarmauri_auth_idp_okta/README.md
+++ b/pkgs/standards/swarmauri_auth_idp_okta/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_auth_idp_okta/">

--- a/pkgs/standards/swarmauri_auth_idp_salesforce/README.md
+++ b/pkgs/standards/swarmauri_auth_idp_salesforce/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_auth_idp_salesforce/">

--- a/pkgs/standards/swarmauri_billing_mock/README.md
+++ b/pkgs/standards/swarmauri_billing_mock/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_billing_mock/">

--- a/pkgs/standards/swarmauri_billing_stripe/README.md
+++ b/pkgs/standards/swarmauri_billing_stripe/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_billing_stripe/">

--- a/pkgs/standards/swarmauri_certs_composite/README.md
+++ b/pkgs/standards/swarmauri_certs_composite/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_certs_composite/">

--- a/pkgs/standards/swarmauri_certs_local_ca/README.md
+++ b/pkgs/standards/swarmauri_certs_local_ca/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 
 <p align="center">

--- a/pkgs/standards/swarmauri_certs_remote_ca/README.md
+++ b/pkgs/standards/swarmauri_certs_remote_ca/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 
 <p align="center">

--- a/pkgs/standards/swarmauri_certs_self_signed/README.md
+++ b/pkgs/standards/swarmauri_certs_self_signed/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 
 <p align="center">

--- a/pkgs/standards/swarmauri_certs_x509/README.md
+++ b/pkgs/standards/swarmauri_certs_x509/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_certs_x509/">

--- a/pkgs/standards/swarmauri_certs_x509verify/README.md
+++ b/pkgs/standards/swarmauri_certs_x509verify/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 
 <p align="center">

--- a/pkgs/standards/swarmauri_cipher_suite_cades/README.md
+++ b/pkgs/standards/swarmauri_cipher_suite_cades/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_cipher_suite_cades/">

--- a/pkgs/standards/swarmauri_cipher_suite_cnsa20/README.md
+++ b/pkgs/standards/swarmauri_cipher_suite_cnsa20/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_cipher_suite_cnsa20/">

--- a/pkgs/standards/swarmauri_cipher_suite_cose/README.md
+++ b/pkgs/standards/swarmauri_cipher_suite_cose/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_cipher_suite_cose/">

--- a/pkgs/standards/swarmauri_cipher_suite_fips1403/README.md
+++ b/pkgs/standards/swarmauri_cipher_suite_fips1403/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_cipher_suite_fips1403/">

--- a/pkgs/standards/swarmauri_cipher_suite_fips203/README.md
+++ b/pkgs/standards/swarmauri_cipher_suite_fips203/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_cipher_suite_fips203/">

--- a/pkgs/standards/swarmauri_cipher_suite_fips204/README.md
+++ b/pkgs/standards/swarmauri_cipher_suite_fips204/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_cipher_suite_fips204/">

--- a/pkgs/standards/swarmauri_cipher_suite_fips205/README.md
+++ b/pkgs/standards/swarmauri_cipher_suite_fips205/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_cipher_suite_fips205/">

--- a/pkgs/standards/swarmauri_cipher_suite_ipsec/README.md
+++ b/pkgs/standards/swarmauri_cipher_suite_ipsec/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_cipher_suite_ipsec/">

--- a/pkgs/standards/swarmauri_cipher_suite_jwa/README.md
+++ b/pkgs/standards/swarmauri_cipher_suite_jwa/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_cipher_suite_jwa/">

--- a/pkgs/standards/swarmauri_cipher_suite_pades/README.md
+++ b/pkgs/standards/swarmauri_cipher_suite_pades/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_cipher_suite_pades/">

--- a/pkgs/standards/swarmauri_cipher_suite_pep458/README.md
+++ b/pkgs/standards/swarmauri_cipher_suite_pep458/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Brand Theme](https://github.com/swarmauri/swarmauri-sdk/blob/main/assets/swarmauri.brand.theme.svg)
+![Swarmauri Brand Theme](https://github.com/swarmauri/swarmauri-sdk/blob/main/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_cipher_suite_pep458/">

--- a/pkgs/standards/swarmauri_cipher_suite_sigstore/README.md
+++ b/pkgs/standards/swarmauri_cipher_suite_sigstore/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_cipher_suite_sigstore/">

--- a/pkgs/standards/swarmauri_cipher_suite_ssh/README.md
+++ b/pkgs/standards/swarmauri_cipher_suite_ssh/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_cipher_suite_ssh/">

--- a/pkgs/standards/swarmauri_cipher_suite_tls13/README.md
+++ b/pkgs/standards/swarmauri_cipher_suite_tls13/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_cipher_suite_tls13/">

--- a/pkgs/standards/swarmauri_cipher_suite_webauthn/README.md
+++ b/pkgs/standards/swarmauri_cipher_suite_webauthn/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_cipher_suite_webauthn/">

--- a/pkgs/standards/swarmauri_cipher_suite_xades/README.md
+++ b/pkgs/standards/swarmauri_cipher_suite_xades/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_cipher_suite_xades/">

--- a/pkgs/standards/swarmauri_cipher_suite_yubikey/README.md
+++ b/pkgs/standards/swarmauri_cipher_suite_yubikey/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_cipher_suite_yubikey/">

--- a/pkgs/standards/swarmauri_cipher_suite_yubikey_fips/README.md
+++ b/pkgs/standards/swarmauri_cipher_suite_yubikey_fips/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/master/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_cipher_suite_yubikey_fips/">

--- a/pkgs/standards/swarmauri_crypto_composite/README.md
+++ b/pkgs/standards/swarmauri_crypto_composite/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_crypto_composite/">

--- a/pkgs/standards/swarmauri_crypto_ecdh_es_a128kw/README.md
+++ b/pkgs/standards/swarmauri_crypto_ecdh_es_a128kw/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_crypto_ecdh_es_a128kw/">

--- a/pkgs/standards/swarmauri_crypto_jwe/README.md
+++ b/pkgs/standards/swarmauri_crypto_jwe/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_crypto_jwe/"><img src="https://img.shields.io/pypi/dm/swarmauri_crypto_jwe" alt="PyPI - Downloads"/></a>

--- a/pkgs/standards/swarmauri_crypto_nacl_pkcs11/README.md
+++ b/pkgs/standards/swarmauri_crypto_nacl_pkcs11/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_crypto_nacl_pkcs11/">

--- a/pkgs/standards/swarmauri_crypto_paramiko/README.md
+++ b/pkgs/standards/swarmauri_crypto_paramiko/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_crypto_paramiko/">

--- a/pkgs/standards/swarmauri_crypto_pgp/README.md
+++ b/pkgs/standards/swarmauri_crypto_pgp/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_crypto_pgp/">

--- a/pkgs/standards/swarmauri_crypto_rust/README.md
+++ b/pkgs/standards/swarmauri_crypto_rust/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_crypto_rust/">

--- a/pkgs/standards/swarmauri_distance_minkowski/README.md
+++ b/pkgs/standards/swarmauri_distance_minkowski/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_distance_minkowski/">

--- a/pkgs/standards/swarmauri_embedding_doc2vec/README.md
+++ b/pkgs/standards/swarmauri_embedding_doc2vec/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_embedding_doc2vec/">

--- a/pkgs/standards/swarmauri_embedding_nmf/README.md
+++ b/pkgs/standards/swarmauri_embedding_nmf/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_embedding_nmf/">

--- a/pkgs/standards/swarmauri_evaluator_abstractmethods/README.md
+++ b/pkgs/standards/swarmauri_evaluator_abstractmethods/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_evaluator_abstractmethods/">

--- a/pkgs/standards/swarmauri_evaluator_anyusage/README.md
+++ b/pkgs/standards/swarmauri_evaluator_anyusage/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_evaluator_anyusage/">

--- a/pkgs/standards/swarmauri_evaluator_constanttime/README.md
+++ b/pkgs/standards/swarmauri_evaluator_constanttime/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_evaluator_constanttime/">

--- a/pkgs/standards/swarmauri_evaluator_externalimports/README.md
+++ b/pkgs/standards/swarmauri_evaluator_externalimports/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_evaluator_externalimports/">

--- a/pkgs/standards/swarmauri_evaluator_subprocess/README.md
+++ b/pkgs/standards/swarmauri_evaluator_subprocess/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_evaluator_subprocess/">

--- a/pkgs/standards/swarmauri_evaluatorpool_accessibility/README.md
+++ b/pkgs/standards/swarmauri_evaluatorpool_accessibility/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_evaluatorpool_accessibility/">

--- a/pkgs/standards/swarmauri_gitfilter_file/README.md
+++ b/pkgs/standards/swarmauri_gitfilter_file/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_gitfilter_file/">

--- a/pkgs/standards/swarmauri_gitfilter_gh_release/README.md
+++ b/pkgs/standards/swarmauri_gitfilter_gh_release/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_gitfilter_gh_release/">

--- a/pkgs/standards/swarmauri_gitfilter_minio/README.md
+++ b/pkgs/standards/swarmauri_gitfilter_minio/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_gitfilter_minio/">

--- a/pkgs/standards/swarmauri_gitfilter_s3fs/README.md
+++ b/pkgs/standards/swarmauri_gitfilter_s3fs/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_gitfilter_s3fs/">

--- a/pkgs/standards/swarmauri_keyprovider_file/README.md
+++ b/pkgs/standards/swarmauri_keyprovider_file/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 
 <p align="center">

--- a/pkgs/standards/swarmauri_keyprovider_hierarchical/README.md
+++ b/pkgs/standards/swarmauri_keyprovider_hierarchical/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 
 <p align="center">

--- a/pkgs/standards/swarmauri_keyprovider_inmemory/README.md
+++ b/pkgs/standards/swarmauri_keyprovider_inmemory/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 
 <p align="center">

--- a/pkgs/standards/swarmauri_keyprovider_local/README.md
+++ b/pkgs/standards/swarmauri_keyprovider_local/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_keyprovider_local/"><img src="https://img.shields.io/pypi/dm/swarmauri_keyprovider_local" alt="PyPI - Downloads"/></a>

--- a/pkgs/standards/swarmauri_keyprovider_remote_jwks/README.md
+++ b/pkgs/standards/swarmauri_keyprovider_remote_jwks/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 
 <p align="center">

--- a/pkgs/standards/swarmauri_keyprovider_ssh/README.md
+++ b/pkgs/standards/swarmauri_keyprovider_ssh/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_keyprovider_ssh/"><img src="https://img.shields.io/pypi/dm/swarmauri_keyprovider_ssh" alt="PyPI - Downloads"/></a>

--- a/pkgs/standards/swarmauri_keyproviders_mirrored/README.md
+++ b/pkgs/standards/swarmauri_keyproviders_mirrored/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 
 <p align="center">

--- a/pkgs/standards/swarmauri_middleware_auth/README.md
+++ b/pkgs/standards/swarmauri_middleware_auth/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_middleware_auth/">

--- a/pkgs/standards/swarmauri_middleware_bulkhead/README.md
+++ b/pkgs/standards/swarmauri_middleware_bulkhead/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_middleware_bulkhead/">

--- a/pkgs/standards/swarmauri_middleware_cachecontrol/README.md
+++ b/pkgs/standards/swarmauri_middleware_cachecontrol/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_middleware_cachecontrol/">

--- a/pkgs/standards/swarmauri_middleware_cors/README.md
+++ b/pkgs/standards/swarmauri_middleware_cors/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_middleware_cors/">

--- a/pkgs/standards/swarmauri_middleware_exceptionhandling/README.md
+++ b/pkgs/standards/swarmauri_middleware_exceptionhandling/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_middleware_exceptionhandling/">

--- a/pkgs/standards/swarmauri_middleware_gzipcompression/README.md
+++ b/pkgs/standards/swarmauri_middleware_gzipcompression/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri-middleware-gzipcompression/">

--- a/pkgs/standards/swarmauri_middleware_httpsig/README.md
+++ b/pkgs/standards/swarmauri_middleware_httpsig/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_middleware_httpsig/">

--- a/pkgs/standards/swarmauri_middleware_jsonrpc/README.md
+++ b/pkgs/standards/swarmauri_middleware_jsonrpc/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_middleware_jsonrpc/">

--- a/pkgs/standards/swarmauri_middleware_jwksverifier/README.md
+++ b/pkgs/standards/swarmauri_middleware_jwksverifier/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 
 <p align="center">

--- a/pkgs/standards/swarmauri_middleware_jwt/README.md
+++ b/pkgs/standards/swarmauri_middleware_jwt/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_middleware_jwt/">

--- a/pkgs/standards/swarmauri_middleware_llamaguard/README.md
+++ b/pkgs/standards/swarmauri_middleware_llamaguard/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_middleware_llamaguard/">

--- a/pkgs/standards/swarmauri_middleware_logging/README.md
+++ b/pkgs/standards/swarmauri_middleware_logging/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_middleware_logging/">

--- a/pkgs/standards/swarmauri_middleware_ratelimit/README.md
+++ b/pkgs/standards/swarmauri_middleware_ratelimit/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_middleware_ratelimit/">

--- a/pkgs/standards/swarmauri_middleware_securityheaders/README.md
+++ b/pkgs/standards/swarmauri_middleware_securityheaders/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri-middleware-securityheaders/">

--- a/pkgs/standards/swarmauri_middleware_session/README.md
+++ b/pkgs/standards/swarmauri_middleware_session/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_middleware_session/">

--- a/pkgs/standards/swarmauri_middleware_stdio/README.md
+++ b/pkgs/standards/swarmauri_middleware_stdio/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_middleware_stdio/">

--- a/pkgs/standards/swarmauri_middleware_time/README.md
+++ b/pkgs/standards/swarmauri_middleware_time/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_middleware_time/">

--- a/pkgs/standards/swarmauri_mre_crypto_age/README.md
+++ b/pkgs/standards/swarmauri_mre_crypto_age/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_mre_crypto_age/">

--- a/pkgs/standards/swarmauri_mre_crypto_ecdh_es_kw/README.md
+++ b/pkgs/standards/swarmauri_mre_crypto_ecdh_es_kw/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_mre_crypto_ecdh_es_kw/">

--- a/pkgs/standards/swarmauri_mre_crypto_keyring/README.md
+++ b/pkgs/standards/swarmauri_mre_crypto_keyring/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 
 <p align="center">

--- a/pkgs/standards/swarmauri_mre_crypto_pgp/README.md
+++ b/pkgs/standards/swarmauri_mre_crypto_pgp/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_mre_crypto_pgp/">

--- a/pkgs/standards/swarmauri_mre_crypto_shamir/README.md
+++ b/pkgs/standards/swarmauri_mre_crypto_shamir/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_mre_crypto_shamir/">

--- a/pkgs/standards/swarmauri_parser_beautifulsoupelement/README.md
+++ b/pkgs/standards/swarmauri_parser_beautifulsoupelement/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_parser_beautifulsoupelement/">

--- a/pkgs/standards/swarmauri_parser_keywordextractor/README.md
+++ b/pkgs/standards/swarmauri_parser_keywordextractor/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_parser_keywordextractor/">

--- a/pkgs/standards/swarmauri_pop_cwt/README.md
+++ b/pkgs/standards/swarmauri_pop_cwt/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_pop_cwt/">

--- a/pkgs/standards/swarmauri_pop_dpop/README.md
+++ b/pkgs/standards/swarmauri_pop_dpop/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_pop_dpop/">

--- a/pkgs/standards/swarmauri_pop_x509/README.md
+++ b/pkgs/standards/swarmauri_pop_x509/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_pop_x509/">

--- a/pkgs/standards/swarmauri_prompt_j2prompttemplate/README.md
+++ b/pkgs/standards/swarmauri_prompt_j2prompttemplate/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_prompt_j2prompttemplate/">

--- a/pkgs/standards/swarmauri_publisher_rabbitmq/README.md
+++ b/pkgs/standards/swarmauri_publisher_rabbitmq/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_publisher_rabbitmq/">

--- a/pkgs/standards/swarmauri_publisher_redis/README.md
+++ b/pkgs/standards/swarmauri_publisher_redis/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_publisher_redis/">

--- a/pkgs/standards/swarmauri_publisher_webhook/README.md
+++ b/pkgs/standards/swarmauri_publisher_webhook/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_publisher_webhook/">

--- a/pkgs/standards/swarmauri_signing_ca/README.md
+++ b/pkgs/standards/swarmauri_signing_ca/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 
 <p align="center">

--- a/pkgs/standards/swarmauri_signing_cms/README.md
+++ b/pkgs/standards/swarmauri_signing_cms/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-    <img src="https://raw.githubusercontent.com/swarmauri/swarmauri-sdk/master/assets/swarmauri.brand.theme.svg" alt="Swarmauri Signing CMS" width="320" />
+    <img src="https://raw.githubusercontent.com/swarmauri/swarmauri-sdk/master/assets/swarmauri_brand_frag_light.png" alt="Swarmauri Signing CMS" width="320" />
 </p>
 
 <p align="center">

--- a/pkgs/standards/swarmauri_signing_dpop/README.md
+++ b/pkgs/standards/swarmauri_signing_dpop/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_signing_dpop/">

--- a/pkgs/standards/swarmauri_signing_ecdsa/README.md
+++ b/pkgs/standards/swarmauri_signing_ecdsa/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 
 <p align="center">

--- a/pkgs/standards/swarmauri_signing_ed25519/README.md
+++ b/pkgs/standards/swarmauri_signing_ed25519/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 
 <p align="center">

--- a/pkgs/standards/swarmauri_signing_hmac/README.md
+++ b/pkgs/standards/swarmauri_signing_hmac/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_signing_hmac/">

--- a/pkgs/standards/swarmauri_signing_jws/README.md
+++ b/pkgs/standards/swarmauri_signing_jws/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 
 <p align="center">

--- a/pkgs/standards/swarmauri_signing_openpgp/README.md
+++ b/pkgs/standards/swarmauri_signing_openpgp/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-    <img src="https://raw.githubusercontent.com/swarmauri/swarmauri-sdk/master/assets/swarmauri.brand.theme.svg" alt="Swarmauri Signing OpenPGP" width="320" />
+    <img src="https://raw.githubusercontent.com/swarmauri/swarmauri-sdk/master/assets/swarmauri_brand_frag_light.png" alt="Swarmauri Signing OpenPGP" width="320" />
 </p>
 
 <p align="center">

--- a/pkgs/standards/swarmauri_signing_pdf/README.md
+++ b/pkgs/standards/swarmauri_signing_pdf/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-    <img src="https://raw.githubusercontent.com/swarmauri/swarmauri-sdk/master/assets/swarmauri.brand.theme.svg" alt="Swarmauri Signing PDF" width="320" />
+    <img src="https://raw.githubusercontent.com/swarmauri/swarmauri-sdk/master/assets/swarmauri_brand_frag_light.png" alt="Swarmauri Signing PDF" width="320" />
 </p>
 
 <p align="center">

--- a/pkgs/standards/swarmauri_signing_pep458/README.md
+++ b/pkgs/standards/swarmauri_signing_pep458/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Brand Theme](https://github.com/swarmauri/swarmauri-sdk/blob/main/assets/swarmauri.brand.theme.svg)
+![Swarmauri Brand Theme](https://github.com/swarmauri/swarmauri-sdk/blob/main/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_signing_pep458/">

--- a/pkgs/standards/swarmauri_signing_pgp/README.md
+++ b/pkgs/standards/swarmauri_signing_pgp/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_signing_pgp/">

--- a/pkgs/standards/swarmauri_signing_rsa/README.md
+++ b/pkgs/standards/swarmauri_signing_rsa/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 
 <p align="center">

--- a/pkgs/standards/swarmauri_signing_secp256k1/README.md
+++ b/pkgs/standards/swarmauri_signing_secp256k1/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 
 <p align="center">

--- a/pkgs/standards/swarmauri_signing_sigv4/README.md
+++ b/pkgs/standards/swarmauri_signing_sigv4/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_signing_sigv4/">

--- a/pkgs/standards/swarmauri_signing_ssh/README.md
+++ b/pkgs/standards/swarmauri_signing_ssh/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_signing_ssh/">

--- a/pkgs/standards/swarmauri_signing_xmld/README.md
+++ b/pkgs/standards/swarmauri_signing_xmld/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="../../../assets/swarmauri.brand.theme.svg" alt="Swarmauri logotype" width="420" />
+  <img src="../../../assets/swarmauri_brand_frag_light.png" alt="Swarmauri logotype" width="420" />
 </p>
 
 <h1 align="center">swarmauri_signing_xmld</h1>

--- a/pkgs/standards/swarmauri_storage_file/README.md
+++ b/pkgs/standards/swarmauri_storage_file/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_storage_file/">

--- a/pkgs/standards/swarmauri_storage_github/README.md
+++ b/pkgs/standards/swarmauri_storage_github/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_storage_github/">

--- a/pkgs/standards/swarmauri_storage_github_release/README.md
+++ b/pkgs/standards/swarmauri_storage_github_release/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_storage_github_release/">

--- a/pkgs/standards/swarmauri_storage_memory/README.md
+++ b/pkgs/standards/swarmauri_storage_memory/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_storage_memory/">

--- a/pkgs/standards/swarmauri_storage_minio/README.md
+++ b/pkgs/standards/swarmauri_storage_minio/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_storage_minio/">

--- a/pkgs/standards/swarmauri_tokens_composite/README.md
+++ b/pkgs/standards/swarmauri_tokens_composite/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tokens_composite/">

--- a/pkgs/standards/swarmauri_tokens_dpopboundjwt/README.md
+++ b/pkgs/standards/swarmauri_tokens_dpopboundjwt/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 
 <p align="center">

--- a/pkgs/standards/swarmauri_tokens_introspection/README.md
+++ b/pkgs/standards/swarmauri_tokens_introspection/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tokens_introspection/">

--- a/pkgs/standards/swarmauri_tokens_jwt/README.md
+++ b/pkgs/standards/swarmauri_tokens_jwt/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tokens_jwt/">

--- a/pkgs/standards/swarmauri_tokens_paseto_v4/README.md
+++ b/pkgs/standards/swarmauri_tokens_paseto_v4/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 
 <p align="center">

--- a/pkgs/standards/swarmauri_tokens_remoteoidc/README.md
+++ b/pkgs/standards/swarmauri_tokens_remoteoidc/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tokens_remoteoidc/">

--- a/pkgs/standards/swarmauri_tokens_rotatingjwt/README.md
+++ b/pkgs/standards/swarmauri_tokens_rotatingjwt/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tokens_rotatingjwt/">

--- a/pkgs/standards/swarmauri_tokens_sshcert/README.md
+++ b/pkgs/standards/swarmauri_tokens_sshcert/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tokens_sshcert/">

--- a/pkgs/standards/swarmauri_tokens_sshsig/README.md
+++ b/pkgs/standards/swarmauri_tokens_sshsig/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tokens_sshsig/">

--- a/pkgs/standards/swarmauri_tokens_tlsboundjwt/README.md
+++ b/pkgs/standards/swarmauri_tokens_tlsboundjwt/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 
 <p align="center">

--- a/pkgs/standards/swarmauri_tool_containerfeedchars/README.md
+++ b/pkgs/standards/swarmauri_tool_containerfeedchars/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_containerfeedchars/">

--- a/pkgs/standards/swarmauri_tool_containermakepr/README.md
+++ b/pkgs/standards/swarmauri_tool_containermakepr/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_containermakepr/">

--- a/pkgs/standards/swarmauri_tool_containernewsession/README.md
+++ b/pkgs/standards/swarmauri_tool_containernewsession/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_containernewsession/">

--- a/pkgs/standards/swarmauri_tool_githubloader/README.md
+++ b/pkgs/standards/swarmauri_tool_githubloader/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_githubloader/">

--- a/pkgs/standards/swarmauri_tool_httploaded/README.md
+++ b/pkgs/standards/swarmauri_tool_httploaded/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_httploaded/">

--- a/pkgs/standards/swarmauri_tool_matplotlib/README.md
+++ b/pkgs/standards/swarmauri_tool_matplotlib/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_tool_matplotlib/">

--- a/pkgs/standards/swarmauri_toolkit_containertoolkit/README.md
+++ b/pkgs/standards/swarmauri_toolkit_containertoolkit/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_toolkit_containertoolkit/">

--- a/pkgs/standards/swarmauri_transport_asgi/README.md
+++ b/pkgs/standards/swarmauri_transport_asgi/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri-transport-asgi/">

--- a/pkgs/standards/swarmauri_transport_h2/README.md
+++ b/pkgs/standards/swarmauri_transport_h2/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri-transport-h2/">

--- a/pkgs/standards/swarmauri_transport_h2mux/README.md
+++ b/pkgs/standards/swarmauri_transport_h2mux/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri-transport-h2mux/">

--- a/pkgs/standards/swarmauri_transport_meshsidecarhttp2/README.md
+++ b/pkgs/standards/swarmauri_transport_meshsidecarhttp2/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri-transport-meshsidecarhttp2/">

--- a/pkgs/standards/swarmauri_transport_mtlsunicast/README.md
+++ b/pkgs/standards/swarmauri_transport_mtlsunicast/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri-transport-mtlsunicast/">

--- a/pkgs/standards/swarmauri_transport_sseoutbound/README.md
+++ b/pkgs/standards/swarmauri_transport_sseoutbound/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri-transport-sseoutbound/">

--- a/pkgs/standards/swarmauri_transport_sshtunnel/README.md
+++ b/pkgs/standards/swarmauri_transport_sshtunnel/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri-transport-sshtunnel/">

--- a/pkgs/standards/swarmauri_transport_stdio/README.md
+++ b/pkgs/standards/swarmauri_transport_stdio/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri-transport-stdio/">

--- a/pkgs/standards/swarmauri_transport_tcpunicast/README.md
+++ b/pkgs/standards/swarmauri_transport_tcpunicast/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri-transport-tcpunicast/">

--- a/pkgs/standards/swarmauri_transport_wsjsonrpcmux/README.md
+++ b/pkgs/standards/swarmauri_transport_wsjsonrpcmux/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri-transport-wsjsonrpcmux/">

--- a/pkgs/standards/swarmauri_vectorstore_doc2vec/README.md
+++ b/pkgs/standards/swarmauri_vectorstore_doc2vec/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri_vectorstore_doc2vec/">

--- a/pkgs/standards/swarmauri_xmp_gif/README.md
+++ b/pkgs/standards/swarmauri_xmp_gif/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 
 <p align="center">

--- a/pkgs/standards/swarmauri_xmp_jpeg/README.md
+++ b/pkgs/standards/swarmauri_xmp_jpeg/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 
 <p align="center">

--- a/pkgs/standards/swarmauri_xmp_mp4/README.md
+++ b/pkgs/standards/swarmauri_xmp_mp4/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 
 <p align="center">

--- a/pkgs/standards/swarmauri_xmp_pdf/README.md
+++ b/pkgs/standards/swarmauri_xmp_pdf/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 
 <p align="center">

--- a/pkgs/standards/swarmauri_xmp_png/README.md
+++ b/pkgs/standards/swarmauri_xmp_png/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 
 <p align="center">

--- a/pkgs/standards/swarmauri_xmp_svg/README.md
+++ b/pkgs/standards/swarmauri_xmp_svg/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 
 <p align="center">

--- a/pkgs/standards/swarmauri_xmp_tiff/README.md
+++ b/pkgs/standards/swarmauri_xmp_tiff/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 
 <p align="center">

--- a/pkgs/standards/swarmauri_xmp_webp/README.md
+++ b/pkgs/standards/swarmauri_xmp_webp/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 
 <p align="center">

--- a/pkgs/standards/swm_example_package/README.md
+++ b/pkgs/standards/swm_example_package/README.md
@@ -1,5 +1,5 @@
 
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swm-example-package/">

--- a/pkgs/swarmauri/README.md
+++ b/pkgs/swarmauri/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri/">

--- a/pkgs/swarmauri_standard/README.md
+++ b/pkgs/swarmauri_standard/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri-standard/">

--- a/pkgs/swarmauri_standard/swarmauri_standard/README.md
+++ b/pkgs/swarmauri_standard/swarmauri_standard/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri-standard/">

--- a/pkgs/typing/README.md
+++ b/pkgs/typing/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri_brand_frag_light.png)
 
 <p align="center">
     <a href="https://pypi.org/project/swarmauri-typing/">


### PR DESCRIPTION
### Motivation
- Tigrbl READMEs mostly use raster PNG logos while Swarmauri READMEs referenced the SVG theme, causing inconsistent branding across packages. 
- Standardize Swarmauri READMEs to prefer the light-theme PNG for light-themed displays and simpler rendering.

### Description
- Replaced occurrences of `swarmauri.brand.theme.svg` with `swarmauri_brand_frag_light.png` in README files under `pkgs/` (string-only, documentation changes). 
- Applied replacements for both absolute GitHub URLs and relative HTML `<img>` references so both markdown and embedded images now use the light PNG. 
- Change set affects 305 README files and contains no code, dependency, or runtime behavior changes. 

### Testing
- Used `rg` to locate matches before and after the change and confirmed `rg -n "swarmauri\.brand\.theme\.svg" pkgs -g 'README.md'` returned no matches after the replacement. 
- Performed the replacement via `sed -i 's/swarmauri.brand.theme.svg/swarmauri_brand_frag_light.png/g'` and re-checked with `rg` to validate the update. 
- No `pytest` or `peagen` runs were performed because this is a documentation-only change and per instructions those tools were not requested.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4fb5d852083269cce875719daa76e)