### PR TITLE
Ignore temporary .tmp artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ node_modules/
 *.zip
 .pymon
 /.tmp_pydeps
+/.tmp/
+.tmp*


### PR DESCRIPTION
### Motivation
- Prevent ephemeral spec scratch files and the top-level `.tmp/` directory from being accidentally committed by adding ignore rules for `/.tmp/` and files matching `.tmp*`.

### Description
- Updated `.gitignore` to add `/.tmp/` and `.tmp*`, and removed local temporary artifacts named `.tmp-spec-adr-adr.yaml`, `.tmp-spec-adr-spec.yaml`, and the `.tmp/` directory from the working tree.

### Testing
- Ran an automated cleanup script `python - <<'PY' ...` to remove the two `.tmp-spec-adr-*.yaml` files and the `.tmp/` directory, followed by `git status --short --untracked-files=all` and `git status --short`, all of which reported a clean working tree.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7180fe4b88326854195dec50d1e1f)