### PR TITLE
fix: rm peagen from workspace

### DIFF
--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -398,7 +398,6 @@ EmbedXMP = { workspace = true }
 # layout-engine = { workspace = true }
 # layout-engine-atoms = { workspace = true }
 MediaSigner = { workspace = true }
-peagen = { workspace = true }
 peagen_templset_vue = { workspace = true }
 ptree_dag_extension_example = { workspace = true }
 # QueryEngine = { workspace = true }

--- a/pkgs/standards/swarmauri_gitfilter_file/pyproject.toml
+++ b/pkgs/standards/swarmauri_gitfilter_file/pyproject.toml
@@ -35,7 +35,6 @@ keywords = [
 ]
 
 [tool.uv.sources]
-peagen = { workspace = true }
 swarmauri_core = { workspace = true }
 swarmauri_base = { workspace = true }
 swarmauri_standard = { workspace = true }

--- a/pkgs/standards/swarmauri_gitfilter_gh_release/pyproject.toml
+++ b/pkgs/standards/swarmauri_gitfilter_gh_release/pyproject.toml
@@ -36,7 +36,6 @@ keywords = [
 ]
 
 [tool.uv.sources]
-peagen = { workspace = true }
 swarmauri_core = { workspace = true }
 swarmauri_base = { workspace = true }
 swarmauri_standard = { workspace = true }

--- a/pkgs/standards/swarmauri_gitfilter_minio/pyproject.toml
+++ b/pkgs/standards/swarmauri_gitfilter_minio/pyproject.toml
@@ -35,7 +35,6 @@ keywords = [
 ]
 
 [tool.uv.sources]
-peagen = { workspace = true }
 swarmauri_core = { workspace = true }
 swarmauri_base = { workspace = true }
 swarmauri_standard = { workspace = true }

--- a/pkgs/standards/swarmauri_gitfilter_s3fs/pyproject.toml
+++ b/pkgs/standards/swarmauri_gitfilter_s3fs/pyproject.toml
@@ -35,7 +35,6 @@ keywords = [
 ]
 
 [tool.uv.sources]
-peagen = { workspace = true }
 swarmauri_core = { workspace = true }
 swarmauri_base = { workspace = true }
 swarmauri_standard = { workspace = true }


### PR DESCRIPTION
## Summary
<!-- Provide a short description of your changes -->

## Checklist
- [ ] I ran `ruff format` and `ruff check`.
- [ ] I ran `mypy --strict` and `bandit -r src`.
- [ ] New plugins are registered under `[project.entry-points]`.
- [ ] `scripts/license_scan.py` reports no disallowed licences.
- [ ] Updated or added docstrings for all public APIs.
- [ ] Documented new plugins in `docs/plugins.md` and capability tags.
- [ ] Added a line to `CHANGELOG.md` if applicable.
