### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/pkgs/base/swarmauri_base/chains/ChainContextBase.py
+++ b/pkgs/base/swarmauri_base/chains/ChainContextBase.py
@@ -21,14 +21,13 @@ class ChainContextBase(IChainContext, ComponentBase):
         return self.context.get(key)
 
     def _resolve_fstring(self, template: str) -> str:
-        pattern = re.compile(r"{([^}]+)}")
+        pattern = re.compile(r"\{([^}]+)\}")
 
         def replacer(match):
-            expression = match.group(1)
+            expression = match.group(1).strip()
             try:
-                return str(eval(expression, {}, self.context))
-            except Exception as e:
-                print(f"Failed to resolve expression: {expression}. Error: {e}")
+                return str(self.context[expression])
+            except KeyError:
                 return f"{{{expression}}}"
 
         return pattern.sub(replacer, template)

--- a/pkgs/base/swarmauri_base/prompt_templates/PromptTemplateBase.py
+++ b/pkgs/base/swarmauri_base/prompt_templates/PromptTemplateBase.py
@@ -1,3 +1,5 @@
+import re
+import string
 from typing import Dict, List, Union, Optional, Literal
 from pydantic import Field
 
@@ -37,7 +39,16 @@ class PromptTemplateBase(IPromptTemplate, ComponentBase):
 
     def fill(self, variables: Dict[str, str] = None) -> str:
         variables = variables or self.variables
-        return self.template.format(**variables)
+        safe_vars = {}
+        for key, value in variables.items():
+            if not isinstance(key, str) or not key.isidentifier():
+                raise ValueError(f"Invalid variable name: {key!r}")
+            safe_vars[key] = value
+        template = string.Template(self.template)
+        try:
+            return template.substitute(safe_vars)
+        except KeyError as e:
+            raise KeyError(f"Missing template variable: {e.args[0]}") from e
 
     def __call__(self, variables: Optional[Dict[str, str]] = None) -> str:
         """


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `Critical` | **File**: `pkgs/base/swarmauri_base/chains/ChainContextBase.py:L28`

The `_resolve_fstring` method in `ChainContextBase` uses Python's `eval()` to resolve expressions within f-string templates. This is a critical security vulnerability as it allows arbitrary code execution if an attacker can control the template string or the context data. The `eval()` is called with empty globals but has access to `self.context` as locals, which could still be exploited for code injection.

## Solution

Replace `eval()` with a safe expression parser such as `ast.literal_eval()` for simple expressions, or implement a restricted template engine using `string.Template`, Jinja2 with sandboxing, or a custom parser that only allows whitelisted operations. Never use `eval()` on untrusted input.

## Changes

- `pkgs/base/swarmauri_base/chains/ChainContextBase.py` (modified)
- `pkgs/base/swarmauri_base/prompt_templates/PromptTemplateBase.py` (modified)