### PR TITLE
Add GetMethodSignatureTool for retrieving method signatures

### DIFF
--- a/pkgs/PACKAGE_INDEX.md
+++ b/pkgs/PACKAGE_INDEX.md
@@ -22,8 +22,8 @@ fail validation because they make composition order ambiguous.
 | `10-interfaces` | 1 | 1 | interface and protocol contracts |
 | `20-bases` | 1 | 1 | reusable base classes, mixins, and component models |
 | `30-standard-kernel` | 1 | 1 | bundled first-party standard component kernel |
-| `40-standards` | 175 | 175 | first-party split standard packages |
-| `50-community` | 106 | 106 | community and provider-specific packages |
+| `40-standards` | 181 | 181 | first-party split standard packages |
+| `50-community` | 107 | 107 | community and provider-specific packages |
 | `60-plugins` | 5 | 5 | plugin packages and plugin examples |
 | `70-experimental` | 36 | 12 | incubating and planning-stage packages |
 | `80-facades` | 1 | 1 | aggregate user-facing facade packages |
@@ -173,6 +173,10 @@ fail validation because they make composition order ambiguous.
 | `40.0` | [swarmauri_signing_sigv4](standards/swarmauri_signing_sigv4/) | `standards/swarmauri_signing_sigv4` | `signing` | `atomic-concrete` | `standard` | yes |
 | `40.0` | [swarmauri_signing_ssh](standards/swarmauri_signing_ssh/) | `standards/swarmauri_signing_ssh` | `signing` | `atomic-concrete` | `standard` | yes |
 | `40.0` | [swarmauri_signing_xmld](standards/swarmauri_signing_xmld/) | `standards/swarmauri_signing_xmld` | `signing` | `atomic-concrete` | `standard` | yes |
+| `40.0` | [swarmauri_skill_dummy_filesystem](standards/swarmauri_skill_dummy_filesystem/) | `standards/swarmauri_skill_dummy_filesystem` | `skill` | `atomic-concrete` | `standard` | yes |
+| `40.0` | [swarmauri_skill_dummy_local](standards/swarmauri_skill_dummy_local/) | `standards/swarmauri_skill_dummy_local` | `skill` | `atomic-concrete` | `standard` | yes |
+| `40.0` | [swarmauri_skill_filesystem](standards/swarmauri_skill_filesystem/) | `standards/swarmauri_skill_filesystem` | `skill` | `atomic-concrete` | `standard` | yes |
+| `40.0` | [swarmauri_skill_local](standards/swarmauri_skill_local/) | `standards/swarmauri_skill_local` | `skill` | `atomic-concrete` | `standard` | yes |
 | `40.0` | [swarmauri_storage_file](standards/swarmauri_storage_file/) | `standards/swarmauri_storage_file` | `storage` | `atomic-concrete` | `standard` | yes |
 | `40.0` | [swarmauri_storage_github](standards/swarmauri_storage_github/) | `standards/swarmauri_storage_github` | `storage` | `atomic-concrete` | `standard` | yes |
 | `40.0` | [swarmauri_storage_github_release](standards/swarmauri_storage_github_release/) | `standards/swarmauri_storage_github_release` | `storage` | `atomic-concrete` | `standard` | yes |
@@ -195,6 +199,7 @@ fail validation because they make composition order ambiguous.
 | `40.0` | [swarmauri_tool_githubloader](standards/swarmauri_tool_githubloader/) | `standards/swarmauri_tool_githubloader` | `tool` | `atomic-concrete` | `standard` | yes |
 | `40.0` | [swarmauri_tool_httploaded](standards/swarmauri_tool_httploaded/) | `standards/swarmauri_tool_httploaded` | `tool` | `atomic-concrete` | `standard` | yes |
 | `40.0` | [swarmauri_tool_matplotlib](standards/swarmauri_tool_matplotlib/) | `standards/swarmauri_tool_matplotlib` | `tool` | `atomic-concrete` | `standard` | yes |
+| `40.0` | [swarmauri_tool_skill_execution](standards/swarmauri_tool_skill_execution/) | `standards/swarmauri_tool_skill_execution` | `tool` | `atomic-concrete` | `standard` | yes |
 | `40.0` | [swarmauri_transport_asgi](standards/swarmauri_transport_asgi/) | `standards/swarmauri_transport_asgi` | `transport` | `atomic-concrete` | `standard` | yes |
 | `40.0` | [swarmauri_transport_h2](standards/swarmauri_transport_h2/) | `standards/swarmauri_transport_h2` | `transport` | `atomic-concrete` | `standard` | yes |
 | `40.0` | [swarmauri_transport_h2mux](standards/swarmauri_transport_h2mux/) | `standards/swarmauri_transport_h2mux` | `transport` | `atomic-concrete` | `standard` | yes |
@@ -217,6 +222,7 @@ fail validation because they make composition order ambiguous.
 | `40.0` | [swarmauri_xmp_svg](standards/swarmauri_xmp_svg/) | `standards/swarmauri_xmp_svg` | `xmp` | `atomic-concrete` | `standard` | yes |
 | `40.0` | [swarmauri_xmp_tiff](standards/swarmauri_xmp_tiff/) | `standards/swarmauri_xmp_tiff` | `xmp` | `atomic-concrete` | `standard` | yes |
 | `40.0` | [swarmauri_xmp_webp](standards/swarmauri_xmp_webp/) | `standards/swarmauri_xmp_webp` | `xmp` | `atomic-concrete` | `standard` | yes |
+| `40.1` | [swarmauri_agent_skill](standards/swarmauri_agent_skill/) | `standards/swarmauri_agent_skill` | `agent` | `composite-concrete` | `standard` | yes |
 | `40.1` | [swarmauri_certs_composite](standards/swarmauri_certs_composite/) | `standards/swarmauri_certs_composite` | `certs` | `composite-concrete` | `standard` | yes |
 | `40.1` | [swarmauri_certs_x509](standards/swarmauri_certs_x509/) | `standards/swarmauri_certs_x509` | `certs` | `composite-concrete` | `standard` | yes |
 | `40.1` | [swarmauri_crypto_composite](standards/swarmauri_crypto_composite/) | `standards/swarmauri_crypto_composite` | `crypto` | `composite-concrete` | `standard` | yes |
@@ -300,6 +306,7 @@ fail validation because they make composition order ambiguous.
 | `50.0` | [swarmauri_tool_downloadpdf](community/swarmauri_tool_downloadpdf/) | `community/swarmauri_tool_downloadpdf` | `tool` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_tool_entityrecognition](community/swarmauri_tool_entityrecognition/) | `community/swarmauri_tool_entityrecognition` | `tool` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_tool_folium](community/swarmauri_tool_folium/) | `community/swarmauri_tool_folium` | `tool` | `atomic-concrete` | `community` | yes |
+| `50.0` | [swarmauri_tool_getmethodsignature](community/swarmauri_tool_getmethodsignature/) | `community/swarmauri_tool_getmethodsignature` | `tool` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_tool_gmail](community/swarmauri_tool_gmail/) | `community/swarmauri_tool_gmail` | `tool` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_tool_jupyterclearoutput](community/swarmauri_tool_jupyterclearoutput/) | `community/swarmauri_tool_jupyterclearoutput` | `tool` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_tool_jupyterdisplay](community/swarmauri_tool_jupyterdisplay/) | `community/swarmauri_tool_jupyterdisplay` | `tool` | `atomic-concrete` | `community` | yes |
@@ -556,6 +563,10 @@ fail validation because they make composition order ambiguous.
 | [swarmauri_signing_sigv4](standards/swarmauri_signing_sigv4/) | `signing` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_signing_ssh](standards/swarmauri_signing_ssh/) | `signing` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_signing_xmld](standards/swarmauri_signing_xmld/) | `signing` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
+| [swarmauri_skill_dummy_filesystem](standards/swarmauri_skill_dummy_filesystem/) | `skill` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
+| [swarmauri_skill_dummy_local](standards/swarmauri_skill_dummy_local/) | `skill` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
+| [swarmauri_skill_filesystem](standards/swarmauri_skill_filesystem/) | `skill` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
+| [swarmauri_skill_local](standards/swarmauri_skill_local/) | `skill` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_storage_file](standards/swarmauri_storage_file/) | `storage` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_storage_github](standards/swarmauri_storage_github/) | `storage` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_storage_github_release](standards/swarmauri_storage_github_release/) | `storage` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
@@ -578,6 +589,7 @@ fail validation because they make composition order ambiguous.
 | [swarmauri_tool_githubloader](standards/swarmauri_tool_githubloader/) | `tool` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_tool_httploaded](standards/swarmauri_tool_httploaded/) | `tool` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_tool_matplotlib](standards/swarmauri_tool_matplotlib/) | `tool` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
+| [swarmauri_tool_skill_execution](standards/swarmauri_tool_skill_execution/) | `tool` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_transport_asgi](standards/swarmauri_transport_asgi/) | `transport` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_transport_h2](standards/swarmauri_transport_h2/) | `transport` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_transport_h2mux](standards/swarmauri_transport_h2mux/) | `transport` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
@@ -605,6 +617,7 @@ fail validation because they make composition order ambiguous.
 
 | Package | Family | Role | Source | Composes | Order reason |
 |---|---|---|---|---:|---|
+| [swarmauri_agent_skill](standards/swarmauri_agent_skill/) | `agent` | `composite-concrete` | `inferred` | 1 | raised to order 1 because it depends on same-layer package swarmauri_tool_skill_execution at 40.0 |
 | [swarmauri_certs_composite](standards/swarmauri_certs_composite/) | `certs` | `composite-concrete` | `inferred` | 0 | composite signal from metadata for swarmauri_certs_composite |
 | [swarmauri_certs_x509](standards/swarmauri_certs_x509/) | `certs` | `composite-concrete` | `inferred` | 2 | depends on 2 internal concrete packages |
 | [swarmauri_crypto_composite](standards/swarmauri_crypto_composite/) | `crypto` | `composite-concrete` | `inferred` | 0 | composite signal from metadata for swarmauri_crypto_composite |
@@ -693,6 +706,7 @@ fail validation because they make composition order ambiguous.
 | [swarmauri_tool_downloadpdf](community/swarmauri_tool_downloadpdf/) | `tool` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_tool_entityrecognition](community/swarmauri_tool_entityrecognition/) | `tool` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_tool_folium](community/swarmauri_tool_folium/) | `tool` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
+| [swarmauri_tool_getmethodsignature](community/swarmauri_tool_getmethodsignature/) | `tool` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_tool_gmail](community/swarmauri_tool_gmail/) | `tool` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_tool_jupyterclearoutput](community/swarmauri_tool_jupyterclearoutput/) | `tool` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_tool_jupyterdisplay](community/swarmauri_tool_jupyterdisplay/) | `tool` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
@@ -877,6 +891,12 @@ fail validation because they make composition order ambiguous.
 | Index | Package | Layer | Path | Role | Maturity | Workspace |
 |---|---|---|---|---|---|---|
 | `70.0` | [9x](experimental/9x/) | `70-experimental` | `experimental/9x` | `experimental-atomic` | `experimental` | no |
+
+### `agent`
+
+| Index | Package | Layer | Path | Role | Maturity | Workspace |
+|---|---|---|---|---|---|---|
+| `40.1` | [swarmauri_agent_skill](standards/swarmauri_agent_skill/) | `40-standards` | `standards/swarmauri_agent_skill` | `composite-concrete` | `standard` | yes |
 
 ### `auth_idp`
 
@@ -1339,6 +1359,15 @@ fail validation because they make composition order ambiguous.
 | `40.2` | [swarmauri_signing_dpop](standards/swarmauri_signing_dpop/) | `40-standards` | `standards/swarmauri_signing_dpop` | `orchestrator` | `standard` | yes |
 | `50.0` | [swarmauri_signing_dsse](community/swarmauri_signing_dsse/) | `50-community` | `community/swarmauri_signing_dsse` | `atomic-concrete` | `community` | yes |
 
+### `skill`
+
+| Index | Package | Layer | Path | Role | Maturity | Workspace |
+|---|---|---|---|---|---|---|
+| `40.0` | [swarmauri_skill_dummy_filesystem](standards/swarmauri_skill_dummy_filesystem/) | `40-standards` | `standards/swarmauri_skill_dummy_filesystem` | `atomic-concrete` | `standard` | yes |
+| `40.0` | [swarmauri_skill_dummy_local](standards/swarmauri_skill_dummy_local/) | `40-standards` | `standards/swarmauri_skill_dummy_local` | `atomic-concrete` | `standard` | yes |
+| `40.0` | [swarmauri_skill_filesystem](standards/swarmauri_skill_filesystem/) | `40-standards` | `standards/swarmauri_skill_filesystem` | `atomic-concrete` | `standard` | yes |
+| `40.0` | [swarmauri_skill_local](standards/swarmauri_skill_local/) | `40-standards` | `standards/swarmauri_skill_local` | `atomic-concrete` | `standard` | yes |
+
 ### `snt`
 
 | Index | Package | Layer | Path | Role | Maturity | Workspace |
@@ -1410,11 +1439,13 @@ fail validation because they make composition order ambiguous.
 | `40.0` | [swarmauri_tool_githubloader](standards/swarmauri_tool_githubloader/) | `40-standards` | `standards/swarmauri_tool_githubloader` | `atomic-concrete` | `standard` | yes |
 | `40.0` | [swarmauri_tool_httploaded](standards/swarmauri_tool_httploaded/) | `40-standards` | `standards/swarmauri_tool_httploaded` | `atomic-concrete` | `standard` | yes |
 | `40.0` | [swarmauri_tool_matplotlib](standards/swarmauri_tool_matplotlib/) | `40-standards` | `standards/swarmauri_tool_matplotlib` | `atomic-concrete` | `standard` | yes |
+| `40.0` | [swarmauri_tool_skill_execution](standards/swarmauri_tool_skill_execution/) | `40-standards` | `standards/swarmauri_tool_skill_execution` | `atomic-concrete` | `standard` | yes |
 | `50.0` | [swarmauri_tool_captchagenerator](community/swarmauri_tool_captchagenerator/) | `50-community` | `community/swarmauri_tool_captchagenerator` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_tool_dalechallreadability](community/swarmauri_tool_dalechallreadability/) | `50-community` | `community/swarmauri_tool_dalechallreadability` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_tool_downloadpdf](community/swarmauri_tool_downloadpdf/) | `50-community` | `community/swarmauri_tool_downloadpdf` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_tool_entityrecognition](community/swarmauri_tool_entityrecognition/) | `50-community` | `community/swarmauri_tool_entityrecognition` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_tool_folium](community/swarmauri_tool_folium/) | `50-community` | `community/swarmauri_tool_folium` | `atomic-concrete` | `community` | yes |
+| `50.0` | [swarmauri_tool_getmethodsignature](community/swarmauri_tool_getmethodsignature/) | `50-community` | `community/swarmauri_tool_getmethodsignature` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_tool_gmail](community/swarmauri_tool_gmail/) | `50-community` | `community/swarmauri_tool_gmail` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_tool_jupyterclearoutput](community/swarmauri_tool_jupyterclearoutput/) | `50-community` | `community/swarmauri_tool_jupyterclearoutput` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_tool_jupyterdisplay](community/swarmauri_tool_jupyterdisplay/) | `50-community` | `community/swarmauri_tool_jupyterdisplay` | `atomic-concrete` | `community` | yes |

--- a/pkgs/community/swarmauri_tool_getmethodsignature/LICENSE
+++ b/pkgs/community/swarmauri_tool_getmethodsignature/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/community/swarmauri_tool_getmethodsignature/README.md
+++ b/pkgs/community/swarmauri_tool_getmethodsignature/README.md
@@ -1,0 +1,172 @@
+![Swarmauri Logo](https://raw.githubusercontent.com/swarmauri/swarmauri-sdk/master/assets/swarmauri_sdk_brand.png)
+
+<p align="center">
+    <a href="https://pepy.tech/project/swarmauri_tool_getmethodsignature/">
+        <img src="https://static.pepy.tech/badge/swarmauri_tool_getmethodsignature/month" alt="PyPI - Downloads"/></a>
+    <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/community/swarmauri_tool_getmethodsignature/">
+        <img alt="Hits" src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/community/swarmauri_tool_getmethodsignature.svg"/></a>
+    <a href="https://pypi.org/project/swarmauri_tool_getmethodsignature/">
+        <img src="https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue" alt="PyPI - Python Version"/></a>
+    <a href="https://pypi.org/project/swarmauri_tool_getmethodsignature/">
+        <img src="https://img.shields.io/pypi/l/swarmauri_tool_getmethodsignature" alt="PyPI - License"/></a>
+    <a href="https://pypi.org/project/swarmauri_tool_getmethodsignature/">
+        <img src="https://img.shields.io/pypi/v/swarmauri_tool_getmethodsignature?label=swarmauri_tool_getmethodsignature&color=green" alt="PyPI - swarmauri_tool_getmethodsignature"/></a>
+    <a href="https://discord.gg/N4UpBuQv8T">
+        <img src="https://img.shields.io/badge/Discord-Join%20Chat-5865F2?logo=discord&logoColor=white" alt="Discord"/></a></p>
+
+# Swarmauri Tool Get Method Signature
+
+`swarmauri_tool_getmethodsignature` is a Swarmauri tool that parses Python
+source code with the standard-library `ast` module and returns the
+signature of a specified function or method, including its name,
+parameters, and return type. It is useful for documentation generation,
+refactoring assistants, agent-driven code review, and static
+introspection workflows.
+
+## Why Use Swarmauri Tool Get Method Signature
+
+- Inspect function and method signatures without importing source code.
+- Capture parameter names, annotations, and defaults in one call.
+- Detect overloaded definitions that share a single function name.
+- Distinguish synchronous functions from `async def` coroutines.
+- Reuse the same tool in agents, notebooks, scripts, and backend
+  workflows.
+
+## FAQ
+
+> **What does the tool return?**  
+> A dictionary with `name`, `parameters`, `return_type`, `signature`,
+> and `is_async`. When multiple definitions share the requested name, it
+> returns `{"overloads": [...]}` instead.
+
+> **Does the tool execute the source code?**  
+> No. It uses `ast.parse` for purely static analysis and never imports
+> or executes the supplied source.
+
+> **What happens when the function is missing?**  
+> The tool returns `{"error": "..."}` describing the failure, including
+> cases where the source cannot be parsed.
+
+> **Are parameter defaults and annotations captured?**  
+> Yes. Each parameter entry includes `name`, `annotation` (when present),
+> and `default` (when present), rendered back to source text via
+> `ast.unparse`.
+
+## Features
+
+- Swarmauri `ToolBase` implementation registered as
+  `GetMethodSignatureTool`.
+- Static `ast`-based parsing with no dynamic code execution.
+- Support for positional-only, keyword-only, `*args`, and `**kwargs`
+  parameters.
+- Detection of overloaded functions sharing a single name.
+- Renders a human-readable `signature` string for each definition.
+- Supports Python 3.10, 3.11, 3.12, 3.13, and 3.14.
+
+## Installation
+
+```bash
+uv add swarmauri_tool_getmethodsignature
+```
+
+```bash
+pip install swarmauri_tool_getmethodsignature
+```
+
+## Usage
+
+```python
+from swarmauri_tool_getmethodsignature import GetMethodSignatureTool
+
+tool = GetMethodSignatureTool()
+source = "def add(a: int, b: int = 0) -> int:\n    return a + b\n"
+result = tool(source=source, method_name="add")
+
+print(result["signature"])
+# def add(a: int, b: int = 0) -> int
+```
+
+## Examples
+
+### Inspect an async method inside a class
+
+```python
+from swarmauri_tool_getmethodsignature import GetMethodSignatureTool
+
+tool = GetMethodSignatureTool()
+source = (
+    "class Service:\n"
+    "    async def fetch(self, url: str) -> bytes:\n"
+    "        ...\n"
+)
+result = tool(source=source, method_name="fetch")
+
+print(result["is_async"])  # True
+print(result["return_type"])  # bytes
+```
+
+### Detect overloaded definitions
+
+```python
+from swarmauri_tool_getmethodsignature import GetMethodSignatureTool
+
+tool = GetMethodSignatureTool()
+source = (
+    "def process(x: int) -> int:\n"
+    "    return x\n"
+    "def process(x: str) -> str:\n"
+    "    return x\n"
+)
+result = tool(source=source, method_name="process")
+
+print(len(result["overloads"]))  # 2
+```
+
+### Register the tool inside a Swarmauri tool registry
+
+```python
+from swarmauri_standard.tools.ToolCollection import ToolCollection
+from swarmauri_tool_getmethodsignature import GetMethodSignatureTool
+
+tools = ToolCollection(tools=[GetMethodSignatureTool()])
+print(tools)
+```
+
+## Related Packages
+
+- [swarmauri_tool_searchword](https://pypi.org/project/swarmauri_tool_searchword/)
+- [swarmauri_tool_textlength](https://pypi.org/project/swarmauri_tool_textlength/)
+- [swarmauri_tool_sentencecomplexity](https://pypi.org/project/swarmauri_tool_sentencecomplexity/)
+- [swarmauri_tool_lexicaldensity](https://pypi.org/project/swarmauri_tool_lexicaldensity/)
+- [swarmauri_tool_smogindex](https://pypi.org/project/swarmauri_tool_smogindex/)
+
+## Swarmauri Foundations
+
+- [swarmauri](https://pypi.org/project/swarmauri/)
+- [swarmauri_core](https://pypi.org/project/swarmauri_core/)
+- [swarmauri_base](https://pypi.org/project/swarmauri_base/)
+- [swarmauri_standard](https://pypi.org/project/swarmauri_standard/)
+
+## More Documentation
+
+- [Python ast module](https://docs.python.org/3/library/ast.html)
+- [Swarmauri SDK repository](https://github.com/swarmauri/swarmauri-sdk)
+
+## Best Practices
+
+- Pass complete, syntactically valid Python source for best results.
+- Treat the `signature` string as a rendering hint rather than canonical
+  source; round-trip formatting depends on the Python version.
+- Use the `overloads` list when auditing code that relies on name reuse.
+- Pair this tool with documentation generators to enrich API references.
+- Avoid relying on dynamic imports; this tool performs static analysis
+  only.
+
+> **Note:** This tool performs static analysis on Python source code
+> strings via the `ast` module. For runtime inspection of
+> already-imported callables, see `MethodSignatureExtractor` in
+> `swarmauri_standard.utils.method_signature_extractor_decorator`.
+
+## License
+
+This project is licensed under the Apache-2.0 License.

--- a/pkgs/community/swarmauri_tool_getmethodsignature/README.md
+++ b/pkgs/community/swarmauri_tool_getmethodsignature/README.md
@@ -1,4 +1,4 @@
-![Swarmauri Logo](https://raw.githubusercontent.com/swarmauri/swarmauri-sdk/master/assets/swarmauri_sdk_brand.png)
+![Swarmauri Logo](https://raw.githubusercontent.com/swarmauri/swarmauri-sdk/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
 
 <p align="center">
     <a href="https://pepy.tech/project/swarmauri_tool_getmethodsignature/">

--- a/pkgs/community/swarmauri_tool_getmethodsignature/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_getmethodsignature/pyproject.toml
@@ -1,0 +1,89 @@
+[project]
+name = "swarmauri_tool_getmethodsignature"
+version = "0.11.0.dev1"
+description = "A tool that retrieves method signatures from Python source code."
+license = "Apache-2.0"
+readme = "README.md"
+repository = "http://github.com/swarmauri/swarmauri-sdk"
+requires-python = ">=3.10,<3.15"
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Education",
+    "Operating System :: OS Independent",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
+    "Topic :: Software Development :: Code Generators",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+]
+authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
+dependencies = [
+    "swarmauri_core",
+    "swarmauri_base",
+    "swarmauri_standard",
+]
+keywords = [
+    "swarmauri",
+    "tool",
+    "getmethodsignature",
+    "method signature",
+    "function signature",
+    "ast",
+    "introspection",
+    "static analysis",
+]
+
+[tool.uv.sources]
+swarmauri_core = { workspace = true }
+swarmauri_base = { workspace = true }
+swarmauri_standard = { workspace = true }
+
+[tool.pytest.ini_options]
+norecursedirs = ["combined", "scripts"]
+markers = [
+    "test: standard test",
+    "unit: Unit tests",
+    "i9n: Integration tests",
+    "r8n: Regression tests",
+    "timeout: mark test to timeout after X seconds",
+    "xpass: Expected passes",
+    "xfail: Expected failures",
+    "acceptance: Acceptance tests",
+    "perf: Performance tests that measure execution time and resource usage",
+]
+timeout = 300
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+asyncio_default_fixture_loop_scope = "function"
+
+[project.entry-points.'swarmauri.tools']
+GetMethodSignatureTool = "swarmauri_tool_getmethodsignature:GetMethodSignatureTool"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.1",
+    "pytest-json-report>=1.5.0",
+    "python-dotenv",
+    "httpx>=0.27",
+    "flake8>=7.0",
+    "pytest-timeout>=2.3.1",
+    "ruff>=0.9.9",
+    "pytest-benchmark>=4.0.0",
+]

--- a/pkgs/community/swarmauri_tool_getmethodsignature/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_getmethodsignature/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.10,<3.15"
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 1 - Planning",
     "Intended Audience :: Developers",
     "Intended Audience :: Education",
     "Operating System :: OS Independent",

--- a/pkgs/community/swarmauri_tool_getmethodsignature/swarmauri_tool_getmethodsignature/GetMethodSignatureTool.py
+++ b/pkgs/community/swarmauri_tool_getmethodsignature/swarmauri_tool_getmethodsignature/GetMethodSignatureTool.py
@@ -1,4 +1,5 @@
 import ast
+import inspect
 from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import Field
@@ -22,6 +23,7 @@ def _extract_signature(
     args = node.args
     params: List[Dict[str, Optional[str]]] = []
 
+    posonly_count = len(args.posonlyargs)
     posargs: List[ast.arg] = list(args.posonlyargs) + list(args.args)
     defaults: List[ast.expr] = list(args.defaults)
     offset = len(posargs) - len(defaults)
@@ -29,11 +31,17 @@ def _extract_signature(
         default = None
         if idx >= offset:
             default = _unparse(defaults[idx - offset])
+        kind = (
+            inspect.Parameter.POSITIONAL_ONLY.name
+            if idx < posonly_count
+            else inspect.Parameter.POSITIONAL_OR_KEYWORD.name
+        )
         params.append(
             {
                 "name": arg.arg,
                 "annotation": _unparse(arg.annotation),
                 "default": default,
+                "kind": kind,
             }
         )
 
@@ -43,6 +51,7 @@ def _extract_signature(
                 "name": args.vararg.arg,
                 "annotation": _unparse(args.vararg.annotation),
                 "default": None,
+                "kind": inspect.Parameter.VAR_POSITIONAL.name,
             }
         )
 
@@ -52,6 +61,7 @@ def _extract_signature(
                 "name": kw_arg.arg,
                 "annotation": _unparse(kw_arg.annotation),
                 "default": _unparse(kw_default),
+                "kind": inspect.Parameter.KEYWORD_ONLY.name,
             }
         )
 
@@ -61,6 +71,7 @@ def _extract_signature(
                 "name": args.kwarg.arg,
                 "annotation": _unparse(args.kwarg.annotation),
                 "default": None,
+                "kind": inspect.Parameter.VAR_KEYWORD.name,
             }
         )
 
@@ -69,7 +80,11 @@ def _extract_signature(
     args_str = ast.unparse(args)
     ret_str = f" -> {return_type}" if return_type is not None else ""
     prefix = "async def " if is_async else "def "
-    signature = f"{prefix}{node.name}({args_str}){ret_str}"
+    type_params = getattr(node, "type_params", None)
+    type_params_str = ""
+    if type_params:
+        type_params_str = "[" + ", ".join(ast.unparse(tp) for tp in type_params) + "]"
+    signature = f"{prefix}{node.name}{type_params_str}({args_str}){ret_str}"
 
     return {
         "name": node.name,

--- a/pkgs/community/swarmauri_tool_getmethodsignature/swarmauri_tool_getmethodsignature/GetMethodSignatureTool.py
+++ b/pkgs/community/swarmauri_tool_getmethodsignature/swarmauri_tool_getmethodsignature/GetMethodSignatureTool.py
@@ -1,0 +1,145 @@
+import ast
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import Field
+
+from swarmauri_base.ComponentBase import ComponentBase
+from swarmauri_base.tools.ToolBase import ToolBase
+from swarmauri_standard.tools.Parameter import Parameter
+
+
+def _unparse(node: Optional[ast.expr]) -> Optional[str]:
+    """Render an AST expression node back to source text."""
+    if node is None:
+        return None
+    return ast.unparse(node)
+
+
+def _extract_signature(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> Dict[str, Any]:
+    """Build the signature descriptor for a single function node."""
+    args = node.args
+    params: List[Dict[str, Optional[str]]] = []
+
+    posargs: List[ast.arg] = list(args.posonlyargs) + list(args.args)
+    defaults: List[ast.expr] = list(args.defaults)
+    offset = len(posargs) - len(defaults)
+    for idx, arg in enumerate(posargs):
+        default = None
+        if idx >= offset:
+            default = _unparse(defaults[idx - offset])
+        params.append(
+            {
+                "name": arg.arg,
+                "annotation": _unparse(arg.annotation),
+                "default": default,
+            }
+        )
+
+    if args.vararg is not None:
+        params.append(
+            {
+                "name": args.vararg.arg,
+                "annotation": _unparse(args.vararg.annotation),
+                "default": None,
+            }
+        )
+
+    for kw_arg, kw_default in zip(args.kwonlyargs, args.kw_defaults):
+        params.append(
+            {
+                "name": kw_arg.arg,
+                "annotation": _unparse(kw_arg.annotation),
+                "default": _unparse(kw_default),
+            }
+        )
+
+    if args.kwarg is not None:
+        params.append(
+            {
+                "name": args.kwarg.arg,
+                "annotation": _unparse(args.kwarg.annotation),
+                "default": None,
+            }
+        )
+
+    return_type = _unparse(node.returns)
+    is_async = isinstance(node, ast.AsyncFunctionDef)
+    args_str = ast.unparse(args)
+    ret_str = f" -> {return_type}" if return_type is not None else ""
+    prefix = "async def " if is_async else "def "
+    signature = f"{prefix}{node.name}({args_str}){ret_str}"
+
+    return {
+        "name": node.name,
+        "parameters": params,
+        "return_type": return_type,
+        "signature": signature,
+        "is_async": is_async,
+    }
+
+
+@ComponentBase.register_type(ToolBase, "GetMethodSignatureTool")
+class GetMethodSignatureTool(ToolBase):
+    """
+    Tool that parses Python source code and returns the signature of a
+    specified function or method (name, parameters, return type).
+    """
+
+    version: str = "0.1.dev1"
+    name: str = "GetMethodSignatureTool"
+    description: str = (
+        "Parses Python source code and returns the signature of a "
+        "specified method or function (name, parameters, return type)."
+    )
+    type: Literal["GetMethodSignatureTool"] = "GetMethodSignatureTool"
+    parameters: List[Parameter] = Field(
+        default_factory=lambda: [
+            Parameter(
+                name="source",
+                input_type="string",
+                description="Python source code to parse.",
+                required=True,
+            ),
+            Parameter(
+                name="method_name",
+                input_type="string",
+                description=("Name of the function or method to inspect."),
+                required=True,
+            ),
+        ]
+    )
+
+    def __call__(self, source: str, method_name: str) -> Dict[str, Any]:
+        """
+        Parse ``source`` and return the signature of ``method_name``.
+
+        Returns a single signature dict, an ``overloads`` list when
+        multiple definitions share the name, or an ``error`` dict.
+        """
+        try:
+            tree = ast.parse(source)
+        except SyntaxError as exc:
+            return {"error": f"Failed to parse source: {exc}"}
+
+        matches: List[ast.FunctionDef | ast.AsyncFunctionDef] = [
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and n.name == method_name
+        ]
+
+        if not matches:
+            return {
+                "error": (
+                    f"No function or method named "
+                    f"'{method_name}' found in source."
+                )
+            }
+
+        signatures = [_extract_signature(n) for n in matches]
+
+        if len(signatures) == 1:
+            return signatures[0]
+        return {"overloads": signatures}

--- a/pkgs/community/swarmauri_tool_getmethodsignature/swarmauri_tool_getmethodsignature/__init__.py
+++ b/pkgs/community/swarmauri_tool_getmethodsignature/swarmauri_tool_getmethodsignature/__init__.py
@@ -1,0 +1,17 @@
+from .GetMethodSignatureTool import GetMethodSignatureTool
+
+
+__all__ = ["GetMethodSignatureTool"]
+
+try:
+    # For Python 3.8 and newer
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError:
+    # For older Python versions, use the backport
+    from importlib_metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("swarmauri_tool_getmethodsignature")
+except PackageNotFoundError:
+    # If the package is not installed (for example, during development)
+    __version__ = "0.0.0"

--- a/pkgs/community/swarmauri_tool_getmethodsignature/tests/unit/GetMethodSignatureTool_unit_test.py
+++ b/pkgs/community/swarmauri_tool_getmethodsignature/tests/unit/GetMethodSignatureTool_unit_test.py
@@ -1,0 +1,141 @@
+import pytest
+
+from swarmauri_tool_getmethodsignature.GetMethodSignatureTool import (
+    GetMethodSignatureTool,
+)
+
+
+@pytest.mark.unit
+def test_ubc_resource():
+    tool = GetMethodSignatureTool()
+    assert tool.resource == "Tool"
+
+
+@pytest.mark.unit
+def test_ubc_type():
+    assert GetMethodSignatureTool().type == "GetMethodSignatureTool"
+
+
+@pytest.mark.unit
+def test_initialization():
+    tool = GetMethodSignatureTool()
+    assert isinstance(tool.id, str)
+
+
+@pytest.mark.unit
+def test_serialization():
+    tool = GetMethodSignatureTool()
+    assert (
+        tool.id
+        == GetMethodSignatureTool.model_validate_json(
+            tool.model_dump_json()
+        ).id
+    )
+
+
+@pytest.mark.unit
+def test_call_extracts_signature():
+    tool = GetMethodSignatureTool()
+    src = "def add(a: int, b: int = 0) -> int:\n    return a + b\n"
+    result = tool(source=src, method_name="add")
+    assert result["name"] == "add"
+    assert result["return_type"] == "int"
+    assert result["is_async"] is False
+    assert len(result["parameters"]) == 2
+    assert result["parameters"][0]["name"] == "a"
+    assert result["parameters"][1]["name"] == "b"
+    assert result["parameters"][1]["default"] is not None
+
+
+@pytest.mark.unit
+def test_call_method_not_found():
+    tool = GetMethodSignatureTool()
+    result = tool(source="def f():\n    pass\n", method_name="missing")
+    assert "error" in result
+
+
+@pytest.mark.unit
+def test_call_handles_overloads():
+    tool = GetMethodSignatureTool()
+    src = (
+        "def f(x: int) -> int:\n"
+        "    return x\n"
+        "def f(x: str) -> str:\n"
+        "    return x\n"
+    )
+    result = tool(source=src, method_name="f")
+    assert "overloads" in result
+    assert len(result["overloads"]) == 2
+
+
+@pytest.mark.unit
+def test_call_no_return_annotation():
+    tool = GetMethodSignatureTool()
+    result = tool(source="def f(x):\n    pass\n", method_name="f")
+    assert result["return_type"] is None
+
+
+@pytest.mark.unit
+def test_call_async_function():
+    tool = GetMethodSignatureTool()
+    src = "async def f(x: int) -> int:\n    return x\n"
+    result = tool(source=src, method_name="f")
+    assert result["is_async"] is True
+
+
+@pytest.mark.unit
+def test_call_invalid_source():
+    tool = GetMethodSignatureTool()
+    result = tool(source="def f(:\n", method_name="f")
+    assert "error" in result
+
+
+@pytest.mark.unit
+def test_call_var_args():
+    tool = GetMethodSignatureTool()
+    src = "def f(a, *args, **kwargs):\n    pass\n"
+    result = tool(source=src, method_name="f")
+    names = [p["name"] for p in result["parameters"]]
+    assert names == ["a", "args", "kwargs"]
+    assert result["return_type"] is None
+
+
+@pytest.mark.unit
+def test_call_posonly_args():
+    tool = GetMethodSignatureTool()
+    src = "def f(x, /, y):\n    pass\n"
+    result = tool(source=src, method_name="f")
+    names = [p["name"] for p in result["parameters"]]
+    assert names == ["x", "y"]
+
+
+@pytest.mark.unit
+def test_call_kwonly_args():
+    tool = GetMethodSignatureTool()
+    src = "def f(*, x, y=10):\n    pass\n"
+    result = tool(source=src, method_name="f")
+    params = {p["name"]: p for p in result["parameters"]}
+    assert params["x"]["default"] is None
+    assert params["y"]["default"] == "10"
+
+
+@pytest.mark.unit
+def test_call_class_method():
+    tool = GetMethodSignatureTool()
+    src = (
+        "class Foo:\n    def method(self, a: int) -> int:\n        return a\n"
+    )
+    result = tool(source=src, method_name="method")
+    names = [p["name"] for p in result["parameters"]]
+    assert names == ["self", "a"]
+    assert result["return_type"] == "int"
+
+
+@pytest.mark.unit
+def test_call_complex_default():
+    tool = GetMethodSignatureTool()
+    src = "def f(x=[1, 2, 3]):\n    pass\n"
+    result = tool(source=src, method_name="f")
+    param = result["parameters"][0]
+    assert param["name"] == "x"
+    assert param["default"] is not None

--- a/pkgs/package-index.toml
+++ b/pkgs/package-index.toml
@@ -1275,62 +1275,6 @@ workspace = true
 order_source = "inferred"
 order_reason = "single-capability package by default"
 
-
-[[packages]]
-name = "swarmauri_agent_skill"
-path = "standards/swarmauri_agent_skill"
-distribution = "swarmauri_agent_skill"
-layer = "40-standards"
-family = "agents"
-role = "atomic-concrete"
-maturity = "standard"
-order = 0
-entry_points = ["swarmauri.agents"]
-
-[[packages]]
-name = "swarmauri_skill_dummy_filesystem"
-path = "standards/swarmauri_skill_dummy_filesystem"
-distribution = "swarmauri_skill_dummy_filesystem"
-layer = "40-standards"
-family = "skills"
-role = "atomic-concrete"
-maturity = "standard"
-order = 0
-entry_points = ["swarmauri.skills"]
-
-[[packages]]
-name = "swarmauri_skill_dummy_local"
-path = "standards/swarmauri_skill_dummy_local"
-distribution = "swarmauri_skill_dummy_local"
-layer = "40-standards"
-family = "skills"
-role = "atomic-concrete"
-maturity = "standard"
-order = 0
-entry_points = ["swarmauri.skills"]
-
-[[packages]]
-name = "swarmauri_skill_filesystem"
-path = "standards/swarmauri_skill_filesystem"
-distribution = "swarmauri_skill_filesystem"
-layer = "40-standards"
-family = "skills"
-role = "atomic-concrete"
-maturity = "standard"
-order = 0
-entry_points = ["swarmauri.skills"]
-
-[[packages]]
-name = "swarmauri_skill_local"
-path = "standards/swarmauri_skill_local"
-distribution = "swarmauri_skill_local"
-layer = "40-standards"
-family = "skills"
-role = "atomic-concrete"
-maturity = "standard"
-order = 0
-entry_points = ["swarmauri.skills"]
-
 [[packages]]
 name = "swarmauri_signing_ca"
 path = "standards/swarmauri_signing_ca"
@@ -1481,6 +1425,54 @@ path = "standards/swarmauri_signing_xmld"
 layer = "40-standards"
 order = 0
 family = "signing"
+role = "atomic-concrete"
+maturity = "standard"
+workspace = true
+order_source = "inferred"
+order_reason = "single-capability package by default"
+
+[[packages]]
+name = "swarmauri_skill_dummy_filesystem"
+path = "standards/swarmauri_skill_dummy_filesystem"
+layer = "40-standards"
+order = 0
+family = "skill"
+role = "atomic-concrete"
+maturity = "standard"
+workspace = true
+order_source = "inferred"
+order_reason = "single-capability package by default"
+
+[[packages]]
+name = "swarmauri_skill_dummy_local"
+path = "standards/swarmauri_skill_dummy_local"
+layer = "40-standards"
+order = 0
+family = "skill"
+role = "atomic-concrete"
+maturity = "standard"
+workspace = true
+order_source = "inferred"
+order_reason = "single-capability package by default"
+
+[[packages]]
+name = "swarmauri_skill_filesystem"
+path = "standards/swarmauri_skill_filesystem"
+layer = "40-standards"
+order = 0
+family = "skill"
+role = "atomic-concrete"
+maturity = "standard"
+workspace = true
+order_source = "inferred"
+order_reason = "single-capability package by default"
+
+[[packages]]
+name = "swarmauri_skill_local"
+path = "standards/swarmauri_skill_local"
+layer = "40-standards"
+order = 0
+family = "skill"
 role = "atomic-concrete"
 maturity = "standard"
 workspace = true
@@ -1754,13 +1746,14 @@ order_reason = "single-capability package by default"
 [[packages]]
 name = "swarmauri_tool_skill_execution"
 path = "standards/swarmauri_tool_skill_execution"
-distribution = "swarmauri_tool_skill_execution"
 layer = "40-standards"
+order = 0
 family = "tool"
 role = "atomic-concrete"
 maturity = "standard"
-order = 0
-entry_points = ["swarmauri.tools"]
+workspace = true
+order_source = "inferred"
+order_reason = "single-capability package by default"
 
 [[packages]]
 name = "swarmauri_transport_asgi"
@@ -2025,6 +2018,19 @@ maturity = "standard"
 workspace = true
 order_source = "inferred"
 order_reason = "single-capability package by default"
+
+[[packages]]
+name = "swarmauri_agent_skill"
+path = "standards/swarmauri_agent_skill"
+layer = "40-standards"
+order = 1
+family = "agent"
+role = "composite-concrete"
+maturity = "standard"
+workspace = true
+order_source = "inferred"
+order_reason = "raised to order 1 because it depends on same-layer package swarmauri_tool_skill_execution at 40.0"
+composes = ["swarmauri_tool_skill_execution"]
 
 [[packages]]
 name = "swarmauri_certs_composite"
@@ -2966,6 +2972,18 @@ order_reason = "single-capability package by default"
 [[packages]]
 name = "swarmauri_tool_folium"
 path = "community/swarmauri_tool_folium"
+layer = "50-community"
+order = 0
+family = "tool"
+role = "atomic-concrete"
+maturity = "community"
+workspace = true
+order_source = "inferred"
+order_reason = "single-capability package by default"
+
+[[packages]]
+name = "swarmauri_tool_getmethodsignature"
+path = "community/swarmauri_tool_getmethodsignature"
 layer = "50-community"
 order = 0
 family = "tool"

--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -100,6 +100,7 @@ members = [
     "community/swarmauri_tool_downloadpdf",
     "community/swarmauri_tool_entityrecognition",
     "community/swarmauri_tool_folium",
+    "community/swarmauri_tool_getmethodsignature",
     "community/swarmauri_tool_gmail",
     "community/swarmauri_tool_jupyterclearoutput",
     "community/swarmauri_tool_jupyterdisplay",
@@ -624,6 +625,7 @@ swarmauri_tool_dalechallreadability = { workspace = true }
 swarmauri_tool_downloadpdf = { workspace = true }
 swarmauri_tool_entityrecognition = { workspace = true }
 swarmauri_tool_folium = { workspace = true }
+swarmauri_tool_getmethodsignature = { workspace = true }
 swarmauri_tool_githubloader = { workspace = true }
 swarmauri_tool_gmail = { workspace = true }
 swarmauri_tool_httploaded = { workspace = true }


### PR DESCRIPTION
## Summary

Closes #876

Adds a new `GetMethodSignatureTool` that parses Python source code and returns the signature of a specified function or method (name, parameters, return type, async flag). Designed for **static analysis** scenarios where you want to inspect an API surface without importing/executing the target code.

## What

New community-tier package `swarmauri_tool_getmethodsignature` providing `GetMethodSignatureTool(ToolBase)`:

- Input: `source` (Python source string) + `method_name` (function/method name to look up)
- Output (single definition):
  ```json
  {
    "name": "add",
    "parameters": [{"name": "a", "annotation": "int", "default": null},
                   {"name": "b", "annotation": "int", "default": "0"}],
    "return_type": "int",
    "signature": "def add(a: int, b: int = 0) -> int",
    "is_async": false
  }
  ```
- Multiple same-name definitions -> `{"overloads": [...]}` (mimics PEP 3124 style)
- Not found -> `{"error": "Method '<name>' not found in source."}`
- Malformed source -> `{"error": "Failed to parse source: ..."}` (no exception raised)

Parameter extraction covers all parameter kinds: `posonlyargs`, `args`, `vararg`, `kwonlyargs`, `kwarg`, with `defaults`/`kw_defaults` correctly right-aligned per Python semantics.

## Why

Issue #876 requests a tool for retrieving method signatures. The implementation uses only the stdlib `ast` module — **no code execution, no imports, no third-party deps** — so it is safe to run on untrusted source and friendly to static-analysis pipelines.

> **Note on relationship to existing utility:** `swarmauri_standard.utils.method_signature_extractor_decorator.MethodSignatureExtractor` operates on **runtime callables** (via `inspect`). This tool is the **static counterpart** — it operates on **source strings** (via `ast`). They are complementary; the README documents this.

## How

- Subclasses `ToolBase` and registers via `@ComponentBase.register_type(ToolBase, "GetMethodSignatureTool")`
- Registered as a `swarmauri.tools` entry-point in the package `pyproject.toml`
- Added to `pkgs/pyproject.toml` workspace `members` and `tool.uv.sources` (1 line each, alphabetically ordered)
- Package index regenerated via `python scripts/package_index.py --write`

## Files

| File | Change |
|---|---|
| `pkgs/community/swarmauri_tool_getmethodsignature/GetMethodSignatureTool.py` | new (145 lines) |
| `pkgs/community/swarmauri_tool_getmethodsignature/__init__.py` | new |
| `pkgs/community/swarmauri_tool_getmethodsignature/pyproject.toml` | new |
| `pkgs/community/swarmauri_tool_getmethodsignature/README.md` | new |
| `pkgs/community/swarmauri_tool_getmethodsignature/LICENSE` | new (Apache-2.0, copied from `swarmauri_tool_textlength`) |
| `pkgs/community/swarmauri_tool_getmethodsignature/tests/unit/GetMethodSignatureTool_unit_test.py` | new (15 tests) |
| `pkgs/pyproject.toml` | +2 lines (workspace members + sources) |
| `pkgs/package-index.toml` / `pkgs/PACKAGE_INDEX.md` | auto-generated |

## Testing

All quality gates pass locally:

- `ruff format --check` — 3 files already formatted
- `ruff check` — All checks passed
- `pytest -v` — **15 passed** (5 standard UBC tests + 10 functional/edge-case tests)
- `bandit -r` — No issues identified (pure `ast`, no `exec`/`eval`/dynamic import)
- `mypy --strict` — 7 errors, **all environmental** (upstream `swarmauri_base`/`swarmauri_standard` lack `py.typed` markers; the reference template `swarmauri_tool_textlength` shows 9 of the same kind under identical command). Zero type errors in this package's own logic.

Test coverage includes: standard signature extraction, `*args`/`**kwargs`, positional-only (`/`), keyword-only (`*`), class methods, complex default values, async functions, overloads, missing methods, and invalid (syntactically broken) source.

## Notes for the maintainer

- **Package index diff**: Running `package_index.py --write` also picked up pre-existing index drift on `master` (a few `swarmauri_skill_*` / `swarmauri_agent_skill` entries whose `family` field was stale relative to the current script). The actual lines attributable to this PR are ~12 lines in `package-index.toml` (one new `[[packages]]` block) and ~5 lines in `PACKAGE_INDEX.md`. The remaining diff is the script catching up with `master`. If you prefer, you can refresh the index on `master` separately first and this PR's index diff will shrink to just the new entry.
- No CLA found in `CONTRIBUTING.md`; happy to sign one if required.
- Branch: `feature/getmethodsignature-tool`, single commit, based on current `master`.
