### PR TITLE
fix: resolve #887 — [Feature Request]: QueryImageVectorStoreTool

### DIFF
--- a/pkgs/swarmauri_standard/swarmauri_standard/tools/QueryImageVectorStoreTool.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/tools/QueryImageVectorStoreTool.py
@@ -1,0 +1,77 @@
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import ConfigDict, Field
+
+from swarmauri_base.ComponentBase import ComponentBase
+from swarmauri_base.tools.ToolBase import ToolBase
+from swarmauri_standard.tools.Parameter import Parameter
+
+
+@ComponentBase.register_type(ToolBase, "QueryImageVectorStoreTool")
+class QueryImageVectorStoreTool(ToolBase):
+    version: str = "1.0.0"
+    name: str = "QueryImageVectorStoreTool"
+    description: str = (
+        "Query an image vector store by embedding or image and return ranked similar results."
+    )
+    type: Literal["QueryImageVectorStoreTool"] = "QueryImageVectorStoreTool"
+    vector_store: Any = Field(default=None, exclude=True)
+    parameters: List[Parameter] = Field(
+        default_factory=lambda: [
+            Parameter(
+                name="query",
+                input_type="string",
+                description="Embedding or image used to query the image vector store",
+                required=True,
+            ),
+            Parameter(
+                name="top_k",
+                input_type="integer",
+                description="Number of top similar results to return",
+                required=False,
+            ),
+            Parameter(
+                name="metadata_filter",
+                input_type="object",
+                description="Optional metadata filters applied to the search",
+                required=False,
+            ),
+        ]
+    )
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    def __call__(
+        self,
+        query: str,
+        top_k: int = 5,
+        metadata_filter: Optional[Dict[str, Any]] = None,
+    ) -> List[Dict[str, Any]]:
+        if self.vector_store is None:
+            raise ValueError("vector_store must be set before calling this tool")
+
+        kwargs: Dict[str, Any] = {"top_k": int(top_k)}
+        if metadata_filter is not None:
+            kwargs["metadata_filter"] = metadata_filter
+
+        if hasattr(self.vector_store, "similarity_search"):
+            results = self.vector_store.similarity_search(query, **kwargs)
+        elif hasattr(self.vector_store, "retrieve"):
+            results = self.vector_store.retrieve(query, **kwargs)
+        else:
+            raise AttributeError(
+                "vector_store must implement retrieve or similarity_search"
+            )
+
+        ranked: List[Dict[str, Any]] = []
+        for i, item in enumerate(results):
+            if isinstance(item, dict):
+                entry = {**item, "rank": i + 1}
+            else:
+                entry = {
+                    "rank": i + 1,
+                    "content": getattr(item, "content", str(item)),
+                    "metadata": getattr(item, "metadata", {}),
+                    "score": getattr(item, "score", None),
+                }
+            ranked.append(entry)
+        return ranked

--- a/pkgs/swarmauri_standard/tests/unit/tools/QueryImageVectorStoreTool_test.py
+++ b/pkgs/swarmauri_standard/tests/unit/tools/QueryImageVectorStoreTool_test.py
@@ -1,0 +1,93 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from swarmauri_standard.tools.QueryImageVectorStoreTool import QueryImageVectorStoreTool
+
+
+@pytest.mark.unit
+def test_ubc_resource():
+    tool = QueryImageVectorStoreTool()
+    assert tool.resource == "Tool"
+
+
+@pytest.mark.unit
+def test_ubc_type():
+    tool = QueryImageVectorStoreTool()
+    assert tool.type == "QueryImageVectorStoreTool"
+
+
+@pytest.mark.unit
+def test_initialization():
+    tool = QueryImageVectorStoreTool()
+    assert isinstance(tool.id, str)
+
+
+@pytest.mark.unit
+def test_serialization():
+    tool = QueryImageVectorStoreTool()
+    assert (
+        tool.id
+        == QueryImageVectorStoreTool.model_validate_json(tool.model_dump_json()).id
+    )
+
+
+@pytest.mark.unit
+def test_call_similarity_search():
+    mock_store = MagicMock(spec=["similarity_search"])
+    mock_store.similarity_search.return_value = [
+        {"id": "img1", "score": 0.95, "metadata": {"label": "cat"}},
+        {"id": "img2", "score": 0.80, "metadata": {"label": "dog"}},
+    ]
+
+    tool = QueryImageVectorStoreTool(vector_store=mock_store)
+    results = tool(query="embedding_or_image", top_k=2)
+
+    mock_store.similarity_search.assert_called_once_with(
+        "embedding_or_image", top_k=2
+    )
+    assert len(results) == 2
+    assert results[0]["rank"] == 1
+    assert results[0]["id"] == "img1"
+    assert results[1]["rank"] == 2
+
+
+@pytest.mark.unit
+def test_call_retrieve():
+    mock_store = MagicMock(spec=["retrieve"])
+    mock_store.retrieve.return_value = [
+        {"id": "img1", "score": 0.9},
+    ]
+
+    tool = QueryImageVectorStoreTool(vector_store=mock_store)
+    results = tool(query="img_query", top_k=1)
+
+    mock_store.retrieve.assert_called_once_with("img_query", top_k=1)
+    assert results[0]["rank"] == 1
+
+
+@pytest.mark.unit
+def test_call_with_metadata_filter():
+    mock_store = MagicMock(spec=["similarity_search"])
+    mock_store.similarity_search.return_value = [
+        {"id": "img1", "score": 0.95, "metadata": {"label": "cat"}},
+    ]
+
+    tool = QueryImageVectorStoreTool(vector_store=mock_store)
+    results = tool(
+        query="embedding",
+        top_k=1,
+        metadata_filter={"label": "cat"},
+    )
+
+    mock_store.similarity_search.assert_called_once_with(
+        "embedding", top_k=1, metadata_filter={"label": "cat"}
+    )
+    assert len(results) == 1
+
+
+@pytest.mark.unit
+def test_call_without_vector_store_raises():
+    tool = QueryImageVectorStoreTool()
+    with pytest.raises(ValueError):
+        tool(query="test")


### PR DESCRIPTION
## Summary

fix: resolve #887 — [Feature Request]: QueryImageVectorStoreTool

## Problem

**Severity**: `Medium` | **File**: `pkgs/swarmauri_standard/swarmauri_standard/tools/QueryImageVectorStoreTool.py`

New tool. Query image vector store by embedding/image. Return ranked similar results. Optional metadata filters. No existing impl.

## Solution

Subclass ToolBase. Accept vector_store + input embedding/image. Call store.retrieve/similarity_search. Support top_k + metadata filter. Return ranked list. Add unit test with mock store.

## Changes

- `pkgs/swarmauri_standard/swarmauri_standard/tools/QueryImageVectorStoreTool.py` (new)
- `pkgs/swarmauri_standard/tests/unit/tools/QueryImageVectorStoreTool_test.py` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
_Note: this change was drafted with AI assistance and reviewed locally before submission._