### PR TITLE
fix: resolve #1254 — [GitHub Workflow Enhancement]: Create repository with organizational-level actions

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -1,0 +1,43 @@
+# Shared Composite Actions
+
+Org-level composite GitHub Actions used across Swarmauri repositories.
+
+## Purpose
+
+Centralize reusable CI/CD steps so every repo can adopt the same workflows without copy-paste. Actions live here; consumers pin a ref and call them.
+
+## Usage
+
+From any repo in the org:
+
+```yaml
+- uses: swarmauri/swarmauri-sdk/.github/actions/<name>@<ref>
+  with:
+    # action inputs
+```
+
+Replace `<name>` with the action directory name and `<ref>` with a tag, branch, or commit SHA.
+
+Example:
+
+```yaml
+- uses: swarmauri/swarmauri-sdk/.github/actions/setup-python@v1
+```
+
+## Versioning
+
+- Prefer immutable tags (`v1`, `v1.2.0`) or commit SHAs in production workflows.
+- Branches (`main`) are for development only; they move and can break consumers.
+- Breaking changes get a new major tag. Non-breaking fixes stay on the current major.
+
+## Develop-then-adopt
+
+Flow (see issue #1254):
+
+1. **Develop** the action in this repo under `.github/actions/<name>/`.
+2. **Validate** with workflows in this repo that exercise the action.
+3. **Tag** a release when stable.
+4. **Adopt** in other repos by pointing `uses:` at the tagged ref.
+5. **Iterate** here first; consumers bump their pin when ready.
+
+Do not copy action source into consumer repos. Pin and update the ref instead.

--- a/.github/actions/prepare-package/action.yml
+++ b/.github/actions/prepare-package/action.yml
@@ -1,0 +1,21 @@
+name: Prepare Package
+description: Prepare a package for CI with optional extras
+inputs:
+  path:
+    description: Path to the package directory
+    required: true
+  extras:
+    description: Optional extras to install
+    required: false
+    default: ''
+runs:
+  using: composite
+  steps:
+    - name: Install package
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.extras }}" ]; then
+          pip install -e "${{ inputs.path }}[${{ inputs.extras }}]"
+        else
+          pip install -e "${{ inputs.path }}"
+        fi

--- a/.github/actions/publish-package/action.yml
+++ b/.github/actions/publish-package/action.yml
@@ -1,0 +1,53 @@
+name: Publish Package
+description: Build and publish a package, skip if version already exists on PyPI
+inputs:
+  package-dir:
+    description: Path to package directory
+    required: true
+  token:
+    description: PyPI API token
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Install tools
+      shell: bash
+      run: pip install build twine
+
+    - name: Get package info
+      id: pkg
+      shell: bash
+      working-directory: ${{ inputs.package-dir }}
+      run: |
+        NAME=$(python -c "import tomllib; d=tomllib.load(open('pyproject.toml','rb')); p=d.get('project') or d.get('tool',{}).get('poetry',{}); print(p['name'])")
+        VERSION=$(python -c "import tomllib; d=tomllib.load(open('pyproject.toml','rb')); p=d.get('project') or d.get('tool',{}).get('poetry',{}); print(p['version'])")
+        echo "name=$NAME" >> "$GITHUB_OUTPUT"
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+    - name: Check version exists
+      id: check
+      shell: bash
+      run: |
+        name=$(echo "${{ steps.pkg.outputs.name }}" | tr '[:upper:]' '[:lower:]' | tr '_' '-')
+        version="${{ steps.pkg.outputs.version }}"
+        code=$(curl -s -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/${name}/${version}/json")
+        if [ "$code" = "200" ]; then
+          echo "exists=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "exists=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Build
+      if: steps.check.outputs.exists != 'true'
+      shell: bash
+      working-directory: ${{ inputs.package-dir }}
+      run: python -m build
+
+    - name: Publish
+      if: steps.check.outputs.exists != 'true'
+      shell: bash
+      working-directory: ${{ inputs.package-dir }}
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ inputs.token }}
+      run: twine upload dist/*

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -1,0 +1,37 @@
+name: Setup Python
+description: Setup Python with pip cache keyed on lock/requirements paths
+
+inputs:
+  python-version:
+    description: Python version
+    required: true
+  cache-dependency-path:
+    description: Lock or requirements file path(s) for the cache key
+    required: false
+    default: |
+      **/requirements*.txt
+      **/requirements*.in
+      **/pyproject.toml
+      **/poetry.lock
+      **/pdm.lock
+      **/Pipfile.lock
+      **/uv.lock
+  working-directory:
+    description: Working directory
+    required: false
+    default: "."
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+        cache: pip
+        cache-dependency-path: ${{ inputs.cache-dependency-path }}
+
+    - name: Upgrade pip
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: python -m pip install --upgrade pip

--- a/.github/actions/validate-package/action.yml
+++ b/.github/actions/validate-package/action.yml
@@ -1,0 +1,15 @@
+name: Validate Package
+description: Validate package with pytest
+inputs:
+  path:
+    description: Package path
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Install package
+      shell: bash
+      run: pip install -e "${{ inputs.path }}[dev]"
+    - name: Run tests
+      shell: bash
+      run: pytest "${{ inputs.path }}"


### PR DESCRIPTION
## Summary

fix: resolve #1254 — [GitHub Workflow Enhancement]: Create repository with organizational-level actions

## Problem

**Severity**: `High` | **File**: `.github/actions/README.md`

Entry point for shared devops actions. Explains purpose, how other repos reference actions via `uses: swarmauri/swarmauri-sdk/.github/actions/<name>@<ref>`, versioning policy, and develop-then-adopt flow from issue #1254.

## Solution

|

## Changes

- `.github/actions/README.md` (new)
- `.github/actions/setup-python/action.yml` (new)
- `.github/actions/prepare-package/action.yml` (new)
- `.github/actions/validate-package/action.yml` (new)
- `.github/actions/publish-package/action.yml` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
_Note: this change was drafted with AI assistance and reviewed locally before submission._