### PR TITLE
fix: resolve #1239 — Create Dockerfile for Documentation Website Deployment (mkdocs)

### DIFF
--- a/docs/.dockerignore
+++ b/docs/.dockerignore
@@ -1,0 +1,30 @@
+# VCS
+.git
+.gitignore
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+.venv/
+venv/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+
+# MkDocs build output
+site/
+
+# IDE / OS
+.idea/
+.vscode/
+*.swp
+.DS_Store
+Thumbs.db
+
+# Docker
+Dockerfile*
+.dockerignore

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,0 +1,9 @@
+FROM squidfunk/mkdocs-material
+
+WORKDIR /docs
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["serve", "-a", "0.0.0.0:8000"]


### PR DESCRIPTION
## Summary

fix: resolve #1239 — Create Dockerfile for Documentation Website Deployment (mkdocs)

## Problem

**Severity**: `Medium` | **File**: `docs/Dockerfile`

Containerize docs site per issue #1239. Suggested Dockerfile has syntax error (`COPY` and `WORKDIR` on one line). No existing Dockerfile or mkdocs.yml in tree. File lives under `docs/` so build context is docs dir.

## Solution

Create `docs/Dockerfile`:

## Changes

- `docs/Dockerfile` (new)
- `docs/.dockerignore` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
_Note: this change was drafted with AI assistance and reviewed locally before submission._