### PR TITLE
Fix FunctionMessage conversation history

### DIFF
--- a/pkgs/base/swarmauri_base/conversations/ConversationBase.py
+++ b/pkgs/base/swarmauri_base/conversations/ConversationBase.py
@@ -1,5 +1,6 @@
-from typing import List, Union, Literal
-from pydantic import Field, PrivateAttr, ConfigDict
+from typing import List, Literal, Union
+
+from pydantic import ConfigDict, Field
 
 from swarmauri_core.conversations.IConversation import IConversation
 from swarmauri_base.ComponentBase import (
@@ -17,8 +18,9 @@ class ConversationBase(IConversation, ComponentBase):
     operations.
     """
 
-    _history: List[SubclassUnion[MessageBase]] = PrivateAttr(
-        default_factory=list
+    messages: List[SubclassUnion[MessageBase]] = Field(
+        default_factory=list,
+        description="Messages retained by the conversation.",
     )
     resource: ResourceTypes = Field(default=ResourceTypes.CONVERSATION)
     model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
@@ -29,10 +31,20 @@ class ConversationBase(IConversation, ComponentBase):
         """
         Provides read-only access to the conversation history.
         """
-        return self._history
+        return self.messages
+
+    @property
+    def _history(self) -> List[SubclassUnion[MessageBase]]:
+        """Return the stored messages for legacy conversation subclasses."""
+        return self.messages
+
+    @_history.setter
+    def _history(self, messages: List[SubclassUnion[MessageBase]]) -> None:
+        """Replace stored messages for legacy conversation subclasses."""
+        self.messages = messages
 
     def add_message(self, message: SubclassUnion[MessageBase]):
-        self._history.append(message)
+        self.messages.append(message)
 
     def remove_message(self, message: SubclassUnion[MessageBase]):
         """
@@ -41,18 +53,18 @@ class ConversationBase(IConversation, ComponentBase):
         @param message: Message to remove from the history
         @return None
         """
-        if self._history and message in self._history:
-            self._history.remove(message)
+        if self.messages and message in self.messages:
+            self.messages.remove(message)
         return None
 
     def add_messages(self, messages: List[SubclassUnion[MessageBase]]):
         for message in messages:
-            self._history.append(message)
+            self.messages.append(message)
 
     def get_last(self) -> Union[SubclassUnion[MessageBase], None]:
-        if self._history:
-            return self._history[-1]
+        if self.messages:
+            return self.messages[-1]
         return None
 
     def clear_history(self):
-        self._history.clear()
+        self.messages.clear()

--- a/pkgs/swarmauri_standard/swarmauri_standard/conversations/MaxSystemContextConversation.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/conversations/MaxSystemContextConversation.py
@@ -3,6 +3,7 @@ from pydantic import Field, ConfigDict, field_validator
 from swarmauri_standard.messages.SystemMessage import SystemMessage
 from swarmauri_standard.messages.HumanMessage import HumanMessage
 from swarmauri_standard.messages.AgentMessage import AgentMessage
+from swarmauri_standard.messages.FunctionMessage import FunctionMessage
 from swarmauri_standard.exceptions.IndexErrorWithContext import (
     IndexErrorWithContext,
 )
@@ -60,16 +61,19 @@ class MaxSystemContextConversation(
         alternating = True
         count = 0
         for message in self._history[user_start_index:]:
+            if isinstance(message, FunctionMessage):
+                res.append(message)
+                continue
             if count > self.max_size:  # max size
                 break
-            if (
-                alternating
-                and isinstance(message, HumanMessage)
-                or not alternating
-                and isinstance(message, AgentMessage)
-            ):
+            if alternating and isinstance(message, HumanMessage):
                 res.append(message)
-                alternating = not alternating
+                alternating = False
+                count += 1
+            elif not alternating and isinstance(message, AgentMessage):
+                res.append(message)
+                if not message.tool_calls:
+                    alternating = True
                 count += 1
             elif not alternating and isinstance(message, HumanMessage):
                 # If we find two 'user' messages in a row when expecting an

--- a/pkgs/swarmauri_standard/swarmauri_standard/conversations/SessionCacheConversation.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/conversations/SessionCacheConversation.py
@@ -9,6 +9,7 @@ from swarmauri_base.conversations.ConversationSystemContextMixin import (
 from swarmauri_standard.messages.SystemMessage import SystemMessage
 from swarmauri_standard.messages.HumanMessage import HumanMessage
 from swarmauri_standard.messages.AgentMessage import AgentMessage
+from swarmauri_standard.messages.FunctionMessage import FunctionMessage
 from swarmauri_base.ComponentBase import ComponentBase
 
 
@@ -83,6 +84,9 @@ class SessionCacheConversation(
         count = 0
 
         for message in self._history[-self.max_size :]:
+            if isinstance(message, FunctionMessage):
+                res.append(message)
+                continue
             if isinstance(message, HumanMessage) and alternating:
                 res.append(message)
                 alternating = (
@@ -91,9 +95,8 @@ class SessionCacheConversation(
                 count += 1
             elif isinstance(message, AgentMessage) and not alternating:
                 res.append(message)
-                alternating = (
-                    not alternating
-                )  # Switch to expecting HumanMessage
+                if not message.tool_calls:
+                    alternating = True  # Switch to expecting HumanMessage
                 count += 1
 
             if count >= self.max_size:

--- a/pkgs/swarmauri_standard/swarmauri_standard/messages/AgentMessage.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/messages/AgentMessage.py
@@ -1,4 +1,4 @@
-from typing import Optional, Literal, Union, List
+from typing import Any, List, Literal, Optional, Union
 from pydantic import Field, BaseModel, ConfigDict
 
 from swarmauri_standard.messages.HumanMessage import contentItem
@@ -20,7 +20,7 @@ class UsageData(BaseModel):
 class AgentMessage(MessageBase):
     content: Optional[Union[str, List[contentItem]]] = None
     role: str = Field(default="assistant")
-    # tool_calls: Optional[Any] = None
+    tool_calls: Optional[List[Any]] = None
     name: Optional[str] = None
     type: Literal["AgentMessage"] = "AgentMessage"
     usage: Optional[UsageData] = None

--- a/pkgs/swarmauri_standard/swarmauri_standard/messages/FunctionMessage.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/messages/FunctionMessage.py
@@ -1,13 +1,15 @@
-from typing import Literal, Optional, Any
+from typing import Any, Literal, Optional
+
 from pydantic import Field
+
 from swarmauri_base.messages.MessageBase import MessageBase
 from swarmauri_base.ComponentBase import ComponentBase
 
 
-@ComponentBase.register_type(MessageBase, "ZeroMeasurement")
+@ComponentBase.register_type(MessageBase, "FunctionMessage")
 class FunctionMessage(MessageBase):
     content: str
-    role: str = Field(default="tool")
+    role: Literal["tool"] = Field(default="tool")
     tool_call_id: str
     name: str
     type: Literal["FunctionMessage"] = "FunctionMessage"

--- a/pkgs/swarmauri_standard/swarmauri_standard/tool_llms/GeminiToolModel.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/tool_llms/GeminiToolModel.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 from typing import Any, AsyncIterator, Dict, Iterator, List, Literal, Type
+from uuid import uuid4
 
 import httpx
 from pydantic import PrivateAttr, SecretStr
@@ -199,7 +200,10 @@ class GeminiToolModel(ToolLLMBase):
                     # Create a FunctionMessage for each tool call result
                     tool_messages.append(
                         FunctionMessage(
-                            name=func_name, content=json.dumps(func_result)
+                            name=func_name,
+                            content=json.dumps(func_result),
+                            tool_call_id=tool_call["functionCall"].get("id")
+                            or f"gemini-{uuid4()}",
                         )
                     )
                 except Exception as e:

--- a/pkgs/swarmauri_standard/swarmauri_standard/tool_llms/ToolLLM.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/tool_llms/ToolLLM.py
@@ -60,10 +60,10 @@ class ToolLLM(ToolLLMBase):
         return [
             m.model_dump(include=message_properties, exclude_none=True)
             for m in messages
-            if m.role != "tool"
         ]
 
     def _process_tool_calls(
+        self,
         tool_calls: List[Any],
         toolkit: Toolkit,
         messages: List[Type[MessageBase]],
@@ -105,6 +105,21 @@ class ToolLLM(ToolLLMBase):
                     }
                 )
         return messages
+
+    @staticmethod
+    def _get_function_messages(
+        messages: List[Dict[str, Any]],
+    ) -> List[FunctionMessage]:
+        """Create conversation messages from provider tool results."""
+        return [
+            FunctionMessage(
+                tool_call_id=message["tool_call_id"],
+                name=message["name"],
+                content=message["content"],
+            )
+            for message in messages
+            if message["role"] == "tool"
+        ]
 
     def predict(
         self,
@@ -156,20 +171,19 @@ class ToolLLM(ToolLLMBase):
         tool_calls = tool_response["choices"][0]["message"].get(
             "tool_calls", []
         )
+        if tool_calls:
+            conversation.add_message(
+                AgentMessage(
+                    content=tool_response["choices"][0]["message"].get(
+                        "content"
+                    ),
+                    tool_calls=tool_calls,
+                )
+            )
         messages = self._process_tool_calls(tool_calls, toolkit, messages)
 
         # Add tool messages to Conversation to enable Conversation hooks
-        tool_messages = [
-            FunctionMessage(
-                tool_call_id=m["tool_call_id"],
-                name=m["name"],
-                content=m["content"],
-            )
-            for m in messages
-            if m["role"] == "tool"
-        ]
-
-        conversation.add_messages(tool_messages)
+        conversation.add_messages(self._get_function_messages(messages))
 
         if multiturn:
             payload["messages"] = messages
@@ -240,20 +254,19 @@ class ToolLLM(ToolLLMBase):
         tool_calls = tool_response["choices"][0]["message"].get(
             "tool_calls", []
         )
+        if tool_calls:
+            conversation.add_message(
+                AgentMessage(
+                    content=tool_response["choices"][0]["message"].get(
+                        "content"
+                    ),
+                    tool_calls=tool_calls,
+                )
+            )
         messages = self._process_tool_calls(tool_calls, toolkit, messages)
 
         # Add tool messages to Conversation to enable Conversation hooks
-        tool_messages = [
-            FunctionMessage(
-                tool_call_id=m["tool_call_id"],
-                name=m["name"],
-                content=m["content"],
-            )
-            for m in messages
-            if m["role"] == "tool"
-        ]
-
-        conversation.add_messages(tool_messages)
+        conversation.add_messages(self._get_function_messages(messages))
 
         if multiturn:
             payload["messages"] = messages
@@ -326,7 +339,19 @@ class ToolLLM(ToolLLMBase):
             "tool_calls", []
         )
 
+        if tool_calls:
+            conversation.add_message(
+                AgentMessage(
+                    content=tool_response["choices"][0]["message"].get(
+                        "content"
+                    ),
+                    tool_calls=tool_calls,
+                )
+            )
+
         messages = self._process_tool_calls(tool_calls, toolkit, messages)
+
+        conversation.add_messages(self._get_function_messages(messages))
 
         payload["messages"] = messages
         payload["stream"] = True
@@ -406,7 +431,19 @@ class ToolLLM(ToolLLMBase):
             "tool_calls", []
         )
 
+        if tool_calls:
+            conversation.add_message(
+                AgentMessage(
+                    content=tool_response["choices"][0]["message"].get(
+                        "content"
+                    ),
+                    tool_calls=tool_calls,
+                )
+            )
+
         messages = self._process_tool_calls(tool_calls, toolkit, messages)
+
+        conversation.add_messages(self._get_function_messages(messages))
 
         payload["messages"] = messages
         payload["stream"] = True

--- a/pkgs/swarmauri_standard/tests/unit/conversations/Conversation_unit_test.py
+++ b/pkgs/swarmauri_standard/tests/unit/conversations/Conversation_unit_test.py
@@ -1,6 +1,7 @@
 import pytest
 from swarmauri_standard.conversations.Conversation import Conversation
 from swarmauri_standard.messages.HumanMessage import HumanMessage
+from swarmauri_standard.messages.FunctionMessage import FunctionMessage
 from swarmauri_base.ComponentBase import ResourceTypes
 
 
@@ -23,6 +24,20 @@ def test_serialization():
         conversation.id
         == Conversation.model_validate_json(conversation.model_dump_json()).id
     )
+
+
+@pytest.mark.unit
+def test_serialization_preserves_function_messages():
+    conversation = Conversation()
+    function_message = FunctionMessage(
+        name="calculator", content="3", tool_call_id="call-1"
+    )
+    conversation.add_message(function_message)
+
+    restored = Conversation.model_validate_json(conversation.model_dump_json())
+
+    assert isinstance(restored.history[0], FunctionMessage)
+    assert restored.history[0].tool_call_id == "call-1"
 
 
 @pytest.mark.unit

--- a/pkgs/swarmauri_standard/tests/unit/conversations/MaxSystemContextConversation_unit_test.py
+++ b/pkgs/swarmauri_standard/tests/unit/conversations/MaxSystemContextConversation_unit_test.py
@@ -2,6 +2,7 @@ import pytest
 from swarmauri_standard.messages.SystemMessage import SystemMessage
 from swarmauri_standard.messages.HumanMessage import HumanMessage
 from swarmauri_standard.messages.AgentMessage import AgentMessage
+from swarmauri_standard.messages.FunctionMessage import FunctionMessage
 from swarmauri_standard.conversations.MaxSystemContextConversation import (
     MaxSystemContextConversation,
 )
@@ -102,3 +103,27 @@ def test_add_messages():
     assert conversation.history[2].content == "agent1"
     assert conversation.history[3].content == "human2"
     assert conversation.history[4].content == "agent2"
+
+
+@pytest.mark.unit
+def test_history_includes_function_messages():
+    conversation = MaxSystemContextConversation(max_size=4)
+    function_message = FunctionMessage(
+        name="calculator", content="3", tool_call_id="call-1"
+    )
+    conversation.add_messages(
+        [
+            HumanMessage(content="Add one and two"),
+            AgentMessage(
+                content=None,
+                tool_calls=[
+                    {"id": "call-1", "function": {"name": "calculator"}}
+                ],
+            ),
+            function_message,
+            AgentMessage(content="The answer is three"),
+        ]
+    )
+
+    assert function_message in conversation.history
+    assert conversation.history[-1].content == "The answer is three"

--- a/pkgs/swarmauri_standard/tests/unit/conversations/SessionCacheConversation_unit_test.py
+++ b/pkgs/swarmauri_standard/tests/unit/conversations/SessionCacheConversation_unit_test.py
@@ -1,6 +1,7 @@
 import pytest
 from swarmauri_standard.messages.AgentMessage import AgentMessage
 from swarmauri_standard.messages.HumanMessage import HumanMessage
+from swarmauri_standard.messages.FunctionMessage import FunctionMessage
 from swarmauri_standard.messages.SystemMessage import SystemMessage
 
 from swarmauri_standard.conversations.SessionCacheConversation import (
@@ -170,3 +171,28 @@ def test_add_messages():
     assert conversation.history[2].content == "agent1"
     assert conversation.history[3].content == "human2"
     assert conversation.history[4].content == "agent2"
+
+
+@pytest.mark.unit
+def test_history_includes_function_messages():
+    conversation = SessionCacheConversation(max_size=4)
+    function_message = FunctionMessage(
+        name="calculator", content="3", tool_call_id="call-1"
+    )
+    conversation.add_messages(
+        [
+            HumanMessage(content="Add one and two"),
+            AgentMessage(
+                content=None,
+                tool_calls=[
+                    {"id": "call-1", "function": {"name": "calculator"}}
+                ],
+            ),
+            function_message,
+            AgentMessage(content="The answer is three"),
+        ]
+    )
+
+    assert function_message in conversation.history
+    assert function_message in conversation.session
+    assert conversation.history[-1].content == "The answer is three"

--- a/pkgs/swarmauri_standard/tests/unit/messages/AgentMessage_unit_test.py
+++ b/pkgs/swarmauri_standard/tests/unit/messages/AgentMessage_unit_test.py
@@ -33,3 +33,13 @@ def test_content():
 def test_role():
     message = AgentMessage(content="test")
     assert message.role == "assistant"
+
+
+@pytest.mark.unit
+def test_tool_calls_serialization():
+    tool_calls = [{"id": "call-1", "function": {"name": "calculator"}}]
+    message = AgentMessage(content=None, tool_calls=tool_calls)
+
+    restored = AgentMessage.model_validate_json(message.model_dump_json())
+
+    assert restored.tool_calls == tool_calls

--- a/pkgs/swarmauri_standard/tests/unit/messages/FunctionMessage_unit_test.py
+++ b/pkgs/swarmauri_standard/tests/unit/messages/FunctionMessage_unit_test.py
@@ -1,4 +1,5 @@
 import pytest
+from swarmauri_base.DynamicBase import DynamicBase
 from swarmauri_standard.messages.FunctionMessage import FunctionMessage
 
 
@@ -59,3 +60,11 @@ def test_tool_call_id():
         name="test_name", content="test", tool_call_id="test_tool_call_id"
     )
     assert message.tool_call_id == "test_tool_call_id"
+
+
+@pytest.mark.unit
+def test_registered_as_function_message():
+    registered_type = DynamicBase._registry["MessageBase"]["subtypes"][
+        "FunctionMessage"
+    ]
+    assert registered_type is FunctionMessage

--- a/pkgs/swarmauri_standard/tests/unit/tool_llms/FunctionMessageHistory_unit_test.py
+++ b/pkgs/swarmauri_standard/tests/unit/tool_llms/FunctionMessageHistory_unit_test.py
@@ -1,0 +1,85 @@
+import pytest
+
+from swarmauri_standard.messages.AgentMessage import AgentMessage
+from swarmauri_standard.messages.FunctionMessage import FunctionMessage
+from swarmauri_standard.tool_llms.GeminiToolModel import GeminiToolModel
+from swarmauri_standard.tool_llms.ToolLLM import ToolLLM
+from swarmauri_standard.toolkits.Toolkit import Toolkit
+from swarmauri_standard.tools.AdditionTool import AdditionTool
+
+
+@pytest.mark.unit
+def test_tool_results_become_function_messages():
+    model = ToolLLM(
+        api_key="test-key",
+        name="test-model",
+        allowed_models=["test-model"],
+    )
+    toolkit = Toolkit()
+    toolkit.add_tool(AdditionTool())
+    tool_calls = [
+        {
+            "id": "call-1",
+            "function": {
+                "name": "AdditionTool",
+                "arguments": '{"x": 1, "y": 2}',
+            },
+        }
+    ]
+
+    provider_messages = model._process_tool_calls(tool_calls, toolkit, [])
+    function_messages = model._get_function_messages(provider_messages)
+
+    assert len(function_messages) == 1
+    assert isinstance(function_messages[0], FunctionMessage)
+    assert function_messages[0].name == "AdditionTool"
+    assert function_messages[0].content == '{"sum": "3"}'
+    assert function_messages[0].tool_call_id == "call-1"
+
+
+@pytest.mark.unit
+def test_openai_compatible_history_keeps_tool_call_and_result_together():
+    model = ToolLLM(
+        api_key="test-key",
+        name="test-model",
+        allowed_models=["test-model"],
+    )
+    tool_calls = [{"id": "call-1", "function": {"name": "AdditionTool"}}]
+
+    formatted_messages = model._format_messages(
+        [
+            AgentMessage(content=None, tool_calls=tool_calls),
+            FunctionMessage(
+                name="AdditionTool",
+                content='{"sum": "3"}',
+                tool_call_id="call-1",
+            ),
+        ]
+    )
+
+    assert formatted_messages[0]["tool_calls"] == tool_calls
+    assert formatted_messages[1]["role"] == "tool"
+    assert formatted_messages[1]["tool_call_id"] == "call-1"
+
+
+@pytest.mark.unit
+def test_gemini_tool_results_receive_a_correlation_id():
+    model = GeminiToolModel(api_key="test-key")
+    toolkit = Toolkit()
+    toolkit.add_tool(AdditionTool())
+
+    _, function_messages = model._process_tool_calls(
+        [
+            {
+                "functionCall": {
+                    "name": "AdditionTool",
+                    "args": {"x": 1, "y": 2},
+                }
+            }
+        ],
+        toolkit,
+        [],
+    )
+
+    assert len(function_messages) == 1
+    assert function_messages[0].tool_call_id.startswith("gemini-")


### PR DESCRIPTION
## Summary

- make conversation messages serializable so `FunctionMessage` tool results survive JSON round-trips
- register `FunctionMessage` correctly and preserve assistant tool-call metadata
- retain tool results in filtered conversation histories and generic sync/async streaming paths
- supply Gemini tool results with correlation IDs and keep OpenAI-compatible tool-call/result pairs together
- add regression coverage for registration, serialization, history access, provider formatting, and tool-result conversion

## Root cause

Conversation history was stored as a Pydantic private attribute, so it was omitted from serialized conversations. `FunctionMessage` was also registered under the unrelated `ZeroMeasurement` name, filtered conversation implementations skipped tool results, and generic streaming paths did not add tool results back to the conversation.

## Validation

- `swarmauri_base`: 77 passed, 1 expected xfail
- focused `swarmauri_standard`: 50 passed
- broader `swarmauri_standard`: 1,840 passed, 210 skipped, 1 expected xfail; three unrelated Windows filesystem/subprocess tests failed
- Ruff format and check passed for both changed packages

Fixes #830
