### PR TITLE
fix: harden generic LLM provider hooks

### DIFF
--- a/pkgs/base/swarmauri_base/llms/LLMBase.py
+++ b/pkgs/base/swarmauri_base/llms/LLMBase.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Dict, List, Literal, Optional
+from typing import ClassVar, Dict, FrozenSet, List, Literal, Optional
 
 from pydantic import Field, PrivateAttr, SecretStr, model_validator
 from swarmauri_core.llms.IPredict import IPredict
@@ -9,34 +9,40 @@ from swarmauri_base.ComponentBase import ComponentBase, ResourceTypes
 
 @ComponentBase.register_model()
 class LLMBase(IPredict, ComponentBase):
-    allowed_models: List[str] = []
+    allowed_models: List[str] = Field(default_factory=list)
     resource: Optional[str] = Field(
         default=ResourceTypes.LLM.value, frozen=True
     )
     type: Literal["LLMBase"] = "LLMBase"
 
-    api_key: Optional[SecretStr] = None
+    api_key: Optional[SecretStr] = Field(default=None, exclude=True)
     name: str = ""
     timeout: float = 600.0
     include_usage: bool = True
+    max_retries: int = Field(default=3, ge=1)
+    retry_delay: float = Field(default=2.0, ge=0)
+
+    capabilities: ClassVar[FrozenSet[str]] = frozenset()
+    retryable_status_codes: ClassVar[FrozenSet[int]] = frozenset(
+        {408, 409, 425, 429, 500, 502, 503, 504, 529}
+    )
 
     # Base URL to be overridden by subclasses
     BASE_URL: Optional[str] = None
-    _headers: Dict[str, str] = PrivateAttr(default=None)
+    _headers: Dict[str, str] = PrivateAttr(default_factory=dict)
 
     @model_validator(mode="after")
-    @classmethod
-    def _validate_name_in_allowed_models(cls, values):
-        name = values.name
-        allowed_models = values.allowed_models
-        if name and name not in allowed_models:
+    def _validate_name_in_allowed_models(self):
+        name = self.name
+        allowed_models = self.allowed_models
+        if name and allowed_models and name not in allowed_models:
             raise ValueError(
                 (
                     f"Model name {name} is not allowed. Choose from "
                     f"{allowed_models}"
                 )
             )
-        return values
+        return self
 
     def add_allowed_model(self, model: str) -> None:
         """

--- a/pkgs/base/swarmauri_base/tool_llms/ToolLLMBase.py
+++ b/pkgs/base/swarmauri_base/tool_llms/ToolLLMBase.py
@@ -1,6 +1,15 @@
 import json
 from abc import abstractmethod
-from typing import Any, Dict, List, Literal, Optional, Type
+from typing import (
+    Any,
+    ClassVar,
+    Dict,
+    FrozenSet,
+    List,
+    Literal,
+    Optional,
+    Type,
+)
 
 from pydantic import ConfigDict, Field, PrivateAttr, SecretStr, model_validator
 from swarmauri_core.tool_llms.IToolPredict import IToolPredict
@@ -19,25 +28,31 @@ class ToolLLMBase(IToolPredict, ComponentBase):
     )
     model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
     type: Literal["ToolLLMBase"] = "ToolLLMBase"
-    api_key: Optional[SecretStr] = None
-    allowed_models: List[str] = []
+    api_key: Optional[SecretStr] = Field(default=None, exclude=True)
+    allowed_models: List[str] = Field(default_factory=list)
     timeout: float = 600.0
+    max_retries: int = Field(default=3, ge=1)
+    retry_delay: float = Field(default=2.0, ge=0)
     BASE_URL: str = None
-    _headers: Dict[str, str] = PrivateAttr(default=None)
+    _headers: Dict[str, str] = PrivateAttr(default_factory=dict)
+
+    capabilities: ClassVar[FrozenSet[str]] = frozenset()
+    retryable_status_codes: ClassVar[FrozenSet[int]] = frozenset(
+        {408, 409, 425, 429, 500, 502, 503, 504, 529}
+    )
 
     @model_validator(mode="after")
-    @classmethod
-    def _validate_name_in_allowed_models(cls, values):
-        name = values.name
-        allowed_models = values.allowed_models
-        if name and name not in allowed_models:
+    def _validate_name_in_allowed_models(self):
+        name = self.name
+        allowed_models = self.allowed_models
+        if name and allowed_models and name not in allowed_models:
             raise ValueError(
                 (
                     f"Model name {name} is not allowed. Choose from "
                     f"{allowed_models}"
                 )
             )
-        return values
+        return self
 
     def add_allowed_model(self, model: str) -> None:
         """

--- a/pkgs/swarmauri_standard/swarmauri_standard/llms/LLM.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/llms/LLM.py
@@ -1,6 +1,17 @@
 import asyncio
 import json
-from typing import Any, AsyncGenerator, Dict, Generator, List, Optional, Type
+from typing import (
+    Any,
+    AsyncGenerator,
+    ClassVar,
+    Dict,
+    FrozenSet,
+    Generator,
+    List,
+    Optional,
+    Tuple,
+    Type,
+)
 
 import httpx
 from swarmauri_base.ComponentBase import ComponentBase
@@ -32,6 +43,16 @@ class LLM(LLMBase):
         timeout (float): Timeout for API requests in seconds.
     """
 
+    capabilities: ClassVar[FrozenSet[str]] = frozenset(
+        {
+            "chat_completions",
+            "structured_output",
+            "multimodal_input",
+            "streaming",
+            "stream_usage",
+        }
+    )
+
     def __init__(self, **data) -> None:
         """
         Initialize the LLM class with the provided data.
@@ -43,11 +64,7 @@ class LLM(LLMBase):
         """
         super().__init__(**data)
 
-        # Set up headers for API requests
-        self._headers = {
-            "Authorization": f"Bearer {self.api_key.get_secret_value()}",
-            "Content-Type": "application/json",
-        }
+        self._headers = self._build_headers()
 
         # Load allowed models and set default if needed
         if not self.allowed_models:
@@ -55,6 +72,80 @@ class LLM(LLMBase):
 
         if not self.name and self.allowed_models:
             self.name = self.allowed_models[0]
+
+    def _build_headers(self) -> Dict[str, str]:
+        """Build request headers, allowing provider subclasses to override."""
+        headers = {"Content-Type": "application/json"}
+        if self.api_key is not None:
+            headers["Authorization"] = (
+                f"Bearer {self.api_key.get_secret_value()}"
+            )
+        return headers
+
+    def _build_endpoint(self) -> str:
+        """Return the complete inference endpoint.
+
+        ``BASE_URL`` remains a complete endpoint for backward compatibility.
+        Provider subclasses may assemble an endpoint from provider fields.
+        """
+        if not self.BASE_URL:
+            raise ValueError("BASE_URL must identify an inference endpoint")
+        return self.BASE_URL
+
+    def _build_payload(
+        self,
+        messages: List[Dict[str, Any]],
+        *,
+        temperature: float,
+        max_tokens: int,
+        top_p: float,
+        enable_json: bool,
+        stop: Optional[List[str]],
+        stream: bool = False,
+    ) -> Dict[str, Any]:
+        """Build an OpenAI-compatible chat-completions payload."""
+        payload: Dict[str, Any] = {
+            "model": self.name,
+            "messages": messages,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+            "top_p": top_p,
+            "stop": stop or [],
+        }
+        if enable_json:
+            payload["response_format"] = {"type": "json_object"}
+        if stream:
+            payload["stream"] = True
+            if self.include_usage and "stream_usage" in self.capabilities:
+                payload["stream_options"] = {"include_usage": True}
+        return payload
+
+    def _parse_response(
+        self, response_data: Dict[str, Any]
+    ) -> Tuple[str, Dict[str, Any]]:
+        """Parse content and usage from a chat-completions response."""
+        content = response_data["choices"][0]["message"].get("content")
+        return content or "", response_data.get("usage") or {}
+
+    def _parse_stream_chunk(
+        self, line: str
+    ) -> Tuple[Optional[str], Dict[str, Any]]:
+        """Parse one server-sent chat-completions event."""
+        if not line.startswith("data: "):
+            return None, {}
+        payload = line[6:].strip()
+        if not payload or payload == "[DONE]":
+            return None, {}
+        try:
+            chunk = json.loads(payload)
+        except json.JSONDecodeError:
+            return None, {}
+        usage = chunk.get("usage") or {}
+        choices = chunk.get("choices") or []
+        if not choices:
+            return None, usage
+        content = (choices[0].get("delta") or {}).get("content")
+        return content, usage
 
     def _format_messages(
         self,
@@ -72,10 +163,9 @@ class LLM(LLMBase):
         """
         formatted_messages = []
         for message in messages:
-            if message.role != "assistant":
-                formatted_message = message.model_dump(
-                    include=["content", "role", "name"], exclude_none=True
-                )
+            formatted_message = message.model_dump(
+                include=["content", "role", "name"], exclude_none=True
+            )
 
             # Handle multi-modal content
             if isinstance(formatted_message["content"], list):
@@ -118,7 +208,7 @@ class LLM(LLMBase):
 
         return usage
 
-    @retry_on_status_codes((429, 529), max_retries=3)
+    @retry_on_status_codes()
     def predict(
         self,
         conversation: Conversation,
@@ -146,32 +236,28 @@ class LLM(LLMBase):
         """
         formatted_messages = self._format_messages(conversation.history)
 
-        # Prepare the payload
-        payload = {
-            "model": self.name,
-            "messages": formatted_messages,
-            "temperature": temperature,
-            "max_tokens": max_tokens,
-            "top_p": top_p,
-            "stop": stop or [],
-        }
-
-        # Add JSON response format if requested
-        if enable_json:
-            payload["response_format"] = {"type": "json_object"}
+        payload = self._build_payload(
+            formatted_messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            top_p=top_p,
+            enable_json=enable_json,
+            stop=stop,
+        )
 
         # Make the API request and measure time
         with DurationManager() as prompt_timer:
             with httpx.Client(timeout=self.timeout) as client:
                 response = client.post(
-                    self.BASE_URL, headers=self._headers, json=payload
+                    self._build_endpoint(),
+                    headers=self._build_headers(),
+                    json=payload,
                 )
                 response.raise_for_status()
 
         # Parse the response
         response_data = response.json()
-        message_content = response_data["choices"][0]["message"]["content"]
-        usage_data = response_data.get("usage", {})
+        message_content, usage_data = self._parse_response(response_data)
 
         # Prepare usage data if tracking is enabled
         if self.include_usage:
@@ -183,7 +269,7 @@ class LLM(LLMBase):
             conversation.add_message(AgentMessage(content=message_content))
         return conversation
 
-    @retry_on_status_codes((429, 529), max_retries=3)
+    @retry_on_status_codes()
     async def apredict(
         self,
         conversation: Conversation,
@@ -212,32 +298,28 @@ class LLM(LLMBase):
         """
         formatted_messages = self._format_messages(conversation.history)
 
-        # Prepare the payload
-        payload = {
-            "model": self.name,
-            "messages": formatted_messages,
-            "temperature": temperature,
-            "max_tokens": max_tokens,
-            "top_p": top_p,
-            "stop": stop or [],
-        }
-
-        # Add JSON response format if requested
-        if enable_json:
-            payload["response_format"] = {"type": "json_object"}
+        payload = self._build_payload(
+            formatted_messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            top_p=top_p,
+            enable_json=enable_json,
+            stop=stop,
+        )
 
         # Make the async API request and measure time
         with DurationManager() as prompt_timer:
             async with httpx.AsyncClient(timeout=self.timeout) as client:
                 response = await client.post(
-                    self.BASE_URL, headers=self._headers, json=payload
+                    self._build_endpoint(),
+                    headers=self._build_headers(),
+                    json=payload,
                 )
                 response.raise_for_status()
 
         # Parse the response
         response_data = response.json()
-        message_content = response_data["choices"][0]["message"]["content"]
-        usage_data = response_data.get("usage", {})
+        message_content, usage_data = self._parse_response(response_data)
 
         # Prepare usage data if tracking is enabled
         if self.include_usage:
@@ -250,7 +332,7 @@ class LLM(LLMBase):
 
         return conversation
 
-    @retry_on_status_codes((429, 529), max_retries=3)
+    @retry_on_status_codes()
     def stream(
         self,
         conversation: Conversation,
@@ -278,69 +360,38 @@ class LLM(LLMBase):
         """
         formatted_messages = self._format_messages(conversation.history)
 
-        # Prepare the payload with stream flag
-        payload = {
-            "model": self.name,
-            "messages": formatted_messages,
-            "temperature": temperature,
-            "max_tokens": max_tokens,
-            "top_p": top_p,
-            "stream": True,
-            "stop": stop or [],
-        }
-
-        if enable_json:
-            payload["response_format"] = {"type": "json_object"}
-
-        if self.include_usage:
-            payload["stream_options"] = {"include_usage": True}
+        payload = self._build_payload(
+            formatted_messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            top_p=top_p,
+            enable_json=enable_json,
+            stop=stop,
+            stream=True,
+        )
 
         # Start timing for prompt processing
         with DurationManager() as prompt_timer:
             with httpx.Client(timeout=self.timeout) as client:
-                response = client.post(
-                    self.BASE_URL, headers=self._headers, json=payload
-                )
-                response.raise_for_status()
-
-        # Process the streaming response
-        message_content = ""
-        usage_data = {}
-
-        with DurationManager() as completion_timer:
-            for line in response.iter_lines():
-                if line.startswith("data: "):
-                    json_str = line.replace(
-                        "data: ", ""
-                    )  # Remove 'data: ' prefix
-
-                    if json_str.strip() == "[DONE]":
-                        break
-
-                    try:
-                        if json_str:
-                            chunk = json.loads(json_str)
-                            if (
-                                "choices" in chunk
-                                and chunk["choices"]
-                                and "delta" in chunk["choices"][0]
-                            ):
-                                delta = chunk["choices"][0]["delta"]
-                                if "content" in delta:
-                                    content = delta["content"]
-                                    message_content += content
-                                    yield content
-
-                            # Collect usage data if available
-                            if (
-                                self.include_usage
-                                and "usage" in chunk
-                                and chunk["usage"] is not None
-                            ):
-                                usage_data = chunk["usage"]
-
-                    except json.JSONDecodeError:
-                        pass
+                with client.stream(
+                    "POST",
+                    self._build_endpoint(),
+                    headers=self._build_headers(),
+                    json=payload,
+                ) as response:
+                    response.raise_for_status()
+                    message_content = ""
+                    usage_data: Dict[str, Any] = {}
+                    with DurationManager() as completion_timer:
+                        for line in response.iter_lines():
+                            content, chunk_usage = self._parse_stream_chunk(
+                                line
+                            )
+                            if chunk_usage:
+                                usage_data = chunk_usage
+                            if content is not None:
+                                message_content += content
+                                yield content
 
         # Add the complete message to the conversation
         if self.include_usage:
@@ -353,7 +404,7 @@ class LLM(LLMBase):
         else:
             conversation.add_message(AgentMessage(content=message_content))
 
-    @retry_on_status_codes((429, 529), max_retries=3)
+    @retry_on_status_codes()
     async def astream(
         self,
         conversation: Conversation,
@@ -381,67 +432,38 @@ class LLM(LLMBase):
         """
         formatted_messages = self._format_messages(conversation.history)
 
-        # Prepare the payload with stream flag
-        payload = {
-            "model": self.name,
-            "messages": formatted_messages,
-            "temperature": temperature,
-            "max_tokens": max_tokens,
-            "top_p": top_p,
-            "stream": True,
-            "stop": stop or [],
-        }
-
-        if enable_json:
-            payload["response_format"] = {"type": "json_object"}
-
-        if self.include_usage:
-            payload["stream_options"] = {"include_usage": True}
+        payload = self._build_payload(
+            formatted_messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            top_p=top_p,
+            enable_json=enable_json,
+            stop=stop,
+            stream=True,
+        )
 
         # Start timing for prompt processing
         with DurationManager() as prompt_timer:
             async with httpx.AsyncClient(timeout=self.timeout) as client:
-                response = await client.post(
-                    self.BASE_URL, headers=self._headers, json=payload
-                )
-                response.raise_for_status()
-
-        # Process the streaming response asynchronously
-        message_content = ""
-        usage_data = {}
-
-        with DurationManager() as completion_timer:
-            async for line in response.aiter_lines():
-                if line.startswith("data: "):
-                    json_str = line[6:]  # Remove 'data: ' prefix
-
-                    if json_str.strip() == "[DONE]":
-                        break
-
-                    try:
-                        if json_str:
-                            chunk = json.loads(json_str)
-                            if (
-                                "choices" in chunk
-                                and chunk["choices"]
-                                and "delta" in chunk["choices"][0]
-                            ):
-                                delta = chunk["choices"][0]["delta"]
-                                if "content" in delta:
-                                    content = delta["content"]
-                                    message_content += content
-                                    yield content
-
-                            # Collect usage data if available
-                            if (
-                                self.include_usage
-                                and "usage" in chunk
-                                and chunk["usage"] is not None
-                            ):
-                                usage_data = chunk["usage"]
-
-                    except json.JSONDecodeError:
-                        pass
+                async with client.stream(
+                    "POST",
+                    self._build_endpoint(),
+                    headers=self._build_headers(),
+                    json=payload,
+                ) as response:
+                    response.raise_for_status()
+                    message_content = ""
+                    usage_data: Dict[str, Any] = {}
+                    with DurationManager() as completion_timer:
+                        async for line in response.aiter_lines():
+                            content, chunk_usage = self._parse_stream_chunk(
+                                line
+                            )
+                            if chunk_usage:
+                                usage_data = chunk_usage
+                            if content is not None:
+                                message_content += content
+                                yield content
 
         # Add the complete message to the conversation
         if self.include_usage:
@@ -542,10 +564,13 @@ class LLM(LLMBase):
         """
         Returns a list of allowed models for this LLM provider.
 
-        This default implementation returns a static list. Provider-specific
-        subclasses should override this to query their respective APIs.
+        Provider-specific subclasses should override this to query their APIs.
 
         Returns:
             List[str]: List of allowed model names.
         """
-        return ["gpt-4", "gpt-3.5-turbo", "claude-3-5-sonnet-20240229"]
+        return self._get_models()
+
+    def _get_models(self) -> List[str]:
+        """Provider hook for model discovery without placeholder names."""
+        return []

--- a/pkgs/swarmauri_standard/swarmauri_standard/tool_llms/ToolLLM.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/tool_llms/ToolLLM.py
@@ -1,6 +1,16 @@
 import asyncio
 import json
-from typing import Any, AsyncIterator, Dict, Iterator, List, Type
+from typing import (
+    Any,
+    AsyncIterator,
+    ClassVar,
+    Dict,
+    FrozenSet,
+    Iterator,
+    List,
+    Optional,
+    Type,
+)
 
 import httpx
 from swarmauri_base.ComponentBase import ComponentBase
@@ -20,10 +30,15 @@ from swarmauri_standard.schema_converters.OpenAISchemaConverter import (
     OpenAISchemaConverter,
 )
 from swarmauri_standard.toolkits.Toolkit import Toolkit
+from swarmauri_standard.utils.retry_decorator import retry_on_status_codes
 
 
 @ComponentBase.register_type()
 class ToolLLM(ToolLLMBase):
+    capabilities: ClassVar[FrozenSet[str]] = frozenset(
+        {"chat_completions", "tools", "streaming"}
+    )
+
     def __init__(self, **data: dict[str, Any]) -> None:
         """
         Initialize the OpenAIToolModel class with the provided data.
@@ -32,11 +47,67 @@ class ToolLLM(ToolLLMBase):
             **data: Arbitrary keyword arguments containing initialization data.
         """
         super().__init__(**data)
-        self._headers = {
-            "Authorization": f"Bearer {self.api_key.get_secret_value()}",
-            "Content-Type": "application/json",
-        }
+        self._headers = self._build_headers()
         self.allowed_models = self.allowed_models or self.get_allowed_models()
+
+    def _build_headers(self) -> Dict[str, str]:
+        """Build request headers, allowing provider subclasses to override."""
+        headers = {"Content-Type": "application/json"}
+        if self.api_key is not None:
+            headers["Authorization"] = (
+                f"Bearer {self.api_key.get_secret_value()}"
+            )
+        return headers
+
+    def _build_endpoint(self) -> str:
+        """Return the complete inference endpoint."""
+        if not self.BASE_URL:
+            raise ValueError("BASE_URL must identify an inference endpoint")
+        return self.BASE_URL
+
+    def _build_payload(
+        self,
+        messages: List[Dict[str, Any]],
+        *,
+        toolkit: Optional[Toolkit],
+        tool_choice: Optional[dict[str, Any]],
+        temperature: float,
+        max_tokens: int,
+        stream: bool = False,
+    ) -> Dict[str, Any]:
+        """Build an OpenAI-compatible tool-calling payload."""
+        payload: Dict[str, Any] = {
+            "model": self.name,
+            "messages": messages,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+        }
+        if toolkit is not None:
+            payload["tools"] = self._schema_convert_tools(toolkit.tools)
+            payload["tool_choice"] = tool_choice or "auto"
+        if stream:
+            payload["stream"] = True
+        return payload
+
+    def _parse_response(self, response_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Return the first provider message from a completion response."""
+        return response_data["choices"][0]["message"]
+
+    def _parse_stream_chunk(self, line: str) -> Optional[str]:
+        """Parse text from one server-sent completion event."""
+        if not line.startswith("data: "):
+            return None
+        payload = line[6:].strip()
+        if not payload or payload == "[DONE]":
+            return None
+        try:
+            chunk = json.loads(payload)
+        except json.JSONDecodeError:
+            return None
+        choices = chunk.get("choices") or []
+        if not choices:
+            return None
+        return (choices[0].get("delta") or {}).get("content")
 
     def get_schema_converter(self) -> Type["SchemaConverterBase"]:
         return OpenAISchemaConverter()
@@ -121,6 +192,7 @@ class ToolLLM(ToolLLMBase):
             if message["role"] == "tool"
         ]
 
+    @retry_on_status_codes()
     def predict(
         self,
         conversation: Conversation,
@@ -146,37 +218,33 @@ class ToolLLM(ToolLLMBase):
             calls.
         """
         formatted_messages = self._format_messages(conversation.history)
-        payload = {
-            "model": self.name,
-            "messages": formatted_messages,
-            "temperature": temperature,
-            "max_tokens": max_tokens,
-            "tools": self._schema_convert_tools(toolkit.tools)
-            if toolkit
-            else None,
-            "tool_choice": tool_choice or "auto",
-        }
+        payload = self._build_payload(
+            formatted_messages,
+            toolkit=toolkit,
+            tool_choice=tool_choice,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
 
         with httpx.Client(timeout=self.timeout) as client:
             response = client.post(
-                self.BASE_URL, headers=self._headers, json=payload
+                self._build_endpoint(),
+                headers=self._build_headers(),
+                json=payload,
             )
             response.raise_for_status()
             tool_response = response.json()
 
+        provider_message = self._parse_response(tool_response)
         messages = [
             formatted_messages[-1],
-            tool_response["choices"][0]["message"],
+            provider_message,
         ]
-        tool_calls = tool_response["choices"][0]["message"].get(
-            "tool_calls", []
-        )
+        tool_calls = provider_message.get("tool_calls", [])
         if tool_calls:
             conversation.add_message(
                 AgentMessage(
-                    content=tool_response["choices"][0]["message"].get(
-                        "content"
-                    ),
+                    content=provider_message.get("content"),
                     tool_calls=tool_calls,
                 )
             )
@@ -192,18 +260,19 @@ class ToolLLM(ToolLLMBase):
 
             with httpx.Client(timeout=self.timeout) as client:
                 response = client.post(
-                    self.BASE_URL, headers=self._headers, json=payload
+                    self._build_endpoint(),
+                    headers=self._build_headers(),
+                    json=payload,
                 )
                 response.raise_for_status()
 
-            agent_response = response.json()
+            agent_response = self._parse_response(response.json())
 
-            agent_message = AgentMessage(
-                content=agent_response["choices"][0]["message"]["content"]
-            )
+            agent_message = AgentMessage(content=agent_response.get("content"))
             conversation.add_message(agent_message)
         return conversation
 
+    @retry_on_status_codes()
     async def apredict(
         self,
         conversation: Conversation,
@@ -229,37 +298,33 @@ class ToolLLM(ToolLLMBase):
             calls.
         """
         formatted_messages = self._format_messages(conversation.history)
-        payload = {
-            "model": self.name,
-            "messages": formatted_messages,
-            "temperature": temperature,
-            "max_tokens": max_tokens,
-            "tools": self._schema_convert_tools(toolkit.tools)
-            if toolkit
-            else None,
-            "tool_choice": tool_choice or "auto",
-        }
+        payload = self._build_payload(
+            formatted_messages,
+            toolkit=toolkit,
+            tool_choice=tool_choice,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
 
         async with httpx.AsyncClient(timeout=self.timeout) as client:
             response = await client.post(
-                self.BASE_URL, headers=self._headers, json=payload
+                self._build_endpoint(),
+                headers=self._build_headers(),
+                json=payload,
             )
             response.raise_for_status()
             tool_response = response.json()
 
+        provider_message = self._parse_response(tool_response)
         messages = [
             formatted_messages[-1],
-            tool_response["choices"][0]["message"],
+            provider_message,
         ]
-        tool_calls = tool_response["choices"][0]["message"].get(
-            "tool_calls", []
-        )
+        tool_calls = provider_message.get("tool_calls", [])
         if tool_calls:
             conversation.add_message(
                 AgentMessage(
-                    content=tool_response["choices"][0]["message"].get(
-                        "content"
-                    ),
+                    content=provider_message.get("content"),
                     tool_calls=tool_calls,
                 )
             )
@@ -275,15 +340,15 @@ class ToolLLM(ToolLLMBase):
 
             async with httpx.AsyncClient(timeout=self.timeout) as client:
                 response = await client.post(
-                    self.BASE_URL, headers=self._headers, json=payload
+                    self._build_endpoint(),
+                    headers=self._build_headers(),
+                    json=payload,
                 )
                 response.raise_for_status()
 
-            agent_response = response.json()
+            agent_response = self._parse_response(response.json())
 
-            agent_message = AgentMessage(
-                content=agent_response["choices"][0]["message"]["content"]
-            )
+            agent_message = AgentMessage(content=agent_response.get("content"))
             conversation.add_message(agent_message)
         return conversation
 
@@ -312,39 +377,32 @@ class ToolLLM(ToolLLMBase):
 
         formatted_messages = self._format_messages(conversation.history)
 
-        payload = {
-            "model": self.name,
-            "messages": formatted_messages,
-            "temperature": temperature,
-            "max_tokens": max_tokens,
-            "tools": self._schema_convert_tools(toolkit.tools)
-            if toolkit
-            else [],
-            "tool_choice": tool_choice or "auto",
-        }
+        payload = self._build_payload(
+            formatted_messages,
+            toolkit=toolkit,
+            tool_choice=tool_choice,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
 
         with httpx.Client(timeout=self.timeout) as client:
             response = client.post(
-                self.BASE_URL, headers=self._headers, json=payload
+                self._build_endpoint(),
+                headers=self._build_headers(),
+                json=payload,
             )
             response.raise_for_status()
 
         tool_response = response.json()
 
-        messages = [
-            formatted_messages[-1],
-            tool_response["choices"][0]["message"],
-        ]
-        tool_calls = tool_response["choices"][0]["message"].get(
-            "tool_calls", []
-        )
+        provider_message = self._parse_response(tool_response)
+        messages = [formatted_messages[-1], provider_message]
+        tool_calls = provider_message.get("tool_calls", [])
 
         if tool_calls:
             conversation.add_message(
                 AgentMessage(
-                    content=tool_response["choices"][0]["message"].get(
-                        "content"
-                    ),
+                    content=provider_message.get("content"),
                     tool_calls=tool_calls,
                 )
             )
@@ -358,25 +416,20 @@ class ToolLLM(ToolLLMBase):
         payload.pop("tools", None)
         payload.pop("tool_choice", None)
 
-        with httpx.Client(timeout=self.timeout) as client:
-            response = client.post(
-                self.BASE_URL, headers=self._headers, json=payload
-            )
-            response.raise_for_status()
-
         message_content = ""
-
-        for line in response.iter_lines():
-            json_str = line.replace("data: ", "")
-            try:
-                if json_str:
-                    chunk = json.loads(json_str)
-                    if chunk["choices"][0]["delta"]:
-                        delta = chunk["choices"][0]["delta"]["content"]
+        with httpx.Client(timeout=self.timeout) as client:
+            with client.stream(
+                "POST",
+                self._build_endpoint(),
+                headers=self._build_headers(),
+                json=payload,
+            ) as response:
+                response.raise_for_status()
+                for line in response.iter_lines():
+                    delta = self._parse_stream_chunk(line)
+                    if delta is not None:
                         message_content += delta
                         yield delta
-            except json.JSONDecodeError:
-                pass
 
         conversation.add_message(AgentMessage(content=message_content))
 
@@ -404,39 +457,32 @@ class ToolLLM(ToolLLMBase):
         """
         formatted_messages = self._format_messages(conversation.history)
 
-        payload = {
-            "model": self.name,
-            "messages": formatted_messages,
-            "temperature": temperature,
-            "max_tokens": max_tokens,
-            "tools": self._schema_convert_tools(toolkit.tools)
-            if toolkit
-            else [],
-            "tool_choice": tool_choice or "auto",
-        }
+        payload = self._build_payload(
+            formatted_messages,
+            toolkit=toolkit,
+            tool_choice=tool_choice,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
 
         async with httpx.AsyncClient(timeout=self.timeout) as client:
             response = await client.post(
-                self.BASE_URL, headers=self._headers, json=payload
+                self._build_endpoint(),
+                headers=self._build_headers(),
+                json=payload,
             )
             response.raise_for_status()
 
         tool_response = response.json()
 
-        messages = [
-            formatted_messages[-1],
-            tool_response["choices"][0]["message"],
-        ]
-        tool_calls = tool_response["choices"][0]["message"].get(
-            "tool_calls", []
-        )
+        provider_message = self._parse_response(tool_response)
+        messages = [formatted_messages[-1], provider_message]
+        tool_calls = provider_message.get("tool_calls", [])
 
         if tool_calls:
             conversation.add_message(
                 AgentMessage(
-                    content=tool_response["choices"][0]["message"].get(
-                        "content"
-                    ),
+                    content=provider_message.get("content"),
                     tool_calls=tool_calls,
                 )
             )
@@ -450,24 +496,20 @@ class ToolLLM(ToolLLMBase):
         payload.pop("tools", None)
         payload.pop("tool_choice", None)
 
-        async with httpx.AsyncClient(timeout=self.timeout) as client:
-            agent_response = await client.post(
-                self.BASE_URL, headers=self._headers, json=payload
-            )
-            agent_response.raise_for_status()
-
         message_content = ""
-        async for line in agent_response.aiter_lines():
-            json_str = line.replace("data: ", "")
-            try:
-                if json_str:
-                    chunk = json.loads(json_str)
-                    if chunk["choices"][0]["delta"]:
-                        delta = chunk["choices"][0]["delta"]["content"]
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            async with client.stream(
+                "POST",
+                self._build_endpoint(),
+                headers=self._build_headers(),
+                json=payload,
+            ) as agent_response:
+                agent_response.raise_for_status()
+                async for line in agent_response.aiter_lines():
+                    delta = self._parse_stream_chunk(line)
+                    if delta is not None:
                         message_content += delta
                         yield delta
-            except json.JSONDecodeError:
-                pass
         conversation.add_message(AgentMessage(content=message_content))
 
     def batch(
@@ -552,4 +594,8 @@ class ToolLLM(ToolLLMBase):
         Returns:
             List[str]: List of allowed models.
         """
-        pass
+        return self._get_models()
+
+    def _get_models(self) -> List[str]:
+        """Provider hook for model discovery without placeholder names."""
+        return []

--- a/pkgs/swarmauri_standard/swarmauri_standard/utils/retry_decorator.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/utils/retry_decorator.py
@@ -1,14 +1,30 @@
-import time
-import logging
-import httpx
-from functools import wraps
-from typing import List, Callable, Any
 import asyncio
 import inspect
+import logging
+import time
+from collections.abc import Collection
+from functools import wraps
+from typing import Any, Callable, Optional, Union
+
+import httpx
+
+
+RetryCodes = Union[Collection[int], Callable[[Any], Collection[int]]]
+RetryValue = Union[int, float, Callable[[Any], Union[int, float]]]
+
+
+def _resolve(value: Any, instance: Any, fallback: Any) -> Any:
+    if callable(value):
+        return value(instance)
+    if value is not None:
+        return value
+    return fallback
 
 
 def retry_on_status_codes(
-    status_codes: List[int] = [429], max_retries: int = 3, retry_delay: int = 2
+    status_codes: Optional[RetryCodes] = None,
+    max_retries: Optional[RetryValue] = None,
+    retry_delay: Optional[RetryValue] = None,
 ):
     """
     A decorator to retry both sync and async functions when specific status
@@ -19,20 +35,42 @@ def retry_on_status_codes(
     def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
         @wraps(func)
         async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+            instance = args[0] if args else None
+            resolved_codes = set(
+                _resolve(
+                    status_codes,
+                    instance,
+                    getattr(instance, "retryable_status_codes", {429}),
+                )
+            )
+            resolved_retries = int(
+                _resolve(
+                    max_retries,
+                    instance,
+                    getattr(instance, "max_retries", 3),
+                )
+            )
+            resolved_delay = float(
+                _resolve(
+                    retry_delay,
+                    instance,
+                    getattr(instance, "retry_delay", 2),
+                )
+            )
             last_exception = None
             attempt = 0
-            while attempt < max_retries:
+            while attempt < resolved_retries:
                 try:
                     return await func(*args, **kwargs)
                 except httpx.HTTPStatusError as e:
-                    if e.response.status_code in status_codes:
+                    if e.response.status_code in resolved_codes:
                         attempt += 1
                         last_exception = e
-                        if attempt == max_retries:
+                        if attempt == resolved_retries:
                             break
-                        backoff_time = retry_delay * (2 ** (attempt - 1))
+                        backoff_time = resolved_delay * (2 ** (attempt - 1))
                         logging.warning(
-                            f"Retry attempt {attempt}/{max_retries}: "
+                            f"Retry attempt {attempt}/{resolved_retries}: "
                             f"Received HTTP {e.response.status_code} for "
                             f"{func.__name__}. "
                             f"Retrying in {backoff_time:.2f} seconds. "
@@ -44,34 +82,55 @@ def retry_on_status_codes(
 
             if last_exception:
                 error_message = (
-                    f"Request to {func.__name__} failed after {max_retries} "
-                    f"retries. "
-                    f"Last encountered status code: "
-                    f"{last_exception.response.status_code}. "
-                    f"Last error details: {str(last_exception)}"
+                    f"Request to {func.__name__} failed after "
+                    f"{resolved_retries} retries. Last encountered status "
+                    f"code: {last_exception.response.status_code}. Last "
+                    f"error details: {last_exception}"
                 )
                 logging.error(error_message)
-                raise Exception(error_message)
+                raise Exception(error_message) from last_exception
             raise RuntimeError(
                 f"Unexpected error in retry mechanism for {func.__name__}"
             )
 
         @wraps(func)
         def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+            instance = args[0] if args else None
+            resolved_codes = set(
+                _resolve(
+                    status_codes,
+                    instance,
+                    getattr(instance, "retryable_status_codes", {429}),
+                )
+            )
+            resolved_retries = int(
+                _resolve(
+                    max_retries,
+                    instance,
+                    getattr(instance, "max_retries", 3),
+                )
+            )
+            resolved_delay = float(
+                _resolve(
+                    retry_delay,
+                    instance,
+                    getattr(instance, "retry_delay", 2),
+                )
+            )
             last_exception = None
             attempt = 0
-            while attempt < max_retries:
+            while attempt < resolved_retries:
                 try:
                     return func(*args, **kwargs)
                 except httpx.HTTPStatusError as e:
-                    if e.response.status_code in status_codes:
+                    if e.response.status_code in resolved_codes:
                         attempt += 1
                         last_exception = e
-                        if attempt == max_retries:
+                        if attempt == resolved_retries:
                             break
-                        backoff_time = retry_delay * (2 ** (attempt - 1))
+                        backoff_time = resolved_delay * (2 ** (attempt - 1))
                         logging.warning(
-                            f"Retry attempt {attempt}/{max_retries}: "
+                            f"Retry attempt {attempt}/{resolved_retries}: "
                             f"Received HTTP {e.response.status_code} for "
                             f"{func.__name__}. "
                             f"Retrying in {backoff_time:.2f} seconds. "
@@ -83,14 +142,13 @@ def retry_on_status_codes(
 
             if last_exception:
                 error_message = (
-                    f"Request to {func.__name__} failed after {max_retries} "
-                    f"retries. "
-                    f"Last encountered status code: "
-                    f"{last_exception.response.status_code}. "
-                    f"Last error details: {str(last_exception)}"
+                    f"Request to {func.__name__} failed after "
+                    f"{resolved_retries} retries. Last encountered status "
+                    f"code: {last_exception.response.status_code}. Last "
+                    f"error details: {last_exception}"
                 )
                 logging.error(error_message)
-                raise Exception(error_message)
+                raise Exception(error_message) from last_exception
             raise RuntimeError(
                 f"Unexpected error in retry mechanism for {func.__name__}"
             )

--- a/pkgs/swarmauri_standard/tests/unit/llms/LLM_hardening_test.py
+++ b/pkgs/swarmauri_standard/tests/unit/llms/LLM_hardening_test.py
@@ -1,0 +1,188 @@
+import json
+
+import httpx
+import pytest
+
+from swarmauri_standard.conversations.Conversation import Conversation
+from swarmauri_standard.llms.LLM import LLM
+from swarmauri_standard.messages.AgentMessage import AgentMessage
+from swarmauri_standard.messages.HumanMessage import HumanMessage
+
+
+def _llm(**overrides):
+    values = {
+        "api_key": "secret",
+        "BASE_URL": "https://provider.test/v1/chat/completions",
+        "name": "provider-model",
+        "allowed_models": ["provider-model"],
+        "retry_delay": 0,
+    }
+    values.update(overrides)
+    return LLM(**values)
+
+
+def test_formats_assistant_history_without_reusing_previous_message():
+    conversation = Conversation()
+    conversation.add_message(HumanMessage(content="question"))
+    conversation.add_message(AgentMessage(content="answer"))
+
+    formatted = _llm()._format_messages(conversation.history)
+
+    assert formatted == [
+        {"content": "question", "role": "user"},
+        {"content": "answer", "role": "assistant"},
+    ]
+
+
+def test_provider_hooks_and_capabilities_are_not_serialized():
+    class ProviderLLM(LLM):
+        capabilities = frozenset({"chat_completions"})
+
+        def _build_headers(self):
+            return {"X-Provider-Key": self.api_key.get_secret_value()}
+
+        def _build_endpoint(self):
+            return "https://override.test/chat"
+
+    llm = ProviderLLM(
+        **_llm().model_dump(exclude={"type"}), api_key="secret"
+    )
+
+    assert llm._build_endpoint() == "https://override.test/chat"
+    assert llm._build_headers() == {"X-Provider-Key": "secret"}
+    serialized = llm.model_dump()
+    assert "_headers" not in serialized
+    assert "capabilities" not in serialized
+    assert "api_key" not in serialized
+    assert "secret" not in llm.model_dump_json()
+
+
+def test_model_name_is_allowed_when_provider_discovers_models_later():
+    llm = LLM(
+        api_key="secret",
+        BASE_URL="https://provider.test/v1/chat/completions",
+        name="runtime-model",
+    )
+
+    assert llm.name == "runtime-model"
+    assert llm.allowed_models == []
+
+
+def test_payload_and_stream_parser_are_provider_override_points():
+    llm = _llm()
+    payload = llm._build_payload(
+        [{"role": "user", "content": "hello"}],
+        temperature=0.2,
+        max_tokens=10,
+        top_p=0.9,
+        enable_json=True,
+        stop=None,
+        stream=True,
+    )
+
+    assert payload["response_format"] == {"type": "json_object"}
+    assert payload["stream_options"] == {"include_usage": True}
+    content, usage = llm._parse_stream_chunk(
+        "data: "
+        + json.dumps(
+            {
+                "choices": [{"delta": {"content": "token"}}],
+                "usage": {"total_tokens": 3},
+            }
+        )
+    )
+    assert content == "token"
+    assert usage == {"total_tokens": 3}
+    assert llm._parse_stream_chunk("data: [DONE]") == (None, {})
+
+
+def test_predict_uses_configurable_retry_statuses(monkeypatch):
+    attempts = 0
+
+    def handler(request):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return httpx.Response(503, request=request)
+        return httpx.Response(
+            200,
+            request=request,
+            json={
+                "choices": [{"message": {"content": "ok"}}],
+                "usage": {},
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    original_client = httpx.Client
+
+    def client_factory(**kwargs):
+        return original_client(transport=transport, **kwargs)
+
+    monkeypatch.setattr(
+        "swarmauri_standard.llms.LLM.httpx.Client", client_factory
+    )
+    conversation = Conversation()
+    conversation.add_message(HumanMessage(content="hello"))
+
+    result = _llm(max_retries=2).predict(conversation)
+
+    assert attempts == 2
+    assert result.get_last().content == "ok"
+
+
+def test_stream_uses_streaming_transport(monkeypatch):
+    request_body = None
+
+    def handler(request):
+        nonlocal request_body
+        request_body = json.loads(request.content)
+        events = (
+            'data: {"choices":[{"delta":{"content":"a"}}]}\n\n'
+            'data: {"choices":[{"delta":{"content":"b"}}]}\n\n'
+            "data: [DONE]\n\n"
+        )
+        return httpx.Response(200, request=request, text=events)
+
+    transport = httpx.MockTransport(handler)
+    original_client = httpx.Client
+
+    def client_factory(**kwargs):
+        return original_client(transport=transport, **kwargs)
+
+    monkeypatch.setattr(
+        "swarmauri_standard.llms.LLM.httpx.Client", client_factory
+    )
+    conversation = Conversation()
+    conversation.add_message(HumanMessage(content="hello"))
+
+    assert list(_llm().stream(conversation)) == ["a", "b"]
+    assert request_body["stream"] is True
+    assert conversation.get_last().content == "ab"
+
+
+@pytest.mark.asyncio
+async def test_astream_uses_streaming_transport(monkeypatch):
+    def handler(request):
+        events = (
+            'data: {"choices":[{"delta":{"content":"async"}}]}\n\n'
+            "data: [DONE]\n\n"
+        )
+        return httpx.Response(200, request=request, text=events)
+
+    transport = httpx.MockTransport(handler)
+    original_client = httpx.AsyncClient
+
+    def client_factory(**kwargs):
+        return original_client(transport=transport, **kwargs)
+
+    monkeypatch.setattr(
+        "swarmauri_standard.llms.LLM.httpx.AsyncClient", client_factory
+    )
+    conversation = Conversation()
+    conversation.add_message(HumanMessage(content="hello"))
+
+    chunks = [chunk async for chunk in _llm().astream(conversation)]
+
+    assert chunks == ["async"]
+    assert conversation.get_last().content == "async"

--- a/pkgs/swarmauri_standard/tests/unit/tool_llms/ToolLLM_hardening_test.py
+++ b/pkgs/swarmauri_standard/tests/unit/tool_llms/ToolLLM_hardening_test.py
@@ -1,0 +1,72 @@
+import json
+
+from swarmauri_standard.tool_llms.ToolLLM import ToolLLM
+
+
+def _tool_llm(**overrides):
+    values = {
+        "api_key": "secret",
+        "BASE_URL": "https://provider.test/v1/chat/completions",
+        "name": "provider-model",
+        "allowed_models": ["provider-model"],
+    }
+    values.update(overrides)
+    return ToolLLM(**values)
+
+
+def test_tool_provider_hooks_and_runtime_state_are_not_serialized():
+    class ProviderToolLLM(ToolLLM):
+        capabilities = frozenset({"tools"})
+
+        def _build_endpoint(self):
+            return "https://override.test/tools"
+
+    llm = ProviderToolLLM(**_tool_llm().model_dump(exclude={"type"}))
+
+    assert llm._build_endpoint() == "https://override.test/tools"
+    assert "_headers" not in llm.model_dump()
+    assert "capabilities" not in llm.model_dump()
+    assert "api_key" not in llm.model_dump()
+    assert "secret" not in llm.model_dump_json()
+
+
+def test_tool_payload_can_omit_tools_for_follow_up_turn():
+    llm = _tool_llm()
+
+    payload = llm._build_payload(
+        [{"role": "user", "content": "hello"}],
+        toolkit=None,
+        tool_choice=None,
+        temperature=0.1,
+        max_tokens=20,
+        stream=True,
+    )
+
+    assert payload["stream"] is True
+    assert "tools" not in payload
+    assert "tool_choice" not in payload
+
+
+def test_tool_stream_parser_handles_content_usage_and_done_events():
+    llm = _tool_llm()
+
+    assert (
+        llm._parse_stream_chunk(
+            "data: "
+            + json.dumps({"choices": [{"delta": {"content": "token"}}]})
+        )
+        == "token"
+    )
+    assert llm._parse_stream_chunk("data: [DONE]") is None
+    assert llm._parse_stream_chunk("event: message") is None
+
+
+def test_tool_model_name_can_be_discovered_after_validation():
+    llm = ToolLLM(
+        api_key="secret",
+        BASE_URL="https://provider.test/v1/chat/completions",
+        name="runtime-model",
+    )
+
+    assert llm.name == "runtime-model"
+    assert llm.allowed_models == []


### PR DESCRIPTION
## Summary
- fix assistant-message formatting in the generic LLM
- add provider hooks for headers, endpoints, payloads, responses, model discovery, and streams
- make sync and async streaming incremental
- add configurable retry and capability metadata while keeping runtime secrets private

## Validation
- 14 focused LLM, ToolLLM, and retry tests passed
- swarmauri_base: 67 passed, 1 xfailed
- swarmauri_standard: 1851 passed, 210 skipped, 1 xfailed; three unrelated Windows filesystem/subprocess failures and one file-logger setup error remain
- ruff format and ruff check passed for both changed packages

Prerequisite for #239, #218, #215, and #123.