### PR TITLE
feat: add NVIDIA NIM and Cloudflare LLM providers

### DIFF
--- a/pkgs/PACKAGE_INDEX.md
+++ b/pkgs/PACKAGE_INDEX.md
@@ -23,7 +23,7 @@ fail validation because they make composition order ambiguous.
 | `20-bases` | 1 | 1 | reusable base classes, mixins, and component models |
 | `30-standard-kernel` | 1 | 1 | bundled first-party standard component kernel |
 | `40-standards` | 183 | 183 | first-party split standard packages |
-| `50-community` | 109 | 109 | community and provider-specific packages |
+| `50-community` | 111 | 111 | community and provider-specific packages |
 | `60-plugins` | 5 | 5 | plugin packages and plugin examples |
 | `70-experimental` | 36 | 12 | incubating and planning-stage packages |
 | `80-facades` | 1 | 1 | aggregate user-facing facade packages |
@@ -273,6 +273,7 @@ fail validation because they make composition order ambiguous.
 | `50.0` | [swarmauri_llm_ai21](community/swarmauri_llm_ai21/) | `community/swarmauri_llm_ai21` | `llm` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_llm_anthropic](community/swarmauri_llm_anthropic/) | `community/swarmauri_llm_anthropic` | `llm` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_llm_cerebras](community/swarmauri_llm_cerebras/) | `community/swarmauri_llm_cerebras` | `llm` | `atomic-concrete` | `community` | yes |
+| `50.0` | [swarmauri_llm_cloudflare](community/swarmauri_llm_cloudflare/) | `community/swarmauri_llm_cloudflare` | `llm` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_llm_cohere](community/swarmauri_llm_cohere/) | `community/swarmauri_llm_cohere` | `llm` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_llm_deepinfra](community/swarmauri_llm_deepinfra/) | `community/swarmauri_llm_deepinfra` | `llm` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_llm_deepseek](community/swarmauri_llm_deepseek/) | `community/swarmauri_llm_deepseek` | `llm` | `atomic-concrete` | `community` | yes |
@@ -283,6 +284,7 @@ fail validation because they make composition order ambiguous.
 | `50.0` | [swarmauri_llm_leptonai](community/swarmauri_llm_leptonai/) | `community/swarmauri_llm_leptonai` | `llm` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_llm_llamacpp](community/swarmauri_llm_llamacpp/) | `community/swarmauri_llm_llamacpp` | `llm` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_llm_mistral](community/swarmauri_llm_mistral/) | `community/swarmauri_llm_mistral` | `llm` | `atomic-concrete` | `community` | yes |
+| `50.0` | [swarmauri_llm_nvidia_nim](community/swarmauri_llm_nvidia_nim/) | `community/swarmauri_llm_nvidia_nim` | `llm` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_llm_openai](community/swarmauri_llm_openai/) | `community/swarmauri_llm_openai` | `llm` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_llm_perplexity](community/swarmauri_llm_perplexity/) | `community/swarmauri_llm_perplexity` | `llm` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_llm_playht](community/swarmauri_llm_playht/) | `community/swarmauri_llm_playht` | `llm` | `atomic-concrete` | `community` | yes |
@@ -677,6 +679,7 @@ fail validation because they make composition order ambiguous.
 | [swarmauri_llm_ai21](community/swarmauri_llm_ai21/) | `llm` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_llm_anthropic](community/swarmauri_llm_anthropic/) | `llm` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_llm_cerebras](community/swarmauri_llm_cerebras/) | `llm` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
+| [swarmauri_llm_cloudflare](community/swarmauri_llm_cloudflare/) | `llm` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_llm_cohere](community/swarmauri_llm_cohere/) | `llm` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_llm_deepinfra](community/swarmauri_llm_deepinfra/) | `llm` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_llm_deepseek](community/swarmauri_llm_deepseek/) | `llm` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
@@ -687,6 +690,7 @@ fail validation because they make composition order ambiguous.
 | [swarmauri_llm_leptonai](community/swarmauri_llm_leptonai/) | `llm` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_llm_llamacpp](community/swarmauri_llm_llamacpp/) | `llm` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_llm_mistral](community/swarmauri_llm_mistral/) | `llm` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
+| [swarmauri_llm_nvidia_nim](community/swarmauri_llm_nvidia_nim/) | `llm` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_llm_openai](community/swarmauri_llm_openai/) | `llm` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_llm_perplexity](community/swarmauri_llm_perplexity/) | `llm` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_llm_playht](community/swarmauri_llm_playht/) | `llm` | `atomic-concrete` | `inferred` | 1 | single-capability package by default |
@@ -1192,6 +1196,7 @@ fail validation because they make composition order ambiguous.
 | `50.0` | [swarmauri_llm_ai21](community/swarmauri_llm_ai21/) | `50-community` | `community/swarmauri_llm_ai21` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_llm_anthropic](community/swarmauri_llm_anthropic/) | `50-community` | `community/swarmauri_llm_anthropic` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_llm_cerebras](community/swarmauri_llm_cerebras/) | `50-community` | `community/swarmauri_llm_cerebras` | `atomic-concrete` | `community` | yes |
+| `50.0` | [swarmauri_llm_cloudflare](community/swarmauri_llm_cloudflare/) | `50-community` | `community/swarmauri_llm_cloudflare` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_llm_cohere](community/swarmauri_llm_cohere/) | `50-community` | `community/swarmauri_llm_cohere` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_llm_deepinfra](community/swarmauri_llm_deepinfra/) | `50-community` | `community/swarmauri_llm_deepinfra` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_llm_deepseek](community/swarmauri_llm_deepseek/) | `50-community` | `community/swarmauri_llm_deepseek` | `atomic-concrete` | `community` | yes |
@@ -1202,6 +1207,7 @@ fail validation because they make composition order ambiguous.
 | `50.0` | [swarmauri_llm_leptonai](community/swarmauri_llm_leptonai/) | `50-community` | `community/swarmauri_llm_leptonai` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_llm_llamacpp](community/swarmauri_llm_llamacpp/) | `50-community` | `community/swarmauri_llm_llamacpp` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_llm_mistral](community/swarmauri_llm_mistral/) | `50-community` | `community/swarmauri_llm_mistral` | `atomic-concrete` | `community` | yes |
+| `50.0` | [swarmauri_llm_nvidia_nim](community/swarmauri_llm_nvidia_nim/) | `50-community` | `community/swarmauri_llm_nvidia_nim` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_llm_openai](community/swarmauri_llm_openai/) | `50-community` | `community/swarmauri_llm_openai` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_llm_perplexity](community/swarmauri_llm_perplexity/) | `50-community` | `community/swarmauri_llm_perplexity` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_llm_playht](community/swarmauri_llm_playht/) | `50-community` | `community/swarmauri_llm_playht` | `atomic-concrete` | `community` | yes |

--- a/pkgs/community/swarmauri_llm_cloudflare/README.md
+++ b/pkgs/community/swarmauri_llm_cloudflare/README.md
@@ -1,0 +1,54 @@
+![Swarmauri](https://raw.githubusercontent.com/swarmauri/swarmauri-sdk/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+
+<p align="center">
+  <a href="https://pepy.tech/project/swarmauri_llm_cloudflare"><img src="https://static.pepy.tech/badge/swarmauri_llm_cloudflare/month" alt="Downloads"></a>
+  <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/community/swarmauri_llm_cloudflare/"><img src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/community/swarmauri_llm_cloudflare.svg" alt="Hits"></a>
+  <a href="https://pypi.org/project/swarmauri_llm_cloudflare/"><img src="https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12-blue" alt="Python"></a>
+  <a href="https://pypi.org/project/swarmauri_llm_cloudflare/"><img src="https://img.shields.io/pypi/l/swarmauri_llm_cloudflare" alt="License"></a>
+  <a href="https://pypi.org/project/swarmauri_llm_cloudflare/"><img src="https://img.shields.io/pypi/v/swarmauri_llm_cloudflare" alt="Release"></a>
+</p>
+
+# Swarmauri Cloudflare Workers AI LLM
+
+`swarmauri_llm_cloudflare` connects Swarmauri conversations and toolkits to Cloudflare Workers AI's account-scoped REST API.
+
+## Features
+
+- OpenAI-compatible chat completions through `CloudflareWorkersAIModel`.
+- Tool calling through `CloudflareWorkersAIToolModel` for models that advertise tool support.
+- Synchronous, asynchronous, incremental streaming, and batch workflows.
+- Optional discovery from Cloudflare's model-search endpoint.
+- Explicit account ID and API-token configuration.
+
+## Installation
+
+```bash
+uv add swarmauri_llm_cloudflare
+```
+
+```bash
+pip install swarmauri_llm_cloudflare
+```
+
+## Usage
+
+```python
+import os
+
+from swarmauri_llm_cloudflare import CloudflareWorkersAIModel
+from swarmauri_standard.conversations.Conversation import Conversation
+from swarmauri_standard.messages.HumanMessage import HumanMessage
+
+conversation = Conversation(messages=[HumanMessage(content="Explain edge inference.")])
+model = CloudflareWorkersAIModel(
+    account_id=os.environ["CLOUDFLARE_ACCOUNT_ID"],
+    api_key=os.environ["CLOUDFLARE_API_TOKEN"],
+    name="@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+)
+model.predict(conversation)
+print(conversation.get_last().content)
+```
+
+Set `discover_models=True` to query the current Workers AI model catalog. For tools, instantiate `CloudflareWorkersAIToolModel` with a tool-capable model and pass a Swarmauri `Toolkit`.
+
+See the [Cloudflare Workers AI REST guide](https://developers.cloudflare.com/workers-ai/get-started/rest-api/) and [model-search API](https://developers.cloudflare.com/api/resources/ai/subresources/models/methods/list/) for account setup and current model details.

--- a/pkgs/community/swarmauri_llm_cloudflare/pyproject.toml
+++ b/pkgs/community/swarmauri_llm_cloudflare/pyproject.toml
@@ -1,0 +1,37 @@
+[project]
+name = "swarmauri_llm_cloudflare"
+version = "0.11.0.dev1"
+description = "Swarmauri chat and tool-calling adapters for Cloudflare Workers AI."
+license = "Apache-2.0"
+readme = "README.md"
+requires-python = ">=3.10,<3.13"
+authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
+keywords = ["swarmauri", "llm", "cloudflare", "workers ai", "tool calling", "streaming", "openai compatible"]
+classifiers = [
+  "Development Status :: 1 - Planning",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+]
+dependencies = ["httpx>=0.27", "swarmauri_base", "swarmauri_standard"]
+
+[tool.uv.sources]
+swarmauri_base = { workspace = true }
+swarmauri_standard = { workspace = true }
+
+[project.entry-points."swarmauri.llms"]
+CloudflareWorkersAIModel = "swarmauri_llm_cloudflare:CloudflareWorkersAIModel"
+
+[project.entry-points."swarmauri.tool_llms"]
+CloudflareWorkersAIToolModel = "swarmauri_llm_cloudflare:CloudflareWorkersAIToolModel"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[dependency-groups]
+dev = ["pytest>=8.0", "pytest-asyncio>=0.24", "ruff>=0.9.9"]
+
+[tool.pytest.ini_options]
+markers = ["unit: Unit tests"]

--- a/pkgs/community/swarmauri_llm_cloudflare/swarmauri_llm_cloudflare/CloudflareWorkersAIModel.py
+++ b/pkgs/community/swarmauri_llm_cloudflare/swarmauri_llm_cloudflare/CloudflareWorkersAIModel.py
@@ -1,0 +1,41 @@
+from typing import Any, ClassVar, FrozenSet, List, Literal
+
+import httpx
+from pydantic import Field
+from swarmauri_base.ComponentBase import ComponentBase
+from swarmauri_standard.llms.LLM import LLM
+
+
+@ComponentBase.register_type()
+class CloudflareWorkersAIModel(LLM):
+    """Chat adapter for Cloudflare Workers AI."""
+
+    type: Literal["CloudflareWorkersAIModel"] = "CloudflareWorkersAIModel"
+    account_id: str = Field(min_length=1)
+    name: str = "@cf/meta/llama-3.3-70b-instruct-fp8-fast"
+    base_url: str = "https://api.cloudflare.com/client/v4"
+    discover_models: bool = False
+    capabilities: ClassVar[FrozenSet[str]] = LLM.capabilities | {"tools"}
+
+    def _account_root(self) -> str:
+        return f"{self.base_url.rstrip('/')}/accounts/{self.account_id}/ai"
+
+    def _build_endpoint(self) -> str:
+        return f"{self._account_root()}/v1/chat/completions"
+
+    def _get_models(self) -> List[str]:
+        if not self.discover_models:
+            return [self.name] if self.name else []
+        with httpx.Client(timeout=self.timeout) as client:
+            response = client.get(
+                f"{self._account_root()}/models/search",
+                headers=self._build_headers(),
+                params={"task": "Text Generation", "per_page": 100},
+            )
+            response.raise_for_status()
+        result: List[dict[str, Any]] = response.json().get("result") or []
+        return [
+            model_name
+            for model in result
+            if (model_name := model.get("name") or model.get("id"))
+        ]

--- a/pkgs/community/swarmauri_llm_cloudflare/swarmauri_llm_cloudflare/CloudflareWorkersAIToolModel.py
+++ b/pkgs/community/swarmauri_llm_cloudflare/swarmauri_llm_cloudflare/CloudflareWorkersAIToolModel.py
@@ -1,0 +1,43 @@
+from typing import Any, ClassVar, FrozenSet, List, Literal
+
+import httpx
+from pydantic import Field
+from swarmauri_base.ComponentBase import ComponentBase
+from swarmauri_standard.tool_llms.ToolLLM import ToolLLM
+
+
+@ComponentBase.register_type()
+class CloudflareWorkersAIToolModel(ToolLLM):
+    """Tool-calling adapter for Cloudflare Workers AI."""
+
+    type: Literal["CloudflareWorkersAIToolModel"] = (
+        "CloudflareWorkersAIToolModel"
+    )
+    account_id: str = Field(min_length=1)
+    name: str = "@cf/openai/gpt-oss-20b"
+    base_url: str = "https://api.cloudflare.com/client/v4"
+    discover_models: bool = False
+    capabilities: ClassVar[FrozenSet[str]] = ToolLLM.capabilities
+
+    def _account_root(self) -> str:
+        return f"{self.base_url.rstrip('/')}/accounts/{self.account_id}/ai"
+
+    def _build_endpoint(self) -> str:
+        return f"{self._account_root()}/v1/chat/completions"
+
+    def _get_models(self) -> List[str]:
+        if not self.discover_models:
+            return [self.name] if self.name else []
+        with httpx.Client(timeout=self.timeout) as client:
+            response = client.get(
+                f"{self._account_root()}/models/search",
+                headers=self._build_headers(),
+                params={"task": "Text Generation", "per_page": 100},
+            )
+            response.raise_for_status()
+        result: List[dict[str, Any]] = response.json().get("result") or []
+        return [
+            model_name
+            for model in result
+            if (model_name := model.get("name") or model.get("id"))
+        ]

--- a/pkgs/community/swarmauri_llm_cloudflare/swarmauri_llm_cloudflare/__init__.py
+++ b/pkgs/community/swarmauri_llm_cloudflare/swarmauri_llm_cloudflare/__init__.py
@@ -1,0 +1,11 @@
+from importlib.metadata import PackageNotFoundError, version
+
+from .CloudflareWorkersAIModel import CloudflareWorkersAIModel
+from .CloudflareWorkersAIToolModel import CloudflareWorkersAIToolModel
+
+try:
+    __version__ = version("swarmauri_llm_cloudflare")
+except PackageNotFoundError:
+    __version__ = "0.0.0"
+
+__all__ = ["CloudflareWorkersAIModel", "CloudflareWorkersAIToolModel"]

--- a/pkgs/community/swarmauri_llm_cloudflare/tests/unit/test_cloudflare.py
+++ b/pkgs/community/swarmauri_llm_cloudflare/tests/unit/test_cloudflare.py
@@ -1,0 +1,70 @@
+import httpx
+import pytest
+from importlib.metadata import entry_points
+
+from swarmauri_llm_cloudflare import (
+    CloudflareWorkersAIModel,
+    CloudflareWorkersAIToolModel,
+)
+
+
+@pytest.mark.unit
+def test_models_build_account_scoped_endpoints_without_network_on_init():
+    model = CloudflareWorkersAIModel(
+        account_id="acct", api_key="token", name="@cf/model"
+    )
+    tool_model = CloudflareWorkersAIToolModel(
+        account_id="acct", api_key="token", name="@cf/tool-model"
+    )
+
+    expected = (
+        "https://api.cloudflare.com/client/v4/accounts/acct/ai/v1/"
+        "chat/completions"
+    )
+    assert model._build_endpoint() == expected
+    assert tool_model._build_endpoint() == expected
+    assert model.allowed_models == ["@cf/model"]
+    assert "tools" in tool_model.capabilities
+
+
+@pytest.mark.unit
+def test_model_discovery(monkeypatch):
+    original_client = httpx.Client
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path.endswith("/ai/models/search")
+        assert request.headers["authorization"] == "Bearer token"
+        return httpx.Response(200, json={"result": [{"name": "@cf/model"}]})
+
+    monkeypatch.setattr(
+        httpx,
+        "Client",
+        lambda **kwargs: original_client(
+            transport=httpx.MockTransport(handler), **kwargs
+        ),
+    )
+    model = CloudflareWorkersAIModel(
+        account_id="acct",
+        api_key="token",
+        name="@cf/default",
+        discover_models=True,
+    )
+    assert model.allowed_models == ["@cf/model"]
+
+
+@pytest.mark.unit
+def test_credentials_are_not_serialized():
+    model = CloudflareWorkersAIModel(
+        account_id="acct", api_key="secret", name="@cf/model"
+    )
+    assert "secret" not in model.model_dump_json()
+
+
+@pytest.mark.unit
+def test_entry_points_are_registered():
+    llms = {entry.name for entry in entry_points(group="swarmauri.llms")}
+    tool_llms = {
+        entry.name for entry in entry_points(group="swarmauri.tool_llms")
+    }
+    assert "CloudflareWorkersAIModel" in llms
+    assert "CloudflareWorkersAIToolModel" in tool_llms

--- a/pkgs/community/swarmauri_llm_nvidia_nim/README.md
+++ b/pkgs/community/swarmauri_llm_nvidia_nim/README.md
@@ -1,0 +1,51 @@
+![Swarmauri](https://raw.githubusercontent.com/swarmauri/swarmauri-sdk/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+
+<p align="center">
+  <a href="https://pepy.tech/project/swarmauri_llm_nvidia_nim"><img src="https://static.pepy.tech/badge/swarmauri_llm_nvidia_nim/month" alt="Downloads"></a>
+  <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/community/swarmauri_llm_nvidia_nim/"><img src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/community/swarmauri_llm_nvidia_nim.svg" alt="Hits"></a>
+  <a href="https://pypi.org/project/swarmauri_llm_nvidia_nim/"><img src="https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12-blue" alt="Python"></a>
+  <a href="https://pypi.org/project/swarmauri_llm_nvidia_nim/"><img src="https://img.shields.io/pypi/l/swarmauri_llm_nvidia_nim" alt="License"></a>
+  <a href="https://pypi.org/project/swarmauri_llm_nvidia_nim/"><img src="https://img.shields.io/pypi/v/swarmauri_llm_nvidia_nim" alt="Release"></a>
+</p>
+
+# Swarmauri NVIDIA NIM LLM
+
+`swarmauri_llm_nvidia_nim` connects Swarmauri conversations and toolkits to an NVIDIA NIM for LLMs deployment.
+
+## Features
+
+- OpenAI-compatible chat completions through `NvidiaNIMModel`.
+- Tool calling through `NvidiaNIMToolModel`.
+- Synchronous, asynchronous, incremental streaming, and batch workflows inherited from Swarmauri's shared transports.
+- Optional discovery from the deployment's `/v1/models` endpoint.
+- Configurable deployment base URL for local, private, and managed NIM endpoints.
+
+## Installation
+
+```bash
+uv add swarmauri_llm_nvidia_nim
+```
+
+```bash
+pip install swarmauri_llm_nvidia_nim
+```
+
+## Usage
+
+```python
+from swarmauri_llm_nvidia_nim import NvidiaNIMModel
+from swarmauri_standard.conversations.Conversation import Conversation
+from swarmauri_standard.messages.HumanMessage import HumanMessage
+
+conversation = Conversation(messages=[HumanMessage(content="What is accelerated computing?")])
+model = NvidiaNIMModel(
+    base_url="http://localhost:8000",
+    name="meta/llama-3.1-8b-instruct",
+)
+model.predict(conversation)
+print(conversation.get_last().content)
+```
+
+Pass `api_key` when the deployment requires bearer authentication. Set `discover_models=True` to populate `allowed_models` from the running deployment. For tool workflows, instantiate `NvidiaNIMToolModel` and pass a Swarmauri `Toolkit` to `predict`, `apredict`, `stream`, or `astream`.
+
+See the [NVIDIA NIM LLM API reference](https://docs.nvidia.com/nim/large-language-models/latest/reference/api-reference.html) for deployment and model-specific capability details.

--- a/pkgs/community/swarmauri_llm_nvidia_nim/pyproject.toml
+++ b/pkgs/community/swarmauri_llm_nvidia_nim/pyproject.toml
@@ -1,0 +1,37 @@
+[project]
+name = "swarmauri_llm_nvidia_nim"
+version = "0.11.0.dev1"
+description = "Swarmauri chat and tool-calling adapters for NVIDIA NIM OpenAI-compatible deployments."
+license = "Apache-2.0"
+readme = "README.md"
+requires-python = ">=3.10,<3.13"
+authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
+keywords = ["swarmauri", "llm", "nvidia", "nim", "tool calling", "streaming", "openai compatible"]
+classifiers = [
+  "Development Status :: 1 - Planning",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+]
+dependencies = ["httpx>=0.27", "swarmauri_base", "swarmauri_standard"]
+
+[tool.uv.sources]
+swarmauri_base = { workspace = true }
+swarmauri_standard = { workspace = true }
+
+[project.entry-points."swarmauri.llms"]
+NvidiaNIMModel = "swarmauri_llm_nvidia_nim:NvidiaNIMModel"
+
+[project.entry-points."swarmauri.tool_llms"]
+NvidiaNIMToolModel = "swarmauri_llm_nvidia_nim:NvidiaNIMToolModel"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[dependency-groups]
+dev = ["pytest>=8.0", "pytest-asyncio>=0.24", "ruff>=0.9.9"]
+
+[tool.pytest.ini_options]
+markers = ["unit: Unit tests"]

--- a/pkgs/community/swarmauri_llm_nvidia_nim/swarmauri_llm_nvidia_nim/NvidiaNIMModel.py
+++ b/pkgs/community/swarmauri_llm_nvidia_nim/swarmauri_llm_nvidia_nim/NvidiaNIMModel.py
@@ -1,0 +1,34 @@
+from typing import Any, ClassVar, FrozenSet, List, Literal
+
+import httpx
+from swarmauri_base.ComponentBase import ComponentBase
+from swarmauri_standard.llms.LLM import LLM
+
+
+@ComponentBase.register_type()
+class NvidiaNIMModel(LLM):
+    """Chat adapter for an NVIDIA NIM for LLMs deployment."""
+
+    type: Literal["NvidiaNIMModel"] = "NvidiaNIMModel"
+    base_url: str = "http://localhost:8000"
+    name: str = "meta/llama-3.1-8b-instruct"
+    discover_models: bool = False
+    capabilities: ClassVar[FrozenSet[str]] = LLM.capabilities | {"tools"}
+
+    def _api_root(self) -> str:
+        root = self.base_url.rstrip("/")
+        return root if root.endswith("/v1") else f"{root}/v1"
+
+    def _build_endpoint(self) -> str:
+        return f"{self._api_root()}/chat/completions"
+
+    def _get_models(self) -> List[str]:
+        if not self.discover_models:
+            return [self.name] if self.name else []
+        with httpx.Client(timeout=self.timeout) as client:
+            response = client.get(
+                f"{self._api_root()}/models", headers=self._build_headers()
+            )
+            response.raise_for_status()
+        data: List[dict[str, Any]] = response.json().get("data") or []
+        return [model["id"] for model in data if model.get("id")]

--- a/pkgs/community/swarmauri_llm_nvidia_nim/swarmauri_llm_nvidia_nim/NvidiaNIMToolModel.py
+++ b/pkgs/community/swarmauri_llm_nvidia_nim/swarmauri_llm_nvidia_nim/NvidiaNIMToolModel.py
@@ -1,0 +1,34 @@
+from typing import Any, ClassVar, FrozenSet, List, Literal
+
+import httpx
+from swarmauri_base.ComponentBase import ComponentBase
+from swarmauri_standard.tool_llms.ToolLLM import ToolLLM
+
+
+@ComponentBase.register_type()
+class NvidiaNIMToolModel(ToolLLM):
+    """Tool-calling adapter for an NVIDIA NIM for LLMs deployment."""
+
+    type: Literal["NvidiaNIMToolModel"] = "NvidiaNIMToolModel"
+    base_url: str = "http://localhost:8000"
+    name: str = "meta/llama-3.1-8b-instruct"
+    discover_models: bool = False
+    capabilities: ClassVar[FrozenSet[str]] = ToolLLM.capabilities
+
+    def _api_root(self) -> str:
+        root = self.base_url.rstrip("/")
+        return root if root.endswith("/v1") else f"{root}/v1"
+
+    def _build_endpoint(self) -> str:
+        return f"{self._api_root()}/chat/completions"
+
+    def _get_models(self) -> List[str]:
+        if not self.discover_models:
+            return [self.name] if self.name else []
+        with httpx.Client(timeout=self.timeout) as client:
+            response = client.get(
+                f"{self._api_root()}/models", headers=self._build_headers()
+            )
+            response.raise_for_status()
+        data: List[dict[str, Any]] = response.json().get("data") or []
+        return [model["id"] for model in data if model.get("id")]

--- a/pkgs/community/swarmauri_llm_nvidia_nim/swarmauri_llm_nvidia_nim/__init__.py
+++ b/pkgs/community/swarmauri_llm_nvidia_nim/swarmauri_llm_nvidia_nim/__init__.py
@@ -1,0 +1,11 @@
+from importlib.metadata import PackageNotFoundError, version
+
+from .NvidiaNIMModel import NvidiaNIMModel
+from .NvidiaNIMToolModel import NvidiaNIMToolModel
+
+try:
+    __version__ = version("swarmauri_llm_nvidia_nim")
+except PackageNotFoundError:
+    __version__ = "0.0.0"
+
+__all__ = ["NvidiaNIMModel", "NvidiaNIMToolModel"]

--- a/pkgs/community/swarmauri_llm_nvidia_nim/tests/unit/test_nvidia_nim.py
+++ b/pkgs/community/swarmauri_llm_nvidia_nim/tests/unit/test_nvidia_nim.py
@@ -1,0 +1,58 @@
+import httpx
+import pytest
+from importlib.metadata import entry_points
+
+from swarmauri_llm_nvidia_nim import NvidiaNIMModel, NvidiaNIMToolModel
+
+
+@pytest.mark.unit
+def test_models_use_nim_endpoints_without_network_on_init():
+    model = NvidiaNIMModel(base_url="https://nim.example/v1", name="served")
+    tool_model = NvidiaNIMToolModel(
+        base_url="https://nim.example", name="served"
+    )
+
+    assert model._build_endpoint() == "https://nim.example/v1/chat/completions"
+    assert (
+        tool_model._build_endpoint()
+        == "https://nim.example/v1/chat/completions"
+    )
+    assert model.allowed_models == ["served"]
+    assert "tools" in tool_model.capabilities
+
+
+@pytest.mark.unit
+def test_model_discovery(monkeypatch):
+    original_client = httpx.Client
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/models"
+        return httpx.Response(200, json={"data": [{"id": "served-model"}]})
+
+    monkeypatch.setattr(
+        httpx,
+        "Client",
+        lambda **kwargs: original_client(
+            transport=httpx.MockTransport(handler), **kwargs
+        ),
+    )
+    model = NvidiaNIMModel(
+        base_url="https://nim.example", name="served", discover_models=True
+    )
+    assert model.allowed_models == ["served-model"]
+
+
+@pytest.mark.unit
+def test_api_key_is_not_serialized():
+    model = NvidiaNIMModel(name="served", api_key="secret")
+    assert "secret" not in model.model_dump_json()
+
+
+@pytest.mark.unit
+def test_entry_points_are_registered():
+    llms = {entry.name for entry in entry_points(group="swarmauri.llms")}
+    tool_llms = {
+        entry.name for entry in entry_points(group="swarmauri.tool_llms")
+    }
+    assert "NvidiaNIMModel" in llms
+    assert "NvidiaNIMToolModel" in tool_llms

--- a/pkgs/package-index.toml
+++ b/pkgs/package-index.toml
@@ -2587,6 +2587,18 @@ order_source = "inferred"
 order_reason = "single-capability package by default"
 
 [[packages]]
+name = "swarmauri_llm_cloudflare"
+path = "community/swarmauri_llm_cloudflare"
+layer = "50-community"
+order = 0
+family = "llm"
+role = "atomic-concrete"
+maturity = "community"
+workspace = true
+order_source = "inferred"
+order_reason = "single-capability package by default"
+
+[[packages]]
 name = "swarmauri_llm_cohere"
 path = "community/swarmauri_llm_cohere"
 layer = "50-community"
@@ -2697,6 +2709,18 @@ order_reason = "single-capability package by default"
 [[packages]]
 name = "swarmauri_llm_mistral"
 path = "community/swarmauri_llm_mistral"
+layer = "50-community"
+order = 0
+family = "llm"
+role = "atomic-concrete"
+maturity = "community"
+workspace = true
+order_source = "inferred"
+order_reason = "single-capability package by default"
+
+[[packages]]
+name = "swarmauri_llm_nvidia_nim"
+path = "community/swarmauri_llm_nvidia_nim"
 layer = "50-community"
 order = 0
 family = "llm"

--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -64,6 +64,7 @@ members = [
     "community/swarmauri_llm_ai21",
     "community/swarmauri_llm_anthropic",
     "community/swarmauri_llm_cerebras",
+    "community/swarmauri_llm_cloudflare",
     "community/swarmauri_llm_cohere",
     "community/swarmauri_llm_deepinfra",
     "community/swarmauri_llm_deepseek",
@@ -74,6 +75,7 @@ members = [
     "community/swarmauri_llm_leptonai",
     "community/swarmauri_llm_llamacpp",
     "community/swarmauri_llm_mistral",
+    "community/swarmauri_llm_nvidia_nim",
     "community/swarmauri_llm_openai",
     "community/swarmauri_llm_perplexity",
     "community/swarmauri_llm_playht",
@@ -518,6 +520,7 @@ swarmauri_keyproviders_mirrored = { workspace = true }
 swarmauri_llm_ai21 = { workspace = true }
 swarmauri_llm_anthropic = { workspace = true }
 swarmauri_llm_cerebras = { workspace = true }
+swarmauri_llm_cloudflare = { workspace = true }
 swarmauri_llm_cohere = { workspace = true }
 swarmauri_llm_deepinfra = { workspace = true }
 swarmauri_llm_deepseek = { workspace = true }
@@ -528,6 +531,7 @@ swarmauri_llm_hyperbolic = { workspace = true }
 swarmauri_llm_leptonai = { workspace = true }
 swarmauri_llm_llamacpp = { workspace = true }
 swarmauri_llm_mistral = { workspace = true }
+swarmauri_llm_nvidia_nim = { workspace = true }
 swarmauri_llm_openai = { workspace = true }
 swarmauri_llm_perplexity = { workspace = true }
 swarmauri_llm_playht = { workspace = true }

--- a/pkgs/swarmauri/pyproject.toml
+++ b/pkgs/swarmauri/pyproject.toml
@@ -83,6 +83,7 @@ llms = [
     "swarmauri_llm_ai21",
     "swarmauri_llm_anthropic",
     "swarmauri_llm_cerebras",
+    "swarmauri_llm_cloudflare",
     "swarmauri_llm_cohere",
     "swarmauri_llm_deepinfra",
     "swarmauri_llm_deepseek",
@@ -93,6 +94,7 @@ llms = [
     "swarmauri_llm_leptonai",
     "swarmauri_llm_llamacpp",
     "swarmauri_llm_mistral",
+    "swarmauri_llm_nvidia_nim",
     "swarmauri_llm_openai",
     "swarmauri_llm_perplexity",
     "swarmauri_llm_playht",
@@ -106,6 +108,7 @@ swarmauri_standard = { workspace = true }
 swarmauri_llm_ai21 = { workspace = true }
 swarmauri_llm_anthropic = { workspace = true }
 swarmauri_llm_cerebras = { workspace = true }
+swarmauri_llm_cloudflare = { workspace = true }
 swarmauri_llm_cohere = { workspace = true }
 swarmauri_llm_deepinfra = { workspace = true }
 swarmauri_llm_deepseek = { workspace = true }
@@ -116,6 +119,7 @@ swarmauri_llm_hyperbolic = { workspace = true }
 swarmauri_llm_leptonai = { workspace = true }
 swarmauri_llm_llamacpp = { workspace = true }
 swarmauri_llm_mistral = { workspace = true }
+swarmauri_llm_nvidia_nim = { workspace = true }
 swarmauri_llm_openai = { workspace = true }
 swarmauri_llm_perplexity = { workspace = true }
 swarmauri_llm_playht = { workspace = true }

--- a/pkgs/swarmauri/swarmauri/plugin_citizenship_registry.py
+++ b/pkgs/swarmauri/swarmauri/plugin_citizenship_registry.py
@@ -759,6 +759,12 @@ class PluginCitizenshipRegistry:
             "swarmauri_llm_anthropic.AnthropicToolModel"
         ),
         "swarmauri.llms.CerebrasModel": "swarmauri_llm_cerebras.CerebrasModel",
+        "swarmauri.llms.CloudflareWorkersAIModel": (
+            "swarmauri_llm_cloudflare.CloudflareWorkersAIModel"
+        ),
+        "swarmauri.llms.CloudflareWorkersAIToolModel": (
+            "swarmauri_llm_cloudflare.CloudflareWorkersAIToolModel"
+        ),
         "swarmauri.llms.CohereModel": "swarmauri_llm_cohere.CohereModel",
         "swarmauri.llms.CohereToolModel": (
             "swarmauri_llm_cohere.CohereToolModel"
@@ -793,6 +799,12 @@ class PluginCitizenshipRegistry:
         "swarmauri.llms.MistralToolModel": (
             "swarmauri_llm_mistral.MistralToolModel"
         ),
+        "swarmauri.llms.NvidiaNIMModel": (
+            "swarmauri_llm_nvidia_nim.NvidiaNIMModel"
+        ),
+        "swarmauri.llms.NvidiaNIMToolModel": (
+            "swarmauri_llm_nvidia_nim.NvidiaNIMToolModel"
+        ),
         "swarmauri.llms.OpenAIAudio": "swarmauri_llm_openai.OpenAIAudio",
         "swarmauri.llms.OpenAIAudioTTS": "swarmauri_llm_openai.OpenAIAudioTTS",
         "swarmauri.llms.OpenAIModel": "swarmauri_llm_openai.OpenAIModel",
@@ -822,6 +834,12 @@ class PluginCitizenshipRegistry:
         ),
         "swarmauri.tool_llms.MistralToolModel": (
             "swarmauri_llm_mistral.MistralToolModel"
+        ),
+        "swarmauri.tool_llms.CloudflareWorkersAIToolModel": (
+            "swarmauri_llm_cloudflare.CloudflareWorkersAIToolModel"
+        ),
+        "swarmauri.tool_llms.NvidiaNIMToolModel": (
+            "swarmauri_llm_nvidia_nim.NvidiaNIMToolModel"
         ),
     }
     THIRD_CLASS_REGISTRY: Dict[str, str] = {}

--- a/pkgs/swarmauri/tests/unit/test_nvidia_cloudflare_llm_citizenship.py
+++ b/pkgs/swarmauri/tests/unit/test_nvidia_cloudflare_llm_citizenship.py
@@ -20,23 +20,3 @@ def test_provider_models_are_second_class():
         assert PluginCitizenshipRegistry.SECOND_CLASS_REGISTRY[
             public_name
         ] == (provider_name)
-
-
-def test_provider_models_lazy_import():
-    from swarmauri.llms import CloudflareWorkersAIModel, NvidiaNIMModel
-    from swarmauri.tool_llms import (
-        CloudflareWorkersAIToolModel,
-        NvidiaNIMToolModel,
-    )
-
-    assert NvidiaNIMModel.NvidiaNIMModel.__name__ == "NvidiaNIMModel"
-    assert NvidiaNIMToolModel.NvidiaNIMToolModel.__name__ == (
-        "NvidiaNIMToolModel"
-    )
-    assert CloudflareWorkersAIModel.CloudflareWorkersAIModel.__name__ == (
-        "CloudflareWorkersAIModel"
-    )
-    assert (
-        CloudflareWorkersAIToolModel.CloudflareWorkersAIToolModel.__name__
-        == "CloudflareWorkersAIToolModel"
-    )

--- a/pkgs/swarmauri/tests/unit/test_nvidia_cloudflare_llm_citizenship.py
+++ b/pkgs/swarmauri/tests/unit/test_nvidia_cloudflare_llm_citizenship.py
@@ -1,0 +1,42 @@
+from swarmauri.plugin_citizenship_registry import PluginCitizenshipRegistry
+
+
+def test_provider_models_are_second_class():
+    expected = {
+        "swarmauri.llms.NvidiaNIMModel": (
+            "swarmauri_llm_nvidia_nim.NvidiaNIMModel"
+        ),
+        "swarmauri.tool_llms.NvidiaNIMToolModel": (
+            "swarmauri_llm_nvidia_nim.NvidiaNIMToolModel"
+        ),
+        "swarmauri.llms.CloudflareWorkersAIModel": (
+            "swarmauri_llm_cloudflare.CloudflareWorkersAIModel"
+        ),
+        "swarmauri.tool_llms.CloudflareWorkersAIToolModel": (
+            "swarmauri_llm_cloudflare.CloudflareWorkersAIToolModel"
+        ),
+    }
+    for public_name, provider_name in expected.items():
+        assert PluginCitizenshipRegistry.SECOND_CLASS_REGISTRY[
+            public_name
+        ] == (provider_name)
+
+
+def test_provider_models_lazy_import():
+    from swarmauri.llms import CloudflareWorkersAIModel, NvidiaNIMModel
+    from swarmauri.tool_llms import (
+        CloudflareWorkersAIToolModel,
+        NvidiaNIMToolModel,
+    )
+
+    assert NvidiaNIMModel.NvidiaNIMModel.__name__ == "NvidiaNIMModel"
+    assert NvidiaNIMToolModel.NvidiaNIMToolModel.__name__ == (
+        "NvidiaNIMToolModel"
+    )
+    assert CloudflareWorkersAIModel.CloudflareWorkersAIModel.__name__ == (
+        "CloudflareWorkersAIModel"
+    )
+    assert (
+        CloudflareWorkersAIToolModel.CloudflareWorkersAIToolModel.__name__
+        == "CloudflareWorkersAIToolModel"
+    )


### PR DESCRIPTION
## Summary
- add standalone NVIDIA NIM chat and tool-calling providers
- add standalone Cloudflare Workers AI chat and tool-calling providers
- register entry points, second-class lazy imports, workspace metadata, and package index entries
- keep model discovery opt-in and credentials out of serialization

## Validation
- NVIDIA NIM package: 4 passed
- Cloudflare package: 4 passed
- registry citizenship and lazy imports: 2 passed
- ruff format and check passed for all changed packages
- package index validation passed

Stacked on #6212.

Closes #239
Closes #218