### PR TITLE
feat: add Azure OpenAI and xAI providers

### DIFF
--- a/pkgs/PACKAGE_INDEX.md
+++ b/pkgs/PACKAGE_INDEX.md
@@ -23,7 +23,7 @@ fail validation because they make composition order ambiguous.
 | `20-bases` | 1 | 1 | reusable base classes, mixins, and component models |
 | `30-standard-kernel` | 1 | 1 | bundled first-party standard component kernel |
 | `40-standards` | 183 | 183 | first-party split standard packages |
-| `50-community` | 111 | 111 | community and provider-specific packages |
+| `50-community` | 113 | 113 | community and provider-specific packages |
 | `60-plugins` | 5 | 5 | plugin packages and plugin examples |
 | `70-experimental` | 36 | 12 | incubating and planning-stage packages |
 | `80-facades` | 1 | 1 | aggregate user-facing facade packages |
@@ -272,6 +272,7 @@ fail validation because they make composition order ambiguous.
 | `50.0` | [swarmauri_keyprovider_vaulttransit](community/swarmauri_keyprovider_vaulttransit/) | `community/swarmauri_keyprovider_vaulttransit` | `keyprovider` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_llm_ai21](community/swarmauri_llm_ai21/) | `community/swarmauri_llm_ai21` | `llm` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_llm_anthropic](community/swarmauri_llm_anthropic/) | `community/swarmauri_llm_anthropic` | `llm` | `atomic-concrete` | `community` | yes |
+| `50.0` | [swarmauri_llm_azureopenai](community/swarmauri_llm_azureopenai/) | `community/swarmauri_llm_azureopenai` | `llm` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_llm_cerebras](community/swarmauri_llm_cerebras/) | `community/swarmauri_llm_cerebras` | `llm` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_llm_cloudflare](community/swarmauri_llm_cloudflare/) | `community/swarmauri_llm_cloudflare` | `llm` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_llm_cohere](community/swarmauri_llm_cohere/) | `community/swarmauri_llm_cohere` | `llm` | `atomic-concrete` | `community` | yes |
@@ -289,6 +290,7 @@ fail validation because they make composition order ambiguous.
 | `50.0` | [swarmauri_llm_perplexity](community/swarmauri_llm_perplexity/) | `community/swarmauri_llm_perplexity` | `llm` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_llm_playht](community/swarmauri_llm_playht/) | `community/swarmauri_llm_playht` | `llm` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_llm_whisper](community/swarmauri_llm_whisper/) | `community/swarmauri_llm_whisper` | `llm` | `atomic-concrete` | `community` | yes |
+| `50.0` | [swarmauri_llm_xai](community/swarmauri_llm_xai/) | `community/swarmauri_llm_xai` | `llm` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_measurement_mutualinformation](community/swarmauri_measurement_mutualinformation/) | `community/swarmauri_measurement_mutualinformation` | `measurement` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_measurement_tokencountestimator](community/swarmauri_measurement_tokencountestimator/) | `community/swarmauri_measurement_tokencountestimator` | `measurement` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_metric_hamming](community/swarmauri_metric_hamming/) | `community/swarmauri_metric_hamming` | `metric` | `atomic-concrete` | `community` | yes |
@@ -678,6 +680,7 @@ fail validation because they make composition order ambiguous.
 | [swarmauri_keyprovider_vaulttransit](community/swarmauri_keyprovider_vaulttransit/) | `keyprovider` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_llm_ai21](community/swarmauri_llm_ai21/) | `llm` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_llm_anthropic](community/swarmauri_llm_anthropic/) | `llm` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
+| [swarmauri_llm_azureopenai](community/swarmauri_llm_azureopenai/) | `llm` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_llm_cerebras](community/swarmauri_llm_cerebras/) | `llm` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_llm_cloudflare](community/swarmauri_llm_cloudflare/) | `llm` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_llm_cohere](community/swarmauri_llm_cohere/) | `llm` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
@@ -695,6 +698,7 @@ fail validation because they make composition order ambiguous.
 | [swarmauri_llm_perplexity](community/swarmauri_llm_perplexity/) | `llm` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_llm_playht](community/swarmauri_llm_playht/) | `llm` | `atomic-concrete` | `inferred` | 1 | single-capability package by default |
 | [swarmauri_llm_whisper](community/swarmauri_llm_whisper/) | `llm` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
+| [swarmauri_llm_xai](community/swarmauri_llm_xai/) | `llm` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_measurement_mutualinformation](community/swarmauri_measurement_mutualinformation/) | `measurement` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_measurement_tokencountestimator](community/swarmauri_measurement_tokencountestimator/) | `measurement` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_metric_hamming](community/swarmauri_metric_hamming/) | `metric` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
@@ -1195,6 +1199,7 @@ fail validation because they make composition order ambiguous.
 |---|---|---|---|---|---|---|
 | `50.0` | [swarmauri_llm_ai21](community/swarmauri_llm_ai21/) | `50-community` | `community/swarmauri_llm_ai21` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_llm_anthropic](community/swarmauri_llm_anthropic/) | `50-community` | `community/swarmauri_llm_anthropic` | `atomic-concrete` | `community` | yes |
+| `50.0` | [swarmauri_llm_azureopenai](community/swarmauri_llm_azureopenai/) | `50-community` | `community/swarmauri_llm_azureopenai` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_llm_cerebras](community/swarmauri_llm_cerebras/) | `50-community` | `community/swarmauri_llm_cerebras` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_llm_cloudflare](community/swarmauri_llm_cloudflare/) | `50-community` | `community/swarmauri_llm_cloudflare` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_llm_cohere](community/swarmauri_llm_cohere/) | `50-community` | `community/swarmauri_llm_cohere` | `atomic-concrete` | `community` | yes |
@@ -1212,6 +1217,7 @@ fail validation because they make composition order ambiguous.
 | `50.0` | [swarmauri_llm_perplexity](community/swarmauri_llm_perplexity/) | `50-community` | `community/swarmauri_llm_perplexity` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_llm_playht](community/swarmauri_llm_playht/) | `50-community` | `community/swarmauri_llm_playht` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_llm_whisper](community/swarmauri_llm_whisper/) | `50-community` | `community/swarmauri_llm_whisper` | `atomic-concrete` | `community` | yes |
+| `50.0` | [swarmauri_llm_xai](community/swarmauri_llm_xai/) | `50-community` | `community/swarmauri_llm_xai` | `atomic-concrete` | `community` | yes |
 
 ### `matrix`
 

--- a/pkgs/community/swarmauri_llm_azureopenai/README.md
+++ b/pkgs/community/swarmauri_llm_azureopenai/README.md
@@ -1,0 +1,54 @@
+![Swarmauri](https://raw.githubusercontent.com/swarmauri/swarmauri-sdk/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+
+<p align="center">
+  <a href="https://pepy.tech/project/swarmauri_llm_azureopenai"><img src="https://static.pepy.tech/badge/swarmauri_llm_azureopenai/month" alt="Downloads"></a>
+  <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/community/swarmauri_llm_azureopenai/"><img src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/community/swarmauri_llm_azureopenai.svg" alt="Hits"></a>
+  <a href="https://pypi.org/project/swarmauri_llm_azureopenai/"><img src="https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12-blue" alt="Python"></a>
+  <a href="https://pypi.org/project/swarmauri_llm_azureopenai/"><img src="https://img.shields.io/pypi/l/swarmauri_llm_azureopenai" alt="License"></a>
+  <a href="https://pypi.org/project/swarmauri_llm_azureopenai/"><img src="https://img.shields.io/pypi/v/swarmauri_llm_azureopenai" alt="Release"></a>
+</p>
+
+# Swarmauri Azure OpenAI LLM
+
+`swarmauri_llm_azureopenai` provides provider-native Swarmauri adapters for Azure OpenAI and Microsoft Foundry chat-completions deployments.
+
+## Features
+
+- `AzureOpenAIModel` directly implements the Swarmauri LLM base contract.
+- `AzureOpenAIToolModel` directly implements the tool-LLM base contract.
+- API-key authentication with Azure's `api-key` header.
+- Refreshable Microsoft Entra bearer-token providers kept outside serialized state.
+- Sync, async, streaming, and batch workflows against the current `/openai/v1` API.
+
+## Installation
+
+```bash
+uv add swarmauri_llm_azureopenai
+```
+
+```bash
+pip install swarmauri_llm_azureopenai
+```
+
+## Usage
+
+```python
+import os
+
+from swarmauri_llm_azureopenai import AzureOpenAIModel
+from swarmauri_standard.conversations.Conversation import Conversation
+from swarmauri_standard.messages.HumanMessage import HumanMessage
+
+conversation = Conversation(messages=[HumanMessage(content="Summarize this release.")])
+model = AzureOpenAIModel(
+    endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
+    api_key=os.environ["AZURE_OPENAI_API_KEY"],
+    name="my-gpt-deployment",
+)
+model.predict(conversation)
+print(conversation.get_last().content)
+```
+
+For keyless authentication, omit `api_key` and pass a callable as `token_provider`; it is invoked for every request so refreshed Entra tokens are used. Use `AzureOpenAIToolModel` with a Swarmauri `Toolkit` for function calling.
+
+See the [Azure OpenAI chat REST reference](https://learn.microsoft.com/en-us/rest/api/microsoft-foundry/azureopenai/chat) and [Entra authentication guide](https://learn.microsoft.com/en-us/azure/foundry/foundry-models/how-to/configure-entra-id).

--- a/pkgs/community/swarmauri_llm_azureopenai/pyproject.toml
+++ b/pkgs/community/swarmauri_llm_azureopenai/pyproject.toml
@@ -1,0 +1,37 @@
+[project]
+name = "swarmauri_llm_azureopenai"
+version = "0.11.0.dev1"
+description = "Provider-native Swarmauri chat and tool-calling adapters for Azure OpenAI."
+license = "Apache-2.0"
+readme = "README.md"
+requires-python = ">=3.10,<3.13"
+authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
+keywords = ["swarmauri", "llm", "azure openai", "microsoft foundry", "entra id", "tool calling", "streaming"]
+classifiers = [
+  "Development Status :: 1 - Planning",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+]
+dependencies = ["httpx>=0.27", "swarmauri_base", "swarmauri_standard"]
+
+[tool.uv.sources]
+swarmauri_base = { workspace = true }
+swarmauri_standard = { workspace = true }
+
+[project.entry-points."swarmauri.llms"]
+AzureOpenAIModel = "swarmauri_llm_azureopenai:AzureOpenAIModel"
+
+[project.entry-points."swarmauri.tool_llms"]
+AzureOpenAIToolModel = "swarmauri_llm_azureopenai:AzureOpenAIToolModel"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[dependency-groups]
+dev = ["pytest>=8.0", "pytest-asyncio>=0.24", "ruff>=0.9.9"]
+
+[tool.pytest.ini_options]
+markers = ["unit: Unit tests"]

--- a/pkgs/community/swarmauri_llm_azureopenai/swarmauri_llm_azureopenai/AzureOpenAIModel.py
+++ b/pkgs/community/swarmauri_llm_azureopenai/swarmauri_llm_azureopenai/AzureOpenAIModel.py
@@ -1,0 +1,81 @@
+from typing import Any, Callable, ClassVar, FrozenSet, List, Literal, Optional
+
+import httpx
+from pydantic import Field, PrivateAttr
+from swarmauri_base.ComponentBase import ComponentBase
+from swarmauri_base.llms.LLMBase import LLMBase
+from swarmauri_standard.utils.provider_chat_transport import (
+    abatch_chat,
+    apredict_chat,
+    astream_chat,
+    batch_chat,
+    predict_chat,
+    stream_chat,
+)
+
+
+@ComponentBase.register_type()
+class AzureOpenAIModel(LLMBase):
+    """Provider-native Azure OpenAI chat-completions model."""
+
+    type: Literal["AzureOpenAIModel"] = "AzureOpenAIModel"
+    endpoint: str = Field(min_length=1)
+    api_version: str = "v1"
+    name: str = Field(min_length=1)
+    discover_models: bool = False
+    capabilities: ClassVar[FrozenSet[str]] = frozenset(
+        {"chat_completions", "structured_output", "streaming", "tools"}
+    )
+    _token_provider: Optional[Callable[[], Any]] = PrivateAttr(default=None)
+
+    predict = predict_chat
+    apredict = apredict_chat
+    stream = stream_chat
+    astream = astream_chat
+    batch = batch_chat
+    abatch = abatch_chat
+
+    def __init__(
+        self,
+        *,
+        token_provider: Optional[Callable[[], Any]] = None,
+        **data: Any,
+    ) -> None:
+        super().__init__(**data)
+        self._token_provider = token_provider
+        if self.api_key is None and self._token_provider is None:
+            raise ValueError("api_key or token_provider is required")
+        self.allowed_models = self.allowed_models or self._get_models()
+
+    def _api_root(self) -> str:
+        root = self.endpoint.rstrip("/")
+        suffix = f"/openai/{self.api_version}"
+        return root if root.endswith(suffix) else f"{root}{suffix}"
+
+    def _build_endpoint(self) -> str:
+        return f"{self._api_root()}/chat/completions"
+
+    def _build_headers(self) -> dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if self.api_key is not None:
+            headers["api-key"] = self.api_key.get_secret_value()
+        else:
+            token = self._token_provider()
+            headers["Authorization"] = (
+                f"Bearer {getattr(token, 'token', token)}"
+            )
+        return headers
+
+    def _get_models(self) -> List[str]:
+        if not self.discover_models:
+            return [self.name]
+        with httpx.Client(timeout=self.timeout) as client:
+            response = client.get(
+                f"{self._api_root()}/models", headers=self._build_headers()
+            )
+            response.raise_for_status()
+        return [
+            item["id"]
+            for item in response.json().get("data", [])
+            if item.get("id")
+        ]

--- a/pkgs/community/swarmauri_llm_azureopenai/swarmauri_llm_azureopenai/AzureOpenAIToolModel.py
+++ b/pkgs/community/swarmauri_llm_azureopenai/swarmauri_llm_azureopenai/AzureOpenAIToolModel.py
@@ -1,0 +1,91 @@
+from typing import Any, Callable, ClassVar, FrozenSet, List, Literal, Optional
+
+import httpx
+from pydantic import Field, PrivateAttr
+from swarmauri_base.ComponentBase import ComponentBase
+from swarmauri_base.tool_llms.ToolLLMBase import ToolLLMBase
+from swarmauri_standard.schema_converters.OpenAISchemaConverter import (
+    OpenAISchemaConverter,
+)
+from swarmauri_standard.utils.provider_chat_transport import (
+    abatch_tools,
+    apredict_tools,
+    astream_tools,
+    batch_tools,
+    format_messages,
+    predict_tools,
+    stream_tools,
+)
+
+
+@ComponentBase.register_type()
+class AzureOpenAIToolModel(ToolLLMBase):
+    """Provider-native Azure OpenAI tool-calling model."""
+
+    type: Literal["AzureOpenAIToolModel"] = "AzureOpenAIToolModel"
+    endpoint: str = Field(min_length=1)
+    api_version: str = "v1"
+    name: str = Field(min_length=1)
+    discover_models: bool = False
+    capabilities: ClassVar[FrozenSet[str]] = frozenset(
+        {"chat_completions", "streaming", "tools"}
+    )
+    _token_provider: Optional[Callable[[], Any]] = PrivateAttr(default=None)
+
+    predict = predict_tools
+    apredict = apredict_tools
+    stream = stream_tools
+    astream = astream_tools
+    batch = batch_tools
+    abatch = abatch_tools
+
+    def __init__(
+        self,
+        *,
+        token_provider: Optional[Callable[[], Any]] = None,
+        **data: Any,
+    ) -> None:
+        super().__init__(**data)
+        self._token_provider = token_provider
+        if self.api_key is None and self._token_provider is None:
+            raise ValueError("api_key or token_provider is required")
+        self.allowed_models = self.allowed_models or self._get_models()
+
+    def get_schema_converter(self):
+        return OpenAISchemaConverter()
+
+    def _format_messages(self, messages):
+        return format_messages(messages)
+
+    def _api_root(self) -> str:
+        root = self.endpoint.rstrip("/")
+        suffix = f"/openai/{self.api_version}"
+        return root if root.endswith(suffix) else f"{root}{suffix}"
+
+    def _build_endpoint(self) -> str:
+        return f"{self._api_root()}/chat/completions"
+
+    def _build_headers(self) -> dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if self.api_key is not None:
+            headers["api-key"] = self.api_key.get_secret_value()
+        else:
+            token = self._token_provider()
+            headers["Authorization"] = (
+                f"Bearer {getattr(token, 'token', token)}"
+            )
+        return headers
+
+    def _get_models(self) -> List[str]:
+        if not self.discover_models:
+            return [self.name]
+        with httpx.Client(timeout=self.timeout) as client:
+            response = client.get(
+                f"{self._api_root()}/models", headers=self._build_headers()
+            )
+            response.raise_for_status()
+        return [
+            item["id"]
+            for item in response.json().get("data", [])
+            if item.get("id")
+        ]

--- a/pkgs/community/swarmauri_llm_azureopenai/swarmauri_llm_azureopenai/__init__.py
+++ b/pkgs/community/swarmauri_llm_azureopenai/swarmauri_llm_azureopenai/__init__.py
@@ -1,0 +1,11 @@
+from importlib.metadata import PackageNotFoundError, version
+
+from .AzureOpenAIModel import AzureOpenAIModel
+from .AzureOpenAIToolModel import AzureOpenAIToolModel
+
+try:
+    __version__ = version("swarmauri_llm_azureopenai")
+except PackageNotFoundError:
+    __version__ = "0.0.0"
+
+__all__ = ["AzureOpenAIModel", "AzureOpenAIToolModel"]

--- a/pkgs/community/swarmauri_llm_azureopenai/tests/unit/test_azureopenai.py
+++ b/pkgs/community/swarmauri_llm_azureopenai/tests/unit/test_azureopenai.py
@@ -1,0 +1,50 @@
+from importlib.metadata import entry_points
+
+import pytest
+from swarmauri_base.llms.LLMBase import LLMBase
+from swarmauri_base.tool_llms.ToolLLMBase import ToolLLMBase
+
+from swarmauri_llm_azureopenai import AzureOpenAIModel, AzureOpenAIToolModel
+
+
+@pytest.mark.unit
+def test_models_directly_use_base_contracts_and_v1_endpoint():
+    model = AzureOpenAIModel(
+        endpoint="https://resource.openai.azure.com",
+        api_key="key",
+        name="deployment",
+    )
+    tool_model = AzureOpenAIToolModel(
+        endpoint="https://resource.openai.azure.com/openai/v1",
+        api_key="key",
+        name="deployment",
+    )
+    assert isinstance(model, LLMBase)
+    assert isinstance(tool_model, ToolLLMBase)
+    assert model._build_endpoint().endswith("/openai/v1/chat/completions")
+    assert tool_model._build_headers()["api-key"] == "key"
+
+
+@pytest.mark.unit
+def test_entra_provider_refreshes_and_is_not_serialized():
+    tokens = iter(["token-1", "token-2"])
+    model = AzureOpenAIModel(
+        endpoint="https://resource.openai.azure.com",
+        token_provider=lambda: next(tokens),
+        name="deployment",
+    )
+    assert model._build_headers()["Authorization"] == "Bearer token-1"
+    assert model._build_headers()["Authorization"] == "Bearer token-2"
+    serialized = model.model_dump_json()
+    assert "token_provider" not in serialized
+    assert "token-" not in serialized
+
+
+@pytest.mark.unit
+def test_entry_points_are_registered():
+    assert "AzureOpenAIModel" in {
+        entry.name for entry in entry_points(group="swarmauri.llms")
+    }
+    assert "AzureOpenAIToolModel" in {
+        entry.name for entry in entry_points(group="swarmauri.tool_llms")
+    }

--- a/pkgs/community/swarmauri_llm_xai/README.md
+++ b/pkgs/community/swarmauri_llm_xai/README.md
@@ -1,0 +1,50 @@
+![Swarmauri](https://raw.githubusercontent.com/swarmauri/swarmauri-sdk/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+
+<p align="center">
+  <a href="https://pepy.tech/project/swarmauri_llm_xai"><img src="https://static.pepy.tech/badge/swarmauri_llm_xai/month" alt="Downloads"></a>
+  <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/community/swarmauri_llm_xai/"><img src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/community/swarmauri_llm_xai.svg" alt="Hits"></a>
+  <a href="https://pypi.org/project/swarmauri_llm_xai/"><img src="https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12-blue" alt="Python"></a>
+  <a href="https://pypi.org/project/swarmauri_llm_xai/"><img src="https://img.shields.io/pypi/l/swarmauri_llm_xai" alt="License"></a>
+  <a href="https://pypi.org/project/swarmauri_llm_xai/"><img src="https://img.shields.io/pypi/v/swarmauri_llm_xai" alt="Release"></a>
+</p>
+
+# Swarmauri xAI LLM
+
+`swarmauri_llm_xai` provides provider-native Swarmauri adapters for xAI's Grok chat-completions API.
+
+## Features
+
+- `XAIModel` directly implements the Swarmauri LLM base contract.
+- `XAIToolModel` directly implements the tool-LLM base contract.
+- Bearer-token authentication with credentials excluded from serialized state.
+- Sync, async, incremental streaming, batch, and function-calling workflows.
+- Optional model discovery through xAI's language-model catalog.
+
+## Installation
+
+```bash
+uv add swarmauri_llm_xai
+```
+
+```bash
+pip install swarmauri_llm_xai
+```
+
+## Usage
+
+```python
+import os
+
+from swarmauri_llm_xai import XAIModel
+from swarmauri_standard.conversations.Conversation import Conversation
+from swarmauri_standard.messages.HumanMessage import HumanMessage
+
+conversation = Conversation(messages=[HumanMessage(content="Explain orbital mechanics briefly.")])
+model = XAIModel(api_key=os.environ["XAI_API_KEY"], name="grok-4.3")
+model.predict(conversation)
+print(conversation.get_last().content)
+```
+
+Use `XAIToolModel` with a Swarmauri `Toolkit` for function calling. Set `discover_models=True` to populate allowed model IDs from the authenticated xAI language-model catalog.
+
+See the [xAI inference reference](https://docs.x.ai/developers/rest-api-reference/inference), [chat endpoint](https://docs.x.ai/developers/rest-api-reference/inference/chat), and [function-calling guide](https://docs.x.ai/developers/tools/function-calling).

--- a/pkgs/community/swarmauri_llm_xai/pyproject.toml
+++ b/pkgs/community/swarmauri_llm_xai/pyproject.toml
@@ -1,0 +1,37 @@
+[project]
+name = "swarmauri_llm_xai"
+version = "0.11.0.dev1"
+description = "Provider-native Swarmauri chat and tool-calling adapters for the xAI Inference API."
+license = "Apache-2.0"
+readme = "README.md"
+requires-python = ">=3.10,<3.13"
+authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
+keywords = ["swarmauri", "llm", "xai", "grok", "tool calling", "streaming", "inference api"]
+classifiers = [
+  "Development Status :: 1 - Planning",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+]
+dependencies = ["httpx>=0.27", "swarmauri_base", "swarmauri_standard"]
+
+[tool.uv.sources]
+swarmauri_base = { workspace = true }
+swarmauri_standard = { workspace = true }
+
+[project.entry-points."swarmauri.llms"]
+XAIModel = "swarmauri_llm_xai:XAIModel"
+
+[project.entry-points."swarmauri.tool_llms"]
+XAIToolModel = "swarmauri_llm_xai:XAIToolModel"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[dependency-groups]
+dev = ["pytest>=8.0", "pytest-asyncio>=0.24", "ruff>=0.9.9"]
+
+[tool.pytest.ini_options]
+markers = ["unit: Unit tests"]

--- a/pkgs/community/swarmauri_llm_xai/swarmauri_llm_xai/XAIModel.py
+++ b/pkgs/community/swarmauri_llm_xai/swarmauri_llm_xai/XAIModel.py
@@ -1,0 +1,63 @@
+from typing import Any, ClassVar, FrozenSet, List, Literal
+
+import httpx
+from swarmauri_base.ComponentBase import ComponentBase
+from swarmauri_base.llms.LLMBase import LLMBase
+from swarmauri_standard.utils.provider_chat_transport import (
+    abatch_chat,
+    apredict_chat,
+    astream_chat,
+    batch_chat,
+    predict_chat,
+    stream_chat,
+)
+
+
+@ComponentBase.register_type()
+class XAIModel(LLMBase):
+    """Provider-native xAI chat-completions model."""
+
+    type: Literal["XAIModel"] = "XAIModel"
+    base_url: str = "https://api.x.ai/v1"
+    name: str = "grok-4.3"
+    discover_models: bool = False
+    capabilities: ClassVar[FrozenSet[str]] = frozenset(
+        {"chat_completions", "multimodal_input", "streaming", "tools"}
+    )
+
+    predict = predict_chat
+    apredict = apredict_chat
+    stream = stream_chat
+    astream = astream_chat
+    batch = batch_chat
+    abatch = abatch_chat
+
+    def __init__(self, **data: Any) -> None:
+        super().__init__(**data)
+        if self.api_key is None:
+            raise ValueError("api_key is required")
+        self.allowed_models = self.allowed_models or self._get_models()
+
+    def _build_endpoint(self) -> str:
+        return f"{self.base_url.rstrip('/')}/chat/completions"
+
+    def _build_headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.api_key.get_secret_value()}",
+            "Content-Type": "application/json",
+        }
+
+    def _get_models(self) -> List[str]:
+        if not self.discover_models:
+            return [self.name]
+        with httpx.Client(timeout=self.timeout) as client:
+            response = client.get(
+                f"{self.base_url.rstrip('/')}/language-models",
+                headers=self._build_headers(),
+            )
+            response.raise_for_status()
+        return [
+            item["id"]
+            for item in response.json().get("models", [])
+            if item.get("id")
+        ]

--- a/pkgs/community/swarmauri_llm_xai/swarmauri_llm_xai/XAIToolModel.py
+++ b/pkgs/community/swarmauri_llm_xai/swarmauri_llm_xai/XAIToolModel.py
@@ -1,0 +1,73 @@
+from typing import Any, ClassVar, FrozenSet, List, Literal
+
+import httpx
+from swarmauri_base.ComponentBase import ComponentBase
+from swarmauri_base.tool_llms.ToolLLMBase import ToolLLMBase
+from swarmauri_standard.schema_converters.OpenAISchemaConverter import (
+    OpenAISchemaConverter,
+)
+from swarmauri_standard.utils.provider_chat_transport import (
+    abatch_tools,
+    apredict_tools,
+    astream_tools,
+    batch_tools,
+    format_messages,
+    predict_tools,
+    stream_tools,
+)
+
+
+@ComponentBase.register_type()
+class XAIToolModel(ToolLLMBase):
+    """Provider-native xAI tool-calling model."""
+
+    type: Literal["XAIToolModel"] = "XAIToolModel"
+    base_url: str = "https://api.x.ai/v1"
+    name: str = "grok-4.3"
+    discover_models: bool = False
+    capabilities: ClassVar[FrozenSet[str]] = frozenset(
+        {"chat_completions", "streaming", "tools"}
+    )
+
+    predict = predict_tools
+    apredict = apredict_tools
+    stream = stream_tools
+    astream = astream_tools
+    batch = batch_tools
+    abatch = abatch_tools
+
+    def __init__(self, **data: Any) -> None:
+        super().__init__(**data)
+        if self.api_key is None:
+            raise ValueError("api_key is required")
+        self.allowed_models = self.allowed_models or self._get_models()
+
+    def get_schema_converter(self):
+        return OpenAISchemaConverter()
+
+    def _format_messages(self, messages):
+        return format_messages(messages)
+
+    def _build_endpoint(self) -> str:
+        return f"{self.base_url.rstrip('/')}/chat/completions"
+
+    def _build_headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.api_key.get_secret_value()}",
+            "Content-Type": "application/json",
+        }
+
+    def _get_models(self) -> List[str]:
+        if not self.discover_models:
+            return [self.name]
+        with httpx.Client(timeout=self.timeout) as client:
+            response = client.get(
+                f"{self.base_url.rstrip('/')}/language-models",
+                headers=self._build_headers(),
+            )
+            response.raise_for_status()
+        return [
+            item["id"]
+            for item in response.json().get("models", [])
+            if item.get("id")
+        ]

--- a/pkgs/community/swarmauri_llm_xai/swarmauri_llm_xai/__init__.py
+++ b/pkgs/community/swarmauri_llm_xai/swarmauri_llm_xai/__init__.py
@@ -1,0 +1,11 @@
+from importlib.metadata import PackageNotFoundError, version
+
+from .XAIModel import XAIModel
+from .XAIToolModel import XAIToolModel
+
+try:
+    __version__ = version("swarmauri_llm_xai")
+except PackageNotFoundError:
+    __version__ = "0.0.0"
+
+__all__ = ["XAIModel", "XAIToolModel"]

--- a/pkgs/community/swarmauri_llm_xai/tests/unit/test_xai.py
+++ b/pkgs/community/swarmauri_llm_xai/tests/unit/test_xai.py
@@ -1,0 +1,35 @@
+from importlib.metadata import entry_points
+
+import pytest
+from swarmauri_base.llms.LLMBase import LLMBase
+from swarmauri_base.tool_llms.ToolLLMBase import ToolLLMBase
+
+from swarmauri_llm_xai import XAIModel, XAIToolModel
+
+
+@pytest.mark.unit
+def test_models_directly_use_base_contracts():
+    model = XAIModel(api_key="key")
+    tool_model = XAIToolModel(api_key="key")
+    assert isinstance(model, LLMBase)
+    assert isinstance(tool_model, ToolLLMBase)
+    assert model._build_endpoint() == "https://api.x.ai/v1/chat/completions"
+    assert tool_model._build_headers()["Authorization"] == "Bearer key"
+
+
+@pytest.mark.unit
+def test_credentials_are_not_serialized():
+    model = XAIModel(api_key="secret")
+    serialized = model.model_dump_json()
+    assert "api_key" not in serialized
+    assert "secret" not in serialized
+
+
+@pytest.mark.unit
+def test_entry_points_are_registered():
+    assert "XAIModel" in {
+        entry.name for entry in entry_points(group="swarmauri.llms")
+    }
+    assert "XAIToolModel" in {
+        entry.name for entry in entry_points(group="swarmauri.tool_llms")
+    }

--- a/pkgs/package-index.toml
+++ b/pkgs/package-index.toml
@@ -2575,6 +2575,18 @@ order_source = "inferred"
 order_reason = "single-capability package by default"
 
 [[packages]]
+name = "swarmauri_llm_azureopenai"
+path = "community/swarmauri_llm_azureopenai"
+layer = "50-community"
+order = 0
+family = "llm"
+role = "atomic-concrete"
+maturity = "community"
+workspace = true
+order_source = "inferred"
+order_reason = "single-capability package by default"
+
+[[packages]]
 name = "swarmauri_llm_cerebras"
 path = "community/swarmauri_llm_cerebras"
 layer = "50-community"
@@ -2770,6 +2782,18 @@ composes = ["swarmauri_tts_playht"]
 [[packages]]
 name = "swarmauri_llm_whisper"
 path = "community/swarmauri_llm_whisper"
+layer = "50-community"
+order = 0
+family = "llm"
+role = "atomic-concrete"
+maturity = "community"
+workspace = true
+order_source = "inferred"
+order_reason = "single-capability package by default"
+
+[[packages]]
+name = "swarmauri_llm_xai"
+path = "community/swarmauri_llm_xai"
 layer = "50-community"
 order = 0
 family = "llm"

--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -63,6 +63,7 @@ members = [
     "community/swarmauri_keyprovider_vaulttransit",
     "community/swarmauri_llm_ai21",
     "community/swarmauri_llm_anthropic",
+    "community/swarmauri_llm_azureopenai",
     "community/swarmauri_llm_cerebras",
     "community/swarmauri_llm_cloudflare",
     "community/swarmauri_llm_cohere",
@@ -80,6 +81,7 @@ members = [
     "community/swarmauri_llm_perplexity",
     "community/swarmauri_llm_playht",
     "community/swarmauri_llm_whisper",
+    "community/swarmauri_llm_xai",
     "community/swarmauri_matrix_hamming74",
     "community/swarmauri_measurement_mutualinformation",
     "community/swarmauri_measurement_tokencountestimator",
@@ -519,6 +521,7 @@ swarmauri_keyprovider_vaulttransit = { workspace = true }
 swarmauri_keyproviders_mirrored = { workspace = true }
 swarmauri_llm_ai21 = { workspace = true }
 swarmauri_llm_anthropic = { workspace = true }
+swarmauri_llm_azureopenai = { workspace = true }
 swarmauri_llm_cerebras = { workspace = true }
 swarmauri_llm_cloudflare = { workspace = true }
 swarmauri_llm_cohere = { workspace = true }
@@ -536,6 +539,7 @@ swarmauri_llm_openai = { workspace = true }
 swarmauri_llm_perplexity = { workspace = true }
 swarmauri_llm_playht = { workspace = true }
 swarmauri_llm_whisper = { workspace = true }
+swarmauri_llm_xai = { workspace = true }
 swarmauri_matrix_hamming74 = { workspace = true }
 swarmauri_measurement_mutualinformation = { workspace = true }
 swarmauri_measurement_tokencountestimator = { workspace = true }

--- a/pkgs/swarmauri/pyproject.toml
+++ b/pkgs/swarmauri/pyproject.toml
@@ -82,6 +82,7 @@ full = [
 llms = [
     "swarmauri_llm_ai21",
     "swarmauri_llm_anthropic",
+    "swarmauri_llm_azureopenai",
     "swarmauri_llm_cerebras",
     "swarmauri_llm_cloudflare",
     "swarmauri_llm_cohere",
@@ -99,6 +100,7 @@ llms = [
     "swarmauri_llm_perplexity",
     "swarmauri_llm_playht",
     "swarmauri_llm_whisper",
+    "swarmauri_llm_xai",
 ]
 
 [tool.uv.sources]
@@ -107,6 +109,7 @@ swarmauri_base = { workspace = true }
 swarmauri_standard = { workspace = true }
 swarmauri_llm_ai21 = { workspace = true }
 swarmauri_llm_anthropic = { workspace = true }
+swarmauri_llm_azureopenai = { workspace = true }
 swarmauri_llm_cerebras = { workspace = true }
 swarmauri_llm_cloudflare = { workspace = true }
 swarmauri_llm_cohere = { workspace = true }
@@ -124,6 +127,7 @@ swarmauri_llm_openai = { workspace = true }
 swarmauri_llm_perplexity = { workspace = true }
 swarmauri_llm_playht = { workspace = true }
 swarmauri_llm_whisper = { workspace = true }
+swarmauri_llm_xai = { workspace = true }
 swarmauri_vectorstore_doc2vec = { workspace = true }
 swarmauri_embedding_doc2vec = { workspace = true }
 #swarmauri_embedding_tfidf = { workspace = true }

--- a/pkgs/swarmauri/swarmauri/plugin_citizenship_registry.py
+++ b/pkgs/swarmauri/swarmauri/plugin_citizenship_registry.py
@@ -758,6 +758,12 @@ class PluginCitizenshipRegistry:
         "swarmauri.llms.AnthropicToolModel": (
             "swarmauri_llm_anthropic.AnthropicToolModel"
         ),
+        "swarmauri.llms.AzureOpenAIModel": (
+            "swarmauri_llm_azureopenai.AzureOpenAIModel"
+        ),
+        "swarmauri.llms.AzureOpenAIToolModel": (
+            "swarmauri_llm_azureopenai.AzureOpenAIToolModel"
+        ),
         "swarmauri.llms.CerebrasModel": "swarmauri_llm_cerebras.CerebrasModel",
         "swarmauri.llms.CloudflareWorkersAIModel": (
             "swarmauri_llm_cloudflare.CloudflareWorkersAIModel"
@@ -817,11 +823,16 @@ class PluginCitizenshipRegistry:
         "swarmauri.llms.WhisperLargeModel": (
             "swarmauri_llm_whisper.WhisperLargeModel"
         ),
+        "swarmauri.llms.XAIModel": "swarmauri_llm_xai.XAIModel",
+        "swarmauri.llms.XAIToolModel": "swarmauri_llm_xai.XAIToolModel",
         "swarmauri.tool_llms.OpenAIToolModel": (
             "swarmauri_llm_openai.OpenAIToolModel"
         ),
         "swarmauri.tool_llms.AnthropicToolModel": (
             "swarmauri_llm_anthropic.AnthropicToolModel"
+        ),
+        "swarmauri.tool_llms.AzureOpenAIToolModel": (
+            "swarmauri_llm_azureopenai.AzureOpenAIToolModel"
         ),
         "swarmauri.tool_llms.CohereToolModel": (
             "swarmauri_llm_cohere.CohereToolModel"
@@ -841,6 +852,7 @@ class PluginCitizenshipRegistry:
         "swarmauri.tool_llms.NvidiaNIMToolModel": (
             "swarmauri_llm_nvidia_nim.NvidiaNIMToolModel"
         ),
+        "swarmauri.tool_llms.XAIToolModel": "swarmauri_llm_xai.XAIToolModel",
     }
     THIRD_CLASS_REGISTRY: Dict[str, str] = {}
 

--- a/pkgs/swarmauri/tests/unit/test_azure_xai_llm_citizenship.py
+++ b/pkgs/swarmauri/tests/unit/test_azure_xai_llm_citizenship.py
@@ -16,15 +16,3 @@ def test_provider_models_are_second_class():
         assert PluginCitizenshipRegistry.SECOND_CLASS_REGISTRY[
             public_name
         ] == (provider_name)
-
-
-def test_provider_models_lazy_import():
-    from swarmauri.llms import AzureOpenAIModel, XAIModel
-    from swarmauri.tool_llms import AzureOpenAIToolModel, XAIToolModel
-
-    assert AzureOpenAIModel.AzureOpenAIModel.__name__ == "AzureOpenAIModel"
-    assert AzureOpenAIToolModel.AzureOpenAIToolModel.__name__ == (
-        "AzureOpenAIToolModel"
-    )
-    assert XAIModel.XAIModel.__name__ == "XAIModel"
-    assert XAIToolModel.XAIToolModel.__name__ == "XAIToolModel"

--- a/pkgs/swarmauri/tests/unit/test_azure_xai_llm_citizenship.py
+++ b/pkgs/swarmauri/tests/unit/test_azure_xai_llm_citizenship.py
@@ -1,0 +1,30 @@
+from swarmauri.plugin_citizenship_registry import PluginCitizenshipRegistry
+
+
+def test_provider_models_are_second_class():
+    expected = {
+        "swarmauri.llms.AzureOpenAIModel": (
+            "swarmauri_llm_azureopenai.AzureOpenAIModel"
+        ),
+        "swarmauri.tool_llms.AzureOpenAIToolModel": (
+            "swarmauri_llm_azureopenai.AzureOpenAIToolModel"
+        ),
+        "swarmauri.llms.XAIModel": "swarmauri_llm_xai.XAIModel",
+        "swarmauri.tool_llms.XAIToolModel": "swarmauri_llm_xai.XAIToolModel",
+    }
+    for public_name, provider_name in expected.items():
+        assert PluginCitizenshipRegistry.SECOND_CLASS_REGISTRY[
+            public_name
+        ] == (provider_name)
+
+
+def test_provider_models_lazy_import():
+    from swarmauri.llms import AzureOpenAIModel, XAIModel
+    from swarmauri.tool_llms import AzureOpenAIToolModel, XAIToolModel
+
+    assert AzureOpenAIModel.AzureOpenAIModel.__name__ == "AzureOpenAIModel"
+    assert AzureOpenAIToolModel.AzureOpenAIToolModel.__name__ == (
+        "AzureOpenAIToolModel"
+    )
+    assert XAIModel.XAIModel.__name__ == "XAIModel"
+    assert XAIToolModel.XAIToolModel.__name__ == "XAIToolModel"

--- a/pkgs/swarmauri_standard/swarmauri_standard/utils/provider_chat_transport.py
+++ b/pkgs/swarmauri_standard/swarmauri_standard/utils/provider_chat_transport.py
@@ -1,0 +1,559 @@
+"""HTTP transport helpers for provider-native chat model classes."""
+
+import asyncio
+import json
+from typing import Any, AsyncGenerator, Dict, Generator, List, Optional
+
+import httpx
+
+from swarmauri_standard.messages.AgentMessage import AgentMessage, UsageData
+from swarmauri_standard.messages.FunctionMessage import FunctionMessage
+from swarmauri_standard.utils.duration_manager import DurationManager
+from swarmauri_standard.utils.retry_decorator import retry_on_status_codes
+
+
+def format_messages(messages: List[Any]) -> List[Dict[str, Any]]:
+    properties = ["content", "role", "name", "tool_call_id", "tool_calls"]
+    return [
+        message.model_dump(include=properties, exclude_none=True)
+        for message in messages
+    ]
+
+
+def chat_payload(
+    model: Any,
+    messages: List[Dict[str, Any]],
+    *,
+    temperature: float,
+    max_tokens: int,
+    top_p: float,
+    enable_json: bool,
+    stop: Optional[List[str]],
+    stream: bool = False,
+) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {
+        "model": model.name,
+        "messages": messages,
+        "temperature": temperature,
+        "max_tokens": max_tokens,
+        "top_p": top_p,
+        "stop": stop or [],
+    }
+    if enable_json:
+        payload["response_format"] = {"type": "json_object"}
+    if stream:
+        payload["stream"] = True
+        if model.include_usage:
+            payload["stream_options"] = {"include_usage": True}
+    return payload
+
+
+def _usage(data: Dict[str, Any], prompt: float, completion: float = 0.0):
+    return UsageData(
+        prompt_tokens=data.get("prompt_tokens", 0),
+        completion_tokens=data.get("completion_tokens", 0),
+        total_tokens=data.get("total_tokens", 0),
+        prompt_time=prompt,
+        completion_time=completion,
+        total_time=prompt + completion,
+    )
+
+
+def _add_agent(
+    model: Any,
+    conversation: Any,
+    content: str,
+    usage_data: Optional[Dict[str, Any]] = None,
+    prompt_time: float = 0.0,
+    completion_time: float = 0.0,
+) -> None:
+    usage = None
+    if model.include_usage:
+        usage = _usage(usage_data or {}, prompt_time, completion_time)
+    conversation.add_message(AgentMessage(content=content, usage=usage))
+
+
+@retry_on_status_codes()
+def predict_chat(
+    model: Any,
+    conversation: Any,
+    temperature: float = 0.7,
+    max_tokens: int = 256,
+    top_p: float = 1.0,
+    enable_json: bool = False,
+    stop: Optional[List[str]] = None,
+):
+    payload = chat_payload(
+        model,
+        format_messages(conversation.history),
+        temperature=temperature,
+        max_tokens=max_tokens,
+        top_p=top_p,
+        enable_json=enable_json,
+        stop=stop,
+    )
+    with DurationManager() as timer:
+        with httpx.Client(timeout=model.timeout) as client:
+            response = client.post(
+                model._build_endpoint(),
+                headers=model._build_headers(),
+                json=payload,
+            )
+            response.raise_for_status()
+    data = response.json()
+    content = data["choices"][0]["message"].get("content") or ""
+    _add_agent(model, conversation, content, data.get("usage"), timer.duration)
+    return conversation
+
+
+@retry_on_status_codes()
+async def apredict_chat(
+    model: Any,
+    conversation: Any,
+    temperature: float = 0.7,
+    max_tokens: int = 256,
+    top_p: float = 1.0,
+    enable_json: bool = False,
+    stop: Optional[List[str]] = None,
+):
+    payload = chat_payload(
+        model,
+        format_messages(conversation.history),
+        temperature=temperature,
+        max_tokens=max_tokens,
+        top_p=top_p,
+        enable_json=enable_json,
+        stop=stop,
+    )
+    with DurationManager() as timer:
+        async with httpx.AsyncClient(timeout=model.timeout) as client:
+            response = await client.post(
+                model._build_endpoint(),
+                headers=model._build_headers(),
+                json=payload,
+            )
+            response.raise_for_status()
+    data = response.json()
+    content = data["choices"][0]["message"].get("content") or ""
+    _add_agent(model, conversation, content, data.get("usage"), timer.duration)
+    return conversation
+
+
+def _parse_sse(line: str) -> tuple[Optional[str], Dict[str, Any]]:
+    if not line.startswith("data: "):
+        return None, {}
+    raw = line[6:].strip()
+    if not raw or raw == "[DONE]":
+        return None, {}
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return None, {}
+    choices = data.get("choices") or []
+    content = (
+        (choices[0].get("delta") or {}).get("content") if choices else None
+    )
+    return content, data.get("usage") or {}
+
+
+def stream_chat(
+    model: Any,
+    conversation: Any,
+    temperature: float = 0.7,
+    max_tokens: int = 256,
+    top_p: float = 1.0,
+    enable_json: bool = False,
+    stop: Optional[List[str]] = None,
+) -> Generator[str, None, None]:
+    payload = chat_payload(
+        model,
+        format_messages(conversation.history),
+        temperature=temperature,
+        max_tokens=max_tokens,
+        top_p=top_p,
+        enable_json=enable_json,
+        stop=stop,
+        stream=True,
+    )
+    content = ""
+    usage_data: Dict[str, Any] = {}
+    with DurationManager() as prompt_timer:
+        with httpx.Client(timeout=model.timeout) as client:
+            with client.stream(
+                "POST",
+                model._build_endpoint(),
+                headers=model._build_headers(),
+                json=payload,
+            ) as response:
+                response.raise_for_status()
+                with DurationManager() as completion_timer:
+                    for line in response.iter_lines():
+                        delta, usage = _parse_sse(line)
+                        usage_data = usage or usage_data
+                        if delta is not None:
+                            content += delta
+                            yield delta
+    _add_agent(
+        model,
+        conversation,
+        content,
+        usage_data,
+        prompt_timer.duration,
+        completion_timer.duration,
+    )
+
+
+async def astream_chat(
+    model: Any,
+    conversation: Any,
+    temperature: float = 0.7,
+    max_tokens: int = 256,
+    top_p: float = 1.0,
+    enable_json: bool = False,
+    stop: Optional[List[str]] = None,
+) -> AsyncGenerator[str, None]:
+    payload = chat_payload(
+        model,
+        format_messages(conversation.history),
+        temperature=temperature,
+        max_tokens=max_tokens,
+        top_p=top_p,
+        enable_json=enable_json,
+        stop=stop,
+        stream=True,
+    )
+    content = ""
+    usage_data: Dict[str, Any] = {}
+    with DurationManager() as prompt_timer:
+        async with httpx.AsyncClient(timeout=model.timeout) as client:
+            async with client.stream(
+                "POST",
+                model._build_endpoint(),
+                headers=model._build_headers(),
+                json=payload,
+            ) as response:
+                response.raise_for_status()
+                with DurationManager() as completion_timer:
+                    async for line in response.aiter_lines():
+                        delta, usage = _parse_sse(line)
+                        usage_data = usage or usage_data
+                        if delta is not None:
+                            content += delta
+                            yield delta
+    _add_agent(
+        model,
+        conversation,
+        content,
+        usage_data,
+        prompt_timer.duration,
+        completion_timer.duration,
+    )
+
+
+def batch_chat(model: Any, conversations: List[Any], **kwargs) -> List[Any]:
+    return [
+        predict_chat(model, conversation, **kwargs)
+        for conversation in conversations
+    ]
+
+
+async def abatch_chat(
+    model: Any,
+    conversations: List[Any],
+    max_concurrent: int = 5,
+    **kwargs,
+) -> List[Any]:
+    semaphore = asyncio.Semaphore(max_concurrent)
+
+    async def run(conversation: Any):
+        async with semaphore:
+            return await apredict_chat(model, conversation, **kwargs)
+
+    return await asyncio.gather(*(run(item) for item in conversations))
+
+
+def tool_payload(
+    model: Any,
+    messages: List[Dict[str, Any]],
+    toolkit: Any,
+    tool_choice: Any,
+    temperature: float,
+    max_tokens: int,
+    stream: bool = False,
+) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {
+        "model": model.name,
+        "messages": messages,
+        "temperature": temperature,
+        "max_tokens": max_tokens,
+    }
+    if toolkit is not None:
+        payload["tools"] = model._schema_convert_tools(toolkit.tools)
+        payload["tool_choice"] = tool_choice or "auto"
+    if stream:
+        payload["stream"] = True
+    return payload
+
+
+def _execute_tools(
+    model: Any, tool_calls: List[Dict[str, Any]], toolkit: Any
+) -> List[Dict[str, Any]]:
+    messages = []
+    for call in tool_calls:
+        name = call["function"]["name"]
+        function = toolkit.get_tool_by_name(name)
+        result = function(**json.loads(call["function"]["arguments"]))
+        messages.append(
+            {
+                "role": "tool",
+                "tool_call_id": call["id"],
+                "name": name,
+                "content": json.dumps(result),
+            }
+        )
+    return messages
+
+
+def _record_tool_turn(
+    conversation: Any,
+    provider_message: Dict[str, Any],
+    tool_messages: List[Dict[str, Any]],
+) -> None:
+    conversation.add_message(
+        AgentMessage(
+            content=provider_message.get("content"),
+            tool_calls=provider_message.get("tool_calls"),
+        )
+    )
+    conversation.add_messages(
+        [
+            FunctionMessage(
+                tool_call_id=message["tool_call_id"],
+                name=message["name"],
+                content=message["content"],
+            )
+            for message in tool_messages
+        ]
+    )
+
+
+def _post_tool(model: Any, payload: Dict[str, Any]) -> Dict[str, Any]:
+    with httpx.Client(timeout=model.timeout) as client:
+        response = client.post(
+            model._build_endpoint(),
+            headers=model._build_headers(),
+            json=payload,
+        )
+        response.raise_for_status()
+    return response.json()["choices"][0]["message"]
+
+
+async def _apost_tool(model: Any, payload: Dict[str, Any]) -> Dict[str, Any]:
+    async with httpx.AsyncClient(timeout=model.timeout) as client:
+        response = await client.post(
+            model._build_endpoint(),
+            headers=model._build_headers(),
+            json=payload,
+        )
+        response.raise_for_status()
+    return response.json()["choices"][0]["message"]
+
+
+@retry_on_status_codes()
+def predict_tools(
+    model: Any,
+    conversation: Any,
+    toolkit: Any,
+    tool_choice: Any = None,
+    multiturn: bool = True,
+    temperature: float = 0.7,
+    max_tokens: int = 1024,
+):
+    messages = format_messages(conversation.history)
+    payload = tool_payload(
+        model, messages, toolkit, tool_choice, temperature, max_tokens
+    )
+    provider_message = _post_tool(model, payload)
+    calls = provider_message.get("tool_calls") or []
+    if not calls:
+        conversation.add_message(
+            AgentMessage(content=provider_message.get("content") or "")
+        )
+        return conversation
+    tool_messages = _execute_tools(model, calls, toolkit)
+    _record_tool_turn(conversation, provider_message, tool_messages)
+    if multiturn:
+        follow_up = tool_payload(
+            model,
+            messages + [provider_message] + tool_messages,
+            None,
+            None,
+            temperature,
+            max_tokens,
+        )
+        final = _post_tool(model, follow_up)
+        conversation.add_message(
+            AgentMessage(content=final.get("content") or "")
+        )
+    return conversation
+
+
+@retry_on_status_codes()
+async def apredict_tools(
+    model: Any,
+    conversation: Any,
+    toolkit: Any,
+    tool_choice: Any = None,
+    multiturn: bool = True,
+    temperature: float = 0.7,
+    max_tokens: int = 1024,
+):
+    messages = format_messages(conversation.history)
+    payload = tool_payload(
+        model, messages, toolkit, tool_choice, temperature, max_tokens
+    )
+    provider_message = await _apost_tool(model, payload)
+    calls = provider_message.get("tool_calls") or []
+    if not calls:
+        conversation.add_message(
+            AgentMessage(content=provider_message.get("content") or "")
+        )
+        return conversation
+    tool_messages = _execute_tools(model, calls, toolkit)
+    _record_tool_turn(conversation, provider_message, tool_messages)
+    if multiturn:
+        follow_up = tool_payload(
+            model,
+            messages + [provider_message] + tool_messages,
+            None,
+            None,
+            temperature,
+            max_tokens,
+        )
+        final = await _apost_tool(model, follow_up)
+        conversation.add_message(
+            AgentMessage(content=final.get("content") or "")
+        )
+    return conversation
+
+
+def stream_tools(
+    model: Any,
+    conversation: Any,
+    toolkit: Any,
+    tool_choice: Any = None,
+    temperature: float = 0.7,
+    max_tokens: int = 1024,
+) -> Generator[str, None, None]:
+    messages = format_messages(conversation.history)
+    first = _post_tool(
+        model,
+        tool_payload(
+            model, messages, toolkit, tool_choice, temperature, max_tokens
+        ),
+    )
+    calls = first.get("tool_calls") or []
+    if not calls:
+        content = first.get("content") or ""
+        conversation.add_message(AgentMessage(content=content))
+        if content:
+            yield content
+        return
+    tool_messages = _execute_tools(model, calls, toolkit)
+    _record_tool_turn(conversation, first, tool_messages)
+    payload = tool_payload(
+        model,
+        messages + [first] + tool_messages,
+        None,
+        None,
+        temperature,
+        max_tokens,
+        stream=True,
+    )
+    content = ""
+    with httpx.Client(timeout=model.timeout) as client:
+        with client.stream(
+            "POST",
+            model._build_endpoint(),
+            headers=model._build_headers(),
+            json=payload,
+        ) as response:
+            response.raise_for_status()
+            for line in response.iter_lines():
+                delta, _ = _parse_sse(line)
+                if delta is not None:
+                    content += delta
+                    yield delta
+    conversation.add_message(AgentMessage(content=content))
+
+
+async def astream_tools(
+    model: Any,
+    conversation: Any,
+    toolkit: Any,
+    tool_choice: Any = None,
+    temperature: float = 0.7,
+    max_tokens: int = 1024,
+) -> AsyncGenerator[str, None]:
+    messages = format_messages(conversation.history)
+    first = await _apost_tool(
+        model,
+        tool_payload(
+            model, messages, toolkit, tool_choice, temperature, max_tokens
+        ),
+    )
+    calls = first.get("tool_calls") or []
+    if not calls:
+        content = first.get("content") or ""
+        conversation.add_message(AgentMessage(content=content))
+        if content:
+            yield content
+        return
+    tool_messages = _execute_tools(model, calls, toolkit)
+    _record_tool_turn(conversation, first, tool_messages)
+    payload = tool_payload(
+        model,
+        messages + [first] + tool_messages,
+        None,
+        None,
+        temperature,
+        max_tokens,
+        stream=True,
+    )
+    content = ""
+    async with httpx.AsyncClient(timeout=model.timeout) as client:
+        async with client.stream(
+            "POST",
+            model._build_endpoint(),
+            headers=model._build_headers(),
+            json=payload,
+        ) as response:
+            response.raise_for_status()
+            async for line in response.aiter_lines():
+                delta, _ = _parse_sse(line)
+                if delta is not None:
+                    content += delta
+                    yield delta
+    conversation.add_message(AgentMessage(content=content))
+
+
+def batch_tools(model: Any, conversations: List[Any], **kwargs) -> List[Any]:
+    return [
+        predict_tools(model, conversation, **kwargs)
+        for conversation in conversations
+    ]
+
+
+async def abatch_tools(
+    model: Any,
+    conversations: List[Any],
+    max_concurrent: int = 5,
+    **kwargs,
+) -> List[Any]:
+    semaphore = asyncio.Semaphore(max_concurrent)
+
+    async def run(conversation: Any):
+        async with semaphore:
+            return await apredict_tools(model, conversation, **kwargs)
+
+    return await asyncio.gather(*(run(item) for item in conversations))

--- a/pkgs/swarmauri_standard/tests/unit/utils/provider_chat_transport_test.py
+++ b/pkgs/swarmauri_standard/tests/unit/utils/provider_chat_transport_test.py
@@ -1,0 +1,166 @@
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from swarmauri_standard.conversations.Conversation import Conversation
+from swarmauri_standard.messages.HumanMessage import HumanMessage
+from swarmauri_standard.messages.FunctionMessage import FunctionMessage
+from swarmauri_standard.utils.provider_chat_transport import (
+    apredict_chat,
+    astream_chat,
+    predict_chat,
+    predict_tools,
+    stream_chat,
+)
+
+
+def _model():
+    return SimpleNamespace(
+        name="model",
+        include_usage=True,
+        timeout=1,
+        max_retries=1,
+        retry_delay=0,
+        retryable_status_codes={429, 500},
+        _build_endpoint=lambda: "https://provider.test/v1/chat/completions",
+        _build_headers=lambda: {"Authorization": "Bearer secret"},
+    )
+
+
+@pytest.mark.unit
+def test_predict_and_stream_use_provider_hooks(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["authorization"] == "Bearer secret"
+        body = request.read().decode()
+        if '"stream":true' in body:
+            return httpx.Response(
+                200,
+                text=(
+                    'data: {"choices":[{"delta":{"content":"hel"}}]}\n\n'
+                    'data: {"choices":[{"delta":{"content":"lo"}}]}\n\n'
+                    "data: [DONE]\n\n"
+                ),
+            )
+        return httpx.Response(
+            200,
+            json={
+                "choices": [{"message": {"content": "hello"}}],
+                "usage": {
+                    "prompt_tokens": 1,
+                    "completion_tokens": 1,
+                    "total_tokens": 2,
+                },
+            },
+        )
+
+    original_client = httpx.Client
+    monkeypatch.setattr(
+        httpx,
+        "Client",
+        lambda **kwargs: original_client(
+            transport=httpx.MockTransport(handler), **kwargs
+        ),
+    )
+    conversation = Conversation(messages=[HumanMessage(content="hi")])
+    predict_chat(_model(), conversation)
+    assert conversation.get_last().content == "hello"
+
+    streaming = Conversation(messages=[HumanMessage(content="hi")])
+    assert "".join(stream_chat(_model(), streaming)) == "hello"
+    assert streaming.get_last().content == "hello"
+
+
+@pytest.mark.unit
+def test_tool_round_trip_records_function_history(monkeypatch):
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [
+                        {
+                            "message": {
+                                "role": "assistant",
+                                "content": None,
+                                "tool_calls": [
+                                    {
+                                        "id": "call-1",
+                                        "type": "function",
+                                        "function": {
+                                            "name": "double",
+                                            "arguments": '{"value": 4}',
+                                        },
+                                    }
+                                ],
+                            }
+                        }
+                    ]
+                },
+            )
+        assert '"role":"tool"' in request.read().decode()
+        return httpx.Response(
+            200, json={"choices": [{"message": {"content": "8"}}]}
+        )
+
+    original_client = httpx.Client
+    monkeypatch.setattr(
+        httpx,
+        "Client",
+        lambda **kwargs: original_client(
+            transport=httpx.MockTransport(handler), **kwargs
+        ),
+    )
+    model = _model()
+    model._schema_convert_tools = lambda tools: []
+    toolkit = SimpleNamespace(
+        tools={"double": object()},
+        get_tool_by_name=lambda name: lambda value: value * 2,
+    )
+    conversation = Conversation(messages=[HumanMessage(content="double 4")])
+
+    predict_tools(model, conversation, toolkit)
+
+    assert calls == 2
+    assert isinstance(conversation.history[-2], FunctionMessage)
+    assert conversation.history[-2].role == "tool"
+    assert conversation.get_last().content == "8"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_async_predict_and_stream_use_provider_hooks(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        if '"stream":true' in request.read().decode():
+            return httpx.Response(
+                200,
+                text=(
+                    'data: {"choices":[{"delta":{"content":"ok"}}]}\n\n'
+                    "data: [DONE]\n\n"
+                ),
+            )
+        return httpx.Response(
+            200,
+            json={"choices": [{"message": {"content": "ok"}}]},
+        )
+
+    original_client = httpx.AsyncClient
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda **kwargs: original_client(
+            transport=httpx.MockTransport(handler), **kwargs
+        ),
+    )
+    conversation = Conversation(messages=[HumanMessage(content="hi")])
+    await apredict_chat(_model(), conversation)
+    assert conversation.get_last().content == "ok"
+
+    streaming = Conversation(messages=[HumanMessage(content="hi")])
+    chunks = [chunk async for chunk in astream_chat(_model(), streaming)]
+    assert chunks == ["ok"]
+    assert streaming.get_last().content == "ok"


### PR DESCRIPTION
## Summary
- add provider-native Azure OpenAI chat and tool models directly on LLMBase and ToolLLMBase
- support Azure API keys and refreshable Entra token providers without serializing credentials
- add provider-native xAI chat and tool models directly on the base contracts
- add shared low-level sync, async, streaming, batch, retry, and tool-round-trip HTTP transport
- register entry points, second-class lazy imports, workspace metadata, and package index entries

## Validation
- Azure OpenAI package: 3 passed
- xAI package: 3 passed
- provider transport: 3 passed, covering sync, async, streaming, and FunctionMessage tool history
- registry citizenship and lazy imports: 2 passed
- ruff format and check passed for all changed packages
- package index validation passed

Stacked on #6213.

Closes #215
Closes #123