### PR TITLE
fix: sandbox Jinja prompt templates by default

### DIFF
--- a/pkgs/standards/swarmauri_prompt_j2prompttemplate/README.md
+++ b/pkgs/standards/swarmauri_prompt_j2prompttemplate/README.md
@@ -28,8 +28,9 @@ variables you provide, and registers itself as the `J2PromptTemplate`
   Jinja2 templates with fallback lookup.
 - Ship with helpful filters (`split`, `make_singular`, `make_plural`) for prompt
   engineering tasks.
-- Render in Jinja's sandbox by default so template source cannot traverse the
-  Python object graph or invoke unsafe callables.
+- Render in an immutable Jinja sandbox by default so template source cannot
+  traverse the Python object graph, invoke supplied callables, or mutate
+  caller-provided containers.
 - Call the instance directly (`template({...})`) or use `generate_prompt()` to
   render with the stored variables.
 
@@ -86,9 +87,13 @@ template's own directory.
 
 ### Template trust and sandboxing
 
-`J2PromptTemplate` uses `SandboxedEnvironment` by default. Use this mode for
-template strings and files that may come from users, registries, generated
-artifacts, or any source that is not fully controlled by the application.
+`J2PromptTemplate` uses a strict `ImmutableSandboxedEnvironment` by default.
+Use this mode for template strings and files that may come from users,
+registries, generated artifacts, or any source that is not fully controlled by
+the application. Default-mode templates cannot call functions or methods,
+including callables supplied as variables, and cannot invoke mutating methods
+on list, dictionary, or set inputs. Variable interpolation and registered
+filters remain available.
 
 Applications that intentionally rely on unrestricted Jinja behavior can opt
 in explicitly:
@@ -102,10 +107,10 @@ trusted = J2PromptTemplate(
 
 Trusted mode allows templates to access the same Python capabilities as a
 normal Jinja `Environment`; never enable it for untrusted template source.
-Precompiled templates created by a normal Jinja environment are rejected in
-the default mode because they cannot be retroactively sandboxed. The sandbox
-limits Python object access, but applications should still apply time and
-resource limits when rendering adversarial templates.
+Precompiled templates not created by this strict environment are rejected in
+the default mode because they cannot be retroactively restricted. The sandbox
+limits Python object access and callable execution, but applications should
+still apply time and resource limits when rendering adversarial templates.
 
 ## Want to help?
 

--- a/pkgs/standards/swarmauri_prompt_j2prompttemplate/README.md
+++ b/pkgs/standards/swarmauri_prompt_j2prompttemplate/README.md
@@ -28,6 +28,8 @@ variables you provide, and registers itself as the `J2PromptTemplate`
   Jinja2 templates with fallback lookup.
 - Ship with helpful filters (`split`, `make_singular`, `make_plural`) for prompt
   engineering tasks.
+- Render in Jinja's sandbox by default so template source cannot traverse the
+  Python object graph or invoke unsafe callables.
 - Call the instance directly (`template({...})`) or use `generate_prompt()` to
   render with the stored variables.
 
@@ -81,6 +83,29 @@ print(prompt({"animal": "fox"}))  # Hello, foxes!
 file is located relative to the provided `templates_dir`. If the loader cannot
 find it immediately, the class searches recursively before falling back to the
 template's own directory.
+
+### Template trust and sandboxing
+
+`J2PromptTemplate` uses `SandboxedEnvironment` by default. Use this mode for
+template strings and files that may come from users, registries, generated
+artifacts, or any source that is not fully controlled by the application.
+
+Applications that intentionally rely on unrestricted Jinja behavior can opt
+in explicitly:
+
+```python
+trusted = J2PromptTemplate(
+    template="{{ trusted_helper() }}",
+    trusted_templates=True,
+)
+```
+
+Trusted mode allows templates to access the same Python capabilities as a
+normal Jinja `Environment`; never enable it for untrusted template source.
+Precompiled templates created by a normal Jinja environment are rejected in
+the default mode because they cannot be retroactively sandboxed. The sandbox
+limits Python object access, but applications should still apply time and
+resource limits when rendering adversarial templates.
 
 ## Want to help?
 

--- a/pkgs/standards/swarmauri_prompt_j2prompttemplate/swarmauri_prompt_j2prompttemplate/J2PromptTemplate.py
+++ b/pkgs/standards/swarmauri_prompt_j2prompttemplate/swarmauri_prompt_j2prompttemplate/J2PromptTemplate.py
@@ -3,12 +3,20 @@ from typing import Any, Callable, Dict, List, Literal, Optional, Union
 
 from jinja2 import Environment, FileSystemLoader, Template
 from jinja2.exceptions import SecurityError
-from jinja2.sandbox import SandboxedEnvironment
+from jinja2.sandbox import ImmutableSandboxedEnvironment
 from pydantic import ConfigDict, FilePath
 from swarmauri_base.ComponentBase import ComponentBase
 from swarmauri_base.prompt_templates.PromptTemplateBase import (
     PromptTemplateBase,
 )
+
+
+class _StrictSandboxedEnvironment(ImmutableSandboxedEnvironment):
+    """Sandbox that denies every callable reached from template source."""
+
+    def is_safe_callable(self, obj: Any) -> bool:
+        del obj
+        return False
 
 
 @ComponentBase.register_type(PromptTemplateBase, "J2PromptTemplate")
@@ -61,7 +69,9 @@ class J2PromptTemplate(PromptTemplateBase):
         else:
             loader = None
         environment_type = (
-            Environment if self.trusted_templates else SandboxedEnvironment
+            Environment
+            if self.trusted_templates
+            else _StrictSandboxedEnvironment
         )
         env = environment_type(loader=loader, autoescape=False)
 
@@ -158,7 +168,9 @@ class J2PromptTemplate(PromptTemplateBase):
                 directory = os.getcwd()
         template_name = os.path.basename(template_path_str)
         environment_type = (
-            Environment if self.trusted_templates else SandboxedEnvironment
+            Environment
+            if self.trusted_templates
+            else _StrictSandboxedEnvironment
         )
         fallback_env = environment_type(
             loader=FileSystemLoader([directory]), autoescape=False
@@ -196,11 +208,11 @@ class J2PromptTemplate(PromptTemplateBase):
         env = self.get_env()
         if isinstance(self.template, Template):
             if not self.trusted_templates and not isinstance(
-                self.template.environment, SandboxedEnvironment
+                self.template.environment, _StrictSandboxedEnvironment
             ):
                 raise SecurityError(
-                    "Precompiled templates from an unrestricted Jinja "
-                    "environment "
+                    "Precompiled templates not created by the strict "
+                    "Jinja sandbox "
                     "require trusted_templates=True"
                 )
             tmpl = self.template

--- a/pkgs/standards/swarmauri_prompt_j2prompttemplate/swarmauri_prompt_j2prompttemplate/J2PromptTemplate.py
+++ b/pkgs/standards/swarmauri_prompt_j2prompttemplate/swarmauri_prompt_j2prompttemplate/J2PromptTemplate.py
@@ -2,6 +2,8 @@ import os
 from typing import Any, Callable, Dict, List, Literal, Optional, Union
 
 from jinja2 import Environment, FileSystemLoader, Template
+from jinja2.exceptions import SecurityError
+from jinja2.sandbox import SandboxedEnvironment
 from pydantic import ConfigDict, FilePath
 from swarmauri_base.ComponentBase import ComponentBase
 from swarmauri_base.prompt_templates.PromptTemplateBase import (
@@ -34,8 +36,9 @@ class J2PromptTemplate(PromptTemplateBase):
     # Optional templates_dir attribute (can be a single path or a list of
     # paths)
     templates_dir: Optional[Union[str, List[str]]] = None
-    # Whether to enable code generation specific features like linguistic
-    # filters
+    # Unrestricted Jinja execution is available only as an explicit opt-in for
+    # applications whose template source is fully trusted.
+    trusted_templates: bool = False
 
     model_config = ConfigDict(arbitrary_types_allowed=True, extra="allow")
     type: Literal["J2PromptTemplate"] = "J2PromptTemplate"
@@ -57,7 +60,10 @@ class J2PromptTemplate(PromptTemplateBase):
                 loader = FileSystemLoader(self.templates_dir)
         else:
             loader = None
-        env = Environment(loader=loader, autoescape=False)
+        environment_type = (
+            Environment if self.trusted_templates else SandboxedEnvironment
+        )
+        env = environment_type(loader=loader, autoescape=False)
 
         # Add basic filters
         env.filters["split"] = self.split_whitespace
@@ -151,7 +157,10 @@ class J2PromptTemplate(PromptTemplateBase):
             else:
                 directory = os.getcwd()
         template_name = os.path.basename(template_path_str)
-        fallback_env = Environment(
+        environment_type = (
+            Environment if self.trusted_templates else SandboxedEnvironment
+        )
+        fallback_env = environment_type(
             loader=FileSystemLoader([directory]), autoescape=False
         )
         fallback_env.filters["split"] = self.split_whitespace
@@ -186,6 +195,14 @@ class J2PromptTemplate(PromptTemplateBase):
         variables = variables or self.variables
         env = self.get_env()
         if isinstance(self.template, Template):
+            if not self.trusted_templates and not isinstance(
+                self.template.environment, SandboxedEnvironment
+            ):
+                raise SecurityError(
+                    "Precompiled templates from an unrestricted Jinja "
+                    "environment "
+                    "require trusted_templates=True"
+                )
             tmpl = self.template
         else:
             tmpl = env.from_string(self.template)

--- a/pkgs/standards/swarmauri_prompt_j2prompttemplate/tests/unit/test_J2PromptTemplate.py
+++ b/pkgs/standards/swarmauri_prompt_j2prompttemplate/tests/unit/test_J2PromptTemplate.py
@@ -5,7 +5,7 @@ from tempfile import NamedTemporaryFile
 import pytest
 from jinja2 import Environment
 from jinja2.exceptions import SecurityError
-from jinja2.sandbox import SandboxedEnvironment
+from jinja2.sandbox import ImmutableSandboxedEnvironment, SandboxedEnvironment
 from swarmauri_prompt_j2prompttemplate.J2PromptTemplate import J2PromptTemplate
 
 
@@ -20,7 +20,7 @@ def test_initialization():
     assert isinstance(template.template, str)
     assert isinstance(template.variables, dict)
     assert template.trusted_templates is False
-    assert isinstance(template.get_env(), SandboxedEnvironment)
+    assert isinstance(template.get_env(), ImmutableSandboxedEnvironment)
 
 
 @pytest.mark.unit
@@ -103,6 +103,42 @@ def test_default_sandbox_rejects_object_graph_escape():
 
 
 @pytest.mark.unit
+def test_default_sandbox_rejects_supplied_callable_without_executing_it():
+    calls = []
+    template = J2PromptTemplate(template="{{ helper() }}")
+
+    with pytest.raises(SecurityError):
+        template.fill({"helper": lambda: calls.append("called")})
+
+    assert calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("source", "value"),
+    [
+        ("{{ value.clear() }}", ["kept"]),
+        ("{{ value.update({'changed': true}) }}", {"kept": True}),
+    ],
+)
+def test_default_sandbox_rejects_mutation(source, value):
+    original = value.copy()
+    template = J2PromptTemplate(template=source)
+
+    with pytest.raises(SecurityError):
+        template.fill({"value": value})
+
+    assert value == original
+
+
+@pytest.mark.unit
+def test_default_sandbox_preserves_interpolation_and_filters():
+    template = J2PromptTemplate(template="Hello {{ name | upper }}!")
+
+    assert template.fill({"name": "world"}) == "Hello WORLD!"
+
+
+@pytest.mark.unit
 def test_file_template_uses_default_sandbox(tmp_path: Path):
     template_path = tmp_path / "unsafe.j2"
     template_path.write_text(
@@ -125,6 +161,15 @@ def test_default_sandbox_rejects_unrestricted_precompiled_template():
 
 
 @pytest.mark.unit
+def test_default_sandbox_rejects_ordinary_sandbox_precompiled_template():
+    compiled = SandboxedEnvironment().from_string("{{ helper() }}")
+    template = J2PromptTemplate(template=compiled)
+
+    with pytest.raises(SecurityError, match="trusted_templates=True"):
+        template.fill({"helper": lambda: "unsafe"})
+
+
+@pytest.mark.unit
 def test_explicit_trusted_mode_preserves_unrestricted_jinja_behavior():
     template = J2PromptTemplate(
         template="{{ cycler.__init__.__globals__.os.name }}",
@@ -133,3 +178,13 @@ def test_explicit_trusted_mode_preserves_unrestricted_jinja_behavior():
 
     assert template.fill() == os.name
     assert type(template.get_env()) is Environment
+
+
+@pytest.mark.unit
+def test_explicit_trusted_mode_allows_supplied_callable():
+    template = J2PromptTemplate(
+        template="{{ helper() }}",
+        trusted_templates=True,
+    )
+
+    assert template.fill({"helper": lambda: "trusted"}) == "trusted"

--- a/pkgs/standards/swarmauri_prompt_j2prompttemplate/tests/unit/test_J2PromptTemplate.py
+++ b/pkgs/standards/swarmauri_prompt_j2prompttemplate/tests/unit/test_J2PromptTemplate.py
@@ -1,6 +1,11 @@
 import os
+from pathlib import Path
 from tempfile import NamedTemporaryFile
+
 import pytest
+from jinja2 import Environment
+from jinja2.exceptions import SecurityError
+from jinja2.sandbox import SandboxedEnvironment
 from swarmauri_prompt_j2prompttemplate.J2PromptTemplate import J2PromptTemplate
 
 
@@ -14,6 +19,8 @@ def test_initialization():
     template = J2PromptTemplate()
     assert isinstance(template.template, str)
     assert isinstance(template.variables, dict)
+    assert template.trusted_templates is False
+    assert isinstance(template.get_env(), SandboxedEnvironment)
 
 
 @pytest.mark.unit
@@ -83,3 +90,46 @@ def test_split_whitespace():
 
     with pytest.raises(ValueError):
         J2PromptTemplate.split_whitespace(123)
+
+
+@pytest.mark.unit
+def test_default_sandbox_rejects_object_graph_escape():
+    template = J2PromptTemplate(
+        template="{{ cycler.__init__.__globals__.os.name }}"
+    )
+
+    with pytest.raises(SecurityError):
+        template.fill()
+
+
+@pytest.mark.unit
+def test_file_template_uses_default_sandbox(tmp_path: Path):
+    template_path = tmp_path / "unsafe.j2"
+    template_path.write_text(
+        "{{ cycler.__init__.__globals__.os.name }}", encoding="utf-8"
+    )
+    template = J2PromptTemplate(templates_dir=str(tmp_path))
+    template.set_template(template_path)
+
+    with pytest.raises(SecurityError):
+        template.fill()
+
+
+@pytest.mark.unit
+def test_default_sandbox_rejects_unrestricted_precompiled_template():
+    compiled = Environment().from_string("Hello {{ name }}")
+    template = J2PromptTemplate(template=compiled)
+
+    with pytest.raises(SecurityError, match="trusted_templates=True"):
+        template.fill({"name": "World"})
+
+
+@pytest.mark.unit
+def test_explicit_trusted_mode_preserves_unrestricted_jinja_behavior():
+    template = J2PromptTemplate(
+        template="{{ cycler.__init__.__globals__.os.name }}",
+        trusted_templates=True,
+    )
+
+    assert template.fill() == os.name
+    assert type(template.get_env()) is Environment


### PR DESCRIPTION
## Summary
- render `J2PromptTemplate` strings and files with Jinja's `SandboxedEnvironment` by default
- add an explicit `trusted_templates=True` opt-in for applications that require unrestricted Jinja behavior
- reject unrestricted precompiled Jinja templates in default mode to prevent a sandbox bypass
- document the trust boundary and add regression coverage for inline, file-loaded, and precompiled templates

## Security invariant
Untrusted template source must not traverse Python's object graph or invoke unsafe callables. The reported `cycler.__init__.__globals__` path is blocked in default mode, while ordinary interpolation remains supported. Explicit trusted mode intentionally preserves unrestricted Jinja semantics for fully trusted sources.

## Validation
- Ruff format and lint: passed
- Package suite: `29 passed` with `--pylicense-accept-deps=more_itertools`
- Exact regression: default mode raises `SecurityError`
- Compatibility check: the same expression renders only with `trusted_templates=True`

The explicit dependency acceptance is limited to the validation command because the repository's current license metadata classifies `more_itertools==11.1.0` as unknown; no package policy was broadened in this security patch.

Closes #1394