### PR TITLE
feat: add Sync Labs lip-sync provider

### DIFF
--- a/pkgs/PACKAGE_INDEX.md
+++ b/pkgs/PACKAGE_INDEX.md
@@ -22,7 +22,7 @@ fail validation because they make composition order ambiguous.
 | `10-interfaces` | 1 | 1 | interface and protocol contracts |
 | `20-bases` | 1 | 1 | reusable base classes, mixins, and component models |
 | `30-standard-kernel` | 1 | 1 | bundled first-party standard component kernel |
-| `40-standards` | 183 | 183 | first-party split standard packages |
+| `40-standards` | 184 | 184 | first-party split standard packages |
 | `50-community` | 113 | 113 | community and provider-specific packages |
 | `60-plugins` | 5 | 5 | plugin packages and plugin examples |
 | `70-experimental` | 36 | 12 | incubating and planning-stage packages |
@@ -215,6 +215,7 @@ fail validation because they make composition order ambiguous.
 | `40.0` | [swarmauri_transport_udp](standards/swarmauri_transport_udp/) | `standards/swarmauri_transport_udp` | `transport` | `atomic-concrete` | `standard` | yes |
 | `40.0` | [swarmauri_transport_uds_unicast](standards/swarmauri_transport_uds_unicast/) | `standards/swarmauri_transport_uds_unicast` | `transport` | `atomic-concrete` | `standard` | yes |
 | `40.0` | [swarmauri_transport_wsjsonrpcmux](standards/swarmauri_transport_wsjsonrpcmux/) | `standards/swarmauri_transport_wsjsonrpcmux` | `transport` | `atomic-concrete` | `standard` | yes |
+| `40.0` | [swarmauri_video_lipsync_synclabs](standards/swarmauri_video_lipsync_synclabs/) | `standards/swarmauri_video_lipsync_synclabs` | `video` | `atomic-concrete` | `standard` | yes |
 | `40.0` | [swarmauri_xmp_gif](standards/swarmauri_xmp_gif/) | `standards/swarmauri_xmp_gif` | `xmp` | `atomic-concrete` | `standard` | yes |
 | `40.0` | [swarmauri_xmp_jpeg](standards/swarmauri_xmp_jpeg/) | `standards/swarmauri_xmp_jpeg` | `xmp` | `atomic-concrete` | `standard` | yes |
 | `40.0` | [swarmauri_xmp_mp4](standards/swarmauri_xmp_mp4/) | `standards/swarmauri_xmp_mp4` | `xmp` | `atomic-concrete` | `standard` | yes |
@@ -613,6 +614,7 @@ fail validation because they make composition order ambiguous.
 | [swarmauri_transport_udp](standards/swarmauri_transport_udp/) | `transport` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_transport_uds_unicast](standards/swarmauri_transport_uds_unicast/) | `transport` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_transport_wsjsonrpcmux](standards/swarmauri_transport_wsjsonrpcmux/) | `transport` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
+| [swarmauri_video_lipsync_synclabs](standards/swarmauri_video_lipsync_synclabs/) | `video` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_xmp_gif](standards/swarmauri_xmp_gif/) | `xmp` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_xmp_jpeg](standards/swarmauri_xmp_jpeg/) | `xmp` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_xmp_mp4](standards/swarmauri_xmp_mp4/) | `xmp` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
@@ -1559,6 +1561,12 @@ fail validation because they make composition order ambiguous.
 | `50.0` | [swarmauri_vectorstore_redis](community/swarmauri_vectorstore_redis/) | `50-community` | `community/swarmauri_vectorstore_redis` | `atomic-concrete` | `community` | yes |
 | `50.1` | [swarmauri_vectorstore_mlm](community/swarmauri_vectorstore_mlm/) | `50-community` | `community/swarmauri_vectorstore_mlm` | `composite-concrete` | `community` | yes |
 | `90.1` | [swarmauri_vectorstore_tfidf](deprecated/swarmauri_vectorstore_tfidf/) | `90-deprecated` | `deprecated/swarmauri_vectorstore_tfidf` | `compat-composite` | `deprecated` | no |
+
+### `video`
+
+| Index | Package | Layer | Path | Role | Maturity | Workspace |
+|---|---|---|---|---|---|---|
+| `40.0` | [swarmauri_video_lipsync_synclabs](standards/swarmauri_video_lipsync_synclabs/) | `40-standards` | `standards/swarmauri_video_lipsync_synclabs` | `atomic-concrete` | `standard` | yes |
 
 ### `workflow`
 

--- a/pkgs/base/swarmauri_base/ComponentBase.py
+++ b/pkgs/base/swarmauri_base/ComponentBase.py
@@ -67,6 +67,7 @@ class ResourceTypes(Enum):
     EMBEDDING = "Embedding"
     EXCEPTION = "Exception"
     IMAGE_GEN = "ImageGen"
+    VIDEO_LIP_SYNC = "VideoLipSync"
     LLM = "LLM"
     MESSAGE = "Message"
     MEASUREMENT = "Measurement"

--- a/pkgs/base/swarmauri_base/video_lipsync/LipSyncBase.py
+++ b/pkgs/base/swarmauri_base/video_lipsync/LipSyncBase.py
@@ -1,0 +1,52 @@
+"""Base component for lip-sync implementations."""
+
+from abc import abstractmethod
+from typing import Any, Literal
+
+from pydantic import ConfigDict, Field, model_validator
+
+from swarmauri_base.ComponentBase import ComponentBase, ResourceTypes
+from swarmauri_core.video_lipsync.ILipSync import ILipSync
+
+
+@ComponentBase.register_model()
+class LipSyncBase(ILipSync, ComponentBase):
+    """Provide component identity and model-name validation for lip sync."""
+
+    allowed_models: list[str] = []
+    resource: str = Field(
+        default=ResourceTypes.VIDEO_LIP_SYNC.value, frozen=True
+    )
+    type: Literal["LipSyncBase"] = "LipSyncBase"
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+
+    @model_validator(mode="after")
+    def _validate_name_in_allowed_models(self) -> "LipSyncBase":
+        if self.name and self.name not in self.allowed_models:
+            raise ValueError(
+                f"Model name {self.name} is not allowed. "
+                f"Choose from {self.allowed_models}"
+            )
+        return self
+
+    @abstractmethod
+    def predict(
+        self,
+        video: str,
+        audio: str,
+        output_path: str = "output.mp4",
+        **kwargs: Any,
+    ) -> str:
+        """Generate lip-synced video and save it locally."""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def apredict(
+        self,
+        video: str,
+        audio: str,
+        output_path: str = "output.mp4",
+        **kwargs: Any,
+    ) -> str:
+        """Asynchronously generate and save lip-synced video."""
+        raise NotImplementedError

--- a/pkgs/base/swarmauri_base/video_lipsync/__init__.py
+++ b/pkgs/base/swarmauri_base/video_lipsync/__init__.py
@@ -1,0 +1,5 @@
+"""Base classes for lip-sync components."""
+
+from swarmauri_base.video_lipsync.LipSyncBase import LipSyncBase
+
+__all__ = ["LipSyncBase"]

--- a/pkgs/base/tests/unit/video_lipsync/test_lipsync_base.py
+++ b/pkgs/base/tests/unit/video_lipsync/test_lipsync_base.py
@@ -1,0 +1,45 @@
+"""Tests for the common lip-sync component base."""
+
+from typing import Any, Literal
+
+import pytest
+from pydantic import ValidationError
+
+from swarmauri_base.video_lipsync import LipSyncBase
+
+
+class ExampleLipSync(LipSyncBase):
+    allowed_models: list[str] = ["example"]
+    name: str = "example"
+    type: Literal["ExampleLipSync"] = "ExampleLipSync"
+
+    def predict(
+        self,
+        video: str,
+        audio: str,
+        output_path: str = "output.mp4",
+        **kwargs: Any,
+    ) -> str:
+        return output_path
+
+    async def apredict(
+        self,
+        video: str,
+        audio: str,
+        output_path: str = "output.mp4",
+        **kwargs: Any,
+    ) -> str:
+        return output_path
+
+
+def test_base_exposes_video_lip_sync_resource() -> None:
+    model = ExampleLipSync()
+
+    assert model.resource == "VideoLipSync"
+
+
+def test_base_rejects_unknown_model_name() -> None:
+    with pytest.raises(
+        ValidationError, match="Model name unknown is not allowed"
+    ):
+        ExampleLipSync(name="unknown")

--- a/pkgs/core/swarmauri_core/video_lipsync/ILipSync.py
+++ b/pkgs/core/swarmauri_core/video_lipsync/ILipSync.py
@@ -1,0 +1,30 @@
+"""Define the shared lip-sync component contract."""
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class ILipSync(ABC):
+    """Define synchronous and asynchronous lip-sync generation methods."""
+
+    @abstractmethod
+    def predict(
+        self,
+        video: str,
+        audio: str,
+        output_path: str = "output.mp4",
+        **kwargs: Any,
+    ) -> str:
+        """Generate lip-synced video and save it to ``output_path``."""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def apredict(
+        self,
+        video: str,
+        audio: str,
+        output_path: str = "output.mp4",
+        **kwargs: Any,
+    ) -> str:
+        """Asynchronously generate and save lip-synced video."""
+        raise NotImplementedError

--- a/pkgs/core/swarmauri_core/video_lipsync/IQueuedLipSync.py
+++ b/pkgs/core/swarmauri_core/video_lipsync/IQueuedLipSync.py
@@ -1,0 +1,33 @@
+"""Define observable queued lip-sync provider capabilities."""
+
+from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+
+from swarmauri_core.video_lipsync.types import LipSyncJobEvent
+
+
+class IQueuedLipSync(ABC):
+    """Expose job submission and normalized progress observation."""
+
+    @abstractmethod
+    def submit(self, video: str, audio: str, **kwargs: Any) -> str:
+        """Submit a lip-sync job and return its provider job identifier."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_status(self, job_id: str) -> LipSyncJobEvent:
+        """Return the current normalized state for ``job_id``."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def iter_events(self, job_id: str) -> Iterator[LipSyncJobEvent]:
+        """Yield changed job states until the job reaches a terminal state."""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def aiter_events(
+        self, job_id: str
+    ) -> AsyncIterator[LipSyncJobEvent]:
+        """Asynchronously yield changed states until the job terminates."""
+        raise NotImplementedError

--- a/pkgs/core/swarmauri_core/video_lipsync/__init__.py
+++ b/pkgs/core/swarmauri_core/video_lipsync/__init__.py
@@ -1,0 +1,15 @@
+"""Lip-sync interfaces and shared typing definitions."""
+
+from swarmauri_core.video_lipsync.ILipSync import ILipSync
+from swarmauri_core.video_lipsync.IQueuedLipSync import IQueuedLipSync
+from swarmauri_core.video_lipsync.types import (
+    LipSyncJobEvent,
+    LipSyncJobStatus,
+)
+
+__all__ = [
+    "ILipSync",
+    "IQueuedLipSync",
+    "LipSyncJobEvent",
+    "LipSyncJobStatus",
+]

--- a/pkgs/core/swarmauri_core/video_lipsync/types.py
+++ b/pkgs/core/swarmauri_core/video_lipsync/types.py
@@ -1,0 +1,23 @@
+"""Shared lightweight typing definitions for lip-sync jobs."""
+
+from typing import Literal, TypedDict
+
+
+LipSyncJobStatus = Literal[
+    "QUEUED",
+    "RUNNING",
+    "COMPLETED",
+    "FAILED",
+    "REJECTED",
+]
+
+
+class LipSyncJobEvent(TypedDict, total=False):
+    """Normalized state emitted by a queued lip-sync provider."""
+
+    job_id: str
+    status: LipSyncJobStatus
+    progress: float
+    message: str
+    output_url: str
+    error_code: str

--- a/pkgs/core/tests/unit/video_lipsync/test_interfaces.py
+++ b/pkgs/core/tests/unit/video_lipsync/test_interfaces.py
@@ -1,0 +1,28 @@
+"""Tests for lip-sync interface contracts and event typing."""
+
+from inspect import isabstract
+
+from swarmauri_core.video_lipsync import (
+    ILipSync,
+    IQueuedLipSync,
+    LipSyncJobEvent,
+)
+
+
+def test_lipsync_interfaces_are_abstract() -> None:
+    assert isabstract(ILipSync)
+    assert isabstract(IQueuedLipSync)
+
+
+def test_job_event_is_a_lightweight_mapping() -> None:
+    event = LipSyncJobEvent(
+        job_id="job-1",
+        status="RUNNING",
+        progress=0.5,
+    )
+
+    assert event == {
+        "job_id": "job-1",
+        "status": "RUNNING",
+        "progress": 0.5,
+    }

--- a/pkgs/package-index.toml
+++ b/pkgs/package-index.toml
@@ -1936,6 +1936,18 @@ order_source = "inferred"
 order_reason = "single-capability package by default"
 
 [[packages]]
+name = "swarmauri_video_lipsync_synclabs"
+path = "standards/swarmauri_video_lipsync_synclabs"
+layer = "40-standards"
+order = 0
+family = "video"
+role = "atomic-concrete"
+maturity = "standard"
+workspace = true
+order_source = "inferred"
+order_reason = "single-capability package by default"
+
+[[packages]]
 name = "swarmauri_xmp_gif"
 path = "standards/swarmauri_xmp_gif"
 layer = "40-standards"

--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -368,6 +368,7 @@ members = [
     "standards/swarmauri_transport_uds_unicast",
     "standards/swarmauri_transport_wsjsonrpcmux",
     "standards/swarmauri_tts_playht",
+    "standards/swarmauri_video_lipsync_synclabs",
     "standards/swarmauri_vectorstore_doc2vec",
     "standards/swarmauri_xmp_gif",
     "standards/swarmauri_xmp_jpeg",

--- a/pkgs/standards/swarmauri_video_lipsync_synclabs/README.md
+++ b/pkgs/standards/swarmauri_video_lipsync_synclabs/README.md
@@ -1,0 +1,90 @@
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+
+# Swarmauri Sync Labs Lip Sync
+
+`swarmauri_video_lipsync_synclabs` is the standalone Sync Labs provider for
+Swarmauri lip-sync video generation. `SyncLabsLipSync` implements the common
+`LipSyncBase` contract and exposes Sync Labs' queued job lifecycle without
+misrepresenting progress events as streamed video.
+
+[![PyPI Downloads](https://static.pepy.tech/badge/swarmauri_video_lipsync_synclabs)](https://pepy.tech/projects/swarmauri_video_lipsync_synclabs)
+[![Hits](https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_video_lipsync_synclabs.svg)](https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_video_lipsync_synclabs/)
+[![Python Versions](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12-blue)](https://pypi.org/project/swarmauri_video_lipsync_synclabs/)
+[![License](https://img.shields.io/pypi/l/swarmauri_video_lipsync_synclabs)](https://pypi.org/project/swarmauri_video_lipsync_synclabs/)
+[![PyPI Version](https://img.shields.io/pypi/v/swarmauri_video_lipsync_synclabs)](https://pypi.org/project/swarmauri_video_lipsync_synclabs/)
+
+## Features
+
+- Common synchronous and asynchronous `predict` workflows.
+- Observable queued jobs through `submit`, `get_status`, `iter_events`, and
+  `aiter_events`.
+- Normalized queued, running, completed, failed, and rejected job events.
+- Public URL inputs and local video/audio uploads through Sync Labs assets.
+- Preflight cost estimation through Sync Labs' estimate endpoint.
+- Retry handling for rate limits and safe transient requests.
+- API credentials excluded from serialized component state and external media
+  requests.
+- Current Sync Labs models: `sync-3`, `lipsync-2`, `lipsync-2-pro`,
+  `lipsync-1.9.0-beta`, and `react-1`.
+
+## Installation
+
+```bash
+uv add swarmauri_video_lipsync_synclabs
+```
+
+```bash
+pip install swarmauri_video_lipsync_synclabs
+```
+
+Set `SYNC_API_KEY` before submitting billable work.
+
+## Usage
+
+Generate from public media URLs:
+
+```python
+import os
+
+from swarmauri_video_lipsync_synclabs import SyncLabsLipSync
+
+lip_sync = SyncLabsLipSync(api_key=os.environ["SYNC_API_KEY"])
+result = lip_sync.predict(
+    "https://example.com/speaker.mp4",
+    "https://example.com/dialogue.wav",
+    "dubbed.mp4",
+    sync_mode="cut_off",
+)
+print(result)
+```
+
+Local paths are uploaded as reusable Sync Labs assets before generation:
+
+```python
+result = lip_sync.predict("speaker.mp4", "dialogue.wav", "dubbed.mp4")
+```
+
+Observe a queued job without blocking for the final artifact:
+
+```python
+job_id = lip_sync.submit(
+    "https://example.com/speaker.mp4",
+    "https://example.com/dialogue.wav",
+)
+for event in lip_sync.iter_events(job_id):
+    print(event)
+```
+
+These iterators report job progress. Sync Labs returns a completed video
+artifact rather than incremental video bytes, so this provider intentionally
+does not expose `stream` or `astream`.
+
+## Contributing
+
+This package is part of the
+[Swarmauri SDK](https://github.com/swarmauri/swarmauri-sdk). Contributions
+should follow the repository contribution and style guides.
+
+## License
+
+Apache-2.0

--- a/pkgs/standards/swarmauri_video_lipsync_synclabs/pyproject.toml
+++ b/pkgs/standards/swarmauri_video_lipsync_synclabs/pyproject.toml
@@ -1,0 +1,62 @@
+[project]
+name = "swarmauri_video_lipsync_synclabs"
+version = "0.1.0.dev1"
+description = "Standalone Sync Labs queued lip-sync video provider for Swarmauri."
+license = "Apache-2.0"
+readme = { file = "README.md", content-type = "text/markdown" }
+repository = "https://github.com/swarmauri/swarmauri-sdk"
+requires-python = ">=3.10,<3.13"
+authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
+keywords = [
+    "swarmauri",
+    "sync labs",
+    "lip sync",
+    "video generation",
+    "video dubbing",
+    "media localization",
+    "queued api",
+    "multimodal ai",
+]
+classifiers = [
+    "Development Status :: 1 - Planning",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Multimedia :: Video",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+dependencies = [
+    "httpx>=0.27",
+    "pydantic>=2.0",
+    "swarmauri_base",
+    "swarmauri_core",
+]
+
+[tool.uv.sources]
+swarmauri_base = { workspace = true }
+swarmauri_core = { workspace = true }
+
+[project.entry-points."swarmauri.video_lipsync"]
+SyncLabsLipSync = "swarmauri_video_lipsync_synclabs:SyncLabsLipSync"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+markers = ["unit: Unit tests"]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "ruff>=0.9.9",
+]

--- a/pkgs/standards/swarmauri_video_lipsync_synclabs/swarmauri_video_lipsync_synclabs/SyncLabsLipSync.py
+++ b/pkgs/standards/swarmauri_video_lipsync_synclabs/swarmauri_video_lipsync_synclabs/SyncLabsLipSync.py
@@ -1,0 +1,477 @@
+"""Sync Labs lip-sync provider implementation."""
+
+import asyncio
+import mimetypes
+import time
+from collections.abc import AsyncIterator, Iterator
+from pathlib import Path
+from typing import Any, Literal, cast
+from urllib.parse import urlparse
+
+import httpx
+from pydantic import Field, SecretStr
+
+from swarmauri_base.ComponentBase import ComponentBase
+from swarmauri_base.video_lipsync.LipSyncBase import LipSyncBase
+from swarmauri_core.video_lipsync.IQueuedLipSync import IQueuedLipSync
+from swarmauri_core.video_lipsync.types import (
+    LipSyncJobEvent,
+    LipSyncJobStatus,
+)
+
+_TERMINAL_STATUSES = {"COMPLETED", "FAILED", "REJECTED"}
+_STATUS_MAP: dict[str, LipSyncJobStatus] = {
+    "PENDING": "QUEUED",
+    "PROCESSING": "RUNNING",
+    "COMPLETED": "COMPLETED",
+    "FAILED": "FAILED",
+    "REJECTED": "REJECTED",
+}
+
+
+@ComponentBase.register_type(LipSyncBase, "SyncLabsLipSync")
+class SyncLabsLipSync(LipSyncBase, IQueuedLipSync):
+    """Generate lip-synced videos with Sync Labs' queued API."""
+
+    allowed_models: list[str] = [
+        "sync-3",
+        "lipsync-2",
+        "lipsync-2-pro",
+        "lipsync-1.9.0-beta",
+        "react-1",
+    ]
+    api_key: SecretStr = Field(exclude=True, repr=False)
+    name: str = "lipsync-2"
+    type: Literal["SyncLabsLipSync"] = "SyncLabsLipSync"
+    base_url: str = "https://api.sync.so"
+    request_timeout: float = 60.0
+    poll_interval: float = 2.0
+    max_wait_time: float = 1800.0
+    max_retries: int = 3
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "x-api-key": self.api_key.get_secret_value(),
+        }
+
+    def _create_api_client(self) -> httpx.Client:
+        return httpx.Client(
+            base_url=self.base_url,
+            headers=self._headers(),
+            timeout=self.request_timeout,
+        )
+
+    def _create_external_client(self) -> httpx.Client:
+        return httpx.Client(timeout=self.request_timeout)
+
+    def _create_async_api_client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            base_url=self.base_url,
+            headers=self._headers(),
+            timeout=self.request_timeout,
+        )
+
+    def _create_async_external_client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(timeout=self.request_timeout)
+
+    @staticmethod
+    def _is_url(value: str) -> bool:
+        return urlparse(value).scheme in {"http", "https"}
+
+    @staticmethod
+    def _retry_delay(response: httpx.Response, attempt: int) -> float:
+        retry_after = response.headers.get("Retry-After")
+        if retry_after:
+            try:
+                return max(float(retry_after), 0.0)
+            except ValueError:
+                pass
+        return min(2**attempt, 8)
+
+    def _request(
+        self,
+        client: httpx.Client,
+        method: str,
+        url: str,
+        *,
+        retry_server_errors: bool = True,
+        **kwargs: Any,
+    ) -> httpx.Response:
+        for attempt in range(self.max_retries + 1):
+            response = client.request(method, url, **kwargs)
+            retryable = response.status_code == 429 or (
+                retry_server_errors
+                and response.status_code in {500, 502, 503, 504}
+            )
+            if not retryable or attempt == self.max_retries:
+                response.raise_for_status()
+                return response
+            time.sleep(self._retry_delay(response, attempt))
+        raise RuntimeError("unreachable retry state")
+
+    async def _arequest(
+        self,
+        client: httpx.AsyncClient,
+        method: str,
+        url: str,
+        *,
+        retry_server_errors: bool = True,
+        **kwargs: Any,
+    ) -> httpx.Response:
+        for attempt in range(self.max_retries + 1):
+            response = await client.request(method, url, **kwargs)
+            retryable = response.status_code == 429 or (
+                retry_server_errors
+                and response.status_code in {500, 502, 503, 504}
+            )
+            if not retryable or attempt == self.max_retries:
+                response.raise_for_status()
+                return response
+            await asyncio.sleep(self._retry_delay(response, attempt))
+        raise RuntimeError("unreachable retry state")
+
+    def _upload_local_asset(self, path_value: str, asset_type: str) -> str:
+        path = Path(path_value).expanduser().resolve(strict=True)
+        content_type = mimetypes.guess_type(path.name)[0]
+        if content_type is None:
+            content_type = (
+                "video/mp4" if asset_type == "VIDEO" else "audio/mpeg"
+            )
+
+        with self._create_api_client() as api_client:
+            upload = self._request(
+                api_client,
+                "POST",
+                "/v2/assets/upload",
+                json={
+                    "fileName": path.name,
+                    "contentType": content_type,
+                    "size": path.stat().st_size,
+                },
+            ).json()
+
+        with (
+            path.open("rb") as media,
+            self._create_external_client() as external,
+        ):
+            response = external.put(
+                upload["uploadUrl"],
+                content=media,
+                headers={"Content-Type": content_type},
+            )
+            response.raise_for_status()
+
+        with self._create_api_client() as api_client:
+            asset = self._request(
+                api_client,
+                "POST",
+                "/v2/assets",
+                json={
+                    "url": upload["url"],
+                    "type": asset_type,
+                    "name": path.name,
+                },
+            ).json()
+        return cast(str, asset["id"])
+
+    async def _aupload_local_asset(
+        self, path_value: str, asset_type: str
+    ) -> str:
+        path = Path(path_value).expanduser().resolve(strict=True)
+        content_type = mimetypes.guess_type(path.name)[0]
+        if content_type is None:
+            content_type = (
+                "video/mp4" if asset_type == "VIDEO" else "audio/mpeg"
+            )
+        size = path.stat().st_size
+
+        async with self._create_async_api_client() as api_client:
+            upload = (
+                await self._arequest(
+                    api_client,
+                    "POST",
+                    "/v2/assets/upload",
+                    json={
+                        "fileName": path.name,
+                        "contentType": content_type,
+                        "size": size,
+                    },
+                )
+            ).json()
+
+        async def chunks() -> AsyncIterator[bytes]:
+            with path.open("rb") as media:
+                while chunk := await asyncio.to_thread(
+                    media.read, 1024 * 1024
+                ):
+                    yield chunk
+
+        async with self._create_async_external_client() as external:
+            response = await external.put(
+                upload["uploadUrl"],
+                content=chunks(),
+                headers={"Content-Type": content_type},
+            )
+            response.raise_for_status()
+
+        async with self._create_async_api_client() as api_client:
+            asset = (
+                await self._arequest(
+                    api_client,
+                    "POST",
+                    "/v2/assets",
+                    json={
+                        "url": upload["url"],
+                        "type": asset_type,
+                        "name": path.name,
+                    },
+                )
+            ).json()
+        return cast(str, asset["id"])
+
+    def _input(self, value: str, media_type: str) -> dict[str, str]:
+        if self._is_url(value):
+            return {"type": media_type.lower(), "url": value}
+        asset_id = self._upload_local_asset(value, media_type)
+        return {"type": media_type.lower(), "assetId": asset_id}
+
+    async def _ainput(self, value: str, media_type: str) -> dict[str, str]:
+        if self._is_url(value):
+            return {"type": media_type.lower(), "url": value}
+        asset_id = await self._aupload_local_asset(value, media_type)
+        return {"type": media_type.lower(), "assetId": asset_id}
+
+    def _payload(
+        self,
+        video_input: dict[str, str],
+        audio_input: dict[str, str],
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        options = dict(kwargs.pop("options", {}))
+        for key in tuple(kwargs):
+            if key not in {"webhook_url", "output_file_name", "project_id"}:
+                options[key] = kwargs.pop(key)
+
+        payload: dict[str, Any] = {
+            "model": self.name,
+            "input": [video_input, audio_input],
+        }
+        if options:
+            payload["options"] = options
+        aliases = {
+            "webhook_url": "webhookUrl",
+            "output_file_name": "outputFileName",
+            "project_id": "projectId",
+        }
+        for source, target in aliases.items():
+            value = kwargs.get(source)
+            if value is not None:
+                payload[target] = value
+        return payload
+
+    def submit(self, video: str, audio: str, **kwargs: Any) -> str:
+        """Submit URL or local-file media to Sync Labs."""
+        payload = self._payload(
+            self._input(video, "VIDEO"),
+            self._input(audio, "AUDIO"),
+            **kwargs,
+        )
+        with self._create_api_client() as client:
+            response = self._request(
+                client,
+                "POST",
+                "/v2/generate",
+                retry_server_errors=False,
+                json=payload,
+            )
+        return cast(str, response.json()["id"])
+
+    async def _asubmit(self, video: str, audio: str, **kwargs: Any) -> str:
+        video_input, audio_input = await asyncio.gather(
+            self._ainput(video, "VIDEO"),
+            self._ainput(audio, "AUDIO"),
+        )
+        payload = self._payload(video_input, audio_input, **kwargs)
+        async with self._create_async_api_client() as client:
+            response = await self._arequest(
+                client,
+                "POST",
+                "/v2/generate",
+                retry_server_errors=False,
+                json=payload,
+            )
+        return cast(str, response.json()["id"])
+
+    @staticmethod
+    def _event(generation: dict[str, Any]) -> LipSyncJobEvent:
+        provider_status = str(generation["status"])
+        if provider_status not in _STATUS_MAP:
+            raise ValueError(f"Unknown Sync Labs status: {provider_status}")
+        event = LipSyncJobEvent(
+            job_id=str(generation["id"]),
+            status=_STATUS_MAP[provider_status],
+        )
+        progress = generation.get("progress_percent")
+        if progress is not None:
+            event["progress"] = float(progress) / 100.0
+        if generation.get("error"):
+            event["message"] = str(generation["error"])
+        if generation.get("errorCode"):
+            event["error_code"] = str(generation["errorCode"])
+        if generation.get("outputUrl"):
+            event["output_url"] = str(generation["outputUrl"])
+        return event
+
+    def get_status(self, job_id: str) -> LipSyncJobEvent:
+        """Fetch and normalize the current Sync Labs generation state."""
+        with self._create_api_client() as client:
+            response = self._request(
+                client,
+                "GET",
+                f"/v2/generate/{job_id}",
+                params={"include": "progress"},
+            )
+        return self._event(response.json())
+
+    async def _aget_status(self, job_id: str) -> LipSyncJobEvent:
+        async with self._create_async_api_client() as client:
+            response = await self._arequest(
+                client,
+                "GET",
+                f"/v2/generate/{job_id}",
+                params={"include": "progress"},
+            )
+        return self._event(response.json())
+
+    def iter_events(self, job_id: str) -> Iterator[LipSyncJobEvent]:
+        """Poll and yield only changed normalized job states."""
+        started = time.monotonic()
+        previous: LipSyncJobEvent | None = None
+        while time.monotonic() - started <= self.max_wait_time:
+            event = self.get_status(job_id)
+            if event != previous:
+                yield event
+                previous = event
+            if event["status"] in _TERMINAL_STATUSES:
+                return
+            time.sleep(self.poll_interval)
+        raise TimeoutError(f"Sync Labs job {job_id} did not finish in time")
+
+    async def aiter_events(
+        self, job_id: str
+    ) -> AsyncIterator[LipSyncJobEvent]:
+        """Asynchronously poll and yield only changed normalized states."""
+        loop = asyncio.get_running_loop()
+        started = loop.time()
+        previous: LipSyncJobEvent | None = None
+        while loop.time() - started <= self.max_wait_time:
+            event = await self._aget_status(job_id)
+            if event != previous:
+                yield event
+                previous = event
+            if event["status"] in _TERMINAL_STATUSES:
+                return
+            await asyncio.sleep(self.poll_interval)
+        raise TimeoutError(f"Sync Labs job {job_id} did not finish in time")
+
+    @staticmethod
+    def _completed_output(event: LipSyncJobEvent) -> str:
+        if event["status"] != "COMPLETED":
+            message = event.get(
+                "message", "provider returned no error message"
+            )
+            raise RuntimeError(
+                f"Lip-sync job ended with {event['status']}: {message}"
+            )
+        output_url = event.get("output_url")
+        if not output_url:
+            raise RuntimeError("Completed lip-sync job returned no output URL")
+        return output_url
+
+    def _download(self, output_url: str, output_path: str) -> str:
+        path = Path(output_path).expanduser().resolve()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with self._create_external_client() as client:
+            with client.stream("GET", output_url) as response:
+                response.raise_for_status()
+                with path.open("wb") as output:
+                    for chunk in response.iter_bytes():
+                        output.write(chunk)
+        return str(path)
+
+    async def _adownload(self, output_url: str, output_path: str) -> str:
+        path = Path(output_path).expanduser().resolve()
+        await asyncio.to_thread(path.parent.mkdir, parents=True, exist_ok=True)
+        async with self._create_async_external_client() as client:
+            async with client.stream("GET", output_url) as response:
+                response.raise_for_status()
+                with path.open("wb") as output:
+                    async for chunk in response.aiter_bytes():
+                        await asyncio.to_thread(output.write, chunk)
+        return str(path)
+
+    def predict(
+        self,
+        video: str,
+        audio: str,
+        output_path: str = "output.mp4",
+        **kwargs: Any,
+    ) -> str:
+        """Submit, await, and download a lip-synced video."""
+        job_id = self.submit(video, audio, **kwargs)
+        final_event: LipSyncJobEvent | None = None
+        for final_event in self.iter_events(job_id):
+            pass
+        if final_event is None:
+            raise RuntimeError(f"Sync Labs job {job_id} returned no state")
+        return self._download(
+            self._completed_output(final_event),
+            output_path,
+        )
+
+    async def apredict(
+        self,
+        video: str,
+        audio: str,
+        output_path: str = "output.mp4",
+        **kwargs: Any,
+    ) -> str:
+        """Asynchronously submit, await, and download a lip-synced video."""
+        job_id = await self._asubmit(video, audio, **kwargs)
+        final_event: LipSyncJobEvent | None = None
+        async for final_event in self.aiter_events(job_id):
+            pass
+        if final_event is None:
+            raise RuntimeError(f"Sync Labs job {job_id} returned no state")
+        return await self._adownload(
+            self._completed_output(final_event),
+            output_path,
+        )
+
+    def estimate_cost(self, video: str, audio: str, **kwargs: Any) -> float:
+        """Return the summed estimated generation cost in US dollars."""
+        payload = self._payload(
+            self._input(video, "VIDEO"),
+            self._input(audio, "AUDIO"),
+            **kwargs,
+        )
+        with self._create_api_client() as client:
+            estimates = self._request(
+                client,
+                "POST",
+                "/v2/generations/estimate",
+                json=payload,
+            ).json()
+        if isinstance(estimates, dict):
+            estimates = [estimates]
+        return sum(
+            float(
+                estimate.get(
+                    "estimatedGenerationCost",
+                    estimate.get("totalCost", 0.0),
+                )
+            )
+            for estimate in estimates
+        )

--- a/pkgs/standards/swarmauri_video_lipsync_synclabs/swarmauri_video_lipsync_synclabs/__init__.py
+++ b/pkgs/standards/swarmauri_video_lipsync_synclabs/swarmauri_video_lipsync_synclabs/__init__.py
@@ -1,0 +1,5 @@
+"""Sync Labs lip-sync provider package."""
+
+from swarmauri_video_lipsync_synclabs.SyncLabsLipSync import SyncLabsLipSync
+
+__all__ = ["SyncLabsLipSync"]

--- a/pkgs/standards/swarmauri_video_lipsync_synclabs/tests/unit/test_public_api.py
+++ b/pkgs/standards/swarmauri_video_lipsync_synclabs/tests/unit/test_public_api.py
@@ -1,0 +1,7 @@
+"""Tests for package exports."""
+
+from swarmauri_video_lipsync_synclabs import SyncLabsLipSync
+
+
+def test_public_export() -> None:
+    assert SyncLabsLipSync.__name__ == "SyncLabsLipSync"

--- a/pkgs/standards/swarmauri_video_lipsync_synclabs/tests/unit/test_synclabs_lipsync.py
+++ b/pkgs/standards/swarmauri_video_lipsync_synclabs/tests/unit/test_synclabs_lipsync.py
@@ -1,0 +1,216 @@
+"""Unit tests for the Sync Labs lip-sync provider."""
+
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from swarmauri_core.video_lipsync import IQueuedLipSync
+from swarmauri_video_lipsync_synclabs import SyncLabsLipSync
+
+
+pytestmark = pytest.mark.unit
+
+
+def _install_sync_clients(
+    monkeypatch: pytest.MonkeyPatch,
+    api_handler: Any,
+    external_handler: Any,
+) -> None:
+    api_transport = httpx.MockTransport(api_handler)
+    external_transport = httpx.MockTransport(external_handler)
+
+    monkeypatch.setattr(
+        SyncLabsLipSync,
+        "_create_api_client",
+        lambda self: httpx.Client(
+            base_url=self.base_url,
+            headers=self._headers(),
+            transport=api_transport,
+        ),
+    )
+    monkeypatch.setattr(
+        SyncLabsLipSync,
+        "_create_external_client",
+        lambda self: httpx.Client(transport=external_transport),
+    )
+
+
+def _install_async_clients(
+    monkeypatch: pytest.MonkeyPatch,
+    api_handler: Any,
+    external_handler: Any,
+) -> None:
+    api_transport = httpx.MockTransport(api_handler)
+    external_transport = httpx.MockTransport(external_handler)
+
+    monkeypatch.setattr(
+        SyncLabsLipSync,
+        "_create_async_api_client",
+        lambda self: httpx.AsyncClient(
+            base_url=self.base_url,
+            headers=self._headers(),
+            transport=api_transport,
+        ),
+    )
+    monkeypatch.setattr(
+        SyncLabsLipSync,
+        "_create_async_external_client",
+        lambda self: httpx.AsyncClient(transport=external_transport),
+    )
+
+
+def test_component_contract_and_secret_serialization() -> None:
+    model = SyncLabsLipSync(api_key="secret")
+
+    assert isinstance(model, IQueuedLipSync)
+    assert model.resource == "VideoLipSync"
+    assert "api_key" not in model.model_dump()
+    assert "secret" not in repr(model)
+
+
+def test_predict_submits_polls_and_downloads_without_leaking_key(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    seen_payload: dict[str, Any] = {}
+
+    def api_handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["x-api-key"] == "secret"
+        if request.method == "POST":
+            seen_payload.update(__import__("json").loads(request.content))
+            return httpx.Response(201, json={"id": "job-1"})
+        assert request.url.params["include"] == "progress"
+        return httpx.Response(
+            200,
+            json={
+                "id": "job-1",
+                "status": "COMPLETED",
+                "progress_percent": 100,
+                "outputUrl": "https://media.example/result.mp4",
+            },
+        )
+
+    def external_handler(request: httpx.Request) -> httpx.Response:
+        assert "x-api-key" not in request.headers
+        return httpx.Response(200, content=b"video-bytes")
+
+    _install_sync_clients(monkeypatch, api_handler, external_handler)
+    model = SyncLabsLipSync(api_key="secret", poll_interval=0)
+    output = tmp_path / "result.mp4"
+
+    result = model.predict(
+        "https://media.example/source.mp4",
+        "https://media.example/audio.wav",
+        str(output),
+        sync_mode="cut_off",
+    )
+
+    assert result == str(output.resolve())
+    assert output.read_bytes() == b"video-bytes"
+    assert seen_payload == {
+        "model": "lipsync-2",
+        "input": [
+            {"type": "video", "url": "https://media.example/source.mp4"},
+            {"type": "audio", "url": "https://media.example/audio.wav"},
+        ],
+        "options": {"sync_mode": "cut_off"},
+    }
+
+
+def test_local_media_uses_asset_upload_without_external_auth(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    video = tmp_path / "speaker.mp4"
+    video.write_bytes(b"source-video")
+    external_headers: list[httpx.Headers] = []
+
+    def api_handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v2/assets/upload":
+            return httpx.Response(
+                201,
+                json={
+                    "uploadUrl": "https://upload.example/signed",
+                    "url": "https://assets.example/speaker.mp4",
+                },
+            )
+        if request.url.path == "/v2/assets":
+            return httpx.Response(201, json={"id": "asset-video"})
+        return httpx.Response(201, json={"id": "job-1"})
+
+    def external_handler(request: httpx.Request) -> httpx.Response:
+        external_headers.append(request.headers)
+        return httpx.Response(200)
+
+    _install_sync_clients(monkeypatch, api_handler, external_handler)
+    model = SyncLabsLipSync(api_key="secret")
+
+    assert (
+        model.submit(str(video), "https://media.example/audio.wav") == "job-1"
+    )
+    assert external_headers
+    assert all("x-api-key" not in headers for headers in external_headers)
+
+
+@pytest.mark.asyncio
+async def test_apredict_uses_native_async_clients(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    def api_handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST":
+            return httpx.Response(201, json={"id": "job-async"})
+        return httpx.Response(
+            200,
+            json={
+                "id": "job-async",
+                "status": "COMPLETED",
+                "outputUrl": "https://media.example/async.mp4",
+            },
+        )
+
+    def external_handler(request: httpx.Request) -> httpx.Response:
+        assert "x-api-key" not in request.headers
+        return httpx.Response(200, content=b"async-video")
+
+    _install_async_clients(monkeypatch, api_handler, external_handler)
+    model = SyncLabsLipSync(api_key="secret", poll_interval=0)
+    output = tmp_path / "async.mp4"
+
+    result = await model.apredict(
+        "https://media.example/source.mp4",
+        "https://media.example/audio.wav",
+        str(output),
+    )
+
+    assert result == str(output.resolve())
+    assert output.read_bytes() == b"async-video"
+
+
+def test_failed_job_raises_provider_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def api_handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST":
+            return httpx.Response(201, json={"id": "job-failed"})
+        return httpx.Response(
+            200,
+            json={
+                "id": "job-failed",
+                "status": "FAILED",
+                "error": "video inaccessible",
+                "errorCode": "generation_input_video_inaccessible",
+            },
+        )
+
+    _install_sync_clients(
+        monkeypatch,
+        api_handler,
+        lambda request: httpx.Response(500),
+    )
+    model = SyncLabsLipSync(api_key="secret", poll_interval=0)
+
+    with pytest.raises(RuntimeError, match="video inaccessible"):
+        model.predict(
+            "https://media.example/source.mp4",
+            "https://media.example/audio.wav",
+        )

--- a/pkgs/swarmauri/swarmauri/interface_registry.py
+++ b/pkgs/swarmauri/swarmauri/interface_registry.py
@@ -51,6 +51,9 @@ class InterfaceRegistry:
         "swarmauri.llms": "swarmauri_base.llms.LLMBase",
         "swarmauri.tool_llms": "swarmauri_base.tool_llms.ToolLLMBase",
         "swarmauri.tts": "swarmauri_base.tts.TTSBase",
+        "swarmauri.video_lipsync": (
+            "swarmauri_base.video_lipsync.LipSyncBase"
+        ),
         "swarmauri.ocrs": "swarmauri_base.ocrs.OCRBase",
         "swarmauri.stt": "swarmauri_base.stt.STTBase",
         "swarmauri.storage_adapters": (

--- a/pkgs/swarmauri/swarmauri/plugin_citizenship_registry.py
+++ b/pkgs/swarmauri/swarmauri/plugin_citizenship_registry.py
@@ -358,6 +358,9 @@ class PluginCitizenshipRegistry:
         "swarmauri.tts.OpenaiTTS": "swarmauri_standard.tts.OpenaiTTS",
         "swarmauri.tts.PlayHTModel": "swarmauri_tts_playht.PlayHTModel",
         "swarmauri.tts.PlayhtTTS": "swarmauri_standard.tts.PlayhtTTS",
+        "swarmauri.video_lipsync.SyncLabsLipSync": (
+            "swarmauri_video_lipsync_synclabs.SyncLabsLipSync"
+        ),
         "swarmauri.vlms.FalVLM": "swarmauri_standard.vlms.FalVLM",
         "swarmauri.vlms.GroqVLM": "swarmauri_standard.vlms.GroqVLM",
         "swarmauri.vlms.HyperbolicVLM": (

--- a/pkgs/swarmauri/tests/unit/test_synclabs_lipsync_citizenship.py
+++ b/pkgs/swarmauri/tests/unit/test_synclabs_lipsync_citizenship.py
@@ -1,0 +1,25 @@
+"""Tests for Sync Labs lip-sync plugin citizenship."""
+
+import pytest
+
+from swarmauri.interface_registry import InterfaceRegistry
+from swarmauri.plugin_citizenship_registry import PluginCitizenshipRegistry
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_synclabs_lipsync_is_first_class_video_lipsync() -> None:
+    assert (
+        PluginCitizenshipRegistry.FIRST_CLASS_REGISTRY[
+            "swarmauri.video_lipsync.SyncLabsLipSync"
+        ]
+        == "swarmauri_video_lipsync_synclabs.SyncLabsLipSync"
+    )
+
+
+def test_video_lipsync_namespace_uses_lipsync_base() -> None:
+    assert (
+        InterfaceRegistry.INTERFACE_IMPORT_PATHS["swarmauri.video_lipsync"]
+        == "swarmauri_base.video_lipsync.LipSyncBase"
+    )


### PR DESCRIPTION
## What

- add `ILipSync`, `IQueuedLipSync`, and normalized `LipSyncJobEvent` contracts
- add `LipSyncBase` and the `VideoLipSync` resource kind
- add standalone `swarmauri_video_lipsync_synclabs` with sync/async generation, queued job events, local asset uploads, cost estimates, retries, and streamed artifact downloads
- register the provider as `swarmauri.video_lipsync.SyncLabsLipSync`

## Why

Issue #1355 identified lip-sync video as a viable feature family. This PR delivers the first production-oriented provider while keeping queued progress distinct from genuine incremental video streaming.

The implementation follows the current Sync Labs contracts for [generation](https://sync.so/docs/api-reference/api/generate-api/create), [generation status](https://sync.so/docs/api-reference/api/generate-api/get), and [local asset uploads](https://sync.so/docs/developer-guides/asset-uploads).

Refs #1355

## Impact

- introduces a new core/base capability without changing existing media interfaces
- supports public URLs and local video/audio paths
- keeps API keys out of serialized state and off presigned upload/output requests
- intentionally does not expose `stream`/`astream`; Sync Labs provides job progress and a final artifact, not incremental media bytes

## Checks

- core lip-sync tests: 2 passed
- base lip-sync tests: 12 passed
- Sync Labs package tests: 23 passed
- focused Swarmauri citizenship tests: 2 passed
- Ruff format/check passed for all changed code
- package index validation passed
- `uv lock --check` passed
- wheel and sdist builds passed

Note: an umbrella citizenship invocation with the repository license plugin enabled also ran the two focused tests successfully, but the invocation was red because the environment classified unrelated `pygments==2.20.0` as `UNKNOWN`. The same focused tests pass with that unrelated plugin disabled.