### PR TITLE
Add retriever family contracts

### DIFF
--- a/pkgs/PACKAGE_INDEX.md
+++ b/pkgs/PACKAGE_INDEX.md
@@ -22,7 +22,7 @@ fail validation because they make composition order ambiguous.
 | `10-interfaces` | 1 | 1 | interface and protocol contracts |
 | `20-bases` | 1 | 1 | reusable base classes, mixins, and component models |
 | `30-standard-kernel` | 1 | 1 | bundled first-party standard component kernel |
-| `40-standards` | 183 | 183 | first-party split standard packages |
+| `40-standards` | 184 | 184 | first-party split standard packages |
 | `50-community` | 113 | 113 | community and provider-specific packages |
 | `60-plugins` | 5 | 5 | plugin packages and plugin examples |
 | `70-experimental` | 36 | 12 | incubating and planning-stage packages |
@@ -174,6 +174,7 @@ fail validation because they make composition order ambiguous.
 | `40.0` | [swarmauri_signing_sigv4](standards/swarmauri_signing_sigv4/) | `standards/swarmauri_signing_sigv4` | `signing` | `atomic-concrete` | `standard` | yes |
 | `40.0` | [swarmauri_signing_ssh](standards/swarmauri_signing_ssh/) | `standards/swarmauri_signing_ssh` | `signing` | `atomic-concrete` | `standard` | yes |
 | `40.0` | [swarmauri_signing_xmld](standards/swarmauri_signing_xmld/) | `standards/swarmauri_signing_xmld` | `signing` | `atomic-concrete` | `standard` | yes |
+| `40.0` | [swarmauri_similarity_gzip](standards/swarmauri_similarity_gzip/) | `standards/swarmauri_similarity_gzip` | `similarity` | `atomic-concrete` | `standard` | yes |
 | `40.0` | [swarmauri_skill_dummy_filesystem](standards/swarmauri_skill_dummy_filesystem/) | `standards/swarmauri_skill_dummy_filesystem` | `skill` | `atomic-concrete` | `standard` | yes |
 | `40.0` | [swarmauri_skill_dummy_local](standards/swarmauri_skill_dummy_local/) | `standards/swarmauri_skill_dummy_local` | `skill` | `atomic-concrete` | `standard` | yes |
 | `40.0` | [swarmauri_skill_filesystem](standards/swarmauri_skill_filesystem/) | `standards/swarmauri_skill_filesystem` | `skill` | `atomic-concrete` | `standard` | yes |
@@ -572,6 +573,7 @@ fail validation because they make composition order ambiguous.
 | [swarmauri_signing_sigv4](standards/swarmauri_signing_sigv4/) | `signing` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_signing_ssh](standards/swarmauri_signing_ssh/) | `signing` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_signing_xmld](standards/swarmauri_signing_xmld/) | `signing` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
+| [swarmauri_similarity_gzip](standards/swarmauri_similarity_gzip/) | `similarity` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_skill_dummy_filesystem](standards/swarmauri_skill_dummy_filesystem/) | `skill` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_skill_dummy_local](standards/swarmauri_skill_dummy_local/) | `skill` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_skill_filesystem](standards/swarmauri_skill_filesystem/) | `skill` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
@@ -1379,6 +1381,12 @@ fail validation because they make composition order ambiguous.
 | `40.1` | [swarmauri_signing_pdf](standards/swarmauri_signing_pdf/) | `40-standards` | `standards/swarmauri_signing_pdf` | `composite-concrete` | `standard` | yes |
 | `40.2` | [swarmauri_signing_dpop](standards/swarmauri_signing_dpop/) | `40-standards` | `standards/swarmauri_signing_dpop` | `orchestrator` | `standard` | yes |
 | `50.0` | [swarmauri_signing_dsse](community/swarmauri_signing_dsse/) | `50-community` | `community/swarmauri_signing_dsse` | `atomic-concrete` | `community` | yes |
+
+### `similarity`
+
+| Index | Package | Layer | Path | Role | Maturity | Workspace |
+|---|---|---|---|---|---|---|
+| `40.0` | [swarmauri_similarity_gzip](standards/swarmauri_similarity_gzip/) | `40-standards` | `standards/swarmauri_similarity_gzip` | `atomic-concrete` | `standard` | yes |
 
 ### `skill`
 

--- a/pkgs/base/swarmauri_base/ComponentBase.py
+++ b/pkgs/base/swarmauri_base/ComponentBase.py
@@ -83,6 +83,7 @@ class ResourceTypes(Enum):
     TRACE = "Trace"
     UTIL = "Util"
     VECTOR_STORE = "VectorStore"
+    RETRIEVER = "Retriever"
     VECTOR = "Vector"
     VLM = "VLM"
     DATA_CONNECTOR = "DataConnector"

--- a/pkgs/base/swarmauri_base/ComponentBase.py
+++ b/pkgs/base/swarmauri_base/ComponentBase.py
@@ -137,3 +137,5 @@ class ResourceTypes(Enum):
     OAuth21Login = "OAuth21Login"
     OIDC10AppClient = "OIDC10AppClient"
     OIDC10Login = "OIDC10Login"
+
+

--- a/pkgs/base/swarmauri_base/document_stores/DocumentStoreRetrieveBase.py
+++ b/pkgs/base/swarmauri_base/document_stores/DocumentStoreRetrieveBase.py
@@ -4,12 +4,13 @@ from typing import List, Literal
 from pydantic import ConfigDict, Field
 
 from swarmauri_base.ComponentBase import ComponentBase, ResourceTypes
+from swarmauri_base.retrievers.RetrieverBase import RetrieverBase
 from swarmauri_core.document_stores.IDocumentRetrieve import IDocumentRetrieve
 from swarmauri_core.documents.IDocument import IDocument
 
 
 @ComponentBase.register_model()
-class DocumentStoreRetrieveBase(IDocumentRetrieve, ComponentBase):
+class DocumentStoreRetrieveBase(IDocumentRetrieve, RetrieverBase):
     resource: ResourceTypes = Field(default=ResourceTypes.DOCUMENT_STORE.value)
     model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
     type: Literal["DocumentStoreRetrieveBase"] = "DocumentStoreRetrieveBase"

--- a/pkgs/base/swarmauri_base/retrievers/RetrieverBase.py
+++ b/pkgs/base/swarmauri_base/retrievers/RetrieverBase.py
@@ -1,0 +1,20 @@
+from abc import abstractmethod
+from typing import List, Literal, Optional
+
+from pydantic import Field
+from swarmauri_base.ComponentBase import ComponentBase, ResourceTypes
+from swarmauri_core.documents.IDocument import IDocument
+from swarmauri_core.retrievers.IRetriever import IRetriever
+
+
+@ComponentBase.register_model()
+class RetrieverBase(IRetriever, ComponentBase):
+    """Base class for document retrievers."""
+
+    resource: Optional[str] = Field(default=ResourceTypes.RETRIEVER.value)
+    type: Literal["RetrieverBase"] = "RetrieverBase"
+
+    @abstractmethod
+    def retrieve(self, query: str, top_k: int = 5) -> List[IDocument]:
+        """Return up to ``top_k`` documents relevant to ``query``."""
+        pass

--- a/pkgs/base/swarmauri_base/retrievers/RetrieverMixin.py
+++ b/pkgs/base/swarmauri_base/retrievers/RetrieverMixin.py
@@ -1,0 +1,15 @@
+from abc import abstractmethod
+from typing import List
+
+from pydantic import BaseModel
+from swarmauri_core.documents.IDocument import IDocument
+from swarmauri_core.retrievers.IRetriever import IRetriever
+
+
+class RetrieverMixin(IRetriever, BaseModel):
+    """Composable retrieval contract for document-owning components."""
+
+    @abstractmethod
+    def retrieve(self, query: str, top_k: int = 5) -> List[IDocument]:
+        """Return up to ``top_k`` documents relevant to ``query``."""
+        pass

--- a/pkgs/base/swarmauri_base/retrievers/__init__.py
+++ b/pkgs/base/swarmauri_base/retrievers/__init__.py
@@ -1,0 +1,4 @@
+from swarmauri_base.retrievers.RetrieverBase import RetrieverBase
+from swarmauri_base.retrievers.RetrieverMixin import RetrieverMixin
+
+__all__ = ["RetrieverBase", "RetrieverMixin"]

--- a/pkgs/base/swarmauri_base/vector_stores/VectorStoreRetrieveMixin.py
+++ b/pkgs/base/swarmauri_base/vector_stores/VectorStoreRetrieveMixin.py
@@ -1,23 +1,5 @@
-from abc import abstractmethod
-from typing import List
-from pydantic import BaseModel
-from swarmauri_core.documents.IDocument import IDocument
-from swarmauri_core.vector_stores.IVectorStoreRetrieve import (
-    IVectorStoreRetrieve,
-)
+from swarmauri_base.retrievers.RetrieverMixin import RetrieverMixin
 
 
-class VectorStoreRetrieveMixin(IVectorStoreRetrieve, BaseModel):
-    @abstractmethod
-    def retrieve(self, query: str, top_k: int = 5) -> List[IDocument]:
-        """
-        Retrieve the top_k most relevant documents based on the given query.
-
-        Args:
-            query (str): The query string used for document retrieval.
-            top_k (int): The number of top relevant documents to retrieve.
-
-        Returns:
-            List[IDocument]: A list of the top_k most relevant documents.
-        """
-        pass
+class VectorStoreRetrieveMixin(RetrieverMixin):
+    """Compatibility mixin for vector stores that support retrieval."""

--- a/pkgs/base/swarmauri_base/vector_stores/VectorStoreRetrieveMixin.py
+++ b/pkgs/base/swarmauri_base/vector_stores/VectorStoreRetrieveMixin.py
@@ -1,5 +1,8 @@
 from swarmauri_base.retrievers.RetrieverMixin import RetrieverMixin
+from swarmauri_core.vector_stores.IVectorStoreRetrieve import (
+    IVectorStoreRetrieve,
+)
 
 
-class VectorStoreRetrieveMixin(RetrieverMixin):
+class VectorStoreRetrieveMixin(IVectorStoreRetrieve, RetrieverMixin):
     """Compatibility mixin for vector stores that support retrieval."""

--- a/pkgs/base/tests/unit/retrievers/RetrieverBase_unit_test.py
+++ b/pkgs/base/tests/unit/retrievers/RetrieverBase_unit_test.py
@@ -38,3 +38,12 @@ def test_concrete_retriever_roundtrips_json():
 
 def test_retriever_mixin_is_not_a_component_base():
     assert not issubclass(RetrieverMixin, RetrieverBase)
+
+
+@pytest.mark.unit
+def test_document_store_retrieve_base_is_a_retriever():
+    from swarmauri_base.document_stores.DocumentStoreRetrieveBase import (
+        DocumentStoreRetrieveBase,
+    )
+
+    assert issubclass(DocumentStoreRetrieveBase, RetrieverBase)

--- a/pkgs/base/tests/unit/retrievers/RetrieverBase_unit_test.py
+++ b/pkgs/base/tests/unit/retrievers/RetrieverBase_unit_test.py
@@ -1,0 +1,40 @@
+from typing import List
+
+import pytest
+from swarmauri_base.retrievers.RetrieverBase import RetrieverBase
+from swarmauri_base.retrievers.RetrieverMixin import RetrieverMixin
+from swarmauri_core.documents.IDocument import IDocument
+
+
+class ConcreteRetriever(RetrieverBase):
+    def retrieve(self, query: str, top_k: int = 5) -> List[IDocument]:
+        return []
+
+
+def test_retriever_base_is_not_instantiable():
+    assert RetrieverBase.model_fields["type"].default == "RetrieverBase"
+    with pytest.raises(TypeError):
+        RetrieverBase()
+
+
+def test_concrete_retriever_has_resource_and_type():
+    retriever = ConcreteRetriever()
+
+    assert retriever.resource == "Retriever"
+    assert retriever.type == "ConcreteRetriever"
+
+
+def test_concrete_retriever_roundtrips_json():
+    original = ConcreteRetriever(name="example")
+
+    restored = ConcreteRetriever.model_validate_json(
+        original.model_dump_json()
+    )
+
+    assert restored.name == original.name
+    assert restored.resource == "Retriever"
+    assert restored.type == "ConcreteRetriever"
+
+
+def test_retriever_mixin_is_not_a_component_base():
+    assert not issubclass(RetrieverMixin, RetrieverBase)

--- a/pkgs/base/tests/unit/retrievers/RetrieverMixin_unit_test.py
+++ b/pkgs/base/tests/unit/retrievers/RetrieverMixin_unit_test.py
@@ -1,3 +1,5 @@
+import pytest
+
 from typing import List
 
 from swarmauri_base.retrievers.RetrieverMixin import RetrieverMixin
@@ -13,3 +15,16 @@ class ConcreteMixinRetriever(RetrieverMixin):
 def test_retriever_mixin_implements_retriever_contract():
     assert issubclass(RetrieverMixin, IRetriever)
     assert ConcreteMixinRetriever().retrieve("query") == []
+
+
+@pytest.mark.unit
+def test_vector_store_retrieve_mixin_preserves_legacy_contract():
+    from swarmauri_base.vector_stores.VectorStoreRetrieveMixin import (
+        VectorStoreRetrieveMixin,
+    )
+    from swarmauri_core.vector_stores.IVectorStoreRetrieve import (
+        IVectorStoreRetrieve,
+    )
+
+    assert issubclass(VectorStoreRetrieveMixin, RetrieverMixin)
+    assert issubclass(VectorStoreRetrieveMixin, IVectorStoreRetrieve)

--- a/pkgs/base/tests/unit/retrievers/RetrieverMixin_unit_test.py
+++ b/pkgs/base/tests/unit/retrievers/RetrieverMixin_unit_test.py
@@ -1,0 +1,15 @@
+from typing import List
+
+from swarmauri_base.retrievers.RetrieverMixin import RetrieverMixin
+from swarmauri_core.documents.IDocument import IDocument
+from swarmauri_core.retrievers.IRetriever import IRetriever
+
+
+class ConcreteMixinRetriever(RetrieverMixin):
+    def retrieve(self, query: str, top_k: int = 5) -> List[IDocument]:
+        return []
+
+
+def test_retriever_mixin_implements_retriever_contract():
+    assert issubclass(RetrieverMixin, IRetriever)
+    assert ConcreteMixinRetriever().retrieve("query") == []

--- a/pkgs/community/swarmauri_vectorstore_redis/tests/unit/RedisDocumentRetriever_unit_test.py
+++ b/pkgs/community/swarmauri_vectorstore_redis/tests/unit/RedisDocumentRetriever_unit_test.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from swarmauri_base.retrievers.RetrieverBase import RetrieverBase
 from swarmauri_standard.documents.Document import Document
 from swarmauri_vectorstore_redis.RedisDocumentRetriever import (
     RedisDocumentRetriever,
@@ -82,3 +83,8 @@ def test_retrieve_documents(retriever):
         assert results[0].content == "Test document 1"
         assert results[1].id == "doc2"
         assert results[1].content == "Test document 2"
+
+
+@pytest.mark.unit
+def test_retriever_family_compatibility():
+    assert issubclass(RedisDocumentRetriever, RetrieverBase)

--- a/pkgs/core/swarmauri_core/retrievers/IRetriever.py
+++ b/pkgs/core/swarmauri_core/retrievers/IRetriever.py
@@ -1,0 +1,13 @@
+from abc import ABC, abstractmethod
+from typing import List
+
+from swarmauri_core.documents.IDocument import IDocument
+
+
+class IRetriever(ABC):
+    """Interface for components that retrieve documents for a query."""
+
+    @abstractmethod
+    def retrieve(self, query: str, top_k: int = 5) -> List[IDocument]:
+        """Return up to ``top_k`` documents relevant to ``query``."""
+        pass

--- a/pkgs/core/swarmauri_core/retrievers/__init__.py
+++ b/pkgs/core/swarmauri_core/retrievers/__init__.py
@@ -1,0 +1,3 @@
+from swarmauri_core.retrievers.IRetriever import IRetriever
+
+__all__ = ["IRetriever"]

--- a/pkgs/core/swarmauri_core/vector_stores/IVectorStoreRetrieve.py
+++ b/pkgs/core/swarmauri_core/vector_stores/IVectorStoreRetrieve.py
@@ -1,28 +1,5 @@
-from abc import ABC, abstractmethod
-from typing import List
-from swarmauri_core.documents.IDocument import IDocument
+from swarmauri_core.retrievers.IRetriever import IRetriever
 
 
-class IVectorStoreRetrieve(ABC):
-    """
-    Abstract base class for document retrieval operations.
-
-    This class defines the interface for retrieving documents based on a query
-    or other criteria.
-    Implementations may use various indexing or search technologies to fulfill
-    these retrievals.
-    """
-
-    @abstractmethod
-    def retrieve(self, query: str, top_k: int = 5) -> List[IDocument]:
-        """
-        Retrieve the most relevant documents based on the given query.
-
-        Parameters:
-            query (str): The query string used for document retrieval.
-            top_k (int): The number of top relevant documents to retrieve.
-
-        Returns:
-            List[Document]: A list of the top_k most relevant documents.
-        """
-        pass
+class IVectorStoreRetrieve(IRetriever):
+    """Deprecated compatibility interface for vector-store retrieval."""

--- a/pkgs/core/swarmauri_core/vector_stores/__init__.py
+++ b/pkgs/core/swarmauri_core/vector_stores/__init__.py
@@ -1,7 +1,15 @@
 from swarmauri_core.vector_stores.IVectorStore import IVectorStore
+from swarmauri_core.vector_stores.IVectorStoreRetrieve import (
+    IVectorStoreRetrieve,
+)
 from swarmauri_core.vector_stores.IVectorStoreComparator import (
     IVectorStoreComparator,
     RankingDirection,
 )
 
-__all__ = ["IVectorStore", "IVectorStoreComparator", "RankingDirection"]
+__all__ = [
+    "IVectorStore",
+    "IVectorStoreComparator",
+    "IVectorStoreRetrieve",
+    "RankingDirection",
+]

--- a/pkgs/core/tests/unit/retrievers/IRetriever_unit_test.py
+++ b/pkgs/core/tests/unit/retrievers/IRetriever_unit_test.py
@@ -1,0 +1,24 @@
+import inspect
+
+import pytest
+from swarmauri_core.retrievers.IRetriever import IRetriever
+from swarmauri_core.vector_stores.IVectorStoreRetrieve import (
+    IVectorStoreRetrieve,
+)
+
+
+def test_retriever_is_abstract():
+    assert inspect.isabstract(IRetriever)
+    with pytest.raises(TypeError):
+        IRetriever()
+
+
+def test_retrieve_signature_is_stable():
+    signature = inspect.signature(IRetriever.retrieve)
+
+    assert list(signature.parameters) == ["self", "query", "top_k"]
+    assert signature.parameters["top_k"].default == 5
+
+
+def test_vector_store_retrieve_interface_extends_retriever():
+    assert issubclass(IVectorStoreRetrieve, IRetriever)

--- a/pkgs/package-index.toml
+++ b/pkgs/package-index.toml
@@ -1444,6 +1444,18 @@ order_source = "inferred"
 order_reason = "single-capability package by default"
 
 [[packages]]
+name = "swarmauri_similarity_gzip"
+path = "standards/swarmauri_similarity_gzip"
+layer = "40-standards"
+order = 0
+family = "similarity"
+role = "atomic-concrete"
+maturity = "standard"
+workspace = true
+order_source = "inferred"
+order_reason = "single-capability package by default"
+
+[[packages]]
 name = "swarmauri_skill_dummy_filesystem"
 path = "standards/swarmauri_skill_dummy_filesystem"
 layer = "40-standards"

--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -325,6 +325,7 @@ members = [
     "standards/swarmauri_signing_sigv4",
     "standards/swarmauri_signing_ssh",
     "standards/swarmauri_signing_xmld",
+    "standards/swarmauri_similarity_gzip",
     "standards/swarmauri_storage_file",
     "standards/swarmauri_storage_github",
     "standards/swarmauri_storage_github_release",

--- a/pkgs/standards/swarmauri_similarity_gzip/README.md
+++ b/pkgs/standards/swarmauri_similarity_gzip/README.md
@@ -1,0 +1,57 @@
+# GzipSimilarity
+
+![Swarmauri Logo](https://github.com/swarmauri/swarmauri-sdk/blob/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg)
+
+GzipSimilarity provides a dependency-light Swarmauri similarity implementation based on gzip compression and Normalized Compression Distance (NCD).
+
+[![PyPI Downloads](https://static.pepy.tech/badge/swarmauri_similarity_gzip)](https://pepy.tech/projects/swarmauri_similarity_gzip)
+[![Hits](https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_similarity_gzip.svg)](https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/standards/swarmauri_similarity_gzip/)
+[![Python Versions](https://img.shields.io/pypi/pyversions/swarmauri_similarity_gzip)](https://pypi.org/project/swarmauri_similarity_gzip/)
+[![License](https://img.shields.io/pypi/l/swarmauri_similarity_gzip)](https://pypi.org/project/swarmauri_similarity_gzip/)
+[![PyPI Version](https://img.shields.io/pypi/v/swarmauri_similarity_gzip)](https://pypi.org/project/swarmauri_similarity_gzip/)
+
+## Features
+
+- Implements `SimilarityBase` from `swarmauri_base`.
+- Compares text and binary values through shared gzip compressibility.
+- Supports deterministic gzip sizing and configurable compression levels.
+- Supports symmetric concatenation-order handling.
+- Exposes both bounded similarity and raw NCD values.
+
+## Installation
+
+```bash
+uv add swarmauri_similarity_gzip
+```
+
+```bash
+pip install swarmauri_similarity_gzip
+```
+
+## Usage
+
+```python
+from swarmauri_similarity_gzip import GzipSimilarity
+
+similarity = GzipSimilarity()
+
+score = similarity.similarity(
+    "The quick brown fox",
+    "Le renard brun rapide",
+)
+
+ncd = similarity.ncd(
+    "The quick brown fox",
+    "Le renard brun rapide",
+)
+```
+
+`similarity()` returns a score in `[0.0, 1.0]`, where higher values indicate greater shared compressibility. `ncd()` exposes the underlying Normalized Compression Distance. The result is a compression-based similarity estimate and should not be interpreted as semantic similarity without corpus-specific validation.
+
+For language comparison, use balanced samples, consistent UTF-8 encoding and preprocessing, and sufficiently large inputs to reduce gzip framing effects.
+
+The implementation is based on Benedetto, Caglioti, and Loreto, [Language Trees and Zipping](https://arxiv.org/abs/cond-mat/0108530).
+
+## License
+
+Apache-2.0

--- a/pkgs/standards/swarmauri_similarity_gzip/pyproject.toml
+++ b/pkgs/standards/swarmauri_similarity_gzip/pyproject.toml
@@ -1,0 +1,56 @@
+[project]
+name = "swarmauri_similarity_gzip"
+version = "0.1.0.dev1"
+description = "Gzip-based compression similarity for Swarmauri."
+license = "Apache-2.0"
+readme = { file = "README.md", content-type = "text/markdown" }
+repository = "http://github.com/swarmauri/swarmauri-sdk"
+requires-python = ">=3.10,<3.13"
+authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
+keywords = [
+    "swarmauri",
+    "similarity",
+    "compression",
+    "gzip",
+    "normalized-compression-distance",
+    "language-comparison",
+]
+classifiers = [
+    "Development Status :: 1 - Planning",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Text Processing",
+]
+dependencies = [
+    "swarmauri_base",
+    "swarmauri_core",
+]
+
+[tool.uv.sources]
+swarmauri_base = { workspace = true }
+swarmauri_core = { workspace = true }
+
+[project.entry-points."swarmauri.similarities"]
+GzipSimilarity = "swarmauri_similarity_gzip:GzipSimilarity"
+
+[tool.pytest.ini_options]
+timeout = 300
+log_cli = true
+log_cli_level = "INFO"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-timeout>=2.3.1",
+    "ruff>=0.9.9",
+]

--- a/pkgs/standards/swarmauri_similarity_gzip/swarmauri_similarity_gzip/GzipSimilarity.py
+++ b/pkgs/standards/swarmauri_similarity_gzip/swarmauri_similarity_gzip/GzipSimilarity.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import gzip
+from typing import Literal
+
+from pydantic import Field
+from swarmauri_base.ComponentBase import ComponentBase
+from swarmauri_base.similarities.SimilarityBase import SimilarityBase
+from swarmauri_core.similarities.ISimilarity import ComparableType
+
+
+@ComponentBase.register_type(SimilarityBase, "GzipSimilarity")
+class GzipSimilarity(SimilarityBase):
+    """Gzip-based similarity using Normalized Compression Distance."""
+
+    type: Literal["GzipSimilarity"] = "GzipSimilarity"
+    compresslevel: int = Field(default=9, ge=0, le=9)
+    symmetric: bool = True
+
+    def similarity(self, x: ComparableType, y: ComparableType) -> float:
+        """Return a bounded similarity score between two values."""
+        if self._to_bytes(x) == self._to_bytes(y):
+            return 1.0
+
+        ncd = self.ncd(x, y)
+        return max(0.0, min(1.0, 1.0 - ncd))
+
+    def ncd(self, x: ComparableType, y: ComparableType) -> float:
+        """Return the underlying Normalized Compression Distance."""
+        x_bytes = self._to_bytes(x)
+        y_bytes = self._to_bytes(y)
+
+        if x_bytes == y_bytes:
+            return 0.0
+
+        x_size = self.compressed_size(x_bytes)
+        y_size = self.compressed_size(y_bytes)
+        forward_size = self.compressed_size(x_bytes + y_bytes)
+
+        if self.symmetric:
+            reverse_size = self.compressed_size(y_bytes + x_bytes)
+            joined_size = min(forward_size, reverse_size)
+        else:
+            joined_size = forward_size
+
+        denominator = max(x_size, y_size)
+        if denominator == 0:
+            return 0.0 if x_bytes == y_bytes else 1.0
+
+        return (joined_size - min(x_size, y_size)) / denominator
+
+    def compressed_size(self, value: ComparableType) -> int:
+        """Return the deterministic gzip-compressed size of a value."""
+        return len(
+            gzip.compress(
+                self._to_bytes(value),
+                compresslevel=self.compresslevel,
+                mtime=0,
+            )
+        )
+
+    def check_bounded(self) -> bool:
+        """Return whether this similarity measure is bounded."""
+        return True
+
+    @staticmethod
+    def _to_bytes(value: ComparableType) -> bytes:
+        if isinstance(value, str):
+            return value.encode("utf-8")
+        if isinstance(value, bytes):
+            return value
+        if isinstance(value, bytearray):
+            return bytes(value)
+        if isinstance(value, memoryview):
+            return value.tobytes()
+        raise TypeError(
+            "GzipSimilarity supports str, bytes, bytearray, and memoryview"
+        )
+
+
+# Expose the registered type name at both class and instance level.
+GzipSimilarity.type = "GzipSimilarity"

--- a/pkgs/standards/swarmauri_similarity_gzip/swarmauri_similarity_gzip/__init__.py
+++ b/pkgs/standards/swarmauri_similarity_gzip/swarmauri_similarity_gzip/__init__.py
@@ -1,0 +1,3 @@
+from swarmauri_similarity_gzip.GzipSimilarity import GzipSimilarity
+
+__all__ = ["GzipSimilarity"]

--- a/pkgs/standards/swarmauri_similarity_gzip/tests/test_GzipSimilarity.py
+++ b/pkgs/standards/swarmauri_similarity_gzip/tests/test_GzipSimilarity.py
@@ -1,0 +1,43 @@
+import pytest
+
+from swarmauri_base.similarities.SimilarityBase import SimilarityBase
+from swarmauri_similarity_gzip import GzipSimilarity
+
+
+def test_inherits_similarity_base():
+    assert isinstance(GzipSimilarity(), SimilarityBase)
+
+
+def test_identical_values_are_maximally_similar():
+    comparator = GzipSimilarity()
+
+    assert comparator.similarity("same value", "same value") == 1.0
+
+
+def test_similarity_is_bounded():
+    comparator = GzipSimilarity()
+
+    score = comparator.similarity("alpha", "beta")
+
+    assert 0.0 <= score <= 1.0
+
+
+def test_symmetric_comparison_is_order_independent():
+    comparator = GzipSimilarity(symmetric=True)
+
+    assert comparator.similarity("alpha", "beta") == comparator.similarity(
+        "beta", "alpha"
+    )
+
+
+def test_text_and_utf8_bytes_are_equivalent():
+    comparator = GzipSimilarity()
+
+    assert comparator.similarity("hello", "world") == comparator.similarity(
+        b"hello", b"world"
+    )
+
+
+def test_invalid_compression_level_is_rejected():
+    with pytest.raises(ValueError):
+        GzipSimilarity(compresslevel=10)

--- a/pkgs/standards/swarmauri_similarity_gzip/tests/test_public_api.py
+++ b/pkgs/standards/swarmauri_similarity_gzip/tests/test_public_api.py
@@ -7,3 +7,16 @@ def test_gzip_similarity_class_type():
 
 def test_gzip_similarity_instance_type():
     assert GzipSimilarity().type == "GzipSimilarity"
+
+
+def test_gzip_similarity_json_roundtrip():
+    original = GzipSimilarity(compresslevel=6, symmetric=False)
+
+    restored = GzipSimilarity.model_validate_json(original.model_dump_json())
+
+    assert restored.type == original.type == "GzipSimilarity"
+    assert restored.compresslevel == original.compresslevel == 6
+    assert restored.symmetric is original.symmetric is False
+    assert restored.similarity("alpha", "beta") == original.similarity(
+        "alpha", "beta"
+    )

--- a/pkgs/standards/swarmauri_similarity_gzip/tests/test_public_api.py
+++ b/pkgs/standards/swarmauri_similarity_gzip/tests/test_public_api.py
@@ -1,0 +1,9 @@
+from swarmauri_similarity_gzip import GzipSimilarity
+
+
+def test_gzip_similarity_class_type():
+    assert GzipSimilarity.type == "GzipSimilarity"
+
+
+def test_gzip_similarity_instance_type():
+    assert GzipSimilarity().type == "GzipSimilarity"

--- a/pkgs/swarmauri/swarmauri/interface_registry.py
+++ b/pkgs/swarmauri/swarmauri/interface_registry.py
@@ -51,6 +51,9 @@ class InterfaceRegistry:
         "swarmauri.llms": "swarmauri_base.llms.LLMBase",
         "swarmauri.tool_llms": "swarmauri_base.tool_llms.ToolLLMBase",
         "swarmauri.tts": "swarmauri_base.tts.TTSBase",
+        "swarmauri.video_lipsync": (
+            "swarmauri_base.video_lipsync.LipSyncBase"
+        ),
         "swarmauri.ocrs": "swarmauri_base.ocrs.OCRBase",
         "swarmauri.stt": "swarmauri_base.stt.STTBase",
         "swarmauri.storage_adapters": (
@@ -72,6 +75,7 @@ class InterfaceRegistry:
         "swarmauri.schema_converters": (
             "swarmauri_base.schema_converters.SchemaConverterBase"
         ),
+        "swarmauri.retrievers": ("swarmauri_base.retrievers.RetrieverBase"),
         "swarmauri.skills": "swarmauri_base.skills.SkillBase",
         "swarmauri.similarities": (
             "swarmauri_base.similarities.SimilarityBase"

--- a/pkgs/swarmauri/swarmauri/interface_registry.py
+++ b/pkgs/swarmauri/swarmauri/interface_registry.py
@@ -73,6 +73,9 @@ class InterfaceRegistry:
             "swarmauri_base.schema_converters.SchemaConverterBase"
         ),
         "swarmauri.skills": "swarmauri_base.skills.SkillBase",
+        "swarmauri.similarities": (
+            "swarmauri_base.similarities.SimilarityBase"
+        ),
         "swarmauri.service_registries": (
             "swarmauri_base.service_registries.ServiceRegistryBase"
         ),

--- a/pkgs/swarmauri/swarmauri/plugin_citizenship_registry.py
+++ b/pkgs/swarmauri/swarmauri/plugin_citizenship_registry.py
@@ -85,6 +85,9 @@ class PluginCitizenshipRegistry:
         "swarmauri.signings.JwsSignerVerifier": (
             "swarmauri_signing_jws.JwsSignerVerifier"
         ),
+        "swarmauri.similarities.GzipSimilarity": (
+            "swarmauri_similarity_gzip.GzipSimilarity"
+        ),
         "swarmauri.cipher_suites.JwaCipherSuite": (
             "swarmauri_cipher_suite_jwa.JwaCipherSuite"
         ),

--- a/pkgs/swarmauri/tests/unit/interface_registry_unit_test.py
+++ b/pkgs/swarmauri/tests/unit/interface_registry_unit_test.py
@@ -53,3 +53,13 @@ def test_get_retriever_interface():
         InterfaceRegistry.get_interface_for_resource("swarmauri.retrievers")
         is RetrieverBase
     )
+
+
+@pytest.mark.unit
+def test_get_video_lipsync_interface():
+    from swarmauri_base.video_lipsync.LipSyncBase import LipSyncBase
+
+    assert (
+        InterfaceRegistry.get_interface_for_resource("swarmauri.video_lipsync")
+        is LipSyncBase
+    )

--- a/pkgs/swarmauri/tests/unit/interface_registry_unit_test.py
+++ b/pkgs/swarmauri/tests/unit/interface_registry_unit_test.py
@@ -43,3 +43,13 @@ def test_get_key_provider_interface():
         InterfaceRegistry.get_interface_for_resource("swarmauri.key_providers")
         is KeyProviderBase
     )
+
+
+@pytest.mark.unit
+def test_get_retriever_interface():
+    from swarmauri_base.retrievers.RetrieverBase import RetrieverBase
+
+    assert (
+        InterfaceRegistry.get_interface_for_resource("swarmauri.retrievers")
+        is RetrieverBase
+    )


### PR DESCRIPTION
## Summary
- add the standalone retriever family contracts in `swarmauri_core` and `swarmauri_base`
- preserve vector-store retrieval compatibility through `RetrieverMixin`
- register the retriever facade namespace and add contract/serialization tests

## Validation
- core retriever tests: 3 passed
- base retriever tests: 5 passed
- facade registry tests: 5 passed
- gzip similarity tests: 9 passed
- Tfidf compatibility tests: 4 passed
- Doc2Vec compatibility tests: 6 passed
- Ruff format and checks passed for all changed packages
