### PR TITLE
feat: add ScrollFileTool

### DIFF
--- a/pkgs/PACKAGE_INDEX.md
+++ b/pkgs/PACKAGE_INDEX.md
@@ -341,6 +341,7 @@ fail validation because they make composition order ambiguous.
 | `50.0` | [swarmauri_tool_qrcodegenerator](community/swarmauri_tool_qrcodegenerator/) | `community/swarmauri_tool_qrcodegenerator` | `tool` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_tool_queryimagevectorstore](community/swarmauri_tool_queryimagevectorstore/) | `community/swarmauri_tool_queryimagevectorstore` | `tool` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_tool_queryknowledgebase](community/swarmauri_tool_queryknowledgebase/) | `community/swarmauri_tool_queryknowledgebase` | `tool` | `atomic-concrete` | `community` | yes |
+| `50.0` | [swarmauri_tool_scrollfile](community/swarmauri_tool_scrollfile/) | `community/swarmauri_tool_scrollfile` | `tool` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_tool_searchword](community/swarmauri_tool_searchword/) | `community/swarmauri_tool_searchword` | `tool` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_tool_sentencecomplexity](community/swarmauri_tool_sentencecomplexity/) | `community/swarmauri_tool_sentencecomplexity` | `tool` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_tool_sentimentanalysis](community/swarmauri_tool_sentimentanalysis/) | `community/swarmauri_tool_sentimentanalysis` | `tool` | `atomic-concrete` | `community` | yes |
@@ -751,6 +752,7 @@ fail validation because they make composition order ambiguous.
 | [swarmauri_tool_qrcodegenerator](community/swarmauri_tool_qrcodegenerator/) | `tool` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_tool_queryimagevectorstore](community/swarmauri_tool_queryimagevectorstore/) | `tool` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_tool_queryknowledgebase](community/swarmauri_tool_queryknowledgebase/) | `tool` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
+| [swarmauri_tool_scrollfile](community/swarmauri_tool_scrollfile/) | `tool` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_tool_searchword](community/swarmauri_tool_searchword/) | `tool` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_tool_sentencecomplexity](community/swarmauri_tool_sentencecomplexity/) | `tool` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
 | [swarmauri_tool_sentimentanalysis](community/swarmauri_tool_sentimentanalysis/) | `tool` | `atomic-concrete` | `inferred` | 0 | single-capability package by default |
@@ -1503,6 +1505,7 @@ fail validation because they make composition order ambiguous.
 | `50.0` | [swarmauri_tool_qrcodegenerator](community/swarmauri_tool_qrcodegenerator/) | `50-community` | `community/swarmauri_tool_qrcodegenerator` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_tool_queryimagevectorstore](community/swarmauri_tool_queryimagevectorstore/) | `50-community` | `community/swarmauri_tool_queryimagevectorstore` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_tool_queryknowledgebase](community/swarmauri_tool_queryknowledgebase/) | `50-community` | `community/swarmauri_tool_queryknowledgebase` | `atomic-concrete` | `community` | yes |
+| `50.0` | [swarmauri_tool_scrollfile](community/swarmauri_tool_scrollfile/) | `50-community` | `community/swarmauri_tool_scrollfile` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_tool_searchword](community/swarmauri_tool_searchword/) | `50-community` | `community/swarmauri_tool_searchword` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_tool_sentencecomplexity](community/swarmauri_tool_sentencecomplexity/) | `50-community` | `community/swarmauri_tool_sentencecomplexity` | `atomic-concrete` | `community` | yes |
 | `50.0` | [swarmauri_tool_sentimentanalysis](community/swarmauri_tool_sentimentanalysis/) | `50-community` | `community/swarmauri_tool_sentimentanalysis` | `atomic-concrete` | `community` | yes |

--- a/pkgs/community/swarmauri_tool_scrollfile/LICENSE
+++ b/pkgs/community/swarmauri_tool_scrollfile/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Jacob Stewart @ Swarmauri]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkgs/community/swarmauri_tool_scrollfile/README.md
+++ b/pkgs/community/swarmauri_tool_scrollfile/README.md
@@ -1,0 +1,88 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/swarmauri/swarmauri-sdk/3d4d1cfa949399d7019ae9d8f296afba773dfb7f/assets/swarmauri.brand.theme.svg" alt="Swarmauri" width="420"/>
+</p>
+
+<p align="center">
+  <a href="https://pepy.tech/project/swarmauri_tool_scrollfile/"><img src="https://static.pepy.tech/badge/swarmauri_tool_scrollfile/month" alt="Monthly downloads"/></a>
+  <a href="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/community/swarmauri_tool_scrollfile/"><img src="https://hits.sh/github.com/swarmauri/swarmauri-sdk/tree/master/pkgs/community/swarmauri_tool_scrollfile.svg" alt="Repository hits"/></a>
+  <a href="https://pypi.org/project/swarmauri_tool_scrollfile/"><img src="https://img.shields.io/pypi/pyversions/swarmauri_tool_scrollfile" alt="Supported Python versions"/></a>
+  <a href="https://pypi.org/project/swarmauri_tool_scrollfile/"><img src="https://img.shields.io/pypi/l/swarmauri_tool_scrollfile" alt="License"/></a>
+  <a href="https://pypi.org/project/swarmauri_tool_scrollfile/"><img src="https://img.shields.io/pypi/v/swarmauri_tool_scrollfile?label=release" alt="Release version"/></a>
+</p>
+
+# Swarmauri Tool Scroll File
+
+`swarmauri_tool_scrollfile` gives agents and workflows a bounded way to inspect
+large UTF-8 text files. It returns numbered lines together with stable previous
+and next page positions, avoiding full-file output.
+
+## Features
+
+- Reads at most the requested page size into the result.
+- Navigates up or down using one-based line anchors.
+- Returns line numbers and explicit previous/next page positions.
+- Clamps an anchor beyond EOF to the final available page.
+- Validates paths and navigation arguments before reading.
+- Registers as a `swarmauri.tools` entry point.
+- Supports Python 3.10, 3.11, 3.12, 3.13, and 3.14.
+
+## Installation
+
+```bash
+uv add swarmauri_tool_scrollfile
+```
+
+```bash
+pip install swarmauri_tool_scrollfile
+```
+
+## Usage
+
+```python
+from swarmauri_tool_scrollfile import ScrollFileTool
+
+tool = ScrollFileTool()
+first_page = tool("logs/application.log")
+
+if first_page["has_next"]:
+    second_page = tool(
+        "logs/application.log",
+        start_line=first_page["next_start_line"],
+        page_size=first_page["page_size"],
+        direction="down",
+    )
+```
+
+An upward request treats `start_line` as the current page anchor and returns
+the preceding page:
+
+```python
+previous_page = tool(
+    "logs/application.log",
+    start_line=second_page["start_line"],
+    page_size=second_page["page_size"],
+    direction="up",
+)
+```
+
+Each result contains `lines`, `start_line`, `end_line`, `page_size`,
+`has_previous`, `has_next`, `previous_start_line`, and `next_start_line`.
+
+## Workflow Integration
+
+```python
+from swarmauri_standard.tools.ToolCollection import ToolCollection
+from swarmauri_tool_scrollfile import ScrollFileTool
+
+tools = ToolCollection(tools=[ScrollFileTool()])
+```
+
+## Performance
+
+The tool streams from the start of the file to the requested page and holds at
+most one page plus one lookahead line in memory. Memory use is `O(page_size)`;
+runtime is `O(start_line + page_size)` for a stateless request.
+
+## License
+
+This package is licensed under Apache-2.0.

--- a/pkgs/community/swarmauri_tool_scrollfile/pyproject.toml
+++ b/pkgs/community/swarmauri_tool_scrollfile/pyproject.toml
@@ -1,0 +1,66 @@
+[project]
+name = "swarmauri_tool_scrollfile"
+version = "0.1.0"
+description = "Bounded UTF-8 file navigation tool for Swarmauri agents and workflows."
+authors = [{ name = "Jacob Stewart", email = "jacob@swarmauri.com" }]
+license = "Apache-2.0"
+readme = "README.md"
+repository = "http://github.com/swarmauri/swarmauri-sdk"
+requires-python = ">=3.10,<3.15"
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Development Status :: 1 - Planning",
+    "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+]
+keywords = [
+    "swarmauri",
+    "agent tool",
+    "file navigation",
+    "pagination",
+    "large files",
+    "text files",
+    "line reader",
+    "scroll file",
+]
+dependencies = [
+    "pydantic",
+    "swarmauri_core",
+    "swarmauri_base",
+    "swarmauri_standard",
+]
+
+[tool.uv.sources]
+swarmauri_core = { workspace = true }
+swarmauri_base = { workspace = true }
+swarmauri_standard = { workspace = true }
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-timeout>=2.3.1",
+    "ruff>=0.9.9",
+]
+
+[tool.pytest.ini_options]
+markers = ["unit: Unit tests"]
+timeout = 300
+
+[project.entry-points.'swarmauri.tools']
+ScrollFileTool = "swarmauri_tool_scrollfile:ScrollFileTool"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/pkgs/community/swarmauri_tool_scrollfile/swarmauri_tool_scrollfile/ScrollFileTool.py
+++ b/pkgs/community/swarmauri_tool_scrollfile/swarmauri_tool_scrollfile/ScrollFileTool.py
@@ -1,0 +1,176 @@
+from collections import deque
+from typing import Deque, List, Literal, Optional, TypedDict
+
+from pydantic import Field
+
+from swarmauri_base.ComponentBase import ComponentBase
+from swarmauri_base.tools.ToolBase import ToolBase
+from swarmauri_standard.tools.Parameter import Parameter
+
+
+class ScrollLine(TypedDict):
+    """One line returned by :class:`ScrollFileTool`."""
+
+    line_number: int
+    content: str
+
+
+class ScrollResult(TypedDict):
+    """A bounded page of file content and its navigation metadata."""
+
+    lines: List[ScrollLine]
+    start_line: int
+    end_line: Optional[int]
+    page_size: int
+    has_previous: bool
+    has_next: bool
+    previous_start_line: Optional[int]
+    next_start_line: Optional[int]
+
+
+@ComponentBase.register_type(ToolBase, "ScrollFileTool")
+class ScrollFileTool(ToolBase):
+    """Read a bounded, navigable page from a UTF-8 text file."""
+
+    version: str = "0.1.0"
+    name: str = "ScrollFileTool"
+    description: str = (
+        "Reads a bounded range of numbered lines from a UTF-8 text file and "
+        "provides previous and next page positions."
+    )
+    type: Literal["ScrollFileTool"] = "ScrollFileTool"  # type: ignore[assignment]
+    parameters: List[Parameter] = Field(  # type: ignore[assignment]
+        default_factory=lambda: [
+            Parameter(
+                name="file_path",
+                input_type="string",
+                description="Path to the UTF-8 text file to read.",
+                required=True,
+            ),
+            Parameter(
+                name="start_line",
+                input_type="number",
+                description=(
+                    "One-based page anchor. Down reads from this line; up "
+                    "reads the preceding page. Defaults to 1."
+                ),
+                required=False,
+            ),
+            Parameter(
+                name="page_size",
+                input_type="number",
+                description="Maximum lines to return. Defaults to 10.",
+                required=False,
+            ),
+            Parameter(
+                name="direction",
+                input_type="string",
+                description="Navigation direction: 'up' or 'down'.",
+                required=False,
+                enum=["up", "down"],
+            ),
+        ]
+    )
+
+    def __call__(  # type: ignore[override]
+        self,
+        file_path: str,
+        start_line: int = 1,
+        page_size: int = 10,
+        direction: Literal["up", "down"] = "down",
+    ) -> ScrollResult:
+        """Return one page of numbered lines and navigation positions.
+
+        ``start_line`` is a one-based page anchor. A downward request starts
+        at that line. An upward request returns the page immediately before
+        that anchor. Requests beyond the end of a non-empty file clamp to its
+        final page so callers can recover without knowing the total line count.
+        """
+        self._validate_inputs(file_path, start_line, page_size, direction)
+
+        target_start = (
+            start_line
+            if direction == "down"
+            else max(1, start_line - page_size)
+        )
+        read_size = (
+            min(page_size, start_line - 1)
+            if direction == "up" and start_line > 1
+            else page_size
+        )
+        page, has_next = self._read_page(
+            file_path=file_path,
+            target_start=target_start,
+            page_size=read_size,
+        )
+
+        if page:
+            actual_start = page[0]["line_number"]
+            end_line: Optional[int] = page[-1]["line_number"]
+        else:
+            actual_start = 1
+            end_line = None
+
+        has_previous = actual_start > 1
+        return {
+            "lines": page,
+            "start_line": actual_start,
+            "end_line": end_line,
+            "page_size": page_size,
+            "has_previous": has_previous,
+            "has_next": has_next,
+            "previous_start_line": (
+                max(1, actual_start - page_size) if has_previous else None
+            ),
+            "next_start_line": end_line + 1 if has_next and end_line else None,
+        }
+
+    @staticmethod
+    def _validate_inputs(
+        file_path: str,
+        start_line: int,
+        page_size: int,
+        direction: str,
+    ) -> None:
+        if not isinstance(file_path, str) or not file_path.strip():
+            raise ValueError("file_path must be a non-empty string.")
+        if (
+            not isinstance(start_line, int)
+            or isinstance(start_line, bool)
+            or start_line < 1
+        ):
+            raise ValueError("start_line must be a positive integer.")
+        if (
+            not isinstance(page_size, int)
+            or isinstance(page_size, bool)
+            or page_size < 1
+        ):
+            raise ValueError("page_size must be a positive integer.")
+        if direction not in {"up", "down"}:
+            raise ValueError("direction must be either 'up' or 'down'.")
+
+    @staticmethod
+    def _read_page(
+        file_path: str, target_start: int, page_size: int
+    ) -> tuple[List[ScrollLine], bool]:
+        preceding: Deque[ScrollLine] = deque(maxlen=page_size)
+        window: List[ScrollLine] = []
+
+        with open(file_path, "r", encoding="utf-8") as file:
+            for line_number, raw_line in enumerate(file, start=1):
+                line: ScrollLine = {
+                    "line_number": line_number,
+                    "content": raw_line.rstrip("\r\n"),
+                }
+                if line_number < target_start:
+                    preceding.append(line)
+                    continue
+
+                window.append(line)
+                if len(window) > page_size:
+                    break
+
+        if not window and preceding:
+            return list(preceding), False
+
+        return window[:page_size], len(window) > page_size

--- a/pkgs/community/swarmauri_tool_scrollfile/swarmauri_tool_scrollfile/__init__.py
+++ b/pkgs/community/swarmauri_tool_scrollfile/swarmauri_tool_scrollfile/__init__.py
@@ -1,0 +1,18 @@
+import re
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+from .ScrollFileTool import ScrollFileTool
+
+__all__ = ["ScrollFileTool"]
+
+try:
+    __version__ = version("swarmauri_tool_scrollfile")
+except PackageNotFoundError:
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    match = re.search(
+        r'^version\s*=\s*"([^"]+)"',
+        pyproject.read_text(encoding="utf-8"),
+        flags=re.MULTILINE,
+    )
+    __version__ = match.group(1) if match else "0.0.0"

--- a/pkgs/community/swarmauri_tool_scrollfile/tests/unit/test_ScrollFileTool.py
+++ b/pkgs/community/swarmauri_tool_scrollfile/tests/unit/test_ScrollFileTool.py
@@ -1,0 +1,167 @@
+from pathlib import Path
+
+import pytest
+
+from swarmauri_tool_scrollfile import ScrollFileTool, __version__
+
+
+@pytest.fixture
+def numbered_file(tmp_path: Path) -> Path:
+    path = tmp_path / "numbered.txt"
+    path.write_text(
+        "".join(f"line {line_number}\n" for line_number in range(1, 13)),
+        encoding="utf-8",
+    )
+    return path
+
+
+@pytest.mark.unit
+def test_component_contract_and_serialization() -> None:
+    tool = ScrollFileTool()
+
+    assert tool.resource == "Tool"
+    assert tool.type == "ScrollFileTool"
+    assert isinstance(tool.id, str)
+    assert (
+        ScrollFileTool.model_validate_json(tool.model_dump_json()).id
+        == tool.id
+    )
+    assert [parameter.name for parameter in tool.parameters] == [
+        "file_path",
+        "start_line",
+        "page_size",
+        "direction",
+    ]
+    assert __version__ == "0.1.0"
+
+
+@pytest.mark.unit
+def test_reads_default_first_page(numbered_file: Path) -> None:
+    result = ScrollFileTool()(str(numbered_file))
+
+    assert [line["line_number"] for line in result["lines"]] == list(
+        range(1, 11)
+    )
+    assert result["start_line"] == 1
+    assert result["end_line"] == 10
+    assert result["has_previous"] is False
+    assert result["has_next"] is True
+    assert result["previous_start_line"] is None
+    assert result["next_start_line"] == 11
+
+
+@pytest.mark.unit
+def test_reads_middle_and_final_pages(numbered_file: Path) -> None:
+    middle = ScrollFileTool()(str(numbered_file), start_line=6, page_size=5)
+    final = ScrollFileTool()(str(numbered_file), start_line=11, page_size=5)
+
+    assert [line["content"] for line in middle["lines"]] == [
+        f"line {line_number}" for line_number in range(6, 11)
+    ]
+    assert middle["previous_start_line"] == 1
+    assert middle["next_start_line"] == 11
+    assert [line["line_number"] for line in final["lines"]] == [11, 12]
+    assert final["has_next"] is False
+    assert final["next_start_line"] is None
+
+
+@pytest.mark.unit
+def test_scrolls_up_one_page(numbered_file: Path) -> None:
+    result = ScrollFileTool()(
+        str(numbered_file), start_line=11, page_size=5, direction="up"
+    )
+
+    assert [line["line_number"] for line in result["lines"]] == [
+        6,
+        7,
+        8,
+        9,
+        10,
+    ]
+    assert result["previous_start_line"] == 1
+    assert result["next_start_line"] == 11
+
+
+@pytest.mark.unit
+def test_upward_scroll_does_not_cross_anchor(numbered_file: Path) -> None:
+    result = ScrollFileTool()(
+        str(numbered_file), start_line=3, page_size=5, direction="up"
+    )
+
+    assert [line["line_number"] for line in result["lines"]] == [1, 2]
+    assert result["start_line"] == 1
+    assert result["end_line"] == 2
+    assert result["next_start_line"] == 3
+
+
+@pytest.mark.unit
+def test_clamps_beyond_eof_to_final_page(numbered_file: Path) -> None:
+    result = ScrollFileTool()(str(numbered_file), start_line=100, page_size=5)
+
+    assert [line["line_number"] for line in result["lines"]] == [
+        8,
+        9,
+        10,
+        11,
+        12,
+    ]
+    assert result["start_line"] == 8
+    assert result["end_line"] == 12
+    assert result["has_next"] is False
+
+
+@pytest.mark.unit
+def test_exact_page_and_empty_file(tmp_path: Path) -> None:
+    exact = tmp_path / "exact.txt"
+    exact.write_text("one\ntwo\n", encoding="utf-8")
+    empty = tmp_path / "empty.txt"
+    empty.write_text("", encoding="utf-8")
+
+    exact_result = ScrollFileTool()(str(exact), page_size=2)
+    empty_result = ScrollFileTool()(str(empty))
+
+    assert exact_result["has_next"] is False
+    assert exact_result["end_line"] == 2
+    assert empty_result["lines"] == []
+    assert empty_result["start_line"] == 1
+    assert empty_result["end_line"] is None
+    assert empty_result["has_previous"] is False
+    assert empty_result["has_next"] is False
+
+
+@pytest.mark.unit
+def test_preserves_utf8_and_strips_only_line_endings(tmp_path: Path) -> None:
+    path = tmp_path / "utf8.txt"
+    path.write_text("café  \nनमस्ते\r\n", encoding="utf-8", newline="")
+
+    result = ScrollFileTool()(str(path))
+
+    assert [line["content"] for line in result["lines"]] == [
+        "café  ",
+        "नमस्ते",
+    ]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"file_path": ""}, "file_path"),
+        ({"file_path": "file.txt", "start_line": 0}, "start_line"),
+        ({"file_path": "file.txt", "start_line": True}, "start_line"),
+        ({"file_path": "file.txt", "page_size": 0}, "page_size"),
+        ({"file_path": "file.txt", "page_size": False}, "page_size"),
+        ({"file_path": "file.txt", "direction": "sideways"}, "direction"),
+    ],
+)
+def test_rejects_invalid_arguments(
+    kwargs: dict[str, object], message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        ScrollFileTool()(**kwargs)
+
+
+@pytest.mark.unit
+def test_missing_file_raises_file_not_found() -> None:
+    with pytest.raises(FileNotFoundError):
+        ScrollFileTool()("missing.txt")

--- a/pkgs/package-index.toml
+++ b/pkgs/package-index.toml
@@ -3404,6 +3404,18 @@ order_source = "inferred"
 order_reason = "single-capability package by default"
 
 [[packages]]
+name = "swarmauri_tool_scrollfile"
+path = "community/swarmauri_tool_scrollfile"
+layer = "50-community"
+order = 0
+family = "tool"
+role = "atomic-concrete"
+maturity = "community"
+workspace = true
+order_source = "inferred"
+order_reason = "single-capability package by default"
+
+[[packages]]
 name = "swarmauri_tool_searchword"
 path = "community/swarmauri_tool_searchword"
 layer = "50-community"

--- a/pkgs/pyproject.toml
+++ b/pkgs/pyproject.toml
@@ -131,6 +131,7 @@ members = [
     "community/swarmauri_tool_lexicaldensity",
     "community/swarmauri_tool_psutil",
     "community/swarmauri_tool_qrcodegenerator",
+    "community/swarmauri_tool_scrollfile",
     "community/swarmauri_tool_searchword",
     "community/swarmauri_tool_sentencecomplexity",
     "community/swarmauri_tool_sentimentanalysis",
@@ -670,6 +671,7 @@ swarmauri_tool_lexicaldensity = { workspace = true }
 swarmauri_tool_matplotlib = { workspace = true }
 swarmauri_tool_psutil = { workspace = true }
 swarmauri_tool_qrcodegenerator = { workspace = true }
+swarmauri_tool_scrollfile = { workspace = true }
 swarmauri_tool_searchword = { workspace = true }
 swarmauri_tool_sentencecomplexity = { workspace = true }
 swarmauri_tool_skill_execution = { workspace = true }


### PR DESCRIPTION
## What changed

- add `swarmauri_tool_scrollfile` as a registered community tool package
- return bounded, line-numbered UTF-8 file pages with previous and next positions
- support deterministic upward, downward, end-of-file, and beyond-EOF navigation
- restrict agent-controlled paths to service-configured roots with canonical containment and a default-deny symlink policy
- enforce service-owned limits for page size, scanned lines/bytes, individual lines, elapsed time, and returned bytes
- document privileged path-policy opt-ins and add adversarial security/boundary coverage
- add package documentation, metadata, workspace registration, and package-index entries

## Why

Agents currently lack a bounded file-navigation primitive and otherwise need to read an entire file or use unrelated search tooling. `ScrollFileTool` keeps output and memory limited to the requested page while exposing stable positions for continued navigation.

Closes #867.

## Validation

- `pytest` for `swarmauri_tool_scrollfile` — 25 passed
- `ruff format` — clean
- `ruff check` — passed
- `mypy --strict --follow-untyped-imports` — passed
- `git diff --check` — passed
- `scripts/license_scan.py` — passed with no GPL or AGPL dependencies on the original package addition
